### PR TITLE
builtins: fold sum() over the live iterator, and carry a wide int through the compensated fast paths

### DIFF
--- a/pyre/extra_tests/parity_tests/builtin_sum_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_sum_python314.py
@@ -66,6 +66,18 @@ assert math.isinf(sum([1e308, 1e308]))
 assert sum([1.0, 10**100, 1.0, -(10**100)]) == 2.0
 assert sum([2j, 1.0, 10**100, 1.0, -(10**100)]) == 2 + 2j
 assert sum([1.0, 2**63]) == 1.0 + float(2**63)
+
+# ...but a wide *running total* ends the integer fast path for good, the way
+# `PyLong_AsLongAndOverflow` signalling overflow does: what leaves that path is
+# still an `int`, so no compensated phase can claim it.
+assert sum([2**63, 0.1, 1, -(2**63)]) == 0.0
+assert sum([0.1, 1, -(2**63)], 2**63) == 0.0
+assert sum([2**63, 0.1, -(2**63)]) == 0.0
+assert sum([2**63, 1, -(2**63)]) == 1
+# A wide int reached *after* the total is already a float stays on the
+# compensated path.
+assert sum([0.1, 2**63, 1, -(2**63)]) == 1.1
+
 for values in ([1.0, 10**1000], [1j, 10**1000]):
     try:
         sum(values)
@@ -83,6 +95,33 @@ assert sum(values) == complex(
     sum(value.real for value in values),
     sum(value.imag for value in values),
 )
+
+# The complex fast path takes `PyFloat_Check` / `PyLong_Check`, not the
+# exactness test the float phase uses: a `float` or `int` subclass stays on it
+# and its reflected addition is skipped, while a `complex` subclass leaves.
+class SubFloat(float):
+    def __radd__(self, other):
+        return "radd-float"
+
+
+class SubInt(int):
+    def __radd__(self, other):
+        return "radd-int"
+
+
+class SubComplex(complex):
+    def __radd__(self, other):
+        return "radd-complex"
+
+
+assert sum([1j, SubFloat(1.0)]) == 1 + 1j
+assert sum([1j, SubInt(1)]) == 1 + 1j
+assert sum([1j, True]) == 1 + 1j
+assert sum([1j, SubComplex(1)]) == "radd-complex"
+# The float phase does test exactness, so a `float` subclass leaves it there.
+assert sum([1.0, SubFloat(1.0)]) == "radd-float"
+assert sum([1, SubFloat(1.0)]) == "radd-float"
+assert sum([1.0, SubInt(1)]) == 2.0
 
 for values in (
     [complex(1, -0.0), 1],

--- a/pyre/extra_tests/parity_tests/builtin_sum_python314.py
+++ b/pyre/extra_tests/parity_tests/builtin_sum_python314.py
@@ -1,5 +1,55 @@
+import itertools
 import math
 import random
+
+
+# `pypy/module/__builtin__/app_functional.py:54 _regular_sum` folds over the
+# live iterator, so `next` and `__add__` interleave rather than the whole
+# iterable being materialised first.
+order = []
+
+
+class Item:
+    def __init__(self, value):
+        self.value = value
+
+    def __radd__(self, other):
+        order.append("add%d" % self.value)
+        return other + self.value
+
+
+def items():
+    for i in range(3):
+        order.append("next%d" % i)
+        yield Item(i)
+
+
+assert sum(items()) == 3
+assert order == ["next0", "add0", "next1", "add1", "next2", "add2"], order
+
+
+# Streaming also means an unbounded iterable is folded rather than collected.
+class Stop(Exception):
+    pass
+
+
+seen = 0
+
+
+class Counted:
+    def __radd__(self, other):
+        global seen
+        seen += 1
+        if seen > 10_000:
+            raise Stop
+        return other
+
+
+try:
+    sum(Counted() for _ in itertools.count())
+except Stop:
+    pass
+assert seen == 10_001, seen
 
 
 assert repr(sum([-0.0])) == "0.0"
@@ -9,6 +59,20 @@ assert repr(sum([], -0.0)) == "-0.0"
 assert sum([0.1] * 10) == 1.0
 assert math.isinf(sum([float("inf"), float("inf")]))
 assert math.isinf(sum([1e308, 1e308]))
+
+# An `int` wider than a machine word is folded into the compensated
+# accumulators as a double, so the compensation term survives it; only a
+# magnitude beyond f64 range raises.
+assert sum([1.0, 10**100, 1.0, -(10**100)]) == 2.0
+assert sum([2j, 1.0, 10**100, 1.0, -(10**100)]) == 2 + 2j
+assert sum([1.0, 2**63]) == 1.0 + float(2**63)
+for values in ([1.0, 10**1000], [1j, 10**1000]):
+    try:
+        sum(values)
+    except OverflowError:
+        pass
+    else:
+        raise AssertionError("expected OverflowError for %r" % (values,))
 
 random.seed(0)
 values = [

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15261,6 +15261,13 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `functional.py:_sum` produces.  The int phase is the generic `last + x`
     // loop, which already keeps exact ints exact and promotes to a float on
     // the first float item, so only the float phase needs its own arithmetic.
+    //
+    // The C accumulator is a machine word, and `PyLong_AsLongAndOverflow`
+    // signalling overflow ends the int fast path for good: the value that
+    // leaves it is still an `int`, so neither compensated phase below can
+    // claim it and the rest of the fold is generic.  Leaving on a wide total
+    // reproduces that — `sum([2**63, 0.1, 1, -(2**63)])` is `0.0`, not the
+    // `1.0` a compensated float phase would produce.
     loop {
         ensure_item(&mut pending, &mut exhausted)?;
         if !pending {
@@ -15269,7 +15276,7 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // Nothing between this read and the `add` can collect, so the running
         // total is read once per item rather than re-read for the call.
         let last = roots.get(last_slot);
-        if !unsafe { is_exact_int_operand(last) } || unsafe { is_exact_float_operand(last) } {
+        if !unsafe { is_machine_word_int_operand(last) } {
             break;
         }
         pending = false;
@@ -15385,6 +15392,14 @@ unsafe fn sum_int_as_double(obj: PyObjectRef) -> f64 {
             pyre_object::jit_bigint_to_f64_or_nan(pyre_object::w_long_get_value(obj))
         }
     }
+}
+
+/// An exact `int` the C fast path's `long` accumulator can hold — the
+/// `PyLong_AsLongAndOverflow` precondition guarding `builtin_sum`'s integer
+/// loop.  pyre splits a wide `int` into its own `LONG_TYPE`, so overflow is
+/// the type test rather than a range check.
+unsafe fn is_machine_word_int_operand(obj: PyObjectRef) -> bool {
+    unsafe { is_exact_int_operand(obj) && !pyre_object::is_long(obj) }
 }
 
 /// `PyLong_CheckExact` — an exact `int`, excluding `bool` and any subclass.

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15196,13 +15196,64 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "sum() can't sum bytearray [use b''.join(seq) instead]",
         ));
     }
-    // `_regular_sum`: `last = last + x` over the generic iterator protocol
-    // (so generators, ranges, sets, dict views, ... all work).  Very
-    // intentionally `last + x`, not `+=` — preserving a mutable `start`
-    // (e.g. a list) matches PyPy's app-level definition.
-    let items = crate::builtins::collect_iterable(iterable)?;
-    let mut last = start;
-    let mut i = 0;
+    // `_regular_sum`: `for x in sequence: last = last + x` over the generic
+    // iterator protocol (so generators, ranges, sets, dict views, ... all
+    // work).  Very intentionally `last + x`, not `+=` — preserving a mutable
+    // `start` (e.g. a list) matches PyPy's app-level definition.
+    //
+    // That fold runs over the *live* iterator, so `next` and the addition
+    // interleave.  Materialising the iterable up front reorders those side
+    // effects and turns an unbounded iterable into an unbounded allocation, so
+    // pump the iterator here instead and keep the running total in a
+    // shadow-stack slot: every `next` and every `__add__` can run allocating
+    // Python code and move it.
+    // Every slot here is read and written once per item, so the whole fold
+    // goes through the scope's cached root-stack cell rather than the free
+    // `shadow_stack_*` functions, which re-resolve the thread local on each
+    // call.
+    let roots = pyre_object::gc_roots::push_roots();
+    // `iter(iterable)` runs arbitrary allocating code before the fold begins,
+    // so both operands are already live across a collection point here: root
+    // them first and read every later use back out of the slot, never from the
+    // local a foreign collection has left stale.
+    let last_slot = roots.base();
+    roots.pin_root(start);
+    let iterable_slot = last_slot + 1;
+    roots.pin_root(iterable);
+    let it_slot = iterable_slot + 1;
+    roots.pin_root(crate::baseobjspace::iter(roots.get(iterable_slot))?);
+    // Seeded with `start` purely to own a slot; every read is guarded by
+    // `pending`, which is only set once a real item has been written here.
+    let item_slot = it_slot + 1;
+    roots.pin_root(roots.get(last_slot));
+    // A dict-view iterator is an off-GC carrier whose own walker does not cover
+    // this native loop; retain its source dict for the duration, as
+    // `collect_iterator` does.
+    if unsafe { pyre_object::dictmultiobject::is_dict_view_iterator(roots.get(it_slot)) } {
+        let w_dict = unsafe {
+            pyre_object::dictmultiobject::w_dict_view_iterator_get_dict(roots.get(it_slot))
+        };
+        roots.pin_root(w_dict);
+    }
+    let mut pending = false;
+    let mut exhausted = false;
+    let mut ensure_item =
+        |pending: &mut bool, exhausted: &mut bool| -> Result<(), crate::PyError> {
+            if *pending || *exhausted {
+                return Ok(());
+            }
+            // The iterator may have moved during a prior step; reload it from its
+            // (post-relocation) slot before each call.
+            match crate::baseobjspace::next(roots.get(it_slot)) {
+                Ok(v) => {
+                    roots.set(item_slot, v);
+                    *pending = true;
+                }
+                Err(e) if e.kind == crate::PyErrorKind::StopIteration => *exhausted = true,
+                Err(e) => return Err(e),
+            }
+            Ok(())
+        };
     // `builtin_sum_impl` runs an exact-int accumulator until the running
     // total turns into an exact float, then a float accumulator that carries
     // the improved Kahan-Babuška (Neumaier) compensation term — so
@@ -15210,72 +15261,130 @@ fn builtin_sum(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `functional.py:_sum` produces.  The int phase is the generic `last + x`
     // loop, which already keeps exact ints exact and promotes to a float on
     // the first float item, so only the float phase needs its own arithmetic.
-    while i < items.len()
-        && unsafe { is_exact_int_operand(last) }
-        && !unsafe { is_exact_float_operand(last) }
-    {
-        last = crate::baseobjspace::add(last, items[i])?;
-        i += 1;
+    loop {
+        ensure_item(&mut pending, &mut exhausted)?;
+        if !pending {
+            break;
+        }
+        // Nothing between this read and the `add` can collect, so the running
+        // total is read once per item rather than re-read for the call.
+        let last = roots.get(last_slot);
+        if !unsafe { is_exact_int_operand(last) } || unsafe { is_exact_float_operand(last) } {
+            break;
+        }
+        pending = false;
+        let total = crate::baseobjspace::add(last, roots.get(item_slot))?;
+        roots.set(last_slot, total);
     }
-    if unsafe { is_exact_float_operand(last) } {
-        let mut real_sum =
-            compensated_sum_from_double(unsafe { pyre_object::w_float_get_value(last) });
-        while i < items.len() {
-            let item = items[i];
+    if unsafe { is_exact_float_operand(roots.get(last_slot)) } {
+        let mut real_sum = compensated_sum_from_double(unsafe {
+            pyre_object::w_float_get_value(roots.get(last_slot))
+        });
+        loop {
+            ensure_item(&mut pending, &mut exhausted)?;
+            if !pending {
+                break;
+            }
+            let item = roots.get(item_slot);
             // A float *subclass* leaves the fast path — its `__add__` may be
             // overridden — while `bool` and an `int` subclass stay in it,
             // matching the `PyFloat_CheckExact` / `PyLong_Check` asymmetry of
-            // the C loop.  An int too wide for a machine word leaves it too,
-            // the way `PyLong_AsLongAndOverflow` signals overflow.
+            // the C loop.  An item that leaves it stays `pending` for the
+            // generic fold below.
             let x = unsafe {
                 if pyre_object::is_float(item) && pyre_object::is_exact_builtin_instance(item) {
                     pyre_object::w_float_get_value(item)
-                } else if pyre_object::pyobject::is_int(item) {
-                    pyre_object::w_int_get_value(item) as f64
+                } else if pyre_object::pyobject::is_int_or_long(item) {
+                    let v = sum_int_as_double(item);
+                    if !v.is_finite() {
+                        return Err(crate::PyError::overflow_error(
+                            "int too large to convert to float",
+                        ));
+                    }
+                    v
                 } else {
                     break;
                 }
             };
+            pending = false;
             real_sum = compensated_sum_add(real_sum, x);
-            i += 1;
         }
-        last = pyre_object::w_float_new(compensated_sum_to_double(real_sum));
+        roots.set(
+            last_slot,
+            pyre_object::w_float_new(compensated_sum_to_double(real_sum)),
+        );
     }
     // CPython 3.14's complex fast path carries independent compensated real
     // and imaginary accumulators.  Exact complex items, all ints, and all
     // floats stay on the path; an arbitrary numeric object falls back to the
     // generic left-fold below.
-    if unsafe { is_exact_complex_operand(last) } {
+    if unsafe { is_exact_complex_operand(roots.get(last_slot)) } {
+        let last = roots.get(last_slot);
         let mut real_sum =
             compensated_sum_from_double(unsafe { pyre_object::w_complex_get_real(last) });
         let mut imag_sum =
             compensated_sum_from_double(unsafe { pyre_object::w_complex_get_imag(last) });
-        while i < items.len() {
-            let item = items[i];
+        loop {
+            ensure_item(&mut pending, &mut exhausted)?;
+            if !pending {
+                break;
+            }
+            let item = roots.get(item_slot);
             unsafe {
                 if is_exact_complex_operand(item) {
                     real_sum = compensated_sum_add(real_sum, pyre_object::w_complex_get_real(item));
                     imag_sum = compensated_sum_add(imag_sum, pyre_object::w_complex_get_imag(item));
-                } else if pyre_object::pyobject::is_int(item) {
-                    real_sum =
-                        compensated_sum_add(real_sum, pyre_object::w_int_get_value(item) as f64);
+                } else if pyre_object::pyobject::is_int_or_long(item) {
+                    let v = sum_int_as_double(item);
+                    if !v.is_finite() {
+                        return Err(crate::PyError::overflow_error(
+                            "int too large to convert to float",
+                        ));
+                    }
+                    real_sum = compensated_sum_add(real_sum, v);
                 } else if pyre_object::is_float(item) {
                     real_sum = compensated_sum_add(real_sum, pyre_object::w_float_get_value(item));
                 } else {
                     break;
                 }
             }
-            i += 1;
+            pending = false;
         }
-        last = pyre_object::w_complex_new(
-            compensated_sum_to_double(real_sum),
-            compensated_sum_to_double(imag_sum),
+        roots.set(
+            last_slot,
+            pyre_object::w_complex_new(
+                compensated_sum_to_double(real_sum),
+                compensated_sum_to_double(imag_sum),
+            ),
         );
     }
-    for &item in &items[i..] {
-        last = crate::baseobjspace::add(last, item)?;
+    loop {
+        ensure_item(&mut pending, &mut exhausted)?;
+        if !pending {
+            break;
+        }
+        pending = false;
+        let total = crate::baseobjspace::add(roots.get(last_slot), roots.get(item_slot))?;
+        roots.set(last_slot, total);
     }
-    Ok(last)
+    Ok(roots.get(last_slot))
+}
+
+/// `PyLong_AsDouble` for `builtin_sum`'s compensated fast paths: an `int` of
+/// any width as a double.  A Python `int` is always finite, so a non-finite
+/// result means the magnitude exceeds f64 range and the caller raises.
+///
+/// Signalling over-range through the value rather than a `Result` keeps a
+/// float-payload `Result` out of the JIT codewriter, which cannot flatten a
+/// payload mixing `Float` (`Ok`) and `Ref` (`Err`) into one register kind.
+unsafe fn sum_int_as_double(obj: PyObjectRef) -> f64 {
+    unsafe {
+        if pyre_object::pyobject::is_int(obj) {
+            pyre_object::w_int_get_value(obj) as f64
+        } else {
+            pyre_object::jit_bigint_to_f64_or_nan(pyre_object::w_long_get_value(obj))
+        }
+    }
 }
 
 /// `PyLong_CheckExact` — an exact `int`, excluding `bool` and any subclass.

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1636,7 +1636,7 @@ pub type ModuleDictGuard = parking_lot::lock_api::ReentrantMutexGuard<
 pub struct DictOperationGuard {
     // Drop the mutex before rewinding the roots.
     _lock: ModuleDictGuard,
-    _roots: crate::gc_roots::RootScope,
+    roots: crate::gc_roots::RootScope,
     root_base: usize,
 }
 
@@ -1648,21 +1648,26 @@ impl DictOperationGuard {
         // is a safepoint, and `refs` is a caller-owned native slice no
         // collection rewrites — so pinning `obj` first would leave every
         // operand behind it naming a pre-collection address.
-        let root_base = crate::gc_roots::publish_roots(&[obj]);
-        crate::gc_roots::publish_roots(refs);
-        crate::gc_roots::normalize_roots(root_base, 1 + refs.len());
-        let obj = crate::gc_roots::shadow_stack_get(root_base);
+        //
+        // Every slot access goes through the scope's cached root-stack cell:
+        // a dict operation touches each of its operands again on the way out,
+        // and the free `gc_roots` functions re-resolve the thread local on
+        // every call — which on Darwin is an out-of-line `_tlv_get_addr`.
+        let root_base = roots.publish(&[obj]);
+        roots.publish(refs);
+        roots.normalize(root_base, 1 + refs.len());
+        let obj = roots.get(root_base);
         let lock = unsafe { w_dict_lock_raw(obj) };
         Self {
             _lock: lock,
-            _roots: roots,
+            roots,
             root_base,
         }
     }
 
     #[inline]
     pub fn root(&self, index: usize) -> PyObjectRef {
-        crate::gc_roots::shadow_stack_get(self.root_base + index)
+        self.roots.get(self.root_base + index)
     }
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -368,6 +368,25 @@ impl RootScope {
         // SAFETY: same cell; `slot` bounds-checks `index`.
         unsafe { *(*self.stack_slot).slot(index) }
     }
+
+    /// Scope-local [`shadow_stack_set`] using the cached cell — the write a
+    /// slot whose contents change over the bracket takes on each update.
+    #[majit_macros::dont_look_inside]
+    pub fn set(&self, index: usize, root: PyObjectRef) {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        // Publish the raw value before the query, for the reason [`pin_root`]
+        // gives: the query is itself a GC operation that may park behind
+        // another thread's collection.
+        // SAFETY: same cell; `slot` bounds-checks `index`.
+        unsafe { *(*self.stack_slot).slot(index) = root };
+        let normalized =
+            crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+        if normalized != root {
+            // SAFETY: same slot, still live.
+            unsafe { *(*self.stack_slot).slot(index) = normalized };
+        }
+    }
 }
 
 impl Drop for RootScope {

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -369,6 +369,43 @@ impl RootScope {
         unsafe { *(*self.stack_slot).slot(index) }
     }
 
+    /// Scope-local [`publish_roots`] using the cached cell.
+    #[majit_macros::dont_look_inside]
+    pub fn publish(&self, roots: &[PyObjectRef]) -> usize {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        // SAFETY: this thread's cell, alive for the bracket; `incr_stack`
+        // returns the slot it just claimed.
+        unsafe {
+            let stack = &*self.stack_slot;
+            let base = stack.len();
+            for &root in roots {
+                *stack.incr_stack() = root;
+            }
+            base
+        }
+    }
+
+    /// Scope-local [`normalize_roots`] using the cached cell.
+    #[majit_macros::dont_look_inside]
+    pub fn normalize(&self, base: usize, len: usize) {
+        #[cfg(debug_assertions)]
+        assert_shadow_stack_not_walking();
+        for index in base..base + len {
+            // Re-read the slot each time, as [`normalize_roots`] does: a
+            // collection triggered by an earlier query may already have
+            // rewritten every published root in place.
+            // SAFETY: `publish` claimed every index in this range.
+            let root = unsafe { *(*self.stack_slot).slot(index) };
+            let current =
+                crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
+            if current != root {
+                // SAFETY: same slot, still live.
+                unsafe { *(*self.stack_slot).slot(index) = current };
+            }
+        }
+    }
+
     /// Scope-local [`shadow_stack_set`] using the cached cell — the write a
     /// slot whose contents change over the bracket takes on each update.
     #[majit_macros::dont_look_inside]


### PR DESCRIPTION
`builtin_sum` materialised the iterable with `collect_iterable` and then
indexed the `Vec`. `app_functional.py:54 _regular_sum` is a fold over the
**live** iterator, so `next` and `__add__` interleave.

## The ordering is observable

Both oracles agree with each other and disagree with pyre:

```
pypy3      3 ['next0', 'add0', 'next1', 'add1', 'next2', 'add2']
python3.14 3 ['next0', 'add0', 'next1', 'add1', 'next2', 'add2']
pyre       3 ['next0', 'next1', 'next2', 'add0', 'add1', 'add2']
```

Three consequences: user-visible side effects run in the wrong order, an
iterable the fold consumes in O(1) costs O(n) (`sum(itertools.count())` never
returns a `Stop` from a user `__radd__`), and — the one that matters most —
the running total and the whole item `Vec` were **raw locals across
`baseobjspace::add`**, which allocates. `collect_iterator`'s own doc comment
warns about exactly that hazard for the `Vec` it builds; the fold reintroduced
it by keeping that `Vec` alive across every `add`.

Pump the iterator instead, holding the total, the pending item and the
iterator in shadow-stack slots. The four phases (exact int, compensated
float, compensated complex, generic fold) and the "an item that leaves a
phase stays pending for the next one" handoff are preserved exactly.

## A second, pre-existing defect

Porting CPython's own `test_sum` and `test_sum_accuracy` (54 checks) into a
standalone fixture found two failures that are not caused by the rewrite —
established from the committed source, where the float phase has only
`is_float` / `is_int` arms and `break`s otherwise:

    sum([1.0, 10**100, 1.0, -(10**100)])     -> 0.0   (3.14: 2.0)
    sum([2j, 1.0, 10**100, 1.0, -(10**100)]) -> 2j    (3.14: 2+2j)

The fast paths took only a machine-word `int`, so a wider one left the
compensated loop and flushed the compensation term *before* the large value
arrived. Convert an `int` of any width to a double in the loop, raising
`OverflowError` only past f64 range.

Neither oracle gates this: `test_sum_accuracy` is `@support.cpython_only`,
and the `pypy3` oracle is 3.11, which has no compensated sum at all.

Over-range is signalled through a non-finite `f64` rather than a `Result`,
because `descroperation.rs` documents that the JIT codewriter cannot flatten
a payload mixing `Float` (`Ok`) and `Ref` (`Err`) into one register kind.

## `RootScope::set`

`RootScope` caches the thread-local root-stack cell precisely so a loop need
not re-resolve it per access, but had only `get` / `pin_root`; the free
`shadow_stack_set` resolves the thread local three times per call. Added the
symmetric `set` and put the fold on the cached-cell accessors.

## Cost

Measured control-free, since a sibling-worktree control arm proved invalid:
**+21ns per `sum()` call** (rooting `start` and the item slot) and **+3.8ns
per item** (one forwarding query for the now-rooted accumulator). `sum` on a
large list remains ~40x `pypy3` either way — untouched here.

## Verification

- 54/54 of the ported `test_sum` + `test_sum_accuracy` checks.
- A 43-case behavioural battery byte-identical to CPython 3.14, error
  messages included.
- `check.py` **374/374 on dynasm and cranelift**, with no jit-stats movement;
  `loops_comprehension` reads 10.1x against its 144x ratio gate.
- `cpython_tests` 46/46, no regressions. `cargo test` 799 pass. `cargo fmt`
  clean; the `clippy` errors in `pyre-object` are pre-existing and in files
  this branch does not touch.
- Regression coverage added to `parity_tests/builtin_sum_python314.py`, green
  on cpython, dynasm and cranelift.

Note: the check.py run above was made against the pre-rebase base. #1034 has
since re-recorded 43 baselines and changed the gate, so CI's run is the
authoritative one at this base.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated `sum` to process values incrementally, supporting large and unbounded iterables more efficiently.
  * Improved compensated accumulation for floating-point and complex-number calculations.
  * Added support for summing arbitrarily large integers with appropriate conversion handling.

* **Bug Fixes**
  * Improved accuracy and consistency when combining integers, floats, and complex values.
  * `sum` now raises `OverflowError` when values exceed floating-point limits.
  * Improved handling of numeric subclasses and mixed-type additions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->