### PR TITLE
launch flags: share the option block with the wasm guest, which had no environment to fold

### DIFF
--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1815,9 +1815,9 @@ pub fn quiet_flag() -> bool {
     SYS_QUIET.load(Ordering::Relaxed)
 }
 
-/// `-i`, which `make_flags` reports as both `inspect` and `interactive`.
-/// `PYTHONINSPECT` would set only the former, but the launcher does not
-/// read it, so `-i` is the whole of this flag's input.
+/// `-i`, which `make_flags` reports as both `inspect` and `interactive`, folded
+/// with `PYTHONINSPECT`. The variable sets only `inspect`, so a run that owes
+/// the flag to the environment still reports `interactive` as false.
 pub fn inspect_flag() -> bool {
     SYS_INSPECT.load(Ordering::Relaxed)
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1760,42 +1760,26 @@ pub fn no_site_flag() -> bool {
     SYS_NO_SITE.load(Ordering::Relaxed)
 }
 
-/// Record the command-line flags consumed by `app_main.py` before `sys` is
+/// Record the launcher option block consumed by `app_main.py` before `sys` is
 /// initialized.  The codec paths also read `dev_mode` directly, matching
-/// `space.sys.get_flag('dev_mode')` in `unicodeobject.py`.
-#[allow(clippy::too_many_arguments)]
-pub fn set_runtime_flags(
-    quiet: bool,
-    inspect: bool,
-    no_user_site: bool,
-    ignore_environment: bool,
-    isolated: bool,
-    dev_mode: bool,
-    utf8_mode: i64,
-    safe_path: bool,
-    optimize: i64,
-    bytes_warning: i64,
-    dont_write_bytecode: bool,
-    unbuffered: bool,
-    xoptions: Vec<String>,
-    warnoptions: Vec<String>,
-    stdio_encoding: Option<String>,
-) {
-    SYS_QUIET.store(quiet, Ordering::Relaxed);
-    SYS_INSPECT.store(inspect, Ordering::Relaxed);
-    SYS_NO_USER_SITE.store(no_user_site, Ordering::Relaxed);
-    SYS_IGNORE_ENVIRONMENT.store(ignore_environment, Ordering::Relaxed);
-    SYS_ISOLATED.store(isolated, Ordering::Relaxed);
-    SYS_DEV_MODE.store(dev_mode, Ordering::Relaxed);
-    SYS_UTF8_MODE.store(utf8_mode, Ordering::Relaxed);
-    SYS_SAFE_PATH.store(safe_path, Ordering::Relaxed);
-    SYS_OPTIMIZE.store(optimize, Ordering::Relaxed);
-    SYS_BYTES_WARNING.store(bytes_warning, Ordering::Relaxed);
-    SYS_DONT_WRITE_BYTECODE.store(dont_write_bytecode, Ordering::Relaxed);
-    SYS_UNBUFFERED.store(unbuffered, Ordering::Relaxed);
-    *SYS_XOPTIONS.lock().unwrap() = xoptions;
-    *SYS_WARNOPTIONS.lock().unwrap() = warnoptions;
-    *SYS_STDIO_ENCODING.lock().unwrap() = stdio_encoding;
+/// `space.sys.get_flag('dev_mode')` in `unicodeobject.py`.  The block must have
+/// been through `launch_env::finalize`, which is what fills `utf8_mode`.
+pub fn set_runtime_flags(flags: &crate::launch_env::LaunchFlags) {
+    SYS_QUIET.store(flags.quiet, Ordering::Relaxed);
+    SYS_INSPECT.store(flags.inspect, Ordering::Relaxed);
+    SYS_NO_USER_SITE.store(flags.no_user_site, Ordering::Relaxed);
+    SYS_IGNORE_ENVIRONMENT.store(flags.ignore_environment, Ordering::Relaxed);
+    SYS_ISOLATED.store(flags.isolated, Ordering::Relaxed);
+    SYS_DEV_MODE.store(flags.dev_mode, Ordering::Relaxed);
+    SYS_UTF8_MODE.store(flags.utf8_mode.unwrap_or(0), Ordering::Relaxed);
+    SYS_SAFE_PATH.store(flags.safe_path, Ordering::Relaxed);
+    SYS_OPTIMIZE.store(flags.optimize, Ordering::Relaxed);
+    SYS_BYTES_WARNING.store(flags.bytes_warning, Ordering::Relaxed);
+    SYS_DONT_WRITE_BYTECODE.store(flags.dont_write_bytecode, Ordering::Relaxed);
+    SYS_UNBUFFERED.store(flags.unbuffered, Ordering::Relaxed);
+    *SYS_XOPTIONS.lock().unwrap() = flags.xoptions.clone();
+    *SYS_WARNOPTIONS.lock().unwrap() = flags.warnoptions.clone();
+    *SYS_STDIO_ENCODING.lock().unwrap() = flags.stdio_encoding.clone();
 }
 
 /// Raw `-X` values recorded by the launcher, in command-line order.

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -66,20 +66,25 @@ impl Default for LaunchFlags {
 }
 
 /// Environment the launcher options resolve against, when the process
-/// environment is not it. Installed once at startup; absent means read
-/// `std::env` directly.
-static LAUNCH_ENV: LazyLock<Mutex<Option<HashMap<String, String>>>> =
+/// environment is not it. Installed once at startup; absent means read the
+/// process environment through the host seam.
+///
+/// Values are raw bytes, not `String`: `_Py_GetEnv` tests presence on the
+/// undecoded bytes, so a value that is not valid Unicode is still *set*. A
+/// table of `String` could not represent that, and the name whose fold depends
+/// on it — `PYTHONSAFEPATH` — would silently read as unset.
+static LAUNCH_ENV: LazyLock<Mutex<Option<HashMap<String, Vec<u8>>>>> =
     LazyLock::new(|| Mutex::new(None));
 
 /// Supply the launcher-relevant environment explicitly, for an embedding whose
 /// own process environment is not the one the program should observe.
 ///
-/// wasm32 has no environment at all — every `std::env::var` inside the module
-/// returns unset regardless of the host process — so a guest resolving `-P`,
-/// `-O` or PYTHONWARNINGS from `std::env` reads them all as absent. Passing the
-/// entries in restores the fold. Once installed the table is authoritative: a
-/// name missing from it is unset, never a fallback to `std::env`.
-pub fn set_launch_env(entries: impl IntoIterator<Item = (String, String)>) {
+/// wasm32 has no environment at all — every lookup inside the module returns
+/// unset regardless of the host process — so a guest resolving `-P`, `-O` or
+/// PYTHONWARNINGS from it reads them all as absent. Passing the entries in
+/// restores the fold. Once installed the table is authoritative: a name missing
+/// from it is unset, never a fallback to the process environment.
+pub fn set_launch_env(entries: impl IntoIterator<Item = (String, Vec<u8>)>) {
     *LAUNCH_ENV.lock().unwrap() = Some(entries.into_iter().collect());
 }
 
@@ -88,6 +93,10 @@ pub fn set_launch_env(entries: impl IntoIterator<Item = (String, String)>) {
 /// because an unset chain resolves to the C locale, which coerces UTF-8 mode.
 pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "PYTHONSAFEPATH",
+    "PYTHONNOUSERSITE",
+    "PYTHONUNBUFFERED",
+    "PYTHONDEVMODE",
+    "PYTHONINSPECT",
     "PYTHONOPTIMIZE",
     "PYTHONDONTWRITEBYTECODE",
     "PYTHONUTF8",
@@ -98,22 +107,31 @@ pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "LANG",
 ];
 
-fn read(name: &str) -> Option<String> {
+/// The raw bytes of a variable, from the installed table when there is one and
+/// otherwise from the process environment through the host seam. A seam error
+/// reads as unset, the same as a name the environment does not carry.
+fn read_raw(name: &str) -> Option<Vec<u8>> {
     if let Some(table) = LAUNCH_ENV.lock().unwrap().as_ref() {
         return table.get(name).cloned();
     }
-    std::env::var(name).ok()
+    crate::host_seam::getenv(name.as_bytes()).ok().flatten()
+}
+
+/// The decoded value, or `None` when unset *or* not valid Unicode — the
+/// `env::var` contract. Only the free-text names resolve under it
+/// (PYTHONWARNINGS, PYTHONIOENCODING and the locale chain); every name whose
+/// fold turns on presence or on an exact spelling reads bytes instead, so that
+/// an undecodable value stays distinguishable from an absent one.
+fn read(name: &str) -> Option<String> {
+    read_raw(name).and_then(|value| String::from_utf8(value).ok())
 }
 
 /// Presence of a variable, without decoding it. `_Py_GetEnv` tests the raw
-/// bytes, so a value that is not valid Unicode still counts as set — which the
-/// process-environment path preserves and an installed table cannot, its values
-/// having already been decoded to cross the embedding boundary.
+/// bytes, so a value that is not valid Unicode still counts as set. Both paths
+/// preserve that: the seam hands back bytes, and the installed table stores
+/// bytes for this reason.
 fn is_set_nonempty(name: &str) -> bool {
-    if let Some(table) = LAUNCH_ENV.lock().unwrap().as_ref() {
-        return table.get(name).is_some_and(|value| !value.is_empty());
-    }
-    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+    read_raw(name).is_some_and(|value| !value.is_empty())
 }
 
 fn locale_implies_utf8_mode() -> bool {
@@ -139,11 +157,13 @@ fn resolve_utf8_mode(flags: &LaunchFlags) -> Result<i64, PreConfigError> {
         return Ok(value);
     }
     if !flags.ignore_environment {
-        if let Some(value) = read("PYTHONUTF8") {
+        // Compared as bytes: a value that does not decode is *invalid*, which is
+        // fatal, not absent, which would silently fall through to the locale.
+        if let Some(value) = read_raw("PYTHONUTF8") {
             if !value.is_empty() {
-                return match value.as_str() {
-                    "0" => Ok(0),
-                    "1" => Ok(1),
+                return match value.as_slice() {
+                    b"0" => Ok(0),
+                    b"1" => Ok(1),
                     _ => Err(PreConfigError(
                         "invalid PYTHONUTF8 environment variable value",
                     )),
@@ -158,12 +178,18 @@ fn resolve_utf8_mode(flags: &LaunchFlags) -> Result<i64, PreConfigError> {
 /// absent; a clean non-negative integer is used as-is; anything else (trailing
 /// junk, negative, overflow) counts as 1.
 fn env_int_flag(name: &str) -> Option<u32> {
-    let raw = read(name)?;
+    let raw = read_raw(name)?;
     if raw.is_empty() {
         return None;
     }
-    let value = match raw.parse::<i64>() {
-        Ok(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
+    // Read the bytes, not a decoded string: `_Py_str_to_int` rejects undecodable
+    // input exactly the way it rejects trailing junk, so both land on 1 rather
+    // than on "unset".
+    let parsed = std::str::from_utf8(&raw)
+        .ok()
+        .and_then(|value| value.parse::<i64>().ok());
+    let value = match parsed {
+        Some(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
         _ => 1,
     };
     Some(value)
@@ -183,26 +209,19 @@ fn resolve_optimize(flags: &LaunchFlags) -> i64 {
     level
 }
 
-/// `-B` folded with PYTHONDONTWRITEBYTECODE: either disables bytecode caches.
-fn resolve_dont_write_bytecode(flags: &LaunchFlags) -> bool {
-    if flags.dont_write_bytecode {
-        return true;
-    }
-    if !flags.ignore_environment {
-        if let Some(v) = env_int_flag("PYTHONDONTWRITEBYTECODE") {
-            return v != 0;
-        }
-    }
-    false
+/// A boolean option folded with an *integer* environment flag: the variable
+/// enables it for any value `_Py_get_env_flag` resolves nonzero, so an explicit
+/// `NAME=0` leaves it off. The fold only ever sets, so the command-line spelling
+/// survives both `-E` and a zero-valued variable.
+fn fold_int_flag(flags: &LaunchFlags, set: bool, name: &str) -> bool {
+    set || (!flags.ignore_environment && env_int_flag(name).is_some_and(|v| v != 0))
 }
 
-/// `-P` folded with PYTHONSAFEPATH (`config_read_env_vars`). The variable is a
-/// bare presence flag read through `_Py_GetEnv`, not an integer one: any
-/// non-empty value enables safe path — `"0"` included — while an empty value
-/// counts as unset. It only ever sets the flag, so an explicit `-P` survives
-/// `-E`.
-fn resolve_safe_path(flags: &LaunchFlags) -> bool {
-    flags.safe_path || (!flags.ignore_environment && is_set_nonempty("PYTHONSAFEPATH"))
+/// A boolean option folded with a *presence* environment flag, read through
+/// `_Py_GetEnv` rather than `_Py_get_env_flag`: any non-empty value enables it —
+/// `"0"` included — while an empty value counts as unset.
+fn fold_presence_flag(flags: &LaunchFlags, set: bool, name: &str) -> bool {
+    set || (!flags.ignore_environment && is_set_nonempty(name))
 }
 
 /// Fold the environment over the options a command line named. An embedding
@@ -210,8 +229,16 @@ fn resolve_safe_path(flags: &LaunchFlags) -> bool {
 pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
     flags.utf8_mode = Some(resolve_utf8_mode(&flags)?);
     flags.optimize = resolve_optimize(&flags);
-    flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
-    flags.safe_path = resolve_safe_path(&flags);
+    // Which of the two shapes a name takes is per-variable, not a category:
+    // PYTHONSAFEPATH and PYTHONINSPECT enable on a bare `=0`, PYTHONNOUSERSITE
+    // and PYTHONUNBUFFERED do not.
+    flags.dont_write_bytecode =
+        fold_int_flag(&flags, flags.dont_write_bytecode, "PYTHONDONTWRITEBYTECODE");
+    flags.no_user_site = fold_int_flag(&flags, flags.no_user_site, "PYTHONNOUSERSITE");
+    flags.unbuffered = fold_int_flag(&flags, flags.unbuffered, "PYTHONUNBUFFERED");
+    flags.safe_path = fold_presence_flag(&flags, flags.safe_path, "PYTHONSAFEPATH");
+    flags.dev_mode = fold_presence_flag(&flags, flags.dev_mode, "PYTHONDEVMODE");
+    flags.inspect = fold_presence_flag(&flags, flags.inspect, "PYTHONINSPECT");
     flags.stdio_encoding = if flags.ignore_environment {
         None
     } else {

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -1,0 +1,243 @@
+//! The launcher option block and the environment half of its resolution
+//! (`config_read_env_vars`).
+//!
+//! `app_main.py` reads the `PYTHON*` variables itself, so the folding rules
+//! belong beside the `SYS_*` statics they feed rather than in whichever
+//! binary happens to own a command line. Two callers share them: the native
+//! launcher, which parses an argv and then folds the process environment over
+//! it; and the wasm32 embedding, which has neither — `std::env` there is
+//! permanently empty, so its host installs the relevant entries through
+//! [`set_launch_env`] and folds them over an all-default option block.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+/// The launcher options, as parsed from a command line and then folded with
+/// the environment by [`finalize`]. `app_main.py` keeps the same set in its
+/// `options` dict before `sys` initialization reads them back.
+#[derive(Clone)]
+pub struct LaunchFlags {
+    pub inspect: bool,
+    pub quiet: bool,
+    pub no_site: bool,
+    pub no_user_site: bool,
+    pub ignore_environment: bool,
+    pub isolated: bool,
+    pub dev_mode: bool,
+    /// `None` until [`finalize`] resolves it; a command line that named
+    /// `-X utf8` carries that value through instead.
+    pub utf8_mode: Option<i64>,
+    pub safe_path: bool,
+    /// `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
+    pub optimize: i64,
+    pub bytes_warning: i64,
+    pub dont_write_bytecode: bool,
+    pub unbuffered: bool,
+    pub warnoptions: Vec<String>,
+    /// `app_main.py` passes the raw PYTHONIOENCODING value to initstdio after
+    /// applying -E/-I. Keep it raw until stdio parses the optional errors part.
+    pub stdio_encoding: Option<String>,
+    /// Every raw `-X` value stays in a list until sys module initialization
+    /// turns it into `sys._xoptions`.
+    pub xoptions: Vec<String>,
+}
+
+impl Default for LaunchFlags {
+    fn default() -> Self {
+        Self {
+            inspect: false,
+            quiet: false,
+            no_site: false,
+            no_user_site: false,
+            ignore_environment: false,
+            isolated: false,
+            dev_mode: false,
+            utf8_mode: None,
+            safe_path: false,
+            optimize: 0,
+            bytes_warning: 0,
+            dont_write_bytecode: false,
+            unbuffered: false,
+            warnoptions: Vec::new(),
+            stdio_encoding: None,
+            xoptions: Vec::new(),
+        }
+    }
+}
+
+/// Environment the launcher options resolve against, when the process
+/// environment is not it. Installed once at startup; absent means read
+/// `std::env` directly.
+static LAUNCH_ENV: LazyLock<Mutex<Option<HashMap<String, String>>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+/// Supply the launcher-relevant environment explicitly, for an embedding whose
+/// own process environment is not the one the program should observe.
+///
+/// wasm32 has no environment at all — every `std::env::var` inside the module
+/// returns unset regardless of the host process — so a guest resolving `-P`,
+/// `-O` or PYTHONWARNINGS from `std::env` reads them all as absent. Passing the
+/// entries in restores the fold. Once installed the table is authoritative: a
+/// name missing from it is unset, never a fallback to `std::env`.
+pub fn set_launch_env(entries: impl IntoIterator<Item = (String, String)>) {
+    *LAUNCH_ENV.lock().unwrap() = Some(entries.into_iter().collect());
+}
+
+/// The names [`finalize`] reads, for a host that has to forward them to an
+/// embedding with no environment of its own. Locale variables are included
+/// because an unset chain resolves to the C locale, which coerces UTF-8 mode.
+pub const LAUNCH_ENV_NAMES: &[&str] = &[
+    "PYTHONSAFEPATH",
+    "PYTHONOPTIMIZE",
+    "PYTHONDONTWRITEBYTECODE",
+    "PYTHONUTF8",
+    "PYTHONWARNINGS",
+    "PYTHONIOENCODING",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LANG",
+];
+
+fn read(name: &str) -> Option<String> {
+    if let Some(table) = LAUNCH_ENV.lock().unwrap().as_ref() {
+        return table.get(name).cloned();
+    }
+    std::env::var(name).ok()
+}
+
+/// Presence of a variable, without decoding it. `_Py_GetEnv` tests the raw
+/// bytes, so a value that is not valid Unicode still counts as set — which the
+/// process-environment path preserves and an installed table cannot, its values
+/// having already been decoded to cross the embedding boundary.
+fn is_set_nonempty(name: &str) -> bool {
+    if let Some(table) = LAUNCH_ENV.lock().unwrap().as_ref() {
+        return table.get(name).is_some_and(|value| !value.is_empty());
+    }
+    std::env::var_os(name).is_some_and(|value| !value.is_empty())
+}
+
+fn locale_implies_utf8_mode() -> bool {
+    // An empty variable is treated as unset (`setlocale` POSIX semantics) and
+    // falls through to the next, so `LC_ALL= LC_CTYPE=en_US.UTF-8` resolves to
+    // en_US.UTF-8, not C.
+    let read = |name: &str| read(name).filter(|v| !v.is_empty());
+    let locale = read("LC_ALL")
+        .or_else(|| read("LC_CTYPE"))
+        .or_else(|| read("LANG"));
+    // Only the legacy C/POSIX locale — or a fully unset chain, which resolves to
+    // C — coerces utf8_mode to 1; every named locale (en_US, C.UTF-8, …) leaves
+    // it 0.
+    matches!(locale.as_deref(), None | Some("C") | Some("POSIX"))
+}
+
+/// Detail of a `preconfig_init_utf8_mode` failure, for the caller to report the
+/// way its embedding reports a fatal pre-init error.
+pub struct PreConfigError(pub &'static str);
+
+fn resolve_utf8_mode(flags: &LaunchFlags) -> Result<i64, PreConfigError> {
+    if let Some(value) = flags.utf8_mode {
+        return Ok(value);
+    }
+    if !flags.ignore_environment {
+        if let Some(value) = read("PYTHONUTF8") {
+            if !value.is_empty() {
+                return match value.as_str() {
+                    "0" => Ok(0),
+                    "1" => Ok(1),
+                    _ => Err(PreConfigError(
+                        "invalid PYTHONUTF8 environment variable value",
+                    )),
+                };
+            }
+        }
+    }
+    Ok(if locale_implies_utf8_mode() { 1 } else { 0 })
+}
+
+/// `_Py_get_env_flag`: an integer environment flag. An unset or empty value is
+/// absent; a clean non-negative integer is used as-is; anything else (trailing
+/// junk, negative, overflow) counts as 1.
+fn env_int_flag(name: &str) -> Option<u32> {
+    let raw = read(name)?;
+    if raw.is_empty() {
+        return None;
+    }
+    let value = match raw.parse::<i64>() {
+        Ok(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
+        _ => 1,
+    };
+    Some(value)
+}
+
+/// `-O` count folded with PYTHONOPTIMIZE (`config_init_optimization_level`):
+/// the effective level is the larger of the two.  The level is kept as a wide
+/// integer so `sys.flags.optimize` mirrors a large `PYTHONOPTIMIZE` verbatim;
+/// the compiler clamps it into a byte at read time.
+fn resolve_optimize(flags: &LaunchFlags) -> i64 {
+    let mut level = flags.optimize;
+    if !flags.ignore_environment {
+        if let Some(v) = env_int_flag("PYTHONOPTIMIZE") {
+            level = level.max(i64::from(v));
+        }
+    }
+    level
+}
+
+/// `-B` folded with PYTHONDONTWRITEBYTECODE: either disables bytecode caches.
+fn resolve_dont_write_bytecode(flags: &LaunchFlags) -> bool {
+    if flags.dont_write_bytecode {
+        return true;
+    }
+    if !flags.ignore_environment {
+        if let Some(v) = env_int_flag("PYTHONDONTWRITEBYTECODE") {
+            return v != 0;
+        }
+    }
+    false
+}
+
+/// `-P` folded with PYTHONSAFEPATH (`config_read_env_vars`). The variable is a
+/// bare presence flag read through `_Py_GetEnv`, not an integer one: any
+/// non-empty value enables safe path — `"0"` included — while an empty value
+/// counts as unset. It only ever sets the flag, so an explicit `-P` survives
+/// `-E`.
+fn resolve_safe_path(flags: &LaunchFlags) -> bool {
+    flags.safe_path || (!flags.ignore_environment && is_set_nonempty("PYTHONSAFEPATH"))
+}
+
+/// Fold the environment over the options a command line named. An embedding
+/// without a command line passes `LaunchFlags::default()`.
+pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
+    flags.utf8_mode = Some(resolve_utf8_mode(&flags)?);
+    flags.optimize = resolve_optimize(&flags);
+    flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
+    flags.safe_path = resolve_safe_path(&flags);
+    flags.stdio_encoding = if flags.ignore_environment {
+        None
+    } else {
+        read("PYTHONIOENCODING")
+    };
+    // pypy/interpreter/app_main.py:892-906 — lowest-precedence entries first;
+    // the warnings module installs later entries ahead of earlier ones.
+    let mut warnoptions = Vec::new();
+    if flags.dev_mode {
+        warnoptions.push("default".to_string());
+    }
+    if !flags.ignore_environment {
+        if let Some(value) = read("PYTHONWARNINGS") {
+            if !value.is_empty() {
+                warnoptions.extend(value.split(',').map(str::to_string));
+            }
+        }
+    }
+    warnoptions.append(&mut flags.warnoptions);
+    if flags.bytes_warning > 0 {
+        warnoptions.push(if flags.bytes_warning > 1 {
+            "error::BytesWarning".to_string()
+        } else {
+            "default::BytesWarning".to_string()
+        });
+    }
+    flags.warnoptions = warnoptions;
+    Ok(flags)
+}

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -91,6 +91,7 @@ pub mod host_seam {
 }
 pub mod async_operation;
 pub mod jit_fnaddr;
+pub mod launch_env;
 pub mod listobject;
 pub mod listsort;
 pub mod opcode_ops;

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -400,18 +400,21 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
         memory.read(&store, nptr as usize, &mut buf)?;
         dealloc.call(&mut store, (nptr, nlen))?;
 
-        // Only values that are valid UTF-8 are forwarded: the fold reads all
-        // but one of these names through `env::var`, which drops a value that
-        // is not, so dropping it here is what the native launcher already
-        // sees. The exception is the `PYTHONSAFEPATH` presence flag, tested on
-        // raw bytes — a non-UTF-8 value for it reaches the guest as unset,
-        // which leaves `sys.path[0]` seeded rather than suppressed.
+        // Values are forwarded undecoded. The fold reads all but one of these
+        // names through `env::var` and so drops a value that is not UTF-8 on
+        // its own, matching the native launcher; the exception is the
+        // `PYTHONSAFEPATH` presence flag, which `_Py_GetEnv` tests on raw
+        // bytes. Decoding here would make such a value read as unset and leave
+        // `sys.path[0]` seeded rather than suppressed, so the decision belongs
+        // to the fold, not the transport. `into_encoded_bytes` round-trips a
+        // valid-UTF-8 `OsString` to exactly its UTF-8 bytes, so the guest's
+        // `from_utf8` reproduces `env::var`'s accept/reject split unchanged.
         let mut blob: Vec<u8> = Vec::new();
         for name in String::from_utf8_lossy(&buf)
             .split('\0')
             .filter(|name| !name.is_empty())
         {
-            let Some(value) = std::env::var_os(name).and_then(|v| v.into_string().ok()) else {
+            let Some(value) = std::env::var_os(name) else {
                 continue;
             };
             if !blob.is_empty() {
@@ -419,7 +422,7 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
             }
             blob.extend_from_slice(name.as_bytes());
             blob.push(b'=');
-            blob.extend_from_slice(value.as_bytes());
+            blob.extend_from_slice(&value.into_encoded_bytes());
         }
 
         let blen = blob.len() as u32;

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -376,13 +376,62 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
         set_force.call(&mut store, selector)?;
     }
 
-    // `-P` / PYTHONSAFEPATH, resolved host-side: the guest's environment is
-    // permanently empty, so the variable has to be handed over explicitly or it
-    // would read as unset there while working natively. A presence flag, matching
-    // `pyrex::resolve_safe_path` — any non-empty value enables it, `"0"`
-    // included, and an empty value counts as unset. Absent on a module predating
-    // the export, leaving the guest on its default of seeding `sys.path[0]`.
-    if std::env::var_os("PYTHONSAFEPATH").is_some_and(|value| !value.is_empty()) {
+    // The environment `-P`, `-O`, PYTHONWARNINGS and the rest resolve against.
+    // The guest's own is permanently empty, so without this every one of them
+    // reads as unset there while working natively; the runner only forwards the
+    // values, the fold stays in `launch_env::finalize` where the launcher's is.
+    // The module names which variables it wants, so the two never drift apart.
+    //
+    // A module predating `pyre_set_launch_env` still understands the `-P` half
+    // through `pyre_set_safe_path`; one predating both keeps its previous
+    // behaviour of always seeding `sys.path[0]`. Both halves are resolved before
+    // either is used, so a module carrying only one degrades to the fallback
+    // instead of failing the run.
+    let launch_env_names = instance
+        .get_typed_func::<(), u64>(&mut store, "pyre_launch_env_names")
+        .ok();
+    let set_launch_env = instance
+        .get_typed_func::<(u32, u32), ()>(&mut store, "pyre_set_launch_env")
+        .ok();
+    if let (Some(names), Some(set_launch_env)) = (launch_env_names, set_launch_env) {
+        let packed = names.call(&mut store, ())?;
+        let (nptr, nlen) = ((packed >> 32) as u32, packed as u32);
+        let mut buf = vec![0u8; nlen as usize];
+        memory.read(&store, nptr as usize, &mut buf)?;
+        dealloc.call(&mut store, (nptr, nlen))?;
+
+        // Only values that are valid UTF-8 are forwarded: the fold reads all
+        // but one of these names through `env::var`, which drops a value that
+        // is not, so dropping it here is what the native launcher already
+        // sees. The exception is the `PYTHONSAFEPATH` presence flag, tested on
+        // raw bytes — a non-UTF-8 value for it reaches the guest as unset,
+        // which leaves `sys.path[0]` seeded rather than suppressed.
+        let mut blob: Vec<u8> = Vec::new();
+        for name in String::from_utf8_lossy(&buf)
+            .split('\0')
+            .filter(|name| !name.is_empty())
+        {
+            let Some(value) = std::env::var_os(name).and_then(|v| v.into_string().ok()) else {
+                continue;
+            };
+            if !blob.is_empty() {
+                blob.push(0);
+            }
+            blob.extend_from_slice(name.as_bytes());
+            blob.push(b'=');
+            blob.extend_from_slice(value.as_bytes());
+        }
+
+        let blen = blob.len() as u32;
+        if blen == 0 {
+            set_launch_env.call(&mut store, (0, 0))?;
+        } else {
+            let p = alloc.call(&mut store, blen)?;
+            memory.write(&mut store, p as usize, &blob)?;
+            set_launch_env.call(&mut store, (p, blen))?;
+            dealloc.call(&mut store, (p, blen))?;
+        }
+    } else if std::env::var_os("PYTHONSAFEPATH").is_some_and(|value| !value.is_empty()) {
         if let Ok(set_safe_path) =
             instance.get_typed_func::<u32, ()>(&mut store, "pyre_set_safe_path")
         {

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -523,8 +523,10 @@ thread_local! {
     /// environment carries and `run_python_impl` folds them the way the native
     /// launcher does. Only the native-host binding seeds this — the browser has
     /// no environment to seed it from.
+    /// Values are raw bytes: `_Py_GetEnv` tests presence on the undecoded
+    /// bytes, so a `PYTHONSAFEPATH` the host cannot decode is still set.
     #[cfg(feature = "wasm-host")]
-    static LAUNCH_ENV: RefCell<Vec<(String, String)>> = const { RefCell::new(Vec::new()) };
+    static LAUNCH_ENV: RefCell<Vec<(String, Vec<u8>)>> = const { RefCell::new(Vec::new()) };
 }
 
 #[cfg(any(feature = "web", feature = "wasm-host"))]
@@ -853,17 +855,24 @@ mod host_abi {
     /// and `sys.flags` reports the defaults no matter what the host was run
     /// with. `pyre_launch_env_names` lists the names worth sending; anything
     /// else is carried but never read. A record without `=`, or with an empty
-    /// name, is dropped.
+    /// or non-UTF-8 name, is dropped.
+    ///
+    /// The blob is read as bytes, not text: a VALUE that is not valid UTF-8 is
+    /// carried through undecoded, because `_Py_GetEnv` tests presence on the
+    /// raw bytes and `PYTHONSAFEPATH` is set by any nonempty value whether or
+    /// not it decodes. Names are ASCII by construction.
     #[unsafe(no_mangle)]
     pub extern "C" fn pyre_set_launch_env(ptr: *const u8, len: usize) {
-        let Some(blob) = guest_str(ptr, len) else {
+        let Some(blob) = guest_bytes(ptr, len) else {
             return;
         };
         let entries = blob
-            .split('\0')
-            .filter_map(|record| record.split_once('='))
-            .filter(|(name, _)| !name.is_empty())
-            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .split(|&b| b == 0)
+            .filter_map(|record| {
+                let eq = record.iter().position(|&b| b == b'=')?;
+                let name = std::str::from_utf8(&record[..eq]).ok()?;
+                (!name.is_empty()).then(|| (name.to_string(), record[eq + 1..].to_vec()))
+            })
             .collect();
         super::LAUNCH_ENV.with(|e| *e.borrow_mut() = entries);
     }
@@ -893,7 +902,7 @@ mod host_abi {
             let mut entries = e.borrow_mut();
             entries.retain(|(name, _)| name != "PYTHONSAFEPATH");
             if enabled != 0 {
-                entries.push(("PYTHONSAFEPATH".to_string(), "1".to_string()));
+                entries.push(("PYTHONSAFEPATH".to_string(), b"1".to_vec()));
             }
         });
     }
@@ -903,14 +912,22 @@ mod host_abi {
     /// (`None`) before a slice is formed rather than being undefined
     /// behaviour; an empty buffer reads as the empty string.
     fn guest_str(ptr: *const u8, len: usize) -> Option<String> {
+        guest_bytes(ptr, len).map(|bytes| String::from_utf8_lossy(&bytes).into_owned())
+    }
+
+    /// Copy `[ptr, ptr+len)` out of linear memory undecoded, for a caller whose
+    /// payload is not text. Same bounds contract as [`guest_str`]: the embedder
+    /// supplies the pair raw, so a range escaping linear memory is rejected
+    /// (`None`) before a slice is formed rather than being undefined behaviour;
+    /// an empty buffer reads as an empty slice.
+    fn guest_bytes(ptr: *const u8, len: usize) -> Option<Vec<u8>> {
         if ptr.is_null() || len == 0 {
-            return Some(String::new());
+            return Some(Vec::new());
         }
         let mem_bytes = core::arch::wasm32::memory_size(0).saturating_mul(65536);
         match (ptr as usize).checked_add(len) {
             Some(end) if end <= mem_bytes => {
-                let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
-                Some(String::from_utf8_lossy(bytes).into_owned())
+                Some(unsafe { std::slice::from_raw_parts(ptr, len) }.to_vec())
             }
             _ => None,
         }

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -516,13 +516,15 @@ thread_local! {
     /// compiles as `<string>` and a traceback can name neither the file nor
     /// the offending line.
     static SCRIPT_PATH: RefCell<Option<String>> = const { RefCell::new(None) };
-    /// `-P` / PYTHONSAFEPATH, which suppresses the `sys.path[0]` entry. The
-    /// guest has no environment, so the embedder passes the resolved flag in
-    /// through `pyre_set_safe_path` rather than the variable being read here.
-    /// Only the native-host binding seeds that entry — the browser build has no
-    /// filesystem to seed it from.
+    /// The `PYTHON*` and locale variables the launcher options resolve
+    /// against (`launch_env::LAUNCH_ENV_NAMES`). wasm32's `std::env` is
+    /// permanently empty, so `-P`, `-O`, PYTHONWARNINGS and the rest would every
+    /// one of them read as unset here; the embedder passes over whatever its own
+    /// environment carries and `run_python_impl` folds them the way the native
+    /// launcher does. Only the native-host binding seeds this — the browser has
+    /// no environment to seed it from.
     #[cfg(feature = "wasm-host")]
-    static SAFE_PATH: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+    static LAUNCH_ENV: RefCell<Vec<(String, String)>> = const { RefCell::new(Vec::new()) };
 }
 
 #[cfg(any(feature = "web", feature = "wasm-host"))]
@@ -554,6 +556,39 @@ fn run_python_impl(source: &str) -> String {
     // object-keyed dict, not only after the first JIT-traced bytecode
     // (`dict_eq_hook::missing_hash_hook` fails fast otherwise).
     pyre_jit::eval::init_jit_hooks();
+    // Resolve the launcher options before the first `import sys`, as
+    // `pyrex real_main` does. There is no command line here, so every option
+    // starts at its default and only the environment the embedder handed over
+    // folds in — which is why the table has to be installed first.
+    #[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+    {
+        use pyre_interpreter::launch_env::{self, LaunchFlags};
+        launch_env::set_launch_env(LAUNCH_ENV.with(|e| e.borrow().clone()));
+        match launch_env::finalize(LaunchFlags::default()) {
+            Ok(flags) => {
+                pyre_interpreter::importing::set_no_site(flags.no_site);
+                pyre_interpreter::importing::set_runtime_flags(&flags);
+            }
+            Err(e) => {
+                // `preconfig_init_utf8_mode` is fatal before the interpreter
+                // exists; the guest cannot exit a process, so it reports the
+                // same banner on fd 2 and returns the same status.
+                install_wasm_print_hook();
+                OUTPUT_BUF.with(|buf| buf.borrow_mut().clear());
+                ERR_BUF.with(|buf| buf.borrow_mut().clear());
+                pyre_interpreter::host_seam::emit_stderr(
+                    format!(
+                        "Fatal Python error: preconfig_init_utf8_mode: {}\n\
+                         Python runtime state: preinitializing\n\n",
+                        e.0
+                    )
+                    .as_bytes(),
+                );
+                EXIT_CODE.with(|c| c.set(1));
+                return String::new();
+            }
+        }
+    }
     pyre_interpreter::importing::install_builtin_modules();
     // Give the import machinery a source of module bytes. The browser has no
     // filesystem, so the web build serves the embedded stdlib closure from an
@@ -569,7 +604,7 @@ fn run_python_impl(source: &str) -> String {
         // (safe_path) suppresses it entirely, as it does natively.
         if let Some(dir) = SCRIPT_PATH
             .with(|p| p.borrow().clone())
-            .filter(|_| !SAFE_PATH.with(|f| f.get()))
+            .filter(|_| !pyre_interpreter::importing::safe_path_flag())
             .and_then(|p| std::path::Path::new(&p).parent().map(|d| d.to_path_buf()))
         {
             pyre_interpreter::importing::add_sys_path(&dir);
@@ -720,7 +755,9 @@ pub fn run_python(source: &str) -> String {
 ///      and `pyre_exit_code()` → the status to exit with.
 ///
 /// `pyre_set_script_path(ptr, len)` may precede step 2 to name the file the
-/// source came from.
+/// source came from, and `pyre_set_launch_env(ptr, len)` to supply the
+/// environment the launcher options resolve against — the guest has none of
+/// its own.
 #[cfg(feature = "wasm-host")]
 mod host_abi {
     use super::run_python_impl;
@@ -810,13 +847,55 @@ mod host_abi {
         super::SCRIPT_PATH.with(|p| *p.borrow_mut() = path);
     }
 
+    /// Supply the `PYTHON*` and locale variables the launcher options resolve
+    /// against, as NUL-separated `NAME=VALUE` records. The guest's environment
+    /// is permanently empty, so without this every one of them reads as unset
+    /// and `sys.flags` reports the defaults no matter what the host was run
+    /// with. `pyre_launch_env_names` lists the names worth sending; anything
+    /// else is carried but never read. A record without `=`, or with an empty
+    /// name, is dropped.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyre_set_launch_env(ptr: *const u8, len: usize) {
+        let Some(blob) = guest_str(ptr, len) else {
+            return;
+        };
+        let entries = blob
+            .split('\0')
+            .filter_map(|record| record.split_once('='))
+            .filter(|(name, _)| !name.is_empty())
+            .map(|(name, value)| (name.to_string(), value.to_string()))
+            .collect();
+        super::LAUNCH_ENV.with(|e| *e.borrow_mut() = entries);
+    }
+
+    /// The names [`pyre_set_launch_env`] is worth being given, as NUL-separated
+    /// records in a buffer the host must free with `pyre_dealloc`. Returned so
+    /// a host does not have to keep its own copy of the list in step with the
+    /// interpreter's.
+    #[unsafe(no_mangle)]
+    pub extern "C" fn pyre_launch_env_names() -> u64 {
+        pack_into_guest(
+            pyre_interpreter::launch_env::LAUNCH_ENV_NAMES
+                .join("\0")
+                .into_bytes(),
+        )
+    }
+
     /// Set `-P` / PYTHONSAFEPATH for the next `pyre_run_python`, suppressing the
-    /// `sys.path[0]` entry `pyre_set_script_path` would otherwise seed. Passed in
-    /// rather than read from the environment because the guest's is permanently
-    /// empty, so the flag would silently read as unset there.
+    /// `sys.path[0]` entry `pyre_set_script_path` would otherwise seed. Kept for
+    /// a host predating [`pyre_set_launch_env`], which carries the same flag
+    /// along with the rest of the block; the two write the same entry, but
+    /// `pyre_set_launch_env` replaces the whole table, so a host calling both
+    /// must call this one second.
     #[unsafe(no_mangle)]
     pub extern "C" fn pyre_set_safe_path(enabled: u32) {
-        super::SAFE_PATH.with(|f| f.set(enabled != 0));
+        super::LAUNCH_ENV.with(|e| {
+            let mut entries = e.borrow_mut();
+            entries.retain(|(name, _)| name != "PYTHONSAFEPATH");
+            if enabled != 0 {
+                entries.push(("PYTHONSAFEPATH".to_string(), "1".to_string()));
+            }
+        });
     }
 
     /// Copy `[ptr, ptr+len)` out of linear memory as UTF-8. The embedder

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -44,53 +44,10 @@ enum RunMode {
     },
 }
 
-#[derive(Clone)]
-struct LaunchFlags {
-    inspect: bool,
-    quiet: bool,
-    no_site: bool,
-    no_user_site: bool,
-    ignore_environment: bool,
-    isolated: bool,
-    dev_mode: bool,
-    utf8_mode: Option<i64>,
-    safe_path: bool,
-    // `-O` count on the command line; PYTHONOPTIMIZE folds in during finalize.
-    optimize: i64,
-    bytes_warning: i64,
-    dont_write_bytecode: bool,
-    unbuffered: bool,
-    warnoptions: Vec<String>,
-    // app_main.py passes the raw PYTHONIOENCODING value to initstdio after
-    // applying -E/-I. Keep it raw until stdio parses the optional errors part.
-    stdio_encoding: Option<String>,
-    // PyPy app_main.py keeps every raw `-X` value in a list until sys module
-    // initialization turns it into `sys._xoptions`.
-    xoptions: Vec<String>,
-}
-
-impl Default for LaunchFlags {
-    fn default() -> Self {
-        Self {
-            inspect: false,
-            quiet: false,
-            no_site: false,
-            no_user_site: false,
-            ignore_environment: false,
-            isolated: false,
-            dev_mode: false,
-            utf8_mode: None,
-            safe_path: false,
-            optimize: 0,
-            bytes_warning: 0,
-            dont_write_bytecode: false,
-            unbuffered: false,
-            warnoptions: Vec::new(),
-            stdio_encoding: None,
-            xoptions: Vec::new(),
-        }
-    }
-}
+// The option block and the environment fold over it live in the interpreter,
+// beside the `SYS_*` statics they end up in, because the wasm32 embedding
+// resolves the same block without a command line of its own.
+use pyre_interpreter::launch_env::LaunchFlags;
 
 fn usage(binary_name: &str) -> String {
     format!(
@@ -143,132 +100,14 @@ fn fatal_utf8_config_error(detail: &str) -> ! {
     std::process::exit(1);
 }
 
-fn locale_implies_utf8_mode() -> bool {
-    // An empty variable is treated as unset (`setlocale` POSIX semantics) and
-    // falls through to the next, so `LC_ALL= LC_CTYPE=en_US.UTF-8` resolves to
-    // en_US.UTF-8, not C.
-    let read = |name: &str| std::env::var(name).ok().filter(|v| !v.is_empty());
-    let locale = read("LC_ALL")
-        .or_else(|| read("LC_CTYPE"))
-        .or_else(|| read("LANG"));
-    // Only the legacy C/POSIX locale — or a fully unset chain, which resolves to
-    // C — coerces utf8_mode to 1; every named locale (en_US, C.UTF-8, …) leaves
-    // it 0.
-    matches!(locale.as_deref(), None | Some("C") | Some("POSIX"))
-}
-
-fn resolve_utf8_mode(flags: &LaunchFlags) -> i64 {
-    if let Some(value) = flags.utf8_mode {
-        return value;
+/// Fold the process environment over the parsed options. The launcher owns a
+/// real environment, so `launch_env` reads `std::env` directly here; an invalid
+/// PYTHONUTF8 is fatal during pre-init config, as it is for `-X utf8`.
+fn finalize_flags(flags: LaunchFlags) -> LaunchFlags {
+    match pyre_interpreter::launch_env::finalize(flags) {
+        Ok(flags) => flags,
+        Err(e) => fatal_utf8_config_error(e.0),
     }
-    if !flags.ignore_environment {
-        if let Ok(value) = std::env::var("PYTHONUTF8") {
-            if !value.is_empty() {
-                return match value.as_str() {
-                    "0" => 0,
-                    "1" => 1,
-                    _ => fatal_utf8_config_error("invalid PYTHONUTF8 environment variable value"),
-                };
-            }
-        }
-    }
-    if locale_implies_utf8_mode() { 1 } else { 0 }
-}
-
-/// `_Py_get_env_flag`: an integer environment flag. An unset or empty value is
-/// absent; a clean non-negative integer is used as-is; anything else (trailing
-/// junk, negative, overflow) counts as 1.
-fn env_int_flag(name: &str) -> Option<u32> {
-    let raw = std::env::var(name).ok()?;
-    if raw.is_empty() {
-        return None;
-    }
-    let value = match raw.parse::<i64>() {
-        Ok(v) if (0..=i64::from(u32::MAX)).contains(&v) => v as u32,
-        _ => 1,
-    };
-    Some(value)
-}
-
-/// `-O` count folded with PYTHONOPTIMIZE (`config_init_optimization_level`):
-/// the effective level is the larger of the two.  The level is kept as a wide
-/// integer so `sys.flags.optimize` mirrors a large `PYTHONOPTIMIZE` verbatim;
-/// the compiler clamps it into a byte at read time.
-fn resolve_optimize(flags: &LaunchFlags) -> i64 {
-    let mut level = flags.optimize;
-    if !flags.ignore_environment {
-        if let Some(v) = env_int_flag("PYTHONOPTIMIZE") {
-            level = level.max(i64::from(v));
-        }
-    }
-    level
-}
-
-/// `-B` folded with PYTHONDONTWRITEBYTECODE: either disables bytecode caches.
-fn resolve_dont_write_bytecode(flags: &LaunchFlags) -> bool {
-    if flags.dont_write_bytecode {
-        return true;
-    }
-    if !flags.ignore_environment {
-        if let Some(v) = env_int_flag("PYTHONDONTWRITEBYTECODE") {
-            return v != 0;
-        }
-    }
-    false
-}
-
-/// `-P` folded with PYTHONSAFEPATH (`config_read_env_vars`). The variable is a
-/// bare presence flag read through `_Py_GetEnv`, not an integer one: any
-/// non-empty value enables safe path — `"0"` included — while an empty value
-/// counts as unset. It only ever sets the flag, so an explicit `-P` survives
-/// `-E`.
-fn resolve_safe_path(flags: &LaunchFlags) -> bool {
-    if flags.safe_path {
-        return true;
-    }
-    if !flags.ignore_environment {
-        // Read as an `OsString`: the value is a presence flag, so bytes that
-        // are not valid Unicode still count as set.
-        if let Some(value) = std::env::var_os("PYTHONSAFEPATH") {
-            return !value.is_empty();
-        }
-    }
-    false
-}
-
-fn finalize_flags(mut flags: LaunchFlags) -> LaunchFlags {
-    flags.utf8_mode = Some(resolve_utf8_mode(&flags));
-    flags.optimize = resolve_optimize(&flags);
-    flags.dont_write_bytecode = resolve_dont_write_bytecode(&flags);
-    flags.safe_path = resolve_safe_path(&flags);
-    flags.stdio_encoding = if flags.ignore_environment {
-        None
-    } else {
-        std::env::var("PYTHONIOENCODING").ok()
-    };
-    // pypy/interpreter/app_main.py:892-906 — lowest-precedence entries first;
-    // the warnings module installs later entries ahead of earlier ones.
-    let mut warnoptions = Vec::new();
-    if flags.dev_mode {
-        warnoptions.push("default".to_string());
-    }
-    if !flags.ignore_environment {
-        if let Ok(value) = std::env::var("PYTHONWARNINGS") {
-            if !value.is_empty() {
-                warnoptions.extend(value.split(',').map(str::to_string));
-            }
-        }
-    }
-    warnoptions.append(&mut flags.warnoptions);
-    if flags.bytes_warning > 0 {
-        warnoptions.push(if flags.bytes_warning > 1 {
-            "error::BytesWarning".to_string()
-        } else {
-            "default::BytesWarning".to_string()
-        });
-    }
-    flags.warnoptions = warnoptions;
-    flags
 }
 
 fn parse_args(binary_name: &str) -> Result<(RunMode, LaunchFlags, Vec<String>), lexopt::Error> {
@@ -665,19 +504,7 @@ fn real_main(binary_name: &str) {
         inspect,
         quiet,
         no_site,
-        no_user_site,
-        ignore_environment,
-        isolated,
-        dev_mode,
-        utf8_mode,
-        safe_path,
-        optimize,
-        bytes_warning,
-        dont_write_bytecode,
-        unbuffered,
-        xoptions,
-        warnoptions,
-        stdio_encoding,
+        ..
     } = flags;
 
     // The `interact` controller does not run the embedded interpreter; it only
@@ -707,23 +534,7 @@ fn real_main(binary_name: &str) {
     // Record `-S` before the first `import sys` so `sys.flags.no_site`
     // reflects whether site initialization was skipped.
     importing::set_no_site(no_site);
-    importing::set_runtime_flags(
-        quiet,
-        inspect,
-        no_user_site,
-        ignore_environment,
-        isolated,
-        dev_mode,
-        utf8_mode.unwrap_or(0),
-        safe_path,
-        optimize,
-        bytes_warning,
-        dont_write_bytecode,
-        unbuffered,
-        xoptions,
-        warnoptions,
-        stdio_encoding,
-    );
+    importing::set_runtime_flags(&flags);
 
     // OS-level hardening (default-on in any Linux `sandbox` build): lock the
     // sandboxed child to a host-neutral syscall allowlist so any un-mediated


### PR DESCRIPTION
`LaunchFlags` and the environment fold over it move from `pyrex` into a new
`pyre-interpreter::launch_env`. `importing::set_runtime_flags` takes the block by
reference instead of fifteen positional arguments.

## The gap

wasm32 has no environment — every environment lookup in the guest returns unset.
So `-P`, `-O`, `PYTHONWARNINGS`, `PYTHONUTF8`, `PYTHONIOENCODING`,
`PYTHONDONTWRITEBYTECODE` and the `LC_ALL`/`LC_CTYPE`/`LANG` chain all read as
absent in the guest and `sys.flags` reported the defaults. Measured before the
change, native vs wasm on the same script:

| set | field | native vs wasm |
|---|---|---|
| `PYTHONSAFEPATH=1` | `safe_path` | `True` vs `False` |
| `PYTHONOPTIMIZE=2` | `optimize` | `2` vs `0` |
| `PYTHONDONTWRITEBYTECODE=1` | `dont_write_bytecode` | `1` vs `0` |
| `PYTHONWARNINGS=...` | `warnoptions` | `[...]` vs `[]` |
| `PYTHONUTF8=1` | `utf8_mode` | `1` vs `0` |
| `LC_ALL=C` | `utf8_mode` | `1` vs `0` |

The runner already forwarded `PYTHONSAFEPATH` alone, through a dedicated
`pyre_set_safe_path` export.

## The shape

Rather than teach the runner to reproduce `config_read_env_vars` semantics
(`_Py_get_env_flag`'s unset/empty/clean-int/anything-else ladder, the fatal
`PYTHONUTF8`, the locale chain), the fold moves to a crate both the launcher and
the guest already link, so there is one copy.

`launch_env::set_launch_env` installs an explicit environment table; once
installed it is authoritative and the process environment is not consulted. The
guest gains `pyre_set_launch_env(ptr, len)`, taking NUL-separated `NAME=VALUE`
records, and `pyre_launch_env_names()`, which returns the names the fold reads —
so the host does not keep its own copy of the list and cannot drift from it.

`run_python_impl` folds them over `LaunchFlags::default()` and calls
`set_runtime_flags` before `install_builtin_modules`, i.e. before the first
`import sys`. The `SAFE_PATH` cell is gone; the `sys.path[0]` decision now reads
`importing::safe_path_flag()`, the same value `sys.flags.safe_path` reports.

The runner forwards the named variables as raw bytes and resolves nothing.
`pyre_set_safe_path` stays for a module predating the new exports; the runner
falls back to it when either new export is absent.

An invalid `PYTHONUTF8` is a fatal pre-init error. `finalize` returns it instead
of exiting, so `pyrex` keeps printing the `preconfig_init_utf8_mode` banner and
exiting, and the guest writes the same banner to fd 2 and returns status 1.

## Values travel as bytes, not `String`

Whether a variable is *set* is decided on undecoded bytes, so the table and the
host/guest transport both carry `Vec<u8>`, and reads split by what each fold
needs:

- **presence** (`PYTHONSAFEPATH`, `PYTHONDEVMODE`, `PYTHONINSPECT`) and **exact
  spelling** (`PYTHONUTF8`) compare bytes, so a value that does not decode stays
  distinguishable from an absent one — it is *set*, and for `PYTHONUTF8`
  *invalid*, which is fatal rather than a silent fall-through to the locale.
- **integer flags** (`PYTHONOPTIMIZE`, `PYTHONNOUSERSITE`, …) treat undecodable
  bytes the way `_Py_str_to_int` treats trailing junk: as 1, not as unset.
- **free text** (`PYTHONWARNINGS`, `PYTHONIOENCODING`, the locale chain) keeps the
  `env::var` contract and decodes as UTF-8.

Reads route through `host_seam::getenv`, which hands back raw bytes —
`pyre-interpreter` forbids reaching the process environment directly.

## Four names the launcher never read

`PYTHONNOUSERSITE`, `PYTHONUNBUFFERED`, `PYTHONDEVMODE` and `PYTHONINSPECT` were
absent from `pyrex` before this change as well, so those four `sys.flags` fields
were reachable only from the command line. They fold now.

Which shape each takes is per-variable rather than a category, and was measured
rather than ported: PyPy's `parse_env` promotes every nonempty value to at least
1, which disagrees with 3.14 on two of them.

| name, value `0` | PyPy 3.11 | CPython 3.14 | implemented as |
|---|---|---|---|
| `PYTHONSAFEPATH` | on | on | presence |
| `PYTHONDEVMODE` | on | on | presence |
| `PYTHONINSPECT` | on | on | presence |
| `PYTHONNOUSERSITE` | on | **off** | integer flag |
| `PYTHONUNBUFFERED` | on | **off** | integer flag |

`PYTHONINSPECT` sets only `inspect`, not `interactive`, so a run that owes the
flag to the environment still reports `interactive` as false.

## Verification

25 environment cases diffed three ways — CPython 3.14 vs pyre-native vs
pyre-wasm — covering each name's `=1`, `=0`, junk-value and empty-value arm plus
`-E`/`-I`/`-P`/`-s`/`-OO` precedence. All 25 agree. The rows discriminate:
`PYTHONSAFEPATH=0` enables while `PYTHONSAFEPATH=` does not, and
`PYTHONNOUSERSITE=0` does not enable while `PYTHONNOUSERSITE=x` does.

`check.py` — dynasm 378/378, cranelift 378/378, wasm 374/374.

## Known limits

- `sys.flags` is materialized once per process, so a second `pyre_run_python` in
  the same instance with a different environment would split state. Latent — the
  runner does one run per instance.
- `utf8_mode` still infers the locale from the `LC_ALL`/`LC_CTYPE`/`LANG` strings
  rather than from the effective `LC_CTYPE`. Pre-existing, and it diverges when
  the environment names a locale the system cannot set: on
  `LC_ALL=xx_YY.invalid`, 3.14 falls back to C and reports `utf8_mode 1`. Filed
  separately — the fix needs a `setlocale` entry point on the host seam and a
  defined wasm answer, neither of which exists today.
