### PR TITLE
generator close finalization, coroutine docstrings, and the windows cranelift closure_per_call overlay

### DIFF
--- a/pyre/bench/synth/closure_per_call.cranelift.win32.jitstats
+++ b/pyre/bench/synth/closure_per_call.cranelift.win32.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=2
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=416
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -16949,11 +16949,16 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
             } else {
                 generator_frame_is_finished(gen_obj, &mut *frame_ptr);
             }
+            let ec = crate::call::getexecutioncontext()
+                as *mut crate::executioncontext::ExecutionContext;
+            if !ec.is_null() {
+                (*ec).finalize_explicitly_cleared_frame_references();
+            }
             return Ok(w_none());
         }
     }
     let err = PyError::new(PyErrorKind::GeneratorExit, String::new());
-    match generator_send_ex(gen_obj, w_none(), Some(err), None) {
+    let mut result = match generator_send_ex(gen_obj, w_none(), Some(err), None) {
         Ok(_) => {
             // Generator yielded after GeneratorExit — RuntimeError.
             // generator.py:267-268 `"%s ignored GeneratorExit" % self.KIND`.
@@ -16972,7 +16977,29 @@ pub(crate) fn generator_close_method(args: &[PyObjectRef]) -> PyResult {
         }
         Err(e) if e.kind == PyErrorKind::GeneratorExit => Ok(w_none()),
         Err(e) => Err(e),
+    };
+    unsafe {
+        if w_generator_get_frame(gen_obj).is_null() {
+            // The result has left the cleared generator frame but has not yet
+            // reached the caller's value stack. Publish it while the
+            // compatibility collection below determines which former frame
+            // locals became unreachable.
+            let _roots = pyre_object::gc_roots::push_roots();
+            match &mut result {
+                Ok(value) => pyre_object::gc_roots::pin_root(*value),
+                Err(error) => {
+                    let w_exc = error.to_exc_object();
+                    pyre_object::gc_roots::pin_root(w_exc);
+                }
+            }
+            let ec = crate::call::getexecutioncontext()
+                as *mut crate::executioncontext::ExecutionContext;
+            if !ec.is_null() {
+                (*ec).finalize_explicitly_cleared_frame_references();
+            }
+        }
     }
+    result
 }
 
 /// PyPy `Coroutine.descr__await__`: return a distinct iterator wrapper rather

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -793,6 +793,19 @@ impl ExecutionContext {
         }
     }
 
+    /// CPython 3.14 `gen_clear_frame` / `_PyFrame_ClearExceptCode` releases
+    /// the cleared frame's references synchronously, so an otherwise-dead
+    /// object with `__del__` is finalized before `generator.close()` or
+    /// `frame.clear()` returns (gh-142766).  Pyre's user instances are
+    /// non-moving old-generation objects, so a non-moving major pass is the
+    /// tracing-GC equivalent of those decrefs.  Keep this at the two explicit
+    /// frame-clearing call sites; normal generator exhaustion follows PyPy's
+    /// deferred finalizer scheduling and must not collect on every return.
+    pub fn finalize_explicitly_cleared_frame_references(&mut self) {
+        pyre_object::gc_hook::try_gc_collect_oldgen();
+        self._run_finalizers_now();
+    }
+
     /// pypy/interpreter/executioncontext.py:185-200 `run_trace_func`.
     ///
     /// ```python

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1162,6 +1162,19 @@ pub fn make_builtin_function(name: &'static str, func: BuiltinCodeFn) -> PyObjec
     crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
 }
 
+/// `make_builtin_function` carrying the interpreter-level function's
+/// docstring.  PyPy's `interp2app` reads this from `func.__doc__`; Rust
+/// functions have no app-visible function object, so typedef registrations
+/// pass the upstream literal explicitly.
+pub fn make_builtin_function_with_doc(
+    name: &'static str,
+    func: BuiltinCodeFn,
+    docstring: &'static str,
+) -> PyObjectRef {
+    let code = builtin_code_new_with_doc(name, func, Some(docstring));
+    crate::function_new_with_fixed_code(code as *const (), name.to_string(), pyre_object::PY_NULL)
+}
+
 /// GatewayCache.build parity for an interp2app carrying the text signature
 /// produced by `interp2app._generate_text_signature`.
 pub fn make_builtin_function_with_text_signature(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7541,6 +7541,11 @@ fn init_frame_type(ns: PyObjectRef) {
                     let f = frame_ptr(args[0]);
                     if !f.is_null() {
                         unsafe { &mut *f }.descr_clear()?;
+                        let ec = crate::call::getexecutioncontext()
+                            as *mut crate::executioncontext::ExecutionContext;
+                        if !ec.is_null() {
+                            unsafe { (*ec).finalize_explicitly_cleared_frame_references() };
+                        }
                     }
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -25542,27 +25542,53 @@ fn init_generator_type(ns: PyObjectRef) {
 /// PyPy `generator.py Coroutine.typedef`.
 fn init_coroutine_type(ns: PyObjectRef) {
     unsafe { pyre_object::w_dict_setitem_str(ns, "__doc__", w_none()) };
-    for (name, function, arity) in [
-        ("__repr__", coroutine_descr_repr as DunderFn, 1),
-        ("send", crate::baseobjspace::generator_send_method, 2),
-        ("close", crate::baseobjspace::generator_close_method, 1),
-        ("__await__", crate::baseobjspace::coroutine_await_method, 1),
-        ("__del__", crate::baseobjspace::generator_close_method, 1),
-        ("__sizeof__", generator_descr_sizeof, 1),
+    for (name, function, arity, doc) in [
+        ("__repr__", coroutine_descr_repr as DunderFn, 1, None),
+        (
+            "send",
+            crate::baseobjspace::generator_send_method,
+            2,
+            Some(
+                "send(arg) -> send 'arg' into coroutine,\nreturn next iterated value or raise StopIteration.",
+            ),
+        ),
+        (
+            "close",
+            crate::baseobjspace::generator_close_method,
+            1,
+            Some("close() -> raise GeneratorExit inside coroutine."),
+        ),
+        (
+            "__await__",
+            crate::baseobjspace::coroutine_await_method,
+            1,
+            None,
+        ),
+        (
+            "__del__",
+            crate::baseobjspace::generator_close_method,
+            1,
+            None,
+        ),
+        ("__sizeof__", generator_descr_sizeof, 1, None),
     ] {
-        unsafe {
-            pyre_object::w_dict_setitem_str_no_proxy(
-                ns,
-                name,
-                make_builtin_function_with_arity(name, function, arity),
-            )
+        let function = match doc {
+            Some(doc) => {
+                crate::gateway::make_builtin_function_with_arity_and_doc(name, function, arity, doc)
+            }
+            None => make_builtin_function_with_arity(name, function, arity),
         };
+        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, name, function) };
     }
     unsafe {
         pyre_object::w_dict_setitem_str(
             ns,
             "throw",
-            make_builtin_function("throw", crate::baseobjspace::generator_throw_method),
+            crate::gateway::make_builtin_function_with_doc(
+                "throw",
+                crate::baseobjspace::generator_throw_method,
+                "throw(value)\nthrow(type[,value[,traceback]])\n\nRaise exception in coroutine, return next iterated value or raise\nStopIteration.\nthe (type, val, tb) signature is deprecated, \nand may be removed in a future version of Python.",
+            ),
         );
         // CPython 3.14 Objects/genobject.c coro_methods — Py_GenericAlias
         // with METH_CLASS.
@@ -25611,11 +25637,16 @@ fn init_coroutine_type(ns: PyObjectRef) {
         let get = make_builtin_function_with_arity(name, getter, 2);
         let set = make_builtin_function_with_arity(name, setter, 3);
         let delete = make_builtin_function_with_arity(name, deleter, 2);
+        let doc = match name {
+            "__name__" => "name of the coroutine",
+            "__qualname__" => "qualified name of the coroutine",
+            _ => unreachable!(),
+        };
         unsafe {
             pyre_object::w_dict_setitem_str_no_proxy(
                 ns,
                 name,
-                make_getset_property_full(get, set, delete, PY_NULL, PY_NULL, Some(name)),
+                make_getset_property_named_doc(get, set, delete, doc, name),
             )
         };
     }


### PR DESCRIPTION
Three unrelated commits.

### `generator: finalize references cleared by close`

`generator.close()` clears the frame, but the objects its locals held stayed
unreachable-yet-unfinalized until whatever collection happened to come next, so
`__del__` on a value a closed generator held ran at an arbitrary later point.
Both exits from `generator_close_method` now run the execution context's
`finalize_explicitly_cleared_frame_references` — the already-finished path
directly, and the `GeneratorExit` path once the frame is confirmed cleared.

On the second path the send result has left the cleared frame but has not yet
reached the caller's value stack, so it is pinned as a GC root across the
finalization; otherwise the pass that decides which former locals became
unreachable can reach the in-flight value or exception.

### `coroutine: expose protocol docstrings`

`send`, `close`, `throw`, `__name__` and `__qualname__` on the coroutine type
carried no `__doc__`. They are installed through the doc-taking constructors
instead, which adds `make_builtin_function_with_arity_and_doc` beside the
existing arity and doc variants.

### `bench: record closure_per_call's windows cranelift guard_failures`

check.py resolves `<name>.<backend>.<sys.platform>.jitstats` ahead of the shared
file, and no overlay had ever been written, so the one counter a host genuinely
disagrees on stayed red.

windows-latest cranelift reports `closure_per_call` `guard_failures=416` where
macos-latest and ubuntu-24.04 both report 415, every other counter identical.
Measured three ways: ubuntu passed its cranelift leg 377/377 against the shared
file; two runs of this fixture on macOS report 415; and check.py's own overlay
comment records 416 for windows on two prior independent runs.

`recursive_call_frame_relocation` is the other fixture that comment names. It
passed on windows in the same run, so nothing is recorded for it — an overlay
shadows the shared file permanently, and only a counter that reproduces earns
one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
