### PR TITLE
bench: drop the windows closure_per_call overlay

### DIFF
--- a/pyre/bench/synth/closure_per_call.cranelift.win32.jitstats
+++ b/pyre/bench/synth/closure_per_call.cranelift.win32.jitstats
@@ -1,8 +1,0 @@
-bridges_compiled=2
-descr_set_absent=0
-descr_set_ambiguous=0
-descr_set_stale_absent=0
-guard_failures=416
-internal_compile_panics=0
-loops_aborted=0
-loops_compiled=4


### PR DESCRIPTION
Reverts the overlay added in #1042. It recorded a value the host does not hold
steady, so it moved the failure rather than removing it.

| run | shared file | overlay | windows cranelift observed | result |
| --- | --- | --- | --- | --- |
| check.py's overlay comment (two runs) | 415 | — | 416 | — |
| #1028 CI | 415 | — | 416 | FAIL, regressed |
| #1042 CI | 415 | **416** | **415** | FAIL, improved |

Whichever number is recorded, the other one shows up.

The same run moved the second fixture that comment names, in the opposite
direction relative to its shared file: `recursive_call_frame_relocation`
reported `guard_failures=637` on windows dynasm against a shared 638, having
agreed at 638 one run earlier. One counter drifting toward its shared value
while another drifts away from it in the same run is not a per-host fact, and a
per-host file cannot hold it.

`JITSTATS_STABILITY_RUNS` does not see this: it re-runs one binary inside one
job, and the disagreement is between jobs.

That leaves the two fixtures gated on a counter that disagrees with itself
across windows runs. Nothing here decides what to do about that — an overlay
just is not the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed obsolete JIT statistics data from the Windows 32-bit benchmark output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->