### PR TITLE
jit: inline a user __hash__ under the hash() builtin call residual

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -11765,6 +11765,12 @@ fn hash_call_normalize(
     w_type: PyObjectRef,
 ) -> Result<i64, crate::PyError> {
     let r = unsafe { crate::baseobjspace::get_and_call_function(method, obj, w_type, &[]) }?;
+    normalize_hash_digest(r)
+}
+
+/// The result arms of [`hash_call_normalize`], shared with the JIT's digest
+/// residual: accept `bool`/`int`/`long`, reject other types, map `-1` to `-2`.
+pub fn normalize_hash_digest(r: PyObjectRef) -> Result<i64, crate::PyError> {
     let h = unsafe {
         if is_bool(r) {
             pyre_object::w_bool_get_value(r) as i64

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4053,6 +4053,24 @@ pub fn is_builtin_repr_function(callable: PyObjectRef) -> bool {
     }
 }
 
+/// True iff `callable` is the canonical builtin `hash` function object; the
+/// walker's user-`__hash__` inline keys on this identity.
+pub fn is_builtin_hash_function(callable: PyObjectRef) -> bool {
+    unsafe {
+        if callable.is_null() || !crate::is_function(callable) {
+            return false;
+        }
+        let code = crate::function_get_code(callable) as PyObjectRef;
+        if code.is_null() || !crate::gateway::is_builtin_code(code) {
+            return false;
+        }
+        crate::gateway::builtin_code_fn_eq(
+            crate::gateway::builtin_code_get(code),
+            builtin_hash as crate::gateway::BuiltinCodeFn,
+        )
+    }
+}
+
 /// `len(obj)` — return the length of an object.
 /// `len(obj)` — PyPy: operation.py len → space.len_w
 fn builtin_len(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -316,6 +316,27 @@ pub extern "C" fn jit_mapdict_unboxed_read_raw(
     }
 }
 
+/// `normalize_hash_digest` as a JIT residual: normalize a boxed `__hash__`
+/// digest to the machine hash, raising for a non-integer.  On error the
+/// exception enters both channels for the trailing `GuardNoException`.
+pub extern "C" fn jit_hash_normalize_digest(digest: i64) -> i64 {
+    match pyre_interpreter::builtins::normalize_hash_digest(digest as PyObjectRef) {
+        Ok(h) => h,
+        Err(mut err) => {
+            let exc = err.to_exc_object() as i64;
+            majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc));
+            #[cfg(all(feature = "cranelift", not(target_arch = "wasm32")))]
+            majit_backend_cranelift::jit_exc_raise(exc);
+            #[cfg(all(feature = "dynasm", not(target_arch = "wasm32")))]
+            majit_backend_dynasm::jit_exc_raise(exc);
+            #[cfg(target_arch = "wasm32")]
+            majit_backend_wasm::jit_exc_raise(exc);
+            let _ = exc;
+            0
+        }
+    }
+}
+
 /// Float-bank counterpart of [`jit_mapdict_unboxed_read_raw`].  Unboxed float
 /// storage already contains the value's IEEE-754 bit pattern, so this helper
 /// performs the raw read and reconstructs the float (mapdict.py:577-584).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4951,19 +4951,9 @@ pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
     {
         return Ok(None);
     }
-    // Sample an effect-free body before any IR so a non-machine-int digest
-    // declines cleanly; a side-effecting body is checked after the inline.
-    if body_facts.exc_override_sample_safe {
-        let sampled = {
-            let _plain_guard = pyre_interpreter::call::force_plain_eval();
-            pyre_interpreter::call::call_function_impl_result(method, &[concrete_receiver])
-        };
-        let sampled_is_machine_int =
-            matches!(sampled, Ok(result) if walker_machine_int_value(result).is_some());
-        if !sampled_is_machine_int {
-            return Ok(None);
-        }
-    }
+    // No pre-sampling: `hash_w` calls `__hash__` exactly once, so the digest
+    // is checked after the single authoritative sub-walk run instead.
+    let effect_free = body_facts.exc_override_sample_safe;
 
     let arg_concretes = vec![
         ConcreteValue::Ref(concrete_callable),
@@ -5001,23 +4991,70 @@ pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
 
     if matches!(inlined.0, DispatchOutcome::Continue) {
         let result = ctx.registers_r[dst];
-        let live = walker_concrete_ref_object(ctx, result).and_then(walker_machine_int_value);
-        let Some(live) = live else {
-            // The body already ran (walk is authoritative), so neither
-            // declining nor re-sampling is sound; discard the trace.
-            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        let concrete_result = walker_concrete_ref_object(ctx, result);
+        let live = concrete_result.and_then(walker_machine_int_value);
+        // The inline unbox is guard-free only against a known-class or
+        // trace-built box; a live post-body guard on a side-effecting body
+        // would re-run its effects on failure, so those shapes — and every
+        // bool/long digest — take the fallible normalize residual instead.
+        let inline_unbox = live.is_some()
+            && (effect_free
+                || ctx.trace_ctx.heap_cache().is_class_known(result)
+                || ctx.trace_ctx.heap_cache().is_unescaped(result));
+        let (norm, live_norm) = if inline_unbox {
+            let live = live.unwrap();
+            let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+            let raw = walker_unbox_int(ctx, op.pc, result, int_type_addr)?;
+            // `hash_call_normalize`'s `-1 -> -2` map as `raw - (raw == -1)`.
+            let neg1 = ctx.trace_ctx.const_int(-1);
+            let is_neg1 = ctx.trace_ctx.record_op(OpCode::IntEq, &[raw, neg1]);
+            ctx.trace_ctx
+                .set_opref_concrete(is_neg1, majit_ir::Value::Int((live == -1) as i64));
+            let norm = ctx.trace_ctx.record_op(OpCode::IntSub, &[raw, is_neg1]);
+            let live_norm = if live == -1 { -2 } else { live };
+            ctx.trace_ctx
+                .set_opref_concrete(norm, majit_ir::Value::Int(live_norm));
+            (norm, live_norm)
+        } else {
+            let Some(concrete_result) = concrete_result else {
+                return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+            };
+            let raw = crate::helpers::emit_trace_call_int_typed(
+                ctx.trace_ctx,
+                crate::helpers::jit_hash_normalize_digest as *const (),
+                &[result],
+                &[majit_ir::Type::Ref],
+            );
+            match pyre_interpreter::builtins::normalize_hash_digest(concrete_result) {
+                Ok(live_norm) => {
+                    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
+                    ctx.trace_ctx
+                        .set_opref_concrete(raw, majit_ir::Value::Int(live_norm));
+                    (raw, live_norm)
+                }
+                // A raising digest completes the recording the way the
+                // generic raising residual does: publish the exception,
+                // pin it with GuardException, surface SubRaise.
+                Err(mut err) => {
+                    let exc = err.to_exc_object();
+                    fbw_count_executed_residual(true, true);
+                    ctx.last_exc_value_concrete = ConcreteValue::Ref(exc);
+                    ctx.fbw_mode.class_of_last_exc_is_const = false;
+                    majit_metainterp::blackhole::BH_LAST_EXC_VALUE.with(|c| c.set(exc as i64));
+                    walker_record_guard_exception(ctx, op.pc);
+                    let exc_box = ctx
+                        .last_exc_value
+                        .expect("guard_exception seeds last_exc_value");
+                    return Ok(Some((
+                        DispatchOutcome::SubRaise {
+                            exc: exc_box,
+                            exc_concrete: ConcreteValue::Ref(exc),
+                        },
+                        op.next_pc,
+                    )));
+                }
+            }
         };
-        let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
-        let raw = walker_unbox_int(ctx, op.pc, result, int_type_addr)?;
-        // `hash_call_normalize`'s `-1 -> -2` map as `raw - (raw == -1)`.
-        let neg1 = ctx.trace_ctx.const_int(-1);
-        let is_neg1 = ctx.trace_ctx.record_op(OpCode::IntEq, &[raw, neg1]);
-        ctx.trace_ctx
-            .set_opref_concrete(is_neg1, majit_ir::Value::Int((live == -1) as i64));
-        let norm = ctx.trace_ctx.record_op(OpCode::IntSub, &[raw, is_neg1]);
-        let live_norm = if live == -1 { -2 } else { live };
-        ctx.trace_ctx
-            .set_opref_concrete(norm, majit_ir::Value::Int(live_norm));
         let boxed = walker_box_int(ctx, op.pc, norm, live_norm)?;
         let live_ptr = pyre_object::w_int_new(live_norm) as i64;
         ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4865,6 +4865,168 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
     Ok(Some(inlined))
 }
 
+/// Machine-int digest of a `__hash__` result: a tagged immediate or an exact
+/// heap `W_IntObject`; bool/long take `hash_call_normalize`'s other arms.
+fn walker_machine_int_value(obj: pyre_object::PyObjectRef) -> Option<i64> {
+    if obj.is_null() {
+        return None;
+    }
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(obj) {
+        return Some(pyre_object::tagged_int::untag_int(obj));
+    }
+    unsafe {
+        if pyre_object::is_int(obj) && !pyre_object::is_bool(obj) && !pyre_object::is_long(obj) {
+            Some(pyre_object::w_int_get_value(obj))
+        } else {
+            None
+        }
+    }
+}
+
+/// `hash(x)` over a user instance — the hash sibling of
+/// [`try_walker_inline_exception_string_override`]: pin the receiver class,
+/// inline the resolved `__hash__` body in place of the opaque call residual,
+/// then emit `hash_call_normalize`'s digest check and `-1 -> -2` map as int
+/// ops.  Declines to the residual before any IR is emitted.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if r_args.len() != 3 {
+        return Ok(None);
+    }
+    let Some(concrete_callable) = walker_concrete_ref_object(ctx, r_args[0]) else {
+        return Ok(None);
+    };
+    if walker_concrete_ref_object(ctx, r_args[1]).is_some() {
+        return Ok(None);
+    }
+    let Some(concrete_receiver) = walker_concrete_ref_object(ctx, r_args[2]) else {
+        return Ok(None);
+    };
+    if !pyre_interpreter::builtins::is_builtin_hash_function(concrete_callable) {
+        return Ok(None);
+    }
+    if !unsafe { pyre_object::is_instance(concrete_receiver) } {
+        return Ok(None);
+    }
+    let w_type = unsafe { pyre_object::w_instance_get_type(concrete_receiver) };
+    if w_type.is_null() || !unsafe { pyre_object::is_type(w_type) } {
+        return Ok(None);
+    }
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_type) };
+    if version_tag == 0 {
+        return Ok(None);
+    }
+    let Some(method) =
+        (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__hash__") })
+    else {
+        return Ok(None);
+    };
+    // `__hash__ = None` raises in the residual; a non-Python `__hash__`
+    // has no body to walk.
+    if unsafe { pyre_object::is_none(method) } {
+        return Ok(None);
+    }
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
+        return Ok(None);
+    };
+    if nparams != 1 {
+        return Ok(None);
+    }
+    let Some(body_facts) = sub_jitcode_body_facts_for_code(w_code) else {
+        return Ok(None);
+    };
+    if !body_facts.exc_override_straight_line {
+        return Ok(None);
+    }
+    if crate::state::sub_jitcode_body_for_code(w_code).is_none()
+        || crate::state::sub_jitcode_descr_pool_for_code(w_code).is_none()
+    {
+        return Ok(None);
+    }
+    // Sample an effect-free body before any IR so a non-machine-int digest
+    // declines cleanly; a side-effecting body is checked after the inline.
+    if body_facts.exc_override_sample_safe {
+        let sampled = {
+            let _plain_guard = pyre_interpreter::call::force_plain_eval();
+            pyre_interpreter::call::call_function_impl_result(method, &[concrete_receiver])
+        };
+        let sampled_is_machine_int =
+            matches!(sampled, Ok(result) if walker_machine_int_value(result).is_some());
+        if !sampled_is_machine_int {
+            return Ok(None);
+        }
+    }
+
+    let arg_concretes = vec![
+        ConcreteValue::Ref(concrete_callable),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_receiver),
+    ];
+    let Some(inlined) = try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        funcptr,
+        r_args,
+        call_descr,
+        'r',
+        dst,
+        method,
+        r_args[0],
+        concrete_callable,
+        arg_concretes,
+        vec![r_args[2]],
+        vec![ConcreteValue::Ref(concrete_receiver)],
+        true,
+        None,
+        w_code,
+        nparams,
+        has_closure,
+        Some((r_args[2], concrete_receiver, w_type, version_tag)),
+        None,
+        false,
+        None,
+    )?
+    else {
+        return Ok(None);
+    };
+
+    if matches!(inlined.0, DispatchOutcome::Continue) {
+        let result = ctx.registers_r[dst];
+        let live = walker_concrete_ref_object(ctx, result).and_then(walker_machine_int_value);
+        let Some(live) = live else {
+            // The body already ran (walk is authoritative), so neither
+            // declining nor re-sampling is sound; discard the trace.
+            return Err(DispatchError::LoopBearingCalleeInlineUnsupported { pc: op.pc });
+        };
+        let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+        let raw = walker_unbox_int(ctx, op.pc, result, int_type_addr)?;
+        // `hash_call_normalize`'s `-1 -> -2` map as `raw - (raw == -1)`.
+        let neg1 = ctx.trace_ctx.const_int(-1);
+        let is_neg1 = ctx.trace_ctx.record_op(OpCode::IntEq, &[raw, neg1]);
+        ctx.trace_ctx
+            .set_opref_concrete(is_neg1, majit_ir::Value::Int((live == -1) as i64));
+        let norm = ctx.trace_ctx.record_op(OpCode::IntSub, &[raw, is_neg1]);
+        let live_norm = if live == -1 { -2 } else { live };
+        ctx.trace_ctx
+            .set_opref_concrete(norm, majit_ir::Value::Int(live_norm));
+        let boxed = walker_box_int(ctx, op.pc, norm, live_norm)?;
+        let live_ptr = pyre_object::w_int_new(live_norm) as i64;
+        ctx.trace_ctx
+            .set_opref_concrete(boxed, box_int_concrete(live_norm, live_ptr));
+        write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', boxed)?;
+    }
+    Ok(Some(inlined))
+}
+
 /// Inline a `property` getter read (`obj.value`) after the plain-attribute
 /// mapdict fold declines because the attribute is a data descriptor.  PyPy
 /// traces *through* `space.getattr` → `property.__get__` →

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4246,6 +4246,12 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         )? {
             return Ok(inlined);
         }
+        // hash(x) over a user instance: inline __hash__ plus normalization.
+        if let Some(inlined) =
+            try_walker_inline_hash_builtin(ctx, op, code, funcptr, &r_args, call_descr, dst)?
+        {
+            return Ok(inlined);
+        }
         // A class is not a `Function`, so the user-call route above declined it.
         if let Some(inlined) =
             try_walker_inline_type_call(ctx, op, code, funcptr, &r_args, call_descr, dst_bank, dst)?


### PR DESCRIPTION
## Problem

Second half of the `synth/build_set_hashability` investigation (first half: #1037). `hash(x)` over a user instance runs the resolved `__hash__` through the generic call residual — allocating a PyFrame and entering `eval_loop` on every call — because the builtin `hash` callable declines the user-function inline route (`resolve_inlinable_callee` takes plain Python functions only). A `hash(obj)` hot loop measured ~75x slower than PyPy from the per-call frame/dispatch overhead alone, and the same cost hits any dict/set workload keyed by user objects going through the builtin.

## Fix

Recognize the canonical `hash` builtin at the CallFn residual site (new `is_builtin_hash_function`, keyed on builtin-code identity like `is_builtin_repr_function`) and inline the receiver's `__hash__` the way the exception `__str__`/`__repr__` override does:

- pin the receiver class + type version tag, then sub-walk the resolved `__hash__` body through `try_walker_inline_resolved_user_call`;
- emit `hash_call_normalize`'s digest handling in-trace: unbox the machine-int digest and apply the `-1 -> -2` map as `raw - (raw == -1)` (two int ops, virtualization-friendly);
- an effect-free body is sampled before any IR so a bool/long/non-int digest declines cleanly to the residual; a side-effecting body cannot be sampled or re-run, so an observed bool/long digest (legal but rare) aborts the walk rather than recording a normalization shape that contradicts its own operand;
- every other shape — non-instance receiver, `__hash__ = None`, non-Python or branchy body — declines to the residual unchanged.

## Results

`hash(obj)` hot loop, 2M iterations, dynasm, same quiet machine: **2.8s → 0.85s (3.3x)**. `synth/build_set_hashability` itself is mostly unchanged: its element hashing happens inside the opaque `bh_build_set_from_array` residual, which this PR does not decompose (see below).

## Verification

- `pyre/check.py` all green: dynasm 377/377, cranelift 377/377, no jit-stats gate movement.
- Digest edge cases byte-identical to CPython on dynasm under `MAJIT_STRICT=1`: `-1 -> -2` in a hot loop, `True` and `2**70` digests, raising `__hash__`, `__hash__ = None`, non-int digest TypeError, side-effecting `__hash__` called exactly once per `hash()` call, and a mid-loop digest type flip (int → big int) deopting with exact values.
- `cargo test` for the touched crates: 489 passed; the one failure (`jit_fnaddr::registered_paths_sharing_an_address_are_alias_spellings`) reproduces on clean `upstream/main` locally and is unrelated.

## Follow-up (not in this PR)

Decomposing `bh_build_set_from_array` so set-literal element hashing inlines too has a soundness wall: a guard failure mid-literal resumes at the BUILD_SET opcode and re-executes earlier elements' `__hash__`, duplicating side effects (the fixture's `HASH_CALLS.append` is exactly that shape). The sound scope without mid-opcode resume coordinates is effect-free `__hash__` bodies only; left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved execution speed for `hash()` calls on user-defined instances through safe inlining.
  * Added safeguards to preserve correct behavior when classes or methods change.
* **Bug Fixes**
  * Ensured hash results are validated and normalized correctly, including the reserved `-1` value.
  * Added a safe fallback when hashing cannot be optimized.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->