### PR TITLE
Filesystem names with no UTF-8 spelling, and the symbolic fnaddr tag's co-tenancy with the synthetic space

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3992,6 +3992,13 @@ mod tests {
                 assert!(super::is_callable_fnaddr(real_high));
             }
 
+            // The symbolic tag shares `BhDescr::JitCode.fnaddr` with the
+            // synthetic tag, whose space is every negative `i64`
+            // (`synthetic_cpu::is_synthetic_fnaddr`).  The two must not
+            // overlap.
+            assert!(symbolic > 0, "symbolic fnaddrs must stay out of the synthetic (negative) space");
+            assert!(!majit_backend::synthetic_cpu::is_synthetic_fnaddr(symbolic));
+
             assert!(!super::is_symbolic_fnaddr(0));
             assert!(!super::is_callable_fnaddr(0));
         }

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -7804,8 +7804,7 @@ fn handler_residual_call_r_v(
 // `blackhole.py:107`).  All `*_pyre_u16` width adapters have been
 // retired; canonical `handler_*` decoders own every dispatch slot.
 
-/// Per-thread Backend instance for blackhole's `bh_getfield_gc_*` /
-/// `bh_setfield_gc_*` / `bh_getarrayitem_gc_*` / `bh_arraylen_gc` reads.
+/// Per-thread Backend instance backing every `bh.cpu` call.
 ///
 /// TODO: RPython `blackhole.py:55-56,286` reads
 /// `self.cpu = builder.cpu`, where `builder.cpu` is the metainterp-shared
@@ -7815,11 +7814,24 @@ fn handler_residual_call_r_v(
 ///
 /// pyre's `MetaInterp::backend` is per-instance (not `'static`) and
 /// owns trace-compilation state (descr registries, etc.) that would be
-/// inappropriate to share with the blackhole `bh.cpu` field which only
-/// needs the stateless GC memory-access methods.  We leak ONE
-/// `BackendImpl` instance per thread — its `bh_getfield_gc_*` and
-/// related methods do direct unsafe pointer arithmetic
-/// (`runner.rs:2244-2271` for dynasm).
+/// inappropriate to share with the blackhole `bh.cpu` field.  We leak ONE
+/// `BackendImpl` instance per thread instead, so `bh.cpu` is a *different*
+/// object from the one the metainterp that recorded the trace holds.
+///
+/// ## The invariant that makes the split observationally inert
+///
+/// Every `Backend` method this field reaches must be a pure function of
+/// its arguments — `&self` may not be read.  The full reachable surface is
+/// `bh_getfield_gc_{i,r,f}`, `bh_setfield_gc_{i,r,f}`,
+/// `bh_getarrayitem_gc_{i,r,f}`, `bh_arraylen_gc`, `bh_new`,
+/// `bh_new_with_vtable`, `bh_new_array{,_clear}`, `bh_call_{i,r,f,v}`, and
+/// `clear_stored_exception`.  On dynasm each is descr-supplied offsets fed
+/// to `read_int_at_mem` / `write_int_at_mem` (`runner.rs:1386,1402`) or a
+/// free function (`jit_exc_clear`, `call_stub::bh_call_*_dispatch`); none
+/// touches `&self`.  A method added to that list that *does* read backend
+/// state would make the blackhole observe a fresh, empty `BackendImpl`
+/// where the metainterp observes the populated one, and nothing here would
+/// catch it.
 ///
 /// Convergence path: align with RPython's `builder.cpu` invariant by
 /// passing the metainterp-owned `BackendImpl` to `BlackholeInterpBuilder`
@@ -7827,8 +7839,7 @@ fn handler_residual_call_r_v(
 /// `BH_BUILDER3` outlives any single MetaInterp invocation).  Open
 /// architectural item; not in scope here because the change cascades
 /// through the Backend trait's `Send + Sync` bound and every callsite
-/// that holds `&'static dyn Backend` today.  The leak is functionally
-/// correct because vable handlers only invoke stateless reads.
+/// that holds `&'static dyn Backend` today.
 #[cfg(any(feature = "dynasm", feature = "cranelift"))]
 pub fn pyre_production_cpu() -> &'static dyn majit_backend::Backend {
     // Per-thread leak: `BackendImpl` is not `Sync`, so we keep one

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3996,7 +3996,10 @@ mod tests {
             // synthetic tag, whose space is every negative `i64`
             // (`synthetic_cpu::is_synthetic_fnaddr`).  The two must not
             // overlap.
-            assert!(symbolic > 0, "symbolic fnaddrs must stay out of the synthetic (negative) space");
+            assert!(
+                symbolic > 0,
+                "symbolic fnaddrs must stay out of the synthetic (negative) space"
+            );
             assert!(!majit_backend::synthetic_cpu::is_synthetic_fnaddr(symbolic));
 
             assert!(!super::is_symbolic_fnaddr(0));

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -5940,8 +5940,15 @@ impl CallControl {
 /// regions with bit 47 set — 0xaaab…/0xffff… — so every real funcptr there
 /// would read as symbolic.)  Same scheme as
 /// `assembler::STR_CONST_SENTINEL_BASE`.
+///
+/// Bit 63 stays CLEAR: `BhDescr::JitCode.fnaddr` also carries the synthetic
+/// tag, whose whole space is "negative `i64`"
+/// (`majit-backend::synthetic_cpu`: `SYNTHETIC_FNADDR_BASE = i64::MIN`,
+/// `is_synthetic_fnaddr(x) = x < 0`).  A tag setting bit 63 would put every
+/// symbolic hash inside that space, and `decode_synthetic` would answer with
+/// a fabricated jitcode index.
 pub const SYMBOLIC_FNADDR_HIGH_MASK: u64 = 0xFFFF_0000_0000_0000;
-pub const SYMBOLIC_FNADDR_BASE: u64 = 0xFADD_0000_0000_0000;
+pub const SYMBOLIC_FNADDR_BASE: u64 = 0x7ADD_0000_0000_0000;
 
 /// Whether `fnaddr` is a `symbolic_fnaddr_for_path` placeholder rather than a
 /// callable code address.

--- a/pyre/extra_tests/parity_tests/import_unencodable_path_entry.py
+++ b/pyre/extra_tests/parity_tests/import_unencodable_path_entry.py
@@ -1,0 +1,61 @@
+"""A path entry the filesystem encoding cannot spell raises, it is not skipped.
+
+`os.fsencode` refuses a surrogate outside the escape range (U+DC80..U+DCFF), so
+an entry like `'\\ud800'` on `sys.path` or in a package's `__path__` names no
+file and cannot be passed over: the import reports the encoding failure rather
+than searching on and blaming a missing module.
+
+No filesystem support is needed to reach this, unlike the sibling
+`os_undecodable_name_boundaries.py` — the entry never gets as far as a syscall.
+"""
+
+import os
+import sys
+import tempfile
+
+UNENCODABLE = "\ud800"
+
+try:
+    os.fsencode(UNENCODABLE)
+except UnicodeEncodeError:
+    pass
+else:
+    raise AssertionError("fsencode accepted a lone surrogate")
+
+# sys.path
+sys.path.insert(0, UNENCODABLE)
+try:
+    import pyre_absent_module_for_path_test
+except UnicodeEncodeError:
+    pass
+except ImportError as exc:
+    raise AssertionError("entry was skipped instead of reported: %r" % (exc,))
+else:
+    raise AssertionError("imported a module that does not exist")
+finally:
+    sys.path.pop(0)
+
+# A package's __path__ takes the same treatment.
+with tempfile.TemporaryDirectory() as d:
+    pkg = os.path.join(d, "pyre_pathtest_pkg")
+    os.mkdir(pkg)
+    with open(os.path.join(pkg, "__init__.py"), "w") as fp:
+        fp.write("")
+    sys.path.insert(0, d)
+    try:
+        import pyre_pathtest_pkg
+
+        pyre_pathtest_pkg.__path__.insert(0, UNENCODABLE)
+        try:
+            import pyre_pathtest_pkg.absent
+        except UnicodeEncodeError:
+            pass
+        except ImportError as exc:
+            raise AssertionError("__path__ entry was skipped: %r" % (exc,))
+        else:
+            raise AssertionError("imported a submodule that does not exist")
+    finally:
+        sys.path.pop(0)
+        sys.modules.pop("pyre_pathtest_pkg", None)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/os_undecodable_name_boundaries.py
+++ b/pyre/extra_tests/parity_tests/os_undecodable_name_boundaries.py
@@ -70,4 +70,24 @@ with tempfile.TemporaryDirectory() as d:
     else:
         raise AssertionError("an absent program was found")
 
+    # Reporting a SyntaxError names the file it was found in, so the traceback
+    # printer reads the undecodable name.  It has to render rather than abort;
+    # the escape has no `str` spelling, so it is shown backslashed.  The broken
+    # module is *imported* rather than run, which keeps the undecodable name off
+    # the command line — an argv element that is not valid UTF-8 is a separate
+    # boundary, at process entry rather than at a name read back from the disk.
+    with open(os.path.join(os.fsencode(d), RAW, b"pyre_broken_mod.py"), "wb") as fp:
+        fp.write(b"def (\n")
+    driver = os.path.join(d, "driver.py")
+    with open(driver, "w") as fp:
+        fp.write(
+            "import sys\n"
+            "sys.path.insert(0, %r)\n" % os.path.join(d, NAME)
+            + "import pyre_broken_mod\n"
+        )
+    done = subprocess.run([sys.executable, driver], capture_output=True)
+    assert done.returncode != 0, done
+    assert b"SyntaxError" in done.stderr, done.stderr
+    assert b"pyre_undecodable_" in done.stderr, done.stderr
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/os_undecodable_name_boundaries.py
+++ b/pyre/extra_tests/parity_tests/os_undecodable_name_boundaries.py
@@ -1,0 +1,73 @@
+"""A filename with no UTF-8 spelling survives every boundary that reads it back.
+
+`os.listdir`/`os.scandir` decode `readdir`'s `d_name` with `surrogateescape`
+(`interp_posix.py:1121 space.newfilename`), so a name like `b"bad_\xff"` reaches
+Python as a `str` holding U+DCFF.  Every consumer that then re-reads that `str`
+has to take the filesystem encoding back out of it — a `DirEntry` repr, an
+`__import__` driven by `sys.path`, and the `fork_exec` argv boundary all read
+the same object — rather than demanding a UTF-8 view it cannot have.
+
+The name is only creatable where the kernel takes arbitrary bytes: APFS/HFS+
+answer EILSEQ, so the whole file is skipped where the plant fails.
+"""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+if sys.platform == "win32":
+    print("OK")
+    raise SystemExit
+
+RAW = b"pyre_undecodable_\xff"
+NAME = os.fsdecode(RAW)
+
+with tempfile.TemporaryDirectory() as d:
+    try:
+        os.mkdir(os.path.join(os.fsencode(d), RAW))
+    except (OSError, ValueError):
+        # The filesystem refuses a name that is not valid UTF-8 (APFS/HFS+).
+        print("OK")
+        raise SystemExit
+
+    # `os.listdir` hands the name back with its escape intact.
+    assert os.listdir(d) == [NAME], ascii(os.listdir(d))
+
+    # `DirEntry.__repr__` is `"<DirEntry %R>"` (posixmodule.c), so the name is
+    # rendered by its own repr and keeps the escape.
+    entries = list(os.scandir(d))
+    assert len(entries) == 1, entries
+    assert repr(entries[0]) == "<DirEntry %r>" % NAME, repr(entries[0])
+
+    # In bytes mode the name is `bytes`, and the repr says so.
+    bentries = list(os.scandir(os.fsencode(d)))
+    assert bentries[0].name == RAW, bentries[0].name
+    assert repr(bentries[0]) == "<DirEntry %r>" % RAW, repr(bentries[0])
+
+    # An import driven by such a directory has to encode it back to the bytes
+    # that name it on disk.  The package below is planted inside the
+    # undecodable directory, so it is importable only if the whole path
+    # round-trips.
+    pkg = os.path.join(os.fsencode(d), RAW, b"pyre_undecodable_mod.py")
+    with open(pkg, "wb") as fp:
+        fp.write(b"VALUE = 41\n")
+    sys.path.insert(0, os.path.join(d, NAME))
+    try:
+        import pyre_undecodable_mod
+
+        assert pyre_undecodable_mod.VALUE == 41
+    finally:
+        sys.path.pop(0)
+        sys.modules.pop("pyre_undecodable_mod", None)
+
+    # The exec boundary takes the same encoding: the name reaches the OS as
+    # bytes rather than raising, and a program by that name does not exist.
+    try:
+        subprocess.run([os.path.join(d, NAME, NAME)], capture_output=True)
+    except FileNotFoundError:
+        pass
+    else:
+        raise AssertionError("an absent program was found")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8300,7 +8300,10 @@ pub fn realunicode_w(obj: PyObjectRef) -> Result<&'static str, PyError> {
     if unsafe { !isinstance_str_w(obj) } {
         return Err(PyError::type_error("expected unicode"));
     }
-    Ok(unsafe { pyre_object::w_str_get_value(obj) })
+    // A lone surrogate is reported the way the strict utf-8 encoder reports
+    // one, not by aborting for want of a view the buffer cannot give — see
+    // [`str_utf8_w`].
+    str_utf8_w(obj)
 }
 
 /// baseobjspace.py text0_w — rejects an embedded null character.

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1785,9 +1785,23 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
         let exc = pyre_object::gc_roots::shadow_stack_get(exc_slot);
         crate::baseobjspace::syntax_error_attr(exc, name)
     };
+    // `filename` is the compiled file's own name, so it carries whatever
+    // surrogate escapes the filesystem encoding produced, and `text` is a line
+    // of that file. Printing a traceback must not abort for want of a UTF-8
+    // view: escape what has no spelling, the way stderr already does.
     let str_of = |w: PyObjectRef| -> Option<String> {
-        (!w.is_null() && unsafe { pyre_object::is_str(w) })
-            .then(|| unsafe { pyre_object::w_str_get_value(w) }.to_string())
+        (!w.is_null() && unsafe { pyre_object::is_str(w) }).then(|| {
+            let wtf8 = unsafe { pyre_object::w_str_get_wtf8(w) };
+            match wtf8.as_str() {
+                Ok(s) => s.to_owned(),
+                Err(_) => {
+                    let s_obj = pyre_object::w_str_from_wtf8(wtf8.to_owned());
+                    crate::type_methods::encode_object(s_obj, "utf-8", "backslashreplace")
+                        .map(|b| String::from_utf8_lossy(&b).into_owned())
+                        .unwrap_or_else(|_| "<unprintable>".to_string())
+                }
+            }
+        })
     };
     let int_of = |w: PyObjectRef| -> Option<i64> {
         (!w.is_null() && unsafe { pyre_object::is_int(w) })

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1672,3 +1672,30 @@ pub fn fsencode(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError
     }
     Ok(out)
 }
+
+/// The host `PathBuf` a `str` names, taking the filesystem encoding.
+///
+/// A name that came back from `readdir` carries the surrogate escapes
+/// [`fsdecode_filename_bytes`] produced, and those have no `&str` spelling —
+/// building the path with `w_str_get_value` aborts the process. Route through
+/// [`fsencode`] so the escapes fold back to the original bytes and the path
+/// names the same file it was read from. `None` when the str holds a surrogate
+/// outside the escape range, which no filesystem read can produce.
+pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Option<std::path::PathBuf> {
+    let bytes = fsencode(obj).ok()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+        Some(std::path::PathBuf::from(std::ffi::OsString::from_vec(
+            bytes,
+        )))
+    }
+    #[cfg(not(unix))]
+    {
+        // No byte spelling on this platform; the host API necessarily receives
+        // the text representation.
+        Some(std::path::PathBuf::from(
+            String::from_utf8_lossy(&bytes).into_owned(),
+        ))
+    }
+}

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1679,23 +1679,30 @@ pub fn fsencode(obj: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError
 /// [`fsdecode_filename_bytes`] produced, and those have no `&str` spelling —
 /// building the path with `w_str_get_value` aborts the process. Route through
 /// [`fsencode`] so the escapes fold back to the original bytes and the path
-/// names the same file it was read from. `None` when the str holds a surrogate
-/// outside the escape range, which no filesystem read can produce.
-pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Option<std::path::PathBuf> {
-    let bytes = fsencode(obj).ok()?;
+/// names the same file it was read from.
+///
+/// A str the filesystem encoding cannot spell raises rather than resolving to
+/// some other path: `sys.path.insert(0, '\ud800')` followed by an import
+/// answers `UnicodeEncodeError: surrogates not allowed`, and dropping the entry
+/// instead would search on and report the wrong failure.
+pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Result<std::path::PathBuf, crate::PyError> {
     #[cfg(unix)]
     {
         use std::os::unix::ffi::OsStringExt;
-        Some(std::path::PathBuf::from(std::ffi::OsString::from_vec(
+        let bytes = fsencode(obj)?;
+        Ok(std::path::PathBuf::from(std::ffi::OsString::from_vec(
             bytes,
         )))
     }
     #[cfg(not(unix))]
     {
-        // No byte spelling on this platform; the host API necessarily receives
-        // the text representation.
-        Some(std::path::PathBuf::from(
-            String::from_utf8_lossy(&bytes).into_owned(),
+        // No byte spelling on this platform, so the host API receives the text
+        // itself and a surrogate has nowhere to go: `str_utf8_w` reports it as
+        // an encoding error. Encoding to bytes and decoding them back lossily
+        // would substitute U+FFFD, which addresses a different name and makes
+        // distinct entries alias onto one another.
+        Ok(std::path::PathBuf::from(
+            crate::baseobjspace::str_utf8_w(obj)?,
         ))
     }
 }

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1701,8 +1701,8 @@ pub fn fspath_buf(obj: pyre_object::PyObjectRef) -> Result<std::path::PathBuf, c
         // an encoding error. Encoding to bytes and decoding them back lossily
         // would substitute U+FFFD, which addresses a different name and makes
         // distinct entries alias onto one another.
-        Ok(std::path::PathBuf::from(
-            crate::baseobjspace::str_utf8_w(obj)?,
-        ))
+        Ok(std::path::PathBuf::from(crate::baseobjspace::str_utf8_w(
+            obj,
+        )?))
     }
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1936,32 +1936,35 @@ enum FindInfo {
 }
 
 #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
-fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
+fn find_module(
+    partname: &str,
+    parent_dirs: Option<&[PathBuf]>,
+) -> Result<Option<FindInfo>, crate::PyError> {
     // Submodule import: search ONLY the parent package's `__path__`, never
     // sys.path or builtins by leaf name.  `_bootstrap._find_and_load` resolves
     // `pkg.sub` against `pkg.__path__`; routing through sys.path lets a
     // same-leaf module from an unrelated package on sys.path shadow it (e.g.
     // `concurrent.futures` resolving to `asyncio/futures.py`).
     if let Some(dirs) = parent_dirs {
-        return find_in_dirs(partname, dirs);
+        return Ok(find_in_dirs(partname, dirs));
     }
 
     // Check builtin modules first (PyPy: space.builtin_modules check in find_module)
     let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
-        return Some(FindInfo::Builtin);
+        return Ok(Some(FindInfo::Builtin));
     }
 
     // Try sys.path first
-    if let Some(info) = find_in_sys_path(partname) {
-        return Some(info);
+    if let Some(info) = find_in_sys_path(partname)? {
+        return Ok(Some(info));
     }
 
     // Fallback stdlib detection. `create_sys_path_list` already forces this at
     // sys-module creation, so the `DONE` guard normally makes this a no-op; it
     // stays as a defensive retry for any miss reached before sys exists.
     ensure_stdlib_path();
-    return find_in_sys_path(partname);
+    find_in_sys_path(partname)
 }
 
 // wasm has no current_exe / python3 spawn, so there is no `ensure_stdlib_path`
@@ -1971,24 +1974,30 @@ fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindIn
 // `__path__`, top-level names check builtins then sys.path — all FS probes go
 // through the installed `SourceProvider`.
 #[cfg(all(feature = "host_env", target_arch = "wasm32"))]
-fn find_module(partname: &str, parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
+fn find_module(
+    partname: &str,
+    parent_dirs: Option<&[PathBuf]>,
+) -> Result<Option<FindInfo>, crate::PyError> {
     if let Some(dirs) = parent_dirs {
-        return find_in_dirs(partname, dirs);
+        return Ok(find_in_dirs(partname, dirs));
     }
     let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
-        return Some(FindInfo::Builtin);
+        return Ok(Some(FindInfo::Builtin));
     }
     find_in_sys_path(partname)
 }
 
 #[cfg(not(feature = "host_env"))]
-fn find_module(partname: &str, _parent_dirs: Option<&[PathBuf]>) -> Option<FindInfo> {
+fn find_module(
+    partname: &str,
+    _parent_dirs: Option<&[PathBuf]>,
+) -> Result<Option<FindInfo>, crate::PyError> {
     let is_builtin = BUILTIN_MODULES.lock().unwrap().contains_key(partname);
     if is_builtin {
-        return Some(FindInfo::Builtin);
+        return Ok(Some(FindInfo::Builtin));
     }
-    None
+    Ok(None)
 }
 
 /// Detect and add CPython stdlib to sys.path (once).
@@ -2047,17 +2056,22 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
 /// empty vec before `sys` / its `path` list exists (the pre-`sync` bootstrap
 /// window). Only `str` entries are collected — path hooks (zipimporter keys
 /// and the like) are not resolvable by the native file search.
+///
+/// An entry the filesystem encoding cannot spell raises out of the import
+/// rather than being passed over.
 #[cfg(feature = "host_env")]
-fn python_sys_path_dirs() -> Option<Vec<PathBuf>> {
+fn python_sys_path_dirs() -> Result<Option<Vec<PathBuf>>, crate::PyError> {
     // `None` means the `sys` module does not exist yet (the pre-`sys` bootstrap
     // window) — the caller falls back to the native seed. Once `sys` exists the
     // Python list is authoritative even when empty: a missing / non-list / empty
     // `sys.path` searches nothing, so `del sys.path` and `sys.path.clear()` break
     // imports exactly as they do under CPython, rather than resurrecting the seed.
-    let sys_mod = get_sys_module("sys")?;
+    let Some(sys_mod) = get_sys_module("sys") else {
+        return Ok(None);
+    };
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(sys_mod) };
     if w_dict.is_null() {
-        return None;
+        return Ok(None);
     }
     // Copy the entries up front so no Python borrow is held across the
     // filesystem probes in `find_in_dirs` (which never invoke user code).
@@ -2073,16 +2087,14 @@ fn python_sys_path_dirs() -> Option<Vec<PathBuf>> {
                     // Non-str entries are skipped: pyre's only path hook is the
                     // native filesystem probe, and CPython also skips an entry no
                     // hook accepts.
-                    if unsafe { pyre_object::is_str(item) }
-                        && let Some(dir) = crate::gateway::fspath_buf(item)
-                    {
-                        dirs.push(dir);
+                    if unsafe { pyre_object::is_str(item) } {
+                        dirs.push(crate::gateway::fspath_buf(item)?);
                     }
                 }
             }
         }
     }
-    Some(dirs)
+    Ok(Some(dirs))
 }
 
 /// Search the import path for a top-level `partname`.
@@ -2093,8 +2105,8 @@ fn python_sys_path_dirs() -> Option<Vec<PathBuf>> {
 /// side of a pre-`sys` staging seed (flushed into `sys.path` at sys-module
 /// creation) and is consulted here solely in that pre-`sys` window.
 #[cfg(feature = "host_env")]
-fn find_in_sys_path(partname: &str) -> Option<FindInfo> {
-    match python_sys_path_dirs() {
+fn find_in_sys_path(partname: &str) -> Result<Option<FindInfo>, crate::PyError> {
+    Ok(match python_sys_path_dirs()? {
         Some(dirs) => {
             let found = find_in_dirs(partname, &dirs);
             // Windows: pyre still registers the `posix` builtin (never `nt`),
@@ -2113,7 +2125,7 @@ fn find_in_sys_path(partname: &str) -> Option<FindInfo> {
             let path = SYS_PATH.lock().unwrap();
             find_in_dirs(partname, &path)
         }
-    }
+    })
 }
 
 /// Build the initial Python `sys.path` list from the native `SYS_PATH` seed.
@@ -2151,27 +2163,29 @@ pub(crate) fn create_sys_path_list() -> PyObjectRef {
 /// Returns `None` when `__path__` is absent or is not a plain list of `str`.
 /// `absolute_import` rejects the absent case up front ("'<parent>' is not a
 /// package"), so a `None` reaching the caller means a package whose `__path__`
-/// yielded no usable directories.
-fn parent_package_path(parent: PyObjectRef) -> Option<Vec<PathBuf>> {
+/// yielded no usable directories. An entry the filesystem encoding cannot spell
+/// raises, the same as one on `sys.path`.
+fn parent_package_path(parent: PyObjectRef) -> Result<Option<Vec<PathBuf>>, crate::PyError> {
     let w_dict = unsafe { pyre_object::w_module_get_w_dict(parent) };
     if w_dict.is_null() || !unsafe { pyre_object::is_dict(w_dict) } {
-        return None;
+        return Ok(None);
     }
-    let path_obj = unsafe { pyre_object::w_dict_getitem_str(w_dict, "__path__") }?;
+    let Some(path_obj) = (unsafe { pyre_object::w_dict_getitem_str(w_dict, "__path__") }) else {
+        return Ok(None);
+    };
     if path_obj.is_null() || !unsafe { pyre_object::is_list(path_obj) } {
-        return None;
+        return Ok(None);
     }
     let n = unsafe { pyre_object::listobject::w_list_len(path_obj) };
     let mut dirs = Vec::with_capacity(n);
     for i in 0..n {
         if let Some(item) = unsafe { pyre_object::listobject::w_list_getitem(path_obj, i as i64) }
             && unsafe { pyre_object::is_str(item) }
-            && let Some(dir) = crate::gateway::fspath_buf(item)
         {
-            dirs.push(dir);
+            dirs.push(crate::gateway::fspath_buf(item)?);
         }
     }
-    Some(dirs)
+    Ok(Some(dirs))
 }
 
 // ── parse_source_module ──────────────────────────────────────────────
@@ -2829,8 +2843,7 @@ fn load_part(
     }
 
     // Find the module on disk
-    let find_info = find_module(partname, parent_dirs);
-    let Some(info) = find_info else {
+    let Some(info) = find_module(partname, parent_dirs)? else {
         return Ok(None);
     };
 
@@ -2955,7 +2968,7 @@ fn absolute_import(
                         &full_name,
                     ));
                 }
-                parent_package_path(parent_mod)
+                parent_package_path(parent_mod)?
             }
         };
         let w_mod = load_part(&full_name, part, parent_dirs.as_deref(), execution_context)?;
@@ -4201,7 +4214,7 @@ mod tests {
     fn test_find_module_nonexistent() {
         // Should not find a module that doesn't exist
         let result = find_module("__nonexistent_pyre_test_module__", None);
-        assert!(result.is_none());
+        assert!(matches!(result, Ok(None)));
     }
 
     #[cfg(feature = "wasm_vfs")]

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1417,8 +1417,11 @@ pub fn add_sys_path(dir: &Path) {
     let n = unsafe { pyre_object::listobject::w_list_len(w_path) };
     for i in 0..n {
         if let Some(item) = unsafe { pyre_object::listobject::w_list_getitem(w_path, i as i64) } {
+            // A `sys.path` entry read back from the filesystem can hold a
+            // surrogate escape and so have no `&str` spelling; it simply is
+            // not equal to this ASCII startup entry.
             if unsafe { pyre_object::is_str(item) }
-                && unsafe { pyre_object::w_str_get_value(item) } == entry.as_ref()
+                && unsafe { pyre_object::w_str_get_value_opt(item) } == Some(entry.as_ref())
             {
                 return;
             }
@@ -2070,8 +2073,10 @@ fn python_sys_path_dirs() -> Option<Vec<PathBuf>> {
                     // Non-str entries are skipped: pyre's only path hook is the
                     // native filesystem probe, and CPython also skips an entry no
                     // hook accepts.
-                    if unsafe { pyre_object::is_str(item) } {
-                        dirs.push(PathBuf::from(unsafe { pyre_object::w_str_get_value(item) }));
+                    if unsafe { pyre_object::is_str(item) }
+                        && let Some(dir) = crate::gateway::fspath_buf(item)
+                    {
+                        dirs.push(dir);
                     }
                 }
             }
@@ -2159,10 +2164,11 @@ fn parent_package_path(parent: PyObjectRef) -> Option<Vec<PathBuf>> {
     let n = unsafe { pyre_object::listobject::w_list_len(path_obj) };
     let mut dirs = Vec::with_capacity(n);
     for i in 0..n {
-        if let Some(item) = unsafe { pyre_object::listobject::w_list_getitem(path_obj, i as i64) } {
-            if unsafe { pyre_object::is_str(item) } {
-                dirs.push(PathBuf::from(unsafe { pyre_object::w_str_get_value(item) }));
-            }
+        if let Some(item) = unsafe { pyre_object::listobject::w_list_getitem(path_obj, i as i64) }
+            && unsafe { pyre_object::is_str(item) }
+            && let Some(dir) = crate::gateway::fspath_buf(item)
+        {
+            dirs.push(dir);
         }
     }
     Some(dirs)
@@ -3148,7 +3154,11 @@ fn strip_bootstrap_traceback_frames(mut err: crate::PyError) -> crate::PyError {
                 && crate::pycode::code_get_field(w_code, "co_filename")
                     .ok()
                     .filter(|f| pyre_object::is_str(*f))
-                    .is_some_and(|f| is_bootstrap_filename(&pyre_object::w_str_get_value(f)));
+                    // A module imported from a path with no UTF-8 spelling
+                    // carries a surrogate escape in `co_filename`; it is not
+                    // one of the bootstrap names either way.
+                    .and_then(|f| pyre_object::w_str_get_value_opt(f))
+                    .is_some_and(is_bootstrap_filename);
             if !is_bootstrap {
                 break;
             }

--- a/pyre/pyre-interpreter/src/module/_posixsubprocess/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_posixsubprocess/mod.rs
@@ -78,7 +78,11 @@ mod imp {
     fn obj_to_cstring(o: PyObjectRef, what: &str) -> Result<CString, PyError> {
         let bytes = unsafe {
             if is_str(o) {
-                w_str_get_value(o).as_bytes().to_vec()
+                // The exec boundary carries OS bytes: a program name or argv
+                // entry that came back from the filesystem holds surrogate
+                // escapes, which fold back to the original bytes here rather
+                // than having no `&str` spelling at all.
+                crate::gateway::fsencode(o)?
             } else if is_bytes(o) {
                 w_bytes_data(o).to_vec()
             } else {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2444,8 +2444,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         if args.is_empty() {
             return Err(crate::PyError::type_error("stat() missing argument"));
         }
-        let path = crate::gateway::fsencode_path_w(args[0]).map_err(|_| {
-            crate::PyError::type_error("stat: path should be string, bytes, os.PathLike")
+        // Only a wrong *type* is re-reported under `stat`'s own wording; the
+        // embedded-null ValueError and the surrogate UnicodeEncodeError say
+        // what actually went wrong and have to reach the caller as themselves.
+        // `os.stat('\ud800')` is a `UnicodeEncodeError`, not a `TypeError`.
+        let path = crate::gateway::fsencode_path_w(args[0]).map_err(|err| {
+            if matches!(err.kind, crate::error::PyErrorKind::TypeError) {
+                crate::PyError::type_error("stat: path should be string, bytes, os.PathLike")
+            } else {
+                err
+            }
         })?;
         #[cfg(feature = "sandbox")]
         {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2576,10 +2576,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     fn dir_entry_fspath(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         crate::baseobjspace::getattr_str(args[0], "path")
     }
+    /// `posixmodule.c DirEntry_repr` — `"<DirEntry %R>"`, so the name is
+    /// rendered by its own `repr`.  That keeps `os.scandir(b'.')`'s bytes
+    /// name spelled `b'…'` and lets a name whose bytes have no UTF-8 form
+    /// keep the lone surrogate `fs_name_obj` decoded it to.
     fn dir_entry_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let name = crate::baseobjspace::getattr_str(args[0], "name")?;
-        let name = unsafe { pyre_object::w_str_get_value(name) };
-        Ok(pyre_object::w_str_new(&format!("<DirEntry {name:?}>")))
+        let mut out = rustpython_wtf8::Wtf8Buf::new();
+        out.push_str("<DirEntry ");
+        out.push_wtf8(&unsafe { crate::py_repr_wtf8(name)? });
+        out.push_str(">");
+        Ok(pyre_object::w_str_from_wtf8(out))
     }
     fn dir_entry_type() -> PyObjectRef {
         static CELL: std::sync::OnceLock<usize> = std::sync::OnceLock::new();


### PR DESCRIPTION
Two defect families, both of which abort the process and neither of which
macOS CI can observe.

## 1. Keep the symbolic fnaddr tag out of the synthetic fnaddr space

Follow-up to #1030. That PR replaced the `(fnaddr as u64) >> 47 != 0` heuristic
with an explicit high-16 tag, `SYMBOLIC_FNADDR_BASE = 0xFADD_0000_0000_0000`.
That constant sets bit 63, and `BhDescr::JitCode.fnaddr` is shared with a second
encoding whose *entire space* is a sign test:

```rust
// majit-backend::synthetic_cpu
pub const SYNTHETIC_FNADDR_BASE: i64 = i64::MIN;
pub fn is_synthetic_fnaddr(x: i64) -> bool { x < 0 }
pub fn decode_synthetic(x: i64) -> usize { (x & i64::MAX) as usize }
```

Every symbolic hash therefore landed inside the synthetic space, where
`decode_synthetic` would answer it with a fabricated jitcode index. The tag
moves to `0x7ADD_0000_0000_0000` — the shape the sibling
`STR_CONST_SENTINEL_BASE = 0x7E57_…` already uses in `codewriter/assembler.rs` —
with bit 63 left clear and the reason recorded at the constant.

No test or CI leg could have caught this: the colliding consumer is currently
`unimplemented!()`, so the collision stays latent until a `SyntheticCpu`
dispatch goes live. `fnaddr_classifiers_match_the_walker_symbolic_gate` now
asserts the invariant directly (`symbolic > 0`, `!is_synthetic_fnaddr(symbolic)`)
next to the aarch64-Linux real-address cases #1030 added.

## 2. Filesystem names that have no UTF-8 spelling

Every filesystem name pyre reads is decoded with the surrogateescape handler
(`fs_name_obj` → `fsdecode_filename_bytes` → `charp2uni` →
`decode_utf8_with_errors(data, "surrogateescape")`), so the resulting `str` can
hold lone surrogates in U+DC80..U+DCFF. `w_str_get_value` *panics* on such a
buffer — a process abort, not a raise — and seven boundaries reached it, or
misreported it, with a name that came straight off the filesystem.

| site | was | now |
| --- | --- | --- |
| `importing` `python_sys_path_dirs`, `parent_package_path` | `&str` → `PathBuf` | `gateway::fspath_buf`, which folds the escapes back to the original bytes through `fsencode` |
| `importing` sys.path entry compare, bootstrap-filename check | `w_str_get_value` | `w_str_get_value_opt` — a non-UTF-8 entry compares unequal |
| `posix.DirEntry.__repr__` | `&str` interpolation | the name's own `repr`, matching `DirEntry_repr`'s `"<DirEntry %R>"` |
| `_posixsubprocess.fork_exec` | `w_str_get_value(o).as_bytes()` | `gateway::fsencode` |
| `baseobjspace::realunicode_w` | `w_str_get_value` | `str_utf8_w` → `UnicodeEncodeError: surrogates not allowed` |
| `posix.stat` | every `fsencode_path_w` error remapped to one `TypeError` | only a genuine `TypeError` is re-reported under `stat`'s wording |
| `write_syntax_error_object` (`SyntaxError.filename`, `.text`) | `w_str_get_value` | rendered with `backslashreplace`, as stderr already does |

Two of those fall out on the way past:

- `DirEntry.__repr__` read the name as a `str` unconditionally, so
  `os.scandir(b'.')` — whose `name` is `bytes` — was a type confusion.
  Rendering by `repr` spells a bytes name `b'…'`, as it should.
- `posix.stat` collapsed the embedded-null `ValueError` and the surrogate
  `UnicodeEncodeError` into `TypeError: stat: path should be string, bytes,
  os.PathLike`. CPython 3.14 answers `os.stat('a\0b')` with `ValueError:
  stat: embedded null character in path` and `os.stat('\ud800')` with
  `UnicodeEncodeError`.

**A path entry that cannot be encoded is now reported, not skipped.**
`fspath_buf` first answered `None` there and both import path readers dropped
the entry and searched on. CPython 3.14 raises `UnicodeEncodeError` for
`sys.path.insert(0, '\ud800')` and for the same entry in a package `__path__`,
so the error travels out through `python_sys_path_dirs` → `find_in_sys_path` →
`find_module` to `load_part`, which already returned `Result`. The non-unix arm
of `fspath_buf` also stopped round-tripping through
`String::from_utf8_lossy`, which substituted U+FFFD and made distinct entries
alias onto one another; it reads the text with `str_utf8_w` instead.

**Why none of this shows up on macOS.** Exposure is filesystem *capability*, not
a code branch: APFS and HFS+ reject a non-UTF-8 filename with `EILSEQ`, so the
repro cannot even be planted, while ext4 and tmpfs accept arbitrary bytes.

Two parity tests, deliberately split by what they need:

- `os_undecodable_name_boundaries.py` plants `b"pyre_undecodable_\xff"` in a
  tempdir and covers `os.listdir`, both `DirEntry` reprs, an import off
  `sys.path`, the exec boundary, and the `SyntaxError` traceback. It self-skips
  where the filesystem refuses the name (and on win32), so in practice it runs
  on Linux.
- `import_unencodable_path_entry.py` needs no filesystem support at all — the
  entry never reaches a syscall — so it runs on every platform.

## 3. State the full cpu surface the per-thread `BackendImpl` backs (comment only)

Adjudicating a §3 finding from #1030's Codex review: `pyre_production_cpu` leaks
one `BackendImpl` per thread, so `bh.cpu` is a *different* object from the
`MetaInterp::backend` that recorded the trace, and the finding was that the
blackhole could observe backend state distinct from the metainterpreter's.

It cannot, today. The surface reachable through `bh.cpu` is
`bh_getfield_gc_{i,r,f}`, `bh_setfield_gc_{i,r,f}`,
`bh_getarrayitem_gc_{i,r,f}`, `bh_arraylen_gc`, `bh_new`,
`bh_new_with_vtable`, `bh_new_array{,_clear}`, `bh_call_{i,r,f,v}` and
`clear_stored_exception` — on dynasm every one is a pure function of its
arguments (descr-supplied offsets into `read_int_at_mem`/`write_int_at_mem`, or
a free function such as `jit_exc_clear` / `call_stub::bh_call_*_dispatch`), none
reading `&self`.

The old comment justified the split with "vable handlers only invoke stateless
reads" while listing four of those methods. It now records the whole list, the
invariant, and what breaks if a `&self`-reading method joins it. The
architectural port — hand the metainterp's `BackendImpl` to
`BlackholeInterpBuilder` and delete the TLS — stays open in the in-code TODO,
blocked on the `Backend` trait's `Send + Sync` bound and on `BH_BUILDER3`
outliving any single `MetaInterp`.

## A boundary this does *not* close

Running pyre with a script path that is not valid UTF-8 aborts before Python
starts, in the launcher rather than in anything above:

```
panicked at library/std/src/env.rs:876:51:
called `Result::unwrap()` on an `Err` value: "/tmp/…/broken_pyre_undecodable_\xFF.py"
```

`pyrex/src/lib.rs:656` reads argv with `std::env::args()`, which panics on any
argument that is not valid Unicode (internally `OsString::into_string().unwrap()`
— the `Err` payload above is exactly that). Swapping in `args_os()` is not the
fix: the launcher carries argv as `String` throughout (`RunMode`,
`parser.raw_args()`, `set_sys_argv(&[String])`), and a Rust `String` cannot hold
a surrogate at all. The convergence path is to carry argv as `OsString`/`Vec<u8>`
and build the str objects at the `sys.argv` seam with `fsdecode_filename_bytes`,
the same producer `readdir` names use.

That is the process-entry boundary, not a name read back from disk, so it is
left out rather than folded in here. `os_undecodable_name_boundaries.py`
*imports* its broken module instead of running it precisely to keep the
undecodable name off the command line, and says so where it does it.

## Verification

- Linux (aarch64 Debian trixie, ext4) A/B on the boundary test — before:
  `panicked at pyre/pyre-object/src/unicodeobject.rs:579: w_str_get_value:
  backing Wtf8Buf is not valid UTF-8 (lone surrogate)`; after: `OK`; CPython
  control `OK`. This is where the boundary test's assertions actually run;
  on APFS it skips itself.
- Linux full parity suite on the branch tip: 178 scripts, **0 dynasm FAILs**.
  (The 41 `cpython=FAIL` rows there are the rig — Debian ships python3.13, so
  the `*_python314.py` fixtures fail on the *control* side.)
- macOS `python3 pyre/check.py`: **dynasm 378/378, cranelift 378/378,
  wasm 374/374, 3/3 backend runs**.
- Both new parity tests were validated against a real CPython 3.14.5 first and
  only then against pyre, so each asserts upstream behaviour rather than
  pyre's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
