### PR TITLE
bench: record recursive_call_frame_relocation's windows dynasm guard_failures

### DIFF
--- a/pyre/bench/synth/recursive_call_frame_relocation.dynasm.win32.jitstats
+++ b/pyre/bench/synth/recursive_call_frame_relocation.dynasm.win32.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=3
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=637
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3


### PR DESCRIPTION
main is red on windows dynasm with `recursive_call_frame_relocation`
`guard_failures 638 -> 637`. This records 637 as that host's value.

| sha | windows dynasm | windows cranelift |
| --- | --- | --- |
| #1028's base | 638 (passed) | 416 (failed vs 415) |
| `4fecf865268` (#1042) | **637** | 415 |
| `a8677f4a0a0` (#1043) | **637** | 415 |
| `2f612802f1c` (main, now) | **637** | 415 |

Three consecutive runs at three different base shas, every other counter
identical, and check.py's own overlay comment names 637 for windows from two
earlier runs. macos-latest and ubuntu-24.04 pass their dynasm legs against the
shared 638, so the shared file still describes them.

Both counters stepped down by one at the same point and have held since. That
move left `closure_per_call` agreeing with its shared file — which is why
#1043 dropped its overlay — and left this one disagreeing, which is why it
gets one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
