### PR TITLE
jit: three walk-image defects — locals-typed vable overlay, unpublished escape root stack, unmodeled LOAD_SPECIAL

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -142,8 +142,14 @@ pub(crate) struct LatchedSingleFrameBlackhole {
     pub(crate) miframe: majit_metainterp::MIFrame,
     pub(crate) last_exc_value: i64,
     pub(crate) raising_exception: bool,
-    /// `None` for the `ABORT_TOO_LONG` latch, whose post-step coordinate is an
-    /// opcode boundary the snapshot array does describe.
+    /// The walker's resolved operand-stack image, captured by whichever latch
+    /// stops the walk.  The adopter uses it for legs that stop INSIDE an opcode
+    /// (`WalkAbort` and `VableEscape`) and uses the frame's own snapshot array
+    /// for `ABORT_TOO_LONG`, whose post-step coordinate is an opcode boundary
+    /// the array does describe.
+    ///
+    /// `None` means the walk had no resolvable mirror, and the adopt then
+    /// declines rather than publishing a partial stack.
     pub(crate) mirror_stack: Option<MirrorStackImage>,
 }
 
@@ -246,10 +252,10 @@ macro_rules! latchdbg {
 /// (`pyjitpl.py`) — into the concrete operand stack an abort image publishes.
 ///
 /// Same resolution [`flush_escape_state_with_latched_stack`] performs for the
-/// escape flush, and for the same reason: a walk-abort coordinate sits inside
-/// a Python opcode, where no other source describes the operand stack.  The
-/// tracing snapshot's array is not it — a root walk mirrors nothing into that
-/// frame (see [`MirrorStackImage`]).
+/// escape flush, and for the same reason: the walk-abort latch and the
+/// vable-escape latch both stop inside a Python opcode, where no other source
+/// describes the operand stack.  The tracing snapshot's array is not it — a
+/// root walk mirrors nothing into that frame (see [`MirrorStackImage`]).
 ///
 /// A recorded concrete NULL is a REAL operand — it is `PUSH_NULL`'s
 /// `self_or_null` sentinel — so only `GcRef::NO_CONCRETE`, which is what
@@ -3093,14 +3099,19 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                     if let Some(miframe) = jitcode.and_then(|jitcode| {
                         build_single_frame_miframe(ctx, jitcode, resume_pc, lastop_result)
                     }) {
+                        // `ctx` is the root walk on this arm
+                        // (`framestack.is_empty() && !inline_subwalk`).  It
+                        // stops inside the residual call, and the resumed
+                        // blackhole can reach a `getarrayitem_vable_r` that
+                        // reloads an operand from the virtualizable array, so
+                        // publish the root stack from the walker's mirror.
+                        let mirror_stack = capture_vstack_mirror_image(ctx);
                         FBW_SINGLE_FRAME_BLACKHOLE.with(|slot| {
                             *slot.borrow_mut() = Some(LatchedSingleFrameBlackhole {
                                 miframe,
                                 last_exc_value,
                                 raising_exception,
-                                // The escape leg resumes at a call resume
-                                // marker and publishes no root stack.
-                                mirror_stack: None,
+                                mirror_stack,
                             });
                         });
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -997,9 +997,18 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     guard_jitcode_pc,
                 );
                 let semantic_limit = sym.nlocals() + maps.stack_depth_at_pc;
+                let nlocals = sym.nlocals();
+                // The residual call's result lands on the operand stack, so
+                // only stack slots need reconciling here.  A local's slot is
+                // maintained in lockstep by the shadow, while the per-PC
+                // color-to-slot map is a per-program-point label rather than a
+                // binding: the register allocator can reuse a local's color
+                // for unrelated SSA temps, so projecting a register into a
+                // local's slot can publish an unrelated value.
                 let nvs = crate::virtualizable_gen::NUM_VABLE_SCALARS;
                 for &(bank, color, slot) in &maps.pcdep_entries {
                     if bank != 1
+                        || (slot as usize) < nlocals
                         || slot as usize >= semantic_limit
                         || !banks.ref_.contains(&(color as u32))
                     {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -224,6 +224,20 @@ pub(crate) fn classify_vstack_opcode(
         // any branch guard, so it is never a live kept-stack slot at a resume.
         Instruction::LoadSuperAttr { .. } => VstackOpClass::ResultToTos,
 
+        // LOAD_SPECIAL pops the context-manager object at `prev_depth - 1`
+        // and pushes the special method followed by the call self/NULL slot
+        // upward from that position.  Clear that popped slot and the pushed
+        // range so each pushed slot is sourced from the virtualizable shadow.
+        Instruction::LoadSpecial { method }
+            if matches!(
+                method.get(op_arg),
+                pyre_interpreter::bytecode::SpecialMethod::Enter
+                    | pyre_interpreter::bytecode::SpecialMethod::Exit
+            ) =>
+        {
+            VstackOpClass::MultiResultFromShadow
+        }
+
         // SWAP(i): exchange TOS with the box `i` positions below.  A pure
         // permutation (net depth 0); the decoded `i` drives the
         // `vstack_boxes` exchange in `reconcile_vstack_at_boundary`.

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2287,11 +2287,11 @@ fn try_adopt_single_frame_blackhole(
     // carries the irrevocable, fully preflighted adoption contract.
     let trace_too_long = commit_leg == WalkEndCommitLeg::TraceTooLong
         && crate::jitcode_dispatch::fbw_executed_effect_count() != 0;
-    // Both full-image legs resume the blackhole at a post-step pc it may leave
-    // by arbitrary control flow, so the root operand stack has to be published
-    // with the locals (`fill_trace_too_long_register_banks`).  The vable-escape
-    // leg instead resumes immediately after one forcing residual and keeps its
-    // narrower resume-marker image.
+    // All three full-image legs resume the blackhole at a pc it may leave by
+    // arbitrary control flow, including back around a loop header where the
+    // jitcode reloads operands from the virtualizable array.  The root operand
+    // stack therefore has to be published with the locals
+    // (`fill_trace_too_long_register_banks`) for each leg.
     //
     // `WalkAbort` deliberately does NOT join `trace_too_long` above: that flag
     // promotes a post-latch decline to a release assert, which the too-long arm
@@ -2299,7 +2299,9 @@ fn try_adopt_single_frame_blackhole(
     // (`trace_too_long_abort_safe`).  A capability-gap abort fires regardless of
     // the latch, so its adopt must still be able to decline into legacy replay.
     let publishes_root_stack =
-        commit_leg == WalkEndCommitLeg::TraceTooLong || commit_leg == WalkEndCommitLeg::WalkAbort;
+        commit_leg == WalkEndCommitLeg::TraceTooLong
+            || commit_leg == WalkEndCommitLeg::WalkAbort
+            || commit_leg == WalkEndCommitLeg::VableEscape;
     let Some(mut latched) = crate::jitcode_dispatch::take_single_frame_blackhole() else {
         assert!(
             !trace_too_long,
@@ -2432,12 +2434,15 @@ fn try_adopt_single_frame_blackhole(
             eprintln!("[wa-stack] snapshot-array={from_array:x?} mirror={from_mirror:x?}");
         }
         // `ABORT_TOO_LONG` stops at an opcode boundary, where the snapshot
-        // array is the image RPython would copy.  `WalkAbort` stops INSIDE an
-        // opcode, and for a root walk that array was never written at all — it
-        // still holds the pre-walk stack (see `capture_frame_stack_from_mirror`).
-        // Take the walker's OpRef mirror, which the latch resolved while the
-        // concrete side tables were still live.
-        let captured = if commit_leg == WalkEndCommitLeg::WalkAbort {
+        // array is the image RPython would copy.  `WalkAbort` and
+        // `VableEscape` stop INSIDE an opcode, and for a root walk that array
+        // was never written at all — it still holds the pre-walk stack (see
+        // `capture_frame_stack_from_mirror`). Take the walker's OpRef mirror,
+        // which the latch resolved while the concrete side tables were still
+        // live.
+        let captured = if commit_leg == WalkEndCommitLeg::WalkAbort
+            || commit_leg == WalkEndCommitLeg::VableEscape
+        {
             latched.mirror_stack.as_ref().and_then(|mirror| {
                 crate::state::capture_frame_stack_from_mirror(
                     vable_frame,

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2298,10 +2298,9 @@ fn try_adopt_single_frame_blackhole(
     // earns by aborting only once `latch_abort_blackhole` has succeeded
     // (`trace_too_long_abort_safe`).  A capability-gap abort fires regardless of
     // the latch, so its adopt must still be able to decline into legacy replay.
-    let publishes_root_stack =
-        commit_leg == WalkEndCommitLeg::TraceTooLong
-            || commit_leg == WalkEndCommitLeg::WalkAbort
-            || commit_leg == WalkEndCommitLeg::VableEscape;
+    let publishes_root_stack = commit_leg == WalkEndCommitLeg::TraceTooLong
+        || commit_leg == WalkEndCommitLeg::WalkAbort
+        || commit_leg == WalkEndCommitLeg::VableEscape;
     let Some(mut latched) = crate::jitcode_dispatch::take_single_frame_blackhole() else {
         assert!(
             !trace_too_long,


### PR DESCRIPTION
Three independent defects on the walk / blackhole-adopt path, each of which lets a
frame resume from an image that does not describe the state the residual left behind.
All three were found with the same probe method — run the asyncio suite under
`PYRE_FBW_CENSUS=1` and treat `committed=false AND effects>0` as the hazard predicate —
and each is verified by a deterministic counter, not by the failure rate.

## 1. `resume_snapshot.rs` — the after-residual vable overlay wrote LOCAL slots

The overlay that re-projects live `Ref` registers after a residual call used the
per-PC `pcdep` map to decide which slot a register belongs to. `pcdep` is keyed by
*program point*, not by binding: two registers live at the same PC are indistinguishable
to it. When a local slot and an operand-stack slot were both live across the residual,
the overlay could publish the wrong register into the local slot — a `self` slot holding
a code object, among other faces.

Restrict the overlay to operand-stack slots, where the `pcdep` label *is* the identity.
Locals keep the ordinary snapshot value.

## 2. `residual_call.rs` / `trace.rs` — the vable-escape single-frame adopt published no root operand stack

`try_adopt_single_frame_blackhole` latched a `MIFrame` without publishing the root
operand stack, so a resumed `getarrayitem_vable_r` against that frame read NULL.

The tell is that the `[fbw-escape]` diagnostic line is **not** the image — there are two
latch producers and only one of them published the stack. The `VableEscape` leg now
publishes the root stack like the other producer. 6/6 → 0/6 on the repro.

## 3. `vstack_mirror.rs` — `LOAD_SPECIAL` was unmodeled, so every `with` body killed the walk mirror

The root cause behind the residual asyncio instability. Every link verified in source
**and** measured:

```
with / async with            ->  LOAD_SPECIAL
classify_vstack_opcode       ->  falls through `_ => VstackOpClass::Unmodeled`
apply arm                    ->  ctx.vstack_valid = false   (STICKY for the walk)
mod.rs:8912                  ->  depth_gt_1 && !vstack_valid
                                 => DispatchError::BranchGuardKeptStackUnsupported
leaves_complete_image()      ->  does NOT list it  => no adopt leg covers it
run_perfn_walk epilogue      ->  committed = false
store journal                ->  cannot undo a residual that entered a Python frame
interpreter                  ->  REPLAYS the region
asyncio                      ->  _ready.append / Handle._run / Context.run applied twice
```

That double application accounts for the whole observed symptom set:
`InvalidStateError("FINISHED: …")`, `RuntimeError: cannot enter context … already entered`,
`AttributeError: 'NoneType' object has no attribute '_source_traceback'`, and
`TypeError: 'builtin_function_or_method' object is not an iterator`.

`Instruction::LoadSpecial { method }` restricted to `SpecialMethod::Enter | Exit` now
classifies as `VstackOpClass::MultiResultFromShadow`.

**Why that class and not `ResultToTos`.** `LOAD_SPECIAL` pops the manager at
`prev_depth - 1` and pushes *two* values. `ResultToTos` only writes `[new_depth-1]`,
leaving the popped object as a stale non-NONE box where the bound method belongs — and
both hole-fill helpers skip non-NONE slots (`if *slot != OpRef::NONE { continue; }` in
`reseed_vstack_from_shadow` and `reseed_vstack_from_callee_shadow`). A stale box is
strictly worse than an invalid mirror. `MultiResultFromShadow` NONEs
`[pop_point .. new_depth)` and lets the shadow source each pushed slot; unsourceable slots
stay NONE and the kept-stack check declines — never a corrupt box. Premise verified: both
pushed values go through `emit_pushvalue_ref!` → `setarrayitem_vable_r`
(codewriter.rs 12068 / 12083 / 7716).

`AEnter` / `AExit` are deliberately left `Unmodeled` (permanent-abort lowering).

### Measurement

400-round asyncio harness, one-binary A/B behind a temporary env gate:

| counter | before | after |
|---|---|---|
| mirror invalidations (`op=LoadSpecial arg=OpArg(1)`) | 5 | 0 |
| `BranchGuardKeptStackUnsupported` declines | 5 | 0 |
| walks aborting on that branch guard | 5 | 0 |
| all `committed=false AND effects>0` walks | 11 | 6 |

Before the fix the three counters are **one-to-one** — every mirror kill produced exactly
one decline and exactly one uncommitted-with-effects walk, and all five kills were the
identical `__exit__` site.

End-to-end, as a supporting (two-binary, underpowered) number: the same harness at
600 rounds × 10 tries went from 9/10 tries completing — 1 class-B failure, 2 other
failures, 1 hard non-zero exit — to **10/10 clean, zero failures of any class**.

## Refuted along the way (recorded so they are not re-derived)

- Bridge double-execution rewind at `call_jit.rs:3709` — the comment there describes a
  real but unfiring path.
- `PYRE_WALKABORT_OFF=1` — no change; that leg only covers `leaves_complete_image()`
  errors, and this abort is not one.
- Two synthetic minimal repros of the `_run_once` drain shape — 0 hits. The abort needs
  the real warmed workload.
- Modeling the await opcodes (`SEND` / `GET_AWAITABLE` / `GET_AITER` / `GET_ANEXT`) —
  A/B'd, `decline_why` 5 in *both* arms. Reverted rather than landed unverified.

## Known follow-ups (not in this PR)

1. The remaining 6 hazards are `VableEscapedDuringResidualCall committed=false`. Per-walk
   pairing shows two causes: the latch is skipped entirely for a bridge trace
   (`!ctx.trace_ctx.is_bridge_trace`, residual_call.rs:3081 — listed as a precondition in a
   comment that explicitly refutes the *other* gates), and the inline-sub-walk arm declines
   on `odo_unchanged=false` (residual_call.rs:3142-3143), which is exactly the case where
   replay is unsound.
2. `END_SEND`, `YIELD_VALUE`, `AEnter`, `AExit` remain `Unmodeled` in the mirror.
3. The structural gap: a pyre walk can execute an irreversible residual and then reach a
   state from which no image can be built. Upstream cannot — `_copy_data_from_miframe`
   copies the banks unconditionally and has no failing path (`blackhole.py:1711-1730`,
   cited at mod.rs:2338-2341).
4. #1017 recorded `test.test_asyncio` as TIMEOUT; worth revisiting now.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stack-state handling when tracing stops inside an operation or exceeds trace limits.
  * Fixed recovery of operand-stack values during virtualizable escapes and aborted walks.
  * Improved context-manager stack reconciliation for enter and exit operations.
  * Prevented local variables from being incorrectly treated as operand-stack values during snapshot restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->