### PR TITLE
long, jit: fold divmod(W_LongObject, W_IntObject) to one rbigint.int_divmod

### DIFF
--- a/pyre/bench/synth/divmod_long_int_pair.cranelift.jitstats
+++ b/pyre/bench/synth/divmod_long_int_pair.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/divmod_long_int_pair.dynasm.jitstats
+++ b/pyre/bench/synth/divmod_long_int_pair.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/bench/synth/divmod_long_int_pair.py
+++ b/pyre/bench/synth/divmod_long_int_pair.py
@@ -1,0 +1,59 @@
+# pyre-check: max-pypy-ratio=18
+# `divmod(long, int)` at a traced call site. `_int_divmod` keeps the divisor
+# unwrapped and calls `rbigint.int_divmod`, whose rtyped return is a two-item
+# `GcStruct`: the walker emits one elidable call plus two `getfield_gc_r`, then
+# boxes both halves and builds the specialised object pair. That is three GC
+# allocations per iteration, all inside the loop — an operand varies at every
+# site so the elidable cannot be hoisted out, and the halves stay live across
+# the following iteration's allocations.
+
+BIG = (1 << 200) + 12345
+N = 250000
+
+
+def unpacked(n):
+    """Both halves are consumed at once, so the pair itself never escapes."""
+    acc = 0
+    for i in range(n):
+        q, r = divmod(BIG, 97 + (i & 7))
+        acc = (acc + r) ^ (q & 0xFFFF)
+    return acc
+
+
+def held_across_calls(n):
+    """The quotient outlives the next iteration's three allocations."""
+    prev = 0
+    acc = 0
+    for i in range(n):
+        q, r = divmod(BIG + i, 1000003)
+        acc += (prev ^ q) & 0xFFFFFF
+        prev = q + r
+    return acc % 1000000007
+
+
+def pair_escapes(n):
+    """The tuple is read as a tuple, so the object pair is materialised."""
+    out = None
+    acc = 0
+    for i in range(n):
+        t = divmod(BIG, 3 + (i & 15))
+        acc = (acc + len(t) + (t[1] & 7)) % 999983
+        out = t
+    return acc, out[0] * (3 + ((n - 1) & 15)) + out[1] == BIG
+
+
+def negative_divisor(n):
+    """`othersign == -1 and selfsign != othersign` sends `int_divmod` past
+    `_divrem1` to the full `divmod` against a converted operand, so the same
+    residual returns its pair from the other leg of its own body."""
+    acc = 0
+    for i in range(n):
+        q, r = divmod(BIG, -(97 + (i & 7)))
+        acc = (acc + r + (q & 0xFFFF)) & 0xFFFFFFFF
+    return acc
+
+
+print(unpacked(N))
+print(held_across_calls(N))
+print(pair_escapes(N))
+print(negative_divisor(N))

--- a/pyre/bench/synth/divmod_long_int_pair.wasm.jitstats
+++ b/pyre/bench/synth/divmod_long_int_pair.wasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=9
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=4

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1213,20 +1213,28 @@ class Check:
         # platform. This is for the counter a host genuinely disagrees on, and
         # it keeps the comparison exact everywhere instead of widening the gate
         # for everyone: a band that tolerated the disagreement would tolerate it
-        # on all 371 fixtures and all three backends, and the band this gate
+        # on every fixture and all three backends, and the band this gate
         # replaced is exactly what let eight baselines go stale unnoticed.
         #
-        # Measured, not assumed. windows-latest cranelift reports
-        # `closure_per_call` guard_failures 416 and
-        # `recursive_call_frame_relocation` 637 where macos-latest and
-        # ubuntu-24.04 both report 415 and 638, on two independent runs, with
-        # every other counter identical. `PYPY_GC_NURSERY` is pinned above, so
-        # the nursery is not the differing variable, and the same windows host
-        # passes its dynasm leg 371/371. What is left is that the allocation
+        # Measured, not assumed, and read back from the windows job rather than
+        # predicted. `closure_per_call` is the one fixture that carries an
+        # overlay: windows-latest cranelift reports guard_failures 416 where
+        # macos-latest and ubuntu-24.04 both report 415, every other counter
+        # identical, on every windows run since exact equality replaced the
+        # tolerance band — including the runs taken after PYTHONSAFEPATH moved
+        # the ambient import loop. `PYPY_GC_NURSERY` is pinned above, so the
+        # nursery is not the differing variable, and the same windows host
+        # passes its dynasm leg in full. What is left is that the allocation
         # footprint differs, hence when a collection lands, hence how often the
         # back-edge eval-breaker poll bails out; the specific cause is not
-        # identified. Adding an overlay is therefore recording a fact about the
-        # host, and the shared file still gates the other two.
+        # identified. An overlay is therefore recording a fact about the host,
+        # and the shared file still gates the other two.
+        #
+        # An overlay shadows the shared baseline permanently, so one written
+        # against a value that later converges becomes a failure main does not
+        # have: `recursive_call_frame_relocation` was given one for 637, and
+        # windows has reported the shared 638 on every run since. Read the value
+        # back from the latest windows job before adding another.
         source = Path(script)
         per_platform = source.with_name(f"{source.stem}.{backend}.{sys.platform}.jitstats")
         if per_platform.exists():

--- a/pyre/extra_tests/parity_tests/divmod_long_int_jit.py
+++ b/pyre/extra_tests/parity_tests/divmod_long_int_jit.py
@@ -130,6 +130,60 @@ def tuple_is_a_real_tuple():
     return out
 
 
+def int_min_divisor():
+    """`INT_MIN` is the one divisor `int_in_valid_range` rejects.
+
+    It leaves `_divrem1` for the full `divmod` against a converted operand, as
+    does every negative divisor of a non-negative dividend.
+    """
+    out = None
+    for _ in range(ROUNDS):
+        out = divmod(BIG, -(1 << 63))
+    q, r = out
+    return q * -(1 << 63) + r == BIG, r
+
+
+def negative_one_quotient():
+    """The correction arm that turns a zero quotient into the prebuilt -1.
+
+    Opposite signs with the dividend's magnitude below the divisor's, which
+    needs a long-typed dividend whose value is small.
+    """
+    tiny = (1 << 70) >> 70
+    out = None
+    for _ in range(ROUNDS):
+        out = (divmod(tiny, -7), divmod(tiny, -1), divmod(-tiny, 7))
+    return out
+
+
+def collects_between_halves():
+    """A collection lands while the halves and their pair are being built."""
+    import gc
+
+    held = []
+    for i in range(ROUNDS):
+        q, r = divmod(BIG + i, 97)
+        held.append((q, r))
+        if len(held) > 8:
+            held = held[-4:]
+        if i % 256 == 0:
+            gc.collect()
+    return [q * 97 + r == BIG + i for i, (q, r) in enumerate(held, ROUNDS - len(held))]
+
+
+def shadowed_divmod():
+    """A rebound global `divmod` must not keep the builtin's trace."""
+    global divmod
+    builtin_divmod = divmod
+    out = []
+    for i in range(ROUNDS):
+        if i == ROUNDS - 1:
+            divmod = lambda a, b: ("shadowed", b)  # noqa: E731
+        out = divmod(BIG, 97)
+    divmod = builtin_divmod
+    return out
+
+
 print(floored_pairs())
 print(exact_values())
 print(churn_keeps_earlier_results())
@@ -140,4 +194,8 @@ print(alternating_divisor())
 print(reflected_and_long_long())
 print(int_subclass_divisor())
 print(tuple_is_a_real_tuple())
+print(int_min_divisor())
+print(negative_one_quotient())
+print(collects_between_halves())
+print(shadowed_divmod())
 print("OK")

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1344,6 +1344,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::objspace::descroperation::jit_bigint_int_mod_int_result",
         crate::objspace::descroperation::jit_bigint_int_mod_int_result as *const (),
     );
+    push_fnaddr(
+        &mut entries,
+        "pyre_interpreter::objspace::descroperation::jit_bigint_int_divmod",
+        crate::objspace::descroperation::jit_bigint_int_divmod as *const (),
+    );
     // `jit_bigint_{and,or,xor,sub,mul}` residualize the Rust RBigInt binary
     // operators (`<BigInt as BitAnd>::bitand`, …) the `front::mir` retarget
     // (`front::bigint_binop`) redirects when both operands are the opaque

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -350,6 +350,30 @@ pub extern "C" fn jit_bigint_int_mod_int_result(a: i64, b: i64) -> i64 {
     unsafe { (&*a).int_mod_int_result(b).expect("division by zero") }
 }
 
+/// Both halves of a machine-int divmod (`longobject.py:451 _int_divmod` →
+/// `rbigint.int_divmod`, rbigint.py:1050 `@jit.elidable`). `b` is a bare
+/// machine word, not a payload pointer.
+///
+/// One call produces both results: `//` and `%` each reach `_divmod`, so
+/// splitting this into two residuals would run the division twice. The result
+/// is the RPython `tuple2` the elidable returns, and the caller reads its two
+/// halves with `getfield_gc_r` before boxing each as a `W_LongObject` — the
+/// wrappers and the interpreter tuple stay in traced code, where they remain
+/// virtualizable.
+#[majit_macros::elidable_or_memerror]
+pub extern "C" fn jit_bigint_int_divmod(
+    a: i64,
+    b: i64,
+) -> pyre_object::longobject::JitBigIntPairResult {
+    let a = a as *const BigInt;
+    unsafe {
+        let (div, modulo) = (&*a).int_divmod(b).expect("division by zero");
+        pyre_object::longobject::encode_jit_bigint_pair_result(
+            pyre_object::longobject::alloc_bigint_pair_nursery_collecting(div, modulo),
+        )
+    }
+}
+
 /// `rbigint.divmod`'s floored modulus projection.
 #[majit_macros::elidable_or_memerror]
 pub extern "C" fn jit_bigint_mod_floor(a: i64, b: i64) -> pyre_object::longobject::JitBigIntResult {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1635,6 +1635,42 @@ static ITEMS_BLOCK_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|
     )
 });
 
+// The RPython `tuple2` returned by `rbigint.divmod` / `int_divmod`
+// (rbigint.py:1002/1050). Not a PyObject — no vtable and no allocation type id,
+// because the trace never NEWs one: it arrives as an elidable's result and is
+// only read. Both fields are `Type::Ref`, which is what puts them in
+// `gc_fielddescrs`, and both are immutable, so the two reads CSE the way
+// upstream's pair of `getfield_gc_r` off one `call_pure_r` does.
+static RBIGINT_PAIR_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        pyre_object::longobject::BIGINT_PAIR_SIZE,
+        0,
+        0,
+        &[
+            (
+                "item0",
+                pyre_object::longobject::BIGINT_PAIR_ITEM0_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Ref,
+                false,
+                true,
+                false,
+            ),
+            (
+                "item1",
+                pyre_object::longobject::BIGINT_PAIR_ITEM1_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Ref,
+                false,
+                true,
+                false,
+            ),
+        ],
+        "RBigIntPair",
+        "rbigint::RBigIntPair",
+    )
+});
+
 // `pypy/objspace/std/sliceobject.py:13` `W_SliceObject._immutable_fields_ =
 // ['w_start', 'w_stop', 'w_step']` — all three Ref fields are immutable
 // once `__init__` runs.  The `space.newslice(w_start, w_end, w_step)` JIT
@@ -2728,6 +2764,16 @@ pub fn float_floatval_descr() -> DescrRef {
 /// inline-NEW boxing of a `jit_w_long_*_raw` result.
 pub fn long_value_descr() -> DescrRef {
     field_descr_from_group(&W_LONG_DESCR_GROUP, 0)
+}
+
+/// `RBigIntPair.item0` — the quotient half of a divmod `tuple2`.
+pub fn rbigint_pair_item0_descr() -> DescrRef {
+    field_descr_from_group(&RBIGINT_PAIR_DESCR_GROUP, 0)
+}
+
+/// `RBigIntPair.item1` — the remainder half of a divmod `tuple2`.
+pub fn rbigint_pair_item1_descr() -> DescrRef {
+    field_descr_from_group(&RBIGINT_PAIR_DESCR_GROUP, 1)
 }
 
 pub fn str_len_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6721,14 +6721,24 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
         return Ok(None);
     }
     let int_typeobj = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::INT_TYPE);
+    let is_exact_int = |o: pyre_object::PyObjectRef| unsafe {
+        std::ptr::eq((*o).ob_type, &pyre_object::pyobject::INT_TYPE)
+            && std::ptr::eq((*o).w_class, int_typeobj)
+    };
+    if !is_exact_int(lhs_obj) || !is_exact_int(rhs_obj) {
+        // `_make_descr_binop(_divmod, _int_divmod)` (longobject.py:459) keeps a
+        // dedicated long/int arm; every other operand shape stays generic.
+        return try_walker_specialize_builtin_divmod_long_int(
+            ctx,
+            op,
+            r_args,
+            dst,
+            concrete_callable,
+            lhs_obj,
+            rhs_obj,
+        );
+    }
     let (la, rb) = unsafe {
-        let is_exact_int = |o: pyre_object::PyObjectRef| {
-            std::ptr::eq((*o).ob_type, &pyre_object::pyobject::INT_TYPE)
-                && std::ptr::eq((*o).w_class, int_typeobj)
-        };
-        if !is_exact_int(lhs_obj) || !is_exact_int(rhs_obj) {
-            return Ok(None);
-        }
         (
             pyre_object::w_int_get_value(lhs_obj),
             pyre_object::w_int_get_value(rhs_obj),
@@ -6743,18 +6753,7 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
     }
 
     // --- emit the specialized IR (walker-native) ---
-    // Pin the callable identity (LOAD_GLOBAL `divmod` is usually already a
-    // constant via the namespace cell fold).
-    let callable_op = r_args[0];
-    if !callable_op.is_constant() {
-        let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(callable_op, expected);
-    }
+    walker_guard_builtin_callable_identity(ctx, op.pc, r_args[0], concrete_callable)?;
     let (lhs_op, rhs_op) = (r_args[2], r_args[3]);
     let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
     // `GuardClass` before the `w_class` read: it is the guard that proves the
@@ -6783,6 +6782,219 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
     let (mod_raw, mod_value) = walker_emit_int_py_div_or_mod(ctx, lhs_raw, rhs_raw, la, rb, false);
     let tuple =
         walker_emit_specialised_tuple_ii(ctx, op.pc, div_raw, mod_raw, div_value, mod_value)?;
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', tuple)?;
+    Ok(Some(()))
+}
+
+/// One element of a concrete `W_SpecialisedTupleObject_oo`, or `None` when the
+/// value is any other tuple layout. `newtuple` picks the representation, so a
+/// fold that emits the object-pair shape has to confirm the record-time value
+/// took the same one before reading it through those offsets.
+fn walker_specialised_tuple_oo_item(
+    tuple: pyre_object::PyObjectRef,
+    index: usize,
+) -> Option<pyre_object::PyObjectRef> {
+    if tuple.is_null() {
+        return None;
+    }
+    let ob_type = unsafe { (*(tuple as *const pyre_object::pyobject::PyObject)).ob_type };
+    if !std::ptr::eq(
+        ob_type,
+        &pyre_object::specialisedtupleobject::SPECIALISED_TUPLE_OO_TYPE
+            as *const pyre_object::pyobject::PyType,
+    ) {
+        return None;
+    }
+    let item = unsafe {
+        pyre_object::specialisedtupleobject::w_specialised_tuple_oo_getvalue(tuple, index)
+    };
+    (!item.is_null()).then_some(item)
+}
+
+/// Pin a builtin's identity before folding its call away. `LOAD_GLOBAL divmod`
+/// is usually already a constant via the namespace cell fold, in which case the
+/// guard is unnecessary; a rebound global takes the side exit.
+fn walker_guard_builtin_callable_identity<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    callable_op: OpRef,
+    concrete_callable: pyre_object::PyObjectRef,
+) -> Result<(), DispatchError> {
+    if callable_op.is_constant() {
+        return Ok(());
+    }
+    let expected = ctx.trace_ctx.const_ref(concrete_callable as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[callable_op, expected], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(callable_op, expected);
+    Ok(())
+}
+
+/// `divmod(W_LongObject, W_IntObject)` — `longobject.py:451 _int_divmod`.
+///
+/// One `rbigint.int_divmod` (rbigint.py:1050 `@jit.elidable`) produces both
+/// halves, so the trace is the upstream shape: a single `CallR` returning the
+/// RPython `tuple2`, two `GetfieldGcR` off it, then `newlong` ×2 and the
+/// arity-2 tuple — all three allocations trace-visible, so the shipped oo
+/// unpack fold can virtualize the tuple away at an unpacking use.
+///
+/// Emitting `int_div_floor` and `int_mod_int_result` instead would run the
+/// division twice; `_int_divmod` exists precisely to avoid that.
+///
+/// `int % long` and `divmod(int, long)` are `descr_rdivmod`, which coerces the
+/// left operand and takes the bigint/bigint path — not this arm.
+fn try_walker_specialize_builtin_divmod_long_int<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+    concrete_callable: pyre_object::PyObjectRef,
+    long_obj: pyre_object::PyObjectRef,
+    int_obj: pyre_object::PyObjectRef,
+) -> Result<Option<()>, DispatchError> {
+    let (long_class, int_class, int_value) = unsafe {
+        if !pyre_object::is_long(long_obj) || !pyre_object::is_int(int_obj) {
+            return Ok(None);
+        }
+        let (Some(long_class), Some(int_class)) = (
+            walker_exact_builtin_class(long_obj),
+            walker_exact_builtin_class(int_obj),
+        ) else {
+            return Ok(None);
+        };
+        (long_class, int_class, pyre_object::w_int_get_value(int_obj))
+    };
+    // A zero divisor raises before reaching rbigint; the interpreter owns the
+    // authentic message.
+    if int_value == 0 {
+        return Ok(None);
+    }
+
+    // Take the concretes from the authentic builtin, not from the residual:
+    // the residual's payload allocator collects, and it is only safe to do so
+    // under a gcmap-carrying `CallR`, which the host-side walker is not. This
+    // is the `math.isqrt` fold's route, and it is also what makes the recorded
+    // tuple the one `newtuple` actually picked for these two operands.
+    let tuple_concrete = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(concrete_callable, &[long_obj, int_obj])
+    };
+    let Ok(tuple_concrete) = tuple_concrete else {
+        return Ok(None);
+    };
+    // `_int_divmod` boxes both halves with `newlong`, which does not demote, so
+    // a pair of longs is the only shape this arm may emit — and two longs are
+    // what routes `newtuple` to the object-pair variant.
+    let (Some(w_div), Some(w_mod)) = (
+        walker_specialised_tuple_oo_item(tuple_concrete, 0),
+        walker_specialised_tuple_oo_item(tuple_concrete, 1),
+    ) else {
+        return Ok(None);
+    };
+    if !unsafe { pyre_object::is_long(w_div) && pyre_object::is_long(w_mod) } {
+        return Ok(None);
+    }
+    // The call above allocates, so the operand pointers this function was
+    // handed may have been forwarded. Re-fetch them from the walker's op cells,
+    // which the collector does update, before reading anything through them.
+    let (long_op, int_op) = (r_args[2], r_args[3]);
+    let (Some(long_obj), Some(int_obj)) = (
+        walker_concrete_ref_object(ctx, long_op),
+        walker_concrete_ref_object(ctx, int_op),
+    ) else {
+        return Ok(None);
+    };
+    let read_payload = |o: pyre_object::PyObjectRef| unsafe {
+        *((o as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET) as *const i64)
+            as *mut pyre_object::rbigint::RBigInt
+    };
+    let long_payload = read_payload(long_obj) as i64;
+    let (div_payload, mod_payload) = (read_payload(w_div), read_payload(w_mod));
+    // Both halves are already reachable from `tuple_concrete`, and this
+    // allocation cannot collect, so neither can move under it.
+    let pair = pyre_object::longobject::alloc_bigint_pair_no_collect(div_payload, mod_payload);
+    if pair.is_null() {
+        return Err(DispatchError::ConcreteShadowAllocationFailed { pc: op.pc });
+    }
+
+    // --- emit ---
+    walker_guard_builtin_callable_identity(ctx, op.pc, r_args[0], concrete_callable)?;
+    let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
+    walker_guard_class(ctx, op.pc, long_op, long_type_addr)?;
+    walker_guard_exact_w_class(ctx, op.pc, long_op, long_class)?;
+    let (int_type, int_descr) = crate::state::int_or_bool_unbox_type_descr(int_obj);
+    let int_raw = walker_unbox_int_typed(ctx, op.pc, int_op, int_type, int_descr)?;
+    walker_guard_exact_w_class(ctx, op.pc, int_op, int_class)?;
+    let zero = ctx.trace_ctx.const_int(0);
+    let nonzero = ctx.trace_ctx.record_op(OpCode::IntNe, &[int_raw, zero]);
+    ctx.trace_ctx
+        .set_opref_concrete(nonzero, majit_ir::Value::Int(1));
+    walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardTrue, &[nonzero])?;
+
+    let long_pl = ctx.trace_ctx.record_op_with_descr(
+        OpCode::GetfieldGcR,
+        &[long_op],
+        crate::descr::long_value_descr(),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        long_pl,
+        majit_ir::Value::Ref(majit_ir::GcRef(long_payload as usize)),
+    );
+
+    let helper = pyre_interpreter::objspace::descroperation::jit_bigint_int_divmod as *const ();
+    let pair_op = ctx.trace_ctx.call_typed_with_effect_pure_can_raise(
+        OpCode::CallR,
+        helper,
+        &[long_pl, int_raw],
+        &[majit_ir::Type::Ref, majit_ir::Type::Int],
+        majit_ir::Type::Ref,
+        majit_metainterp::ELIDABLE_OR_MEMERROR_EFFECT_INFO,
+        &[
+            majit_ir::Value::Int(helper as usize as i64),
+            majit_ir::Value::Ref(majit_ir::GcRef(long_payload as usize)),
+            majit_ir::Value::Int(int_value),
+        ],
+        majit_ir::Value::Ref(majit_ir::GcRef(pair as usize)),
+    );
+    ctx.trace_ctx.set_opref_concrete(
+        pair_op,
+        majit_ir::Value::Ref(majit_ir::GcRef(pair as usize)),
+    );
+    if pair_op.inline_const_to_value().is_none() {
+        walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardNoException, &[])?;
+    }
+
+    let mut boxed = Vec::with_capacity(2);
+    for (descr, payload, wrapper) in [
+        (crate::descr::rbigint_pair_item0_descr(), div_payload, w_div),
+        (crate::descr::rbigint_pair_item1_descr(), mod_payload, w_mod),
+    ] {
+        let half = ctx
+            .trace_ctx
+            .record_op_with_descr(OpCode::GetfieldGcR, &[pair_op], descr);
+        ctx.trace_ctx.set_opref_concrete(
+            half,
+            majit_ir::Value::Ref(majit_ir::GcRef(payload as usize)),
+        );
+        let w = crate::helpers::emit_box_long_inline(
+            ctx.trace_ctx,
+            half,
+            crate::descr::w_long_size_descr(),
+            crate::descr::long_value_descr(),
+        );
+        ctx.trace_ctx
+            .set_opref_concrete(w, majit_ir::Value::Ref(majit_ir::GcRef(wrapper as usize)));
+        boxed.push(w);
+    }
+
+    let tuple = crate::helpers::emit_specialised_tuple_oo_inline(ctx.trace_ctx, boxed[0], boxed[1]);
+    ctx.trace_ctx.set_opref_concrete(
+        tuple,
+        majit_ir::Value::Ref(majit_ir::GcRef(tuple_concrete as usize)),
+    );
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', tuple)?;
     Ok(Some(()))
 }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3421,6 +3421,21 @@ fn build_gc() -> Box<MiniMarkGC> {
         <pyre_interpreter::module::__pypy__::interp_buffer::bufferable_impl::W_Bufferable
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // The RPython `tuple2` a two-result elidable returns — here `rbigint.divmod`
+    // / `int_divmod` (rbigint.py:1002/1050). Like W_DequeBlock it is GC-managed
+    // without being an rclass.OBJECT subclass, so it takes a bare `with_gc_ptrs`
+    // id rather than a `register_pyre_class` vtable. BOTH fields are traced
+    // edges: a pair holding a payload the collector cannot see through would
+    // reclaim it under the boxing that follows. Appended at the tail so no
+    // established id moves.
+    let bigint_pair_tid = gc.register_type(TypeInfo::with_gc_ptrs(
+        pyre_object::longobject::BIGINT_PAIR_SIZE,
+        vec![
+            pyre_object::longobject::BIGINT_PAIR_ITEM0_OFFSET,
+            pyre_object::longobject::BIGINT_PAIR_ITEM1_OFFSET,
+        ],
+    ));
+    pyre_object::longobject::set_bigint_pair_gc_type_id(bigint_pair_tid);
     // ── GC-root registration completeness oracle ─────────────────────────
     // Every `#[pyre_class]` type appends its descriptor to the whole-program
     // `PYRE_CLASS_DESCRIPTORS` slice.  A type with inline managed children

--- a/pyre/pyre-object/src/longobject.rs
+++ b/pyre/pyre-object/src/longobject.rs
@@ -66,6 +66,59 @@ pub fn encode_jit_bigint_result(value: *mut BigInt) -> JitBigIntResult {
     value as usize as i64
 }
 
+/// Payload size and traced-field offsets of the `tuple2` of two rbigints.
+pub const BIGINT_PAIR_SIZE: usize = crate::rbigint::RBIGINT_PAIR_SIZE;
+pub const BIGINT_PAIR_ITEM0_OFFSET: usize = crate::rbigint::RBIGINT_PAIR_ITEM0_OFFSET;
+pub const BIGINT_PAIR_ITEM1_OFFSET: usize = crate::rbigint::RBIGINT_PAIR_ITEM1_OFFSET;
+
+/// Same GC-reference result ABI as [`JitBigIntResult`], for the `tuple2` a
+/// two-result elidable returns.
+#[cfg(not(target_arch = "wasm32"))]
+pub type JitBigIntPairResult = *mut crate::rbigint::RBigIntPair;
+#[cfg(target_arch = "wasm32")]
+pub type JitBigIntPairResult = i64;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[inline]
+pub fn encode_jit_bigint_pair_result(
+    value: *mut crate::rbigint::RBigIntPair,
+) -> JitBigIntPairResult {
+    value
+}
+
+#[cfg(target_arch = "wasm32")]
+#[inline]
+pub fn encode_jit_bigint_pair_result(
+    value: *mut crate::rbigint::RBigIntPair,
+) -> JitBigIntPairResult {
+    value as usize as i64
+}
+
+/// Record the GC type id registered for the `tuple2` of two rbigints (called
+/// once from `pyre-jit::eval` after `gc.register_type`).
+pub fn set_bigint_pair_gc_type_id(id: u32) {
+    crate::rbigint::set_rbigint_pair_gc_type_id(id);
+}
+
+/// Allocate the `tuple2` owning both halves of a divmod result.
+#[inline]
+pub fn alloc_bigint_pair_nursery_collecting(
+    item0: BigInt,
+    item1: BigInt,
+) -> *mut crate::rbigint::RBigIntPair {
+    crate::rbigint::alloc_rbigint_pair_nursery_collecting(item0, item1)
+}
+
+/// Non-collecting `tuple2` over two already-reachable payloads, for the
+/// walker's record-time shadow.
+#[inline]
+pub fn alloc_bigint_pair_no_collect(
+    item0: *mut BigInt,
+    item1: *mut BigInt,
+) -> *mut crate::rbigint::RBigIntPair {
+    crate::rbigint::alloc_rbigint_pair_no_collect(item0, item1)
+}
+
 /// GC type id for the raw `rbigint` payload, published at JitDriver init by
 /// `set_bigint_gc_type_id`. `0` until then, in which case the alloc helpers
 /// fall back to leaked raw allocations in bare tests / pre-init bootstrap.

--- a/pyre/pyre-object/src/rbigint.rs
+++ b/pyre/pyre-object/src/rbigint.rs
@@ -711,6 +711,145 @@ pub fn alloc_rbigint_stable(value: RBigInt) -> *mut RBigInt {
     crate::lltype::malloc_raw(value)
 }
 
+/// RPython's `tuple2` of two `rbigint`s — the return type of `rbigint.divmod`
+/// and `rbigint.int_divmod` (rbigint.py:1002 / 1050, both `@jit.elidable`).
+///
+/// RPython gives a multiple-return elidable a real GC struct, so the trace is
+/// one `call_pure_r` yielding this pointer plus two `getfield_gc_r`. Rust
+/// returns `(RBigInt, RBigInt)` by value, which has no address the JIT can name
+/// — hence this explicit struct, whose two fields are the traced edges.
+#[repr(C)]
+pub struct RBigIntPair {
+    pub item0: *mut RBigInt,
+    pub item1: *mut RBigInt,
+}
+
+pub const RBIGINT_PAIR_SIZE: usize = std::mem::size_of::<RBigIntPair>();
+pub const RBIGINT_PAIR_ITEM0_OFFSET: usize = std::mem::offset_of!(RBigIntPair, item0);
+pub const RBIGINT_PAIR_ITEM1_OFFSET: usize = std::mem::offset_of!(RBigIntPair, item1);
+
+/// Runtime GC id for the `tuple2` struct. Both fields are traced edges; a pair
+/// allocated before the id is published (bare tests, pre-init bootstrap) falls
+/// back to a leaked raw allocation, like the payload helpers above.
+static RBIGINT_PAIR_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+pub fn set_rbigint_pair_gc_type_id(id: u32) {
+    RBIGINT_PAIR_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[majit_macros::dont_look_inside]
+pub fn rbigint_pair_gc_type_id() -> u32 {
+    RBIGINT_PAIR_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Explicit root for an already-allocated GC pointer held in a host local.
+///
+/// RPython's stack map covers `div` and `mod` from the moment each is allocated
+/// until the `tuple2` malloc stores them. A Rust local has no generated map, so
+/// each payload pointer registers its own slot; the collector forwards through
+/// it exactly as it would through a shadow-stack entry.
+struct PendingPairItemRoot {
+    slot: *mut *mut u8,
+    registered: bool,
+}
+
+impl PendingPairItemRoot {
+    /// `slot` must outlive the guard and must not move while it is registered.
+    unsafe fn new(slot: *mut *mut RBigInt) -> Self {
+        let slot = slot.cast::<*mut u8>();
+        let registered = unsafe { crate::gc_hook::try_gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for PendingPairItemRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            crate::gc_hook::try_gc_remove_root(self.slot);
+        }
+    }
+}
+
+/// Allocate both halves and the `tuple2` that owns them.
+///
+/// The order is upstream's: `div` and `mod` become GC objects first, the pair
+/// last, so no store outlives the allocation that could move its target. Each
+/// step keeps everything already allocated reachable — the by-value handles via
+/// their `_digits` roots inside the payload allocator, the payload pointers via
+/// the guards here.
+pub fn alloc_rbigint_pair_nursery_collecting(item0: RBigInt, item1: RBigInt) -> *mut RBigIntPair {
+    // Until a half has its own payload it is only a by-value handle, and the
+    // payload allocator roots the digits of the handle it was given — not the
+    // other one. Root both up front, as `_int_divmod`'s caller does around its
+    // two `newlong` calls.
+    let item0 = RBigIntGcRoot::new(item0);
+    let item1 = RBigIntGcRoot::new(item1);
+
+    let mut item0 = alloc_rbigint_nursery_collecting(item0.translated_alias());
+    let _item0_root = unsafe { PendingPairItemRoot::new(&mut item0) };
+    let mut item1 = alloc_rbigint_nursery_collecting(item1.translated_alias());
+    let _item1_root = unsafe { PendingPairItemRoot::new(&mut item1) };
+
+    let tid = rbigint_pair_gc_type_id();
+    if tid != 0 {
+        // The collecting hook is the one the JIT residual wants; backends
+        // without it fall through to the no-collect allocator, and only a
+        // pre-init heap reaches `malloc_raw`. An untraced pair would be an
+        // invisible edge to two GC-managed payloads, so this chain must not end
+        // in `malloc_raw` while the payloads themselves are GC-managed.
+        let raw = crate::gc_hook::GcAllocOutcome::from_hook(
+            crate::gc_hook::try_gc_alloc_collecting(tid, RBIGINT_PAIR_SIZE),
+        )
+        .allocated_or_abort(RBIGINT_PAIR_SIZE)
+        .or_else(|| {
+            crate::gc_hook::GcAllocOutcome::from_hook(crate::gc_hook::try_gc_alloc(
+                tid,
+                RBIGINT_PAIR_SIZE,
+            ))
+            .allocated_or_abort(RBIGINT_PAIR_SIZE)
+        });
+        if let Some(raw) = raw {
+            unsafe {
+                // Any collection the allocation above ran forwarded both roots,
+                // so these reads take the post-collection addresses.
+                std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
+            }
+            // A nursery-full allocation can satisfy the pair from old-gen while
+            // both payloads stay young, so this is not the fresh fixed-size
+            // initialization whose field barriers framework.py:28-61
+            // `propagate_no_write_barrier_needed` removes.
+            crate::gc_hook::try_gc_write_barrier(raw);
+            return raw as *mut RBigIntPair;
+        }
+    }
+    crate::lltype::malloc_raw(RBigIntPair { item0, item1 })
+}
+
+/// Build the `tuple2` over two payloads that are already reachable.
+///
+/// The walker needs a concrete pair to attach to the `CallR` it records, but it
+/// runs on the host stack with no gcmap over its live set — which is the one
+/// thing [`alloc_rbigint_pair_nursery_collecting`] requires of its caller. This
+/// allocation therefore cannot collect, so the caller's live payloads keep the
+/// addresses it read them at.
+pub fn alloc_rbigint_pair_no_collect(item0: *mut RBigInt, item1: *mut RBigInt) -> *mut RBigIntPair {
+    let tid = rbigint_pair_gc_type_id();
+    if tid != 0
+        && let Some(raw) = crate::gc_hook::GcAllocOutcome::from_hook(crate::gc_hook::try_gc_alloc(
+            tid,
+            RBIGINT_PAIR_SIZE,
+        ))
+        .allocated_or_abort(RBIGINT_PAIR_SIZE)
+    {
+        unsafe {
+            std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
+        }
+        crate::gc_hook::try_gc_write_barrier(raw);
+        return raw as *mut RBigIntPair;
+    }
+    crate::lltype::malloc_raw(RBigIntPair { item0, item1 })
+}
+
 impl Clone for RBigInt {
     fn clone(&self) -> Self {
         // Python assignment shares an immutable `rbigint` object.  A clone of


### PR DESCRIPTION
`divmod(long, int)` was the last unfolded arm of the rbigint follow-up plan
(B2). It arrived at a traced call site as an opaque `bh_call_fn` residual —
`CallMayForceR` + `ForceToken` + `GuardNotForced` — because `rbigint.int_divmod`
(rbigint.py:1050, `@jit.elidable`) returns an RPython tuple2 of two rbigints and
pyre had no GC type for that pair.

## The pair type

`RBigIntPair` is a two-field GC struct registered at the tail of eval.rs's
type-id chain with a bare `with_gc_ptrs` id, the way `W_DequeBlock` is — it is
not an `rclass.OBJECT` subclass and has no vtable. Its descr group is built with
pytype 0 and type id 0, the `ItemsBlock` shape, because the trace only ever
reads the pair; both fields are immutable `Type::Ref`, which is what places them
in `gc_fielddescrs`.

`jit_bigint_int_divmod` runs the elidable once and allocates the pair, with the
wasm `i64` encoding analogue of `JitBigIntResult`.

## The walker arm

One `CallR`, two `GetfieldGcR`, two inline `W_LongObject` boxes and the
object-pair specialised tuple — `newlong` ×2 + `newtuple2` stay in traced code,
as `_int_divmod` (longobject.py:451) has them. Emitting `int_div_floor` and
`int_mod_int_result` instead would run the division twice.

Two GC ordering points:

- the pair allocator roots both by-value halves before allocating either
  payload, because the payload allocator only roots the digits of the handle it
  is passed;
- the walker takes its record-time concretes from the authentic builtin under
  `force_plain_eval`, not from the residual, whose collecting allocator is
  documented as safe only under a gcmap-carrying `CallR`.

## Measurement

3M iterations, invariant dividend and varying divisor so the elidable cannot be
hoisted:

| | |
|---|---|
| fold off | 1.090s |
| fold on | 0.367s |
| CPython 3.14 | 0.178s |

2.97x; the gap to CPython 3.14 goes 6.1x -> 2.05x.

## Coverage

`extra_tests/parity_tests/divmod_long_int_jit.py` gains the branches this arm
introduces: the `INT_MIN` divisor that `int_in_valid_range` rejects, the
correction arm that yields the prebuilt -1 quotient, a collection inside the
loop, and a rebound global `divmod`.

`bench/synth/divmod_long_int_pair.py` puts the fold under the check.py gate on
all three backends — four loops, baselines `loops_compiled=4`,
`loops_aborted=0`, `bridges_compiled=0`, `guard_failures=6` native / 9 wasm.
Those counters do not move if the fold is lost (the arm reverts to one
`CallMayForceR` inside the same compiled loop), so `max-pypy-ratio` is what
catches that; it is 18 against a measured 8.4x dynasm / 10.2x cranelift.

## Verification

- `pyre/check.py`: dynasm 379/379, cranelift 379/379, wasm 375/375, rc 0, no
  jit-stats diffs.
- `extra_tests/parity_tests/run.py`: all parity tests pass on cpython, dynasm
  and cranelift, plain and under `--gc-poison`.

Measured on macOS/aarch64 only; the three `.jitstats` baselines are first
recordings, so the ubuntu and windows legs of this PR are their first
cross-platform check.

— *authored by Claude*
