### PR TITLE
codewriter: materialize the caught exception on the value-stack slot at generic handler entry

### DIFF
--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -8090,11 +8090,44 @@ impl CodeWriter {
                                     py_pc as i64,
                                 );
                             } else {
+                                // The generic (non-explicit-raise) handler entry
+                                // reads the propagated exception from the field to
+                                // give the slot a distinct colour, but that leaves
+                                // the operand in a register only.  A blackhole /
+                                // deopt handoff that resumes the interpreter at this
+                                // handler reads the frame's value-stack array and
+                                // finds an empty top slot, so `PushExcInfo`
+                                // underflows.  Materialize the exception on the
+                                // durable slot as well — the interpreter unwinder
+                                // (`eval.rs` `handle_exception` `frame.push(exc)`)
+                                // and the explicit-raise arm's slot the
+                                // `getarrayitem_vable_r` above reads both keep it
+                                // there.  On the standard virtualizable
+                                // `setarrayitem_vable_r` costs no compiled op; it
+                                // updates the operand image the blackhole hands back
+                                // and the resume snapshots restore.  `depth_at_pc`
+                                // already publishes `vsd = base + current_depth`, so
+                                // no `emit_vsd!` is needed.
                                 record_graph_op(
                                     &current_block.block(),
                                     "last_exc_value",
                                     Vec::new(),
-                                    Some(exc_value),
+                                    Some(exc_value.clone()),
+                                    py_pc as i64,
+                                );
+                                let stack_slot =
+                                    stack_base_absolute + current_depth.saturating_sub(1) as usize;
+                                let stack_idx: super::flow::FlowValue =
+                                    super::flow::Constant::signed(stack_slot as i64).into();
+                                record_graph_op(
+                                    &current_block.block(),
+                                    "setarrayitem_vable_r",
+                                    vable_setarrayitem_ref_graph_args(
+                                        frame_var.into(),
+                                        stack_idx.into(),
+                                        exc_value.into(),
+                                    ),
+                                    None,
                                     py_pc as i64,
                                 );
                             }


### PR DESCRIPTION
Single fix, rebased onto current `main`.

### codewriter: materialize the caught exception on the value-stack slot at generic handler entry (task #52)

At a generic (non-explicit-raise) exception-handler entry the caught exception was read from the field but not materialized onto the value-stack slot the handler body expects, so a warmed-JIT `assertRaises` → `clear_frames` / `frame.clear()` path could underflow and let a `RuntimeError` escape. Materialize the exception on the value-stack slot at generic handler entry (`eval.rs handle_exception` `frame.push(exc)` parity), satisfying the existing `"exceptblock edge requires materialized exception pair"` invariant.

### Scope note
This PR originally carried three asyncio-surfaced warmed-JIT fixes, but the other two — the locals-typed vable overlay and the unpublished single-frame vable-escape root stack — already landed on `main` via #1051, so the branch was reduced to the one novel commit. It applies cleanly to current `main` (`codewriter.rs` is untouched since the base).

### Verification
Compiles on current `main`; was `check.py` 378/378 (dynasm/cranelift/wasm) when first committed. The escape it guards was a warmed-JIT Heisenbug that did not reproduce deterministically, so this is a land-safe fix for a latent gap; CI re-runs the full suite + parity review.

— opened by Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception handling during interpreter unwinding and deoptimization resumes.
  * Preserved propagated exception values reliably across execution transitions.
  * Improved recovery after optimized execution exits, preserving operand-stack state during resumed execution.
  * Fixed cases where local-variable and operand-stack values could be incorrectly mixed during recovery.
  * Added safer fallback behavior when complete execution state cannot be represented.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->