### PR TITLE
interp: report a lone surrogate in __slots__ and in a property's owner name

### DIFF
--- a/pyre/extra_tests/parity_tests/surrogate_name_boundaries.py
+++ b/pyre/extra_tests/parity_tests/surrogate_name_boundaries.py
@@ -1,0 +1,57 @@
+"""A lone surrogate in an ordinary name is reported, never fatal.
+
+`'\\udc80'` is an ordinary `str` literal — no filesystem, no `os`, no encoding
+boundary is involved — so every place that reads a name back has to cope with
+one.  pyre stores `str` as WTF-8 and the `&str` accessor cannot represent a lone
+surrogate, so each of these was a process abort rather than an exception.
+
+Covers the boundaries where the answer is exactly CPython's; the remaining
+members of this family (a module or function `__name__`, an AST identifier)
+still abort and are tracked separately.
+"""
+
+SURROGATE = "\udc80"
+
+
+# `__slots__` entries are identifiers, and a lone surrogate is not one, so it
+# takes the same rejection as a name starting with a digit.
+try:
+
+    class WithBadSlot:
+        __slots__ = (SURROGATE,)
+
+except TypeError as exc:
+    assert str(exc) == "__slots__ must be identifiers", ascii(str(exc))
+else:
+    raise AssertionError("__slots__ accepted a non-identifier")
+
+# A digit-leading name is the same rejection, so the surrogate arm is not a
+# special case bolted on beside it.
+try:
+
+    class WithDigitSlot:
+        __slots__ = ("1a",)
+
+except TypeError as exc:
+    assert str(exc) == "__slots__ must be identifiers", ascii(str(exc))
+else:
+    raise AssertionError("__slots__ accepted a digit-leading name")
+
+
+# A property error names the owning type's `__qualname__`, so the message
+# formatter reads a name the program chose.
+class WithProperty:
+    prop = property()
+
+
+WithProperty.__qualname__ = SURROGATE
+
+try:
+    WithProperty().prop
+except AttributeError as exc:
+    expected = "property 'prop' of %r object has no getter" % SURROGATE
+    assert str(exc) == expected, (ascii(str(exc)), ascii(expected))
+else:
+    raise AssertionError("a property with no getter returned a value")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -16169,7 +16169,12 @@ unsafe fn property_no_accessor(
 ) -> Result<crate::PyError, crate::PyError> {
     let qualname = match crate::typedef::r#type(obj) {
         Some(w_type) => match getattr_str(w_type.as_ptr(), "__qualname__") {
-            Ok(q) if !q.is_null() && is_str(q) => pyre_object::w_str_get_value(q).to_string(),
+            // A `__qualname__` holding a lone surrogate is ordinary Python, and
+            // this message is only ever displayed, so escape what has no `&str`
+            // form rather than aborting. The escape is visible where CPython
+            // shows the raw surrogate — `PyError::message` is a `String`, so
+            // the exact spelling waits on that field becoming WTF-8.
+            Ok(q) if !q.is_null() && is_str(q) => unsafe { crate::display::py_str_display(q) },
             _ => pyre_object::w_type_get_name(w_type.as_ptr()).to_string(),
         },
         None => (*(*obj).ob_type).name.to_string(),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4835,7 +4835,15 @@ pub(crate) fn collect_slot_names(
                     "__slots__ items must be strings, not type".to_string(),
                 ));
             }
-            let slot_name = pyre_object::w_str_get_value(w_slot_name).to_string();
+            // A name with no UTF-8 form is not an identifier, so it takes the
+            // same rejection as `('1a',)` rather than aborting for want of a
+            // `&str` view: `__slots__ = ('\udc80',)` is a `TypeError`.
+            let Some(slot_name) = (unsafe { pyre_object::w_str_get_value_opt(w_slot_name) }) else {
+                return Err(crate::PyError::type_error(
+                    "__slots__ must be identifiers".to_string(),
+                ));
+            };
+            let slot_name = slot_name.to_string();
             // typeobject.py:1208-1209 valid_slot_name
             if !valid_slot_name(&slot_name) {
                 return Err(crate::PyError::type_error(


### PR DESCRIPTION
`'\udc80'` is an ordinary `str` literal. No filesystem, no `os`, no encoding
boundary is involved, yet two name readers reached it through
`w_str_get_value`, whose `&str` view cannot spell a lone surrogate, so each was
a process abort rather than an exception.

* `collect_slot_names` (`call.rs`) reads every `__slots__` entry to validate it
  as an identifier. A name with no UTF-8 form is not an identifier, so it now
  takes the same rejection as `('1a',)`: `TypeError: __slots__ must be
  identifiers`.
* `property_no_accessor` (`baseobjspace.rs`) names the owning type in its
  message and read `__qualname__` for it. The message is only ever displayed,
  so it now renders through `display::py_str_display`, which never panics. The
  escape is visible where CPython shows the raw surrogate — `PyError::message`
  is a `String`, so the exact spelling waits on that field becoming WTF-8.

`extra_tests/parity_tests/surrogate_name_boundaries.py` covers both, pairing
the `__slots__` case with a digit-leading name so the surrogate arm is not a
special case bolted on beside it. It passes on CPython 3.14.5 and on both
backends.

Follows #1048, which closed the filesystem-name half of the same family. The
remaining members (a module or function `__name__`, an AST identifier) still
abort and are tracked separately: `NameStorage = String` is one GC type id
shared by `Function.name` and `W_TypeObject.name`, and the vendored parser's
`Identifier` is UTF-8 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of names containing lone surrogate characters.
  * Invalid `__slots__` names now produce the expected `TypeError` instead of failing during conversion.
  * Attribute errors involving surrogate-containing qualified names now display safely escaped names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->