### PR TITLE
jit: the rest of the walk mirror's unmodelled opcodes, and a CI gate for the roll-back-with-effects class

### DIFF
--- a/pyre/bench/fannkuch.cranelift.jitstats
+++ b/pyre/bench/fannkuch.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=5049
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fannkuch.dynasm.jitstats
+++ b/pyre/bench/fannkuch.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=5049
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fannkuch.wasm.jitstats
+++ b/pyre/bench/fannkuch.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=22
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=5049
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_loop.cranelift.jitstats
+++ b/pyre/bench/fib_loop.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=191
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_loop.dynasm.jitstats
+++ b/pyre/bench/fib_loop.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=191
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_loop.wasm.jitstats
+++ b/pyre/bench/fib_loop.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=189
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=406
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=406
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/fib_recursive.wasm.jitstats
+++ b/pyre/bench/fib_recursive.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=406
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.cranelift.jitstats
+++ b/pyre/bench/float_loop.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.dynasm.jitstats
+++ b/pyre/bench/float_loop.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/float_loop.wasm.jitstats
+++ b/pyre/bench/float_loop.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.cranelift.jitstats
+++ b/pyre/bench/inline_helper.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.dynasm.jitstats
+++ b/pyre/bench/inline_helper.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/inline_helper.wasm.jitstats
+++ b/pyre/bench/inline_helper.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.cranelift.jitstats
+++ b/pyre/bench/int_loop.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.dynasm.jitstats
+++ b/pyre/bench/int_loop.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/int_loop.wasm.jitstats
+++ b/pyre/bench/int_loop.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nbody.cranelift.jitstats
+++ b/pyre/bench/nbody.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nbody.dynasm.jitstats
+++ b/pyre/bench/nbody.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nbody.wasm.jitstats
+++ b/pyre/bench/nbody.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=1547
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.cranelift.jitstats
+++ b/pyre/bench/nested_loop.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.dynasm.jitstats
+++ b/pyre/bench/nested_loop.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/nested_loop.wasm.jitstats
+++ b/pyre/bench/nested_loop.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.cranelift.jitstats
+++ b/pyre/bench/raise_catch_loop.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.dynasm.jitstats
+++ b/pyre/bench/raise_catch_loop.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/raise_catch_loop.wasm.jitstats
+++ b/pyre/bench/raise_catch_loop.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.cranelift.jitstats
+++ b/pyre/bench/spectral_norm.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=520
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.dynasm.jitstats
+++ b/pyre/bench/spectral_norm.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=520
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/spectral_norm.wasm.jitstats
+++ b/pyre/bench/spectral_norm.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
 guard_failures=520
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.wasm.jitstats
+++ b/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=14
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=3062
 internal_compile_panics=0
 loops_aborted=1

--- a/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
+++ b/pyre/bench/synth/global_store_plain_dict_globals.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=1

--- a/pyre/bench/synth/match_sequence_of_class_patterns.cranelift.jitstats
+++ b/pyre/bench/synth/match_sequence_of_class_patterns.cranelift.jitstats
@@ -1,8 +1,9 @@
-bridges_compiled=0
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=1
+fbw_rolled_back_with_effects=0
+guard_failures=401
 internal_compile_panics=0
-loops_aborted=5
-loops_compiled=1
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/match_sequence_of_class_patterns.dynasm.jitstats
+++ b/pyre/bench/synth/match_sequence_of_class_patterns.dynasm.jitstats
@@ -1,8 +1,9 @@
-bridges_compiled=0
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=1
+fbw_rolled_back_with_effects=0
+guard_failures=401
 internal_compile_panics=0
-loops_aborted=5
-loops_compiled=1
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/match_sequence_of_class_patterns.wasm.jitstats
+++ b/pyre/bench/synth/match_sequence_of_class_patterns.wasm.jitstats
@@ -1,8 +1,9 @@
-bridges_compiled=0
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
-guard_failures=1
+fbw_rolled_back_with_effects=0
+guard_failures=402
 internal_compile_panics=0
-loops_aborted=5
-loops_compiled=1
+loops_aborted=0
+loops_compiled=2

--- a/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=5
 guard_failures=451
 internal_compile_panics=0
 loops_aborted=13

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.cranelift.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=5
 internal_compile_panics=0
 loops_aborted=2

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.dynasm.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=5
 internal_compile_panics=0
 loops_aborted=2

--- a/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
+++ b/pyre/bench/synth/raise_reg_unbound_jitstress.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=5
 internal_compile_panics=0
 loops_aborted=1

--- a/pyre/bench/synth/recursive_forced_frame_kept_stack.cranelift.jitstats
+++ b/pyre/bench/synth/recursive_forced_frame_kept_stack.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=1000
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/recursive_forced_frame_kept_stack.dynasm.jitstats
+++ b/pyre/bench/synth/recursive_forced_frame_kept_stack.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=1000
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/recursive_forced_frame_kept_stack.wasm.jitstats
+++ b/pyre/bench/synth/recursive_forced_frame_kept_stack.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=1000
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/set_hash_protocol.cranelift.jitstats
+++ b/pyre/bench/synth/set_hash_protocol.cranelift.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/set_hash_protocol.dynasm.jitstats
+++ b/pyre/bench/synth/set_hash_protocol.dynasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/bench/synth/set_hash_protocol.wasm.jitstats
+++ b/pyre/bench/synth/set_hash_protocol.wasm.jitstats
@@ -2,6 +2,7 @@ bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
+fbw_rolled_back_with_effects=1
 guard_failures=201
 internal_compile_panics=0
 loops_aborted=0

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -634,12 +634,28 @@ def _parse_jit_stats(snapshot):
 # expressed as a counter that must not rise off zero. A field absent from a
 # baseline reads as 0, so these gate from the first run without re-recording
 # anything.
+#
+# `fbw_rolled_back_with_effects` counts walks that ended UNCOMMITTED after a
+# residual had already run an irreversible effect — it wrote live heap outside
+# the journals, or it entered a Python frame. The store journal cannot undo
+# either, so the legacy replay the caller falls back to applies those effects a
+# second time. Upstream has no counterpart state: `_copy_data_from_miframe`
+# (blackhole.py) copies the register banks unconditionally and has no failing
+# path, so every abort there leaves a resumable image. Pyre's mirror is partial,
+# so an abort can arrive with no image to adopt, and the difference is a wrong
+# answer rather than a slow one — three such bugs (a locals-typed vable overlay,
+# an unpublished escape root stack, an unmodelled LOAD_SPECIAL) were each found
+# by reading this counter's population by hand. Gating it is what makes the
+# fourth one fail CI instead of surfacing as an intermittent asyncio failure.
+# Like `loops_aborted` it is not absolute: the baseline pins the instances that
+# exist today and a rise means a new one.
 JITSTATS_BADNESS_FIELDS = (
     "loops_aborted",
     "internal_compile_panics",
     "descr_set_absent",
     "descr_set_ambiguous",
     "descr_set_stale_absent",
+    "fbw_rolled_back_with_effects",
 )
 
 # The three count-valued counters, and what a move in either direction means:

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -77,6 +77,13 @@ pub(crate) fn classify_vstack_opcode(
         | Instruction::LoadName { .. }
         | Instruction::LoadDeref { .. }
         | Instruction::LoadLocals
+        // LOAD_BUILD_CLASS shares one codewriter arm and one liveness arm with
+        // LOAD_LOCALS (`(d + 1, d + 1)`), and the `abort_permanent` arm there is
+        // gated on `is_locals && !is_true_portal`, so it always lowers to the
+        // `load_build_class` residual plus `emit_pushvalue_ref!`.  Left
+        // unmodeled it killed the mirror at the first `class` statement in a
+        // loop-owning frame.
+        | Instruction::LoadBuildClass
         | Instruction::UnaryNegative
         | Instruction::UnaryNot
         | Instruction::UnaryInvert
@@ -95,6 +102,14 @@ pub(crate) fn classify_vstack_opcode(
         | Instruction::ToBool
         | Instruction::GetIter
         | Instruction::GetLen
+        // MATCH_SEQUENCE / MATCH_MAPPING / MATCH_KEYS peek their operands and
+        // push one result (liveness `(d + 1, d + 1)`), the same shape as GET_LEN
+        // and IMPORT_FROM in this group.  `match_keys` is bound MayForce — it
+        // runs the subject's `get` — so a replay of a region containing one can
+        // re-enter a Python frame.
+        | Instruction::MatchSequence
+        | Instruction::MatchMapping
+        | Instruction::MatchKeys
         | Instruction::LoadAttr { .. }
         | Instruction::ImportFrom { .. }
         | Instruction::BinaryOp { .. }
@@ -119,6 +134,14 @@ pub(crate) fn classify_vstack_opcode(
         | Instruction::ConvertValue { .. }
         | Instruction::BinarySlice
         | Instruction::ImportName { .. }
+        // MATCH_CLASS pops the keyword-names tuple, the class and the subject
+        // and pushes one result (liveness `(d - 2, d - 2)`), so the new TOS sits
+        // where the popped `subject` box was and `ResultToTos` overwrites it.
+        // `MultiResultFromShadow` would be wrong here: its pop point is
+        // `vstack_depth - 1`, which for a net-negative opcode is an EMPTY clear
+        // range, and both hole-fill helpers skip non-NONE slots — the stale
+        // `subject` box would survive as the result.
+        | Instruction::MatchClass { .. }
         // MAKE_FUNCTION pops the code object and pushes the built function
         // (net 0, `stack_effects` `(d, d)`).  The `make_function_value`
         // residual's Ref result reaches the new TOS through the operand-stack

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -833,6 +833,23 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
         let descr_set_absent = counter("pyre_jit_descr_set_absent", &mut missing);
         let descr_set_ambiguous = counter("pyre_jit_descr_set_ambiguous", &mut missing);
         let descr_set_stale_absent = counter("pyre_jit_descr_set_stale_absent", &mut missing);
+        // Walks that ended uncommitted after a residual had already run an
+        // irreversible effect. Reached through the slot-indexed `pyre_fbw_diag`
+        // export rather than a counter of its own; slot 1 is
+        // `pyre_jit_trace::trace::fbw_diag::ROLLED_BACK_WITH_EFFECTS`. It carries
+        // the same key the native backends print, because `_jit_stats_change`
+        // compares by name and a name only one backend emits gates nothing on
+        // the others.
+        let fbw_rolled_back_with_effects = match instance
+            .get_typed_func::<u32, u64>(&mut store, "pyre_fbw_diag")
+            .and_then(|f| f.call(&mut store, 1))
+        {
+            Ok(v) => v,
+            Err(_) => {
+                missing.push("pyre_fbw_diag");
+                0
+            }
+        };
         if !missing.is_empty() {
             eprintln!(
                 "pyre-wasm-runner: MAJIT_STATS is set but the module exports no {} — \
@@ -850,7 +867,8 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
              descr_set_resolved={descr_set_resolved} \
              descr_set_absent={descr_set_absent} \
              descr_set_ambiguous={descr_set_ambiguous} \
-             descr_set_stale_absent={descr_set_stale_absent}"
+             descr_set_stale_absent={descr_set_stale_absent} \
+             fbw_rolled_back_with_effects={fbw_rolled_back_with_effects}"
         );
     }
     let packed = match run_result {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -823,6 +823,16 @@ fn maybe_print_jit_stats() {
         pyre_jit::fbw_diag_counter(9),
         pyre_jit::fbw_diag_counter(10),
     );
+    // Walks that ended uncommitted after a residual had already run an
+    // irreversible effect: the store journal cannot undo a residual that wrote
+    // live heap or entered a Python frame, so the replay the caller falls back
+    // to applies those effects twice. `fbw_diag::ROLLED_BACK_WITH_EFFECTS`,
+    // which the wasm runner already exports; a nonzero value names a walk-abort
+    // variant that reaches `run_perfn_walk`'s epilogue without an adopt leg.
+    eprintln!(
+        "[jit-stats] fbw_rolled_back_with_effects={}",
+        pyre_jit::fbw_diag_counter(1),
+    );
     let stats = pyre_jit::eval::driver_pair().0.get_stats();
     eprintln!(
         "[jit-stats] loops_compiled={} bridges_compiled={} loops_aborted={} \


### PR DESCRIPTION
Follow-ups to #1051. Two changes: the rest of the walk mirror's unmodelled-opcode set,
and a CI gate for the whole double-execution bug class that #1051's three defects belonged
to.

## 1. `LOAD_BUILD_CLASS` and the `MATCH_*` opcodes in the walk operand-stack mirror

#1051's own follow-up list named `END_SEND`, `YIELD_VALUE`, `AEnter` and `AExit`. **That
list was wrong.** All four lower to `emit_abort_permanent!` (codewriter.rs:11641, :12920,
:12096), so the walk ends inside the opcode's own jitcode region and never crosses the
boundary that applies a `VstackOpClass`. Their classification is unreachable — and the
earlier A/B that modelled the four await opcodes and moved no counter in either arm was
structurally guaranteed, not workload-specific.

Diffing the 227-variant `Instruction` enum against the 97 arms `classify_vstack_opcode`
names leaves 130 fallthroughs, of which only 21 are ever emitted and 16 of those are that
permanent-abort family. The real remaining set is five opcodes, all `ResultToTos`:

| opcode | stack effect | why |
|---|---|---|
| `LOAD_BUILD_CLASS` | 0 → 1 | shares one codewriter arm with `LOAD_LOCALS` (codewriter.rs:12385); the `abort_permanent` arm there is gated `is_locals && !is_true_portal`, so it always lowers to the residual plus the push. A plain omission. |
| `MATCH_SEQUENCE` / `MATCH_MAPPING` / `MATCH_KEYS` | peek, push 1 | same liveness arm as `GET_LEN` / `IMPORT_FROM`, same `push_and_bump!` lowering |
| `MATCH_CLASS` | pop 3 → push 1 | `emit_popvalue_ref!` ×3 then `push_and_bump!` |

All five push through `push_and_bump!` → `emit_pushvalue_ref!` → `setarrayitem_vable_r`,
which stamps `vstack_last_ref` — exactly what `ResultToTos` consumes.

**`MultiResultFromShadow` is wrong for `MATCH_CLASS`.** Its pop point is hard-coded
`vstack_depth - 1`, so for a net-negative opcode the clear loop `pop_point..new_depth` is
an *empty* range; nothing is NONEd, both hole-fill helpers skip non-NONE slots, and the
popped `subject` survives as a stale box in the result slot. That class is only sound for
pop-1/push-N.

### Measurement

`PYRE_VSTACK_DIAG=1` over the 361 synth fixtures, run sequentially: 34462 reconcile
events, of which `class=Unmodeled` occurs in exactly two fixtures —
`match_sequence_of_class_patterns` (5× MatchSequence) and `slots_class_var_conflict`
(2× LoadBuildClass). Nothing else, on any fixture. Both go to **0**.

`match_sequence_of_class_patterns` also moves, identically on all three backends:

```
improved:  loops_aborted 5 -> 0,  loops_compiled 1 -> 2
regressed: bridges_compiled 0 -> 2, guard_failures 1 -> 401 (402 on wasm)
```

The mirror surviving `MATCH_SEQUENCE` is what lets that loop compile at all; the guard and
bridge rise is the documented consequence of a loop that now has compiled guards.

## 2. Gate the walks that roll back after an irreversible residual

`fbw_diag` slot 1 (`ROLLED_BACK_WITH_EFFECTS`, trace.rs) counts walks that ended
uncommitted with `effects > 0` — a residual had already written live heap or entered a
Python frame, neither of which the store journal undoes, so the legacy replay the caller
falls back to applies those effects twice. **All three defects in #1051 were found by
reading this counter's population by hand. The counter was computed on every walk and read
by no gate.**

It is now printed as `fbw_rolled_back_with_effects` and is a member of
`JITSTATS_BADNESS_FIELDS`.

The wasm runner already read the same slot — but printed it under a *different key*, inside
the `PYRE_WASM_JIT_STATS` block, which check.py does not set. `_jit_stats_change` compares
by field name and reads a field absent from a run as `0`, the healthy value, so that key
gated nothing. Moving it into the `MAJIT_STATS` block (which already refuses to report a
missing export as 0) is what surfaced half the population below.

### The population it names — 6 latent instances, recorded, unfixed

| fixture | dynasm | cranelift | wasm | abort variant |
|---|---|---|---|---|
| `raise_reg_unbound_jitstress` | 1 | 1 | 1 | `ResidualCallArgUnbound` |
| `recursive_forced_frame_kept_stack` | 1 | 1 | 1 | `CompileTracePending` |
| `set_hash_protocol` | 1 | 1 | 1 | `CompileTracePending`, bridge |
| `ca_bridge_multiframe_resume_double_call` | 0 | 0 | **1** | |
| `global_store_plain_dict_globals` | 0 | 0 | **1** | |
| `pickle_terminal_raise_resume` | 0 | 0 | **5** | |

Each count repeats identically across five runs, which is what makes them gateable. A
baseline field that no run emits reads as 0, so only these needed recording; the remaining
fixtures took the field at 0 with no other counter moving (audited: the only numeric
movement in the 42 touched `.jitstats` files is `match_sequence_of_class_patterns`).

Two things worth calling out:

- **`CompileTracePending` is not an undermodelling abort.** It is a routine control-flow
  outcome, and it reaches the walk-end epilogue uncommitted with effects already applied.
  This bug class is therefore not confined to the vstack mirror, which is where all three
  of #1051's defects lived.
- **Three rows are wasm-only**, which is a backend divergence in its own right.
  `ca_bridge_multiframe_resume_double_call` is named for the symptom.

## Verification

`pyre/check.py`: dynasm 379/379, cranelift 379/379, wasm 375/375, 3/3 backends, on this
base.

`test.test_asyncio`, which #1017 recorded as `TIMEOUT` ("stalls in about one arm in four"),
now runs to completion: 6 arms with `--full`, **5 PASS / 1 FAIL / 0 TIMEOUT**. The stall is
gone; the baseline entry is left alone in this PR because one arm still fails and recording
`PASS` would make the gate flaky.

## Still open

- `!ctx.trace_ctx.is_bridge_trace` at residual_call.rs:3081 still skips the vable-escape
  blackhole latch entirely for a bridge walk. Measured population on the asyncio harness:
  of 18 forced escapes, **11** are `bridge=true bh=true fs=0 subwalk=false` — the largest
  group, larger than the 5 non-bridge shapes that do take the latch. The conjunct entered
  as one of seven in a default-off rollout gate and is the last of that set never
  individually argued; the adopt machinery contains no bridge term. The reason not to lift
  it blind: a bridge shape that passes the pre-drive gates and then loses frame identity
  hits `.expect(...)` at trace.rs:2572/2616, a process abort rather than a free decline.
  `set_hash_protocol` (bridge, in the table above) is the deterministic test — its counter
  should go 1 → 0.
- The multi-frame arm at residual_call.rs:3142 still hardcodes `publish_root_stack: false`
  and gates on `writes_live_heap && odometer_unchanged`, the two gates the comment directly
  above argues against for its sibling. An adversarial review could not establish that this
  arm actually reaches a root-frame `getarrayitem_vable_r`, so it needs a reachability tally
  before anything is changed.
