### PR TITLE
majit: open the retrace path, and detect a stale LLBC before it ships wrong field offsets

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8204,21 +8204,31 @@ impl CraneliftBackend {
     /// backend's `gc_rewriter`: `x86/regalloc.py:187` calls
     /// `cpu.gc_ll_descr.rewrite_assembler` straight through and `gc.py:109-112`
     /// defines it on the base `GcLLDescription`, so the pass runs even for a
-    /// configuration with no nursery and no write barrier. Only four fields are
-    /// collector-derived; with no collector they take the upstream base values
+    /// configuration with no nursery and no write barrier. Four fields come from
+    /// the collector and two more take their boehm values when there is none
+    /// (gc.py:151-162); with no collector they take the upstream base values
     /// (`can_use_nursery_malloc -> False`, gc.py:81-82, spelled
     /// `max_nursery_size: 0`; `write_barrier_descr = None`, gc.py:156).
     fn gc_rewriter(&self) -> GcRewriterImpl {
+        let collector = with_cranelift_gc(|gc| {
+            (
+                gc.nursery_free_addr(),
+                gc.nursery_top_addr(),
+                gc.max_nursery_object_size(),
+                gc.get_write_barrier_descr(),
+            )
+        });
+        // gc.py:653-664 `get_ll_description(gcdescr)`: `gcdescr is None`
+        // selects `GcLLDescr_boehm`, so upstream has no "no collector" state
+        // at all — the configuration with none installed IS boehm, and
+        // gc.py:151-162 is its field block. Two of the four collector-sourced
+        // values already take the base-class answer here
+        // (`can_use_nursery_malloc -> False`, gc.py:81-82, spelled
+        // `max_nursery_size: 0`; `write_barrier_descr = None`, gc.py:156);
+        // this flag carries the other two, below.
+        let is_boehm = collector.is_none();
         let (nursery_free_addr, nursery_top_addr, max_nursery_size, wb_descr) =
-            with_cranelift_gc(|gc| {
-                (
-                    gc.nursery_free_addr(),
-                    gc.nursery_top_addr(),
-                    gc.max_nursery_object_size(),
-                    gc.get_write_barrier_descr(),
-                )
-            })
-            .unwrap_or((0, 0, 0, None));
+            collector.unwrap_or((0, 0, 0, None));
         GcRewriterImpl {
             nursery_free_addr,
             nursery_top_addr,
@@ -8243,11 +8253,15 @@ impl CraneliftBackend {
             // at the IR level), so the rewriter takes the single-LEA
             // path (rewrite.py:1083-1088).
             supports_load_effective_address: true,
-            // incminimark.py:211 `malloc_zero_filled = False`:
-            // clear_gc_fields / clear_varsize_gc_fields emit only the
-            // per-object GC-pointer initialization required by
-            // rewrite.py:498-535.
-            malloc_zero_filled: false,
+            // incminimark.py:211 `malloc_zero_filled = False` when a
+            // collector answers: clear_gc_fields / clear_varsize_gc_fields
+            // emit the per-object GC-pointer initialization
+            // rewrite.py:498-535 requires. With none installed the value is
+            // gc.py:153 `GcLLDescr_boehm.malloc_zero_filled = True` and both
+            // are inert (rewrite.py:499-500, :521-522), which is what this
+            // configuration's allocation actually does: every malloc reaches
+            // a raw fallback built on `libc::calloc`.
+            malloc_zero_filled: is_boehm,
             // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
             // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
             memcpy_fn: majit_ir::memcpy_fn_addr(),
@@ -8271,12 +8285,15 @@ impl CraneliftBackend {
             // Some unconditionally.
             fielddescr_vtable: Some(majit_ir::make_vtable_field_descr()),
             // gc.py:394 `self.fielddescr_tid = get_field_descr(self,
-            // self.GCClass.HDR, 'tid')` — framework GC.  pyre's GC is
-            // always framework-style (incminimark-shaped), so install
-            // Some unconditionally; the helper translates the descr's
-            // offset by `-HDR_SIZE` because pyre's HDR sits before the
-            // object pointer.
-            fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
+            // self.GCClass.HDR, 'tid')` — framework GC; the helper
+            // translates the descr's offset by `-HDR_SIZE` because pyre's HDR
+            // sits before the object pointer. gc.py:157
+            // `GcLLDescr_boehm.fielddescr_tid = None` makes
+            // gen_initialize_tid (rewrite.py:914-918) emit nothing, which is
+            // right with no collector: the raw malloc fallbacks stamp the
+            // header themselves, so a second tid GC_STORE has no producer to
+            // agree with.
+            fielddescr_tid: (!is_boehm).then(majit_ir::make_tid_field_descr),
             malloc_array_fn: gc_malloc_array_helper as *const () as i64,
             malloc_array_nonstandard_fn: gc_malloc_array_nonstandard_helper as *const () as i64,
             malloc_array_oldgen_fn: gc_malloc_array_oldgen_helper as *const () as i64,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3408,11 +3408,13 @@ fn call_assembler_guard_failure_inner(
     // bridge has just returned another guard failure, `fail_descr_ptr` is
     // the bridge descriptor, not necessarily `target.fail_descrs[fail_index]`.
     let fail_descr = fail_descr_ref;
-    // pyjitpl.py:2897-2899 parity: recover the owning Arc<JitCellToken>
+    // pyjitpl.py:2921-2923 parity: recover the owning Arc<JitCellToken>
     // identity from the descr.  When the weakref is dead (memmgr-evicted
     // JCT — "should be rare" per upstream), `compile.giveup()` raises
-    // `SwitchToBlackhole(ABORT_BRIDGE)` (compile.py:27-29), caught at
-    // pyjitpl.py:2906-2907, falling through to blackhole resume.  Pyre
+    // `SwitchToBlackhole(ABORT_BRIDGE)` (compile.py:27-29).  That raise sits
+    // ABOVE the `try:` at pyjitpl.py:2926, so the `except SwitchToBlackhole`
+    // at :2930-2931 does NOT catch it and the `finally:` at :2932-2935 does
+    // not run: it leaves `handle_guard_failure` with nothing traced.  Pyre
     // mirrors this by gating bridge tracing on `Some(jct)` and passing
     // `green_key=0` to the blackhole callback so it derives the key from
     // the deadframe's pyframe pointer (call_jit.rs:1694-1704); never

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -676,11 +676,13 @@ fn handle_fail_resume_guard(
         raw_values.push(unsafe { llmodel::get_int_value_direct(frame_ptr, slot) as i64 });
     }
 
-    // pyjitpl.py:2897-2899 parity: recover the owning Arc<JitCellToken>
+    // pyjitpl.py:2921-2923 parity: recover the owning Arc<JitCellToken>
     // identity from the descr.  When the weakref is dead (memmgr-evicted
     // JCT — "should be rare" per upstream), `compile.giveup()` raises
-    // `SwitchToBlackhole(ABORT_BRIDGE)` (compile.py:27-29), caught at
-    // pyjitpl.py:2906-2907, falling through to blackhole resume.  Pyre
+    // `SwitchToBlackhole(ABORT_BRIDGE)` (compile.py:27-29).  That raise sits
+    // ABOVE the `try:` at pyjitpl.py:2926, so the `except SwitchToBlackhole`
+    // at :2930-2931 does NOT catch it and the `finally:` at :2932-2935 does
+    // not run: it leaves `handle_guard_failure` with nothing traced.  Pyre
     // mirrors this by gating bridge tracing on `Some(jct)` and passing
     // `green_key=0` to the blackhole callback so it derives the key from
     // the deadframe's pyframe pointer (call_jit.rs:1694-1704); never

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1628,7 +1628,8 @@ impl DynasmBackend {
     /// backend whose only surviving load op wants a *constant* offset
     /// (`aarch64/regalloc.py:535` `op.getarg(1).getint()`).
     ///
-    /// Exactly four fields come from the collector. With none installed
+    /// Four fields come from the collector and two more take their boehm values
+    /// when there is none (gc.py:151-162). With none installed
     /// they take upstream's base-class values: `can_use_nursery_malloc`
     /// returns False (gc.py:81-82, inherited by `GcLLDescr_boehm`), spelled
     /// here as `max_nursery_size: 0`, and `write_barrier_descr = None`
@@ -1642,16 +1643,25 @@ impl DynasmBackend {
     /// already been consulted), and emitting barriers for a program that
     /// has no collector would call through an absent helper.
     fn gc_rewriter(&self) -> majit_gc::rewrite::GcRewriterImpl {
+        let collector = with_dynasm_active_gc(|gc| {
+            (
+                gc.nursery_free_addr(),
+                gc.nursery_top_addr(),
+                gc.max_nursery_object_size(),
+                gc.get_write_barrier_descr(),
+            )
+        });
+        // gc.py:653-664 `get_ll_description(gcdescr)`: `gcdescr is None`
+        // selects `GcLLDescr_boehm`, so upstream has no "no collector" state
+        // at all — the configuration with none installed IS boehm, and
+        // gc.py:151-162 is its field block. Two of the four collector-sourced
+        // values already take the base-class answer here
+        // (`can_use_nursery_malloc -> False`, gc.py:81-82, spelled
+        // `max_nursery_size: 0`; `write_barrier_descr = None`, gc.py:156);
+        // this flag carries the other two, below.
+        let is_boehm = collector.is_none();
         let (nursery_free_addr, nursery_top_addr, max_nursery_size, wb_descr) =
-            with_dynasm_active_gc(|gc| {
-                (
-                    gc.nursery_free_addr(),
-                    gc.nursery_top_addr(),
-                    gc.max_nursery_object_size(),
-                    gc.get_write_barrier_descr(),
-                )
-            })
-            .unwrap_or((0, 0, 0, None));
+            collector.unwrap_or((0, 0, 0, None));
         majit_gc::rewrite::GcRewriterImpl {
             nursery_free_addr,
             nursery_top_addr,
@@ -1683,11 +1693,15 @@ impl DynasmBackend {
             // even though the aarch64 backend has a native
             // `genop_load_effective_address` lowering.
             supports_load_effective_address: supports_load_effective_address(),
-            // incminimark.py:211 `malloc_zero_filled = False`:
-            // clear_gc_fields / clear_varsize_gc_fields emit only the
-            // per-object GC-pointer initialization required by
-            // rewrite.py:498-535.
-            malloc_zero_filled: false,
+            // incminimark.py:211 `malloc_zero_filled = False` when a
+            // collector answers: clear_gc_fields / clear_varsize_gc_fields
+            // emit the per-object GC-pointer initialization
+            // rewrite.py:498-535 requires. With none installed the value is
+            // gc.py:153 `GcLLDescr_boehm.malloc_zero_filled = True` and both
+            // are inert (rewrite.py:499-500, :521-522), which is what this
+            // configuration's allocation actually does: every malloc reaches
+            // a raw fallback built on `libc::calloc`.
+            malloc_zero_filled: is_boehm,
             // gc.py:39 `self.memcpy_fn = memcpy_fn` cast through
             // `cast_ptr_to_adr` + `cast_adr_to_int` (rewrite.py:1046-1047).
             memcpy_fn: majit_ir::memcpy_fn_addr(),
@@ -1714,8 +1728,13 @@ impl DynasmBackend {
             // self.GCClass.HDR, 'tid')` — framework GC.  pyre's GC
             // is always framework-style; gen_initialize_tid translates
             // the descr's offset by `-HDR_SIZE` because pyre's HDR
-            // sits before the object pointer.
-            fielddescr_tid: Some(majit_ir::make_tid_field_descr()),
+            // sits before the object pointer. gc.py:157
+            // `GcLLDescr_boehm.fielddescr_tid = None` makes
+            // gen_initialize_tid (rewrite.py:914-918) emit nothing, which is
+            // right with no collector: the raw malloc fallbacks stamp the
+            // header themselves, so a second tid GC_STORE has no producer to
+            // agree with.
+            fielddescr_tid: (!is_boehm).then(majit_ir::make_tid_field_descr),
             malloc_array_fn: dynasm_malloc_array as *const () as i64,
             malloc_array_nonstandard_fn: dynasm_malloc_array_nonstandard as *const () as i64,
             malloc_array_oldgen_fn: dynasm_malloc_array_oldgen as *const () as i64,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4841,11 +4841,22 @@ fn find_jump_target_label_index(ops: &[Op], jump: &Op) -> Option<usize> {
 }
 
 fn find_loop_label_index(ops: &[Op]) -> Option<usize> {
-    ops.iter()
-        .rev()
-        .find(|op| op.opcode == OpCode::Jump)
-        .and_then(|jump| find_jump_target_label_index(ops, jump))
-        .or_else(|| ops.iter().rposition(|op| op.opcode == OpCode::Label))
+    match ops.iter().rev().find(|op| op.opcode == OpCode::Jump) {
+        // x86/assembler.py:2463 `if target_token in
+        // self.target_tokens_currently_compiling` — the TOKEN decides. A JUMP
+        // that names a token this compilation does not define is upstream's
+        // `else` arm at :2467 (`JMP(imm(target))`, an absolute jump into
+        // another trace), even when this trace defines labels of its own.
+        // That is exactly a `jump_to_preamble` retrace: compile.py:381 keeps
+        // the retrace's own label_op in the middle while unroll.py:238-242
+        // retargets the JUMP at the ORIGINAL loop's start descr. Answering
+        // with the trailing label here would turn that JUMP into a back-edge
+        // to a label it does not name.
+        Some(jump) if jump.has_descr() => find_jump_target_label_index(ops, jump),
+        // No descr to decide with (legacy IR whose JUMP carries none), or no
+        // JUMP at all: keep the historical last-LABEL answer.
+        _ => ops.iter().rposition(|op| op.opcode == OpCode::Label),
+    }
 }
 
 fn find_label_args(ops: &[Op], jump: &Op) -> Vec<OpRef> {

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2214,7 +2214,18 @@ impl majit_backend::Backend for WasmBackend {
                 );
             }
         } else {
-            let publishable = label_descrs.first().is_some_and(|&id| id != 0)
+            // A LABEL with real work before it is not reachable through the plain
+            // entry: key 0 runs the function from its first op, so a bridge chaining
+            // there would re-run that work. Before the descr-strict dispatch every
+            // such trace was `is_resumable_peeled` and never reached this branch; a
+            // `jump_to_preamble` retrace (own LABEL, foreign closing JUMP) is not, so
+            // state the assumption the comment below already relies on.
+            let first_label_at_entry = ops
+                .iter()
+                .position(|op| op.opcode == majit_ir::OpCode::Label)
+                == Some(0);
+            let publishable = first_label_at_entry
+                && label_descrs.first().is_some_and(|&id| id != 0)
                 && label_num_args.first() == Some(&inputargs.len());
             if !publishable {
                 diag_bump(21);

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5250,10 +5250,22 @@ impl TraceCtx {
         // by shape length instead of asserting — a shape mismatch means
         // the merge point was seeded under a different frame layout and
         // should not match.
-        self.current_merge_points
-            .iter()
-            .rev()
-            .any(|mp| mp.green_key == key && mp.green_boxes.len() == live_args_len)
+        // Same reverse scan, same short-circuit; the loop form exists only so
+        // the SHAPE REJECTION can be tallied. `pyjitpl.py:3020 assert
+        // len(original_boxes) == len(live_arg_boxes)` asserts here — upstream
+        // never filters. Slot 54 counts every same-green-key merge point this
+        // rule discards, so a corpus reading 0 can promote the filter to a
+        // `debug_assert!`.
+        for mp in self.current_merge_points.iter().rev() {
+            if mp.green_key != key {
+                continue;
+            }
+            if mp.green_boxes.len() == live_args_len {
+                return true;
+            }
+            crate::mc_diag_bump(54);
+        }
+        false
     }
 
     /// pyjitpl.py:3029-3030 — record a loop header visit with position
@@ -5365,10 +5377,22 @@ impl TraceCtx {
     /// greens (nothing to compare against, so the session's own header is
     /// the only candidate).
     pub fn close_header_pc(&self) -> usize {
-        self.close_greens
+        match self
+            .close_greens
             .as_ref()
             .and_then(|greens| greens.0.first().copied())
-            .map_or(self.header_pc, |pc| pc as usize)
+        {
+            Some(pc) => pc as usize,
+            None => {
+                // `pyjitpl.py:3021 same_greenkey(original_boxes,
+                // live_arg_boxes, num_green_args)` always compares the actual
+                // closing boxes; upstream has no header-pc fallback. Slot 56
+                // counts every firing so a corpus reading 0 can promote this
+                // fallback to a `debug_assert!`.
+                crate::mc_diag_bump(56);
+                self.header_pc
+            }
+        }
     }
 
     pub fn get_merge_point_at(&self, key: u64, header_pc: usize) -> Option<&MergePoint> {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2772,6 +2772,19 @@ impl<S: JitState> JitDriver<S> {
                     // (`RetraceNeeded` / `Declined`) that second set lands after
                     // `compile_trace` sampled `potential_retrace_position`, moving
                     // every later trace position off by the number of rewrites.
+                    // `reached_loop_header` (pyjitpl.py:2974-2989) runs on a live
+                    // MIFrame and builds `live_arg_boxes` from `greenboxes +
+                    // redboxes`; upstream has no "no symbolic state" arm, so the
+                    // `None` fallback below stands in for an invariant rather than
+                    // for a real state. It holds by construction: `merge_point`
+                    // returns early when `self.sym.is_none()`, its walk loop head
+                    // re-establishes `Some` on every iteration, and `trace_fn`
+                    // receives `&mut S::Sym` — never `&mut self` — so nothing
+                    // between the loop head and here can write the `Option`.
+                    debug_assert!(
+                        self.sym.is_some(),
+                        "reached_loop_header: sym must be live on the CloseLoop arm",
+                    );
                     let live_arg_boxes: Vec<OpRef> = match self.sym.as_ref() {
                         Some(sym) => {
                             // pyjitpl.py:2982-2989: carry virtualizable_boxes[:-1]
@@ -3038,6 +3051,19 @@ impl<S: JitState> JitDriver<S> {
                             .trace_ctx()
                             .and_then(|ctx| ctx.close_green_key_hash())
                             .or_else(|| self.current_trace_green_key());
+                        // The cell token a close resolves is `jump_op.getdescr()`
+                        // upstream (unroll.py:196 `cell_token =
+                        // jump_op.getdescr()`, :321-322 `jitcelltoken =
+                        // jump_op.getdescr()`), an object identity that cannot
+                        // miss, so the `unwrap_or(bridge_key)` below stands in for
+                        // an invariant. It holds: `current_trace_green_key()` is
+                        // `trace_ctx().map(|c| c.green_key())` and `merge_point`
+                        // only dispatches while `is_tracing()`, so the `or_else`
+                        // leg always answers.
+                        debug_assert!(
+                            resolved_key.is_some(),
+                            "reached_loop_header: bridge close must resolve a target green key",
+                        );
                         if crate::closedbg_enabled() {
                             eprintln!(
                                 "@@@CLOSE BRIDGE-TARGET close_greens={close_greens:?} resolved_key={} origin_key={}",

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -597,6 +597,10 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
     let _ = STACK_ALMOST_FULL_FN.set(f);
 }
 
+/// Number of `MC_DIAG` slots. Declared once so the counter array and
+/// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
+pub const MC_DIAG_SLOTS: usize = 57;
+
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
 /// entered, 1 = declined_bridge_guards short-circuit, 2 = descr_addr==0 skip,
@@ -652,17 +656,34 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 /// 50 = `close_bridge` declined while closing a bridge, 51 = bridge close found
 /// no compiled target, 52 = abort after a declined bridge attempt, 53 =
 /// `compile_trace` called `compile_bridge` and it returned false.
-pub static MC_DIAG: [std::sync::atomic::AtomicU64; 54] = {
+///
+/// 54-56 are the merge-point path's three silent recovery rules, each counted
+/// where it FIRES rather than where it is called, so a slot reading 0 over the
+/// corpus is the evidence needed to replace the rule with a `debug_assert!`:
+/// 54 = `has_merge_point_with_shape_assert` rejected a SAME-green-key merge
+/// point because its `green_boxes` length differed from `live_args_len`, where
+/// `pyjitpl.py:3020 assert len(original_boxes) == len(live_arg_boxes)` asserts
+/// instead of filtering; 55 = `register_retrace_merge_point` declined to
+/// register because some jump arg carried no intrinsic type, where
+/// `pyjitpl.py:3059-3060 self.current_merge_points.append((live_arg_boxes,
+/// start))` appends unconditionally; 56 = `close_header_pc` fell back to
+/// `self.header_pc` because the walk recorded no close greens, where
+/// `pyjitpl.py:3021 same_greenkey(original_boxes, live_arg_boxes,
+/// num_green_args)` always compares the actual closing boxes. 55 and 56 are
+/// gated behind a non-zero `retrace_limit` (default 0, `warmstate.rs`
+/// DEFAULT_RETRACE_LIMIT / `rpython/rlib/jit.py:595`), so a default-parameter
+/// run reading 0 on them proves nothing.
+pub static MC_DIAG: [std::sync::atomic::AtomicU64; MC_DIAG_SLOTS] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
         Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
 /// Short label per [`MC_DIAG`] slot, in index order, so a tally cannot be added
 /// without naming it. Readers join these with the counter values.
-pub const MC_DIAG_LABELS: [&str; 54] = [
+pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     "mc_entered",
     "decl_shortcircuit",
     "descr0_skip",
@@ -717,6 +738,9 @@ pub const MC_DIAG_LABELS: [&str; 54] = [
     "bridge_no_targets_close",
     "abort_after_declined",
     "ct_compile_bridge_false",
+    "mp_shape_filtered",
+    "retrace_mp_untyped",
+    "close_hdr_fallback",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -599,7 +599,7 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 
 /// Number of `MC_DIAG` slots. Declared once so the counter array and
 /// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
-pub const MC_DIAG_SLOTS: usize = 57;
+pub const MC_DIAG_SLOTS: usize = 58;
 
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
@@ -673,11 +673,16 @@ pub const MC_DIAG_SLOTS: usize = 57;
 /// gated behind a non-zero `retrace_limit` (default 0, `warmstate.rs`
 /// DEFAULT_RETRACE_LIMIT / `rpython/rlib/jit.py:595`), so a default-parameter
 /// run reading 0 on them proves nothing.
+///
+/// 57 = the unroll pass abandoned a retrace because `jump_to_preamble` would
+/// have landed a body JUMP on a preamble LABEL of a different arity
+/// (`compile.py:334`). Non-zero means a retrace was built and discarded; see
+/// the preamble-arity item.
 pub static MC_DIAG: [std::sync::atomic::AtomicU64; MC_DIAG_SLOTS] = {
     const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
     [
         Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
-        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
+        Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z, Z,
     ]
 };
 
@@ -741,6 +746,7 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     "mp_shape_filtered",
     "retrace_mp_untyped",
     "close_hdr_fallback",
+    "retrace_arity_giveup",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1832,21 +1832,53 @@ impl UnrollOptimizer {
             // unroll.py:170-171: jump_to_preamble — body JUMP → preamble Label
             //
             // force_box_for_end_of_preamble (unroll.py:126-127) has already run
-            // over the body JUMP's args above, so they carry the types the
-            // preamble's Label declares and the retarget below is a plain
-            // send_extra_operation.
+            // over the body JUMP's args above, so each arg is a forced box rather
+            // than a virtual. That is a per-ARG property and says nothing about the
+            // arg LIST matching the preamble Label's — on a retrace it does not, and
+            // the arity check below is what catches it.
             let preamble_target = self
                 .target_tokens
                 .first()
                 .expect("preamble target token must exist before jump_to_preamble")
                 .clone();
             let preamble_arity = exported_renamed_inputargs.len();
+            let body_jump_arity = body_terminal_op.as_ref().map(|j| j.num_args()).unwrap_or(0);
             if crate::majit_log_enabled() {
-                let body_jump_arity = body_terminal_op.as_ref().map(|j| j.num_args()).unwrap_or(0);
                 eprintln!(
                     "[jit] jump_to_preamble: body_jump_args={} preamble_arity={} start_label_args={:?}",
                     body_jump_arity, preamble_arity, exported_renamed_inputargs,
                 );
+            }
+            // `compile.py:334 assert jump.numargs() == label.numargs()`.
+            // Upstream can assert because its `target_tokens[0]` is the start
+            // label whose args ARE `loop.inputargs` — the same loop-carried
+            // positions the body JUMP carries — so `unroll.py:238-242`'s
+            // arg-preserving retarget is sound by construction.
+            //
+            // A pyre RETRACE has no start label of its own (see
+            // `emit_start_label`), so `target_tokens[0]` is the ORIGINAL loop's
+            // start label: the portal's entry contract, one boxed Ref per frame
+            // local. The optimized loop-carried set is wider and mixed, so the
+            // retarget can land N values on an M-slot label and the target then
+            // reads a raw integer as a Ref — measured as EXC_BAD_ACCESS on the
+            // loop counter inside GuardClass.
+            //
+            // Give up, which is `unroll.py:242`'s own escape (it lets
+            // `send_extra_operation` raise `InvalidLoop`) and lands on
+            // `compile.py:368-371`'s cancel. Scoped to the retrace: a
+            // `compile_loop` unroll keeps its start label in the SAME artifact,
+            // so its preamble target is local and this mismatch cannot arise.
+            if !self.emit_start_label && body_jump_arity != preamble_arity {
+                crate::mc_diag_bump(57);
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] jump_to_preamble giveup: body JUMP args {body_jump_arity} \
+                         != preamble LABEL args {preamble_arity}"
+                    );
+                }
+                return Err(crate::optimize::InvalidLoop(
+                    "jump_to_preamble: body JUMP arity != preamble LABEL arity",
+                ));
             }
             if let Some(mut end_jump) = body_terminal_op {
                 end_jump.setdescr(preamble_target.as_jump_target_descr());

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -1467,6 +1467,17 @@ impl VirtualState {
         // a Virtual/VArray/VStruct, the comparison is handled by the
         // VirtualStateInfo._generate_guards path (the main match below),
         // which does struct-level field comparison — not type-tag matching.
+        //
+        // This gate is ALSO what rejects a Virtual / VArray / VStruct /
+        // VArrayStruct incoming against a NotVirtual `expected`, the
+        // LEVEL_CONSTANT one included: `info_type_matches`
+        // (virtualstate.rs:103-145) has no arm accepting a Virtual* incoming
+        // for any expected type — Int, Float and Ref all fall to their
+        // `_ => false` catch-alls. That is the port of virtualstate.py:392-394
+        // for the Int/Float constant leaves and of virtualstate.py:525-529 for
+        // the Ptr leaf. The `(Constant(_), _)` arm below is therefore never
+        // entered with a virtual incoming; do NOT add a separate
+        // `other.is_virtual()` arm there — it would be dead code.
         if !expected_info.is_virtual() {
             if let Some(expected_type) = expected_info.info_type() {
                 if !info_type_matches(expected_type, incoming_info) {
@@ -1497,7 +1508,24 @@ impl VirtualState {
             (VirtualStateInfo::Unknown(_), _) => Ok(()),
 
             // ── Constant target ── (virtualstate.py:396-405)
+            //
+            //     if other.level == LEVEL_CONSTANT:
+            //         if self.constbox.same_constant(other.constbox):
+            //             return
+            //         raise VirtualStatesCantMatch("different constants")
+            //
+            // virtualstate.py:396-399 settles a LEVEL_CONSTANT incoming
+            // STATICALLY, ahead of the runtime-box test at :400-405: two
+            // different constants can never match, whatever value the runtime
+            // box happens to carry at the jump point. Falling through to the
+            // runtime test instead would emit a GUARD_VALUE against a target
+            // constant the incoming state already contradicts.
+            // `Value`'s PartialEq is the `same_constant` port
+            // (majit-ir/src/value.rs:84-95 — bitwise for floats,
+            // history.py:292).
             (VirtualStateInfo::Constant(a), VirtualStateInfo::Constant(b)) if a == b => Ok(()),
+            // virtualstate.py:399 `raise VirtualStatesCantMatch("different constants")`.
+            (VirtualStateInfo::Constant(_), VirtualStateInfo::Constant(_)) => Err(()),
             (VirtualStateInfo::Constant(val), _) => {
                 // virtualstate.py:400-405: emit GUARD_VALUE only when the
                 // concrete runtime box already equals the target constant.
@@ -3109,6 +3137,54 @@ mod tests {
         assert!(
             expected
                 .generate_guards(&incoming, &boxes, &[mismatching_runtime], &mut ctx, false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_differing_constants_reject_before_the_runtime_box_test() {
+        // virtualstate.py:396-399: a LEVEL_CONSTANT incoming is settled
+        // statically — `raise VirtualStatesCantMatch("different constants")` —
+        // and never reaches the runtime-box GUARD_VALUE path at :400-405.
+        // Without the explicit arm a runtime box that happens to equal the
+        // TARGET constant makes pyre emit a GUARD_VALUE where upstream reports
+        // CantMatch.
+        let expected = VirtualState::new(vec![VirtualStateInfo::Constant(Value::Int(7))]);
+        let incoming = VirtualState::new(vec![VirtualStateInfo::Constant(Value::Int(8))]);
+        let boxes = vec![OpRef::int_op(10)];
+
+        let mut ctx = OptContext::new(128);
+        let runtime = ctx.make_constant_int(7);
+        assert!(
+            expected
+                .generate_guards(&incoming, &boxes, &[runtime], &mut ctx, false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn test_constant_target_rejects_virtual_incoming() {
+        // virtualstate.py:392-394 (Int/Float leaves) / :525-529 (Ptr leaf): a
+        // virtual incoming can never satisfy a NotVirtual expected. In pyre the
+        // rejection is performed by the `info_type_matches` gate
+        // (virtualstate.rs:1470-1476) before the Constant match arm is reached;
+        // this test pins that gate so the arm stays unreachable for virtuals.
+        let mut ctx = OptContext::new(128);
+        let descr = test_descr(1);
+        let expected =
+            VirtualState::new(vec![VirtualStateInfo::Constant(Value::Ref(GcRef(0x1234)))]);
+        let incoming = VirtualState::new(vec![VirtualStateInfo::VArray {
+            descr,
+            items: vec![VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
+                Value::Int(1),
+            ))],
+            lenbound: None,
+        }]);
+        let boxes = vec![OpRef::ref_op(10)];
+        let runtime = ctx.make_constant_ref(GcRef(0x1234));
+        assert!(
+            expected
+                .generate_guards(&incoming, &boxes, &[runtime], &mut ctx, false)
                 .is_err()
         );
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6956,6 +6956,14 @@ impl<M: Clone> MetaInterp<M> {
             .filter_map(|&op| op.ty().map(|ty| crate::trace_ctx::GreenBox::new(op, ty)))
             .collect();
         if green_boxes.len() != jump_args.len() {
+            // `pyjitpl.py:3059-3060 self.current_merge_points.append(
+            // (live_arg_boxes, start))` appends unconditionally. This decline
+            // is a pyre stand-in and it ALSO suppresses the
+            // `keep_tracing_after_close` write below, so the trace is
+            // abandoned without appearing in `loops_aborted`. Slot 55 counts
+            // every firing so a corpus (run with a non-zero `retrace_limit`)
+            // reading 0 can promote it to a `debug_assert!`.
+            crate::mc_diag_bump(55);
             return;
         }
         let key = ctx.green_key;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7702,41 +7702,17 @@ impl<M: Clone> MetaInterp<M> {
         // `jump_to_existing_trace`, and the foreign-target fallback at
         // `unroll.rs:1797-1810` all reach it.
         //
-        // It is declined here for a BACKEND reason, and only one backend:
-        // `majit-backend-wasm` decides local-vs-external JUMP on `has_loop`
-        // (`codegen.rs:1983`), not on whether the descr resolves. A retrace has
-        // its own LABEL, so `find_loop_label_index`'s
-        // `.or_else(rposition(Label))` fallback (`codegen.rs:4785-4791`) makes
-        // `has_loop` true, the external arm at `codegen.rs:2195` is skipped,
-        // and `find_label_args` (`codegen.rs:4806-4810`) falls back to the
-        // trailing label — silently turning the preamble JUMP into a back-edge
-        // to this trace's own label. Cranelift has no such gap
-        // (`compiler.rs:13247-13302` resolves by descr and emits an external
-        // exit). Until the wasm dispatch is descr-driven, take
-        // `compile.py:368-371`'s cancel shape: declining costs the guard its
-        // retrace, compiling it would miscompile on wasm.
-        let closes_on_own_label = {
-            let jump_descr = combined_ops
-                .iter()
-                .rev()
-                .find(|op| op.opcode == OpCode::Jump)
-                .and_then(|op| op.getdescr())
-                .map(|descr| descr.index());
-            let label_descr = combined_ops
-                .iter()
-                .rev()
-                .find(|op| op.opcode == OpCode::Label)
-                .and_then(|op| op.getdescr())
-                .map(|descr| descr.index());
-            jump_descr.is_some() && jump_descr == label_descr
-        };
-        if !closes_on_own_label {
-            crate::debug::log_one(
-                "jit-abort",
-                "compile_retrace: closing JUMP does not target this trace's label",
-            );
-            return false;
-        }
+        // Both outcomes are compiled, as upstream does: `compile.py:341-394
+        // compile_retrace` declines only on `InvalidLoop` (:368-371), and both
+        // `jump_to_preamble` sites return a full `UnrollInfo`.
+        //
+        // This used to decline the retargeted outcome for a single backend's sake.
+        // All three now decide local-vs-external on the TOKEN, which is
+        // `x86/assembler.py:2461-2467 closing_jump`'s own test
+        // (`target_token in self.target_tokens_currently_compiling`): dynasm at
+        // `aarch64/assembler.rs:3129` / `x86/assembler.rs:4126`, cranelift at
+        // `compiler.rs:13244-13310`, and wasm at `codegen.rs find_loop_label_index`
+        // since the descr-strict dispatch landed.
 
         let num_combined_ops = combined_ops.len();
         let has_guard = combined_ops.iter().any(|op| op.opcode.is_guard());

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11758,26 +11758,39 @@ impl<M: Clone> MetaInterp<M> {
         }
         let cell_token_key = self.bridge_cell_token_key(green_key, jump_target_key);
 
-        // `pyjitpl.py:2897-2899` parity:
+        // `pyjitpl.py:2921-2923`:
         //   self.resumekey_original_loop_token =
         //       resumedescr.rd_loop_token.loop_token_wref()
         //   if self.resumekey_original_loop_token is None:
-        //       raise compile.giveup()  # should be rare
-        // `compile.giveup()` (`compile.py:27-29`) raises
-        // `SwitchToBlackhole(ABORT_BRIDGE)`, which RPython catches at
-        // `pyjitpl.py:2906-2907` and falls through to blackhole resume.
-        // Pyre's `compile_bridge` mirrors that abort by returning `false`;
-        // the caller (`compile_trace`) maps `false` to
-        // `CompileOutcome::Cancelled`, the same control-flow blackhole
-        // resume observes.  The weakref-dead path is "should be rare" per
-        // upstream, but structurally required — never panic.
+        //       raise compile.giveup() # should be rare
+        //
+        // That check runs at the TOP of `handle_guard_failure`, before
+        // `create_history` (`pyjitpl.py:2925`) and ABOVE the `try:` at
+        // `:2926` — so the `except SwitchToBlackhole` at `:2930-2931` does
+        // NOT catch the `SwitchToBlackhole(ABORT_BRIDGE)` that
+        // `compile.giveup()` (`compile.py:27-29`) raises, and the `finally:`
+        // at `:2932-2935` does not run.  It propagates out with nothing yet
+        // traced, so there is no trace to give up on.
+        //
+        // This site is at a later phase, inside the compile, where upstream
+        // asserts rather than gives up: `compile.py:800
+        // assert metainterp.resumekey_original_loop_token is not None`.
+        // Returning `false` becomes `CompileOutcome::Cancelled` and thence
+        // `Declined`, which keeps the trace alive — the shape `compile.py:1085
+        // return None` already has at a bridge close, since
+        // `raise_if_successful` does not raise on `None`.
+        //
+        // "Should be rare" upstream; here it is unobserved, because every
+        // `set_rd_loop_token_clt` site is preceded by `keep_loop_alive`, which
+        // pins the token in `alive_loops`.  Structurally required — never
+        // panic.
         let source_jct: Arc<JitCellToken> = match majit_backend::descr_owning_jct(fail_descr) {
             Some(jct) => jct,
             None => {
                 if crate::majit_log_enabled() {
                     eprintln!(
                         "[jit] compile_bridge: rd_loop_token weakref dead → \
-                         compile.giveup() (pyjitpl.py:2898), key={} fail_index={}",
+                         compile.giveup() (pyjitpl.py:2923), key={} fail_index={}",
                         green_key, fail_index,
                     );
                 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8071,6 +8071,43 @@ impl<M: Clone> MetaInterp<M> {
             );
             return false;
         };
+        // `compile.py:797-811 ResumeGuardDescr.compile_and_attach` installs a
+        // finished retrace under ONE identity: the source guard's own loop
+        // token (`metainterp.resumekey_original_loop_token`), which it uses for
+        // `new_loop.original_jitcell_token`, for `send_bridge_to_backend` and
+        // for `record_loop_or_bridge` alike. This function binds the artifact
+        // to `source_jct` the same way (`set_original_jitcell_token_number`,
+        // `record_loop_or_bridge`) but files everything else under the
+        // caller-supplied `green_key`: `set_next_header_pc`, the
+        // `previous_tokens` read, `caller_recovery_layout`,
+        // `build_guard_metadata`'s key, and the `compiled.traces` insert. Those
+        // five only name the right loop while the two identities agree.
+        //
+        // They do agree by construction — the bridge entry derives its key from
+        // this very token (`descr_owning_jct(descr)?.green_key()`) before the
+        // trace context exists, and seeds both `TraceCtx::green_key` and
+        // `BridgeTraceInfo::green_key` from it — but nothing in this function
+        // said so. State it, exactly as `compile_bridge` already does for its
+        // own origin key.
+        //
+        // The retrace-budget half is deliberately NOT covered here: the
+        // `loop_jitcell_token` charges (`record_target_token`,
+        // `set_retraced_count`) follow the loop being ENTERED
+        // (`unroll.py:213-215`, `unroll.py:290-297`), which is a different
+        // question from which loop the artifact hangs off.
+        debug_assert_eq!(
+            green_key,
+            source_jct.green_key(),
+            "compile.py:801 — the retrace artifact is bound to source_jct, so \
+             the key its resume/exit layouts are filed under must name the same \
+             loop"
+        );
+        debug_assert_eq!(
+            bridge.green_key, green_key,
+            "pyjitpl.py:2890 — BridgeTraceInfo.green_key (the origin key stashed \
+             at start_retrace_from_guard) must match the trace-context key \
+             compile_retrace passes down"
+        );
         let fail_index = fail_descr.fail_index_per_trace();
         let source_trace_id = fail_descr.trace_id();
         let bridge_trace_id = self.alloc_trace_id();

--- a/pyre/bench/synth/retrace_accumulator_type_flip.cranelift.jitstats
+++ b/pyre/bench/synth/retrace_accumulator_type_flip.cranelift.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1202
+internal_compile_panics=0
+loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/retrace_accumulator_type_flip.dynasm.jitstats
+++ b/pyre/bench/synth/retrace_accumulator_type_flip.dynasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1202
+internal_compile_panics=0
+loops_aborted=5
+loops_compiled=1

--- a/pyre/bench/synth/retrace_accumulator_type_flip.py
+++ b/pyre/bench/synth/retrace_accumulator_type_flip.py
@@ -1,0 +1,40 @@
+# A loop-carried accumulator that flips int -> float partway through, so the
+# guard at that position fails repeatedly and the bridge grown there closes with
+# a virtual state matching no existing target. That makes the optimizer ask for a
+# retrace (`compile.py:1085 retrace_needed`), and `retrace_limit` is what lets
+# one be BUILT: it defaults to 0 (`rpython/rlib/jit.py:595`), so no other fixture
+# in this corpus reaches `compile_retrace` at all.
+#
+# What this currently covers is the retrace path up to and including its give-up:
+# `retrace_needed` -> `cut_retrace_from` -> the unroll pass -> `jump_to_preamble`
+# (`unroll.py:156/171`) -> the `compile.py:334` arity give-up. The retrace is not
+# assembled, because pyre's start label is the portal entry contract while the
+# optimized loop-carried set is wider — see MC_DIAG slot 57. When that contract
+# is unified this fixture is what starts exercising a compiled retrace, and its
+# jit-stats row is what will say so.
+#
+# CPython (the oracle) has no `pypyjit`; PyPy and pyre do. Guarding the import
+# keeps the output identical across all three while the param only binds where a
+# JIT exists. `set_param` rather than an environment variable because the wasm
+# guest sees no environment.
+try:
+    import pypyjit
+
+    pypyjit.set_param("retrace_limit=5")
+except ImportError:
+    pass
+
+
+def f(n):
+    s = 0
+    i = 0
+    while i < n:
+        if i > 4000:
+            s = s + 0.5
+        else:
+            s = s + 1
+        i += 1
+    return s
+
+
+print(f(60000))

--- a/pyre/bench/synth/retrace_accumulator_type_flip.wasm.jitstats
+++ b/pyre/bench/synth/retrace_accumulator_type_flip.wasm.jitstats
@@ -1,0 +1,8 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+guard_failures=1202
+internal_compile_panics=0
+loops_aborted=5
+loops_compiled=1

--- a/pyre/extra_tests/parity_tests/dir_entry_uninstantiable_python314.py
+++ b/pyre/extra_tests/parity_tests/dir_entry_uninstantiable_python314.py
@@ -1,0 +1,84 @@
+"""`os.DirEntry` / `posix.ScandirIterator` are produced only by `os.scandir`.
+
+`interp_scandir.py:468-487` gives `W_DirEntry.typedef` no `__new__` and sets
+`acceptable_as_base_class = False` (:487); `:172-180` does the same for
+`W_ScandirIterator.typedef`.  `:463-465 descr_reduce_ex` refuses to pickle an
+entry, spelling the type with `%T` (`error.py:592-593` -> the qualified typedef
+name `'posix.DirEntry'`, `:469`).
+
+Pickle protocols 0 and 1 are deliberately NOT asserted: they never reach
+`reduce_newobj`, they land in `copyreg._reduce_ex`, and that leg already
+diverges for every static type.  It is a separate, pre-existing defect.
+"""
+
+import copy
+import os
+import pickle
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+
+assert os.DirEntry.__module__ == "posix", os.DirEntry.__module__
+assert os.DirEntry.__name__ == "DirEntry", os.DirEntry.__name__
+assert os.DirEntry.__qualname__ == "DirEntry", os.DirEntry.__qualname__
+assert repr(os.DirEntry) == "<class 'posix.DirEntry'>", repr(os.DirEntry)
+
+try:
+    os.DirEntry()
+except TypeError as exc:
+    assert str(exc) == "cannot create 'posix.DirEntry' instances", str(exc)
+else:
+    raise AssertionError("os.DirEntry() must not construct an entry")
+
+try:
+    class _Sub(os.DirEntry):
+        pass
+except TypeError as exc:
+    assert str(exc) == "type 'posix.DirEntry' is not an acceptable base type", str(exc)
+else:
+    raise AssertionError("os.DirEntry must not be an acceptable base type")
+
+it = os.scandir(HERE)
+scandir_iterator = type(it)
+assert scandir_iterator.__module__ == "posix", scandir_iterator.__module__
+assert scandir_iterator.__name__ == "ScandirIterator", scandir_iterator.__name__
+
+try:
+    scandir_iterator()
+except TypeError as exc:
+    assert str(exc) == "cannot create 'posix.ScandirIterator' instances", str(exc)
+else:
+    raise AssertionError("ScandirIterator() must not construct an iterator")
+
+try:
+    class _SubIter(scandir_iterator):
+        pass
+except TypeError as exc:
+    assert str(exc) == "type 'posix.ScandirIterator' is not an acceptable base type", str(exc)
+else:
+    raise AssertionError("ScandirIterator must not be an acceptable base type")
+
+entries = list(it)
+it.close()
+assert entries
+entry = entries[0]
+assert isinstance(entry, os.DirEntry)
+assert isinstance(entry.name, str)
+assert entry.path == os.path.join(HERE, entry.name), (entry.path, entry.name)
+
+for protocol in range(2, pickle.HIGHEST_PROTOCOL + 1):
+    try:
+        pickle.dumps(entry, protocol)
+    except TypeError as exc:
+        assert str(exc) == "cannot pickle 'posix.DirEntry' object", (protocol, str(exc))
+    else:
+        raise AssertionError("a DirEntry must refuse to be pickled")
+
+for clone in (copy.copy, copy.deepcopy):
+    try:
+        clone(entry)
+    except TypeError as exc:
+        assert str(exc) == "cannot pickle 'posix.DirEntry' object", (clone, str(exc))
+    else:
+        raise AssertionError("a DirEntry must refuse to be copied")
+
+print("OK")

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2596,10 +2596,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         out.push_str(">");
         Ok(pyre_object::w_str_from_wtf8(out))
     }
+    /// `interp_scandir.py:463-465 descr_reduce_ex` — an entry names a live
+    /// position in a directory listing, so it refuses to be pickled.  `%T` is
+    /// `error.py:592-593 space.type(value).name`, the qualified typedef name
+    /// (`interp_scandir.py:469 'posix.DirEntry'`), which is what
+    /// `w_type_get_name` returns; the flag-driven `reduce_newobj` refusal in
+    /// `reduce_protocol_app.py:13-14` spells it with the bare `__name__`.
+    fn dir_entry_reduce_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let type_name = match crate::typedef::r#type(args[0]) {
+            Some(tp) => unsafe { pyre_object::typeobject::w_type_get_name(tp.as_ptr()) },
+            None => "posix.DirEntry",
+        };
+        Err(crate::PyError::type_error(format!(
+            "cannot pickle '{type_name}' object"
+        )))
+    }
     fn dir_entry_type() -> PyObjectRef {
         static CELL: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
         *CELL.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("DirEntry", |ns| {
+            // `interp_scandir.py:469` names the typedef `'posix.DirEntry'`.
+            // typedef.rs:2285-2291 turns the leading component of a qualified
+            // builtin name into a `__module__` entry, so `type(e).__module__`
+            // reports `posix` and every type-name-bearing error message is
+            // spelled the way the typedef spells it.
+            let tp = crate::typedef::make_builtin_type("posix.DirEntry", |ns| {
                 for (name, f) in [
                     ("is_dir", dir_entry_is_dir as crate::gateway::BuiltinCodeFn),
                     ("is_file", dir_entry_is_file),
@@ -2609,6 +2629,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ("stat", dir_entry_stat),
                     ("__fspath__", dir_entry_fspath),
                     ("__repr__", dir_entry_repr),
+                    ("__reduce_ex__", dir_entry_reduce_ex),
                 ] {
                     unsafe {
                         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
@@ -2632,6 +2653,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 };
             });
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            // `interp_scandir.py:468-487` declares no `__new__` on the typedef
+            // and `:487` sets `acceptable_as_base_class = False`; `typedef.py:55
+            // acceptable_as_base_class = '__new__' in rawdict` is the rule, and
+            // `typedef.py:754 assert not PyFrame.typedef.acceptable_as_base_class
+            // # no __new__` is the same shape typedef.rs:534-539 already ports.
+            // `scandir_fn` below allocates entries with
+            // `pyre_object::w_instance_new`, which never enters `type.__call__`,
+            // so the producer is untouched by the instantiation gate.
+            unsafe {
+                pyre_object::typeobject::w_type_set_disallow_instantiation(tp);
+                pyre_object::typeobject::w_type_set_acceptable_as_base_class(tp, false);
+            }
             tp as usize
         }) as PyObjectRef
     }
@@ -2662,7 +2695,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     fn scandir_iter_type() -> PyObjectRef {
         static CELL: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
         *CELL.get_or_init(|| {
-            let tp = crate::typedef::make_builtin_type("ScandirIterator", |ns| {
+            // `interp_scandir.py:173` names the typedef `'posix.ScandirIterator'`.
+            let tp = crate::typedef::make_builtin_type("posix.ScandirIterator", |ns| {
                 for (name, f) in [
                     (
                         "__iter__",
@@ -2683,6 +2717,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 }
             });
             unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+            // `interp_scandir.py:172-180` declares no `__new__` on the typedef
+            // and `:180` sets `acceptable_as_base_class = False`.  The iterator
+            // is produced only by `scandir_fn` below, through
+            // `pyre_object::w_instance_new`.
+            unsafe {
+                pyre_object::typeobject::w_type_set_disallow_instantiation(tp);
+                pyre_object::typeobject::w_type_set_acceptable_as_base_class(tp, false);
+            }
             tp as usize
         }) as PyObjectRef
     }

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -133,6 +133,12 @@ fn emit_llbc_extraction_placeholders() {
     }
 }
 
+/// Crates whose Charon artefact this build consumes.  The `.ullbc` and its
+/// `.fingerprint` stamp are both named after the crate.  Pyre production
+/// configures the exact `eval::eval_loop_jit` portal, so unlike generic
+/// two-artefact consumers it requires `pyre-jit` too.
+const LLBC_CRATES: &[&str] = &["pyre-object", "pyre-interpreter", "pyre-jit"];
+
 /// Pre-flight the LLBC prerequisite, mirroring the resolution order in
 /// `majit-translate` (`build_semantic_program_via_active_frontend`):
 /// honour the `PYRE_MIR_FRONTEND_LLBC` override, else require the canonical
@@ -147,6 +153,11 @@ fn emit_llbc_extraction_placeholders() {
 /// `cargo build`, which would block on the outer build's target-directory
 /// lock (deadlock), and a build script that downloads a toolchain breaks
 /// hermetic / offline / CI builds.
+///
+/// That ban does not cover the stamp comparison in `warn_if_llbc_stale`:
+/// `scripts/extract-llbc.py --fingerprint` returns before `extract` runs and
+/// only performs a `cargo metadata` walk plus `git ls-files`, so it starts no
+/// nested build and takes no target-directory lock.
 fn preflight_llbc_or_fail() {
     // Explicit override: trust it and let the translator validate the
     // individual paths (its loader panics per-file with the bad path).
@@ -161,17 +172,10 @@ fn preflight_llbc_or_fail() {
         .join("..")
         .join("..");
     let llbc_dir = repo_root.join("build").join("llbc");
-    // Pyre production configures the exact `eval::eval_loop_jit` portal, so
-    // unlike generic two-artifact consumers it requires pyre-jit.ullbc too.
-    const REQUIRED: &[&str] = &[
-        "pyre-object.ullbc",
-        "pyre-interpreter.ullbc",
-        "pyre-jit.ullbc",
-    ];
-    let mut missing: Vec<String> = REQUIRED
+    let mut missing: Vec<String> = LLBC_CRATES
         .iter()
+        .map(|crate_name| format!("{crate_name}.ullbc"))
         .filter(|name| !llbc_dir.join(name).exists())
-        .map(|name| (*name).to_string())
         .collect();
     // Cross-compiling additionally needs this target's layout sidecars:
     // Charon resolves struct layouts per target, and the artefacts above
@@ -184,6 +188,10 @@ fn preflight_llbc_or_fail() {
         }
     }
     if missing.is_empty() {
+        // Present is not the same as current: the artefacts are frozen
+        // snapshots (AGENTS.md:48) and nothing above compares them to the
+        // sources they were extracted from.
+        warn_if_llbc_stale(&repo_root);
         return;
     }
 
@@ -258,6 +266,164 @@ fn preflight_llbc_or_fail() {
     );
 
     std::process::exit(1);
+}
+
+/// Read one `key=value` line out of a `.fingerprint` stamp.
+///
+/// `scripts/llbc_extract.py:449-476` (`stamp_for`) writes the stamp as one
+/// `key=value` per line, so a prefix match is the whole parse.  `key` includes
+/// the `=`.
+fn stamp_field(stamp: &str, key: &str) -> Option<String> {
+    stamp
+        .lines()
+        .find_map(|line| line.strip_prefix(key).map(str::to_string))
+}
+
+/// Wait for the fingerprint oracle with a deadline.
+///
+/// A build script that blocks forever is strictly worse than a missing
+/// warning, and `std` has no `wait_timeout`, so the wait runs on a helper
+/// thread and a timeout abandons the child.  Every non-answer — spawn failure,
+/// non-zero exit, unparseable stdout — collapses to `None`, i.e. silence: an
+/// unavailable oracle must not break offline, hermetic or vendored builds.
+fn llbc_fingerprint_output(child: std::process::Child) -> Option<String> {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait_with_output());
+    });
+    let output = rx
+        .recv_timeout(std::time::Duration::from_secs(120))
+        .ok()?
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    // A bare lowercase sha256 and nothing else; anything else means the driver
+    // printed something this code does not model.
+    let is_hash = value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit());
+    is_hash.then_some(value)
+}
+
+/// Ask the extraction driver what the current sources hash to.
+///
+/// `scripts/llbc_extract.py:815-817` prints exactly the value the stamp's
+/// `source=` line holds — same `source_fingerprint()` call, same single-crate
+/// list as `stamp_for` at `:474` — so there is one implementation of the
+/// digest and it is not this one.
+///
+/// `CARGO_FEATURES` and `LLBC_LAYOUT_TARGETS` are replayed out of the stamp:
+/// `fingerprint_inputs` (`scripts/llbc_extract.py:255-360`) walks the
+/// dependency closure under the feature set and the cross-target layout set in
+/// force at extraction time, so recomputing under this build's defaults would
+/// report a difference the sources do not have.
+fn llbc_source_fingerprint(
+    repo_root: &std::path::Path,
+    driver: &std::path::Path,
+    crate_name: &str,
+    features: &str,
+    layout_targets: &str,
+) -> Option<String> {
+    for python in ["python3", "python"] {
+        let spawned = std::process::Command::new(python)
+            .arg(driver)
+            .arg("--fingerprint")
+            .arg(crate_name)
+            .current_dir(repo_root)
+            .env("CARGO_FEATURES", features)
+            .env("LLBC_LAYOUT_TARGETS", layout_targets)
+            .stdin(std::process::Stdio::null())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::null())
+            .spawn();
+        let Ok(child) = spawned else {
+            continue;
+        };
+        return llbc_fingerprint_output(child);
+    }
+    None
+}
+
+/// Compare every `.ullbc` against the sources it was extracted from.
+///
+/// The prepass reads `build/llbc/*.ullbc`, never the Rust sources
+/// (AGENTS.md:48), so a field inserted anywhere but last in a `#[repr(C)]`
+/// struct shifts every following descr offset while the build stays green.
+/// The existence test in `preflight_llbc_or_fail` cannot see this, and
+/// `codegen_cache_key` makes it worse rather than better: it hashes every
+/// `<crate>/src`, so a source edit reliably invalidates the codegen cache and
+/// re-runs the prepass — over the same unchanged artefact.
+///
+/// The oracle is the extractor's own stamp.  `scripts/llbc_extract.py:643-652`
+/// already skips a crate whose stamp still matches, so this is the comparison
+/// the producer trusts, evaluated by the consumer.
+///
+/// Warning-only by default: a stale artefact still yields a working build for
+/// everything whose layout did not move, and the remedy is a multi-minute
+/// re-extraction.  `PYRE_LLBC_STRICT=1` promotes the same finding to a hard
+/// failure for callers that want a gate, and
+/// `PYRE_LLBC_SKIP_FINGERPRINT_CHECK` opts out entirely.
+fn warn_if_llbc_stale(repo_root: &std::path::Path) {
+    println!("cargo::rerun-if-env-changed=PYRE_LLBC_STRICT");
+    println!("cargo::rerun-if-env-changed=PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
+    if std::env::var_os("PYRE_LLBC_SKIP_FINGERPRINT_CHECK").is_some() {
+        return;
+    }
+    let driver = repo_root.join("scripts").join("extract-llbc.py");
+    if !driver.is_file() {
+        return;
+    }
+    let llbc_dir = repo_root.join("build").join("llbc");
+    let mut stale: Vec<(&str, String, String)> = Vec::new();
+    for &crate_name in LLBC_CRATES {
+        let stamp_path = llbc_dir.join(format!("{crate_name}.ullbc.fingerprint"));
+        let Ok(stamp) = std::fs::read_to_string(&stamp_path) else {
+            continue;
+        };
+        let Some(recorded) = stamp_field(&stamp, "source=") else {
+            continue;
+        };
+        let features = stamp_field(&stamp, "features=").unwrap_or_default();
+        let layout_targets = stamp_field(&stamp, "layout_targets=").unwrap_or_default();
+        let current =
+            llbc_source_fingerprint(repo_root, &driver, crate_name, &features, &layout_targets);
+        let Some(current) = current else {
+            continue;
+        };
+        if current != recorded {
+            stale.push((crate_name, recorded, current));
+        }
+    }
+    if stale.is_empty() {
+        return;
+    }
+    // The directive string is the only difference between the two modes, so it
+    // is chosen once and the same lines go through it.  `cargo::warning=` and
+    // `cargo::error=` each carry a single line with no embedded newline.
+    let strict = std::env::var_os("PYRE_LLBC_STRICT").as_deref() == Some(std::ffi::OsStr::new("1"));
+    let directive = if strict {
+        "cargo::error"
+    } else {
+        "cargo::warning"
+    };
+    for (crate_name, recorded, current) in &stale {
+        println!(
+            "{directive}=LLBC STALE: {crate_name}.ullbc was extracted at source={recorded}, \
+             sources now hash to {current}"
+        );
+    }
+    let crates = stale
+        .iter()
+        .map(|(crate_name, _, _)| *crate_name)
+        .collect::<Vec<_>>()
+        .join(" ");
+    println!(
+        "{directive}=Field offsets read out of these artefacts may name the wrong bytes; \
+         re-extract with: python3 scripts/extract-llbc.py {crates}"
+    );
+    if strict {
+        std::process::exit(1);
+    }
 }
 
 /// Run the codegen worker on a large-stack thread, propagating any panic so

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -10977,9 +10977,22 @@ fn handle<Sym: WalkSym>(
                                         entry_meta,
                                     )
                                 }
-                                None => driver
-                                    .meta_interp_mut()
-                                    .compile_trace(key, &live_args, None),
+                                // compile.py:1002-1021 — an interp-origin close is a
+                                // `ResumeFromInterpDescr` entry bridge, and with no
+                                // entry data there is no original green key to attach
+                                // it to. `compile_trace(key, args, None)` cannot serve
+                                // that state: its `None`-origin arm demands the
+                                // entry-bridge payload and answers `Cancelled` for
+                                // every input, after deep-cloning the whole
+                                // trace-so-far and lowering its snapshot pool. Decline
+                                // here instead, so the give-up reads as one.
+                                // `compile_trace_entry_data` reads
+                                // `trace_ctx().root_green_key()` and `trace_meta()`,
+                                // and every `JitDriver` trace start installs both
+                                // halves, so this is unreachable from a jd0 walk; only
+                                // `MetaInterp::force_start_tracing` opens a tracer with
+                                // no session envelope.
+                                None => majit_metainterp::CompileOutcome::Cancelled,
                             },
                         };
                         if matches!(outcome, majit_metainterp::CompileOutcome::Compiled { .. }) {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -717,6 +717,9 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 "bridge_no_targets_close",
                 "abort_after_declined",
                 "ct_compile_bridge_false",
+                "mp_shape_filtered",
+                "retrace_mp_untyped",
+                "close_hdr_fallback",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -720,6 +720,7 @@ fn run(module_path: &PathBuf, source: &str, script: &Path) -> Result<i32> {
                 "mp_shape_filtered",
                 "retrace_mp_untyped",
                 "close_hdr_fallback",
+                "retrace_arity_giveup",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {


### PR DESCRIPTION
Twelve commits on top of `6b843fa4b76`, in three groups.

## 1. The retrace path (#33)

`closes_on_own_label` declined **every** retrace on **every** backend, because every `jump_to_preamble` outcome closes on a foreign token. `compile.py:341-394 compile_retrace` declines only on `InvalidLoop` (`:368-371`), and both `jump_to_preamble` sites (`unroll.py:156`, `:171`) return a full `UnrollInfo`, so the check had no upstream counterpart.

Removing it exposed `EXC_BAD_ACCESS` on two of four repros on **both** native backends — a `GuardClass` reading the class word of a register holding the unboxed loop counter (`ldr x16, [x8]`, `x8 = 4405`, `INT_TYPE` in `x16`/`x17`). Root cause: `jump_to_preamble` retargets the body JUMP at `target_tokens[0]` and keeps its args (`unroll.py:238-242`). Upstream's `target_tokens[0]` is the start label whose args *are* `loop.inputargs`, so `compile.py:334`'s `assert jump.numargs() == label.numargs()` holds by construction. A pyre retrace emits no start label of its own, so `target_tokens[0]` is the **original loop's** start label — the portal entry contract, one boxed Ref per frame local — while the optimized loop-carried set is wider and mixed: measured 13 vs 8, 14 vs 9, 13 vs 8.

So the decline moves to `jump_to_preamble`, where both correct numbers exist together, and raises `InvalidLoop` — which is `unroll.py:242`'s own escape, landing on `compile.py:368-371`'s cancel. Scoped to retraces: a `compile_loop` unroll keeps its start label in the same artifact. Counted as `MC_DIAG` slot 57 `retrace_arity_giveup`.

All three backends now decide local-vs-external on the **token**, which is `x86/assembler.py:2461-2467 closing_jump`'s own test. The wasm backend used a trace-global "does this trace have a LABEL" heuristic instead; a census over 362/362 existing synth fixtures reads 0 on a counter of exactly the affected traces, so the change is provably inert for the corpus.

A new synth fixture reaches `retrace_needed` → `cut_retrace_from` → unroll → `jump_to_preamble` → the arity give-up. **It does not cover a compiled retrace**, because no retrace in this tree satisfies the arity contract; before this, zero fixtures reached `compile_retrace` at all. All three backends record an identical row. The remaining work — unifying pyre's start-label contract with its loop-carried contract — is filed separately.

## 2. A stale `build/llbc` shipped wrong field offsets in silence (#44)

`preflight_llbc_or_fail` tested only that the artefacts *exist*. The prepass reads them and never the Rust sources (`AGENTS.md:48`), so a field inserted anywhere but last in a `#[repr(C)]` struct shifts every following descr offset while the build stays green. `codegen_cache_key` makes it worse rather than better: it hashes every `<crate>/src`, so a source edit reliably invalidates the codegen cache and re-runs the prepass — over the same unchanged artefact.

**This tree is stale right now.** `ff42f0e3317` (#950) inserted five `abi_*: i64` fields into `W_TypeObject` *before* `weak_subclasses`, `terminator` and `version_tag`; the installed artefacts predate it. `version_tag` is rescued at runtime by `offset_of!`; the other two are not.

The detector compares each artefact's stamp against the sources on the silent-success exit, using the extractor's own oracle — `scripts/llbc_extract.py:815-817` prints the same `source_fingerprint()` value that `:474` writes into the stamp, and `:643-652` already skips a crate whose stamp matches. One implementation of the digest, and it is not in `build.rs`. Warning by default; `PYRE_LLBC_STRICT=1` promotes it to `cargo::error`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK` opts out. Every non-answer from the oracle is silence, so an unavailable `python3` cannot break the build.

Re-extraction is deliberately **not** part of this PR.

## 3. Parity

- **`posix.DirEntry` / `posix.ScandirIterator`** were instantiable, subclassable and named without their module. `interp_scandir.py:468-487` gives the typedef no `__new__` and sets `acceptable_as_base_class = False`; `:172-180` likewise for the iterator. `descr_reduce_ex` (`:463-465`) is ported too — without it `copy.copy(entry)` returned a **nameless entry** whose `repr()` then raised `AttributeError`. New fixture is byte-identical to CPython 3.14 on nine probes across both backends. `name`/`path` stay writable on purpose: `scandir_fn` populates them with `setattr_str`, so a read-only getset would silently ship nameless entries.
- Three copies of the dead-`rd_loop_token` comment claimed `compile.giveup()`'s `SwitchToBlackhole` is "caught at `pyjitpl.py:2906-2907` and falls through to blackhole resume". The raise is at `:2923`, above the `try:` at `:2926`, so `except SwitchToBlackhole` at `:2930-2931` does not catch it and the `finally:` does not run. Comments only.
- Two `reached_loop_header` fallbacks and `attach_retrace_to_source_guard`'s two key identities are now `debug_assert`s; `generate_guards`' `Constant` arm rejects differing constants (`virtualstate.py:392-394`); the no-collector `GcRewriterImpl` gets its boehm fields (`gc.py:151-162`); the walker declines directly where `compile_trace` could only cancel.

## Verification

`pyre/check.py` green on all three backends at each landing point — final run `dynasm 380/380 · cranelift 380/380 · wasm 376/376`, `CHECKPY_RC=0`, HEAD stamps equal at both ends, **zero existing `.jitstats` modified** (only the retrace fixture's three new ones added). Parity suite under CPython 3.14: `all parity tests pass`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python 3.14-compatible behavior for `posix.DirEntry` and `posix.ScandirIterator`, including qualified type names and restrictions on instantiation, subclassing, copying, and pickling.
  * Added a retracing benchmark covering accumulator type changes.

* **Bug Fixes**
  * Improved JIT handling for loop targets, retracing, garbage collection configurations, and control-flow edge cases.
  * Corrected loop and type matching behavior to prevent invalid compilation paths.

* **Diagnostics**
  * Expanded JIT diagnostics and statistics for retracing, loop compilation, and rejected optimization cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->