### PR TITLE
gh#346: ll_alloc_and_set list-allocation family + full newlist_clear compound jitcode opcode

### DIFF
--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1704,6 +1704,94 @@ impl JitCodeBuilder {
         self.push_reg_u8(dst, "new_array_clear dst");
     }
 
+    /// Emit `newlist_clear/idddd>r` (`handler_newlist_clear`,
+    /// `blackhole.py:1173-1180`): the compound resizable-list allocation
+    /// `do_resizable_newlist_clear` emits.  ONE opcode carrying the
+    /// element count (int register) plus FOUR descriptors in the exact
+    /// read order the handler and trace dispatch agree on —
+    /// structdescr (`list` header Size), lengthdescr (`list.length`
+    /// FieldDescr), itemsdescr (`list.items` FieldDescr), arraydescr
+    /// (the length-prefixed items block).  The list header layout is
+    /// `{ length: Signed @ length_offset, items: Ptr(GcArray) @
+    /// items_offset }`; the items block is `arraydescrof(item_type,
+    /// len_offset = Some(0))`.  Registers the header layout under
+    /// `struct_type_id` so the two setfield FieldDescrs carry a parent
+    /// SizeDescr (`descr.py:238`).
+    #[allow(clippy::too_many_arguments)]
+    pub fn newlist_clear(
+        &mut self,
+        dest: u16,
+        length_reg: u16,
+        struct_type_id: u64,
+        struct_size: usize,
+        length_offset: usize,
+        items_offset: usize,
+        array_type_id: u64,
+        item_type: majit_ir::value::Type,
+    ) {
+        self.touch_int_reg_or_pool_slot(length_reg);
+        self.touch_ref_reg(dest);
+        // Register the `list` header layout so the length/items field
+        // descrs resolve a parent SizeDescr + index_in_parent.
+        self.register_struct_layout(
+            struct_size,
+            struct_type_id,
+            true,
+            false,
+            &[
+                (length_offset, false, "length"),
+                (items_offset, true, "items"),
+            ],
+        );
+        let all_fielddescrs = self
+            .struct_size_specs
+            .get(&struct_type_id)
+            .expect("register_struct_layout just inserted this type_id")
+            .all_fielddescrs
+            .clone();
+        // structdescr: the `list` header Size descr (resizable list, no vtable).
+        let struct_descr = self.add_bh_descr(CanonicalBhDescr::Size {
+            size: struct_size,
+            type_id: struct_type_id,
+            vtable: 0,
+            owner: String::new(),
+            all_fielddescrs,
+            is_gc_managed: true,
+        });
+        // lengthdescr / itemsdescr: parent-carrying field descrs.
+        let length_descr =
+            self.add_struct_field_descr(length_offset, majit_ir::value::Type::Int, struct_type_id);
+        let items_descr =
+            self.add_struct_field_descr(items_offset, majit_ir::value::Type::Ref, struct_type_id);
+        // arraydescr: length-prefixed items block (length word at offset 0).
+        let is_item_signed = !matches!(
+            item_type,
+            majit_ir::value::Type::Ref | majit_ir::value::Type::Float
+        );
+        let array_descr = self.add_array_descr(CanonicalBhDescr::Array {
+            base_size: std::mem::size_of::<usize>(),
+            itemsize: scalar_size(item_type),
+            len_offset: Some(0),
+            type_id: array_type_id,
+            gc_type_id: 0,
+            item_type,
+            is_array_of_pointers: matches!(item_type, majit_ir::value::Type::Ref),
+            is_array_of_structs: false,
+            is_item_signed,
+            ei_index: u32::MAX,
+            array_type_id: None,
+            interior_fields: Vec::new(),
+            is_gc_managed: true,
+        });
+        self.write_insn("newlist_clear/idddd>r");
+        self.push_reg_u8(length_reg, "newlist_clear length");
+        self.push_u16(struct_descr);
+        self.push_u16(length_descr);
+        self.push_u16(items_descr);
+        self.push_u16(array_descr);
+        self.push_reg_u8(dest, "newlist_clear dst");
+    }
+
     /// Store a Ref element into a GC-managed array.
     ///
     /// blackhole.py `bhimpl_setarrayitem_gc_r @arguments("cpu","r","i",

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7772,6 +7772,162 @@ where
             // (length reg + array descr -> ref) on the BC_NEW / BC_NEW_WITH_VTABLE
             // template above: execute the live allocation and record
             // OpCode::NewArray{,Clear} so the optimizer can still virtualize it.
+            jitcode::insns::BC_NEWLIST_CLEAR => {
+                // opimpl_newlist_clear (pyjitpl.py:792-798): decompose ONE
+                // opcode into New + SetfieldGc(length) + NewArrayClear +
+                // SetfieldGc(items).  The tracer both *records* all four
+                // resops (so the optimizer can virtualize the list header +
+                // its items block when they do not escape) and *executes* the
+                // two live allocations plus the two field stores (so the
+                // subsequent steps of this same trace read live memory), the
+                // same dual discipline BC_NEW / BC_SETFIELD_GC follow.
+                let (
+                    length_reg,
+                    struct_descr_idx,
+                    length_descr_idx,
+                    items_descr_idx,
+                    array_descr_idx,
+                    dest,
+                ) = self.frames.current_mut().read_newlist_clear();
+                // structdescr (`list` header SizeDescr): size + gc identity +
+                // the DescrRef the recorded New carries.
+                let (struct_size, struct_type_id, struct_headerless, struct_descr) = {
+                    let frame = self.frames.current_mut();
+                    let bh = frame.runtime_bh_descr(struct_descr_idx).unwrap_or_else(|| {
+                        panic!(
+                            "BC_NEWLIST_CLEAR: descrs[{struct_descr_idx}] is not a BhDescr entry"
+                        )
+                    });
+                    (
+                        bh.as_size(),
+                        bh.resolve_gc_tid(),
+                        bh.is_headerless(),
+                        size_descr_ref_from_bh(bh),
+                    )
+                };
+                // lengthdescr / itemsdescr: plain FieldDescrs — byte offset +
+                // the DescrRef the two recorded SetfieldGc ops carry.
+                let (length_offset, length_fielddescr) = {
+                    let frame = self.frames.current_mut();
+                    let bh = frame.runtime_bh_descr(length_descr_idx).unwrap_or_else(|| {
+                        panic!(
+                            "BC_NEWLIST_CLEAR: descrs[{length_descr_idx}] is not a BhDescr entry"
+                        )
+                    });
+                    field_descr_ref_from_bh(bh)
+                };
+                let (items_offset, items_fielddescr) = {
+                    let frame = self.frames.current_mut();
+                    let bh = frame.runtime_bh_descr(items_descr_idx).unwrap_or_else(|| {
+                        panic!("BC_NEWLIST_CLEAR: descrs[{items_descr_idx}] is not a BhDescr entry")
+                    });
+                    field_descr_ref_from_bh(bh)
+                };
+                // arraydescr: geometry for the live items-block allocation
+                // (`base_size + length*itemsize` bytes, cleared, length word
+                // at `len_offset`), matching `bh_new_array`
+                // (runner.rs `dynasm_alloc_oldgen_varsize_typed_and_set_len`).
+                let (array_base_size, array_itemsize, array_len_offset, array_type_id) = {
+                    let frame = self.frames.current_mut();
+                    let bh = frame.runtime_bh_descr(array_descr_idx).unwrap_or_else(|| {
+                        panic!("BC_NEWLIST_CLEAR: descrs[{array_descr_idx}] is not a BhDescr entry")
+                    });
+                    let (base_size, itemsize, _signed) = bh.unpack_arraydescr_size();
+                    (
+                        base_size,
+                        itemsize,
+                        bh.array_len_offset(),
+                        bh.resolve_gc_tid(),
+                    )
+                };
+                let Some(array_descr) = self.dispatch_array_descr_ref(ctx, array_descr_idx) else {
+                    return TraceAction::Abort;
+                };
+                // The length operand feeds both the length-field store and the
+                // items-block element count (opimpl_newlist_clear passes the
+                // same `sizebox` to `_opimpl_setfield_gc_any` and
+                // `opimpl_new_array_clear`).
+                let (length_opref, length_val) = self.read_int_reg(length_reg);
+
+                // ── 1. sbox: live-alloc the `list` header (BC_NEW no-collect
+                // discipline — the struct ptr is live in the register bank,
+                // which is no root set, so the array allocation that follows
+                // must not move it; old-gen is mark-sweep non-moving and both
+                // GC paths are no-collect). ──
+                let struct_size = struct_size.max(1);
+                let struct_gc_ptr = if struct_headerless {
+                    majit_gc::alloc_nursery_headerless_no_collect(struct_size).0
+                } else if struct_type_id != 0 {
+                    majit_gc::alloc_oldgen_typed(struct_type_id, struct_size).0
+                } else {
+                    0
+                };
+                let struct_ptr = if struct_gc_ptr != 0 {
+                    struct_gc_ptr as i64
+                } else {
+                    let layout = std::alloc::Layout::from_size_align(struct_size, 8)
+                        .expect("BC_NEWLIST_CLEAR: invalid list-header layout");
+                    unsafe { std::alloc::alloc_zeroed(layout) as i64 }
+                };
+                let sbox_op = ctx.record_op_with_descr(OpCode::New, &[], struct_descr);
+                ctx.set_opref_concrete(sbox_op, Value::Ref(majit_ir::GcRef(struct_ptr as usize)));
+
+                // ── 2. store the length into the header's `length` field. ──
+                ctx.record_op_with_descr(
+                    OpCode::SetfieldGc,
+                    &[sbox_op, length_opref],
+                    length_fielddescr,
+                );
+                if struct_ptr != 0 {
+                    unsafe {
+                        *((struct_ptr as *mut u8).add(length_offset) as *mut i64) = length_val
+                    };
+                }
+
+                // ── 3. abox: live-alloc the cleared items block.  Payload is
+                // `base_size + length*itemsize`, zero-filled by the old-gen
+                // allocator (`finish_alloc_in_oldgen` write_bytes 0 — the
+                // CLEAR), no-collect; the length word is written at
+                // `len_offset` for a length-prefixed array. ──
+                let length_count =
+                    usize::try_from(length_val).expect("BC_NEWLIST_CLEAR: negative list length");
+                let array_payload = array_itemsize
+                    .checked_mul(length_count)
+                    .and_then(|var| array_base_size.checked_add(var))
+                    .expect("BC_NEWLIST_CLEAR: items-block size overflow");
+                let array_payload = array_payload.max(1);
+                let array_gc_ptr = if array_type_id != 0 {
+                    majit_gc::alloc_oldgen_typed(array_type_id, array_payload).0
+                } else {
+                    0
+                };
+                let array_ptr = if array_gc_ptr != 0 {
+                    array_gc_ptr as i64
+                } else {
+                    let layout = std::alloc::Layout::from_size_align(array_payload, 8)
+                        .expect("BC_NEWLIST_CLEAR: invalid items-block layout");
+                    unsafe { std::alloc::alloc_zeroed(layout) as i64 }
+                };
+                if array_ptr != 0 {
+                    if let Some(len_ofs) = array_len_offset {
+                        unsafe { *((array_ptr as *mut u8).add(len_ofs) as *mut i64) = length_val };
+                    }
+                }
+                let abox_op = ctx.record_new_array_clear(length_opref, array_descr);
+                ctx.set_opref_concrete(abox_op, Value::Ref(majit_ir::GcRef(array_ptr as usize)));
+
+                // ── 4. store the items block into the header's `items` field.
+                // A ref store adds a heap edge header→items, so notify the GC
+                // on the container (mirrors BC_SETFIELD_GC_R / bh_setfield_gc_r).
+                ctx.record_op_with_descr(OpCode::SetfieldGc, &[sbox_op, abox_op], items_fielddescr);
+                if struct_ptr != 0 {
+                    unsafe { *((struct_ptr as *mut u8).add(items_offset) as *mut i64) = array_ptr };
+                    majit_gc::gc_write_barrier(majit_ir::GcRef(struct_ptr as usize));
+                }
+
+                // ── 5. bind the list header to the destination ref register. ──
+                self.set_ref_reg(dest, Some(sbox_op), Some(struct_ptr));
+            }
             other => panic!("unknown jitcode bytecode {other}"),
         }
 
@@ -10498,6 +10654,76 @@ mod tests {
             op.getdescr()
                 .and_then(|d| d.as_size_descr().map(|s| s.size())),
             Some(16)
+        );
+    }
+
+    #[test]
+    fn jitcode_newlist_clear_records_new_setfield_newarrayclear_setfield() {
+        // opimpl_newlist_clear (pyjitpl.py:792-798): ONE opcode decomposes
+        // into New + SetfieldGc(length) + NewArrayClear + SetfieldGc(items).
+        // The `list` header is { length: i64 @0, items: ref @8 } (size 16)
+        // wrapping a length-prefixed items block of i64 elements.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_i_value(0, 3); // int reg 0 = list length 3
+        builder.newlist_clear(
+            0,    // dest ref reg 0 = list header
+            0,    // length_reg = int reg 0
+            0x51, // struct_type_id (list header identity)
+            16,   // struct_size (length @0, items @8)
+            0,    // length_offset
+            8,    // items_offset
+            0xA1, // array_type_id (items block identity)
+            majit_ir::value::Type::Int,
+        );
+        let jitcode = builder.finish();
+
+        let mut ctx = TraceCtx::for_test(0);
+        let mut sym = DummySym::default();
+        let action = trace_jitcode_with_args(&mut ctx, &mut sym, &jitcode, 0, |_pc| 0, &[]);
+        assert!(matches!(action, TraceAction::Continue));
+
+        let recorder = ctx.into_recorder();
+        // The leading int_copy const load records nothing; the four resops
+        // are the entire trace.
+        let opcodes: Vec<_> = recorder.ops().iter().map(|o| o.opcode).collect();
+        assert_eq!(
+            opcodes,
+            vec![
+                OpCode::New,
+                OpCode::SetfieldGc,
+                OpCode::NewArrayClear,
+                OpCode::SetfieldGc,
+            ]
+        );
+
+        // The New (sbox) result feeds BOTH SetfieldGc records as arg 0.
+        let new_pos = recorder.ops()[0].pos.get().raw();
+        assert_eq!(recorder.ops()[1].arg(0).position(), Some(new_pos));
+        assert_eq!(recorder.ops()[3].arg(0).position(), Some(new_pos));
+        // The NewArrayClear (abox) result feeds the items SetfieldGc as arg 1.
+        let arr_pos = recorder.ops()[2].pos.get().raw();
+        assert_eq!(recorder.ops()[3].arg(1).position(), Some(arr_pos));
+
+        // The recorded field descrs carry the resolved byte offsets.
+        let len_off = recorder.ops()[1]
+            .getdescr()
+            .and_then(|d| d.as_field_descr().map(|f| f.offset()));
+        let items_off = recorder.ops()[3]
+            .getdescr()
+            .and_then(|d| d.as_field_descr().map(|f| f.offset()));
+        assert_eq!(len_off, Some(0));
+        assert_eq!(items_off, Some(8));
+
+        // The New carries a SizeDescr sized like the list header.
+        let struct_size = recorder.ops()[0]
+            .getdescr()
+            .and_then(|d| d.as_size_descr().map(|s| s.size()));
+        assert_eq!(struct_size, Some(16));
+        // The sbox result is bound to a live (non-null) list-header pointer.
+        let sbox_val = recorder.ops()[0].get_value();
+        assert!(
+            matches!(sbox_val, Some(Value::Ref(r)) if r.as_usize() != 0),
+            "list header pointer must be a non-null ref, got {sbox_val:?}"
         );
     }
 

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -340,6 +340,30 @@ impl MIFrame {
         (struct_reg, value_reg, descr_idx)
     }
 
+    /// Decode a `newlist_clear/idddd>r` operand septuple, returning
+    /// `(length_reg, struct_descr_idx, length_descr_idx, items_descr_idx,
+    /// array_descr_idx, dest)`. Canonical layout: 1B length_reg + 2B
+    /// structdescr_idx + 2B lengthdescr_idx + 2B itemsdescr_idx + 2B
+    /// arraydescr_idx + 1B dest_reg — the exact read order
+    /// `handler_newlist_clear` (`blackhole.py:1173-1180`) and the
+    /// codewriter emit (`assembler.rs` NewListClear arm) agree on.
+    pub fn read_newlist_clear(&mut self) -> (usize, usize, usize, usize, usize, usize) {
+        let length_reg = self.next_u8() as usize;
+        let struct_descr = self.next_u16() as usize;
+        let length_descr = self.next_u16() as usize;
+        let items_descr = self.next_u16() as usize;
+        let array_descr = self.next_u16() as usize;
+        let dest = self.next_u8() as usize;
+        (
+            length_reg,
+            struct_descr,
+            length_descr,
+            items_descr,
+            array_descr,
+            dest,
+        )
+    }
+
     /// Decode a `getfield_gc_<kind>/rd>X` operand triple, returning
     /// `(struct_reg, descr_pool_idx, dest_reg)`. Canonical layout: 1B
     /// struct_reg + 2B descr_pool_idx + 1B dest_reg

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1613,6 +1613,51 @@ impl Assembler {
                 let key = format!("new/{argcodes}");
                 state.code[startposition] = self.get_opnum(&key);
             }
+            // RPython `new_array_clear(v_length, arraydescr)` — the cleared
+            // fixed-size array allocation `do_fixed_newlist_clear` emits
+            // (`jtransform.py:1858-1863`).  `bhimpl_new_array_clear`
+            // (`blackhole.py:1311-1313`, `@arguments("cpu", "i", "d",
+            // returns="r")`) gives the canonical key `new_array_clear/id>r`:
+            // length (Int) + arraydescr + ref result.  The arraydescr is the
+            // same `arraydescrof(item_ty, array_type_id, len_offset=Some(0))`
+            // shape `ArrayRead`/`ArrayWrite` mint for the length-prefixed
+            // items block.
+            OpKind::NewArrayClear {
+                length,
+                item_ty,
+                array_type_id,
+            } => {
+                let (reg, kc) = self.lookup_reg_with_kind_var(length, regallocs);
+                assert_eq!(
+                    kc, 'i',
+                    "new_array_clear length must be int-kind, got {kc:?}",
+                );
+                state.code.push(reg);
+                argcodes.push(kc);
+                let descr_idx = self.emit_ready_descr(arraydescrof(
+                    item_ty,
+                    array_type_id,
+                    Some(0),
+                    callcontrol,
+                ));
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                let result = op
+                    .result
+                    .as_ref()
+                    .expect("new_array_clear must produce a result");
+                let (reg, kind) = self.lookup_reg_with_kind_var(result, regallocs);
+                assert_eq!(
+                    kind, 'r',
+                    "new_array_clear result must use the ref register bank"
+                );
+                state.code.push(reg);
+                argcodes.push('>');
+                argcodes.push('r');
+                let key = format!("new_array_clear/{argcodes}");
+                state.code[startposition] = self.get_opnum(&key);
+            }
             // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
             // tracer oracle (`box_trace.rs trace_box_float`): a `new_with_vtable`
             // carrying ONLY a size descriptor and a fresh ref-kind result, no
@@ -2640,6 +2685,7 @@ impl Assembler {
                 OpKind::GetSlice { .. } => "GetSlice",
                 OpKind::New { .. } => "New",
                 OpKind::NewWithVtable { .. } => "NewWithVtable",
+                OpKind::NewArrayClear { .. } => "NewArrayClear",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
             }
@@ -4171,6 +4217,11 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::FieldWrite { ty, .. } => format!("setfield_gc_{}", value_type_to_kind(ty)),
         OpKind::New { .. } => "new".into(),
         OpKind::NewWithVtable { .. } => "new_with_vtable".into(),
+        // `NewArrayClear` carries a descriptor operand (`new_array_clear/id>r`)
+        // so it is encoded by its dedicated `encode_op` arm, never the
+        // descriptor-less default path that calls this helper — the arm exists
+        // only to keep the opname map exhaustive.
+        OpKind::NewArrayClear { .. } => "new_array_clear".into(),
         // RPython: getarrayitem_gc_i etc.
         OpKind::ArrayRead { item_ty, .. } => {
             format!("getarrayitem_gc_{}", value_type_to_kind(item_ty))

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1658,6 +1658,23 @@ impl Assembler {
                 let key = format!("new_array_clear/{argcodes}");
                 state.code[startposition] = self.get_opnum(&key);
             }
+            // `newlist_clear/idddd>r` (`handler_newlist_clear`,
+            // blackhole.rs, wired for length + four descriptors:
+            // struct, length, items, array) has no emit arm yet — the
+            // dedicated encoding lands with the codewriter producer.
+            // Fail loud rather than fall through the descriptor-less
+            // `other =>` default below, which would build the key
+            // `newlist_clear/i>r` and let `get_opnum` mint an
+            // unregistered dynamic opcode with no wired runtime handler
+            // (a silent miscompile).  This placeholder enforces the
+            // ordering: the emit arm must land before any producer.
+            OpKind::NewListClear { .. } => {
+                panic!(
+                    "newlist_clear emit is not implemented: a NewListClear op reached \
+                     the assembler before its `newlist_clear/idddd>r` encoding arm was \
+                     added (length + structdescr/lengthdescr/itemsdescr/arraydescr)"
+                );
+            }
             // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
             // tracer oracle (`box_trace.rs trace_box_float`): a `new_with_vtable`
             // carrying ONLY a size descriptor and a fresh ref-kind result, no
@@ -4218,10 +4235,11 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         OpKind::FieldWrite { ty, .. } => format!("setfield_gc_{}", value_type_to_kind(ty)),
         OpKind::New { .. } => "new".into(),
         OpKind::NewWithVtable { .. } => "new_with_vtable".into(),
-        // `NewArrayClear` carries a descriptor operand (`new_array_clear/id>r`)
-        // so it is encoded by its dedicated `encode_op` arm, never the
-        // descriptor-less default path that calls this helper — the arm exists
-        // only to keep the opname map exhaustive.
+        // `NewArrayClear` (`new_array_clear/id>r`) and `NewListClear`
+        // (`newlist_clear/idddd>r`) both carry descriptor operands and are
+        // encoded by their dedicated `encode_op` arms, never the
+        // descriptor-less default path that calls this helper — these arms
+        // exist only to keep the opname map exhaustive.
         OpKind::NewArrayClear { .. } => "new_array_clear".into(),
         OpKind::NewListClear { .. } => "newlist_clear".into(),
         // RPython: getarrayitem_gc_i etc.
@@ -5333,10 +5351,12 @@ mod tests {
         // proves the length field was rewritten, not merely preserved.
         assert_ne!(length, remapped_length);
 
+        // `array_type_id` is the ITEMS ARRAY identity (`cpu.arraydescrof(
+        // ARRAY)`), not the enclosing struct name — use a plausible array id.
         let kind = OpKind::NewListClear {
             length: length.clone(),
             item_ty: ValueType::Ref(None),
-            array_type_id: Some("list".to_string()),
+            array_type_id: Some("list_items".to_string()),
         };
 
         // Run it through the inline var remap: length is rewritten via the
@@ -5359,7 +5379,7 @@ mod tests {
             } => {
                 assert_eq!(*l, remapped_length, "length must be rewritten by remap");
                 assert!(matches!(item_ty, ValueType::Ref(None)));
-                assert_eq!(array_type_id.as_deref(), Some("list"));
+                assert_eq!(array_type_id.as_deref(), Some("list_items"));
             }
             other => panic!("expected NewListClear, got {other:?}"),
         }

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1659,21 +1659,95 @@ impl Assembler {
                 state.code[startposition] = self.get_opnum(&key);
             }
             // `newlist_clear/idddd>r` (`handler_newlist_clear`,
-            // blackhole.rs, wired for length + four descriptors:
-            // struct, length, items, array) has no emit arm yet — the
-            // dedicated encoding lands with the codewriter producer.
-            // Fail loud rather than fall through the descriptor-less
-            // `other =>` default below, which would build the key
-            // `newlist_clear/i>r` and let `get_opnum` mint an
-            // unregistered dynamic opcode with no wired runtime handler
-            // (a silent miscompile).  This placeholder enforces the
-            // ordering: the emit arm must land before any producer.
-            OpKind::NewListClear { .. } => {
-                panic!(
-                    "newlist_clear emit is not implemented: a NewListClear op reached \
-                     the assembler before its `newlist_clear/idddd>r` encoding arm was \
-                     added (length + structdescr/lengthdescr/itemsdescr/arraydescr)"
+            // blackhole.rs) lowers the resizable-list allocation
+            // `do_resizable_newlist` emits (blackhole.py:1173-1180): a
+            // `list` GcStruct header wrapping a cleared items array.  The
+            // handler reads length (Int) then FOUR descriptors in this
+            // order — structdescr, lengthdescr, itemsdescr, arraydescr —
+            // then the ref result.  The four descrs must be pushed in that
+            // exact read order or the handler misreads them.  The list
+            // header (`GcStruct("list", ("length", Signed), ("items",
+            // Ptr(GcArray(ITEM))))`) is resizable and carries no vtable, so
+            // its Size descr takes vtable 0.
+            OpKind::NewListClear {
+                length,
+                item_ty,
+                array_type_id,
+            } => {
+                let (reg, kc) = self.lookup_reg_with_kind_var(length, regallocs);
+                assert_eq!(kc, 'i', "newlist_clear length must be int-kind, got {kc:?}",);
+                state.code.push(reg);
+                argcodes.push(kc);
+                // structdescr: the `list` header Size descr.  Mirror the
+                // `OpKind::New` arm — a resizable list header has no vtable.
+                let spec = bh_size_spec_from_callcontrol(
+                    callcontrol.expect("newlist_clear assembly requires a CallControl"),
+                    "list",
+                )
+                .unwrap_or_else(|| {
+                    panic!("newlist_clear: no struct layout registered for owner \"list\"")
+                });
+                let descr_idx = self.emit_ready_descr(crate::jitcode::BhDescr::Size {
+                    size: spec.size,
+                    type_id: spec.type_id,
+                    vtable: 0,
+                    owner: String::new(),
+                    all_fielddescrs: spec.all_fielddescrs,
+                    is_gc_managed: spec.is_gc_managed,
+                });
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                // lengthdescr: fielddescr for `list.length` (Signed word).
+                // Mirror the `FieldWrite` arm's fielddescr interning — the
+                // local free `fielddescrof` builds the `BhDescr::Field`,
+                // resolving the offset off the registered `list` layout.
+                let length_field =
+                    crate::model::FieldDescriptor::new("length", Some("list".to_string()));
+                let descr_idx = self.emit_ready_descr(fielddescrof(
+                    &length_field,
+                    &crate::model::ValueType::Int,
+                    callcontrol,
+                ));
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                // itemsdescr: fielddescr for `list.items` (Ptr to array).
+                let items_field =
+                    crate::model::FieldDescriptor::new("items", Some("list".to_string()));
+                let descr_idx = self.emit_ready_descr(fielddescrof(
+                    &items_field,
+                    &crate::model::ValueType::Ref(None),
+                    callcontrol,
+                ));
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                // arraydescr: the length-prefixed items block, identical to
+                // the `NewArrayClear` arm.
+                let descr_idx = self.emit_ready_descr(arraydescrof(
+                    item_ty,
+                    array_type_id,
+                    Some(0),
+                    callcontrol,
+                ));
+                state.code.push((descr_idx & 0xFF) as u8);
+                state.code.push((descr_idx >> 8) as u8);
+                argcodes.push('d');
+                let result = op
+                    .result
+                    .as_ref()
+                    .expect("newlist_clear must produce a result");
+                let (reg, kind) = self.lookup_reg_with_kind_var(result, regallocs);
+                assert_eq!(
+                    kind, 'r',
+                    "newlist_clear result must use the ref register bank"
                 );
+                state.code.push(reg);
+                argcodes.push('>');
+                argcodes.push('r');
+                let key = format!("newlist_clear/{argcodes}");
+                state.code[startposition] = self.get_opnum(&key);
             }
             // Boxing GC allocation (`fuse_boxing_alloc`).  Mirrors the runtime
             // tracer oracle (`box_trace.rs trace_box_float`): a `new_with_vtable`
@@ -5702,6 +5776,120 @@ mod tests {
             "expected Field descrs for `value` + `mutate_value`, got {:?}",
             field_descr_names
         );
+    }
+
+    /// `OpKind::NewListClear` assembles to the wired `newlist_clear/idddd>r`
+    /// opcode: length (Int) + four descriptors (structdescr, lengthdescr,
+    /// itemsdescr, arraydescr) + ref result.  The `list` GcStruct header
+    /// layout (`length@0`, `items@8`) is registered on the CallControl so
+    /// the struct/field descrs resolve, and the four descr slots must be
+    /// interned in exactly that read order (`handler_newlist_clear`,
+    /// blackhole.rs).
+    #[test]
+    fn assembles_newlist_clear_with_four_descrs_in_read_order() {
+        use crate::call::CallControl;
+        use crate::flatten::flatten_graph;
+        use crate::jtransform::{GraphTransformConfig, Transformer};
+        use crate::model::{FunctionGraph, OpKind, ValueType};
+
+        // Mirror `rtyper_synthesised_list_struct_resolves_its_field_descrs`
+        // (call.rs): register the rtyper-synthesised `GcStruct("list",
+        // ("length", Signed), ("items", Ptr(GcArray(ITEM))))` shape so the
+        // structdescr and the `length`/`items` fielddescrs resolve.
+        let mut cc = CallControl::new();
+        let mut registry = crate::front::StructFieldRegistry::default();
+        registry.fields.insert(
+            "list".to_string(),
+            vec![
+                ("length".to_string(), "i64".to_string()),
+                ("items".to_string(), "&[i64]".to_string()),
+            ],
+        );
+        cc.set_struct_fields(registry);
+
+        let mut graph = FunctionGraph::new("newlist_clear_graph");
+        let length_var = push_input_var(&mut graph, "n", ValueType::Int);
+        let result_var = graph
+            .push_op_var(
+                graph.startblock,
+                OpKind::NewListClear {
+                    length: length_var.clone(),
+                    item_ty: ValueType::Int,
+                    array_type_id: Some("list_items".to_string()),
+                },
+                true,
+            )
+            .unwrap();
+        graph.set_return(graph.startblock, Some(result_var.clone()));
+
+        FunctionGraph::set_concretetype_of_inline(
+            &length_var,
+            crate::codewriter::type_state::ConcreteType::Signed,
+        );
+        FunctionGraph::set_concretetype_of_inline(
+            &result_var,
+            crate::codewriter::type_state::ConcreteType::GcRef,
+        );
+
+        let config = GraphTransformConfig::default();
+        let mut transformer = Transformer::new(&config).with_callcontrol(&mut cc);
+        let mut rewritten = transformer.transform(&graph).graph;
+        regalloc::augment_canonical_exceptblock_on_graph(&mut rewritten);
+        let mut regallocs = regalloc::perform_all_register_allocations(&rewritten);
+        let mut flat = flatten_graph(&rewritten, &mut regallocs);
+        let mut asm = Assembler::new();
+        let _ = asm.assemble_with_callcontrol(&mut flat, &regallocs, Some(&cc));
+
+        // The key must be exactly `newlist_clear/idddd>r` — four `d` descr
+        // slots in the length/struct-length-items-array order.  Any drift
+        // (wrong descr count) would mint a different dynamic opname.
+        assert!(
+            asm.insns.contains_key("newlist_clear/idddd>r"),
+            "expected key newlist_clear/idddd>r, got {:?}",
+            asm.insns.keys().collect::<Vec<_>>()
+        );
+
+        // Four descrs interned in read order: Size (struct) → Field
+        // (length) → Field (items) → Array (items block).
+        let descrs = asm.snapshot_descrs();
+        let list_size = descrs.iter().position(
+            |d| matches!(d, crate::jitcode::BhDescr::Size { vtable, .. } if *vtable == 0),
+        );
+        assert!(
+            list_size.is_some(),
+            "expected a vtable-0 Size descr for the list header, got {descrs:?}"
+        );
+        let length_pos = descrs.iter().position(
+            |d| matches!(d, crate::jitcode::BhDescr::Field { name, .. } if name == "length"),
+        );
+        let items_pos = descrs.iter().position(
+            |d| matches!(d, crate::jitcode::BhDescr::Field { name, .. } if name == "items"),
+        );
+        let array_pos = descrs
+            .iter()
+            .position(|d| matches!(d, crate::jitcode::BhDescr::Array { .. }));
+        let (length_pos, items_pos, array_pos) = (
+            length_pos.expect("length fielddescr interned"),
+            items_pos.expect("items fielddescr interned"),
+            array_pos.expect("array descr interned"),
+        );
+        assert!(
+            list_size.unwrap() < length_pos && length_pos < items_pos && items_pos < array_pos,
+            "descrs must intern in struct/length/items/array order, got {descrs:?}"
+        );
+
+        // The `list` header layout resolved off the registered struct:
+        // length@0 (Signed word) and items@8 (pointer to the array block).
+        let field_at = |name: &str| {
+            descrs.iter().find_map(|d| match d {
+                crate::jitcode::BhDescr::Field {
+                    name: n, offset, ..
+                } if n == name => Some(*offset),
+                _ => None,
+            })
+        };
+        assert_eq!(field_at("length"), Some(0), "length is the first word");
+        assert_eq!(field_at("items"), Some(8), "items follows the length word");
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -2686,6 +2686,7 @@ impl Assembler {
                 OpKind::New { .. } => "New",
                 OpKind::NewWithVtable { .. } => "NewWithVtable",
                 OpKind::NewArrayClear { .. } => "NewArrayClear",
+                OpKind::NewListClear { .. } => "NewListClear",
                 OpKind::LoweredBlackholeOp { .. } => "LoweredBlackholeOp",
                 OpKind::LoadStatic { .. } => "LoadStatic",
             }
@@ -4222,6 +4223,7 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         // descriptor-less default path that calls this helper — the arm exists
         // only to keep the opname map exhaustive.
         OpKind::NewArrayClear { .. } => "new_array_clear".into(),
+        OpKind::NewListClear { .. } => "newlist_clear".into(),
         // RPython: getarrayitem_gc_i etc.
         OpKind::ArrayRead { item_ty, .. } => {
             format!("getarrayitem_gc_{}", value_type_to_kind(item_ty))
@@ -5313,6 +5315,64 @@ mod tests {
         // jtransform.py:1718 `SpaceOperation('loop_header', [c_index], None)`
         let header = crate::model::OpKind::LoopHeader { jitdriver_index: 0 };
         assert_eq!(op_kind_to_opname(&header), "loop_header");
+    }
+
+    /// `OpKind::NewListClear` (`opimpl_newlist_clear`, pyjitpl.py:792-798)
+    /// carries the same `{length, item_ty, array_type_id}` shape as
+    /// `NewArrayClear`.  Its length operand must survive the inline var
+    /// remap while the descriptor fields (`item_ty`/`array_type_id`) copy
+    /// through unchanged, and it must map to the opname `newlist_clear`.
+    #[test]
+    fn newlist_clear_survives_remap_and_names() {
+        use crate::flowspace::model::Variable;
+        use crate::model::{OpKind, ValueType};
+
+        let length = Variable::new();
+        let remapped_length = Variable::new();
+        // The remapped length must be a *distinct* SSA var so the assert
+        // proves the length field was rewritten, not merely preserved.
+        assert_ne!(length, remapped_length);
+
+        let kind = OpKind::NewListClear {
+            length: length.clone(),
+            item_ty: ValueType::Ref(None),
+            array_type_id: Some("list".to_string()),
+        };
+
+        // Run it through the inline var remap: length is rewritten via the
+        // closure, the descriptor fields clone through unchanged.
+        let remapped_length_c = remapped_length.clone();
+        let length_c = length.clone();
+        let remap = move |v: &Variable| {
+            if *v == length_c {
+                remapped_length_c.clone()
+            } else {
+                v.clone()
+            }
+        };
+        let remapped = crate::inline::remap_op_kind(&kind, &remap);
+        match &remapped {
+            OpKind::NewListClear {
+                length: l,
+                item_ty,
+                array_type_id,
+            } => {
+                assert_eq!(*l, remapped_length, "length must be rewritten by remap");
+                assert!(matches!(item_ty, ValueType::Ref(None)));
+                assert_eq!(array_type_id.as_deref(), Some("list"));
+            }
+            other => panic!("expected NewListClear, got {other:?}"),
+        }
+
+        // Only the length is an SSA operand; the descrs are not values.
+        let refs = crate::inline::op_variable_refs(&kind);
+        assert_eq!(refs, vec![length.clone()]);
+
+        // Allocation is never pure — CSE must not coalesce two of them.
+        assert!(!crate::inline::is_pure_op(&kind));
+
+        // opname map: `newlist_clear`.
+        assert_eq!(op_kind_to_opname(&kind), "newlist_clear");
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7569,9 +7569,10 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // `ignore_memoryerror` it is treated as non-raising
         // (canraise = (MemoryError,)).  `new_array_clear` is the cleared
         // varsize allocation, same class.
-        OpKind::New { .. } | OpKind::NewWithVtable { .. } | OpKind::NewArrayClear { .. } => {
-            RaiseClass::MemoryErrorOnly
-        }
+        OpKind::New { .. }
+        | OpKind::NewWithVtable { .. }
+        | OpKind::NewArrayClear { .. }
+        | OpKind::NewListClear { .. } => RaiseClass::MemoryErrorOnly,
         // RPython LL: getarrayitem_gc, setarrayitem_gc, arraylen_gc → cannot raise
         OpKind::ArrayRead { .. } | OpKind::ArrayWrite { .. } | OpKind::ArrayLen { .. } => {
             RaiseClass::No

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -9537,6 +9537,54 @@ mod tests {
     }
 
     #[test]
+    fn rtyper_synthesised_list_struct_resolves_its_field_descrs() {
+        // The rtyper synthesises `GcStruct("list", ("length", Signed),
+        // ("items", Ptr(GcArray(ITEM))))` (`translator/rtyper/rlist.rs:1112`).
+        // `lib.rs` registers the {length, items} shape into `struct_fields`
+        // before `set_struct_fields`; mirror that injection here.  The
+        // heuristic accumulation over two word-sized fields must land
+        // length@0, items@8, struct size 16.
+        let mut cc = CallControl::new();
+        let mut registry = crate::front::StructFieldRegistry::default();
+        registry.fields.insert(
+            "list".to_string(),
+            vec![
+                ("length".to_string(), "i64".to_string()),
+                ("items".to_string(), "&[i64]".to_string()),
+            ],
+        );
+        cc.set_struct_fields(registry);
+
+        let length = cc
+            .fielddescrof(0, "list", None, "length")
+            .expect("list.length descr resolves");
+        assert_eq!(
+            length
+                .as_field_descr()
+                .expect("length is a field descr")
+                .offset(),
+            0,
+            "length is the first field",
+        );
+        let items = cc
+            .fielddescrof(1, "list", None, "items")
+            .expect("list.items descr resolves");
+        assert_eq!(
+            items
+                .as_field_descr()
+                .expect("items is a field descr")
+                .offset(),
+            8,
+            "items follows the 8-byte length word",
+        );
+        assert_eq!(
+            compute_struct_size(&cc, "list"),
+            16,
+            "two word-sized fields → 16-byte struct",
+        );
+    }
+
+    #[test]
     fn raw_pointer_field_is_not_flattened_as_a_known_pointee_struct() {
         use majit_ir::descr::ArrayFlag;
         use majit_ir::value::Type;

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -9550,7 +9550,7 @@ mod tests {
             "list".to_string(),
             vec![
                 ("length".to_string(), "i64".to_string()),
-                ("items".to_string(), "&[i64]".to_string()),
+                ("items".to_string(), "&()".to_string()),
             ],
         );
         cc.set_struct_fields(registry);

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7565,9 +7565,13 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         // ── Known non-raising ops (canraise = ()) ─────────────────
         // RPython LL: getfield_gc, setfield_gc → cannot raise
         OpKind::FieldRead { .. } | OpKind::FieldWrite { .. } => RaiseClass::No,
-        // `malloc` can only raise MemoryError; with `ignore_memoryerror`
-        // it is treated as non-raising (canraise = (MemoryError,)).
-        OpKind::New { .. } | OpKind::NewWithVtable { .. } => RaiseClass::MemoryErrorOnly,
+        // `malloc` / `malloc_varsize` can only raise MemoryError; with
+        // `ignore_memoryerror` it is treated as non-raising
+        // (canraise = (MemoryError,)).  `new_array_clear` is the cleared
+        // varsize allocation, same class.
+        OpKind::New { .. } | OpKind::NewWithVtable { .. } | OpKind::NewArrayClear { .. } => {
+            RaiseClass::MemoryErrorOnly
+        }
         // RPython LL: getarrayitem_gc, setarrayitem_gc, arraylen_gc → cannot raise
         OpKind::ArrayRead { .. } | OpKind::ArrayWrite { .. } | OpKind::ArrayLen { .. } => {
             RaiseClass::No

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -10893,6 +10893,62 @@ mod tests {
         assert_eq!(new_array_clear, count);
     }
 
+    /// T3 end-to-end: the rtyper mints the `_ll_alloc_and_set` family (whose
+    /// clear sub-helper is named `_ll_alloc_and_clear` for BOTH the resized
+    /// and fixed layouts), and `lib.rs` attaches the `newlist_clear(count)`
+    /// oopspec under the single-segment path `["_ll_alloc_and_clear"]`.  A
+    /// `direct_call` to a `_ll_alloc_and_clear` funcptr therefore resolves to
+    /// that path and lowers to `new_array_clear` — this locks that the path
+    /// `lib.rs` registers is exactly the one the minted graph's name produces.
+    #[test]
+    fn t3_ll_alloc_and_clear_oopspec_registration_lowers_to_new_array_clear() {
+        // Exactly the registration `lib.rs` performs beside the jit.* specs.
+        let mut cc = crate::call::CallControl::new();
+        cc.mark_oopspec(
+            crate::parse::CallPath::from_segments(["_ll_alloc_and_clear"]),
+            "newlist_clear(count)".to_string(),
+        );
+
+        let mut graph = FunctionGraph::new("caller");
+        let count = graph.alloc_value_var();
+        let result = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&count, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::GcRef);
+        let startblock = graph.startblock;
+        graph.push_op_var(
+            startblock,
+            OpKind::Call {
+                target: CallTarget::function_path(["_ll_alloc_and_clear"]),
+                args: vec![count.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph
+            .block_mut(startblock)
+            .operations
+            .last_mut()
+            .unwrap()
+            .result = Some(result.clone());
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+
+        let lowered = transformed
+            .graph
+            .block(startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::NewArrayClear { length, .. } => Some(length.clone()),
+                _ => None,
+            })
+            .expect("minted _ll_alloc_and_clear must lower to new_array_clear");
+        assert_eq!(lowered, count);
+    }
+
     /// `list.int_getitem(l, i)` lowers to `getfield_gc_r(l,
     /// int_items.block)` feeding `getarrayitem_gc_i(block, i)`.
     #[test]

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4092,15 +4092,62 @@ impl<'a> Transformer<'a> {
             // over `new_array` (jtransform.py:1851-1855).
             "newlist_clear" => {
                 let length = args.first()?.clone();
-                (
-                    "newlist_clear → new_array_clear(count, arraydescr)",
-                    vec![SpaceOperation {
-                        result: op.result.clone(),
-                        kind: OpKind::NewArrayClear {
+                // Fork on the result's list layout, mirroring upstream's
+                // `LIST = op.result.concretetype.TO; resizable =
+                // isinstance(LIST, lltype.GcStruct)` split in
+                // `_handle_list_call` (jtransform.py:1762-1785):
+                // `do_resizable_newlist_clear` (jtransform.py:1938) allocates
+                // the `"list"` header struct plus a cleared items array,
+                // `do_fixed_newlist_clear` (jtransform.py:1858) emits a bare
+                // cleared array.  `item_ty` / `array_type_id` are recovered
+                // from the result element lltype in BOTH cases — never
+                // hardcoded — so a non-pointer element list is not GC-traced
+                // as a pointer array, and a resized result carries the struct
+                // header instead of a bare array (C1).
+                let (detail, kind) = match newlist_clear_shape(op.result.as_ref()) {
+                    NewlistClearShape::Resized {
+                        item_ty,
+                        array_type_id,
+                    } => (
+                        "newlist_clear → newlist_clear(count, arraydescr) \
+                         [resized list header]",
+                        OpKind::NewListClear {
+                            length,
+                            item_ty,
+                            array_type_id,
+                        },
+                    ),
+                    NewlistClearShape::Fixed {
+                        item_ty,
+                        array_type_id,
+                    } => (
+                        "newlist_clear → new_array_clear(count, arraydescr) \
+                         [fixed array]",
+                        OpKind::NewArrayClear {
+                            length,
+                            item_ty,
+                            array_type_id,
+                        },
+                    ),
+                    // OBJECTPTR / None fallback: the pre-fork behavior, kept
+                    // until N7 rewrites `_handle_list_call`'s tests with typed
+                    // results.  A generic `OBJECTPTR` result (e.g. a test that
+                    // stamped `alloc_value_var_with_type(GcRef)`) or a missing
+                    // concretetype hits this arm.
+                    NewlistClearShape::Fallback => (
+                        "newlist_clear → new_array_clear(count, arraydescr)",
+                        OpKind::NewArrayClear {
                             length,
                             item_ty: ValueType::Ref(None),
                             array_type_id: None,
                         },
+                    ),
+                };
+                (
+                    detail,
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind,
                     }],
                 )
             }
@@ -6475,6 +6522,108 @@ fn stroruni_first_arg_kind(var: &crate::flowspace::model::Variable) -> StrOrUniK
         "rpy_unicode" => StrOrUniKind::Unicode,
         "rpy_bytearray" => StrOrUniKind::ByteArray,
         _ => StrOrUniKind::Other,
+    }
+}
+
+/// The result-layout fork `_handle_list_call`'s `"newlist_clear"` arm
+/// selects between, mirroring upstream's `LIST = op.result.concretetype.TO;
+/// resizable = isinstance(LIST, lltype.GcStruct)` split
+/// (`jtransform.py:1762-1785`).  `item_ty` / `array_type_id` are recovered
+/// from the result element lltype in the `Resized` / `Fixed` cases (C1: the
+/// pre-fork arm hardcoded `Ref(None)` / `None`, so a non-pointer element
+/// list was GC-traced as a pointer array and a resized result emitted a
+/// bare array with no struct header); `Fallback` keeps the pre-fork shape
+/// for an untyped-or-`OBJECTPTR` result (pending N7's typed-result tests).
+enum NewlistClearShape {
+    /// Result is `Ptr(GcStruct("list", {length, items}))` — the resized
+    /// list header.  `do_resizable_newlist_clear` (jtransform.py:1938).
+    Resized {
+        item_ty: ValueType,
+        array_type_id: Option<String>,
+    },
+    /// Result is `Ptr(Array(ITEM))` — a bare fixed-size cleared array.
+    /// `do_fixed_newlist_clear` (jtransform.py:1858).
+    Fixed {
+        item_ty: ValueType,
+        array_type_id: Option<String>,
+    },
+    /// No concretetype, or a pointee that is neither the `"list"` struct
+    /// nor an array (a generic `OBJECTPTR` from an untyped test).
+    Fallback,
+}
+
+/// Classify a `newlist_clear` result Variable by its pointee list layout,
+/// recovering the items-array element `ValueType` (C1: never hardcoded)
+/// from the result lltype.
+///
+/// The element lltype → `ValueType` path is `getkind` (`model::getkind`,
+/// the canonical `LowLevelType → kind` projection) → `ConcreteType` →
+/// `ValueType`, matching `Transformer::get_value_type`'s kind-collapsed
+/// mapping (Char/Bool/Signed → `Int`, gc `Ptr` → `Ref`).
+///
+/// `array_type_id` is the ITEMS ARRAY identity string
+/// (`cpu.arraydescrof(ARRAY)` cache key).  It is a Rust-type spelling
+/// produced by the MIR front-end and is not recoverable from an rtyped
+/// lltype here, so it is `None`; `arraydescrof(item_ty, None, Some(0), cc)`
+/// derives a correct-width descr from `item_ty` alone — both the
+/// `CallControl` path (`arraydescrof_concrete`'s `elem_ref == None` branch)
+/// and the codewriter-less `assembler::arraydescrof` fallback key itemsize
+/// and pointer-ness off `item_ty` when `array_type_id` is absent (pointer
+/// elements stride by the target word, int/float by 8; the flag follows the
+/// item type).
+fn newlist_clear_shape(result: Option<&crate::flowspace::model::Variable>) -> NewlistClearShape {
+    use crate::translator::rtyper::lltypesystem::lltype::{LowLevelType, PtrTarget};
+
+    fn resolve(target: PtrTarget) -> Option<LowLevelType> {
+        match target {
+            PtrTarget::ForwardReference(fwd) => fwd.resolved(),
+            other => Some(LowLevelType::from(other)),
+        }
+    }
+
+    // Element `LowLevelType` → `ValueType`, collapsed through `getkind`'s
+    // kind space.  `getkind` never returns `Void`/`Unknown` for a real
+    // array element (it panics on the unsupported longlonglong / longfloat
+    // / interiorptr shapes), so those arms are defensive and land on the
+    // GC-pointer default.
+    fn element_value_type(elem: &LowLevelType) -> ValueType {
+        use crate::codewriter::type_state::ConcreteType;
+        match crate::model::getkind(elem) {
+            ConcreteType::Signed => ValueType::Int,
+            ConcreteType::Float => ValueType::Float,
+            ConcreteType::GcRef | ConcreteType::Void | ConcreteType::Unknown => {
+                ValueType::Ref(None)
+            }
+        }
+    }
+
+    let Some(LowLevelType::Ptr(ptr)) = result.and_then(|v| v.concretetype()) else {
+        return NewlistClearShape::Fallback;
+    };
+    let Some(pointee) = resolve(ptr.TO) else {
+        return NewlistClearShape::Fallback;
+    };
+    match pointee {
+        // Resized layout: the `"list"` GcStruct header.  Its `items` field
+        // is `Ptr(GcArray(ITEM))`; walk struct → `items` → array → OF.
+        LowLevelType::Struct(s) if s._name == "list" => {
+            let Some(LowLevelType::Ptr(items_ptr)) = s._flds.get("items") else {
+                return NewlistClearShape::Fallback;
+            };
+            let Some(LowLevelType::Array(a)) = resolve(items_ptr.TO.clone()) else {
+                return NewlistClearShape::Fallback;
+            };
+            NewlistClearShape::Resized {
+                item_ty: element_value_type(&a.OF),
+                array_type_id: None,
+            }
+        }
+        // Fixed layout: the pointee is the items array directly.
+        LowLevelType::Array(a) => NewlistClearShape::Fixed {
+            item_ty: element_value_type(&a.OF),
+            array_type_id: None,
+        },
+        _ => NewlistClearShape::Fallback,
     }
 }
 
@@ -10837,6 +10986,133 @@ mod tests {
             } => {
                 assert_eq!(length, &count);
                 assert!(matches!(item_ty, ValueType::Ref(None)));
+                assert_eq!(array_type_id, &None);
+            }
+            other => panic!("expected NewArrayClear, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// C1 fork, resized layout: a result typed
+    /// `Ptr(GcStruct("list", {length, items: Ptr(GcArray(Signed))}))` — the
+    /// resized `ListRepr` shape (`do_resizable_newlist_clear`,
+    /// jtransform.py:1938) — lowers to `NewListClear` (the struct-header
+    /// compound op) with `item_ty` recovered from the items array element
+    /// (`Signed` → `Int`), NOT the pre-fork bare `new_array_clear`.
+    #[test]
+    fn handle_list_call_newlist_clear_resized_lowers_to_newlist_clear() {
+        use crate::translator::rtyper::lltypesystem::lltype::{
+            Array, LowLevelType, Ptr, PtrTarget, Struct,
+        };
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+
+        // upstream `GcStruct("list", ("length", Signed), ("items",
+        // Ptr(GcArray(ITEM))))` with ITEM = Signed (an int-element list).
+        let items_ptr = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Array(Array::gc(LowLevelType::Signed)),
+        }));
+        let list_struct = Struct::gc(
+            "list",
+            vec![
+                ("length".to_string(), LowLevelType::Signed),
+                ("items".to_string(), items_ptr),
+            ],
+        );
+        let list_ptr = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Struct(list_struct),
+        }));
+
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("newlist_clear_resized");
+        let count = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = variable_with_lltype("l", list_ptr);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "newlist_clear",
+                &op,
+                &[count.clone()],
+                &mut graph,
+                "newlist_clear_resized",
+            )
+            .expect("newlist_clear must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::NewListClear {
+                length,
+                item_ty,
+                array_type_id,
+            } => {
+                assert_eq!(length, &count);
+                assert!(
+                    matches!(item_ty, ValueType::Int),
+                    "int-element list items array must recover ValueType::Int, got {item_ty:?}"
+                );
+                assert_eq!(array_type_id, &None);
+            }
+            other => panic!("expected NewListClear, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// C1 fork, fixed layout: a result typed `Ptr(GcArray(Signed))` — the
+    /// fixed `FixedSizeListRepr` shape (`do_fixed_newlist_clear`,
+    /// jtransform.py:1858) — lowers to `NewArrayClear` with `item_ty`
+    /// recovered from the array element (`Signed` → `Int`), proving the C1
+    /// element-type recovery: the pre-fork arm hardcoded `Ref(None)`, which
+    /// would GC-trace int slots as pointers.
+    #[test]
+    fn handle_list_call_newlist_clear_fixed_recovers_int_item_ty() {
+        use crate::translator::rtyper::lltypesystem::lltype::{
+            Array, LowLevelType, Ptr, PtrTarget,
+        };
+        use crate::translator::rtyper::rtyper::variable_with_lltype;
+
+        let array_ptr = LowLevelType::Ptr(Box::new(Ptr {
+            TO: PtrTarget::Array(Array::gc(LowLevelType::Signed)),
+        }));
+
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("newlist_clear_fixed");
+        let count = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = variable_with_lltype("a", array_ptr);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "newlist_clear",
+                &op,
+                &[count.clone()],
+                &mut graph,
+                "newlist_clear_fixed",
+            )
+            .expect("newlist_clear must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::NewArrayClear {
+                length,
+                item_ty,
+                array_type_id,
+            } => {
+                assert_eq!(length, &count);
+                assert!(
+                    matches!(item_ty, ValueType::Int),
+                    "int-element fixed array must recover ValueType::Int (NOT Ref(None)), \
+                     got {item_ty:?}"
+                );
                 assert_eq!(array_type_id, &None);
             }
             other => panic!("expected NewArrayClear, got {other:?}"),

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -10949,13 +10949,20 @@ mod tests {
         assert_eq!(ops[0].result, Some(result));
     }
 
-    /// `newlist_clear(count)` (`_ll_alloc_and_clear`, rlist.py:522-528)
-    /// lowers to a single `new_array_clear(count, arraydescr)`
-    /// (`do_fixed_newlist_clear`, jtransform.py:1858-1863). The `count`
-    /// operand is the initial length; the cleared items array holds GC
-    /// pointers, so the emitted `item_ty` is `Ref`.
+    /// Fallback arm: a `newlist_clear` result with no recoverable list
+    /// layout — a generic `OBJECTPTR` (`Ptr(GcStruct("object"))`) or a
+    /// missing concretetype — is neither the `"list"` header struct nor an
+    /// items array, so `newlist_clear_shape` returns `Fallback` and the arm
+    /// emits a conservative `new_array_clear(count, arraydescr)` with a
+    /// GC-pointer element (`Ref(None)`) and no array identity.  This input
+    /// does not occur in a real translation (the rtyper stamps the list
+    /// type on the `_ll_alloc_and_clear` result); it is only reachable from
+    /// synthetic graphs that leave the result untyped.  The recovered-shape
+    /// arms are covered by
+    /// `handle_list_call_newlist_clear_resized_lowers_to_newlist_clear` and
+    /// `handle_list_call_newlist_clear_fixed_recovers_int_item_ty`.
     #[test]
-    fn handle_list_call_newlist_clear_lowers_to_new_array_clear() {
+    fn handle_list_call_newlist_clear_untyped_result_falls_back_to_ref_array() {
         let config = GraphTransformConfig::default();
         let mut graph = FunctionGraph::new("newlist_clear");
         let count = graph.alloc_value_var_with_type(ConcreteType::Signed);
@@ -11171,8 +11178,10 @@ mod tests {
             .operations
             .iter()
             .find_map(|op| match &op.kind {
+                // The GcRef result stamps a generic OBJECTPTR (not a
+                // `"list"` struct), so the fork lands on Fallback →
+                // NewArrayClear, never NewListClear.
                 OpKind::NewArrayClear { length, .. } => Some(length.clone()),
-                OpKind::NewListClear { length, .. } => Some(length.clone()),
                 _ => None,
             })
             .expect("marked newlist_clear must lower to new_array_clear");
@@ -11229,8 +11238,8 @@ mod tests {
             .operations
             .iter()
             .find_map(|op| match &op.kind {
+                // GcRef result → generic OBJECTPTR → Fallback → NewArrayClear.
                 OpKind::NewArrayClear { length, .. } => Some(length.clone()),
-                OpKind::NewListClear { length, .. } => Some(length.clone()),
                 _ => None,
             })
             .expect("minted _ll_alloc_and_clear must lower to new_array_clear");
@@ -11287,8 +11296,8 @@ mod tests {
             .operations
             .iter()
             .find_map(|op| match &op.kind {
+                // GcRef result → generic OBJECTPTR → Fallback → NewArrayClear.
                 OpKind::NewArrayClear { length, .. } => Some(length.clone()),
-                OpKind::NewListClear { length, .. } => Some(length.clone()),
                 _ => None,
             })
             .expect("minted _ll_fixed_alloc_and_clear must lower to new_array_clear");

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -4076,6 +4076,34 @@ impl<'a> Transformer<'a> {
                     }],
                 )
             }
+            // `do_fixed_newlist_clear` (jtransform.py:1858-1863):
+            //   v_length = self._get_initial_newlist_length(op, args)
+            //   return SpaceOperation('new_array_clear', [v_length, arraydescr],
+            //                         op.result)
+            // `_ll_alloc_and_clear` (rlist.py:522-528, `@jit.oopspec(
+            // "newlist_clear(count)")`) reaches here through
+            // `_handle_list_call`; the `count` arg is the initial length.
+            // `_get_initial_newlist_length` (jtransform.py:1835-1842):
+            // `args[0]` when present, else the constant 0 — pyre carries the
+            // materialised `count` Variable, so a `newlist_clear(count)`
+            // callsite always supplies `args[0]`.  The cleared list holds GC
+            // pointers, so the arraydescr's item type is `Ref` — the exact
+            // shape that makes `do_fixed_newlist` select `new_array_clear`
+            // over `new_array` (jtransform.py:1851-1855).
+            "newlist_clear" => {
+                let length = args.first()?.clone();
+                (
+                    "newlist_clear → new_array_clear(count, arraydescr)",
+                    vec![SpaceOperation {
+                        result: op.result.clone(),
+                        kind: OpKind::NewArrayClear {
+                            length,
+                            item_ty: ValueType::Ref(None),
+                            array_type_id: None,
+                        },
+                    }],
+                )
+            }
             "list.obj_setitem" => {
                 let l = args.first()?.clone();
                 let index = args.get(1)?.clone();
@@ -5847,6 +5875,15 @@ fn remap_op(
         },
         OpKind::NewList { args } => OpKind::NewList {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
+        },
+        OpKind::NewArrayClear {
+            length,
+            item_ty,
+            array_type_id,
+        } => OpKind::NewArrayClear {
+            length: remap_value(length, aliases),
+            item_ty: item_ty.clone(),
+            array_type_id: array_type_id.clone(),
         },
         OpKind::GetSlice { args } => OpKind::GetSlice {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
@@ -10752,6 +10789,108 @@ mod tests {
             other => panic!("expected FieldRead, got {other:?}"),
         }
         assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// `newlist_clear(count)` (`_ll_alloc_and_clear`, rlist.py:522-528)
+    /// lowers to a single `new_array_clear(count, arraydescr)`
+    /// (`do_fixed_newlist_clear`, jtransform.py:1858-1863). The `count`
+    /// operand is the initial length; the cleared items array holds GC
+    /// pointers, so the emitted `item_ty` is `Ref`.
+    #[test]
+    fn handle_list_call_newlist_clear_lowers_to_new_array_clear() {
+        let config = GraphTransformConfig::default();
+        let mut graph = FunctionGraph::new("newlist_clear");
+        let count = graph.alloc_value_var_with_type(ConcreteType::Signed);
+        let result = graph.alloc_value_var_with_type(ConcreteType::GcRef);
+        let op = SpaceOperation {
+            result: Some(result.clone()),
+            kind: OpKind::ConstInt(0),
+        };
+        let mut transformer = Transformer::new(&config);
+        let rewrite = transformer
+            ._handle_list_call(
+                "newlist_clear",
+                &op,
+                &[count.clone()],
+                &mut graph,
+                "newlist_clear",
+            )
+            .expect("newlist_clear must lower");
+        let RewriteResult::Replace(ops) = rewrite else {
+            panic!("expected Replace");
+        };
+        assert_eq!(ops.len(), 1);
+        match &ops[0].kind {
+            OpKind::NewArrayClear {
+                length,
+                item_ty,
+                array_type_id,
+            } => {
+                assert_eq!(length, &count);
+                assert!(matches!(item_ty, ValueType::Ref(None)));
+                assert_eq!(array_type_id, &None);
+            }
+            other => panic!("expected NewArrayClear, got {other:?}"),
+        }
+        assert_eq!(ops[0].result, Some(result));
+    }
+
+    /// End-to-end rendezvous: a minted throwaway helper graph is given the
+    /// `newlist_clear(count)` oopspec via [`CallControl::mark_oopspec`]
+    /// (the same field [`CallControl::get_oopspec`] reads at
+    /// `handle_builtin_call`), so a call to it classifies `Builtin` and
+    /// dispatches through `_handle_list_call` to `new_array_clear`.  This
+    /// locks the T2↔T3 contract: `mark_oopspec(path, "newlist_clear(count)")`
+    /// is exactly what T3 must attach to the minted `_ll_alloc_and_clear`
+    /// graph for it to lower instead of residualizing.
+    #[test]
+    fn marked_newlist_clear_oopspec_dispatches_call_to_new_array_clear() {
+        let path = crate::parse::CallPath::from_segments(["_ll_alloc_and_clear"]);
+        let target = CallTarget::function_path(["_ll_alloc_and_clear"]);
+
+        let mut cc = crate::call::CallControl::new();
+        // The spec STRING form the codewriter reader parses: bare name
+        // before `(`, so the dispatch keys on `newlist_clear`.
+        cc.mark_oopspec(path, "newlist_clear(count)".to_string());
+
+        let mut graph = FunctionGraph::new("caller");
+        let count = graph.alloc_value_var();
+        let result = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&count, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::GcRef);
+        let startblock = graph.startblock;
+        graph.push_op_var(
+            startblock,
+            OpKind::Call {
+                target,
+                args: vec![count.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph
+            .block_mut(startblock)
+            .operations
+            .last_mut()
+            .unwrap()
+            .result = Some(result.clone());
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+
+        let new_array_clear = transformed
+            .graph
+            .block(startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::NewArrayClear { length, .. } => Some(length.clone()),
+                _ => None,
+            })
+            .expect("marked newlist_clear must lower to new_array_clear");
+        assert_eq!(new_array_clear, count);
     }
 
     /// `list.int_getitem(l, i)` lowers to `getfield_gc_r(l,

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -5885,6 +5885,15 @@ fn remap_op(
             item_ty: item_ty.clone(),
             array_type_id: array_type_id.clone(),
         },
+        OpKind::NewListClear {
+            length,
+            item_ty,
+            array_type_id,
+        } => OpKind::NewListClear {
+            length: remap_value(length, aliases),
+            item_ty: item_ty.clone(),
+            array_type_id: array_type_id.clone(),
+        },
         OpKind::GetSlice { args } => OpKind::GetSlice {
             args: args.iter().map(|a| remap_value(a, aliases)).collect(),
         },
@@ -10887,6 +10896,7 @@ mod tests {
             .iter()
             .find_map(|op| match &op.kind {
                 OpKind::NewArrayClear { length, .. } => Some(length.clone()),
+                OpKind::NewListClear { length, .. } => Some(length.clone()),
                 _ => None,
             })
             .expect("marked newlist_clear must lower to new_array_clear");
@@ -10943,6 +10953,7 @@ mod tests {
             .iter()
             .find_map(|op| match &op.kind {
                 OpKind::NewArrayClear { length, .. } => Some(length.clone()),
+                OpKind::NewListClear { length, .. } => Some(length.clone()),
                 _ => None,
             })
             .expect("minted _ll_alloc_and_clear must lower to new_array_clear");

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -10904,12 +10904,13 @@ mod tests {
     }
 
     /// T3 end-to-end: the rtyper mints the `_ll_alloc_and_set` family (whose
-    /// clear sub-helper is named `_ll_alloc_and_clear` for BOTH the resized
-    /// and fixed layouts), and `lib.rs` attaches the `newlist_clear(count)`
-    /// oopspec under the single-segment path `["_ll_alloc_and_clear"]`.  A
-    /// `direct_call` to a `_ll_alloc_and_clear` funcptr therefore resolves to
-    /// that path and lowers to `new_array_clear` — this locks that the path
-    /// `lib.rs` registers is exactly the one the minted graph's name produces.
+    /// clear sub-helper is named `_ll_alloc_and_clear` for the resized layout
+    /// and `_ll_fixed_alloc_and_clear` for the fixed layout), and `lib.rs`
+    /// attaches the `newlist_clear(count)` oopspec under BOTH single-segment
+    /// paths.  A `direct_call` to the resized `_ll_alloc_and_clear` funcptr
+    /// therefore resolves to that path and lowers to `new_array_clear` — this
+    /// locks that the path `lib.rs` registers is exactly the one the minted
+    /// graph's name produces.
     #[test]
     fn t3_ll_alloc_and_clear_oopspec_registration_lowers_to_new_array_clear() {
         // Exactly the registration `lib.rs` performs beside the jit.* specs.
@@ -10957,6 +10958,64 @@ mod tests {
                 _ => None,
             })
             .expect("minted _ll_alloc_and_clear must lower to new_array_clear");
+        assert_eq!(lowered, count);
+    }
+
+    /// The fixed layout mints its clear sub-helper as `_ll_fixed_alloc_and_clear`
+    /// (per `alloc_and_set_sub_names`), so `lib.rs` must register the
+    /// `newlist_clear(count)` oopspec on that path too.  A `direct_call` to a
+    /// `_ll_fixed_alloc_and_clear` funcptr must lower to `new_array_clear`,
+    /// exactly like the resized `_ll_alloc_and_clear` — locking that both
+    /// per-layout clear names carry the spec.
+    #[test]
+    fn t3_ll_fixed_alloc_and_clear_oopspec_registration_lowers_to_new_array_clear() {
+        // Both leaf paths `lib.rs` registers beside the jit.* specs.
+        let mut cc = crate::call::CallControl::new();
+        for clear_name in ["_ll_alloc_and_clear", "_ll_fixed_alloc_and_clear"] {
+            cc.mark_oopspec(
+                crate::parse::CallPath::from_segments([clear_name]),
+                "newlist_clear(count)".to_string(),
+            );
+        }
+
+        let mut graph = FunctionGraph::new("caller");
+        let count = graph.alloc_value_var();
+        let result = graph.alloc_value_var();
+        FunctionGraph::set_concretetype_of_inline(&count, ConcreteType::Signed);
+        FunctionGraph::set_concretetype_of_inline(&result, ConcreteType::GcRef);
+        let startblock = graph.startblock;
+        graph.push_op_var(
+            startblock,
+            OpKind::Call {
+                target: CallTarget::function_path(["_ll_fixed_alloc_and_clear"]),
+                args: vec![count.clone()],
+                result_ty: ValueType::Ref(None),
+            },
+            false,
+        );
+        graph
+            .block_mut(startblock)
+            .operations
+            .last_mut()
+            .unwrap()
+            .result = Some(result.clone());
+
+        let config = GraphTransformConfig::default();
+        let transformed = Transformer::new(&config)
+            .with_callcontrol(&mut cc)
+            .transform(&graph);
+
+        let lowered = transformed
+            .graph
+            .block(startblock)
+            .operations
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::NewArrayClear { length, .. } => Some(length.clone()),
+                OpKind::NewListClear { length, .. } => Some(length.clone()),
+                _ => None,
+            })
+            .expect("minted _ll_fixed_alloc_and_clear must lower to new_array_clear");
         assert_eq!(lowered, count);
     }
 

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -726,6 +726,9 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::NewList { args }
         | OpKind::GetSlice { args }
         | OpKind::LoweredBlackholeOp { args, .. } => args.clone(),
+        // `new_array_clear(v_length, arraydescr)` — only the length is an
+        // SSA operand; the arraydescr is a descriptor, not a value.
+        OpKind::NewArrayClear { length, .. } => vec![length.clone()],
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
         OpKind::GuardValue { value, .. }
         | OpKind::AssertGreen { value, .. }

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -729,6 +729,9 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         // `new_array_clear(v_length, arraydescr)` — only the length is an
         // SSA operand; the arraydescr is a descriptor, not a value.
         OpKind::NewArrayClear { length, .. } => vec![length.clone()],
+        // `newlist_clear(v_length, ...)` — same operand shape: only the
+        // length is an SSA operand; the struct/array descrs are not values.
+        OpKind::NewListClear { length, .. } => vec![length.clone()],
         OpKind::GuardTrue { cond } | OpKind::GuardFalse { cond } => vec![cond.clone()],
         OpKind::GuardValue { value, .. }
         | OpKind::AssertGreen { value, .. }

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -438,6 +438,15 @@ pub(crate) fn remap_op_kind(
             owner: owner.clone(),
             vtable: *vtable,
         },
+        OpKind::NewArrayClear {
+            length,
+            item_ty,
+            array_type_id,
+        } => OpKind::NewArrayClear {
+            length: remap_var(length),
+            item_ty: item_ty.clone(),
+            array_type_id: array_type_id.clone(),
+        },
         OpKind::FieldRead {
             base,
             field,
@@ -890,6 +899,9 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         }
         OpKind::NewTuple { args } => args.iter().map(clone_var).collect(),
         OpKind::NewList { args } => args.iter().map(clone_var).collect(),
+        // `new_array_clear(v_length, arraydescr)` — only the length Variable
+        // is an SSA operand; the arraydescr is a descriptor, not a value.
+        OpKind::NewArrayClear { length, .. } => vec![clone_var(length)],
         OpKind::GetSlice { args } => args.iter().map(clone_var).collect(),
         OpKind::LoweredBlackholeOp { args, .. } => args.iter().map(clone_var).collect(),
         OpKind::VableForce { base } => vec![clone_var(base)],
@@ -1119,10 +1131,10 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
 /// pure op's args even though both should die together.
 pub fn is_pure_op(kind: &OpKind) -> bool {
     match kind {
-        // `new` / `new_with_vtable` heap-allocate fresh objects: NOT pure.
-        // CSE must never coalesce two allocations, or Python `is` object
-        // identity would break.
-        OpKind::New { .. } | OpKind::NewWithVtable { .. } => false,
+        // `new` / `new_with_vtable` / `new_array_clear` heap-allocate fresh
+        // objects: NOT pure.  CSE must never coalesce two allocations, or
+        // Python `is` object identity would break.
+        OpKind::New { .. } | OpKind::NewWithVtable { .. } | OpKind::NewArrayClear { .. } => false,
         // `OpKind::ConstInt` / `OpKind::ConstFloat` materialize a
         // `Variable` for a literal in pyre's IR.  There
         // is NO upstream `int_constant` op — RPython's `Constant` is

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -447,6 +447,15 @@ pub(crate) fn remap_op_kind(
             item_ty: item_ty.clone(),
             array_type_id: array_type_id.clone(),
         },
+        OpKind::NewListClear {
+            length,
+            item_ty,
+            array_type_id,
+        } => OpKind::NewListClear {
+            length: remap_var(length),
+            item_ty: item_ty.clone(),
+            array_type_id: array_type_id.clone(),
+        },
         OpKind::FieldRead {
             base,
             field,
@@ -902,6 +911,10 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         // `new_array_clear(v_length, arraydescr)` — only the length Variable
         // is an SSA operand; the arraydescr is a descriptor, not a value.
         OpKind::NewArrayClear { length, .. } => vec![clone_var(length)],
+        // `newlist_clear(v_length, ...)` — same operand shape: only the
+        // length Variable is an SSA operand; the struct/array descrs are
+        // descriptors, not values.
+        OpKind::NewListClear { length, .. } => vec![clone_var(length)],
         OpKind::GetSlice { args } => args.iter().map(clone_var).collect(),
         OpKind::LoweredBlackholeOp { args, .. } => args.iter().map(clone_var).collect(),
         OpKind::VableForce { base } => vec![clone_var(base)],
@@ -1134,7 +1147,10 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         // `new` / `new_with_vtable` / `new_array_clear` heap-allocate fresh
         // objects: NOT pure.  CSE must never coalesce two allocations, or
         // Python `is` object identity would break.
-        OpKind::New { .. } | OpKind::NewWithVtable { .. } | OpKind::NewArrayClear { .. } => false,
+        OpKind::New { .. }
+        | OpKind::NewWithVtable { .. }
+        | OpKind::NewArrayClear { .. }
+        | OpKind::NewListClear { .. } => false,
         // `OpKind::ConstInt` / `OpKind::ConstFloat` materialize a
         // `Variable` for a literal in pyre's IR.  There
         // is NO upstream `int_constant` op — RPython's `Constant` is

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -812,7 +812,7 @@ fn analyze_pipeline_from_module_paths(
     // `scripts/extract-llbc.py`), located via `PYRE_MIR_FRONTEND_LLBC`
     // or workspace auto-discovery.
     mark_phase!("known_statics + struct_field_attrs populated");
-    let program = build_semantic_program_via_active_frontend(
+    let mut program = build_semantic_program_via_active_frontend(
         module_paths,
         static_addrs,
         explicit_llbc_paths,
@@ -874,6 +874,32 @@ fn analyze_pipeline_from_module_paths(
             program.exact_layouts.len(),
         )
     });
+    // The rtyper synthesises a resizable-list `GcStruct("list", ("length",
+    // Signed), ("items", Ptr(GcArray(ITEM))), hints={'list': True})`
+    // (`translator/rtyper/rlist.rs:1112-1124`).  Because it is synthesised by
+    // the rtyper — not a Rust source type Charon extracts — it never appears
+    // in `program.struct_fields`, so `fielddescrof`/`compute_struct_size`
+    // return None/0 for owner "list" and any `new(descr)` keyed on it would
+    // trip the `bh_size_spec_from_callcontrol().unwrap_or_else(panic!)` in
+    // `codewriter/assembler.rs:1595`.  Register the {length, items} shape here,
+    // before both the `set_struct_fields` snapshot (:1076 below) and the
+    // `struct_layouts` loop (:1140 below), so both see it.  Offsets accumulate
+    // by field order via `get_type_flag`: `i64`→(Signed,8) and a leading-`&`
+    // spelling→(Pointer,Ref,8), giving length@0, items@8, struct size 16 — the
+    // natural word-sized GcStruct layout the backend's `build_ll_newlist`
+    // malloc uses (length-first, items-second, both word-sized;
+    // `rlist.rs:3444-3479`).  `.entry().or_insert_with` leaves a real "list"
+    // entry untouched if one ever exists.
+    program
+        .struct_fields
+        .fields
+        .entry("list".to_string())
+        .or_insert_with(|| {
+            vec![
+                ("length".to_string(), "i64".to_string()),
+                ("items".to_string(), "&[i64]".to_string()),
+            ]
+        });
     let mut canonical_trait_impls = Vec::new();
     let mut canonical_inherent_methods = Vec::new();
     // `(trait_leaf, trait_qualified, method_name, owner, return_type,

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1804,6 +1804,18 @@ fn analyze_pipeline_from_module_paths(
             call_control.mark_oopspec(path, spec.to_string());
         }
     }
+    // rlist.py:522 — `@jit.oopspec("newlist_clear(count)")` on
+    // `_ll_alloc_and_clear`.  The helper graph is minted by the rtyper
+    // (`rtype_alloc_and_set`), so there is no source-level `#[oopspec]`
+    // attribute for the walker above to harvest.  Attach the spec here,
+    // keyed on the minted graph's NAME — the codewriter derives the
+    // CallPath from the funcptr's graph name (`target_to_path`), so a
+    // `direct_call` to `_ll_alloc_and_clear` lowers to `new_array_clear`
+    // instead of residualizing.
+    call_control.mark_oopspec(
+        parse::CallPath::from_segments(["_ll_alloc_and_clear"]),
+        "newlist_clear(count)".to_string(),
+    );
     let mut policy = policy::DefaultJitPolicy::new();
     call_control.find_all_graphs(&mut policy);
     prof.mark("  find_all_graphs");

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -1810,12 +1810,17 @@ fn analyze_pipeline_from_module_paths(
     // attribute for the walker above to harvest.  Attach the spec here,
     // keyed on the minted graph's NAME — the codewriter derives the
     // CallPath from the funcptr's graph name (`target_to_path`), so a
-    // `direct_call` to `_ll_alloc_and_clear` lowers to `new_array_clear`
-    // instead of residualizing.
-    call_control.mark_oopspec(
-        parse::CallPath::from_segments(["_ll_alloc_and_clear"]),
-        "newlist_clear(count)".to_string(),
-    );
+    // `direct_call` to the clear helper lowers to `new_array_clear`
+    // instead of residualizing.  `alloc_and_set_sub_names` mints a
+    // per-layout clear helper (`_ll_alloc_and_clear` resized,
+    // `_ll_fixed_alloc_and_clear` fixed) so the `(name, args, ret)` helper
+    // cache stays disjoint; both names must carry the spec.
+    for clear_name in ["_ll_alloc_and_clear", "_ll_fixed_alloc_and_clear"] {
+        call_control.mark_oopspec(
+            parse::CallPath::from_segments([clear_name]),
+            "newlist_clear(count)".to_string(),
+        );
+    }
     let mut policy = policy::DefaultJitPolicy::new();
     call_control.find_all_graphs(&mut policy);
     prof.mark("  find_all_graphs");

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -889,7 +889,11 @@ fn analyze_pipeline_from_module_paths(
     // natural word-sized GcStruct layout the backend's `build_ll_newlist`
     // malloc uses (length-first, items-second, both word-sized;
     // `rlist.rs:3444-3479`).  `.entry().or_insert_with` leaves a real "list"
-    // entry untouched if one ever exists.
+    // entry untouched if one ever exists.  The `items` type is a bare pointer
+    // spelling: the field only has to classify as `(Pointer, Ref, word)`, and
+    // the real element type is inert here — it lives on the op's `item_ty`
+    // (the `new_array_clear` / `newlist_clear` arraydescr), never in this
+    // struct layout, since the resized list header is element-uniform.
     program
         .struct_fields
         .fields
@@ -897,7 +901,7 @@ fn analyze_pipeline_from_module_paths(
         .or_insert_with(|| {
             vec![
                 ("length".to_string(), "i64".to_string()),
-                ("items".to_string(), "&[i64]".to_string()),
+                ("items".to_string(), "&()".to_string()),
             ]
         });
     let mut canonical_trait_impls = Vec::new();

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -666,6 +666,29 @@ pub enum OpKind {
         owner: String,
         vtable: i64,
     },
+    /// RPython `new_array_clear(v_length, arraydescr)` — the cleared
+    /// fixed-size array allocation `do_fixed_newlist_clear` emits
+    /// (`jtransform.py:1858-1863`, `corresponds to rtyper.rlist.
+    /// ll_alloc_and_clear: needs to clear the items`).  Also the
+    /// allocation half `do_fixed_newlist` picks (`jtransform.py:1851-1855`)
+    /// when `ARRAY.OF` is a GC `Ptr` or `Struct` — the exact case that
+    /// distinguishes `new_array_clear` from the uninitialised `new_array`.
+    ///
+    /// `length` is the item count (`_get_initial_newlist_length`,
+    /// `jtransform.py:1835-1842`).  `item_ty` / `array_type_id` resolve the
+    /// `arraydescr` at assembly exactly like `ArrayRead`/`ArrayWrite`; a
+    /// cleared list holds GC pointers (`Ptr(GcArray(OBJECTPTR))`), so
+    /// `item_ty` is `Ref`.  The allocator zero-fills every slot
+    /// (`bhimpl_new_array_clear`, `blackhole.py:1311-1313`), so the result
+    /// register is always a fresh `Ref` ('r') and the emitted key is
+    /// `new_array_clear/id>r`.
+    NewArrayClear {
+        length: crate::flowspace::model::Variable,
+        item_ty: ValueType,
+        /// ARRAY identity for `cpu.arraydescrof(ARRAY)`, same role as
+        /// `ArrayRead::array_type_id`.
+        array_type_id: Option<String>,
+    },
     ArrayRead {
         base: crate::flowspace::model::Variable,
         index: crate::flowspace::model::Variable,

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -689,6 +689,32 @@ pub enum OpKind {
         /// `ArrayRead::array_type_id`.
         array_type_id: Option<String>,
     },
+    /// The compound resizable-list allocation `opimpl_newlist_clear`
+    /// records (`pyjitpl.py:792-798`) — the resized-layout counterpart to
+    /// `do_resizable_newlist_clear` (`jtransform.py:1938-1943`).  Allocates
+    /// the resizable-list `GcStruct` header (the struct named `"list"`),
+    /// zero-clears a fresh items array of `length` slots, and wires the two
+    /// header fields `length`/`items` so the result is a fully-formed empty
+    /// resizable list.  `bhimpl_newlist_clear` (`blackhole.py:1174-1181`,
+    /// `@arguments("cpu", "i", "d", "d", returns="r")`) runs the same four
+    /// steps at the blackhole boundary: `new(structdescr)` +
+    /// `setfield(length)` + `new_array_clear(items_arraydescr)` +
+    /// `setfield(items)`.
+    ///
+    /// The owner struct is always `"list"` and its fields are always
+    /// `length`/`items`, so neither is carried on the variant — only the
+    /// `new_array_clear` sub-operation's operands survive: `length` (item
+    /// count), `item_ty` (the items array element type, `Ref` for a cleared
+    /// list of GC pointers), and `array_type_id` (the items ARRAY identity
+    /// for `cpu.arraydescrof(ARRAY)`).  Field shape is identical to
+    /// `NewArrayClear` above.
+    NewListClear {
+        length: crate::flowspace::model::Variable,
+        item_ty: ValueType,
+        /// ARRAY identity for `cpu.arraydescrof(ARRAY)`, same role as
+        /// `NewArrayClear::array_type_id`.
+        array_type_id: Option<String>,
+    },
     ArrayRead {
         base: crate::flowspace::model::Variable,
         index: crate::flowspace::model::Variable,

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2640,6 +2640,7 @@ fn opkind_variant_name(kind: &OpKind) -> &'static str {
         OpKind::LoopHeader { .. } => "LoopHeader",
         OpKind::Abort { .. } => "Abort",
         OpKind::NewArrayClear { .. } => "NewArrayClear",
+        OpKind::NewListClear { .. } => "NewListClear",
         // Catch-all for variants pyre may add without bumping this
         // table — surfaces as `<unknown>` in the fail-loud message
         // rather than a misleading variant tag.  The catch-all message
@@ -2680,6 +2681,9 @@ fn post_rtyper_jtransform_variant_name(kind: &OpKind) -> Option<&'static str> {
         OpKind::LoopHeader { .. } => "LoopHeader (jtransform.py:1690-1718)",
         OpKind::NewArrayClear { .. } => {
             "NewArrayClear (jtransform.py:1858-1863 do_fixed_newlist_clear)"
+        }
+        OpKind::NewListClear { .. } => {
+            "NewListClear (jtransform.py:1938-1943 do_resizable_newlist_clear)"
         }
         // `OpKind::Abort` is pyre-only — RPython raises `FlowingError`
         // (`flowspace/flowcontext.py:258,417`) and drops the function

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -2639,6 +2639,7 @@ fn opkind_variant_name(kind: &OpKind) -> &'static str {
         OpKind::JitMergePoint { .. } => "JitMergePoint",
         OpKind::LoopHeader { .. } => "LoopHeader",
         OpKind::Abort { .. } => "Abort",
+        OpKind::NewArrayClear { .. } => "NewArrayClear",
         // Catch-all for variants pyre may add without bumping this
         // table — surfaces as `<unknown>` in the fail-loud message
         // rather than a misleading variant tag.  The catch-all message
@@ -2677,6 +2678,9 @@ fn post_rtyper_jtransform_variant_name(kind: &OpKind) -> Option<&'static str> {
         OpKind::Live => "Live (jtransform.py:469,481,533)",
         OpKind::JitMergePoint { .. } => "JitMergePoint (jtransform.py:1690-1718)",
         OpKind::LoopHeader { .. } => "LoopHeader (jtransform.py:1690-1718)",
+        OpKind::NewArrayClear { .. } => {
+            "NewArrayClear (jtransform.py:1858-1863 do_fixed_newlist_clear)"
+        }
         // `OpKind::Abort` is pyre-only — RPython raises `FlowingError`
         // (`flowspace/flowcontext.py:258,417`) and drops the function
         // before reaching the rtyper.  Now handled by an explicit

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -290,6 +290,9 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // `new_array_clear` yields a `Ref` to the freshly allocated,
         // zero-cleared items array (`Ptr(GcArray(OBJECTPTR))`).
         OpKind::NewArrayClear { .. } => ValueType::Ref(None),
+        // `newlist_clear` yields a `Ref` to the freshly allocated
+        // resizable-list `GcStruct` header (the `"list"` struct).
+        OpKind::NewListClear { .. } => ValueType::Ref(None),
         OpKind::ArrayRead { item_ty, .. } => item_ty.clone(),
         OpKind::ArrayLen { .. } => ValueType::Int,
         OpKind::ArrayWrite { .. } => ValueType::Void,

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -287,6 +287,9 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         OpKind::FieldWrite { .. } => ValueType::Void,
         OpKind::New { owner } => ValueType::Ref(Some(owner.clone())),
         OpKind::NewWithVtable { owner, .. } => ValueType::Ref(Some(owner.clone())),
+        // `new_array_clear` yields a `Ref` to the freshly allocated,
+        // zero-cleared items array (`Ptr(GcArray(OBJECTPTR))`).
+        OpKind::NewArrayClear { .. } => ValueType::Ref(None),
         OpKind::ArrayRead { item_ty, .. } => item_ty.clone(),
         OpKind::ArrayLen { .. } => ValueType::Int,
         OpKind::ArrayWrite { .. } => ValueType::Void,

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rbuilder.rs
@@ -19,7 +19,7 @@ use crate::flowspace::pygraph::PyGraph;
 use crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{
-    ForwardReference, LowLevelType, Ptr, PtrTarget, Struct,
+    Array, ForwardReference, LowLevelType, Ptr, PtrTarget, Struct,
 };
 use crate::translator::rtyper::lltypesystem::rstr::{STRPTR, UNICODEPTR};
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
@@ -5163,6 +5163,369 @@ pub fn build_ll_build_helper_graph(
     ))
 }
 
+/// `Ptr(GcArray(ITEM))` for an item lltype — the array pointer shape both
+/// `ll_arrayclear` and `ll_arrayfill` operate on (`p` is the array itself:
+/// `len(p)`, `p[i]`, `typeOf(p).TO`).
+fn array_ptr_lltype(item_lltype: &LowLevelType) -> LowLevelType {
+    LowLevelType::Ptr(Box::new(Ptr {
+        TO: PtrTarget::Array(Array::gc(item_lltype.clone())),
+    }))
+}
+
+/// Synthesise `rgc.ll_arrayclear(p)` (`rpython/rlib/rgc.py:510`):
+///
+/// ```python
+/// def ll_arrayclear(p):
+///     length = len(p)
+///     ARRAY = typeOf(p).TO
+///     if must_split_gc_address_space():
+///         i = 0
+///         if isinstance(ARRAY.OF, Ptr):
+///             while i < length:
+///                 p[i] = nullptr(ARRAY.OF.TO)
+///                 i += 1
+///         else:
+///             ZERO = rffi.cast(ARRAY.OF, 0)
+///             while i < length:
+///                 p[i] = ZERO
+///                 i += 1
+///     else:
+///         offset = itemoffsetof(ARRAY, 0)
+///         dest_addr = cast_ptr_to_adr(p) + offset
+///         raw_memclear(dest_addr, sizeof(ARRAY.OF) * length)
+///     keepalive_until_here(p)
+/// ```
+///
+/// Three-block loop over the bare `Ptr(GcArray(ITEM))` operand: writes the
+/// null/zero element into every slot. Writing NULL never creates an
+/// old->young reference, so no write barrier is emitted. `@specialize.ll()`
+/// picks the two `isinstance(ARRAY.OF, Ptr)` arms per concrete item type;
+/// the Rust-side match on `item_lltype` folds that specialisation to one
+/// `ZERO` element constant (`nullptr` for a `Ptr` item, `0` otherwise). The
+/// `raw_memclear` fast path (the `must_split_gc_address_space()` `else`
+/// branch) is deferred as a translation-time concern, mirroring
+/// [`build_ll_arraycopy_helper_graph`](../../rlist.rs) which lowers the
+/// sibling `rgc.ll_arraycopy` to the same bare element loop and defers its
+/// `raw_memcopy` fast path (`rgc.py:403-411`); the `itemoffsetof` / `sizeof`
+/// / `cast_ptr_to_adr` / `raw_memclear` address machinery has no
+/// construction-side surface here.
+pub fn build_ll_arrayclear_helper_graph(
+    name: &str,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let items_ptr = array_ptr_lltype(&item_lltype);
+    let signed = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let bool_case = |b: bool| {
+        Some(constant_with_lltype(
+            ConstValue::Bool(b),
+            LowLevelType::Bool,
+        ))
+    };
+    let none_void = || constant_with_lltype(ConstValue::None, LowLevelType::Void);
+
+    // `ZERO`: the null pointer for a `Ptr` item, else the zero primitive.
+    let zero_value = match &item_lltype {
+        LowLevelType::Ptr(_) => constant_with_lltype(ConstValue::None, item_lltype.clone()),
+        LowLevelType::Float | LowLevelType::SingleFloat | LowLevelType::LongFloat => {
+            constant_with_lltype(ConstValue::float(0.0), item_lltype.clone())
+        }
+        _ => constant_with_lltype(ConstValue::Int(0), item_lltype.clone()),
+    };
+
+    let p = variable_with_lltype("p", items_ptr.clone());
+    let startblock = Block::shared(vec![Hlvalue::Variable(p.clone())]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // Loop blocks carry (p, length, i) as fresh inputargs.
+    let p_c = variable_with_lltype("p", items_ptr.clone());
+    let len_c = variable_with_lltype("length", LowLevelType::Signed);
+    let i_c = variable_with_lltype("i", LowLevelType::Signed);
+    let block_cond = Block::shared(vec![
+        Hlvalue::Variable(p_c.clone()),
+        Hlvalue::Variable(len_c.clone()),
+        Hlvalue::Variable(i_c.clone()),
+    ]);
+
+    let p_b = variable_with_lltype("p", items_ptr.clone());
+    let len_b = variable_with_lltype("length", LowLevelType::Signed);
+    let i_b = variable_with_lltype("i", LowLevelType::Signed);
+    let block_body = Block::shared(vec![
+        Hlvalue::Variable(p_b.clone()),
+        Hlvalue::Variable(len_b.clone()),
+        Hlvalue::Variable(i_b.clone()),
+    ]);
+
+    // ---- startblock: length = len(p); i = 0.
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarraysize",
+        vec![Hlvalue::Variable(p.clone())],
+        Hlvalue::Variable(length.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(p), Hlvalue::Variable(length), signed(0)],
+            Some(block_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_cond: int_lt(i, length). True -> body; False -> return None.
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(i_c.clone()),
+            Hlvalue::Variable(len_c.clone()),
+        ],
+        Hlvalue::Variable(cond.clone()),
+    ));
+    block_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    block_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(p_c),
+                Hlvalue::Variable(len_c),
+                Hlvalue::Variable(i_c),
+            ],
+            Some(block_body.clone()),
+            bool_case(true),
+        )
+        .into_ref(),
+        Link::new(
+            vec![none_void()],
+            Some(graph.returnblock.clone()),
+            bool_case(false),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_body: p[i] = ZERO; i += 1.
+    let store_void = variable_with_lltype("v", LowLevelType::Void);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "setarrayitem",
+        vec![
+            Hlvalue::Variable(p_b.clone()),
+            Hlvalue::Variable(i_b.clone()),
+            zero_value,
+        ],
+        Hlvalue::Variable(store_void),
+    ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(i_b), signed(1)],
+        Hlvalue::Variable(i_next.clone()),
+    ));
+    block_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(p_b),
+                Hlvalue::Variable(len_b),
+                Hlvalue::Variable(i_next),
+            ],
+            Some(block_cond),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["p".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `rgc.ll_arrayfill(p, item)` (`rpython/rlib/rgc.py:540`,
+/// `@jit.dont_look_inside @specialize.ll()`):
+///
+/// ```python
+/// def ll_arrayfill(p, item):
+///     i = 0
+///     length = len(p)
+///     if we_are_translated():
+///         llop.gc_writebarrier(Void, p)
+///         while i < length:
+///             llop.bare_setarrayitem(Void, p, i, item)
+///             i += 1
+///     else:
+///         while i < length:
+///             p[i] = item
+///             i += 1
+///     keepalive_until_here(p)
+/// ```
+///
+/// A lifted low-level helper is part of the translated program, so
+/// `we_are_translated()` folds to the translated arm (as
+/// [`build_ll_mallocstr_helper_graph`](../rstr.rs) resolves the same
+/// predicate): one `gc_writebarrier(p)` before the loop covers every slot
+/// (if `p` is old it is added to `old_objects_pointing_to_young`; if young
+/// the barrier is a no-op), then the loop stores `item` into each slot via
+/// `bare_setarrayitem`. Three-block loop over the bare `Ptr(GcArray(ITEM))`
+/// operand.
+pub fn build_ll_arrayfill_helper_graph(
+    name: &str,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let items_ptr = array_ptr_lltype(&item_lltype);
+    let signed = |n: i64| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    let bool_case = |b: bool| {
+        Some(constant_with_lltype(
+            ConstValue::Bool(b),
+            LowLevelType::Bool,
+        ))
+    };
+    let none_void = || constant_with_lltype(ConstValue::None, LowLevelType::Void);
+
+    let p = variable_with_lltype("p", items_ptr.clone());
+    let item = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(p.clone()),
+        Hlvalue::Variable(item.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", LowLevelType::Void);
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // Loop blocks carry (p, item, length, i) as fresh inputargs.
+    let p_c = variable_with_lltype("p", items_ptr.clone());
+    let item_c = variable_with_lltype("item", item_lltype.clone());
+    let len_c = variable_with_lltype("length", LowLevelType::Signed);
+    let i_c = variable_with_lltype("i", LowLevelType::Signed);
+    let block_cond = Block::shared(vec![
+        Hlvalue::Variable(p_c.clone()),
+        Hlvalue::Variable(item_c.clone()),
+        Hlvalue::Variable(len_c.clone()),
+        Hlvalue::Variable(i_c.clone()),
+    ]);
+
+    let p_b = variable_with_lltype("p", items_ptr.clone());
+    let item_b = variable_with_lltype("item", item_lltype.clone());
+    let len_b = variable_with_lltype("length", LowLevelType::Signed);
+    let i_b = variable_with_lltype("i", LowLevelType::Signed);
+    let block_body = Block::shared(vec![
+        Hlvalue::Variable(p_b.clone()),
+        Hlvalue::Variable(item_b.clone()),
+        Hlvalue::Variable(len_b.clone()),
+        Hlvalue::Variable(i_b.clone()),
+    ]);
+
+    // ---- startblock: length = len(p); gc_writebarrier(p); i = 0.
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarraysize",
+        vec![Hlvalue::Variable(p.clone())],
+        Hlvalue::Variable(length.clone()),
+    ));
+    let wb_void = variable_with_lltype("v", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "gc_writebarrier",
+        vec![Hlvalue::Variable(p.clone())],
+        Hlvalue::Variable(wb_void),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(p),
+                Hlvalue::Variable(item),
+                Hlvalue::Variable(length),
+                signed(0),
+            ],
+            Some(block_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_cond: int_lt(i, length). True -> body; False -> return None.
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(i_c.clone()),
+            Hlvalue::Variable(len_c.clone()),
+        ],
+        Hlvalue::Variable(cond.clone()),
+    ));
+    block_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    block_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(p_c),
+                Hlvalue::Variable(item_c),
+                Hlvalue::Variable(len_c),
+                Hlvalue::Variable(i_c),
+            ],
+            Some(block_body.clone()),
+            bool_case(true),
+        )
+        .into_ref(),
+        Link::new(
+            vec![none_void()],
+            Some(graph.returnblock.clone()),
+            bool_case(false),
+        )
+        .into_ref(),
+    ]);
+
+    // ---- block_body: bare_setarrayitem(p, i, item); i += 1.
+    let store_void = variable_with_lltype("v", LowLevelType::Void);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "bare_setarrayitem",
+        vec![
+            Hlvalue::Variable(p_b.clone()),
+            Hlvalue::Variable(i_b.clone()),
+            Hlvalue::Variable(item_b.clone()),
+        ],
+        Hlvalue::Variable(store_void),
+    ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(i_b), signed(1)],
+        Hlvalue::Variable(i_next.clone()),
+    ));
+    block_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(p_b),
+                Hlvalue::Variable(item_b),
+                Hlvalue::Variable(len_b),
+                Hlvalue::Variable(i_next),
+            ],
+            Some(block_cond),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["p".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
 /// RPython `class BaseStringBuilderRepr(AbstractStringBuilderRepr)`.
 #[derive(Debug, Default)]
 pub struct BaseStringBuilderRepr;
@@ -6510,6 +6873,82 @@ mod tests {
             ret.concretetype.borrow().clone(),
             Some(super::STRPTR.clone())
         );
+    }
+
+    #[test]
+    fn build_ll_arrayclear_zeroes_each_slot_in_a_bare_element_loop() {
+        use super::Hlvalue;
+        let helper = super::build_ll_arrayclear_helper_graph("ll_arrayclear", LowLevelType::Signed)
+            .expect("build_ll_arrayclear_helper_graph");
+        assert_eq!(helper.func.name, "ll_arrayclear");
+        let inner = helper.graph.borrow();
+
+        // start: length = len(p); i = 0 (a single unconditional exit).
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["getarraysize"]);
+        assert_eq!(startblock.inputargs.len(), 1); // p
+        assert_eq!(startblock.exits.len(), 1);
+        drop(startblock);
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, cond, body, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("getarraysize"), 1);
+        assert_eq!(n("int_lt"), 1); // loop header
+        assert_eq!(n("setarrayitem"), 1); // p[i] = ZERO
+        assert_eq!(n("int_add"), 1); // i += 1
+        assert_eq!(n("gc_writebarrier"), 0); // NULL store needs no barrier
+        assert_eq!(n("raw_memclear"), 0); // fast path deferred
+
+        // Void return.
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(ret.concretetype.borrow().clone(), Some(LowLevelType::Void));
+    }
+
+    #[test]
+    fn build_ll_arrayfill_barriers_once_then_fills_each_slot() {
+        use super::Hlvalue;
+        let helper = super::build_ll_arrayfill_helper_graph("ll_arrayfill", LowLevelType::Signed)
+            .expect("build_ll_arrayfill_helper_graph");
+        assert_eq!(helper.func.name, "ll_arrayfill");
+        let inner = helper.graph.borrow();
+
+        // start: length = len(p); one gc_writebarrier(p) before the loop.
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["getarraysize", "gc_writebarrier"]);
+        assert_eq!(startblock.inputargs.len(), 2); // p, item
+        assert_eq!(startblock.exits.len(), 1);
+        drop(startblock);
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, cond, body, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("getarraysize"), 1);
+        assert_eq!(n("gc_writebarrier"), 1); // one barrier covers all slots
+        assert_eq!(n("int_lt"), 1); // loop header
+        assert_eq!(n("bare_setarrayitem"), 1); // p[i] = item, barrier-free
+        assert_eq!(n("setarrayitem"), 0); // uses the bare store
+        assert_eq!(n("int_add"), 1); // i += 1
+
+        // Void return.
+        let Hlvalue::Variable(ret) = &inner.returnblock.borrow().inputargs[0] else {
+            panic!("returnblock inputarg must be a Variable");
+        };
+        assert_eq!(ret.concretetype.borrow().clone(), Some(LowLevelType::Void));
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -845,7 +845,7 @@ fn alloc_and_set_sub_names(
     match layout {
         ListLayout::Fixed => (
             "ll_fixed_newlist",
-            "_ll_alloc_and_clear",
+            "_ll_fixed_alloc_and_clear",
             "_ll_fixed_alloc_and_set_nonnull",
             "_ll_fixed_alloc_and_set_jit",
             "_ll_fixed_alloc_and_set_nojit",
@@ -9313,6 +9313,23 @@ mod tests {
             !names.iter().any(|n| n == "ll_alloc_and_set"),
             "fixed arm must NOT mint the resized ll_alloc_and_set, got {names:?}"
         );
+    }
+
+    /// The two layouts must name their clear sub-helper DISTINCTLY, otherwise
+    /// the `(name, args, ret)` helper cache and the `mark_oopspec` CallPath
+    /// registration collide: a resized `newlist_clear` registration would
+    /// overwrite (or serve) the fixed one.  Fixed prefixes `_ll_fixed_*`,
+    /// resized stays unprefixed.
+    #[test]
+    fn alloc_and_set_sub_names_clear_helpers_are_per_layout_distinct() {
+        let (_, fixed_clear, _, _, _) = alloc_and_set_sub_names(ListLayout::Fixed);
+        let (_, resized_clear, _, _, _) = alloc_and_set_sub_names(ListLayout::Resized);
+        assert_ne!(
+            fixed_clear, resized_clear,
+            "fixed and resized clear helpers must be distinct names"
+        );
+        assert_eq!(fixed_clear, "_ll_fixed_alloc_and_clear");
+        assert_eq!(resized_clear, "_ll_alloc_and_clear");
     }
 
     /// `ll_alloc_and_set` clamps `count` with `int_force_ge_zero` and branches

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -7034,6 +7034,91 @@ mod tests {
         );
     }
 
+    /// `translate_operation("alloc_and_set")` routes to
+    /// [`rtype_alloc_and_set`] (rtyper.py:534-535), which lowers a
+    /// `[item] * count` display to a single `gendirectcall(ll_alloc_and_set,
+    /// count, item)` (rlist.py:346-350). Unlike `newlist`, the count is a
+    /// runtime `Signed` operand (not a static element enumeration), so the
+    /// dispatch emits exactly one `direct_call` and mints the
+    /// `ll_alloc_and_set` dispatch helper graph.
+    #[test]
+    fn translate_operation_alloc_and_set_dispatches_to_ll_alloc_and_set() {
+        use crate::annotator::model::SomeValue;
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+
+        // Upstream `v_count, v_item = hop.inputargs(Signed, r_list.item_repr)`
+        // — arg 0 is the runtime count, arg 1 is the fill item.
+        let v_count = Variable::new();
+        v_count.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_count_h = Hlvalue::Variable(v_count);
+        let v_item_h = Hlvalue::Variable(v_item);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "alloc_and_set".to_string(),
+            vec![v_count_h.clone(), v_item_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_count_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r
+            .borrow_mut()
+            .push(Some(
+                Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_"))) as Arc<dyn Repr>,
+            ));
+        hop.args_v.borrow_mut().push(v_item_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let out = rtyper
+            .translate_operation(&hop)
+            .expect("translate_operation alloc_and_set must dispatch to rtype_alloc_and_set")
+            .expect("alloc_and_set returns the fresh list Variable");
+        let Hlvalue::Variable(_) = out else {
+            panic!("alloc_and_set must return a Variable (the ll_alloc_and_set result)");
+        };
+        let ops = hop.llops.borrow();
+        let direct_calls = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .count();
+        // A single `gendirectcall(ll_alloc_and_set, count, item)`.
+        assert_eq!(
+            direct_calls,
+            1,
+            "expected one ll_alloc_and_set direct_call, got {:?}",
+            ops.ops.iter().map(|op| &op.opname).collect::<Vec<_>>()
+        );
+
+        // The resized arm must mint the `ll_alloc_and_set` dispatch helper.
+        let translator = ann.translator.clone();
+        let names: Vec<String> = translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "ll_alloc_and_set"),
+            "resized arm must mint an ll_alloc_and_set helper graph, got {names:?}"
+        );
+    }
+
     /// `l[start:stop]` on a resized `ListRepr` with non-constant nonneg int
     /// bounds decomposes to `"startstop"` (rtyper.py:781) and lowers to
     /// `gendirectcall(ll_listslice_startstop, l, start, stop)`, which mints the

--- a/majit/majit-translate/src/translator/rtyper/rlist.rs
+++ b/majit/majit-translate/src/translator/rtyper/rlist.rs
@@ -23,6 +23,7 @@ use crate::flowspace::model::{
     SpaceOperation, Variable,
 };
 use crate::flowspace::pygraph::PyGraph;
+use crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{
     Array, LowLevelType, Ptr, PtrTarget, Struct,
@@ -31,8 +32,8 @@ use crate::translator::rtyper::lltypesystem::rstr::sub_helper_funcptr_constant;
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
     ConvertedTo, GenopResult, HighLevelOp, LowLevelFunction, RPythonTyper, SliceKind,
-    constant_with_lltype, exception_args, helper_pygraph_from_graph, variable_with_lltype,
-    void_field_const,
+    constant_with_lltype, exception_args, functionptr_const, helper_pygraph_from_graph,
+    variable_with_lltype, void_field_const,
 };
 
 /// RPython `class FixedSizeListRepr(AbstractFixedSizeListRepr,
@@ -523,36 +524,344 @@ fn rtype_newlist_layout(
     Ok(Some(v_result))
 }
 
-pub fn rtype_alloc_and_set() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("rtype_alloc_and_set"))
+/// RPython `rtype_alloc_and_set(hop)` (`rlist.py:346-351`):
+///
+/// ```python
+/// def rtype_alloc_and_set(hop):
+///     r_list = hop.r_result
+///     v_count, v_item = hop.inputargs(Signed, r_list.item_repr)
+///     cLIST = hop.inputconst(Void, r_list.LIST)
+///     return hop.gendirectcall(ll_alloc_and_set, cLIST, v_count, v_item)
+/// ```
+///
+/// Mirrors [`rtype_newlist`]: dispatch on the concrete `hop.r_result` repr
+/// (`ListRepr` → resized, `FixedSizeListRepr` → fixed) and forward to the
+/// repr-generic [`rtype_alloc_and_set_layout`]. The upstream `cLIST` Void arg
+/// selects `LIST.ll_newlist`; pyre folds it into the helper IDENTITY (a
+/// distinct helper name per layout selects the newlist body), so it is not
+/// passed at runtime.
+pub fn rtype_alloc_and_set(hop: &HighLevelOp) -> RTypeResult {
+    let r_result = hop
+        .r_result
+        .borrow()
+        .clone()
+        .ok_or_else(|| TyperError::message("rtype_alloc_and_set: r_result missing"))?;
+    let any_r: &dyn std::any::Any = r_result.as_ref();
+    if let Some(r_list) = any_r.downcast_ref::<ListRepr>() {
+        return rtype_alloc_and_set_layout(
+            hop,
+            r_list.lltype.clone(),
+            r_list.item_repr.lowleveltype().clone(),
+            r_list.item_repr.as_ref(),
+            ListLayout::Resized,
+        );
+    }
+    if let Some(r_list) = any_r.downcast_ref::<FixedSizeListRepr>() {
+        return rtype_alloc_and_set_layout(
+            hop,
+            r_list.lltype.clone(),
+            r_list.item_repr.lowleveltype().clone(),
+            r_list.item_repr.as_ref(),
+            ListLayout::Fixed,
+        );
+    }
+    Err(TyperError::message(
+        "rtype_alloc_and_set: hop.r_result is not a ListRepr or FixedSizeListRepr",
+    ))
 }
 
-pub fn _ll_zero_or_null() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("_ll_zero_or_null"))
+/// Repr-generic body of [`rtype_alloc_and_set`]. `hop.inputargs(Signed,
+/// r_list.item_repr)` yields `(v_count, v_item)`; then `ll_alloc_and_set` is
+/// minted (with its full `{jit, nojit} → {clear, nonnull, arrayclear,
+/// arrayfill}` sub-helper closure) and `direct_call`ed with `[v_count,
+/// v_item]`.
+///
+/// Distinct helper names per layout (`ll_alloc_and_set` /
+/// `ll_fixed_alloc_and_set`) keep the `(name, args, result)` helper cache from
+/// serving a resized graph for a fixed request — the same discipline
+/// [`rtype_newlist_layout`] documents.
+fn rtype_alloc_and_set_layout(
+    hop: &HighLevelOp,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    item_repr: &dyn Repr,
+    layout: ListLayout,
+) -> RTypeResult {
+    // upstream `v_count, v_item = hop.inputargs(Signed, r_list.item_repr)`.
+    let inputs = hop.inputargs(vec![
+        ConvertedTo::LowLevelType(&LowLevelType::Signed),
+        ConvertedTo::Repr(item_repr),
+    ])?;
+    let mut inputs = inputs.into_iter();
+    let v_count = inputs
+        .next()
+        .ok_or_else(|| TyperError::message("rtype_alloc_and_set: missing count arg"))?;
+    let v_item = inputs
+        .next()
+        .ok_or_else(|| TyperError::message("rtype_alloc_and_set: missing item arg"))?;
+
+    let helper_name = alloc_and_set_helper_name(layout);
+    let helper = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        hop.rtyper.lowlevel_helper_function_with_builder(
+            helper_name.to_string(),
+            vec![LowLevelType::Signed, item_lltype.clone()],
+            ptr_lltype.clone(),
+            move |rtyper, _args, _result| {
+                build_alloc_and_set_family(rtyper, layout, ptr.clone(), item.clone())
+            },
+        )?
+    };
+    hop.gendirectcall(&helper, vec![v_count, v_item])
+}
+
+/// Per-layout name for the dispatch helper (`ll_alloc_and_set`). The `(name,
+/// args, result)` helper cache would otherwise serve a resized graph for a
+/// fixed request, so the fixed layout gets its own identity.
+fn alloc_and_set_helper_name(layout: ListLayout) -> &'static str {
+    match layout {
+        ListLayout::Fixed => "ll_fixed_alloc_and_set",
+        ListLayout::Resized => "ll_alloc_and_set",
+    }
+}
+
+/// Mint the six sub-helpers of the `ll_alloc_and_set` family in dependency
+/// order and build the top-level dispatch graph
+/// ([`build_ll_alloc_and_set_helper_graph`]).
+///
+/// The chain (`rlist.py:487-537`) is
+/// `ll_alloc_and_set → {_ll_alloc_and_set_jit, _ll_alloc_and_set_nojit}`,
+/// with the jit arm reaching `{_ll_alloc_and_clear, _ll_alloc_and_set_nonnull}`
+/// and both leaf arms reaching `LIST.ll_newlist` plus the T1 rgc helpers
+/// `rgc.ll_arrayclear` / `rgc.ll_arrayfill`. Each sub-helper is minted through
+/// [`RPythonTyper::lowlevel_helper_function_with_builder`], converted to a
+/// callee `Constant` by [`functionptr_const`], and threaded into the parent
+/// builder — the exact orchestration shape of `rtype_builder_new`.
+fn build_alloc_and_set_family(
+    rtyper: &RPythonTyper,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    let items_ptr = items_array_ptr_lltype(&item_lltype);
+    let (newlist_name, clear_name, nonnull_name, jit_name, nojit_name) =
+        alloc_and_set_sub_names(layout);
+
+    // LIST.ll_newlist(count) — shared by every leaf arm.
+    let newlist = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            newlist_name.to_string(),
+            vec![LowLevelType::Signed],
+            ptr_lltype.clone(),
+            move |_r, _a, _res| {
+                build_ll_newlist_helper_graph(newlist_name, layout, ptr.clone(), item.clone())
+            },
+        )?
+    };
+
+    // rgc.ll_arrayclear(items) / rgc.ll_arrayfill(items, item) — the T1
+    // helpers.  Both take the ELEMENT lltype and build `Ptr(GcArray(ITEM))`
+    // internally, so their `p` param IS the items-array ptr.
+    let arrayclear = {
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            "ll_arrayclear".to_string(),
+            vec![items_ptr.clone()],
+            LowLevelType::Void,
+            move |_r, _a, _res| {
+                crate::translator::rtyper::lltypesystem::rbuilder::build_ll_arrayclear_helper_graph(
+                    "ll_arrayclear",
+                    item.clone(),
+                )
+            },
+        )?
+    };
+    let arrayfill = {
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            "ll_arrayfill".to_string(),
+            vec![items_ptr.clone(), item_lltype.clone()],
+            LowLevelType::Void,
+            move |_r, _a, _res| {
+                crate::translator::rtyper::lltypesystem::rbuilder::build_ll_arrayfill_helper_graph(
+                    "ll_arrayfill",
+                    item.clone(),
+                )
+            },
+        )?
+    };
+
+    // ll_setitem_fast(l, i, item) — the resized/fixed store used by the
+    // nonnull loop.  It takes the LIST ptr directly (does the items getfield
+    // internally for the resized layout).
+    let setitem = {
+        let ptr = ptr_lltype.clone();
+        let item = item_lltype.clone();
+        let setitem_name = layout.setitem_fast_name();
+        rtyper.lowlevel_helper_function_with_builder(
+            setitem_name.to_string(),
+            vec![
+                ptr_lltype.clone(),
+                LowLevelType::Signed,
+                item_lltype.clone(),
+            ],
+            LowLevelType::Void,
+            move |_r, _a, _res| match layout {
+                ListLayout::Fixed => build_ll_fixed_setitem_fast_helper_graph(
+                    setitem_name,
+                    ptr.clone(),
+                    item.clone(),
+                ),
+                ListLayout::Resized => {
+                    build_ll_setitem_fast_helper_graph(setitem_name, ptr.clone(), item.clone())
+                }
+            },
+        )?
+    };
+
+    // @jit.oopspec("newlist_clear(count)") _ll_alloc_and_clear(LIST, count)
+    // (rlist.py:522-528).  The oopspec is attached in lib.rs by CallPath —
+    // the codewriter derives the path from this graph's NAME.
+    let clear = {
+        let ptr = ptr_lltype.clone();
+        let newlist_fn = functionptr_const(rtyper, &newlist)?;
+        let arrayclear_fn = functionptr_const(rtyper, &arrayclear)?;
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            clear_name.to_string(),
+            vec![LowLevelType::Signed],
+            ptr_lltype.clone(),
+            move |_r, _a, _res| {
+                build_ll_alloc_and_clear_helper_graph(
+                    clear_name,
+                    layout,
+                    ptr.clone(),
+                    item.clone(),
+                    newlist_fn.clone(),
+                    arrayclear_fn.clone(),
+                )
+            },
+        )?
+    };
+
+    // _ll_alloc_and_set_nonnull(LIST, count, item) (rlist.py:530-537).
+    let nonnull = {
+        let ptr = ptr_lltype.clone();
+        let newlist_fn = functionptr_const(rtyper, &newlist)?;
+        let setitem_fn = functionptr_const(rtyper, &setitem)?;
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            nonnull_name.to_string(),
+            vec![LowLevelType::Signed, item_lltype.clone()],
+            ptr_lltype.clone(),
+            move |_r, _a, _res| {
+                build_ll_alloc_and_set_nonnull_helper_graph(
+                    nonnull_name,
+                    ptr.clone(),
+                    item.clone(),
+                    newlist_fn.clone(),
+                    setitem_fn.clone(),
+                )
+            },
+        )?
+    };
+
+    // _ll_alloc_and_set_jit(LIST, count, item) (rlist.py:510-520).
+    let jit = {
+        let ptr = ptr_lltype.clone();
+        let clear_fn = functionptr_const(rtyper, &clear)?;
+        let nonnull_fn = functionptr_const(rtyper, &nonnull)?;
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            jit_name.to_string(),
+            vec![LowLevelType::Signed, item_lltype.clone()],
+            ptr_lltype.clone(),
+            move |_r, _a, _res| {
+                build_ll_alloc_and_set_jit_helper_graph(
+                    jit_name,
+                    ptr.clone(),
+                    item.clone(),
+                    clear_fn.clone(),
+                    nonnull_fn.clone(),
+                )
+            },
+        )?
+    };
+
+    // _ll_alloc_and_set_nojit(LIST, count, item) (rlist.py:494-508).
+    let nojit = {
+        let ptr = ptr_lltype.clone();
+        let newlist_fn = functionptr_const(rtyper, &newlist)?;
+        let arrayclear_fn = functionptr_const(rtyper, &arrayclear)?;
+        let arrayfill_fn = functionptr_const(rtyper, &arrayfill)?;
+        let item = item_lltype.clone();
+        rtyper.lowlevel_helper_function_with_builder(
+            nojit_name.to_string(),
+            vec![LowLevelType::Signed, item_lltype.clone()],
+            ptr_lltype.clone(),
+            move |_r, _a, _res| {
+                build_ll_alloc_and_set_nojit_helper_graph(
+                    nojit_name,
+                    layout,
+                    ptr.clone(),
+                    item.clone(),
+                    newlist_fn.clone(),
+                    arrayclear_fn.clone(),
+                    arrayfill_fn.clone(),
+                )
+            },
+        )?
+    };
+
+    let jit_fn = functionptr_const(rtyper, &jit)?;
+    let nojit_fn = functionptr_const(rtyper, &nojit)?;
+    build_ll_alloc_and_set_helper_graph(
+        alloc_and_set_helper_name(layout),
+        ptr_lltype,
+        item_lltype,
+        jit_fn,
+        nojit_fn,
+    )
+}
+
+/// Per-layout names for the five sub-helpers minted alongside the dispatch
+/// helper. The `newlist` name matches [`rtype_newlist_layout`]'s so the shared
+/// `ll_newlist` graph is reused; the alloc-family sub-helpers get the upstream
+/// spellings (Fixed prefixes its own so the helper cache stays disjoint).
+///
+/// Returns `(newlist, clear, nonnull, jit, nojit)`.
+fn alloc_and_set_sub_names(
+    layout: ListLayout,
+) -> (
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+    &'static str,
+) {
+    match layout {
+        ListLayout::Fixed => (
+            "ll_fixed_newlist",
+            "_ll_alloc_and_clear",
+            "_ll_fixed_alloc_and_set_nonnull",
+            "_ll_fixed_alloc_and_set_jit",
+            "_ll_fixed_alloc_and_set_nojit",
+        ),
+        ListLayout::Resized => (
+            "ll_newlist",
+            "_ll_alloc_and_clear",
+            "_ll_alloc_and_set_nonnull",
+            "_ll_alloc_and_set_jit",
+            "_ll_alloc_and_set_nojit",
+        ),
+    }
 }
 
 pub fn _null_of_type() -> Result<(), TyperError> {
     Err(rlist_runtime_deferred("_null_of_type"))
-}
-
-pub fn ll_alloc_and_set() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("ll_alloc_and_set"))
-}
-
-pub fn _ll_alloc_and_set_nojit() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("_ll_alloc_and_set_nojit"))
-}
-
-pub fn _ll_alloc_and_set_jit() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("_ll_alloc_and_set_jit"))
-}
-
-pub fn _ll_alloc_and_clear() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("_ll_alloc_and_clear"))
-}
-
-pub fn _ll_alloc_and_set_nonnull() -> Result<(), TyperError> {
-    Err(rlist_runtime_deferred("_ll_alloc_and_set_nonnull"))
 }
 
 pub fn ll_null_item() -> Result<(), TyperError> {
@@ -3188,6 +3497,727 @@ pub(crate) fn build_ll_newlist_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["length".to_string()],
+        func,
+    ))
+}
+
+/// Emit the `_ll_zero_or_null(item)` op chain (`rlist.py:472-479`) onto
+/// `block`, returning a Bool var that is `True` when `item` IS zero/null:
+///
+/// ```python
+/// def _ll_zero_or_null(item):
+///     T = typeOf(item)
+///     if T is Char or T is UniChar:
+///         check = ord(item)
+///     elif isinstance(T, Number):
+///         check = widen(item)
+///     else:
+///         check = item
+///     return not check
+/// ```
+///
+/// The `check`/`not check` shape is realised per element type: a Char/UniChar
+/// is cast to int then `int_is_true` (matching `not ord(item)`); an integer
+/// is tested with `<prefix>is_true` directly (`not widen(item)`); a Float with
+/// `float_is_true`; a Ptr with `ptr_nonzero`.  Every arm produces the
+/// "nonzero" boolean, which is then negated with `bool_not` to yield the
+/// "zero/null" result the caller branches on.
+fn emit_zero_or_null(block: &BlockRef, item_lltype: &LowLevelType, item: Hlvalue) -> Variable {
+    let (opname, operand) = match item_lltype {
+        LowLevelType::Char => {
+            let as_int = variable_with_lltype("check", LowLevelType::Signed);
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "cast_char_to_int",
+                vec![item],
+                Hlvalue::Variable(as_int.clone()),
+            ));
+            ("int_is_true", Hlvalue::Variable(as_int))
+        }
+        LowLevelType::UniChar => {
+            let as_int = variable_with_lltype("check", LowLevelType::Signed);
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "cast_unichar_to_int",
+                vec![item],
+                Hlvalue::Variable(as_int.clone()),
+            ));
+            ("int_is_true", Hlvalue::Variable(as_int))
+        }
+        LowLevelType::Float | LowLevelType::SingleFloat | LowLevelType::LongFloat => {
+            ("float_is_true", item)
+        }
+        LowLevelType::Ptr(_) | LowLevelType::Address => ("ptr_nonzero", item),
+        // Signed/Unsigned/LongLong/etc.: `not widen(item)` — the widened
+        // integer is-true test.  `int_is_true` covers the machine-word ints
+        // the list-repeat subjects reach here with.
+        _ => ("int_is_true", item),
+    };
+    let nonzero = variable_with_lltype("nonzero", LowLevelType::Bool);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        opname,
+        vec![operand],
+        Hlvalue::Variable(nonzero.clone()),
+    ));
+    let is_zero = variable_with_lltype("is_zero_or_null", LowLevelType::Bool);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "bool_not",
+        vec![Hlvalue::Variable(nonzero)],
+        Hlvalue::Variable(is_zero.clone()),
+    ));
+    is_zero
+}
+
+/// Read `l.ll_items()` for `layout` onto `block`, returning the items-array
+/// ptr operand `rgc.ll_arrayclear` / `ll_arrayfill` receive.  A
+/// `FixedSizeListRepr` value IS the array ptr (no read); the resized header
+/// reaches its array through `getfield(l, "items")`.
+fn emit_list_items_read(
+    block: &BlockRef,
+    layout: ListLayout,
+    item_lltype: &LowLevelType,
+    l: &Variable,
+) -> Hlvalue {
+    match layout {
+        ListLayout::Fixed => Hlvalue::Variable(l.clone()),
+        ListLayout::Resized => {
+            let items = variable_with_lltype("items", items_array_ptr_lltype(item_lltype));
+            block.borrow_mut().operations.push(SpaceOperation::new(
+                "getfield",
+                vec![Hlvalue::Variable(l.clone()), void_field_const("items")],
+                Hlvalue::Variable(items.clone()),
+            ));
+            Hlvalue::Variable(items)
+        }
+    }
+}
+
+/// Synthesise `ll_alloc_and_set(LIST, count, item)` (`rlist.py:487-492`):
+///
+/// ```python
+/// def ll_alloc_and_set(LIST, count, item):
+///     count = int_force_ge_zero(count)
+///     if jit.we_are_jitted():
+///         return _ll_alloc_and_set_jit(LIST, count, item)
+///     else:
+///         return _ll_alloc_and_set_nojit(LIST, count, item)
+/// ```
+///
+/// The startblock clamps `count` with `int_force_ge_zero`, then branches on
+/// the identity-bearing `we_are_jitted()` `SpecTag` exitswitch (the append
+/// helper's shape): true → `direct_call` the jit arm, false → the nojit arm.
+/// `LIST` is folded into the callee identities, so only `(count, item)` cross
+/// the call.
+#[allow(clippy::too_many_arguments)]
+fn build_ll_alloc_and_set_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    jit_fn: Constant,
+    nojit_fn: Constant,
+) -> Result<PyGraph, TyperError> {
+    let count_arg = variable_with_lltype("count", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(count_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // count = int_force_ge_zero(count).
+    let count_clamped = variable_with_lltype("count", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_force_ge_zero",
+        vec![Hlvalue::Variable(count_arg)],
+        Hlvalue::Variable(count_clamped.clone()),
+    ));
+
+    // jit arm: return _ll_alloc_and_set_jit(count, item).
+    let jit_count = variable_with_lltype("count", LowLevelType::Signed);
+    let jit_item = variable_with_lltype("item", item_lltype.clone());
+    let block_jit = Block::shared(vec![
+        Hlvalue::Variable(jit_count.clone()),
+        Hlvalue::Variable(jit_item.clone()),
+    ]);
+    let jit_res = variable_with_lltype("result", ptr_lltype.clone());
+    block_jit.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(jit_fn),
+            Hlvalue::Variable(jit_count),
+            Hlvalue::Variable(jit_item),
+        ],
+        Hlvalue::Variable(jit_res.clone()),
+    ));
+    block_jit.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(jit_res)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // nojit arm: return _ll_alloc_and_set_nojit(count, item).
+    let nj_count = variable_with_lltype("count", LowLevelType::Signed);
+    let nj_item = variable_with_lltype("item", item_lltype);
+    let block_nojit = Block::shared(vec![
+        Hlvalue::Variable(nj_count.clone()),
+        Hlvalue::Variable(nj_item.clone()),
+    ]);
+    let nj_res = variable_with_lltype("result", ptr_lltype);
+    block_nojit
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(nojit_fn),
+                Hlvalue::Variable(nj_count),
+                Hlvalue::Variable(nj_item),
+            ],
+            Hlvalue::Variable(nj_res.clone()),
+        ));
+    block_nojit.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(nj_res)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Constant(Constant::with_concretetype(
+        ConstValue::SpecTag(WE_ARE_JITTED_TAG_ID),
+        LowLevelType::Bool,
+    )));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(count_clamped.clone()),
+                Hlvalue::Variable(item_arg.clone()),
+            ],
+            Some(block_jit),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(count_clamped),
+                Hlvalue::Variable(item_arg),
+            ],
+            Some(block_nojit),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["count".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `_ll_alloc_and_set_jit(LIST, count, item)` (`rlist.py:510-520`):
+///
+/// ```python
+/// def _ll_alloc_and_set_jit(LIST, count, item):
+///     if _ll_zero_or_null(item):
+///         return _ll_alloc_and_clear(LIST, count)
+///     else:
+///         return _ll_alloc_and_set_nonnull(LIST, count, item)
+/// ```
+///
+/// Startblock runs the [`emit_zero_or_null`] op chain and branches on it:
+/// true (zero/null) → `direct_call` the clear arm `(count)`; false → the
+/// nonnull arm `(count, item)`.
+fn build_ll_alloc_and_set_jit_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    clear_fn: Constant,
+    nonnull_fn: Constant,
+) -> Result<PyGraph, TyperError> {
+    let count_arg = variable_with_lltype("count", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(count_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // clear arm: return _ll_alloc_and_clear(count).
+    let cl_count = variable_with_lltype("count", LowLevelType::Signed);
+    let block_clear = Block::shared(vec![Hlvalue::Variable(cl_count.clone())]);
+    let cl_res = variable_with_lltype("result", ptr_lltype.clone());
+    block_clear
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![Hlvalue::Constant(clear_fn), Hlvalue::Variable(cl_count)],
+            Hlvalue::Variable(cl_res.clone()),
+        ));
+    block_clear.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(cl_res)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // nonnull arm: return _ll_alloc_and_set_nonnull(count, item).
+    let nn_count = variable_with_lltype("count", LowLevelType::Signed);
+    let nn_item = variable_with_lltype("item", item_lltype.clone());
+    let block_nonnull = Block::shared(vec![
+        Hlvalue::Variable(nn_count.clone()),
+        Hlvalue::Variable(nn_item.clone()),
+    ]);
+    let nn_res = variable_with_lltype("result", ptr_lltype);
+    block_nonnull
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "direct_call",
+            vec![
+                Hlvalue::Constant(nonnull_fn),
+                Hlvalue::Variable(nn_count),
+                Hlvalue::Variable(nn_item),
+            ],
+            Hlvalue::Variable(nn_res.clone()),
+        ));
+    block_nonnull.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(nn_res)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let is_zero = emit_zero_or_null(
+        &startblock,
+        &item_lltype,
+        Hlvalue::Variable(item_arg.clone()),
+    );
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_zero));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(count_arg.clone())],
+            Some(block_clear),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(count_arg), Hlvalue::Variable(item_arg)],
+            Some(block_nonnull),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["count".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `_ll_alloc_and_set_nojit(LIST, count, item)`
+/// (`rlist.py:494-508`):
+///
+/// ```python
+/// def _ll_alloc_and_set_nojit(LIST, count, item):
+///     l = LIST.ll_newlist(count)
+///     if _ll_zero_or_null(item):
+///         if not malloc_zero_filled:
+///             if not isinstance(typeOf(item), Ptr):
+///                 rgc.ll_arrayclear(l.ll_items())
+///         return l
+///     rgc.ll_arrayfill(l.ll_items(), item)
+///     return l
+/// ```
+///
+/// `l = ll_newlist(count)` runs in the startblock, which then branches on the
+/// [`emit_zero_or_null`] chain.  The `not malloc_zero_filled` guard collapses
+/// to always-do (a translated program has `malloc_zero_filled=False`, the
+/// `mallocstr` precedent), and the `not isinstance(typeOf(item), Ptr)` guard
+/// is a BUILD-TIME element-type check: a Ptr item's array was already zeroed
+/// by `ll_newlist`'s `zero_gc_pointers_inside`, so the zero arm just returns
+/// `l`; a non-Ptr item emits `rgc.ll_arrayclear(items)`.  The nonzero arm
+/// always emits `rgc.ll_arrayfill(items, item)`.
+#[allow(clippy::too_many_arguments)]
+fn build_ll_alloc_and_set_nojit_helper_graph(
+    name: &str,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist_fn: Constant,
+    arrayclear_fn: Constant,
+    arrayfill_fn: Constant,
+) -> Result<PyGraph, TyperError> {
+    let count_arg = variable_with_lltype("count", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(count_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // l = LIST.ll_newlist(count).
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![Hlvalue::Constant(newlist_fn), Hlvalue::Variable(count_arg)],
+        Hlvalue::Variable(l.clone()),
+    ));
+
+    // zero/null arm: (build-time) arrayclear unless the element is a Ptr; then
+    // return l.  Threads `l` through the link and reads `items` in the arm.
+    let cl_l = variable_with_lltype("l", ptr_lltype.clone());
+    let cl_item = variable_with_lltype("item", item_lltype.clone());
+    let block_zero = Block::shared(vec![
+        Hlvalue::Variable(cl_l.clone()),
+        Hlvalue::Variable(cl_item.clone()),
+    ]);
+    // upstream `not isinstance(typeOf(item), Ptr)` — only a `Ptr` element had
+    // its slots pre-zeroed by `ll_newlist`'s `zero_gc_pointers_inside`, so only
+    // a `Ptr` item skips `ll_arrayclear`. `Address` is not a `Ptr`, so it (and
+    // every primitive) still clears.
+    let item_is_ptr = matches!(item_lltype, LowLevelType::Ptr(_));
+    if !item_is_ptr {
+        let items = emit_list_items_read(&block_zero, layout, &item_lltype, &cl_l);
+        let cl_void = variable_with_lltype("v", LowLevelType::Void);
+        block_zero.borrow_mut().operations.push(SpaceOperation::new(
+            "direct_call",
+            vec![Hlvalue::Constant(arrayclear_fn), items],
+            Hlvalue::Variable(cl_void),
+        ));
+    }
+    block_zero.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(cl_l)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // nonzero arm: rgc.ll_arrayfill(l.ll_items(), item); return l.
+    let nz_l = variable_with_lltype("l", ptr_lltype.clone());
+    let nz_item = variable_with_lltype("item", item_lltype.clone());
+    let block_fill = Block::shared(vec![
+        Hlvalue::Variable(nz_l.clone()),
+        Hlvalue::Variable(nz_item.clone()),
+    ]);
+    let fill_items = emit_list_items_read(&block_fill, layout, &item_lltype, &nz_l);
+    let fill_void = variable_with_lltype("v", LowLevelType::Void);
+    block_fill.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(arrayfill_fn),
+            fill_items,
+            Hlvalue::Variable(nz_item),
+        ],
+        Hlvalue::Variable(fill_void),
+    ));
+    block_fill.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(nz_l)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let is_zero = emit_zero_or_null(
+        &startblock,
+        &item_lltype,
+        Hlvalue::Variable(item_arg.clone()),
+    );
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(is_zero));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l.clone()),
+                Hlvalue::Variable(item_arg.clone()),
+            ],
+            Some(block_zero),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l), Hlvalue::Variable(item_arg)],
+            Some(block_fill),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["count".to_string(), "item".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `_ll_alloc_and_clear(LIST, count)` (`rlist.py:522-528`,
+/// `@jit.oopspec("newlist_clear(count)")`):
+///
+/// ```python
+/// def _ll_alloc_and_clear(LIST, count):
+///     l = LIST.ll_newlist(count)
+///     if malloc_zero_filled:
+///         return l
+///     rgc.ll_arrayclear(l.ll_items())
+///     return l
+/// ```
+///
+/// `malloc_zero_filled` collapses to `False` (translated program), so the
+/// early return is dead and the body unconditionally emits `ll_newlist(count)`
+/// → `rgc.ll_arrayclear(items)` → return `l`.  The `newlist_clear(count)`
+/// oopspec is attached in lib.rs by CallPath (the codewriter derives the path
+/// from this graph's NAME `_ll_alloc_and_clear`), so a JIT-path call lowers to
+/// `new_array_clear` instead of residualizing.
+fn build_ll_alloc_and_clear_helper_graph(
+    name: &str,
+    layout: ListLayout,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist_fn: Constant,
+    arrayclear_fn: Constant,
+) -> Result<PyGraph, TyperError> {
+    let count_arg = variable_with_lltype("count", LowLevelType::Signed);
+    let startblock = Block::shared(vec![Hlvalue::Variable(count_arg.clone())]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // l = LIST.ll_newlist(count).
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![Hlvalue::Constant(newlist_fn), Hlvalue::Variable(count_arg)],
+        Hlvalue::Variable(l.clone()),
+    ));
+    // rgc.ll_arrayclear(l.ll_items()).
+    let items = emit_list_items_read(&startblock, layout, &item_lltype, &l);
+    let clear_void = variable_with_lltype("v", LowLevelType::Void);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![Hlvalue::Constant(arrayclear_fn), items],
+        Hlvalue::Variable(clear_void),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(l)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["count".to_string()],
+        func,
+    ))
+}
+
+/// Synthesise `_ll_alloc_and_set_nonnull(LIST, count, item)`
+/// (`rlist.py:530-537`):
+///
+/// ```python
+/// def _ll_alloc_and_set_nonnull(LIST, count, item):
+///     l = LIST.ll_newlist(count)
+///     i = 0
+///     while i < count:
+///         l.ll_setitem_fast(i, item)
+///         i += 1
+///     return l
+/// ```
+///
+/// The `@jit.look_inside_iff(isconstant(count) and count < 137)` marker is a
+/// TRACING policy and is omitted (optional fidelity follow-up).  Three-block
+/// loop: startblock `l = ll_newlist(count)` then enters the header with
+/// `i = 0`; header `int_lt(i, count)` branches true → body, false → return l;
+/// body `ll_setitem_fast(l, i, item)` then `i += 1` back to header.
+fn build_ll_alloc_and_set_nonnull_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+    item_lltype: LowLevelType,
+    newlist_fn: Constant,
+    setitem_fn: Constant,
+) -> Result<PyGraph, TyperError> {
+    let count_arg = variable_with_lltype("count", LowLevelType::Signed);
+    let item_arg = variable_with_lltype("item", item_lltype.clone());
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(count_arg.clone()),
+        Hlvalue::Variable(item_arg.clone()),
+    ]);
+    let return_var = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(return_var),
+    );
+
+    // Loop blocks carry (l, count, item, i) as fresh inputargs.
+    let l_c = variable_with_lltype("l", ptr_lltype.clone());
+    let count_c = variable_with_lltype("count", LowLevelType::Signed);
+    let item_c = variable_with_lltype("item", item_lltype.clone());
+    let i_c = variable_with_lltype("i", LowLevelType::Signed);
+    let block_cond = Block::shared(vec![
+        Hlvalue::Variable(l_c.clone()),
+        Hlvalue::Variable(count_c.clone()),
+        Hlvalue::Variable(item_c.clone()),
+        Hlvalue::Variable(i_c.clone()),
+    ]);
+
+    let l_b = variable_with_lltype("l", ptr_lltype.clone());
+    let count_b = variable_with_lltype("count", LowLevelType::Signed);
+    let item_b = variable_with_lltype("item", item_lltype.clone());
+    let i_b = variable_with_lltype("i", LowLevelType::Signed);
+    let block_body = Block::shared(vec![
+        Hlvalue::Variable(l_b.clone()),
+        Hlvalue::Variable(count_b.clone()),
+        Hlvalue::Variable(item_b.clone()),
+        Hlvalue::Variable(i_b.clone()),
+    ]);
+
+    // startblock: l = ll_newlist(count); enter header with i = 0.
+    let l = variable_with_lltype("l", ptr_lltype.clone());
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(newlist_fn),
+            Hlvalue::Variable(count_arg.clone()),
+        ],
+        Hlvalue::Variable(l.clone()),
+    ));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l),
+                Hlvalue::Variable(count_arg),
+                Hlvalue::Variable(item_arg),
+                signed_const(0),
+            ],
+            Some(block_cond.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    // header: int_lt(i, count). True -> body; False -> return l.
+    let cond = variable_with_lltype("cond", LowLevelType::Bool);
+    block_cond.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(i_c.clone()),
+            Hlvalue::Variable(count_c.clone()),
+        ],
+        Hlvalue::Variable(cond.clone()),
+    ));
+    block_cond.borrow_mut().exitswitch = Some(Hlvalue::Variable(cond));
+    block_cond.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_c.clone()),
+                Hlvalue::Variable(count_c),
+                Hlvalue::Variable(item_c),
+                Hlvalue::Variable(i_c),
+            ],
+            Some(block_body.clone()),
+            Some(bool_const(true)),
+        )
+        .into_ref(),
+        Link::new(
+            vec![Hlvalue::Variable(l_c)],
+            Some(graph.returnblock.clone()),
+            Some(bool_const(false)),
+        )
+        .into_ref(),
+    ]);
+
+    // body: ll_setitem_fast(l, i, item); i += 1.
+    let set_void = variable_with_lltype("v", LowLevelType::Void);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(setitem_fn),
+            Hlvalue::Variable(l_b.clone()),
+            Hlvalue::Variable(i_b.clone()),
+            Hlvalue::Variable(item_b.clone()),
+        ],
+        Hlvalue::Variable(set_void),
+    ));
+    let i_next = variable_with_lltype("i", LowLevelType::Signed);
+    block_body.borrow_mut().operations.push(SpaceOperation::new(
+        "int_add",
+        vec![Hlvalue::Variable(i_b), signed_const(1)],
+        Hlvalue::Variable(i_next.clone()),
+    ));
+    block_body.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(l_b),
+                Hlvalue::Variable(count_b),
+                Hlvalue::Variable(item_b),
+                Hlvalue::Variable(i_next),
+            ],
+            Some(block_cond),
+            None,
+        )
+        .into_ref(),
+    ]);
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["count".to_string(), "item".to_string()],
         func,
     ))
 }
@@ -8009,6 +9039,457 @@ mod tests {
         assert!(
             dbg.contains("ll_listnext"),
             "expected 'll_listnext' in {dbg}"
+        );
+    }
+
+    /// BFS the CFG from `start`, returning `(block_count, all_opnames)`.
+    /// Mirrors the `walk_ops` helper the rbuilder tests use.
+    fn walk_ops(start: &BlockRef) -> (usize, Vec<String>) {
+        let mut seen = std::collections::HashSet::new();
+        let mut stack = vec![start.clone()];
+        let mut all_ops: Vec<String> = Vec::new();
+        let mut count = 0usize;
+        while let Some(b) = stack.pop() {
+            if !seen.insert(Rc::as_ptr(&b) as usize) {
+                continue;
+            }
+            count += 1;
+            let bb = b.borrow();
+            for op in &bb.operations {
+                all_ops.push(op.opname.clone());
+            }
+            for link in &bb.exits {
+                if let Some(t) = link.borrow().target.clone() {
+                    stack.push(t);
+                }
+            }
+        }
+        (count, all_ops)
+    }
+
+    fn dummy_funcptr_const() -> Constant {
+        Constant::with_concretetype(ConstValue::None, LowLevelType::Void)
+    }
+
+    /// Signed `Ptr(GcStruct("list", …))` lltype for the resized layout tests.
+    fn resized_list_lltype() -> LowLevelType {
+        let rtyper = fresh_rtyper();
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        ListRepr::new(&rtyper, r_int)
+            .expect("ListRepr::new")
+            .lowleveltype()
+            .clone()
+    }
+
+    /// `rtype_alloc_and_set` on a resized `ListRepr` mints `ll_alloc_and_set`
+    /// and emits a single top-level `direct_call` to it. The `(count, item)`
+    /// pair is threaded; the `LIST` is folded into the helper identity.
+    #[test]
+    fn rtype_alloc_and_set_resized_mints_ll_alloc_and_set() {
+        use crate::annotator::model::SomeValue;
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> =
+            Arc::new(ListRepr::new(&rtyper, r_int.clone()).expect("ListRepr::new"));
+
+        let v_count = Variable::new();
+        v_count.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_count_h = Hlvalue::Variable(v_count);
+        let v_item_h = Hlvalue::Variable(v_item);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "alloc_and_set".to_string(),
+            vec![v_count_h.clone(), v_item_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_count_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_item_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        let out = rtype_alloc_and_set(&hop)
+            .expect("rtype_alloc_and_set must lower")
+            .expect("alloc_and_set returns the fresh list Variable");
+        assert!(matches!(out, Hlvalue::Variable(_)));
+
+        let ops = hop.llops.borrow();
+        let calls: Vec<_> = ops
+            .ops
+            .iter()
+            .filter(|op| op.opname == "direct_call")
+            .collect();
+        assert_eq!(
+            calls.len(),
+            1,
+            "one top-level direct_call to ll_alloc_and_set"
+        );
+
+        // The minted family graphs must be registered under their upstream
+        // names (the resized spellings).
+        let names: Vec<String> = ann
+            .translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        for expected in [
+            "ll_alloc_and_set",
+            "_ll_alloc_and_set_jit",
+            "_ll_alloc_and_set_nojit",
+            "_ll_alloc_and_clear",
+            "_ll_alloc_and_set_nonnull",
+            "ll_arrayclear",
+            "ll_arrayfill",
+            "ll_newlist",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "family must mint `{expected}`, got {names:?}"
+            );
+        }
+    }
+
+    /// The fixed layout mints the `ll_fixed_*` dispatch/jit/nojit spellings so
+    /// the `(name, args, result)` helper cache never serves a resized graph
+    /// for a fixed request.
+    #[test]
+    fn rtype_alloc_and_set_fixed_mints_ll_fixed_alloc_and_set() {
+        use crate::annotator::model::SomeValue;
+        use crate::flowspace::model::SpaceOperation;
+        use std::cell::RefCell as StdRef;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_int: Arc<dyn Repr> = Arc::new(IntegerRepr::new(LowLevelType::Signed, Some("int_")));
+        let r_list: Arc<dyn Repr> = Arc::new(
+            FixedSizeListRepr::new(&rtyper, r_int.clone()).expect("FixedSizeListRepr::new"),
+        );
+
+        let v_count = Variable::new();
+        v_count.set_concretetype(Some(LowLevelType::Signed));
+        let v_item = Variable::new();
+        v_item.set_concretetype(Some(LowLevelType::Signed));
+        let v_count_h = Hlvalue::Variable(v_count);
+        let v_item_h = Hlvalue::Variable(v_item);
+        let result_var = Variable::new();
+        let spaceop = SpaceOperation::new(
+            "alloc_and_set".to_string(),
+            vec![v_count_h.clone(), v_item_h.clone()],
+            Hlvalue::Variable(result_var),
+        );
+        let llops = Rc::new(StdRef::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(rtyper.clone(), spaceop, Vec::new(), llops);
+        hop.args_v.borrow_mut().push(v_count_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        hop.args_v.borrow_mut().push(v_item_h);
+        hop.args_s.borrow_mut().push(SomeValue::Impossible);
+        hop.args_r.borrow_mut().push(Some(r_int.clone()));
+        *hop.r_result.borrow_mut() = Some(r_list.clone());
+
+        rtype_alloc_and_set(&hop)
+            .expect("rtype_alloc_and_set must lower")
+            .expect("alloc_and_set returns the fresh list Variable");
+
+        let names: Vec<String> = ann
+            .translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|g| g.borrow().name.clone())
+            .collect();
+        assert!(
+            names.iter().any(|n| n == "ll_fixed_alloc_and_set"),
+            "fixed arm mints ll_fixed_alloc_and_set, got {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n == "ll_fixed_newlist"),
+            "fixed arm mints ll_fixed_newlist, got {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n == "ll_alloc_and_set"),
+            "fixed arm must NOT mint the resized ll_alloc_and_set, got {names:?}"
+        );
+    }
+
+    /// `ll_alloc_and_set` clamps `count` with `int_force_ge_zero` and branches
+    /// on the `we_are_jitted()` SpecTag: true → jit arm direct_call, false →
+    /// nojit arm direct_call.
+    #[test]
+    fn build_ll_alloc_and_set_clamps_then_branches_on_we_are_jitted() {
+        let helper = build_ll_alloc_and_set_helper_graph(
+            "ll_alloc_and_set",
+            resized_list_lltype(),
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_helper_graph");
+        assert_eq!(helper.func.name, "ll_alloc_and_set");
+        let inner = helper.graph.borrow();
+
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["int_force_ge_zero"]);
+        assert_eq!(startblock.inputargs.len(), 2); // count, item
+        assert_eq!(startblock.exits.len(), 2); // jit / nojit arms
+        // exitswitch is the identity-bearing we_are_jitted SpecTag.
+        let Some(Hlvalue::Constant(c)) = &startblock.exitswitch else {
+            panic!("exitswitch must be the we_are_jitted SpecTag constant");
+        };
+        assert!(matches!(c.value, ConstValue::SpecTag(_)));
+        drop(startblock);
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, jit, nojit, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("int_force_ge_zero"), 1);
+        assert_eq!(n("direct_call"), 2); // jit + nojit arms
+    }
+
+    /// `_ll_alloc_and_set_jit` branches on `_ll_zero_or_null(item)`: true →
+    /// clear arm `(count)`, false → nonnull arm `(count, item)`. The
+    /// integer-item zero test is `int_is_true` negated by `bool_not`.
+    #[test]
+    fn build_ll_alloc_and_set_jit_branches_on_zero_or_null() {
+        let helper = build_ll_alloc_and_set_jit_helper_graph(
+            "_ll_alloc_and_set_jit",
+            resized_list_lltype(),
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_jit_helper_graph");
+        let inner = helper.graph.borrow();
+
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        // integer item: int_is_true then bool_not.
+        assert_eq!(start_ops, vec!["int_is_true", "bool_not"]);
+        assert_eq!(startblock.exits.len(), 2);
+        assert!(matches!(startblock.exitswitch, Some(Hlvalue::Variable(_))));
+        drop(startblock);
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, clear arm, nonnull arm, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("direct_call"), 2); // clear + nonnull
+        assert_eq!(n("bool_not"), 1);
+    }
+
+    /// `_ll_alloc_and_set_jit` with a Ptr item uses `ptr_nonzero` (negated by
+    /// `bool_not`) for the zero/null test.
+    #[test]
+    fn build_ll_alloc_and_set_jit_ptr_item_uses_ptr_nonzero() {
+        let ptr_list = resized_list_lltype();
+        // item lltype = generic gc pointer.
+        let item = items_array_ptr_lltype(&LowLevelType::Signed);
+        let helper = build_ll_alloc_and_set_jit_helper_graph(
+            "_ll_alloc_and_set_jit",
+            ptr_list,
+            item,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_jit_helper_graph");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["ptr_nonzero", "bool_not"]);
+    }
+
+    /// `_ll_alloc_and_set_nojit` (resized, non-Ptr item): `ll_newlist(count)`,
+    /// branch on zero/null; the zero arm reads `items` (getfield) then
+    /// `ll_arrayclear`, the nonzero arm reads `items` then `ll_arrayfill`.
+    #[test]
+    fn build_ll_alloc_and_set_nojit_resized_nonptr_clears_and_fills() {
+        let helper = build_ll_alloc_and_set_nojit_helper_graph(
+            "_ll_alloc_and_set_nojit",
+            ListLayout::Resized,
+            resized_list_lltype(),
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_nojit_helper_graph");
+        let inner = helper.graph.borrow();
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, zero arm, nonzero arm, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        // ll_newlist + arrayclear (zero arm) + arrayfill (nonzero arm).
+        assert_eq!(n("direct_call"), 3);
+        // Resized reads `items` on BOTH arms.
+        assert_eq!(n("getfield"), 2);
+        assert_eq!(n("bool_not"), 1);
+    }
+
+    /// A Ptr-element resized nojit clear arm skips `ll_arrayclear` entirely
+    /// (the array was zeroed by `ll_newlist`), so only the nonzero arm reads
+    /// `items` and calls `ll_arrayfill` — 2 direct_calls, 1 getfield.
+    #[test]
+    fn build_ll_alloc_and_set_nojit_ptr_item_skips_arrayclear() {
+        let item = items_array_ptr_lltype(&LowLevelType::Signed);
+        let helper = build_ll_alloc_and_set_nojit_helper_graph(
+            "_ll_alloc_and_set_nojit",
+            ListLayout::Resized,
+            resized_list_lltype(),
+            item,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_nojit_helper_graph");
+        let inner = helper.graph.borrow();
+        let (_count, all_ops) = walk_ops(&inner.startblock);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        // ll_newlist + arrayfill only (no arrayclear on the zero arm).
+        assert_eq!(n("direct_call"), 2);
+        // Only the nonzero (fill) arm reads `items`.
+        assert_eq!(n("getfield"), 1);
+    }
+
+    /// Fixed-layout nojit: the receiver IS the array ptr, so NO `items`
+    /// getfield is emitted on either arm.
+    #[test]
+    fn build_ll_alloc_and_set_nojit_fixed_passes_receiver_directly() {
+        let rtyper = fresh_rtyper();
+        let fixed_lltype = FixedSizeListRepr::new(&rtyper, signed_repr() as Arc<dyn Repr>)
+            .expect("FixedSizeListRepr::new")
+            .lowleveltype()
+            .clone();
+        let helper = build_ll_alloc_and_set_nojit_helper_graph(
+            "_ll_fixed_alloc_and_set_nojit",
+            ListLayout::Fixed,
+            fixed_lltype,
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_nojit_helper_graph");
+        let inner = helper.graph.borrow();
+        let (_count, all_ops) = walk_ops(&inner.startblock);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("getfield"), 0); // fixed value is already the array ptr
+        assert_eq!(n("direct_call"), 3); // newlist + arrayclear + arrayfill
+    }
+
+    /// `_ll_alloc_and_clear` (resized): `ll_newlist(count)` → `getfield(items)`
+    /// → `ll_arrayclear(items)` → return l — a single straight-line block
+    /// (`malloc_zero_filled` collapses the early return away).
+    #[test]
+    fn build_ll_alloc_and_clear_newlist_then_arrayclear() {
+        let helper = build_ll_alloc_and_clear_helper_graph(
+            "_ll_alloc_and_clear",
+            ListLayout::Resized,
+            resized_list_lltype(),
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_clear_helper_graph");
+        assert_eq!(helper.func.name, "_ll_alloc_and_clear");
+        let inner = helper.graph.borrow();
+        let startblock = inner.startblock.borrow();
+        let start_ops: Vec<&str> = startblock
+            .operations
+            .iter()
+            .map(|o| o.opname.as_str())
+            .collect();
+        assert_eq!(start_ops, vec!["direct_call", "getfield", "direct_call"]);
+        assert_eq!(startblock.inputargs.len(), 1); // count only (LIST folded)
+        assert_eq!(startblock.exits.len(), 1); // straight-line return
+    }
+
+    /// `_ll_alloc_and_set_nonnull`: `ll_newlist(count)` then the runtime
+    /// `while i < count: setitem_fast(l, i, item); i += 1` loop.
+    #[test]
+    fn build_ll_alloc_and_set_nonnull_newlist_then_setitem_loop() {
+        let helper = build_ll_alloc_and_set_nonnull_helper_graph(
+            "_ll_alloc_and_set_nonnull",
+            resized_list_lltype(),
+            LowLevelType::Signed,
+            dummy_funcptr_const(),
+            dummy_funcptr_const(),
+        )
+        .expect("build_ll_alloc_and_set_nonnull_helper_graph");
+        let inner = helper.graph.borrow();
+
+        let (count, all_ops) = walk_ops(&inner.startblock);
+        // start, loop header, loop body, returnblock.
+        assert_eq!(count, 4);
+        let n = |name: &str| all_ops.iter().filter(|o| o.as_str() == name).count();
+        assert_eq!(n("direct_call"), 2); // ll_newlist + ll_setitem_fast (loop body)
+        assert_eq!(n("int_lt"), 1); // loop header
+        assert_eq!(n("int_add"), 1); // i += 1
+    }
+
+    /// Char-element zero test uses `cast_char_to_int` then `int_is_true`;
+    /// UniChar uses `cast_unichar_to_int`; Float uses `float_is_true`.
+    #[test]
+    fn emit_zero_or_null_op_chain_per_element_type() {
+        let probe = |lltype: LowLevelType| -> Vec<String> {
+            let item = variable_with_lltype("item", lltype.clone());
+            let block = Block::shared(vec![Hlvalue::Variable(item.clone())]);
+            emit_zero_or_null(&block, &lltype, Hlvalue::Variable(item));
+            block
+                .borrow()
+                .operations
+                .iter()
+                .map(|o| o.opname.clone())
+                .collect()
+        };
+        assert_eq!(
+            probe(LowLevelType::Char),
+            vec!["cast_char_to_int", "int_is_true", "bool_not"]
+        );
+        assert_eq!(
+            probe(LowLevelType::UniChar),
+            vec!["cast_unichar_to_int", "int_is_true", "bool_not"]
+        );
+        assert_eq!(
+            probe(LowLevelType::Float),
+            vec!["float_is_true", "bool_not"]
+        );
+        assert_eq!(probe(LowLevelType::Signed), vec!["int_is_true", "bool_not"]);
+        assert_eq!(
+            probe(items_array_ptr_lltype(&LowLevelType::Signed)),
+            vec!["ptr_nonzero", "bool_not"]
         );
     }
 }

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -2216,6 +2216,10 @@ impl RPythonTyper {
             // function `rlist.rtype_newlist(hop)` (`ll_newlist` +
             // positional `ll_setitem_fast`). No per-Repr dispatch.
             "newlist" => super::rlist::rtype_newlist(hop),
+            // rtyper.py:534-535 — `translate_op_alloc_and_set` calls the
+            // free function `rlist.rtype_alloc_and_set(hop)` (`ll_newlist`
+            // + `ll_alloc_and_set`). No per-Repr dispatch.
+            "alloc_and_set" => super::rlist::rtype_alloc_and_set(hop),
             // rtyper.py:531-532 — `translate_op_newdict` calls the free
             // function `rdict.rtype_newdict(hop)` (`ll_newdict`). No
             // per-Repr dispatch.


### PR DESCRIPTION
## Summary

Ports the resizable-list allocation path end to end: the rtyper `ll_alloc_and_set` helper-graph family (T1–T4) and the full `newlist_clear` compound jitcode opcode (N1–N7), replacing the earlier codewriter arm that miscompiled a resized-list result.

13 commits, one coherent epic. No backend (dynasm/cranelift/wasm) resop changes — `newlist_clear` is a jitcode opcode that both the tracer and the blackhole decompose into already-wired primitives (`New` + `SetfieldGc` + `NewArrayClear` + `SetfieldGc`).

## The two defects this closes

- **C1 (latent heap corruption).** The `newlist_clear` codewriter arm hardcoded `item_ty: Ref(None)` and discarded `op.result.concretetype`. For a resized list result (`Ptr(GcStruct("list", {length, items}))`) it emitted a bare `new_array_clear` — an items array with no struct header, so downstream `.length`/`.items` reads hit absent offsets, and non-pointer element slots were GC-traced as pointers. **N5** forks on the result list layout (`newlist_clear_shape`, mirroring upstream's `resizable = isinstance(LIST, GcStruct)`): a `"list"` struct pointee lowers to `NewListClear`, an array pointee to `NewArrayClear`, both recovering `item_ty` from the element lltype via `model::getkind` — never hardcoded.
- **C2 (shared clear-helper name).** Both the fixed and resized layouts named the clear sub-helper `_ll_alloc_and_clear`, so the resized `mark_oopspec` registration overwrote the fixed one. **N6** renames the fixed layout's helper `_ll_fixed_alloc_and_clear` and registers the `newlist_clear(count)` oopspec on both paths.

## What each commit does

**Family (T1–T4)**
- `b5637937418` — port `rgc.ll_arrayclear` / `ll_arrayfill` helper-graph builders into `rbuilder.rs` (three-block element loops over `Ptr(GcArray(ITEM))`; arrayfill emits one `gc_writebarrier` before the loop).
- `f59d96d3302` — lower the `newlist_clear` oopspec to `new_array_clear` in the codewriter; add `OpKind::NewArrayClear` and wire it through the exhaustive matches.
- `c36c2ef470f` — implement the `ll_alloc_and_set` family in `rlist.rs`: `rtype_alloc_and_set` dispatches on the result repr and gendirectcalls a minted helper; `build_alloc_and_set_family` mints six sub-helpers with per-element-type zero/null realization.
- `b7ad03253e3` — dispatch the `alloc_and_set` operation to `rtype_alloc_and_set` in the rtyper.

**Opcode (N1–N7)**
- `50a9249b150` (N2) — add compound `OpKind::NewListClear { length, item_ty, array_type_id }` beside `NewArrayClear`; wire every exhaustive OpKind match.
- `238e5958f6b` (N6) — per-layout clear-helper name + both oopspecs (C2 fix).
- `d10c07d8220` — fail-loud placeholder arm in the assembler (enforces emit-before-producer; replaced by N3 below).
- `e931aaeb7ab` + `9bea0bccd04` (N1) — register the synthetic resizable-list `"list"` GcStruct in the field registry (`length@0`, `items@8`, size 16); items field spelled as a bare pointer.
- `481459860db` (N3) — emit `newlist_clear/idddd>r`: length int register + four interned descrs in the handler read order (Size structdescr, `length`/`items` Field descrs, items array descr) + ref result.
- `839857f4a28` (N5) — fork on the result list layout, recovering the element type (C1 fix).
- `d10f3ac0c0b` (N4) — decompose `BC_NEWLIST_CLEAR` in the tracer into `New + 2×SetfieldGc + NewArrayClear`, live-allocating the header (no-collect nursery/old-gen) and cleared items block with a write barrier; adds the `frame.rs` decoder and the emit test builder.
- `13d533c2fe8` (N7) — relabel the untyped-result test (`..._untyped_result_falls_back_to_ref_array`) and pin the three oopspec-dispatch matchers to `NewArrayClear`.

## GC safety (N4)

The struct header is allocated no-collect on the `BC_NEW` discipline (headerless → no-collect nursery, typed → old-gen), then the items block via `alloc_oldgen_typed` — the non-collecting, non-moving mark-sweep path — so the unrooted struct pointer held in the register bank across the items allocation cannot move or be freed. The hand-inlined items allocation is byte-identical to `dynasm_alloc_oldgen_varsize_typed_and_set_len` (`runner.rs`). The record order and dataflow (`sbox` feeds both setfields as arg0, `abox` feeds the items setfield as arg1) match `opimpl_newlist_clear`.

## Scope note

Census yield is ~0 by construction — no current producer emits `alloc_and_set` → `_ll_alloc_and_clear` reaching a resized list into a lifting graph. The value is the C1 correctness fix plus structural parity with `opimpl_newlist_clear` / `bhimpl_newlist_clear` / `do_resizable_newlist_clear`. This is correct-when-reached infrastructure.

Known backlog (pre-existing, not introduced, likely unreachable): the `array_type_id: None` path collapses sub-word element widths through `getkind`, so a hypothetical resized list of sub-word elements would get an 8-byte-stride items descr. Corpus resizable lists are word-element (int/float/ref).

## Verification

`cargo test --all --no-default-features --features dynasm` — green (0 failures, `default_bh_builder_unwired_set_matches_task_85_snapshot` + `production_bh_builder_covers_every_build_emitted_opname` both ok). `majit-translate` lib 3118 passed, `majit-metainterp` lib 1443 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating cleared arrays and lists with zero-initialized contents.
  * Added typed handling for resizable lists, fixed-size arrays, and pointer elements.
  * Added runtime allocation, layout detection, and memory-safety handling for these operations.

* **Bug Fixes**
  * Corrected operation tracking and optimization behavior for cleared allocations.
  * Improved diagnostics for unsupported allocation stages and layouts.

* **Tests**
  * Added coverage for allocation behavior, list layouts, descriptor handling, zero initialization, and write-barrier usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->