### PR TITLE
mapdict, dict, inline: instance-dict backing, live exact-dict lookups, and a materialized callee frame's locals

### DIFF
--- a/pyre/bench/materialized_callee_local_regression.py
+++ b/pyre/bench/materialized_callee_local_regression.py
@@ -1,0 +1,18 @@
+def callee(i):
+    local_value = i + 1
+    raise RuntimeError
+
+
+def main():
+    bound = 0
+    for i in range(4000):
+        try:
+            callee(i)
+        except RuntimeError as exc:
+            frame_locals = exc.__traceback__.tb_next.tb_frame.f_locals
+            if frame_locals.get("local_value") == i + 1:
+                bound += 1
+    print(f"{bound}/4000")
+
+
+main()

--- a/pyre/extra_tests/parity_tests/dict_subscript_fold.py
+++ b/pyre/extra_tests/parity_tests/dict_subscript_fold.py
@@ -110,3 +110,28 @@ CountingKey.eq_count = 0
 assert read_tag(counted, stored) == 7 * N
 assert CountingKey.hash_count == N
 assert CountingKey.eq_count == 0
+
+
+def read_varying_int_keys(d):
+    total = 0
+    for i in range(N):
+        total += d[i]
+    return total
+
+
+def write_new_keys_and_read_first(d):
+    total = 0
+    for i in range(N):
+        d[i] = i * 3
+        total += d[0]
+    return total
+
+
+varying = {}
+for i in range(N):
+    varying[i] = i + 5
+assert read_varying_int_keys(varying) == (N * (N - 1)) // 2 + 5 * N
+
+mutating = {0: 11}
+assert write_new_keys_and_read_first(mutating) == 0
+assert mutating[N - 1] == (N - 1) * 3

--- a/pyre/extra_tests/parity_tests/dict_subscript_fold.py
+++ b/pyre/extra_tests/parity_tests/dict_subscript_fold.py
@@ -1,0 +1,112 @@
+N = 3000
+
+
+def read_tag(d, k):
+    n = 0
+    for _ in range(N):
+        n += d[k]
+    return n
+
+
+def read_last(d, k):
+    out = None
+    for _ in range(N):
+        out = d[k]
+    return out
+
+
+def read_mixed(d, k):
+    out = None
+    for _ in range(N):
+        out = d[k]
+    return out
+
+
+d = {"tag": 1}
+assert read_tag(d, "tag") == N
+d["tag"] = 2
+assert read_tag(d, "tag") == 2 * N
+
+gone = {"tag": 3}
+assert read_tag(gone, "tag") == 3 * N
+del gone["tag"]
+try:
+    read_last(gone, "tag")
+except KeyError as exc:
+    assert exc.args == ("tag",)
+else:
+    raise AssertionError("deleted key still readable")
+
+
+class MissingDict(dict):
+    def __missing__(self, key):
+        return 41
+
+
+missing = MissingDict()
+assert read_last(missing, "tag") == 41
+
+mixed = {1: "int", "1": "str"}
+assert read_mixed(mixed, 1) == "int"
+assert read_mixed(mixed, "1") == "str"
+
+computed_key = "".join(["ta", "g"])
+assert computed_key == "tag"
+assert read_last({"tag": "computed"}, computed_key) == "computed"
+
+
+class MyStr(str):
+    def __hash__(self):
+        return str.__hash__(self)
+
+    def __eq__(self, other):
+        return str.__eq__(self, other)
+
+
+incoming_sub = MyStr("tag")
+assert read_last({"tag": "incoming"}, incoming_sub) == "incoming"
+
+stored_sub = MyStr("tag")
+stored_sub_dict = {stored_sub: "stored"}
+assert next(iter(stored_sub_dict)) is stored_sub
+assert read_last(stored_sub_dict, "tag") == "stored"
+
+surrogate = "\ud800"
+assert read_last({surrogate: "surrogate"}, surrogate) == "surrogate"
+
+devolved = {"tag": 5}
+assert read_tag(devolved, "tag") == 5 * N
+devolved[1] = 99
+assert read_tag(devolved, "tag") == 5 * N
+
+
+class CountingKey:
+    hash_count = 0
+    eq_count = 0
+
+    def __init__(self, value):
+        self.value = value
+
+    def __hash__(self):
+        type(self).hash_count += 1
+        return 123
+
+    def __eq__(self, other):
+        type(self).eq_count += 1
+        return isinstance(other, CountingKey) and self.value == other.value
+
+
+stored = CountingKey("tag")
+probe = CountingKey("tag")
+counted = {stored: 7}
+CountingKey.hash_count = 0
+CountingKey.eq_count = 0
+assert read_tag(counted, probe) == 7 * N
+assert CountingKey.hash_count == N
+assert CountingKey.eq_count == N
+
+CountingKey.hash_count = 0
+CountingKey.eq_count = 0
+assert read_tag(counted, stored) == 7 * N
+assert CountingKey.hash_count == N
+assert CountingKey.eq_count == 0

--- a/pyre/extra_tests/parity_tests/exception_instance_dict_attr.py
+++ b/pyre/extra_tests/parity_tests/exception_instance_dict_attr.py
@@ -1,0 +1,115 @@
+"""A user attribute on an exception instance lives in its instance dict, which
+is mapdict-backed.  Each block below runs the read hot enough to compile, then
+perturbs the one thing that has to invalidate the compiled read.
+"""
+
+N = 3000
+
+
+class E(Exception):
+    pass
+
+
+def read_sum(e):
+    n = 0
+    for _ in range(N):
+        n += e.tag
+    return n
+
+
+def read_last(e):
+    out = None
+    for _ in range(N):
+        out = e.tag
+    return out
+
+
+# An unboxed int slot, rewritten in place, then retyped so the slot migrates
+# off unboxed storage.
+e = E()
+e.tag = 7
+assert read_sum(e) == 7 * N
+e.tag = 9
+assert read_sum(e) == 9 * N
+e.tag = "s"
+assert read_last(e) == "s"
+
+# A boxed slot, then a second attribute grows the map.
+boxed = E()
+boxed.tag = "seven"
+assert read_last(boxed) == "seven"
+boxed.other = 1
+assert read_last(boxed) == "seven"
+
+# Deleting the attribute.
+gone = E()
+gone.tag = 11
+read_sum(gone)
+del gone.tag
+try:
+    gone.tag
+except AttributeError:
+    pass
+else:
+    raise AssertionError("deleted attribute still readable")
+
+# A second instance whose map places the attribute at another index, read at
+# the same site.
+shifted = E()
+shifted.pad = 0
+shifted.tag = 13
+assert read_sum(shifted) == 13 * N
+assert read_last(boxed) == "seven"
+
+# Devolving the dictionary out from under the read.
+devolved = E()
+devolved.tag = 21
+read_sum(devolved)
+d = devolved.__dict__
+for i in range(200):
+    d["k%d" % i] = i
+assert read_sum(devolved) == 21 * N
+assert devolved.__dict__["tag"] == 21
+
+# Writing through __dict__ rather than through the attribute.
+written = E()
+written.tag = 31
+read_sum(written)
+written.__dict__["tag"] = 32
+assert read_sum(written) == 32 * N
+
+
+# A class attribute of the same name: the instance attribute wins until it is
+# deleted.
+class F(E):
+    pass
+
+
+f = F()
+f.tag = 41
+assert read_sum(f) == 41 * N
+F.tag = 99
+assert read_sum(f) == 41 * N
+del f.tag
+assert read_sum(f) == 99 * N
+
+# A data descriptor added to the class shadows the instance dictionary.
+shadowed = E()
+shadowed.tag = 3
+assert read_sum(shadowed) == 3 * N
+E.tag = property(lambda self: 77)
+assert read_sum(shadowed) == 77 * N
+del E.tag
+
+
+# A non-exception receiver reaching the same read site.
+class O:
+    pass
+
+
+o = O()
+o.tag = 5
+assert read_sum(o) == 5 * N
+
+# The typed `args` slot is not a dictionary attribute.
+assert E(1, 2).args == (1, 2)

--- a/pyre/extra_tests/parity_tests/object_init_text_signature.py
+++ b/pyre/extra_tests/parity_tests/object_init_text_signature.py
@@ -1,0 +1,20 @@
+"""`object.__init__` is a slot wrapper, and a slot wrapper carries the text
+signature `inspect.signature` parses. `object.__new__` and `int.__pow__` pin the
+two neighbouring shapes that already worked.
+"""
+
+import inspect
+import types
+
+assert type(object.__dict__["__init__"]) is types.WrapperDescriptorType
+assert type(object.__dict__["__new__"]) is types.BuiltinFunctionType
+
+assert object.__init__.__text_signature__ == "($self, /, *args, **kwargs)"
+assert object.__new__.__text_signature__ == "($type, *args, **kwargs)"
+assert int.__dict__["__pow__"].__text_signature__ == "($self, value, mod=None, /)"
+
+assert str(inspect.signature(object.__init__)) == "(self, /, *args, **kwargs)"
+# `object.__new__` is bound through its `staticmethod` shape, so `$type` is
+# consumed and does not survive into the rendered signature.
+assert str(inspect.signature(object.__new__)) == "(*args, **kwargs)"
+assert str(inspect.signature(int.__dict__["__pow__"])) == "(self, value, mod=None, /)"

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -1373,7 +1373,7 @@ pub unsafe fn function_getdict(obj: PyObjectRef) -> PyObjectRef {
             // Marking first would leave the young dict stored under a clean
             // bit, so the next minor walk skips the slot and the dict goes
             // stale (`walk_raw_function_roots` then drags a dead pointer).
-            let w_dict = pyre_object::w_dict_new();
+            let w_dict = crate::objspace::std::mapdict::make_instance_dict();
             function_write_barrier(obj);
             (*func).w_func_dict = w_dict;
         }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -1621,6 +1621,95 @@ pub unsafe fn load_attr_fast_path(
     Some((w_type, version_tag, map, p.storageindex))
 }
 
+/// The [`load_attr_fast_path`] twin for a receiver that keeps its attributes in
+/// a `newdict(instance=True)` dictionary rather than in header mapdict storage
+/// (`mapdict.py:1299-1303 make_instance_dict`). It applies the same
+/// `load_attr_slowpath` gates (mapdict.py:1496-1527) and differs only in where
+/// the map comes from — the fake carrier the dictionary erases into rather than
+/// the receiver's own header. Returns the type and its version tag alongside
+/// the fold ingredients: the carrier, its map, the `storageindex`, and the
+/// `(typ, listindex)` pair when the attribute took an unboxed transition.
+///
+/// The carrier's map holds only dictionary attributes, so a `__slots__` member
+/// — which mapdict.py:1518 would resolve through the receiver's own map — is
+/// declined here rather than looked up under the `"slot"` name.
+///
+/// Declines a dictionary that is not `MapDictStrategy`-backed. The caller must
+/// still prove that at trace time before dereferencing `dstorage` as a carrier:
+/// a devolved dictionary erases a smaller storage box, and reading a carrier
+/// field off it is out of bounds.
+///
+/// # Safety
+/// `w_obj` must be live, and `w_dict` must point at its live `W_DictObject`.
+pub unsafe fn instance_dict_attr_fast_path(
+    w_obj: PyObjectRef,
+    w_dict: PyObjectRef,
+    name: &str,
+) -> Option<(
+    PyObjectRef,
+    u64,
+    PyObjectRef,
+    MapRef,
+    usize,
+    Option<(UnboxType, usize)>,
+)> {
+    // mapdict.py:1496 `w_type = map.terminator.w_cls` — the carrier's own
+    // terminator is the shared fake one, so the type comes off the receiver.
+    let w_type = unsafe { (*w_obj).w_class };
+    if w_type.is_null() {
+        return None;
+    }
+    // mapdict.py:1497-1499 — a custom `__getattribute__` handles the access.
+    if unsafe { crate::baseobjspace::getattribute_if_not_from_object(w_type) }.is_some() {
+        return None;
+    }
+    // mapdict.py:1500-1501 `version_tag = w_type.version_tag(); if is not None:`.
+    let version_tag = unsafe { crate::baseobjspace::w_type_version_tag(w_type) };
+    if version_tag == 0 {
+        return None;
+    }
+    // mapdict.py:1504-1526 `_pure_lookup_where_with_method_cache` + classify.
+    let w_descr = unsafe { crate::baseobjspace::lookup_in_type_where(w_type, name) };
+    let (attrkind, is_slot) = unsafe { classify_attr(w_type, w_descr, false) };
+    if attrkind != DICT || is_slot {
+        return None;
+    }
+    let dict = unsafe { &*(w_dict as *const pyre_object::dictmultiobject::W_DictObject) };
+    if dict.dstrategy.strategy_kind() != pyre_object::dictmultiobject::StrategyKind::Map {
+        return None;
+    }
+    let carrier = dict.dstorage as PyObjectRef;
+    if carrier.is_null() {
+        return None;
+    }
+    let map = unsafe { (*(carrier as *const pyre_object::W_ObjectObject)).map as MapRef };
+    if map.is_null() || unsafe { map_is_devolved(map) } {
+        return None;
+    }
+    // mapdict.py:1527 `attr = map.find_map_attr(attrname, attrkind)`.
+    let attr = unsafe { find_map_attr(map, Wtf8::new(name), DICT) }?;
+    let plain = unsafe { (*attr).as_plain() };
+    // `_direct_read` migrates the instance off unboxed storage once its class
+    // has frozen unboxing (mapdict.py:594-596); the fold performs
+    // `_prim_direct_read` alone, so a frozen class stays on the residual that
+    // still runs the migration.
+    if plain.unboxed.is_some()
+        && !unsafe { (*plain.terminator).as_terminator() }
+            .allow_unboxing
+            .get()
+    {
+        return None;
+    }
+    Some((
+        w_type,
+        version_tag,
+        carrier,
+        map,
+        plain.storageindex,
+        plain.unboxed.as_ref().map(|u| (u.typ, u.listindex)),
+    ))
+}
+
 /// Shared resolution for [`property_get_fast_path`] / [`property_set_fast_path`]:
 /// when `name` on `w_obj`'s type resolves to a `property` data descriptor,
 /// return the type, its cacheable version tag, and the property object.  Applies
@@ -4456,7 +4545,7 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         use pyre_object::dictmultiobject::DictStrategy;
 
         let copy = pyre_object::w_dict_new_with(
-            &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY,
+            &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF,
             pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage(),
         );
         for (w_key, w_value) in instance_node_dict_items(mapdict_strategy_unerase(w_dict)) {
@@ -5647,7 +5736,11 @@ mod tests {
             );
 
             // A non-str write devolves while retaining previous string keys.
-            MAP_DICT_STRATEGY.setitem(first, pyre_object::w_int_new(7), pyre_object::w_str_new("v"));
+            MAP_DICT_STRATEGY.setitem(
+                first,
+                pyre_object::w_int_new(7),
+                pyre_object::w_str_new("v"),
+            );
             assert_eq!(
                 (*(first as *const pyre_object::W_DictObject))
                     .dstrategy

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -5683,7 +5683,7 @@ mod tests {
             ));
             assert!(instance_node_setdictvalue(obj_ref, &sur, sentinel(0x55)));
 
-            let w_dict = pyre_object::w_dict_new_with(&MAP_DICT_STRATEGY, obj_ref as *mut u8);
+            let w_dict = pyre_object::w_dict_new_with(&MAP_DICT_STRATEGY_REF, obj_ref as *mut u8);
             assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 2);
 
             let (w_sur_key, w_sur_value) = MAP_DICT_STRATEGY.popitem(w_dict).unwrap();

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -4530,11 +4530,11 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         let inst = &*(w_obj as *const pyre_object::W_ObjectObject);
         let curr = node_search(inst._get_mapdict_map(), DICT)?;
         let key = &(*curr).as_plain().name;
-        let w_value = self.getitem_str(
-            w_dict,
-            key.as_str()
-                .expect("mapdict key is valid UTF-8 for DictStrategy::getitem_str"),
-        )?;
+        // mapdict.py:1231 reads the value with `getitem_str(w_dict, key)`, but
+        // the trait's `getitem_str` takes a `&str` and a node name is WTF-8:
+        // `setitem` stores the full name (mapdict.py:1180), so a lone surrogate
+        // is a node here and has no `&str` form. Read the node layer directly.
+        let w_value = instance_node_getdictvalue(w_obj, key)?;
         let w_key = pyre_object::unicodeobject::box_str_constant(key);
         self.delitem(w_dict, w_key);
         Some((w_key, w_value))
@@ -5657,6 +5657,48 @@ mod tests {
             MAP_DICT_STRATEGY.clear(w_dict);
             assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 0);
             assert_eq!(MAP_DICT_STRATEGY.getitem_str(w_dict, "y"), None);
+        }
+    }
+
+    #[test]
+    fn map_dict_strategy_popitem_preserves_surrogate_node_name() {
+        use pyre_object::dictmultiobject::DictStrategy;
+
+        unsafe {
+            // Install the surrogate-named attribute last so the DICT search
+            // reaches it first. The mapdict node name is WTF-8; popitem must
+            // preserve that name when materialising the returned key.
+            let term = boxed_dict_terminator();
+            let obj_ref = pyre_object::w_instance_new(pyre_object::PY_NULL);
+            let obj = &mut *(obj_ref as *mut pyre_object::W_ObjectObject);
+            obj._set_mapdict_map(term);
+
+            let mut sur = Wtf8Buf::new();
+            sur.push(rustpython_wtf8::CodePoint::from_u32(0xD800).unwrap());
+
+            assert!(instance_node_setdictvalue(
+                obj_ref,
+                wn("ascii"),
+                sentinel(0x44)
+            ));
+            assert!(instance_node_setdictvalue(obj_ref, &sur, sentinel(0x55)));
+
+            let w_dict = pyre_object::w_dict_new_with(&MAP_DICT_STRATEGY, obj_ref as *mut u8);
+            assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 2);
+
+            let (w_sur_key, w_sur_value) = MAP_DICT_STRATEGY.popitem(w_dict).unwrap();
+            assert_eq!(pyre_object::w_str_get_wtf8(w_sur_key), &*sur);
+            assert_eq!(w_sur_value, sentinel(0x55));
+            assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 1);
+            assert_eq!(MAP_DICT_STRATEGY.getitem(w_dict, w_sur_key), None);
+            assert_eq!(instance_node_getdictvalue(obj_ref, &sur), None);
+
+            let (w_ascii_key, w_ascii_value) = MAP_DICT_STRATEGY.popitem(w_dict).unwrap();
+            assert_eq!(pyre_object::w_str_get_value(w_ascii_key), "ascii");
+            assert_eq!(w_ascii_value, sentinel(0x44));
+            assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 0);
+            assert_eq!(MAP_DICT_STRATEGY.getitem_str(w_dict, "ascii"), None);
+            assert_eq!(instance_node_getdictvalue(obj_ref, wn("ascii")), None);
         }
     }
 

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -2662,11 +2662,11 @@ impl MapdictObject for pyre_object::W_ObjectObject {
     }
 }
 
-/// mapdict.py:978-985 `Object` — the generic `MapdictStorageMixin` carrier used
-/// to back instance dictionaries and to hold the result of `delete`/`copy`
-/// (its `storage`/`map` are transplanted into the real instance by
-/// `_set_mapdict_storage_and_map`). pyre uses this lightweight owned-`Vec`
-/// carrier rather than allocating a throwaway `W_ObjectObject`.
+/// mapdict.py:978-985 `Object` — the transient `MapdictStorageMixin` carrier
+/// for the result of `delete`/`copy` (its `storage`/`map` are transplanted
+/// into the real instance by `_set_mapdict_storage_and_map`). pyre keeps that
+/// lightweight owned-`Vec` role here, while a real `W_ObjectObject` provides
+/// the fake-instance-dict-backing role.
 pub(crate) struct Object {
     map: MapRef,
     storage: Vec<PyObjectRef>,
@@ -2737,10 +2737,12 @@ impl MapdictObject for Object {
         self.map = map;
     }
     fn getdict(&self) -> PyObjectRef {
-        // The `Object` carrier (mapdict.py:978) lacks `MapdictDictSupport`; a
-        // `DevolvedDictTerminator`'s read/write/delete only ever runs on the live
-        // instance, never on this transient copy/materialize carrier.
-        unimplemented!("Object carrier has no __dict__ (no MapdictDictSupport)")
+        // mapdict.py:979-985 gives `Object` both transient-copy and fake-dict
+        // roles. pyre gives the fake-dict role to `W_ObjectObject`, whose
+        // getdict is implemented, leaving this carrier transient only. The
+        // terminator_read Devolved arm, write_terminator's Devolved and LIMIT
+        // arms, and node_delete's Devolved arm must therefore never reach it.
+        unimplemented!("transient Object carrier has no __dict__")
     }
 }
 
@@ -4259,9 +4261,32 @@ pub unsafe fn mapdict_switch_to_text_strategy(w_dict: PyObjectRef) {
 /// mapdict.py:1123-1279 `MapDictStrategy` — the dict strategy a user instance's
 /// `__dict__` adopts. `dstorage` erases the backing `W_ObjectObject`
 /// (mapdict.py:1502), so every routed get/set/del/iter funnels into the
-/// instance's mapdict map+storage. Unwired — the `_obj_getdict` flip
-/// installs it; defined now so that flip is a one-line strategy swap.
+/// instance's mapdict map+storage. `_obj_getdict` installs this view.
 pub struct MapDictStrategy;
+
+// mapdict.py:310: allow_unboxing remains true on this shared terminator. A
+// type conflict in holder_pick_attr consequently freezes unboxing for every
+// instance dictionary sharing this transition tree.
+static TERMINATOR_FOR_DICTS: LazyLock<usize> =
+    LazyLock::new(|| new_dict_terminator(pyre_object::PY_NULL) as usize);
+
+pub fn get_terminator_for_dicts() -> MapRef {
+    *TERMINATOR_FOR_DICTS as MapRef
+}
+
+/// mapdict.py:1299-1303 `make_instance_dict`.
+#[majit_macros::dont_look_inside]
+pub fn make_instance_dict() -> PyObjectRef {
+    let w_fake_object = pyre_object::w_instance_new(pyre_object::PY_NULL);
+    let _roots = pyre_object::gc_roots::push_roots();
+    let fake_slot = pyre_object::gc_roots::pin_roots(&[w_fake_object]);
+    unsafe {
+        (&mut *(pyre_object::gc_roots::shadow_stack_get(fake_slot)
+            as *mut pyre_object::W_ObjectObject))
+            ._set_mapdict_map(get_terminator_for_dicts());
+    }
+    _obj_getdict(pyre_object::gc_roots::shadow_stack_get(fake_slot))
+}
 
 /// `space.fromcache(MapDictStrategy)` process-wide singleton — same `&'static`
 /// ZST contract as [`pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY`].
@@ -4280,14 +4305,16 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
     }
 
     /// mapdict.py:1132-1137 `get_empty_storage` — "mainly used for tests": a
-    /// fresh `Object` carrier on a dict terminator, erased. pyre's production
-    /// MapDictStrategy dstorage is always the backing instance (mapdict.py:1502);
-    /// this Object-backed storage is the faithful test constructor and is not
-    /// consumed by the instance-routing trait methods below.
+    /// fresh fake `W_ObjectObject` carrier on the shared dict terminator,
+    /// erased. Production dstorage is likewise the backing instance
+    /// (mapdict.py:1502).
     fn get_empty_storage(&self) -> *mut u8 {
-        let terminator = new_dict_terminator(pyre_object::PY_NULL);
-        let w_result = Object::new_empty(terminator);
-        Box::into_raw(Box::new(w_result)) as *mut u8
+        let w_result = pyre_object::w_instance_new(pyre_object::PY_NULL);
+        unsafe {
+            (&mut *(w_result as *mut pyre_object::W_ObjectObject))
+                ._set_mapdict_map(get_terminator_for_dicts());
+        }
+        w_result as *mut u8
     }
 
     /// mapdict.py:1157-1166 `getitem`.
@@ -4341,6 +4368,28 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         instance_node_setdictvalue(mapdict_strategy_unerase(w_dict), Wtf8::new(key), w_value);
     }
 
+    /// mapdict.py:1185-1196 `setdefault`.
+    unsafe fn setdefault(
+        &self,
+        w_dict: PyObjectRef,
+        w_key: PyObjectRef,
+        w_default: PyObjectRef,
+    ) -> PyObjectRef {
+        if pyre_object::is_exact_type(w_key, &pyre_object::STR_TYPE) {
+            let key = pyre_object::w_str_get_wtf8(w_key);
+            if let Some(w_result) =
+                instance_node_getdictvalue(mapdict_strategy_unerase(w_dict), key)
+            {
+                return w_result;
+            }
+            instance_node_setdictvalue(mapdict_strategy_unerase(w_dict), key, w_default);
+            return w_default;
+        }
+        self.switch_to_object_strategy(w_dict);
+        pyre_object::dictmultiobject::w_dict_setdefault_checked(w_dict, w_key, w_default)
+            .unwrap_or(w_default)
+    }
+
     /// mapdict.py:1198-1211 `delitem`. pyre's trait returns `bool` (true =
     /// removed) where PyPy raises KeyError on a miss; the caller raises.
     unsafe fn delitem(&self, w_dict: PyObjectRef, w_key: PyObjectRef) -> bool {
@@ -4382,6 +4431,74 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
     /// mapdict.py:1222-1225 `clear`.
     unsafe fn clear(&self, w_dict: PyObjectRef) {
         instance_node_dict_clear(mapdict_strategy_unerase(w_dict));
+    }
+
+    /// mapdict.py:1227-1235 `popitem`.
+    unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
+        let w_obj = mapdict_strategy_unerase(w_dict);
+        let _instance_guard = instance_lock(w_obj);
+        ensure_mapdict_initialized(w_obj);
+        let inst = &*(w_obj as *const pyre_object::W_ObjectObject);
+        let curr = node_search(inst._get_mapdict_map(), DICT)?;
+        let key = &(*curr).as_plain().name;
+        let w_value = self.getitem_str(
+            w_dict,
+            key.as_str()
+                .expect("mapdict key is valid UTF-8 for DictStrategy::getitem_str"),
+        )?;
+        let w_key = pyre_object::unicodeobject::box_str_constant(key);
+        self.delitem(w_dict, w_key);
+        Some((w_key, w_value))
+    }
+
+    /// mapdict.py:1237-1253 `copy`.
+    unsafe fn copy(&self, w_dict: PyObjectRef) -> PyObjectRef {
+        use pyre_object::dictmultiobject::DictStrategy;
+
+        let copy = pyre_object::w_dict_new_with(
+            &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY,
+            pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage(),
+        );
+        for (w_key, w_value) in instance_node_dict_items(mapdict_strategy_unerase(w_dict)) {
+            pyre_object::w_dict_store(copy, w_key, w_value);
+        }
+        copy
+    }
+
+    /// mapdict.py:1268-1276 iterator order.
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        let w_obj = mapdict_strategy_unerase(w_dict);
+        let _instance_guard = instance_lock(w_obj);
+        ensure_mapdict_initialized(w_obj);
+        let inst = &*(w_obj as *const pyre_object::W_ObjectObject);
+        let nodes = dict_nodes_in_order(inst);
+        let node = *nodes.get(index)?;
+        Some((
+            pyre_object::unicodeobject::box_str_constant(&(*node).as_plain().name),
+            plain_direct_read(node, inst),
+        ))
+    }
+
+    /// mapdict.py:1278-1279 `MapDictKeyIteratorReversed`.
+    unsafe fn getiterreversed(&self, w_dict: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
+        let w_obj = mapdict_strategy_unerase(w_dict);
+        let _instance_guard = instance_lock(w_obj);
+        ensure_mapdict_initialized(w_obj);
+        let inst = &*(w_obj as *const pyre_object::W_ObjectObject);
+        let mut items = Vec::new();
+        let mut curr = node_search(inst._get_mapdict_map(), DICT);
+        while let Some(node) = curr {
+            items.push((
+                pyre_object::unicodeobject::box_str_constant(&(*node).as_plain().name),
+                plain_direct_read(node, inst),
+            ));
+            curr = node_search((*node).as_plain().back, DICT);
+        }
+        items
     }
 
     /// mapdict.py:1139-1146 `switch_to_object_strategy` — Slice E (#196). The
@@ -5451,6 +5568,133 @@ mod tests {
             MAP_DICT_STRATEGY.clear(w_dict);
             assert_eq!(MAP_DICT_STRATEGY.length(w_dict), 0);
             assert_eq!(MAP_DICT_STRATEGY.getitem_str(w_dict, "y"), None);
+        }
+    }
+
+    #[test]
+    fn make_instance_dict_uses_shared_fake_carriers() {
+        use pyre_object::dictmultiobject::{DictStrategy, StrategyKind};
+
+        crate::test_hooks::install_hash_hook();
+        unsafe {
+            let first = make_instance_dict();
+            let second = make_instance_dict();
+            assert_eq!(
+                (*(first as *const pyre_object::W_DictObject))
+                    .dstrategy
+                    .strategy_kind(),
+                StrategyKind::Map
+            );
+            assert_eq!(MAP_DICT_STRATEGY.length(first), 0);
+
+            // `Object.getdict` stores the wrapper in its SPECIAL slot, so a
+            // second lookup must preserve wrapper identity.
+            let first_carrier =
+                (*(first as *const pyre_object::W_DictObject)).dstorage as PyObjectRef;
+            assert_eq!(_obj_getdict(first_carrier), first);
+            // The carrier is allocated with `w_class = PY_NULL`, so it reaches
+            // `maybe_register_user_finalizer`. Its type resolves through the
+            // `INSTANCE_TYPE` fallback, whose `hasuserdel` is false — but the
+            // app-level type registry is not initialized in a bare lib test,
+            // so `r#type` answers None here and the check only runs once a
+            // registry exists.
+            if let Some(carrier_type) = crate::typedef::r#type(first_carrier) {
+                assert!(
+                    !pyre_object::w_type_get_hasuserdel(carrier_type.as_ptr()),
+                    "the fake carrier must not enter the user-finalizer queue"
+                );
+            }
+
+            // The shared terminator keeps mapdict.py:310's `allow_unboxing`
+            // default, so every write type-inspects its value. `sentinel` is a
+            // bare integer cast to a pointer and would be dereferenced here;
+            // this test uses real objects throughout for that reason.
+            let first_shared = pyre_object::w_str_new("first");
+            let second_shared = pyre_object::w_str_new("second");
+            pyre_object::w_dict_setitem_str(first, "shared", first_shared);
+            pyre_object::w_dict_setitem_str(second, "shared", second_shared);
+            assert_eq!(
+                pyre_object::w_dict_getitem_str(first, "shared"),
+                Some(first_shared)
+            );
+            assert_eq!(
+                pyre_object::w_dict_getitem_str(second, "shared"),
+                Some(second_shared)
+            );
+            let first_node = node_search(
+                (&*(first_carrier as *const pyre_object::W_ObjectObject))._get_mapdict_map(),
+                DICT,
+            );
+            let second_carrier =
+                (*(second as *const pyre_object::W_DictObject)).dstorage as PyObjectRef;
+            let second_node = node_search(
+                (&*(second_carrier as *const pyre_object::W_ObjectObject))._get_mapdict_map(),
+                DICT,
+            );
+            assert_eq!(first_node, second_node);
+
+            // The process-shared terminator preserves mapdict.py:310's true
+            // allow_unboxing default, so an int takes the unboxed transition.
+            pyre_object::w_dict_setitem_str(first, "number", pyre_object::w_int_new(42));
+            let number_node = node_search(
+                (&*(first_carrier as *const pyre_object::W_ObjectObject))._get_mapdict_map(),
+                DICT,
+            )
+            .unwrap();
+            assert!(
+                (*number_node).as_plain().unboxed.is_some(),
+                "int attribute did not use the shared terminator's unboxed transition"
+            );
+
+            // A non-str write devolves while retaining previous string keys.
+            MAP_DICT_STRATEGY.setitem(first, pyre_object::w_int_new(7), pyre_object::w_str_new("v"));
+            assert_eq!(
+                (*(first as *const pyre_object::W_DictObject))
+                    .dstrategy
+                    .strategy_kind(),
+                StrategyKind::Object
+            );
+            assert_eq!(
+                pyre_object::w_dict_getitem_str(first, "shared"),
+                Some(first_shared)
+            );
+
+            // A separate carrier drives the LIMIT arm, which reads its wrapper
+            // back through getdict before changing to a Unicode dictionary.
+            let limit_dict = make_instance_dict();
+            for i in 0..LIMIT_MAP_ATTRIBUTES {
+                pyre_object::w_dict_setitem_str(
+                    limit_dict,
+                    &format!("k{i}"),
+                    pyre_object::w_str_new(&format!("v{i}")),
+                );
+            }
+            assert_eq!(
+                (*(limit_dict as *const pyre_object::W_DictObject))
+                    .dstrategy
+                    .strategy_kind(),
+                StrategyKind::Unicode
+            );
+
+            // A new carrier devolves on a non-str key; reads and deletes then
+            // use the Devolved read and delete arms' fake-carrier getdict.
+            let devolved_dict = make_instance_dict();
+            let kept = pyre_object::w_str_new("kept-value");
+            pyre_object::w_dict_setitem_str(devolved_dict, "kept", kept);
+            MAP_DICT_STRATEGY.setitem(
+                devolved_dict,
+                pyre_object::w_int_new(8),
+                pyre_object::w_str_new("devolve"),
+            );
+            assert_eq!(
+                pyre_object::w_dict_getitem_str(devolved_dict, "kept"),
+                Some(kept)
+            );
+            assert!(
+                (*(devolved_dict as *const pyre_object::W_DictObject))
+                    .dstrategy
+                    .delitem(devolved_dict, pyre_object::w_str_new("kept"))
+            );
         }
     }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -18626,12 +18626,13 @@ fn init_object_type(ns: PyObjectRef) {
         );
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, "__new__", object_new)
     };
+    let object_init = make_builtin_function("__init__", object_descr_init);
     unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__init__",
-            make_builtin_function("__init__", object_descr_init),
-        )
+        crate::function::fset_func_text_signature(
+            object_init,
+            pyre_object::w_str_new("($self, /, *args, **kwargs)"),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, "__init__", object_init)
     };
     // PyPy: objectobject.py — default comparison/hash/repr for all objects
     unsafe {

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1211,8 +1211,8 @@ static FUNCTION_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
 /// identity-key lookup can therefore guard this field to pin the resolved
 /// entry index while continuing to read that entry's value live.
 ///
-/// The `dstrategy_word` and `dstorage_lookup_ns` keys deliberately do NOT match
-/// the Rust field names they cover.  `gc_cache().get_field_descr` is keyed by
+/// The `dstrategy_word`, `dstorage_lookup_ns` and `dstorage_as_gcref` keys
+/// deliberately do NOT match the Rust field names they cover.  `gc_cache().get_field_descr` is keyed by
 /// `(struct_key, field_name)` and a cache HIT returns the cached descriptor with
 /// the caller's declared type ignored, while the LLBC analyzer resolves a real
 /// struct field access by name — so a key spelled `dstrategy` would share one
@@ -1253,11 +1253,33 @@ static W_DICT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
                 false,
                 false,
             ),
+            // A second view of `dstorage`, typed `Ref`: the analyzer lowers the
+            // strategy dispatch and so types `dstorage` as the raw `*mut u8` it
+            // is declared as, while a fold that walks to the storage box needs
+            // to read it as a reference.  Two views of one word need two keys
+            // for the same reason the keys above avoid the Rust field names.
+            (
+                "dstorage_as_gcref",
+                std::mem::offset_of!(pyre_object::dictmultiobject::W_DictObject, dstorage),
+                std::mem::size_of::<usize>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
         ],
         "W_DictObject",
         "dictmultiobject::W_DictObject",
     )
 });
+
+/// Locate a `W_DictObject` field descr by offset rather than by a hand-counted
+/// index: the census above is edited by hand, and naming the wrong index does
+/// not fail to compile, it silently reads a neighbouring word.
+fn w_dict_field_descr(offset: usize) -> DescrRef {
+    let parent = W_DICT_DESCR_GROUP.size_descr.clone() as DescrRef;
+    majit_ir::descr::field_descr_from_parent_by_offset(&parent, offset)
+}
 
 /// `Method` field layout — `w_function`, `w_self`, `w_class`, `w_module`.
 /// All four are Ref slots; the JIT only consumes `w_function` (for guarding
@@ -2448,12 +2470,31 @@ pub fn w_function_size_descr() -> DescrRef {
 }
 
 pub fn dict_keys_version_descr() -> DescrRef {
-    field_descr_from_group(&W_DICT_DESCR_GROUP, 0)
+    w_dict_field_descr(std::mem::offset_of!(
+        pyre_object::dictmultiobject::W_DictObject,
+        keys_version
+    ))
+}
+
+/// `W_DictObject.dstorage` — the strategy-erased storage box
+/// (`dictmultiobject.py:47`). Read as a `Ref` only after the trace has pinned
+/// the strategy through [`dict_strategy_word_descr`], because what the pointer
+/// addresses is whatever the live strategy erased into it.
+/// Reached by census index rather than by offset: `dstorage_lookup_ns` covers
+/// the same word as an `Int`, and `field_descr_from_parent_by_offset` returns
+/// the first descr at an offset, so the offset form would hand back the `Int`
+/// view and silently mis-type the read.
+pub fn dict_dstorage_descr() -> DescrRef {
+    field_descr_from_group(&W_DICT_DESCR_GROUP, 3)
 }
 
 /// `W_DictObject.dstrategy` as a raw word, for the `GuardValue` that pins a
 /// dict to one strategy singleton.  The census key is deliberately not the
 /// struct field name — see the group's doc comment.
+///
+/// `keys_version` is not an alternative for that guard — `MapDictStrategy`
+/// never bumps it, which is why the `dict.get` fold declines a Map-backed
+/// dictionary outright.
 pub fn dict_strategy_word_descr() -> DescrRef {
     field_descr_from_group(&W_DICT_DESCR_GROUP, 1)
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1204,37 +1204,23 @@ static FUNCTION_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
-/// `W_DictObject.keys_version` is pyre's explicit representation of the live
-/// strategy-iterator state PyPy carries implicitly
-/// (`dictmultiobject.py:807-845`).  Key insertion/removal/strategy replacement
-/// bumps it; value-only replacement deliberately does not.  A promoted
-/// identity-key lookup can therefore guard this field to pin the resolved
-/// entry index while continuing to read that entry's value live.
+/// Dict storage descriptors, read after a trace has pinned the live strategy.
 ///
 /// The `dstrategy_word`, `dstorage_lookup_ns` and `dstorage_as_gcref` keys
-/// deliberately do NOT match the Rust field names they cover.  `gc_cache().get_field_descr` is keyed by
-/// `(struct_key, field_name)` and a cache HIT returns the cached descriptor with
-/// the caller's declared type ignored, while the LLBC analyzer resolves a real
-/// struct field access by name — so a key spelled `dstrategy` would share one
-/// descriptor with the analyzer's own mint and whichever side initialised first
-/// would decide the field's type for both.  A distinct key is a distinct cache
-/// slot, which is what keeps these raw-word views honest.  They are appended
-/// rather than placed in offset order so `keys_version` keeps census index 0.
+/// deliberately do NOT match the Rust field names they cover.
+/// `gc_cache().get_field_descr` is keyed by `(struct_key, field_name)` and a
+/// cache HIT returns the cached descriptor with the caller's declared type
+/// ignored, while the LLBC analyzer resolves a real struct field access by name
+/// — so a key spelled `dstrategy` would share one descriptor with the
+/// analyzer's own mint and whichever side initialised first would decide the
+/// field's type for both.  A distinct key is a distinct cache slot, which is
+/// what keeps these raw-word views honest.
 static W_DICT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         pyre_object::dictmultiobject::W_DICT_OBJECT_SIZE,
         W_DICT_GC_TYPE_ID,
         &pyre_object::pyobject::DICT_TYPE as *const _ as usize,
         &[
-            (
-                "keys_version",
-                std::mem::offset_of!(pyre_object::dictmultiobject::W_DictObject, keys_version),
-                std::mem::size_of::<usize>(),
-                Type::Int,
-                false,
-                false,
-                false,
-            ),
             (
                 "dstrategy_word",
                 std::mem::offset_of!(pyre_object::dictmultiobject::W_DictObject, dstrategy),
@@ -1272,14 +1258,6 @@ static W_DICT_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
         "dictmultiobject::W_DictObject",
     )
 });
-
-/// Locate a `W_DictObject` field descr by offset rather than by a hand-counted
-/// index: the census above is edited by hand, and naming the wrong index does
-/// not fail to compile, it silently reads a neighbouring word.
-fn w_dict_field_descr(offset: usize) -> DescrRef {
-    let parent = W_DICT_DESCR_GROUP.size_descr.clone() as DescrRef;
-    majit_ir::descr::field_descr_from_parent_by_offset(&parent, offset)
-}
 
 /// `Method` field layout — `w_function`, `w_self`, `w_class`, `w_module`.
 /// All four are Ref slots; the JIT only consumes `w_function` (for guarding
@@ -2469,13 +2447,6 @@ pub fn w_function_size_descr() -> DescrRef {
     FUNCTION_DESCR_GROUP.size_descr.clone()
 }
 
-pub fn dict_keys_version_descr() -> DescrRef {
-    w_dict_field_descr(std::mem::offset_of!(
-        pyre_object::dictmultiobject::W_DictObject,
-        keys_version
-    ))
-}
-
 /// `W_DictObject.dstorage` — the strategy-erased storage box
 /// (`dictmultiobject.py:47`). Read as a `Ref` only after the trace has pinned
 /// the strategy through [`dict_strategy_word_descr`], because what the pointer
@@ -2485,7 +2456,7 @@ pub fn dict_keys_version_descr() -> DescrRef {
 /// the first descr at an offset, so the offset form would hand back the `Int`
 /// view and silently mis-type the read.
 pub fn dict_dstorage_descr() -> DescrRef {
-    field_descr_from_group(&W_DICT_DESCR_GROUP, 3)
+    field_descr_from_group(&W_DICT_DESCR_GROUP, 2)
 }
 
 /// `W_DictObject.dstrategy` as a raw word, for the `GuardValue` that pins a
@@ -2496,14 +2467,14 @@ pub fn dict_dstorage_descr() -> DescrRef {
 /// never bumps it, which is why the `dict.get` fold declines a Map-backed
 /// dictionary outright.
 pub fn dict_strategy_word_descr() -> DescrRef {
-    field_descr_from_group(&W_DICT_DESCR_GROUP, 1)
+    field_descr_from_group(&W_DICT_DESCR_GROUP, 0)
 }
 
 /// The cache-namespace half of the `dict.lookup` oopspec's `extradescrs`
 /// (`heap.py:504-511 descrs[0]`), naming the entry table a lookup probes.
 /// Only its identity is read; the slot is never loaded.
 pub fn dict_lookup_namespace_descr() -> DescrRef {
-    field_descr_from_group(&W_DICT_DESCR_GROUP, 2)
+    field_descr_from_group(&W_DICT_DESCR_GROUP, 1)
 }
 
 /// `extradescrs[1]` — the entry-array descr `_optimize_CALL_DICT_LOOKUP`

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -130,15 +130,15 @@ pub extern "C" fn jit_dict_nth_value_versioned(
         // safepoint, so `dict` arrives as a raw JIT argument that must be
         // shadow-rooted across the lock and re-read afterwards —
         // `DictOperationGuard` is that bracket. The stripe is reentrant, so the
-        // nested acquire inside `w_dict_nth_item` neither blocks nor releases
+        // nested acquire inside `w_dict_nth_value` neither blocks nor releases
         // this guard.
         let dict_guard = pyre_object::dictmultiobject::DictOperationGuard::new(dict, &[]);
         let dict = dict_guard.root(0);
         if pyre_object::dictmultiobject::w_dict_keys_version(dict) != expected_version as usize {
             return PY_NULL as i64;
         }
-        pyre_object::dictmultiobject::w_dict_nth_item(dict, index as usize)
-            .map_or(PY_NULL as i64, |(_, value)| value as i64)
+        pyre_object::dictmultiobject::w_dict_nth_value(dict, index as usize)
+            .map_or(PY_NULL as i64, |value| value as i64)
     }
 }
 

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -166,6 +166,15 @@ pub extern "C" fn jit_dict_value_at(dict: i64, index: i64, key: i64, hash: i64) 
     }
 }
 
+pub extern "C" fn jit_exact_unicode_matches_stored_key(key: i64, stored_key: i64) -> i64 {
+    unsafe {
+        pyre_object::dictmultiobject::w_exact_unicode_matches_stored_key(
+            key as PyObjectRef,
+            stored_key as PyObjectRef,
+        ) as i64
+    }
+}
+
 pub fn emit_trace_call_ref_typed_elidable_cannot_raise(
     ctx: &mut TraceCtx,
     helper: *const (),

--- a/pyre/pyre-jit-trace/src/helpers.rs
+++ b/pyre/pyre-jit-trace/src/helpers.rs
@@ -106,39 +106,33 @@ pub fn emit_trace_call_ref_typed(
     ctx.call_ref_typed_with_effect(helper, args, arg_types, default_effect_info())
 }
 
-/// Read the value at a promoted exact-dict entry index, re-checking
-/// `W_DictObject.keys_version` — the explicit pyre representation of PyPy's
-/// live strategy-iterator state — under the dict's own lock.
+/// Run one strategy's lookup on raw JIT arguments.
 ///
-/// The trace's `keys_version` guard is an unlocked field read, so another
-/// thread can mutate the key set between that guard and this call.
-/// `IndexMap::shift_remove_index` compacts, so a stale index names a
-/// different key or none at all; one `w_dict_lock` held across the version
-/// re-check and the indexed read keeps `index` attached to the guarded
-/// identity key.  A mismatch or an out-of-range index returns `PY_NULL` for
-/// the caller's `guard_nonnull` to side-exit on.  Value overwrites do not bump
-/// the version and are observed by this live read, matching the r_dict
-/// entry-value load.
-pub extern "C" fn jit_dict_nth_value_versioned(
+/// A contended stripe acquire enters `before_external_block`, which is a GC
+/// safepoint, so `dict` and `key` arrive as raw arguments that must be
+/// shadow-rooted across the lock and re-read afterwards — `DictOperationGuard`
+/// is that bracket.  The stripe is reentrant, so the nested acquire inside the
+/// lookup neither blocks nor releases this guard.  A miss returns `PY_NULL` for
+/// the caller's `guard_nonnull` to side-exit on.
+unsafe fn jit_dict_exact_lookup_or_null(
     dict: i64,
-    index: i64,
-    expected_version: i64,
+    key: i64,
+    lookup: unsafe fn(PyObjectRef, PyObjectRef) -> Option<PyObjectRef>,
 ) -> i64 {
-    let dict = dict as PyObjectRef;
+    let guard = pyre_object::dictmultiobject::DictOperationGuard::new(
+        dict as PyObjectRef,
+        &[key as PyObjectRef],
+    );
+    lookup(guard.root(0), guard.root(1)).map_or(PY_NULL as i64, |value| value as i64)
+}
+
+pub extern "C" fn jit_dict_exact_int_lookup_or_null(dict: i64, key: i64) -> i64 {
     unsafe {
-        // A contended acquire enters `before_external_block`, which is a GC
-        // safepoint, so `dict` arrives as a raw JIT argument that must be
-        // shadow-rooted across the lock and re-read afterwards —
-        // `DictOperationGuard` is that bracket. The stripe is reentrant, so the
-        // nested acquire inside `w_dict_nth_value` neither blocks nor releases
-        // this guard.
-        let dict_guard = pyre_object::dictmultiobject::DictOperationGuard::new(dict, &[]);
-        let dict = dict_guard.root(0);
-        if pyre_object::dictmultiobject::w_dict_keys_version(dict) != expected_version as usize {
-            return PY_NULL as i64;
-        }
-        pyre_object::dictmultiobject::w_dict_nth_value(dict, index as usize)
-            .map_or(PY_NULL as i64, |value| value as i64)
+        jit_dict_exact_lookup_or_null(
+            dict,
+            key,
+            pyre_object::dictmultiobject::w_dict_lookup_or_null_int_strategy,
+        )
     }
 }
 
@@ -166,12 +160,13 @@ pub extern "C" fn jit_dict_value_at(dict: i64, index: i64, key: i64, hash: i64) 
     }
 }
 
-pub extern "C" fn jit_exact_unicode_matches_stored_key(key: i64, stored_key: i64) -> i64 {
+pub extern "C" fn jit_dict_exact_unicode_lookup_or_null(dict: i64, key: i64) -> i64 {
     unsafe {
-        pyre_object::dictmultiobject::w_exact_unicode_matches_stored_key(
-            key as PyObjectRef,
-            stored_key as PyObjectRef,
-        ) as i64
+        jit_dict_exact_lookup_or_null(
+            dict,
+            key,
+            pyre_object::dictmultiobject::w_dict_lookup_or_null_unicode_strategy,
+        )
     }
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4228,7 +4228,22 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 shadow.frame_box = sub_wc.registers_r[callee_portal_frame_reg as usize];
             }
             if !try_multiframe {
-                sub_wc.callee_shadow.as_mut().unwrap().fold_frame_reg = callee_portal_frame_reg;
+                let shadow = sub_wc.callee_shadow.as_mut().unwrap();
+                shadow.fold_frame_reg = callee_portal_frame_reg;
+                // The fold's premise (`setarrayitem_vable_via_metainterp`) is
+                // that it writes away from an UNSEEDED portal frame — a pure
+                // SSA mirror with no heap array behind it.  The seed block
+                // above may have materialized a real callee `PyFrame`, whose
+                // `NewArrayClear` locals array is stored into only for the
+                // parameters and freevar cells; folding away the in-callee
+                // STORE_FASTs would leave every other local holding the
+                // zero-fill, and a frame reachable afterwards through a
+                // traceback, `f_locals` or `sys._getframe` reads them as
+                // unbound.  Record that here so the store handler demotes just
+                // the LOCAL region to a recorded `SETARRAYITEM_GC`, which is
+                // what `_opimpl_setarrayitem_vable` (`pyjitpl.py`) does for a
+                // `_nonstandard_virtualizable`.
+                shadow.frame_materialized = callee_frame_seeded;
             }
             for i in 0..nparams {
                 let slot = i as i64;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3977,6 +3977,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             "Collapse::Other"
         });
     }
+    let callee_frame_materialized_has_resume = callee_frame_seeded && parent_frame.is_some();
 
     // CODEX1 parity: snapshot the heap-effect state before the callee
     // sub-walk.  If the prologue (callee pc 0 → its loop header) mutates the
@@ -4241,9 +4242,14 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // traceback, `f_locals` or `sys._getframe` reads them as
                 // unbound.  Record that here so the store handler demotes just
                 // the LOCAL region to a recorded `SETARRAYITEM_GC`, which is
-                // what `_opimpl_setarrayitem_vable` (`pyjitpl.py`) does for a
-                // `_nonstandard_virtualizable`.
-                shadow.frame_materialized = callee_frame_seeded;
+                // what `_opimpl_setarrayitem_vable` does for a
+                // `_nonstandard_virtualizable` (`pyjitpl.py:1120`). Recording
+                // those stores also emits the promote guard in
+                // `vable_getfield_*` (`pyjitpl.py:1916,2582`), whose resume
+                // image must include the paused caller frame
+                // (`opencoder.py:819`). If this sub-walk has no caller image,
+                // keep folding: publishing only the callee frame is unsound.
+                shadow.frame_materialized = callee_frame_materialized_has_resume;
             }
             for i in 0..nparams {
                 let slot = i as i64;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -407,6 +407,12 @@ pub struct CalleeLocalsShadow {
     /// Box seeded into `fold_frame_reg`; `OpRef::NONE` means the frame register
     /// was not seeded, so the fold must not be disarmed into nonstandard ops.
     pub frame_box: OpRef,
+    /// The seed block emitted a real callee `PyFrame` for this inline level, so
+    /// the fold is writing away from a frame that has a heap locals array
+    /// behind it.  Its LOCAL region is then observable — through a traceback,
+    /// `f_locals` or `sys._getframe` — and must not be folded away; the operand
+    /// -stack region above `nlocals` is not reachable that way and still folds.
+    pub frame_materialized: bool,
 }
 
 impl Default for CalleeLocalsShadow {
@@ -417,6 +423,7 @@ impl Default for CalleeLocalsShadow {
             fold_frame_reg: u16::MAX,
             concrete_frame: 0,
             frame_box: OpRef::NONE,
+            frame_materialized: false,
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1515,11 +1515,15 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     if caller_sym.jitcode().is_null() {
         return Err(unavail("Unavail::Top/NoJitCode"));
     }
-    let (jitcode_index, fallthrough_py_pc, resume_marker_jit_pc, code_ptr) = unsafe {
+    let (jitcode_index, fallthrough_py_pc, resume_marker_jit_pc, code_ptr, call_is_void) = unsafe {
         let jc = &*caller_sym.jitcode();
         if jc.payload.code_ptr.is_null() || !jc.payload.is_populated() {
             return Err(unavail("Unavail::Top/NotPopulated"));
         }
+        let call_is_void =
+            crate::jitcode_runtime::decode_op_at(jc.payload.jitcode.code.as_slice(), call_jit_pc)
+                .and_then(|op| op.argcodes.chars().last())
+                .is_some_and(|bank| bank == 'v');
         // A CALL inside a try-block: inline it only when its exception handler
         // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
         // the residual path handles the raise via its after-residual catch
@@ -1569,9 +1573,12 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             fallthrough,
             inline_call_return_marker(&jc.payload, call_jit_pc),
             jc.payload.code_ptr,
+            call_is_void,
         )
     };
-    // The call result is the top operand-stack slot at the return point.
+    // The call result is the top operand-stack slot only when it remains live
+    // at the return point; a call whose value is immediately discarded can
+    // resume with depth zero.
     let depth = match resume_marker_jit_pc {
         Some(marker) => unsafe { &(*caller_sym.jitcode()).payload }
             .depth_trivia_for_jitcode_pc(marker)
@@ -1605,15 +1612,20 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             }
         }
     };
-    if depth == 0 {
+    // A depth read that finds no trivia entry falls back to zero, so a zero
+    // depth only reliably means "empty operand stack" for a CALL that produces
+    // no result at all. Keep declining it otherwise.
+    if depth == 0 && !call_is_void {
         return Err(unavail("Unavail::Top/DepthZero"));
     }
     let call_stack_overrides = collect_call_stack_overrides(caller_sym, ctx, call_jit_pc);
     // #73: the result slot's color comes from the codewriter-precomputed
     // `result_color_at_pc` (top-of-stack color at the return pc), not the flat
-    // `stack_slot_color_map` — the result is not a live Variable here, so it
-    // carries no pcdep entry.
-    let result_color = {
+    // `stack_slot_color_map` — when the result remains live, it is not a live
+    // Variable here, so it carries no pcdep entry.
+    let result_color = if call_is_void {
+        None
+    } else {
         let payload = unsafe { &(*caller_sym.jitcode()).payload };
         // The trivia twin resolves the return marker only while that marker
         // doubles as the fallthrough PC's own resume marker (a pc_map
@@ -1630,14 +1642,16 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
                     .filter(|&color| color != u16::MAX)
             })
             .map(|color| color as usize)
+    };
+    if !call_is_void && result_color.is_none() {
+        return Err(unavail("Unavail::Top/NoResultColor"));
     }
-    .ok_or_else(|| unavail("Unavail::Top/NoResultColor"))?;
-    // Null the not-yet-produced result slot, build the box list, then restore
-    // the caller's register (the inlined callee, not the walk, produces the
-    // result; the inner frame supplies it on resume).
+    // Null the not-yet-produced result slot when one is live, build the box
+    // list, then restore the caller's register (the inlined callee, not the
+    // walk, produces the result; the inner frame supplies it on resume).
     let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
-    let saved = ctx.registers_r.get(result_color).copied();
-    if result_color < ctx.registers_r.len() {
+    let saved = result_color.and_then(|color| ctx.registers_r.get(color).copied());
+    if let Some(result_color) = result_color.filter(|&color| color < ctx.registers_r.len()) {
         ctx.registers_r[result_color] = null_ref;
     }
     // Keep the caller at the immediate post-call `-live-`, matching the
@@ -1661,7 +1675,10 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         None,
         &[],
     );
-    if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
+    if let (Some(result_color), Some(saved)) = (
+        result_color.filter(|&color| color < ctx.registers_r.len()),
+        saved,
+    ) {
         ctx.registers_r[result_color] = saved;
     }
     Ok(InlineParentFrame {
@@ -1696,6 +1713,10 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         return Err(unavail("Unavail::Nested/NotPopulated"));
     }
     let resume_marker_jit_pc = inline_call_return_marker(&pjc, call_jit_pc);
+    let call_is_void =
+        crate::jitcode_runtime::decode_op_at(pjc.jitcode.code.as_slice(), call_jit_pc)
+            .and_then(|op| op.argcodes.chars().last())
+            .is_some_and(|bank| bank == 'v');
     let after_residual_call_resume = pjc.after_residual_call_resume_for_jitcode_pc(call_jit_pc);
     // A CALL inside a try-block at inline depth ≥2: the rejoin-loop lift is
     // scoped to the top-level caller (`compute_inline_caller_frame`) for now, so
@@ -1712,7 +1733,9 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         let code = &*pjc.code_ptr;
         crate::pyjitpl::semantic_fallthrough_pc(code, call_py) as u32
     };
-    // The call result is the top operand-stack slot at the return point.
+    // The call result is the top operand-stack slot only when it remains live
+    // at the return point; a call whose value is immediately discarded can
+    // resume with depth zero.
     let depth = match resume_marker_jit_pc {
         Some(marker) => pjc.depth_trivia_for_jitcode_pc(marker).unwrap_or(0) as usize,
         None => {
@@ -1743,7 +1766,9 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
             }
         }
     };
-    if depth == 0 {
+    // Zero depth is only known to be an empty operand stack for a result-less
+    // CALL — see the top-level sibling.
+    if depth == 0 && !call_is_void {
         return Err(unavail("Unavail::Nested/DepthZero"));
     }
     // #73: result slot color from the precomputed `result_color_at_pc`, not
@@ -1757,22 +1782,28 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     // after-residual twin — which keys the same fallthrough coordinate by the
     // CALL's byte offset — answers for it.  Selecting one twin on whether a
     // marker exists reports "no result color" for exactly that shape.
-    let result_color = resume_marker_jit_pc
-        .and_then(|marker| pjc.result_color_trivia_for_jitcode_pc(marker))
-        .filter(|&color| color != u16::MAX)
-        .or_else(|| {
-            pjc.result_color_after_residual_for_jitcode_pc(call_jit_pc)
-                .filter(|&color| color != u16::MAX)
-        })
-        .map(|color| color as usize)
-        .ok_or_else(|| unavail("Unavail::Nested/NoResultColor"))?;
-    // Null the not-yet-produced result slot, build the box list, then restore
-    // the caller's register (the inlined callee, not the walk, produces the
-    // result; the inner frame supplies it on resume) — same as the top-level
-    // `in_a_call=true` shape.
+    let result_color = if call_is_void {
+        None
+    } else {
+        resume_marker_jit_pc
+            .and_then(|marker| pjc.result_color_trivia_for_jitcode_pc(marker))
+            .filter(|&color| color != u16::MAX)
+            .or_else(|| {
+                pjc.result_color_after_residual_for_jitcode_pc(call_jit_pc)
+                    .filter(|&color| color != u16::MAX)
+            })
+            .map(|color| color as usize)
+    };
+    if !call_is_void && result_color.is_none() {
+        return Err(unavail("Unavail::Nested/NoResultColor"));
+    }
+    // Null the not-yet-produced result slot when one is live, build the box
+    // list, then restore the caller's register (the inlined callee, not the
+    // walk, produces the result; the inner frame supplies it on resume) — same
+    // as the top-level `in_a_call=true` shape.
     let null_ref = ctx.trace_ctx.const_ref(pyre_object::PY_NULL as i64);
-    let saved = ctx.registers_r.get(result_color).copied();
-    if result_color < ctx.registers_r.len() {
+    let saved = result_color.and_then(|color| ctx.registers_r.get(color).copied());
+    if let Some(result_color) = result_color.filter(|&color| color < ctx.registers_r.len()) {
         ctx.registers_r[result_color] = null_ref;
     }
     // Keep the caller at the immediate post-call `-live-`, matching the
@@ -1791,7 +1822,10 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         call_jit_pc,
         caller_liveness_word,
     );
-    if let (Some(saved), true) = (saved, result_color < ctx.registers_r.len()) {
+    if let (Some(result_color), Some(saved)) = (
+        result_color.filter(|&color| color < ctx.registers_r.len()),
+        saved,
+    ) {
         ctx.registers_r[result_color] = saved;
     }
     let boxes = match boxes {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5347,7 +5347,7 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
 
     if let Some(hit) = walker_probe_exact_dict_hit(list_obj, key_obj)? {
         return walker_emit_exact_dict_hit(
-            ctx, op_pc, list_op, key_op, list_obj, key_obj, hit, dst, dst_bank,
+            ctx, op_pc, list_op, key_op, list_obj, hit, dst, dst_bank,
         );
     }
 
@@ -5937,17 +5937,12 @@ fn is_builtin_dict_get_function(callable: pyre_object::PyObjectRef) -> bool {
 #[derive(Clone, Copy)]
 enum DictFoldKeyProbe {
     Int,
-    Unicode {
-        stored_key: pyre_object::PyObjectRef,
-    },
-    Identity,
+    Unicode,
 }
 
 #[derive(Clone, Copy)]
 struct DictFoldHit {
-    index: usize,
     concrete_value: pyre_object::PyObjectRef,
-    concrete_version: usize,
     key_probe: DictFoldKeyProbe,
 }
 
@@ -5965,14 +5960,11 @@ fn walker_probe_exact_dict_hit(
         return Ok(None);
     }
 
+    // Only the two homogeneous strategies fold: their lookups probe a native
+    // table and so cannot run Python-level `__hash__` or `__eq__`.  Every other
+    // strategy, a mapdict-backed instance dict included, keeps the real lookup.
     let strategy_kind =
         unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(dict).strategy_kind() };
-    // A mapdict-backed instance dict keeps its keys in the carrier's attribute
-    // map, and those adds/deletes never reach `w_dict_bump_keys_version`.
-    if strategy_kind == pyre_object::dictmultiobject::StrategyKind::Map {
-        return Ok(None);
-    }
-
     let int_probe = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Int
         && unsafe { pyre_object::listobject::is_plain_int1(key) && pyre_object::is_int(key) };
     let unicode_probe = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Unicode
@@ -5985,54 +5977,29 @@ fn walker_probe_exact_dict_hit(
                 .is_some()
         };
 
-    let identity_probe = !int_probe
-        && !unicode_probe
-        // typeobject.py:353-371 — only object-default equality/hash makes an
-        // identity hit safe to fold; Python-level methods must keep the real
-        // lookup so their hash/equality effects remain observable.
-        && unsafe { pyre_object::dictmultiobject::key_compares_by_identity(key) };
-
     let found = if int_probe {
         let index =
             unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) };
         index.and_then(|index| {
             unsafe { pyre_object::dictmultiobject::w_dict_nth_value(dict, index) }
-                .map(|value| (index, value, DictFoldKeyProbe::Int))
+                .map(|value| (value, DictFoldKeyProbe::Int))
         })
     } else if unicode_probe {
         let index =
             unsafe { pyre_object::dictmultiobject::w_dict_index_of_unicode_strategy(dict, key) };
         index.and_then(|index| {
-            unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) }
-                .map(|(stored_key, value)| (index, value, DictFoldKeyProbe::Unicode { stored_key }))
+            unsafe { pyre_object::dictmultiobject::w_dict_nth_value(dict, index) }
+                .map(|value| (value, DictFoldKeyProbe::Unicode))
         })
-    } else if identity_probe {
-        let len = unsafe { pyre_object::w_dict_len(dict) };
-        let mut found = None;
-        for index in 0..len {
-            let Some((stored_key, value)) =
-                (unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) })
-            else {
-                return Ok(None);
-            };
-            if std::ptr::eq(stored_key, key) {
-                found = Some((index, value, DictFoldKeyProbe::Identity));
-                break;
-            }
-        }
-        found
     } else {
         None
     };
 
-    let Some((index, concrete_value, key_probe)) = found else {
+    let Some((concrete_value, key_probe)) = found else {
         return Ok(None);
     };
-    let concrete_version = unsafe { pyre_object::dictmultiobject::w_dict_keys_version(dict) };
     Ok(Some(DictFoldHit {
-        index,
         concrete_value,
-        concrete_version,
         key_probe,
     }))
 }
@@ -6043,7 +6010,6 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     dict_op: OpRef,
     key_op: OpRef,
     dict: pyre_object::PyObjectRef,
-    key: pyre_object::PyObjectRef,
     hit: DictFoldHit,
     dst: usize,
     dst_bank: char,
@@ -6057,128 +6023,49 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     )?;
     walker_guard_exact_w_class(ctx, op_pc, dict_op, canonical_dict)?;
 
-    match hit.key_probe {
-        DictFoldKeyProbe::Int => {
-            walker_guard_class(
-                ctx,
-                op_pc,
-                key_op,
-                &pyre_object::pyobject::INT_TYPE as *const _ as i64,
-            )?;
-            walker_guard_exact_w_class(
-                ctx,
-                op_pc,
-                key_op,
-                pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
-            )?;
-            let (key_type, key_descr) = crate::state::int_or_bool_unbox_type_descr(key);
-            let raw_key = walker_unbox_int_typed(ctx, op_pc, key_op, key_type, key_descr)?;
-            let expected_key = ctx
-                .trace_ctx
-                .const_int(unsafe { pyre_object::w_int_get_value(key) });
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op_pc,
-                OpCode::GuardValue,
-                &[raw_key, expected_key],
-            )?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .replace_box(raw_key, expected_key);
-        }
-        DictFoldKeyProbe::Unicode { stored_key } => {
-            walker_guard_class(
-                ctx,
-                op_pc,
-                key_op,
-                &pyre_object::pyobject::STR_TYPE as *const _ as i64,
-            )?;
-            walker_guard_exact_w_class(
-                ctx,
-                op_pc,
-                key_op,
-                pyre_object::get_instantiate(&pyre_object::pyobject::STR_TYPE),
-            )?;
-            let strategy = crate::state::opimpl_getfield_gc_i(
-                ctx.trace_ctx,
-                dict_op,
-                crate::descr::dict_strategy_word_descr(),
-            );
-            let strategy_const = ctx.trace_ctx.const_int(
-                &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF as *const _ as i64,
-            );
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op_pc,
-                OpCode::GuardValue,
-                &[strategy, strategy_const],
-            )?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .replace_box(strategy, strategy_const);
+    let (key_type, canonical_key, strategy_ref, lookup_helper) = match hit.key_probe {
+        DictFoldKeyProbe::Int => (
+            &pyre_object::pyobject::INT_TYPE as *const _ as i64,
+            pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
+            &pyre_object::dictmultiobject::INT_DICT_STRATEGY_REF as *const _ as i64,
+            crate::helpers::jit_dict_exact_int_lookup_or_null as *const (),
+        ),
+        DictFoldKeyProbe::Unicode => (
+            &pyre_object::pyobject::STR_TYPE as *const _ as i64,
+            pyre_object::get_instantiate(&pyre_object::pyobject::STR_TYPE),
+            &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF as *const _ as i64,
+            crate::helpers::jit_dict_exact_unicode_lookup_or_null as *const (),
+        ),
+    };
 
-            let stored_key = ctx.trace_ctx.const_ref(stored_key as i64);
-            let matches = ctx.trace_ctx.call_int_typed_with_effect(
-                crate::helpers::jit_exact_unicode_matches_stored_key as *const (),
-                &[key_op, stored_key],
-                &[majit_ir::Type::Ref, majit_ir::Type::Ref],
-                majit_ir::EffectInfo::new(
-                    majit_ir::ExtraEffect::CannotRaise,
-                    majit_ir::OopSpecIndex::None,
-                ),
-            );
-            ctx.trace_ctx
-                .set_opref_concrete(matches, majit_ir::Value::Int(1));
-            walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[matches])?;
-        }
-        DictFoldKeyProbe::Identity => {
-            let key_expected = ctx.trace_ctx.const_ref(key as i64);
-            if !key_op.is_constant() {
-                walker_emit_fold_guard_with_snapshot(
-                    ctx,
-                    op_pc,
-                    OpCode::GuardValue,
-                    &[key_op, key_expected],
-                )?;
-                ctx.trace_ctx
-                    .heap_cache_mut()
-                    .replace_box(key_op, key_expected);
-            }
-        }
-    }
-
-    let live_version = crate::state::opimpl_getfield_gc_i(
+    let strategy = crate::state::opimpl_getfield_gc_i(
         ctx.trace_ctx,
         dict_op,
-        crate::descr::dict_keys_version_descr(),
+        crate::descr::dict_strategy_word_descr(),
     );
-    let expected_version = ctx.trace_ctx.const_int(hit.concrete_version as i64);
+    let strategy_const = ctx.trace_ctx.const_int(strategy_ref);
     walker_emit_fold_guard_with_snapshot(
         ctx,
         op_pc,
         OpCode::GuardValue,
-        &[live_version, expected_version],
+        &[strategy, strategy_const],
     )?;
     ctx.trace_ctx
         .heap_cache_mut()
-        .replace_box(live_version, expected_version);
+        .replace_box(strategy, strategy_const);
 
-    let index_op = ctx.trace_ctx.const_int(hit.index as i64);
+    walker_guard_class(ctx, op_pc, key_op, key_type)?;
+    walker_guard_exact_w_class(ctx, op_pc, key_op, canonical_key)?;
+
     let value = ctx.trace_ctx.call_ref_typed_with_effect(
-        crate::helpers::jit_dict_nth_value_versioned as *const (),
-        &[dict_op, index_op, expected_version],
-        &[
-            majit_ir::Type::Ref,
-            majit_ir::Type::Int,
-            majit_ir::Type::Int,
-        ],
+        lookup_helper,
+        &[dict_op, key_op],
+        &[majit_ir::Type::Ref, majit_ir::Type::Ref],
         majit_ir::EffectInfo::new(
             majit_ir::ExtraEffect::CannotRaise,
             majit_ir::OopSpecIndex::None,
         ),
     );
-    // A key set that moved after the unlocked version guard, or an index the
-    // compacted table no longer holds, comes back as `PY_NULL`.
     walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[value])?;
     ctx.trace_ctx.set_opref_concrete(
         value,
@@ -6188,23 +6075,14 @@ fn walker_emit_exact_dict_hit<Sym: WalkSym>(
     Ok(Some(()))
 }
 
-/// `dict.get` on an exact dictionary and a safely probed promoted key.
+/// `dict.get` on an exact dictionary and an Int/Unicode strategy hit.
 ///
 /// `dictmultiobject.py:1095-1098` probes an Int strategy with the unboxed key
-/// value.  All other strategies retain the identity-only recording-time probe;
-/// Object and Identity strategy equality can execute user code.  The selected
-/// entry index remains valid until the key set changes; `W_DictObject` exposes
-/// that state as `keys_version`, so guard it and issue a live nth-value read.
-/// Value-only replacement remains visible without invalidation.
-///
-/// The emitted `keys_version` guard is an unlocked field read, which is a
-/// pre-filter only — `jit_dict_nth_value_versioned` re-checks the version
-/// under the dict's own lock, and a `guard_nonnull` on its result side-exits
-/// when a concurrent key-set mutation detached the index from the key.
-///
-/// Equal-but-nonidentical non-Int keys and misses remain residual.  Object and
-/// Identity strategy probes require the complete r_dict lookup to preserve
-/// their hash/equality effects (`rdict.py:576`).
+/// value, and `dictmultiobject.py:1315-1318` probes a Unicode strategy with
+/// exact-str bytes. The trace guards the exact dict, strategy vtable, and exact
+/// key type, then performs a live strategy-specific lookup and guards that it
+/// hit. Misses and object/identity strategy keys remain residual so their
+/// hash/equality effects stay observable (`rdict.py:576`).
 pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -6286,7 +6164,7 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
             .heap_cache_mut()
             .replace_box(callable_op, expected);
     }
-    walker_emit_exact_dict_hit(ctx, op.pc, dict_op, r_args[2], dict, key, hit, dst, 'r')
+    walker_emit_exact_dict_hit(ctx, op.pc, dict_op, r_args[2], dict, hit, dst, 'r')
 }
 
 /// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5781,22 +5781,23 @@ fn is_builtin_dict_get_function(callable: pyre_object::PyObjectRef) -> bool {
             == pyre_interpreter::type_methods::dict_method_get as *const () as usize
 }
 
-/// `dict.get` on an exact dictionary and an identity-present promoted key.
+/// `dict.get` on an exact dictionary and a safely probed promoted key.
 ///
-/// PyPy traces `DictStrategy.getitem` into its r_dict lookup.  Once the
-/// observed key is the exact stored key, the hash/equality probe selects a
-/// stable entry index; PyPy's native iterator/table state keeps that selection
-/// valid until the key set changes.  Pyre represents the same state explicitly
-/// as `W_DictObject.keys_version`, so guard it and issue a live nth-value read.
-/// Value-only replacement is intentionally visible without invalidation.
+/// `dictmultiobject.py:1095-1098` probes an Int strategy with the unboxed key
+/// value.  All other strategies retain the identity-only recording-time probe;
+/// Object and Identity strategy equality can execute user code.  The selected
+/// entry index remains valid until the key set changes; `W_DictObject` exposes
+/// that state as `keys_version`, so guard it and issue a live nth-value read.
+/// Value-only replacement remains visible without invalidation.
 ///
 /// The emitted `keys_version` guard is an unlocked field read, which is a
 /// pre-filter only — `jit_dict_nth_value_versioned` re-checks the version
 /// under the dict's own lock, and a `guard_nonnull` on its result side-exits
 /// when a concurrent key-set mutation detached the index from the key.
 ///
-/// Equal-but-nonidentical keys and misses remain residual because reproducing
-/// their hash/equality effects requires the complete r_dict probe.
+/// Equal-but-nonidentical non-Int keys and misses remain residual.  Object and
+/// Identity strategy probes require the complete r_dict lookup to preserve
+/// their hash/equality effects (`rdict.py:576`).
 pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -5846,19 +5847,42 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
         return Ok(None);
     }
 
-    let len = unsafe { pyre_object::w_dict_len(dict) };
-    let mut found = None;
-    for index in 0..len {
-        let Some((stored_key, value)) =
-            (unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) })
-        else {
-            return Ok(None);
-        };
-        if std::ptr::eq(stored_key, key) {
-            found = Some((index, value));
-            break;
-        }
+    let strategy_kind =
+        unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(dict).strategy_kind() };
+    // A mapdict-backed instance dict keeps its keys in the carrier's attribute
+    // map, and those adds/deletes never reach `w_dict_bump_keys_version` — the
+    // wrapper is only a view.  `keys_version` is therefore constant for a Map
+    // dict, so the guard below would certify an entry index that a `del
+    // o.attr` has already re-numbered.  Decline instead of certifying a
+    // version that cannot move.
+    if strategy_kind == pyre_object::dictmultiobject::StrategyKind::Map {
+        return Ok(None);
     }
+    let value_probed_int = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Int
+        && unsafe { pyre_object::listobject::is_plain_int1(key) && pyre_object::is_int(key) };
+    let found = if value_probed_int {
+        let index =
+            unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) };
+        index.and_then(|index| {
+            unsafe { pyre_object::dictmultiobject::w_dict_nth_value(dict, index) }
+                .map(|value| (index, value))
+        })
+    } else {
+        let len = unsafe { pyre_object::w_dict_len(dict) };
+        let mut found = None;
+        for index in 0..len {
+            let Some((stored_key, value)) =
+                (unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) })
+            else {
+                return Ok(None);
+            };
+            if std::ptr::eq(stored_key, key) {
+                found = Some((index, value));
+                break;
+            }
+        }
+        found
+    };
     let Some((index, concrete_value)) = found else {
         return Ok(None);
     };
@@ -5910,17 +5934,46 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
     )?;
     walker_guard_exact_w_class(ctx, op.pc, dict_op, canonical_dict)?;
     let key_op = r_args[2];
-    let key_expected = ctx.trace_ctx.const_ref(key as i64);
-    if !key_op.is_constant() {
+    if value_probed_int {
+        walker_guard_class(
+            ctx,
+            op.pc,
+            key_op,
+            &pyre_object::pyobject::INT_TYPE as *const _ as i64,
+        )?;
+        walker_guard_exact_w_class(
+            ctx,
+            op.pc,
+            key_op,
+            pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
+        )?;
+        let (key_type, key_descr) = crate::state::int_or_bool_unbox_type_descr(key);
+        let raw_key = walker_unbox_int_typed(ctx, op.pc, key_op, key_type, key_descr)?;
+        let expected_key = ctx
+            .trace_ctx
+            .const_int(unsafe { pyre_object::w_int_get_value(key) });
         walker_emit_fold_guard_with_snapshot(
             ctx,
             op.pc,
             OpCode::GuardValue,
-            &[key_op, key_expected],
+            &[raw_key, expected_key],
         )?;
         ctx.trace_ctx
             .heap_cache_mut()
-            .replace_box(key_op, key_expected);
+            .replace_box(raw_key, expected_key);
+    } else {
+        let key_expected = ctx.trace_ctx.const_ref(key as i64);
+        if !key_op.is_constant() {
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op.pc,
+                OpCode::GuardValue,
+                &[key_op, key_expected],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(key_op, key_expected);
+        }
     }
     let live_version = crate::state::opimpl_getfield_gc_i(
         ctx.trace_ctx,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -2413,6 +2413,153 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         }
     }
 
+    // A user attribute on an exception instance. `mapdict.py:1483-1490
+    // LOAD_ATTR_caching` declines this receiver upstream too — an exception is
+    // not a `MapdictStorageMixin` and `_get_mapdict_map` answers None
+    // (`baseobjspace.py:204-205`) — and it reaches its speed by inlining
+    // `getdictvalue -> MapDictStrategy.getitem_str -> AbstractAttribute.read`
+    // (`mapdict.py:55-66`, `:442-444`) instead. The attribute lives in the
+    // `newdict(instance=True)` dictionary, two hops out: `w_dict` ->
+    // `W_DictObject.dstorage` -> the fake carrier that holds the map.
+    //
+    // `w_exception_get_kind` and `w_exception_peek_dict` both cast straight to
+    // `W_BaseException`, so the `is_exception` test is load-bearing: this
+    // function runs for every `LOAD_ATTR` receiver that reached it.
+    let exc_dict = unsafe {
+        pyre_object::is_exception(concrete_obj)
+            .then(|| pyre_object::interp_exceptions::w_exception_peek_dict(concrete_obj))
+            .filter(|dict| !dict.is_null())
+    };
+    if let Some(dict) = exc_dict
+        && let Some((w_type, _version_tag, carrier, map, storageindex, unboxed)) = unsafe {
+            pyre_interpreter::objspace::std::mapdict::instance_dict_attr_fast_path(
+                concrete_obj,
+                dict,
+                &name,
+            )
+        }
+        // An unboxed float slot keeps the `f64` bit pattern in the same
+        // longlong block as an int, so folding it needs a bits-to-float
+        // reinterpret the trace has no operation for; leave it on the residual.
+        && !matches!(
+            unboxed,
+            Some((pyre_interpreter::objspace::std::mapdict::UnboxType::Float, _))
+        )
+    {
+        let kind = unsafe { pyre_object::w_exception_get_kind(concrete_obj) };
+        let phys_type = unsafe { (*concrete_obj).ob_type as i64 };
+        if !ctx.trace_ctx.heap_cache().is_class_known(obj) {
+            let type_const = ctx.trace_ctx.const_int(phys_type);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardClass,
+                &[obj, type_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(obj, phys_type);
+        }
+        let w_class = walker_record_getfield_gc_r_uncached(ctx, obj, crate::descr::w_class_descr());
+        let w_type_const = ctx.trace_ctx.const_ref(w_type as i64);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[w_class, w_type_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(w_class, w_type_const);
+        walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
+
+        let dict_op = walker_record_getfield_gc_r_uncached(
+            ctx,
+            obj,
+            crate::descr::w_exception_dict_descr(kind),
+        );
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[dict_op])?;
+        ctx.trace_ctx.set_opref_concrete(
+            dict_op,
+            majit_ir::Value::Ref(majit_ir::GcRef(dict as usize)),
+        );
+
+        // `instance_dict_attr_fast_path` declines a dictionary that is not
+        // `MapDictStrategy`-backed, and the carrier read below is out of bounds
+        // on a devolved one, so pin the strategy before dereferencing
+        // `dstorage`.
+        let strategy = crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            dict_op,
+            crate::descr::dict_strategy_word_descr(),
+        );
+        let strategy_const = ctx.trace_ctx.const_int(
+            &pyre_interpreter::objspace::std::mapdict::MAP_DICT_STRATEGY_REF as *const _ as i64,
+        );
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[strategy, strategy_const],
+        )?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(strategy, strategy_const);
+
+        let carrier_op =
+            walker_record_getfield_gc_r_uncached(ctx, dict_op, crate::descr::dict_dstorage_descr());
+        ctx.trace_ctx.set_opref_concrete(
+            carrier_op,
+            majit_ir::Value::Ref(majit_ir::GcRef(carrier as usize)),
+        );
+        let map_op =
+            walker_record_getfield_gc_i_uncached(ctx, carrier_op, crate::descr::object_map_descr());
+        let map_const = ctx.trace_ctx.const_int(map as i64);
+        walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[map_op, map_const])?;
+        ctx.trace_ctx
+            .heap_cache_mut()
+            .replace_box(map_op, map_const);
+
+        let block = crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            carrier_op,
+            crate::descr::object_storage_descr(),
+        );
+        let index = ctx.trace_ctx.const_int(storageindex as i64);
+        let slot = crate::state::trace_mapdict_storage_getitem(ctx.trace_ctx, block, index);
+        let value = match unboxed {
+            None => slot,
+            // `_prim_direct_read` (mapdict.py:600-601): the storage slot holds
+            // the shared longlong block, and the value is `items[listindex]`.
+            // Keeping the boxing in the trace lets an immediate integer
+            // consumer virtualize it away.
+            Some((_, listindex)) => {
+                let listindex_const = ctx.trace_ctx.const_int(listindex as i64);
+                let live = unsafe {
+                    pyre_interpreter::objspace::std::mapdict::read_unboxed_storage_raw(
+                        carrier,
+                        storageindex,
+                        listindex,
+                    )
+                };
+                let raw = crate::state::trace_int_block_getitem_value(
+                    ctx.trace_ctx,
+                    slot,
+                    listindex_const,
+                );
+                ctx.trace_ctx
+                    .set_opref_concrete(raw, majit_ir::Value::Int(live));
+                let boxed = walker_box_int(ctx, op_pc, raw, live)?;
+                let live_ptr = pyre_object::w_int_new(live) as i64;
+                ctx.trace_ctx
+                    .set_opref_concrete(boxed, box_int_concrete(live, live_ptr));
+                boxed
+            }
+        };
+        write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+        return Ok(Some(()));
+    }
+
     if let Some((slot, kind, w_type, version_tag, stored)) = unsafe {
         pyre_interpreter::baseobjspace::exception_attr_slot_fold(concrete_obj, &name, false)
     } {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -5345,6 +5345,12 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
         return Ok(None);
     };
 
+    if let Some(hit) = walker_probe_exact_dict_hit(list_obj, key_obj)? {
+        return walker_emit_exact_dict_hit(
+            ctx, op_pc, list_op, key_op, list_obj, key_obj, hit, dst, dst_bank,
+        );
+    }
+
     // #171/#11 Approach C: canonical array-backed `W_TupleObject[i]`.  Two
     // gates, both required:
     //   * `ob_type == &TUPLE_TYPE` (tupleobject.py / tupleobject.rs) —
@@ -5928,6 +5934,260 @@ fn is_builtin_dict_get_function(callable: pyre_object::PyObjectRef) -> bool {
             == pyre_interpreter::type_methods::dict_method_get as *const () as usize
 }
 
+#[derive(Clone, Copy)]
+enum DictFoldKeyProbe {
+    Int,
+    Unicode {
+        stored_key: pyre_object::PyObjectRef,
+    },
+    Identity,
+}
+
+#[derive(Clone, Copy)]
+struct DictFoldHit {
+    index: usize,
+    concrete_value: pyre_object::PyObjectRef,
+    concrete_version: usize,
+    key_probe: DictFoldKeyProbe,
+}
+
+fn walker_probe_exact_dict_hit(
+    dict: pyre_object::PyObjectRef,
+    key: pyre_object::PyObjectRef,
+) -> Result<Option<DictFoldHit>, DispatchError> {
+    let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
+    if canonical_dict.is_null()
+        || !unsafe {
+            std::ptr::eq((*dict).ob_type, &pyre_object::pyobject::DICT_TYPE)
+                && std::ptr::eq((*dict).w_class, canonical_dict)
+        }
+    {
+        return Ok(None);
+    }
+
+    let strategy_kind =
+        unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(dict).strategy_kind() };
+    // A mapdict-backed instance dict keeps its keys in the carrier's attribute
+    // map, and those adds/deletes never reach `w_dict_bump_keys_version`.
+    if strategy_kind == pyre_object::dictmultiobject::StrategyKind::Map {
+        return Ok(None);
+    }
+
+    let int_probe = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Int
+        && unsafe { pyre_object::listobject::is_plain_int1(key) && pyre_object::is_int(key) };
+    let unicode_probe = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Unicode
+        && unsafe {
+            pyre_object::is_exact_type(key, &pyre_object::pyobject::STR_TYPE)
+                && pyre_object::w_str_get_value_opt(key).is_some()
+                && pyre_object::dict_eq_hook::try_hash_str(
+                    pyre_object::w_str_get_value_opt(key).unwrap().as_bytes(),
+                )
+                .is_some()
+        };
+
+    let identity_probe = !int_probe
+        && !unicode_probe
+        // typeobject.py:353-371 — only object-default equality/hash makes an
+        // identity hit safe to fold; Python-level methods must keep the real
+        // lookup so their hash/equality effects remain observable.
+        && unsafe { pyre_object::dictmultiobject::key_compares_by_identity(key) };
+
+    let found = if int_probe {
+        let index =
+            unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) };
+        index.and_then(|index| {
+            unsafe { pyre_object::dictmultiobject::w_dict_nth_value(dict, index) }
+                .map(|value| (index, value, DictFoldKeyProbe::Int))
+        })
+    } else if unicode_probe {
+        let index =
+            unsafe { pyre_object::dictmultiobject::w_dict_index_of_unicode_strategy(dict, key) };
+        index.and_then(|index| {
+            unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) }
+                .map(|(stored_key, value)| (index, value, DictFoldKeyProbe::Unicode { stored_key }))
+        })
+    } else if identity_probe {
+        let len = unsafe { pyre_object::w_dict_len(dict) };
+        let mut found = None;
+        for index in 0..len {
+            let Some((stored_key, value)) =
+                (unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) })
+            else {
+                return Ok(None);
+            };
+            if std::ptr::eq(stored_key, key) {
+                found = Some((index, value, DictFoldKeyProbe::Identity));
+                break;
+            }
+        }
+        found
+    } else {
+        None
+    };
+
+    let Some((index, concrete_value, key_probe)) = found else {
+        return Ok(None);
+    };
+    let concrete_version = unsafe { pyre_object::dictmultiobject::w_dict_keys_version(dict) };
+    Ok(Some(DictFoldHit {
+        index,
+        concrete_value,
+        concrete_version,
+        key_probe,
+    }))
+}
+
+fn walker_emit_exact_dict_hit<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    dict_op: OpRef,
+    key_op: OpRef,
+    dict: pyre_object::PyObjectRef,
+    key: pyre_object::PyObjectRef,
+    hit: DictFoldHit,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
+    walker_guard_class(
+        ctx,
+        op_pc,
+        dict_op,
+        &pyre_object::pyobject::DICT_TYPE as *const _ as i64,
+    )?;
+    walker_guard_exact_w_class(ctx, op_pc, dict_op, canonical_dict)?;
+
+    match hit.key_probe {
+        DictFoldKeyProbe::Int => {
+            walker_guard_class(
+                ctx,
+                op_pc,
+                key_op,
+                &pyre_object::pyobject::INT_TYPE as *const _ as i64,
+            )?;
+            walker_guard_exact_w_class(
+                ctx,
+                op_pc,
+                key_op,
+                pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
+            )?;
+            let (key_type, key_descr) = crate::state::int_or_bool_unbox_type_descr(key);
+            let raw_key = walker_unbox_int_typed(ctx, op_pc, key_op, key_type, key_descr)?;
+            let expected_key = ctx
+                .trace_ctx
+                .const_int(unsafe { pyre_object::w_int_get_value(key) });
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[raw_key, expected_key],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(raw_key, expected_key);
+        }
+        DictFoldKeyProbe::Unicode { stored_key } => {
+            walker_guard_class(
+                ctx,
+                op_pc,
+                key_op,
+                &pyre_object::pyobject::STR_TYPE as *const _ as i64,
+            )?;
+            walker_guard_exact_w_class(
+                ctx,
+                op_pc,
+                key_op,
+                pyre_object::get_instantiate(&pyre_object::pyobject::STR_TYPE),
+            )?;
+            let strategy = crate::state::opimpl_getfield_gc_i(
+                ctx.trace_ctx,
+                dict_op,
+                crate::descr::dict_strategy_word_descr(),
+            );
+            let strategy_const = ctx.trace_ctx.const_int(
+                &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF as *const _ as i64,
+            );
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardValue,
+                &[strategy, strategy_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(strategy, strategy_const);
+
+            let stored_key = ctx.trace_ctx.const_ref(stored_key as i64);
+            let matches = ctx.trace_ctx.call_int_typed_with_effect(
+                crate::helpers::jit_exact_unicode_matches_stored_key as *const (),
+                &[key_op, stored_key],
+                &[majit_ir::Type::Ref, majit_ir::Type::Ref],
+                majit_ir::EffectInfo::new(
+                    majit_ir::ExtraEffect::CannotRaise,
+                    majit_ir::OopSpecIndex::None,
+                ),
+            );
+            ctx.trace_ctx
+                .set_opref_concrete(matches, majit_ir::Value::Int(1));
+            walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardTrue, &[matches])?;
+        }
+        DictFoldKeyProbe::Identity => {
+            let key_expected = ctx.trace_ctx.const_ref(key as i64);
+            if !key_op.is_constant() {
+                walker_emit_fold_guard_with_snapshot(
+                    ctx,
+                    op_pc,
+                    OpCode::GuardValue,
+                    &[key_op, key_expected],
+                )?;
+                ctx.trace_ctx
+                    .heap_cache_mut()
+                    .replace_box(key_op, key_expected);
+            }
+        }
+    }
+
+    let live_version = crate::state::opimpl_getfield_gc_i(
+        ctx.trace_ctx,
+        dict_op,
+        crate::descr::dict_keys_version_descr(),
+    );
+    let expected_version = ctx.trace_ctx.const_int(hit.concrete_version as i64);
+    walker_emit_fold_guard_with_snapshot(
+        ctx,
+        op_pc,
+        OpCode::GuardValue,
+        &[live_version, expected_version],
+    )?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(live_version, expected_version);
+
+    let index_op = ctx.trace_ctx.const_int(hit.index as i64);
+    let value = ctx.trace_ctx.call_ref_typed_with_effect(
+        crate::helpers::jit_dict_nth_value_versioned as *const (),
+        &[dict_op, index_op, expected_version],
+        &[
+            majit_ir::Type::Ref,
+            majit_ir::Type::Int,
+            majit_ir::Type::Int,
+        ],
+        majit_ir::EffectInfo::new(
+            majit_ir::ExtraEffect::CannotRaise,
+            majit_ir::OopSpecIndex::None,
+        ),
+    );
+    // A key set that moved after the unlocked version guard, or an index the
+    // compacted table no longer holds, comes back as `PY_NULL`.
+    walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[value])?;
+    ctx.trace_ctx.set_opref_concrete(
+        value,
+        majit_ir::Value::Ref(majit_ir::GcRef(hit.concrete_value as usize)),
+    );
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, value)?;
+    Ok(Some(()))
+}
+
 /// `dict.get` on an exact dictionary and a safely probed promoted key.
 ///
 /// `dictmultiobject.py:1095-1098` probes an Int strategy with the unboxed key
@@ -5984,56 +6244,9 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
     if callable.is_null() || dict.is_null() || !is_builtin_dict_get_function(callable) {
         return Ok(None);
     }
-    let canonical_dict = pyre_object::get_instantiate(&pyre_object::pyobject::DICT_TYPE);
-    if canonical_dict.is_null()
-        || !unsafe {
-            std::ptr::eq((*dict).ob_type, &pyre_object::pyobject::DICT_TYPE)
-                && std::ptr::eq((*dict).w_class, canonical_dict)
-        }
-    {
-        return Ok(None);
-    }
-
-    let strategy_kind =
-        unsafe { pyre_object::dictmultiobject::w_dict_get_strategy(dict).strategy_kind() };
-    // A mapdict-backed instance dict keeps its keys in the carrier's attribute
-    // map, and those adds/deletes never reach `w_dict_bump_keys_version` — the
-    // wrapper is only a view.  `keys_version` is therefore constant for a Map
-    // dict, so the guard below would certify an entry index that a `del
-    // o.attr` has already re-numbered.  Decline instead of certifying a
-    // version that cannot move.
-    if strategy_kind == pyre_object::dictmultiobject::StrategyKind::Map {
-        return Ok(None);
-    }
-    let value_probed_int = strategy_kind == pyre_object::dictmultiobject::StrategyKind::Int
-        && unsafe { pyre_object::listobject::is_plain_int1(key) && pyre_object::is_int(key) };
-    let found = if value_probed_int {
-        let index =
-            unsafe { pyre_object::dictmultiobject::w_dict_index_of_int_strategy(dict, key) };
-        index.and_then(|index| {
-            unsafe { pyre_object::dictmultiobject::w_dict_nth_value(dict, index) }
-                .map(|value| (index, value))
-        })
-    } else {
-        let len = unsafe { pyre_object::w_dict_len(dict) };
-        let mut found = None;
-        for index in 0..len {
-            let Some((stored_key, value)) =
-                (unsafe { pyre_object::dictmultiobject::w_dict_nth_item(dict, index) })
-            else {
-                return Ok(None);
-            };
-            if std::ptr::eq(stored_key, key) {
-                found = Some((index, value));
-                break;
-            }
-        }
-        found
-    };
-    let Some((index, concrete_value)) = found else {
+    let Some(hit) = walker_probe_exact_dict_hit(dict, key)? else {
         return Ok(None);
     };
-    let concrete_version = unsafe { pyre_object::dictmultiobject::w_dict_keys_version(dict) };
 
     let mut callable_op = r_args[0];
     let dict_op;
@@ -6073,95 +6286,7 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
             .heap_cache_mut()
             .replace_box(callable_op, expected);
     }
-    walker_guard_class(
-        ctx,
-        op.pc,
-        dict_op,
-        &pyre_object::pyobject::DICT_TYPE as *const _ as i64,
-    )?;
-    walker_guard_exact_w_class(ctx, op.pc, dict_op, canonical_dict)?;
-    let key_op = r_args[2];
-    if value_probed_int {
-        walker_guard_class(
-            ctx,
-            op.pc,
-            key_op,
-            &pyre_object::pyobject::INT_TYPE as *const _ as i64,
-        )?;
-        walker_guard_exact_w_class(
-            ctx,
-            op.pc,
-            key_op,
-            pyre_object::get_instantiate(&pyre_object::pyobject::INT_TYPE),
-        )?;
-        let (key_type, key_descr) = crate::state::int_or_bool_unbox_type_descr(key);
-        let raw_key = walker_unbox_int_typed(ctx, op.pc, key_op, key_type, key_descr)?;
-        let expected_key = ctx
-            .trace_ctx
-            .const_int(unsafe { pyre_object::w_int_get_value(key) });
-        walker_emit_fold_guard_with_snapshot(
-            ctx,
-            op.pc,
-            OpCode::GuardValue,
-            &[raw_key, expected_key],
-        )?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(raw_key, expected_key);
-    } else {
-        let key_expected = ctx.trace_ctx.const_ref(key as i64);
-        if !key_op.is_constant() {
-            walker_emit_fold_guard_with_snapshot(
-                ctx,
-                op.pc,
-                OpCode::GuardValue,
-                &[key_op, key_expected],
-            )?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .replace_box(key_op, key_expected);
-        }
-    }
-    let live_version = crate::state::opimpl_getfield_gc_i(
-        ctx.trace_ctx,
-        dict_op,
-        crate::descr::dict_keys_version_descr(),
-    );
-    let expected_version = ctx.trace_ctx.const_int(concrete_version as i64);
-    walker_emit_fold_guard_with_snapshot(
-        ctx,
-        op.pc,
-        OpCode::GuardValue,
-        &[live_version, expected_version],
-    )?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(live_version, expected_version);
-
-    let index_op = ctx.trace_ctx.const_int(index as i64);
-    let value = ctx.trace_ctx.call_ref_typed_with_effect(
-        crate::helpers::jit_dict_nth_value_versioned as *const (),
-        &[dict_op, index_op, expected_version],
-        &[
-            majit_ir::Type::Ref,
-            majit_ir::Type::Int,
-            majit_ir::Type::Int,
-        ],
-        majit_ir::EffectInfo::new(
-            majit_ir::ExtraEffect::CannotRaise,
-            majit_ir::OopSpecIndex::None,
-        ),
-    );
-    // A key set that moved after the unlocked version guard, or an index the
-    // compacted table no longer holds, comes back as `PY_NULL`: side-exit to
-    // the generic `dict.get` residual instead of writing it to a Ref register.
-    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardNonnull, &[value])?;
-    ctx.trace_ctx.set_opref_concrete(
-        value,
-        majit_ir::Value::Ref(majit_ir::GcRef(concrete_value as usize)),
-    );
-    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', value)?;
-    Ok(Some(()))
+    walker_emit_exact_dict_hit(ctx, op.pc, dict_op, r_args[2], dict, key, hit, dst, 'r')
 }
 
 /// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -615,6 +615,31 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
 /// 1B r-reg(vable) + 1B i-reg(index) + 1B X-reg(value) + 2B
 /// fdescr(VableArray) + 2B adescr(Array). No dst byte.
 ///
+/// A folded store lands in a slot whose value survives the trace: the inline
+/// level materialized a real callee `PyFrame` and `slot` is in its LOCAL
+/// region.  Such a slot is readable after the call through a traceback,
+/// `f_locals` or `sys._getframe`, so the store must be recorded rather than
+/// mirrored.  Slots at or above `nlocals` are operand-stack cells, which no
+/// Python-level read can reach and which the resume snapshot reconstructs.
+fn folded_store_is_observable_local<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+    slot: i64,
+) -> bool {
+    let Some(shadow) = ctx.callee_shadow.as_ref() else {
+        return false;
+    };
+    if !shadow.frame_materialized {
+        return false;
+    }
+    let sym = ctx.fbw_mode.snapshot_sym;
+    if sym.is_null() {
+        return false;
+    }
+    // SAFETY: pointer live for the full-body walk; read-only.
+    let nlocals = unsafe { (*sym).nlocals() } as i64;
+    slot >= 0 && slot < nlocals
+}
+
 /// RPython parity: `pyjitpl.py _opimpl_setarrayitem_vable`.
 /// Delegates to `TraceCtx::vable_setarrayitem_indexed`
 /// (`trace_ctx.rs`) which implements the `_nonstandard_virtualizable`
@@ -636,7 +661,9 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     let fold_frame_reg = fbw_strict_fold_frame_reg(ctx);
     if fold_frame_reg != u16::MAX && code[op.pc + 1] as u16 == fold_frame_reg {
         let index = read_int_reg(code, op, 1, ctx)?;
-        if let Some(majit_ir::Value::Int(slot)) = ctx.trace_ctx.concrete_of_opref(index) {
+        if let Some(majit_ir::Value::Int(slot)) = ctx.trace_ctx.concrete_of_opref(index)
+            && !folded_store_is_observable_local(ctx, slot)
+        {
             let value = match value_bank {
                 'i' => read_int_reg(code, op, 2, ctx)?,
                 'r' => read_ref_reg(code, op, 2, ctx)?,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6331,6 +6331,9 @@ pub fn init_jit_hooks() {
     pyre_object::dict_eq_hook::register_compares_by_identity_hook(
         pyre_object_compares_by_identity_trampoline,
     );
+    pyre_object::dictmultiobject::register_make_instance_dict_hook(
+        pyre_interpreter::objspace::std::mapdict::make_instance_dict,
+    );
 }
 
 #[repr(u8)]

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4168,6 +4168,25 @@ pub unsafe fn w_dict_index_of_int_strategy(obj: PyObjectRef, key: PyObjectRef) -
     w_dict_int_storage(obj).get_index_of(&crate::listobject::plain_int_w(key))
 }
 
+/// Return the live value selected by an int-strategy lookup.
+///
+/// Residualise the native table probe for the same reason as
+/// [`w_dict_lookup_int_strategy`] (`rdict.py:576`). The index lookup and value
+/// read share one dict lock so the insertion-order index cannot be invalidated
+/// between the two operations.
+///
+/// # Safety
+/// Same as [`w_dict_lookup_int_strategy`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_lookup_or_null_int_strategy(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+) -> Option<PyObjectRef> {
+    lock_dict_refs!(_dict_guard, obj, key);
+    let index = w_dict_index_of_int_strategy(obj, key)?;
+    w_dict_nth_value(obj, index)
+}
+
 /// Return the insertion-order index selected by a Unicode-strategy lookup.
 ///
 /// `dictmultiobject.py:1315-1318` routes exact-str keys through the raw
@@ -4195,38 +4214,22 @@ pub unsafe fn w_dict_index_of_unicode_strategy(
     dict_entries_index_of_str_hashed(entries, hash, key)
 }
 
-/// Exact-str content guard used by compiled exact-dict reads.
+/// Return the live value selected by a Unicode-strategy lookup.
 ///
-/// `dictmultiobject.py:1315-1318` hashes and compares the string contents,
-/// not the object identity.  The stored key is the trace constant; the live
-/// key is rechecked for exact type, hash, and bytes every iteration.
+/// `dictmultiobject.py:1315-1318` routes exact-str keys through the raw
+/// string probe. The index lookup and value read share one dict lock so the
+/// insertion-order index cannot be invalidated between the two operations.
 ///
 /// # Safety
-/// `key` and `stored_key` must be valid object references.
+/// Same as [`w_dict_index_of_unicode_strategy`].
 #[majit_macros::dont_look_inside]
-pub unsafe fn w_exact_unicode_matches_stored_key(
+pub unsafe fn w_dict_lookup_or_null_unicode_strategy(
+    obj: PyObjectRef,
     key: PyObjectRef,
-    stored_key: PyObjectRef,
-) -> bool {
-    lock_dict_refs!(_guard, key, stored_key);
-    if !crate::is_exact_type(key, &crate::STR_TYPE)
-        || !crate::is_exact_type(stored_key, &crate::STR_TYPE)
-    {
-        return false;
-    }
-    let Some(key) = crate::w_str_get_value_opt(key) else {
-        return false;
-    };
-    let Some(stored_key) = crate::w_str_get_value_opt(stored_key) else {
-        return false;
-    };
-    let Some(key_hash) = crate::dict_eq_hook::try_hash_str(key.as_bytes()) else {
-        return false;
-    };
-    let Some(stored_hash) = crate::dict_eq_hook::try_hash_str(stored_key.as_bytes()) else {
-        return false;
-    };
-    key_hash == stored_hash && key.as_bytes() == stored_key.as_bytes()
+) -> Option<PyObjectRef> {
+    lock_dict_refs!(_dict_guard, obj, key);
+    let index = w_dict_index_of_unicode_strategy(obj, key)?;
+    w_dict_nth_value(obj, index)
 }
 
 /// Internal helper: `IntDictStrategy::delitem` body —

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1261,6 +1261,30 @@ pub fn w_dict_new() -> PyObjectRef {
     )
 }
 
+pub type MakeInstanceDictHookFn = fn() -> PyObjectRef;
+
+majit_gc::global_hook!(static MAKE_INSTANCE_DICT_HOOK: MakeInstanceDictHookFn);
+
+pub fn register_make_instance_dict_hook(hook: MakeInstanceDictHookFn) {
+    MAKE_INSTANCE_DICT_HOOK.set(Some(hook));
+}
+
+pub fn clear_make_instance_dict_hook() {
+    MAKE_INSTANCE_DICT_HOOK.set(None);
+}
+
+/// `dictmultiobject.py:56-73` `space.newdict(instance=True)`.
+///
+/// The interpreter installs the mapdict factory once its hooks are available.
+/// The plain-dict fallback keeps pyre-object-only users working before that
+/// initialization.
+pub fn w_dict_new_instance() -> PyObjectRef {
+    match MAKE_INSTANCE_DICT_HOOK.get() {
+        Some(factory) => factory(),
+        None => w_dict_new(),
+    }
+}
+
 /// `dictmultiobject.py:77-80 allocate_and_init_instance` kwargs
 /// branch — `strategy = space.fromcache(EmptyKwargsDictStrategy)`.
 /// Function-call sites that build a `**kwargs` dict route through

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4034,6 +4034,18 @@ pub unsafe fn w_dict_nth_item(
     w_dict_get_strategy(obj).nth_item(obj, index)
 }
 
+/// Read only the value at iteration position `index`.
+///
+/// `dictmultiobject.py:1095-1098` reads the typed storage value without
+/// wrapping its key.
+///
+/// # Safety
+/// `obj` must be a valid `W_DictObject` PyObjectRef.
+pub unsafe fn w_dict_nth_value(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+    lock_dict_refs!(_dict_guard, obj);
+    w_dict_get_strategy(obj).nth_value(obj, index)
+}
+
 /// Return the `index`-th key together with the hash stored in an exact dict's
 /// object-shaped table.
 ///
@@ -4117,6 +4129,19 @@ pub unsafe fn w_dict_lookup_int_strategy(
     let entries = w_dict_int_storage(obj);
     let k = crate::listobject::plain_int_w(key);
     entries.get(&k).copied()
+}
+
+/// Return the insertion-order index selected by an int-strategy lookup.
+///
+/// Residualise the native table probe for the same reason as
+/// [`w_dict_lookup_int_strategy`] (`rdict.py:576`).
+///
+/// # Safety
+/// Same as [`w_dict_lookup_int_strategy`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_index_of_int_strategy(obj: PyObjectRef, key: PyObjectRef) -> Option<usize> {
+    lock_dict_refs!(_dict_guard, obj, key);
+    w_dict_int_storage(obj).get_index_of(&crate::listobject::plain_int_w(key))
 }
 
 /// Internal helper: `IntDictStrategy::delitem` body —
@@ -5169,6 +5194,15 @@ pub trait DictStrategy {
         self.items(w_dict).into_iter().nth(index)
     }
 
+    /// Read the value at iteration position `index` without requiring a
+    /// separately materialised key (`dictmultiobject.py:1095-1098`).
+    ///
+    /// # Safety
+    /// `w_dict` must be a valid PyObjectRef.
+    unsafe fn nth_value(&self, w_dict: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+        self.nth_item(w_dict, index).map(|(_, value)| value)
+    }
+
     /// `dictmultiobject.py:624-634 DictStrategy.pop` — remove and
     /// return the value for `w_key`.  Returns `Ok(value)` on hit,
     /// `Ok(w_default)` on miss when a default is provided, or
@@ -6206,6 +6240,13 @@ impl DictStrategy for BytesDictStrategy {
         crate::dictmultiobject::w_dict_nth_item_bytes_strategy(w_dict, index)
     }
 
+    unsafe fn nth_value(&self, w_dict: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+        lock_dict_refs!(_dict_guard, w_dict);
+        crate::dictmultiobject::w_dict_bytes_storage(w_dict)
+            .get_index(index)
+            .map(|(_, &value)| value)
+    }
+
     unsafe fn clear(&self, w_dict: PyObjectRef) {
         crate::dictmultiobject::w_dict_clear_bytes_strategy(w_dict);
     }
@@ -6582,6 +6623,13 @@ impl DictStrategy for IntDictStrategy {
         index: usize,
     ) -> Option<(PyObjectRef, PyObjectRef)> {
         crate::dictmultiobject::w_dict_nth_item_int_strategy(w_dict, index)
+    }
+
+    unsafe fn nth_value(&self, w_dict: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+        lock_dict_refs!(_dict_guard, w_dict);
+        crate::dictmultiobject::w_dict_int_storage(w_dict)
+            .get_index(index)
+            .map(|(_, &value)| value)
     }
 
     unsafe fn clear(&self, w_dict: PyObjectRef) {

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4168,6 +4168,67 @@ pub unsafe fn w_dict_index_of_int_strategy(obj: PyObjectRef, key: PyObjectRef) -
     w_dict_int_storage(obj).get_index_of(&crate::listobject::plain_int_w(key))
 }
 
+/// Return the insertion-order index selected by a Unicode-strategy lookup.
+///
+/// `dictmultiobject.py:1315-1318` routes exact-str keys through the raw
+/// string probe.  The trace-time caller declines when `w_str_get_value_opt`
+/// or the raw hash hook is unavailable, so this helper has no allocating
+/// object-key fallback.
+///
+/// # Safety
+/// `obj` must point to a valid `W_DictObject` on
+/// [`crate::dictmultiobject::UNICODE_DICT_STRATEGY`].
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_dict_index_of_unicode_strategy(
+    obj: PyObjectRef,
+    key: PyObjectRef,
+) -> Option<usize> {
+    lock_dict_refs!(_dict_guard, obj, key);
+    if !crate::is_exact_type(key, &crate::STR_TYPE) {
+        return None;
+    }
+    let key = crate::w_str_get_value_opt(key)?;
+    let hash = crate::dict_eq_hook::try_hash_str(key.as_bytes())?;
+    crate::dict_eq_hook::take_eq_error();
+    let dict = &*(obj as *const W_DictObject);
+    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    dict_entries_index_of_str_hashed(entries, hash, key)
+}
+
+/// Exact-str content guard used by compiled exact-dict reads.
+///
+/// `dictmultiobject.py:1315-1318` hashes and compares the string contents,
+/// not the object identity.  The stored key is the trace constant; the live
+/// key is rechecked for exact type, hash, and bytes every iteration.
+///
+/// # Safety
+/// `key` and `stored_key` must be valid object references.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_exact_unicode_matches_stored_key(
+    key: PyObjectRef,
+    stored_key: PyObjectRef,
+) -> bool {
+    lock_dict_refs!(_guard, key, stored_key);
+    if !crate::is_exact_type(key, &crate::STR_TYPE)
+        || !crate::is_exact_type(stored_key, &crate::STR_TYPE)
+    {
+        return false;
+    }
+    let Some(key) = crate::w_str_get_value_opt(key) else {
+        return false;
+    };
+    let Some(stored_key) = crate::w_str_get_value_opt(stored_key) else {
+        return false;
+    };
+    let Some(key_hash) = crate::dict_eq_hook::try_hash_str(key.as_bytes()) else {
+        return false;
+    };
+    let Some(stored_hash) = crate::dict_eq_hook::try_hash_str(stored_key.as_bytes()) else {
+        return false;
+    };
+    key_hash == stored_hash && key.as_bytes() == stored_key.as_bytes()
+}
+
 /// Internal helper: `IntDictStrategy::delitem` body —
 /// `dictmultiobject.py:1083 del self.unerase(w_dict.dstorage)[self.unwrap(w_key)]`.
 /// Returns `true` if a key was removed.

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -201,7 +201,7 @@ pub unsafe fn w_staticmethod_getdict(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         let sm = obj as *mut StaticMethod;
         if (*sm).w_dict.is_null() {
-            (*sm).w_dict = crate::w_dict_new();
+            (*sm).w_dict = crate::dictmultiobject::w_dict_new_instance();
             crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
         }
         (*sm).w_dict
@@ -293,7 +293,7 @@ pub unsafe fn w_classmethod_getdict(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         let cm = obj as *mut ClassMethod;
         if (*cm).w_dict.is_null() {
-            (*cm).w_dict = crate::w_dict_new();
+            (*cm).w_dict = crate::dictmultiobject::w_dict_new_instance();
             crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
         }
         (*cm).w_dict

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -1021,7 +1021,7 @@ pub unsafe fn w_exception_getdict(obj: PyObjectRef) -> PyObjectRef {
     unsafe {
         let exc = obj as *mut W_BaseException;
         if (*exc).w_dict.is_null() {
-            (*exc).w_dict = crate::w_dict_new();
+            (*exc).w_dict = crate::dictmultiobject::w_dict_new_instance();
             exception_write_barrier(obj);
         }
         (*exc).w_dict


### PR DESCRIPTION
Seven commits on top of `origin/main`, spanning an inlined-frame correctness fix, the mapdict instance-dictionary port, and three dict/attribute folds.

## Correctness

**`inline: record a materialized callee frame's local stores instead of folding them`**
The strict-inline seed block emits a real callee `PyFrame`, but the sub-walk then armed the strict fresh-frame fold on that same frame, so every in-callee `setarrayitem_vable_r` recorded no IR. Each non-parameter local kept the zero fill in compiled code, and a traceback, `f_locals` or `sys._getframe` read it as unbound. A witness that raises from a straight-line callee and reads `tb_next.tb_frame.f_locals` goes from 1242/4000 iterations to 4000/4000. Slots at or above `nlocals` are operand-stack cells that no Python-level read reaches, so those keep folding.

**`typedef: give object.__init__ its text signature`**
`object.__init__` is a slot wrapper and had no `__text_signature__`, so `inspect.signature(object.__init__)` did not resolve. Mirrors the existing `__new__` site. New parity test pins `object.__init__`, `object.__new__` and `int.__pow__`.

## Instance dictionaries

**`mapdict: back an instance __dict__ with make_instance_dict`** ports the upstream construction, and **`mapdict: fold a LOAD_ATTR that reads an exception's instance dictionary`** adds the tracer arm on top of it, applying the full `mapdict.py:1496-1527` gate set — `getattribute_if_not_from_object`, the type version tag, `lookup_in_type_where` + `classify_attr`, and a decline for non-`DICT` attrkinds and slots.

Reading a user attribute off a caught exception goes 74.7 → 1.2 ns/op; the same read after assignment goes 63.3 → 1.6 ns/op, against 2.1 ns/op for the equivalent plain-object attribute.

## Dict folds

**`dict: probe an int-strategy dict.get by unboxed key value, not pointer identity`**, then **`jit: fold an exact-dict subscript, and match a Unicode key by content`** extended the fold to `d[k]` and matched Unicode-strategy keys by content rather than identity.

**`jit: look an exact-dict key up live instead of pinning its value, index and version`** is the important one. The fold as first written baked three trace constants and guarded each — the key's value, the entry's insertion-order index, and `keys_version`. A loop over a varying key, or one that writes the dict it reads, failed a guard every iteration. Measured against an in-place revert at the same base, eight synthetic benchmarks regressed, `synth/dict_set` worst at `guard_failures` 608 → 231109 and `bridges_compiled` 3 → 22.

It now guards the dict's type, its exact `w_class`, the `dstrategy` vtable word read off the live dict, and the key's exact type, then calls the strategy's lookup and guards the result non-null. Nothing about the key or the dict's contents is constant-folded. The compiled loop for a varying `d[i]`:

```
GuardClass(v33, DICT)
v38 = GetfieldGcR(v33); v39 = PtrEq(v38, canonical); GuardTrue(v39)
v41 = GetfieldGcI(v33)          # dstrategy_vtable_word
GuardValue(v41, ...)            # strategy only — no guard on the key
v47 = CallR(jit_dict_exact_int_lookup_or_null, v33, key)
GuardNonnullClass(v47, INT)
```

No `CallMayForce`, no `GuardNotForced`, no `ForceToken` for the subscript. `DictFoldKeyProbe::Identity` is gone — it cannot avoid pinning the key pointer, and dropping it also restores the observability of a key's `__hash__`/`__eq__` on object-strategy dicts.

## Verification

`cargo test -p pyre-object -p pyre-jit-trace -p pyre-interpreter --features dynasm`, `cargo test -p majit-metainterp` and `cargo fmt --all -- --check` are green. New parity tests: `dict_subscript_fold.py`, `exception_instance_dict_attr.py`, `object_init_text_signature.py`.

`check.py --backend dynasm` went from 10 failed / 372 passed to 2 failed / 380 passed once the fold was reworked; the two remaining are `fbw_rolled_back_with_effects 1 -> 0` on `synth/recursive_forced_frame_kept_stack` and `synth/set_hash_protocol`, which pass 6/6 in isolation on an idle machine against the same baseline and binary and fail only under load. Their baselines are left untouched rather than re-recorded.

All three backends were then re-run against a fresh LLBC extraction at the rebased base. The branch was rebased onto the current `origin/main` partway through this work, which staled the local LLBC; the first sweep was taken against that stale artefact and produced several failures that do not survive re-extraction (a cranelift `fib_recursive` timeout and two cranelift exception ratio gates all disappear).

| backend | result |
|---|---|
| dynasm | **386/386 all passed** |
| cranelift | 385 passed, 1 re-recorded below |
| wasm | 380 passed, 2 failed |

`synth/pickle_ctor_args` on cranelift improved to `guard_failures` 436 → 201, stable across three isolated runs with `loops_compiled` and `bridges_compiled` unchanged — the dict reads stop side-exiting once the fold drops its pinned key value and `keys_version`. Re-recorded in the last commit.

The two remaining wasm failures:

- `synth/exception_escape_hot_callee_tb_node_once` has **no committed wasm baseline on `origin/main` either** — it arrived in #1033 with dynasm and cranelift baselines only. Pre-existing, and since wasm baselines have to come from CI rather than a local run, not something to record here.
- `synth/property_protocol_hot` regresses `loops_aborted` 0 → 5, `loops_compiled` 1 → 0 — the hot loop stops compiling. This is **open**. It is deterministic (identical across three isolated runs, before and after the LLBC re-extract) and wasm-only; dynasm and cranelift both pass it. The benchmark is `counter.value = i; total += counter.value` over a `@property` whose `__init__` does `self._value = 0`, which is precisely the instance-dictionary surface these commits touch, so the two mapdict commits are the prime suspects in the order they appear. Branch-vs-base attribution is not settled locally, because the committed baseline was recorded on CI hardware and a local wasm number is not comparable to it — the wasm job on this PR is the authority.
