### PR TITLE
jit: execute the walker's setfield_gc store, and admit RETURN_VALUE to the FOR_ITER body allow-list

### DIFF
--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -85,6 +85,50 @@ pub fn do_getfield_gc_f(
     cpu.bh_getfield_gc_f(struct_, fielddescr)
 }
 
+// executor.py:215-222
+//
+//     def do_setfield_gc(cpu, _, structbox, itembox, fielddescr):
+//         struct = structbox.getref_base()
+//         if fielddescr.is_pointer_field():
+//             cpu.bh_setfield_gc_r(struct, itembox.getref_base(), fielddescr)
+//         elif fielddescr.is_float_field():
+//             cpu.bh_setfield_gc_f(struct, itembox.getfloatstorage(), fielddescr)
+//         else:
+//             cpu.bh_setfield_gc_i(struct, itembox.getint(), fielddescr)
+//
+// One RPython function covering all three banks, so the type dispatch is
+// the descr's own `is_pointer_field()` / `is_float_field()` — not the
+// caller's.  `itembox` arrives here already projected to its concrete
+// `Value`, the flat-box analog of the `getref_base()` / `getint()` /
+// `getfloatstorage()` accessors upstream calls on the box.  Returns
+// `false` when the value's bank disagrees with the descr's, which
+// upstream cannot express (its boxes are typed by construction).
+pub fn do_setfield_gc(
+    cpu: &dyn majit_backend::Backend,
+    _metainterp: (),
+    structbox: i64,
+    itembox: majit_ir::Value,
+    fielddescr: &majit_translate::jitcode::BhDescr,
+    field_type: majit_ir::Type,
+) -> bool {
+    let struct_ = structbox;
+    match (field_type, itembox) {
+        (majit_ir::Type::Ref, majit_ir::Value::Ref(r)) => {
+            cpu.bh_setfield_gc_r(struct_, r, fielddescr);
+            true
+        }
+        (majit_ir::Type::Float, majit_ir::Value::Float(f)) => {
+            cpu.bh_setfield_gc_f(struct_, f, fielddescr);
+            true
+        }
+        (majit_ir::Type::Int, majit_ir::Value::Int(i)) => {
+            cpu.bh_setfield_gc_i(struct_, i, fielddescr);
+            true
+        }
+        _ => false,
+    }
+}
+
 // executor.py:206-212 do_getarrayitem_gc_{i,r,f}: project box → gcref +
 // concrete index, dispatch to `cpu.bh_getarrayitem_gc_*`.  Pyre's flat
 // box analog passes `(array, index)` as plain `i64` values projected

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -816,6 +816,33 @@ impl TraceCtx {
         }
     }
 
+    /// `executor.py:215-222 do_setfield_gc(cpu, _, structbox, itembox,
+    /// fielddescr)` analog — the store half of [`Self::field_sanity_load`].
+    /// `_opimpl_setfield_gc_any` reaches it through `execute_and_record`
+    /// (`pyjitpl.py:979`), so upstream really performs the field store while
+    /// recording the `SETFIELD_GC`; a tracer that only records leaves the
+    /// concrete object disagreeing with the value the heapcache now carries.
+    ///
+    /// Returns `false` when `self.cpu` is unwired, the descr does not
+    /// resolve to a `BhDescr::Field`, or the value's bank disagrees with the
+    /// field's type — the same conditions under which `field_sanity_load`
+    /// returns `None`.
+    pub fn field_store(&self, struct_ptr: i64, descr: &DescrRef, value: Value) -> bool {
+        let Some(cpu_ptr) = self.cpu else {
+            return false;
+        };
+        // SAFETY: cpu pointer was installed via `set_cpu` against a
+        // backend that outlives this TraceCtx.
+        let cpu = unsafe { &*cpu_ptr };
+        let Some(bh_descr) = descr_to_bh_field_descr(descr) else {
+            return false;
+        };
+        let Some(field_type) = descr.as_field_descr().map(|f| f.field_type()) else {
+            return false;
+        };
+        crate::executor::do_setfield_gc(cpu, (), struct_ptr, value, &bh_descr, field_type)
+    }
+
     /// `blackhole.py:1370 bhimpl_arraylen_gc(cpu, array, arraydescr)`
     /// analog — read the GC array's length through
     /// `cpu.bh_arraylen_gc(array_ptr, &arraydescr)`.  RPython has no

--- a/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.wasm.jitstats
+++ b/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.wasm.jitstats
@@ -1,0 +1,9 @@
+bridges_compiled=5
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_rolled_back_with_effects=0
+guard_failures=1016
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=15

--- a/pyre/bench/synth/foriter_body_return.cranelift.jitstats
+++ b/pyre/bench/synth/foriter_body_return.cranelift.jitstats
@@ -1,9 +1,9 @@
-bridges_compiled=0
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 fbw_rolled_back_with_effects=0
-guard_failures=2
+guard_failures=604
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/foriter_body_return.dynasm.jitstats
+++ b/pyre/bench/synth/foriter_body_return.dynasm.jitstats
@@ -1,9 +1,9 @@
-bridges_compiled=0
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 fbw_rolled_back_with_effects=0
-guard_failures=2
+guard_failures=604
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/foriter_body_return.py
+++ b/pyre/bench/synth/foriter_body_return.py
@@ -1,0 +1,34 @@
+# A `return` inside a `FOR_ITER` body — the early-exit search shape
+# (`for x in xs: if pred(x): return x`), which is the single most common
+# reason `for_iter_bodies_all_jit_safe` used to decline a frame on real code:
+# a census over stdlib test modules put `RETURN_VALUE` first at 95 of 223
+# first-rejections, ahead of the documented `LIST_APPEND`-with-`CALL` case.
+#
+# A declined frame runs fully interpreted, so it reports `loops_compiled=0`
+# AND `loops_aborted=0` — the tracer never sees it. That invisibility is why
+# no fixture covered the shape before this one: the decline leaves no counter
+# to notice.
+#
+# Both exits are driven. `i % (N + 8)` overshoots the largest element for one
+# probe in five, so the scan returns from inside the loop for the rest and
+# falls through to the exhaustion `return` for those.
+N = 32
+ITERS = 20000
+
+
+def first_at_least(xs, threshold):
+    for x in xs:
+        if x >= threshold:
+            return x
+    return -1
+
+
+def main():
+    xs = list(range(N))
+    total = 0
+    for i in range(ITERS):
+        total += first_at_least(xs, i % (N + 8))
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/foriter_body_return.wasm.jitstats
+++ b/pyre/bench/synth/foriter_body_return.wasm.jitstats
@@ -1,9 +1,9 @@
-bridges_compiled=0
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 fbw_rolled_back_with_effects=0
-guard_failures=2
+guard_failures=612
 internal_compile_panics=0
-loops_aborted=1
+loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.cranelift.jitstats
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.cranelift.jitstats
@@ -1,9 +1,9 @@
-bridges_compiled=1
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
 fbw_rolled_back_with_effects=0
-guard_failures=201
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=1
-loops_compiled=2
+loops_compiled=3

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.dynasm.jitstats
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.dynasm.jitstats
@@ -6,4 +6,4 @@ fbw_rolled_back_with_effects=0
 guard_failures=1
 internal_compile_panics=0
 loops_aborted=1
-loops_compiled=2
+loops_compiled=3

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/heapcache_ops.rs
@@ -409,12 +409,39 @@ pub(crate) fn setfield_gc_via_heapcache<Sym: WalkSym>(
             .profiler()
             .count_ops(OpCode::SetfieldGc, majit_metainterp::counters::RECORDED_OPS);
         ctx.trace_ctx
-            .record_op_with_descr(OpCode::SetfieldGc, &[obj, valuebox], descr);
+            .record_op_with_descr(OpCode::SetfieldGc, &[obj, valuebox], descr.clone());
         // Write-through with alias-clearing semantics
         // (`heapcache.py do_write_with_aliasing`).  Mirrors
         // `upd.setfield(valuebox)` (heapcache.py).
         ctx.trace_ctx
             .heapcache_setfield_cached(obj, descr_index, valuebox);
+        // Authoritative-executor eager store, the same posture as the
+        // module-global cell fold in `mod.rs`: `_opimpl_setfield_gc_any`
+        // reaches `executor.execute` → `cpu.bh_setfield_gc_*` through
+        // `execute_and_record` (`pyjitpl.py:979`), so the store really
+        // happens while the op is recorded.  Recording alone leaves the
+        // concrete object holding its pre-store bytes while the trace
+        // heapcache carries `valuebox`, and the next `getfield_gc_*` on the
+        // same field hits the cache and trips its `executor.execute`
+        // sanity check (`pyjitpl.py:934-945`) on the divergence.
+        //
+        // Restricted to boxes this walk allocated (`heapcache.new`'s
+        // HF_SEEN_ALLOCATION, set by `new/d>r` and `new_with_vtable/d>r`
+        // right after `execute_new_allocation` hands back a real, zeroed
+        // object).  Nothing outside the walk holds such an object, so the
+        // write needs no journal entry to survive a non-commit rollback —
+        // the abandoned allocation goes with it.  A store into a
+        // pre-existing object stays record-only: that write *is* observable
+        // and would double-apply against the walk's own concrete execution.
+        if ctx.trace_ctx.heap_cache().saw_allocation(obj)
+            && let Some(majit_ir::Value::Ref(struct_ref)) = ctx.trace_ctx.box_value(obj)
+            && let Some(value) = ctx.trace_ctx.box_value(valuebox)
+        {
+            let struct_ptr = struct_ref.0 as i64;
+            if struct_ptr != usize::MAX as i64 && struct_ptr != 0 {
+                ctx.trace_ctx.field_store(struct_ptr, &descr, value);
+            }
+        }
     }
     Ok((DispatchOutcome::Continue, op.next_pc))
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3518,6 +3518,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // below met).  For a strict callee this gates routing its guards through the
     // multi-frame snapshot vs. falling back to collapse.
     let mut callee_frame_seeded = false;
+    // Names the `break 'seed` arm that left `callee_frame_seeded` false, for
+    // the `[fbw-census]` collapse tally at the `parent_frame` decision below.
+    // Empty means the seed block was never entered or ran to completion.
+    let mut seed_break_reason: &'static str = "";
     // The concrete callee frame the seed block materializes, retained so the
     // sub-walk can put it on the interpreter frame chain: the walk executes
     // the callee's residuals for real, and a residual that reads the chain
@@ -3645,6 +3649,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     if try_multiframe {
                         return Ok(None);
                     }
+                    seed_break_reason = "Collapse::IsNoneBranch";
                     break 'seed;
                 }
             }
@@ -3658,6 +3663,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 if try_multiframe {
                     return Ok(None);
                 }
+                seed_break_reason = "Collapse::NoCalleeJitcode";
                 break 'seed;
             };
             let (frame_reg, ec_reg) = crate::state::portal_red_regs_at(callee_jitcode_index as i32);
@@ -3669,6 +3675,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 if try_multiframe {
                     return Ok(None);
                 }
+                seed_break_reason = "Collapse::NoPortalRedRegs";
                 break 'seed;
             }
 
@@ -3684,6 +3691,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 if try_multiframe {
                     return Ok(None);
                 }
+                seed_break_reason = "Collapse::NoSnapshotSym";
                 break 'seed;
             }
             let sym = unsafe { &*sym_ptr };
@@ -3848,6 +3856,28 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         // straight-line callee (its pre-multiframe behavior).
         None
     };
+    // Name the population a collapsing CALL falls into, so the
+    // `PYRE_FBW_DEBUG_ABORT` corpus can rank the remaining collapse sources
+    // the same way it ranks walk declines.  A collapse is not an abort and
+    // discards no trace, so this counts a resume-SHAPE choice, not a failure;
+    // it is read only to decide which population to retire next.
+    if fbw_debug_abort_enabled() && parent_frame.is_none() {
+        census_record(if !seed_break_reason.is_empty() {
+            seed_break_reason
+        } else if callee_frame_seeded {
+            // Seeded, but `compute_inline_caller_frame` could not build the
+            // caller side (`InlineCallerFrameDecline::Unavailable`).
+            "Collapse::ParentUnavailable"
+        } else if inline_depth >= fbw_max_multiframe_depth() {
+            "Collapse::DepthCap"
+        } else if !callee_code.cellvars.is_empty() {
+            "Collapse::CellVars"
+        } else if constructor_result.is_some() {
+            "Collapse::Constructor"
+        } else {
+            "Collapse::Other"
+        });
+    }
 
     // CODEX1 parity: snapshot the heap-effect state before the callee
     // sub-walk.  If the prologue (callee pc 0 → its loop header) mutates the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1167,6 +1167,16 @@ pub(crate) enum InlineCallerFrameDecline {
     Unavailable,
 }
 
+/// Name the `Unavailable` site for the `[fbw-census]` tally, then return it.
+/// Report-only: gated on `fbw_debug_abort_enabled`, so the cost on a build
+/// without the flag is one predictable branch on an already-cold path.
+fn unavail(site: &'static str) -> InlineCallerFrameDecline {
+    if fbw_debug_abort_enabled() {
+        crate::jitcode_dispatch::census_record(site);
+    }
+    InlineCallerFrameDecline::Unavailable
+}
+
 pub(crate) fn decline_inline_caller_frame_for_catch_marker(
     after_residual_call_resume: Option<usize>,
     caller_jitcode: &[u8],
@@ -1497,18 +1507,18 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
     }
     let caller_sym_ptr = ctx.fbw_mode.snapshot_sym;
     if caller_sym_ptr.is_null() {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Top/NoSym"));
     }
     // SAFETY: set for the lifetime of the top-level `dispatch_via_miframe`;
     // read-only access to immutable layout fields.
     let caller_sym = unsafe { &*caller_sym_ptr };
     if caller_sym.jitcode().is_null() {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Top/NoJitCode"));
     }
     let (jitcode_index, fallthrough_py_pc, resume_marker_jit_pc, code_ptr) = unsafe {
         let jc = &*caller_sym.jitcode();
         if jc.payload.code_ptr.is_null() || !jc.payload.is_populated() {
-            return Err(InlineCallerFrameDecline::Unavailable);
+            return Err(unavail("Unavail::Top/NotPopulated"));
         }
         // A CALL inside a try-block: inline it only when its exception handler
         // rejoins the loop (the exc-edge-bridgeable shape); otherwise decline so
@@ -1596,7 +1606,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         }
     };
     if depth == 0 {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Top/DepthZero"));
     }
     let call_stack_overrides = collect_call_stack_overrides(caller_sym, ctx, call_jit_pc);
     // #73: the result slot's color comes from the codewriter-precomputed
@@ -1621,7 +1631,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
             })
             .map(|color| color as usize)
     }
-    .ok_or(InlineCallerFrameDecline::Unavailable)?;
+    .ok_or_else(|| unavail("Unavail::Top/NoResultColor"))?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume).
@@ -1679,11 +1689,11 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     callee_has_freevars: bool,
 ) -> Result<InlineParentFrame, InlineCallerFrameDecline> {
     let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())
-        .ok_or(InlineCallerFrameDecline::Unavailable)? as u32;
+        .ok_or_else(|| unavail("Unavail::Nested/NoJitcodeIndex"))? as u32;
     let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)
-        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+        .ok_or_else(|| unavail("Unavail::Nested/NoPjc"))?;
     if !pjc.is_populated() || pjc.code_ptr.is_null() {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Nested/NotPopulated"));
     }
     let resume_marker_jit_pc = inline_call_return_marker(&pjc, call_jit_pc);
     let after_residual_call_resume = pjc.after_residual_call_resume_for_jitcode_pc(call_jit_pc);
@@ -1734,21 +1744,28 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
         }
     };
     if depth == 0 {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Nested/DepthZero"));
     }
     // #73: result slot color from the precomputed `result_color_at_pc`, not
     // the flat `stack_slot_color_map` (see `compute_inline_caller_frame`).
-    let result_color = match resume_marker_jit_pc {
-        Some(marker) => pjc
-            .result_color_trivia_for_jitcode_pc(marker)
-            .filter(|&color| color != u16::MAX)
-            .map(|color| color as usize),
-        None => pjc
-            .result_color_after_residual_for_jitcode_pc(call_jit_pc)
-            .filter(|&color| color != u16::MAX)
-            .map(|color| color as usize),
-    }
-    .ok_or(InlineCallerFrameDecline::Unavailable)?;
+    //
+    // Both twins are consulted, in that order, for the reason the top-level
+    // sibling states: the trivia twin resolves the return marker only while
+    // that marker doubles as the fallthrough pc's own resume marker (a pc_map
+    // block head).  A CALL whose fallthrough carries its own per-pc marker
+    // leaves the trailing marker un-keyed in the trivia twin, and only the
+    // after-residual twin — which keys the same fallthrough coordinate by the
+    // CALL's byte offset — answers for it.  Selecting one twin on whether a
+    // marker exists reports "no result color" for exactly that shape.
+    let result_color = resume_marker_jit_pc
+        .and_then(|marker| pjc.result_color_trivia_for_jitcode_pc(marker))
+        .filter(|&color| color != u16::MAX)
+        .or_else(|| {
+            pjc.result_color_after_residual_for_jitcode_pc(call_jit_pc)
+                .filter(|&color| color != u16::MAX)
+        })
+        .map(|color| color as usize)
+        .ok_or_else(|| unavail("Unavail::Nested/NoResultColor"))?;
     // Null the not-yet-produced result slot, build the box list, then restore
     // the caller's register (the inlined callee, not the walk, produces the
     // result; the inner frame supplies it on resume) — same as the top-level
@@ -1779,7 +1796,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     }
     let boxes = match boxes {
         Ok(b) => b,
-        Err(_) => return Err(InlineCallerFrameDecline::Unavailable),
+        Err(_) => return Err(unavail("Unavail::Nested/BoxesErr")),
     };
     // #343 depth-2 operand flush.  `emit_new_pyframe_inline_with_params` seeds
     // this inlined-callee frame's `locals_cells_stack_w` virtual array with LOCALS
@@ -1909,17 +1926,17 @@ pub(crate) fn compute_inline_helper_call_entry_frame<Sym: WalkSym>(
         .framestack
         .last()
         .map(|frame| frame.w_code)
-        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+        .ok_or_else(|| unavail("Unavail::Helper/NoFramestack"))?;
     let jitcode_index = crate::state::ensure_jitcode_index(caller_code as *const ())
-        .ok_or(InlineCallerFrameDecline::Unavailable)? as u32;
+        .ok_or_else(|| unavail("Unavail::Helper/NoJitcodeIndex"))? as u32;
     let pjc = crate::state::pyjitcode_for_jitcode_index(jitcode_index as i32)
-        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+        .ok_or_else(|| unavail("Unavail::Helper/NoPjc"))?;
     if !pjc.is_populated() || pjc.code_ptr.is_null() {
-        return Err(InlineCallerFrameDecline::Unavailable);
+        return Err(unavail("Unavail::Helper/NotPopulated"));
     }
     let resume_marker_jit_pc = pjc
         .resume_marker_for_jitcode_pc(call_jit_pc)
-        .ok_or(InlineCallerFrameDecline::Unavailable)?;
+        .ok_or_else(|| unavail("Unavail::Helper/NoResumeMarker"))?;
     let boxes = collect_callee_active_boxes(
         ctx.registers_i,
         ctx.registers_r,
@@ -1928,7 +1945,7 @@ pub(crate) fn compute_inline_helper_call_entry_frame<Sym: WalkSym>(
         call_jit_pc,
         resume_marker_jit_pc as i32,
     )
-    .map_err(|_| InlineCallerFrameDecline::Unavailable)?;
+    .map_err(|_| unavail("Unavail::Helper/BoxesErr"))?;
     Ok(InlineParentFrame {
         jitcode_index,
         call_jitcode_pc: None,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6324,7 +6324,7 @@ fn cached_unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> Unsuppor
             _ => unreachable!("invalid cached UnsupportedJitShape discriminant"),
         };
     }
-    let shape = unsupported_jit_shape(code);
+    let (shape, _census_key) = unsupported_jit_shape(code);
     callcontrol.graph_jit_shapes.insert(key, shape as u8);
     shape
 }
@@ -6378,6 +6378,12 @@ fn for_iter_body_op_is_jit_safe(instr: pyre_interpreter::Instruction) -> bool {
             | I::JumpForward { .. }
             | I::JumpBackward { .. }
             | I::JumpBackwardNoInterrupt { .. }
+            // `return` out of the loop.  It pops TOS and ends the frame: no
+            // heap mutation, no sub-walk, so it cannot reach the
+            // append/STORE_SUBSCR path this gate exists for.  The list already
+            // admits `RaiseVarargs` / `Reraise`, which leave the frame by a
+            // strictly more involved route.
+            | I::ReturnValue
             // nested FOR_ITER: the inner loop's iterator setup and iteration
             | I::GetIter
             | I::ForIter { .. }
@@ -6902,10 +6908,17 @@ fn const_pool_slot_upper_bound(c: &pyre_interpreter::ConstantData) -> usize {
 /// `PyCode.code_ptr` (`Box::into_raw`, never freed), so its address is a stable
 /// key that is never reused — the same property the frame-shape decline census
 /// already relies on.
-fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
+///
+/// The second element is the census key for the decline, naming the specific
+/// arm that produced it. `CurrentFrameOnly` is reached from five unrelated
+/// predicates, so the shape alone does not say which defect kept the frame
+/// interpreted; the key does. It is `""` for [`UnsupportedJitShape::None`].
+fn unsupported_jit_shape(
+    code: &pyre_interpreter::CodeObject,
+) -> (UnsupportedJitShape, &'static str) {
     thread_local! {
         static SHAPE_CACHE: std::cell::RefCell<
-            std::collections::HashMap<usize, UnsupportedJitShape>,
+            std::collections::HashMap<usize, (UnsupportedJitShape, &'static str)>,
         > = std::cell::RefCell::new(std::collections::HashMap::new());
     }
     let key = code as *const _ as usize;
@@ -6919,7 +6932,9 @@ fn unsupported_jit_shape(code: &pyre_interpreter::CodeObject) -> UnsupportedJitS
     shape
 }
 
-fn unsupported_jit_shape_uncached(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
+fn unsupported_jit_shape_uncached(
+    code: &pyre_interpreter::CodeObject,
+) -> (UnsupportedJitShape, &'static str) {
     // RPython/PyPy has no counterpart to this function at all: `jit_merge_point`
     // and `can_enter_jit` are unconditional (`pypy/module/pypyjit/interp_jit.py`),
     // and `JitPolicy.look_inside_graph` (`rpython/jit/codewriter/policy.py:48`)
@@ -6970,11 +6985,17 @@ fn unsupported_jit_shape_uncached(code: &pyre_interpreter::CodeObject) -> Unsupp
         .sum::<usize>()
         + code.names.len();
     if register_slots_upper_bound + constant_slots_upper_bound > 256 {
-        return UnsupportedJitShape::ConstEncodingOverflow;
+        return (
+            UnsupportedJitShape::ConstEncodingOverflow,
+            "FrameShape::ConstEncodingOverflow",
+        );
     }
 
     if nested_break_bridge_resume_hazard(code) {
-        return UnsupportedJitShape::NestedBreakBridgeResume;
+        return (
+            UnsupportedJitShape::NestedBreakBridgeResume,
+            "FrameShape::NestedBreakBridgeResume",
+        );
     }
 
     let mut arg_state = pyre_interpreter::OpArgState::default();
@@ -6984,13 +7005,19 @@ fn unsupported_jit_shape_uncached(code: &pyre_interpreter::CodeObject) -> Unsupp
         match instruction {
             pyre_interpreter::Instruction::ForIter { .. } => has_for_iter = true,
             pyre_interpreter::Instruction::CheckEgMatch => {
-                return UnsupportedJitShape::CurrentFrameOnly;
+                return (
+                    UnsupportedJitShape::CurrentFrameOnly,
+                    "FrameShape::CurrentFrameOnly/CheckEgMatch",
+                );
             }
             pyre_interpreter::Instruction::CallIntrinsic2 { func }
                 if func.get(op_arg)
                     == pyre_interpreter::bytecode::IntrinsicFunction2::PrepReraiseStar =>
             {
-                return UnsupportedJitShape::CurrentFrameOnly;
+                return (
+                    UnsupportedJitShape::CurrentFrameOnly,
+                    "FrameShape::CurrentFrameOnly/PrepReraiseStar",
+                );
             }
             _ => {}
         }
@@ -7003,14 +7030,28 @@ fn unsupported_jit_shape_uncached(code: &pyre_interpreter::CodeObject) -> Unsupp
         // caught exception and then raises re-aborts the walk for the whole run,
         // and an abort with an item in flight drops that iteration (see
         // `for_iter_frame_has_raising_named_handler`).
-        if !for_iter_bodies_all_jit_safe(code)
-            || for_iter_frame_is_finally_duplicated(code)
-            || for_iter_frame_has_raising_named_handler(code)
-        {
-            return UnsupportedJitShape::CurrentFrameOnly;
+        // Tested one at a time rather than as one `||` so the census names the
+        // predicate that fired; the three are unrelated defects.
+        if !for_iter_bodies_all_jit_safe(code) {
+            return (
+                UnsupportedJitShape::CurrentFrameOnly,
+                "FrameShape::CurrentFrameOnly/ForIterBodyNotJitSafe",
+            );
+        }
+        if for_iter_frame_is_finally_duplicated(code) {
+            return (
+                UnsupportedJitShape::CurrentFrameOnly,
+                "FrameShape::CurrentFrameOnly/ForIterFinallyDuplicated",
+            );
+        }
+        if for_iter_frame_has_raising_named_handler(code) {
+            return (
+                UnsupportedJitShape::CurrentFrameOnly,
+                "FrameShape::CurrentFrameOnly/ForIterRaisingNamedHandler",
+            );
         }
     }
-    UnsupportedJitShape::None
+    (UnsupportedJitShape::None, "")
 }
 
 fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
@@ -7054,36 +7095,23 @@ fn eval_with_jit_inner(frame: &mut PyFrame) -> PyResult {
         crate::call_jit::cranelift_recovery_layout_for_descr,
     );
     let jit_shape = cached_unsupported_jit_shape(code);
+    // Every declining shape runs the frame in the plain interpreter, so the
+    // tracer never sees it. Record the decline in the census — keyed by the
+    // predicate that fired, not just the shape — rather than leaving a silent
+    // no-token gap. `CurrentFrameOnly` covers five unrelated defects and
+    // `ConstEncodingOverflow` is not a defect at all (the frame genuinely
+    // cannot be encoded), so one key per shape cannot rank them. The key comes
+    // from the memoized `unsupported_jit_shape`, read only on the decline path
+    // so the `graph_jit_shapes` fast path stays a single map hit.
+    // Declining is per-frame: nested callees stay JIT-eligible.
     match jit_shape {
         UnsupportedJitShape::None => {}
-        UnsupportedJitShape::CurrentFrameOnly => {
-            // Run frames with unsupported current-frame bytecode shapes in the
-            // plain interpreter. The tracer never sees them, so record the
-            // frame-shape decline in the census rather than leaving a silent
-            // no-token gap.
+        UnsupportedJitShape::CurrentFrameOnly
+        | UnsupportedJitShape::NestedBreakBridgeResume
+        | UnsupportedJitShape::ConstEncodingOverflow => {
             pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
                 code as *const _ as usize,
-                "FrameShape::CurrentFrameOnly",
-            );
-            return frame_root.frame().execute_frame(None, None);
-        }
-        UnsupportedJitShape::NestedBreakBridgeResume => {
-            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
-                code as *const _ as usize,
-                "FrameShape::NestedBreakBridgeResume",
-            );
-            return frame_root.frame().execute_frame(None, None);
-        }
-        UnsupportedJitShape::ConstEncodingOverflow => {
-            // The frame's constant pool plus register file overruns the
-            // single-byte register-or-constant index encoding, so no jitcode
-            // can be assembled for it (`unsupported_jit_shape`).  Run this frame
-            // in the plain interpreter; nested callees stay JIT-eligible (the
-            // overflow is per-frame).  Record the decline in the census so the
-            // interpreted frame is visible, not a silent no-token gap.
-            pyre_jit_trace::jitcode_dispatch::census_record_frame_shape_decline(
-                code as *const _ as usize,
-                "FrameShape::ConstEncodingOverflow",
+                unsupported_jit_shape(code).1,
             );
             return frame_root.frame().execute_frame(None, None);
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6932,6 +6932,14 @@ fn unsupported_jit_shape(
     shape
 }
 
+/// The shape half of [`unsupported_jit_shape`], for the tests that assert only
+/// the classification. The tests that turn on *which* predicate fired assert
+/// the whole pair instead, since that is the half the census keys off.
+#[cfg(test)]
+fn unsupported_jit_shape_of(code: &pyre_interpreter::CodeObject) -> UnsupportedJitShape {
+    unsupported_jit_shape(code).0
+}
+
 fn unsupported_jit_shape_uncached(
     code: &pyre_interpreter::CodeObject,
 ) -> (UnsupportedJitShape, &'static str) {
@@ -12156,7 +12164,7 @@ mod tests {
             .expect("test code should compile");
         let code = function_code_from_module(&module, "f");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12186,7 +12194,7 @@ mod tests {
             let module = compile_exec(source).expect("test code should compile");
             let code = function_code_from_module(&module, "f");
             assert!(for_iter_bodies_all_jit_safe(&code));
-            assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+            assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
         }
     }
 
@@ -12205,7 +12213,10 @@ mod tests {
             assert!(!for_iter_bodies_all_jit_safe(&code));
             assert_eq!(
                 unsupported_jit_shape(&code),
-                UnsupportedJitShape::CurrentFrameOnly
+                (
+                    UnsupportedJitShape::CurrentFrameOnly,
+                    "FrameShape::CurrentFrameOnly/ForIterBodyNotJitSafe"
+                )
             );
         }
     }
@@ -12219,7 +12230,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "f");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12246,7 +12257,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "g");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12260,7 +12271,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "k");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12276,7 +12287,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "s");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12305,7 +12316,7 @@ mod tests {
         let code = function_code_from_module(&module, "f");
 
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12347,7 +12358,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12360,7 +12371,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12374,7 +12385,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12393,7 +12404,7 @@ mod tests {
                 .any(|unit| { matches!(arg_state.get(unit).0, Instruction::StoreDeref { .. }) })
         );
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12407,7 +12418,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12421,7 +12432,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12433,7 +12444,7 @@ mod tests {
                 .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12445,7 +12456,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "w");
         assert!(for_iter_bodies_all_jit_safe(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12462,7 +12473,7 @@ mod tests {
         let code = function_code_from_module(&module, "r");
         assert!(for_iter_bodies_all_jit_safe(&code));
         assert!(!for_iter_frame_has_raising_named_handler(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12483,7 +12494,10 @@ mod tests {
         assert!(for_iter_frame_has_raising_named_handler(&code));
         assert_eq!(
             unsupported_jit_shape(&code),
-            UnsupportedJitShape::CurrentFrameOnly
+            (
+                UnsupportedJitShape::CurrentFrameOnly,
+                "FrameShape::CurrentFrameOnly/ForIterRaisingNamedHandler"
+            )
         );
     }
 
@@ -12500,7 +12514,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "r");
         assert!(!for_iter_frame_has_raising_named_handler(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12514,7 +12528,7 @@ mod tests {
         .expect("test code should compile");
         let code = function_code_from_module(&module, "r");
         assert!(!for_iter_frame_has_raising_named_handler(&code));
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     #[test]
@@ -12531,7 +12545,7 @@ mod tests {
         )
         .expect("test code should compile");
         let code = function_code_from_module(&module, "wf");
-        assert_eq!(unsupported_jit_shape(&code), UnsupportedJitShape::None);
+        assert_eq!(unsupported_jit_shape_of(&code), UnsupportedJitShape::None);
     }
 
     fn ensure_test_jit_callbacks() {


### PR DESCRIPTION
Five commits: two FOR_ITER / census changes, one test fix, the walker `setfield_gc` store, and one missing wasm baseline.

## `setfield_gc` was recorded but never executed

`setfield_gc_via_heapcache` recorded `SetfieldGc` and wrote the trace heapcache without performing the store on the concrete object, while its sibling `new_with_vtable/d>r` runs `execute_new_allocation` and stamps the real pointer on the box. A box the walk allocated therefore kept its zeroed payload while the heapcache carried the stored value, and the next `getfield_gc_f` on that field hit the cache and aborted the process on the `executor.execute` sanity check.

```
_opimpl_getfield_gc_any_pureornot sanity check (float):
loaded 0 != cached 0.13287809491157532 (field_index=268435714, ...)
```

Upstream `_opimpl_setfield_gc_any` (`pyjitpl.py:974-980`) reaches `executor.execute` → `do_setfield_gc` (`executor.py:215-222`) → `cpu.bh_setfield_gc_*` through `execute_and_record`, so the store runs while the op is recorded. The half-port — New executed, Setfield not — is the deviation. The in-tree precedent is the module-global int-cell store fold, which already does record + heapcache write-through + eager concrete store + journal.

The change ports `do_setfield_gc`, adds `TraceCtx::field_store` beside `field_sanity_load`, and performs the store for boxes this walk allocated (`heapcache.saw_allocation`). Stores into pre-existing objects stay record-only: those writes are observable and would double-apply against the walk's own concrete execution.

Instrumented evidence — the trace builds a genuine `W_FloatObject` (size 40) and the descr is the same `Arc` on both sides, so this is neither a descr-index collision nor a recycled OpRef:

```
SETFIELD obj=RefOp(57) value=FloatOp(52) v=0.13287809491157532 obj_concrete=GcRef(0x...671C8)
HIT      cached=FloatOp(52) obj=RefOp(57) struct_ptr=0x...671C8 loaded=0
MEM      [w_class=FLOAT_TYPE, hdr, 0, 0, 0]
RefOp(57) = NewWithVtable  descr(W_FloatObject, size 40)
VoidOp(58) = SetfieldGc [RefOp(57) FloatOp(52)]  descr(W_FloatObject.floatval)
```

### Attribution

Measured off **one** binary, gating the eager store on a temporary `PYRE_WALK_SETFIELD_STORE` and demoting the sanity `assert_eq!` under `PYRE_FLOAT_SANITY_ASSERT=0`. Both gates were removed before committing.

`for i in range(20000): n += random()`, assert on, 3 runs per leg:

| leg | result |
|---|---|
| record-only (control) | 3/3 abort |
| eager store | 3/3 `done True` |

At `range(200000)` with the assert demoted, 5 runs per leg:

| leg | doneTrue | LazyLock poisoned | hang | signal | float divergence |
|---|---|---|---|---|---|
| record-only | 0 | 2 | 3 | 0 | **2** |
| eager store | 0 | 2 | 2 | 1 | **0** |

The store removes the float divergence and moves nothing else. The `LazyLock poisoned` / hang / SIGSEGV population appears on **both** legs, so it is pre-existing and only becomes visible once the assert stops firing — a GC root walk (`mapdict_root_walker_area`) initialising a `LazyLock` for the first time inside a collection and blocking on its `Once`. Tracked separately.

## Missing wasm baseline

#1033 added `exception_escape_hot_callee_tb_node_once` with dynasm and cranelift baselines only, so the wasm run reported `no committed jit-stats baseline` on this branch and on `main`. Recorded: `loops_compiled=15` matches the other two backends; `bridges_compiled=5` / `guard_failures=1016` vs their 4 / 814 is the wasm backend's usual counter divergence.

## Verification

- `cargo fmt --all -- --check` — clean
- `cargo test --all --no-default-features --features dynasm` — 40 suites, 0 failures
- `python3 ./pyre/check.py` — dynasm 386 passed, cranelift 386 passed, wasm 382 passed; **no jit-stats regressions**

Two `check.py` failures remain and are **not** from these commits:

- `synth/pickle_ctor_args` ratio 38.5x (dynasm) / 47.3x (cranelift) against a `max-pypy-ratio=36` gate that #1033 last touched. The committed jit-stats baseline (recorded by #1059) matches exactly, and the one-binary A/B measures 0.79s on both legs, so these commits do not change the bench at all. macOS is the pessimistic platform for this ratio; the gate is not relaxed here.
- The wasm baseline above, fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)