### PR TITLE
rbigint follow-ups: two JIT folds and the iterator `__setstate__` cursor

### DIFF
--- a/pyre/bench/rbigint_perf_matrix.py
+++ b/pyre/bench/rbigint_perf_matrix.py
@@ -1,8 +1,13 @@
 """Focused steady-state workloads for PyPy rbigint ↔ pyre RBigInt parity.
 
-Usage: rbigint_perf_matrix.py CASE [ROUNDS]
+Usage: rbigint_perf_matrix.py [CASE [ROUNDS]]
 Each case keeps operand sizes stable and mutates at least one operand so a
 meta-tracer cannot fold the arbitrary-precision operation out of the loop.
+
+With no CASE, every case runs at a reduced round count and prints its name and
+checksum. That mode is a cross-engine oracle rather than a measurement: it is
+what `wasm_check.py` gets, since that harness runs every `pyre/bench/*.py` with
+no argv and requires the outputs to match across host engines.
 """
 
 import math
@@ -177,7 +182,17 @@ CASES = {
 }
 
 
+# Divisor applied to every case's round count in the no-argument oracle mode.
+# Large enough that each case still enters its steady state and forms a trace,
+# small enough that all fourteen fit one run of a wasm host interpreter.
+ORACLE_ROUND_DIVISOR = 20
+
+
 def main():
+    if len(sys.argv) < 2:
+        for case, (function, default_rounds) in CASES.items():
+            print(case, function(max(1, default_rounds // ORACLE_ROUND_DIVISOR)))
+        return
     case = sys.argv[1]
     function, default_rounds = CASES[case]
     rounds = int(sys.argv[2]) if len(sys.argv) > 2 else default_rounds

--- a/pyre/bench/synth/divmod_long_int_pair.py
+++ b/pyre/bench/synth/divmod_long_int_pair.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=18
+# pyre-check: max-pypy-ratio=14
 # `divmod(long, int)` at a traced call site. `_int_divmod` keeps the divisor
 # unwrapped and calls `rbigint.int_divmod`, whose rtyped return is a two-item
 # `GcStruct`: the walker emits one elidable call plus two `getfield_gc_r`, then

--- a/pyre/bench/synth/divmod_long_int_pair.py
+++ b/pyre/bench/synth/divmod_long_int_pair.py
@@ -1,4 +1,10 @@
-# pyre-check: max-pypy-ratio=14
+# pyre-check: max-pypy-ratio=8
+# Sized for headroom, not sensitivity: the worst ratio measured across
+# platforms is 3.7x (macOS cranelift; macOS dynasm 2.9x, linux/aarch64 2.4x
+# dynasm and 3.2x cranelift), and CI runners swing this fixture by ~20% under
+# load. Losing either fold this file covers also moves `guard_failures`, which
+# the jit-stats baselines gate in both directions, so that is the sensitive
+# guard and this one is the net beneath it.
 # `divmod(long, int)` at a traced call site. `_int_divmod` keeps the divisor
 # unwrapped and calls `rbigint.int_divmod`, whose rtyped return is a two-item
 # `GcStruct`: the walker emits one elidable call plus two `getfield_gc_r`, then

--- a/pyre/extra_tests/parity_tests/iterator_setstate_python314.py
+++ b/pyre/extra_tests/parity_tests/iterator_setstate_python314.py
@@ -1,0 +1,176 @@
+"""Cursor restore protocol of the builtin iterators, per Python 3.14.
+
+`__setstate__` is the pickle half of `__reduce__`, so the two have to agree on
+which cursor values mean "exhausted".  3.14 answers that per producer: the
+length-aware iterators clamp an over-long cursor to the sequence's *current*
+length, the generic `__getitem__` iterator cannot and stores it verbatim, and
+the two producers that carry exhaustion in the cursor rather than in a cleared
+sequence reject every later state once it goes negative.
+"""
+
+import array
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def state(it):
+    """The cursor `__reduce__` pickles, or EXHAUSTED for the empty form."""
+    reduced = it.__reduce__()
+    return reduced[2] if len(reduced) > 2 else "EXHAUSTED"
+
+
+def remaining(it):
+    """`__length_hint__`, which `array.arrayiterator` alone does not declare."""
+    return it.__length_hint__() if hasattr(it, "__length_hint__") else None
+
+
+class Getitem:
+    """A sequence reachable only through the `__getitem__` protocol."""
+
+    def __len__(self):
+        return 3
+
+    def __getitem__(self, index):
+        if index >= 3:
+            raise IndexError(index)
+        return index
+
+
+# ── an over-long cursor clamps to the length, except for the generic iterator ──
+
+for label, make in (
+    ("tuple", lambda: iter((10, 20, 30))),
+    ("str_ascii", lambda: iter("abc")),
+    ("str_wide", lambda: iter("a\xe9中")),
+    ("bytes", lambda: iter(b"abc")),
+    ("bytearray", lambda: iter(bytearray(b"abc"))),
+    ("array", lambda: iter(array.array("i", [10, 20, 30]))),
+):
+    it = make()
+    it.__setstate__(99)
+    check(state(it) == 3, label + " clamps an over-long cursor to the length")
+    check(remaining(it) in (0, None), label + " reports nothing left at the end")
+    check(next(it, "STOP") == "STOP", label + " is exhausted at the length")
+    it = make()
+    it.__setstate__(2)
+    check(state(it) == 2, label + " keeps an in-range cursor")
+
+it = iter(Getitem())
+it.__setstate__(99)
+check(state(it) == 99, "the generic iterator has no length to clamp against")
+check(next(it, "STOP") == "STOP", "an out-of-range generic cursor stops")
+
+# The clamp reads the sequence live, so a mutable producer grown after the
+# iterator was made clamps to the new length.
+data = bytearray(b"abc")
+it = iter(data)
+data.extend(b"defghij")
+it.__setstate__(99)
+check(state(it) == 10, "bytearray clamps against the grown length")
+
+values = [10, 20, 30]
+it = iter(values)
+values.extend([40, 50])
+it.__setstate__(99)
+check(state(it) == 5, "list clamps against the grown length")
+
+# ── a negative cursor rewinds, except where it is the exhausted sentinel ──
+
+for label, make in (
+    ("tuple", lambda: iter((10, 20, 30))),
+    ("str", lambda: iter("abc")),
+    ("bytes", lambda: iter(b"abc")),
+    ("array", lambda: iter(array.array("i", [10, 20, 30]))),
+    ("generic", lambda: iter(Getitem())),
+):
+    it = make()
+    it.__setstate__(-5)
+    check(state(it) == 0, label + " rewinds a negative cursor to the front")
+    check(remaining(it) in (3, None), label + " has the whole sequence left")
+
+# `list_iterator` and `list_reverseiterator` store -1 as the exhausted cursor
+# while keeping the list, so a later in-range state revives them.
+it = iter([10, 20, 30])
+it.__setstate__(-5)
+check(state(it) == "EXHAUSTED", "a negative list cursor is exhausted")
+it.__setstate__(1)
+check(state(it) == 1 and next(it) == 20, "a list iterator revives")
+
+it = reversed([10, 20, 30])
+it.__setstate__(-5)
+check(state(it) == "EXHAUSTED", "a negative list_reverseiterator is exhausted")
+it.__setstate__(1)
+check(state(it) == 1 and next(it) == 20, "a list_reverseiterator revives")
+
+# `bytearray_iterator` and `reversed` reject every later state instead.
+for label, make, revived in (
+    ("bytearray", lambda: iter(bytearray(b"abc")), 1),
+    ("reversed", lambda: reversed((10, 20, 30)), 1),
+):
+    it = make()
+    it.__setstate__(-5)
+    check(state(it) == "EXHAUSTED", label + " exhausts on a negative cursor")
+    check(remaining(it) == 0, label + " reports nothing left")
+    it.__setstate__(revived)
+    check(state(it) == "EXHAUSTED", label + " does not revive")
+    check(next(it, "STOP") == "STOP", label + " stays exhausted")
+
+# An empty sequence starts `reversed` already off the front.
+check(state(reversed(())) == "EXHAUSTED", "reversed(()) starts exhausted")
+it = reversed(())
+it.__setstate__(0)
+check(state(it) == "EXHAUSTED", "reversed(()) cannot be positioned")
+
+# `reversed` clamps an over-long cursor to the last index, not the length.
+it = reversed((10, 20, 30))
+it.__setstate__(99)
+check(state(it) == 2 and next(it) == 30, "reversed clamps to the last index")
+
+# ── the state argument is read as a C ssize_t ──
+
+makers = (
+    ("tuple", lambda: iter((10, 20))),
+    ("list", lambda: iter([10, 20])),
+    ("str", lambda: iter("ab")),
+    ("bytes", lambda: iter(b"ab")),
+    ("bytearray", lambda: iter(bytearray(b"ab"))),
+    ("array", lambda: iter(array.array("i", [10, 20]))),
+    ("generic", lambda: iter(Getitem())),
+    ("reversed", lambda: reversed((10, 20))),
+    ("list_reverse", lambda: reversed([10, 20])),
+)
+
+
+class Index:
+    def __index__(self):
+        return 1
+
+
+class MyInt(int):
+    pass
+
+
+for label, make in makers:
+    for bad in ("1", 1.5, None, Index()):
+        try:
+            make().__setstate__(bad)
+        except TypeError as exc:
+            check(str(exc) == "an integer is required",
+                  label + " rejects a non-integer state: " + str(exc))
+        else:
+            raise AssertionError(label + " accepted a non-integer state")
+    try:
+        make().__setstate__(1 << 100)
+    except OverflowError as exc:
+        check(str(exc) == "Python int too large to convert to C ssize_t",
+              label + " overflow message: " + str(exc))
+    else:
+        raise AssertionError(label + " accepted an oversized state")
+    it = make()
+    it.__setstate__(MyInt(1))
+    check(state(it) == 1, label + " accepts an int subclass")
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
+++ b/pyre/extra_tests/parity_tests/rbigint_mixed_int_jit.py
@@ -100,4 +100,34 @@ def shift_guards(rounds):
 
 assert shift_guards(20_000) == (True, -1)
 
+
+def fitting_results(rounds):
+    """Long-typed operands whose results land back inside a machine word.
+
+    Nothing in `_make_generic_descr_binop`, `_int_lshift`/`_int_rshift` or
+    `_int_floordiv` demotes such a result to a compact int, so a traced arm has
+    to box it the same way the interpreter's `w_long_new` does. Every operator
+    below is driven from `tiny`, which is a long by construction, while its
+    result stays machine-sized; the final term keeps a non-fitting shift at the
+    same site.
+    """
+    tiny = BIG >> 4090
+    checksum = 0
+    for i in range(rounds):
+        small = 1 + (i & 7)
+        checksum += tiny & 0xFF
+        checksum += tiny | small
+        checksum += tiny ^ small
+        checksum += tiny + small
+        checksum += tiny - small
+        checksum += tiny * small
+        checksum += tiny // small
+        checksum += tiny << (i & 3)
+        checksum += BIG >> (4000 + (i & 7))
+        checksum %= 1000000007
+    return checksum
+
+
+assert fitting_results(20_000) == 489_509_669
+
 print("OK")

--- a/pyre/extra_tests/parity_tests/subscr_specialised_pair_shapes.py
+++ b/pyre/extra_tests/parity_tests/subscr_specialised_pair_shapes.py
@@ -1,0 +1,143 @@
+# `len(pair)` and `pair[i]` across every makespecialisedtuple2 arm, plus the
+# shapes the fold must decline: a slice key, an out-of-range index, an
+# __index__ key, a mixed class site, and a tuple subclass overriding both.
+#
+# Every accumulator is position-sensitive (`acc * k + item`), so reading the
+# wrong slot changes the printed value instead of cancelling out.
+BIG = (1 << 4095) + (1 << 2001) + 0x123456789
+MOD = 1000000007
+
+
+def oo_longs(rounds):
+    acc = 0
+    for i in range(rounds):
+        t = divmod(BIG + i, (1 << 755) + 0xABCDEF)
+        acc = (acc * 3 + len(t) + (t[0] & 0xFFFF) * 5 + (t[1] & 0xFFFF)) % MOD
+    return acc
+
+
+def ii_ints(rounds):
+    acc = 0
+    for i in range(rounds):
+        t = divmod(i + 7919, 97)
+        acc = (acc * 3 + len(t) + t[0] * 5 + t[1]) % MOD
+    return acc
+
+
+def float_pair(rounds):
+    # `w_tuple_new` sends a plain-float pair to `Cls_oo` rather than `Cls_ff`
+    # so that `(x, x)` keeps the 3.14 pointer identity of `x`, so this is an
+    # object pair whose slots happen to hold floats.
+    acc = 0.0
+    for i in range(rounds):
+        t = (1.5, i * 0.25)
+        acc = (acc + len(t) + t[0] * 5 + t[1]) % 65536.0
+    return acc
+
+
+def negative_index(rounds):
+    # `getitem` adds `typelen` before the unrolled slot comparison, so -1 and
+    # -2 must reach the same slots as 1 and 0.
+    acc = 0
+    for i in range(rounds):
+        t = (i, i * 7 + 1)
+        acc = (acc * 3 + t[-1] * 5 + t[-2] + t[1] * 11 + t[0]) % MOD
+    return acc
+
+
+def alternating_index(rounds):
+    # One subscript site sees 0, 1, -1 and -2 in turn; the recorded slot is
+    # pinned per trace, so the other three arrive as side exits.
+    acc = 0
+    for i in range(rounds):
+        t = (i, BIG)
+        item = t[i & 1] if i & 2 else t[(i & 1) - 2]
+        acc = (acc * 3 + (item & 0xFFFF)) % MOD
+    return acc
+
+
+def bool_index(rounds):
+    acc = 0
+    for i in range(rounds):
+        t = (i, i * 7 + 3)
+        acc = (acc * 3 + t[True] * 5 + t[False]) % MOD
+    return acc
+
+
+def alternating_class(rounds):
+    # The same site sees ii, ff, oo and a plain arity-3 tuple, so the class
+    # guard has to deopt rather than read one layout's slots off another.
+    acc = 0
+    for i in range(rounds):
+        kind = i & 3
+        if kind == 0:
+            t = (i, i + 1)
+        elif kind == 1:
+            t = (0.5, i * 1.5)
+        elif kind == 2:
+            t = (BIG + i, "s")
+        else:
+            t = (i, i + 1, i + 2)
+        acc = (acc * 3 + len(t) + int(t[0]) + int(t[-1] != "s")) % MOD
+    return acc
+
+
+def slice_key(rounds):
+    acc = 0
+    for i in range(rounds):
+        t = (i, BIG + i)
+        acc = (acc * 3 + len(t[:]) + len(t[0:1]) + (t[1:][0] & 0xFFFF)) % MOD
+    return acc
+
+
+class Index:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        return self.value
+
+
+def index_protocol_key(rounds):
+    acc = 0
+    for i in range(rounds):
+        t = (i, i * 7 + 5)
+        acc = (acc * 3 + t[Index(i & 1)]) % MOD
+    return acc
+
+
+def out_of_range_raises(rounds):
+    seen = 0
+    for i in range(rounds):
+        t = (i, i + 1)
+        for bad in (2, -3):
+            try:
+                t[bad]
+            except IndexError:
+                seen += 1
+    return seen
+
+
+class Pair(tuple):
+    def __len__(self):
+        return 99
+
+    def __getitem__(self, index):
+        return 7
+
+
+def subclass_overrides(rounds):
+    # A subclass keeps the canonical layout and overrides both dunders; the
+    # exact-`w_class` guard must send it to the generic residual.
+    acc = 0
+    for i in range(rounds):
+        t = Pair((i, i + 1))
+        acc = (acc * 3 + len(t) + t[0] * 5 + t[1]) % MOD
+    return acc
+
+
+for fn in (oo_longs, ii_ints, float_pair, negative_index, alternating_index,
+           bool_index, alternating_class, slice_key, index_protocol_key,
+           out_of_range_raises, subclass_overrides):
+    print(fn.__name__, fn(3000))
+print("OK")

--- a/pyre/extra_tests/parity_tests/unpack_specialised_pair_shapes.py
+++ b/pyre/extra_tests/parity_tests/unpack_specialised_pair_shapes.py
@@ -35,7 +35,11 @@ def ii_ints(rounds):
     return acc
 
 
-def ff_floats(rounds):
+def float_pair(rounds):
+    # `w_tuple_new` sends a plain-float pair to `Cls_oo` rather than `Cls_ff`
+    # so that `(x, x)` keeps the exact `x` object, and `specialized_zip_2_lists`
+    # — the other `Cls_ff` producer upstream — is not ported, so this is an
+    # object pair whose slots happen to hold floats.
     acc = 0.0
     for i in range(rounds):
         a, b = (1.5, 2.5)
@@ -80,7 +84,7 @@ def alternating(rounds):
     return acc
 
 
-for fn in (oo_longs, oo_strings, oo_mixed, ii_ints, ff_floats, arity3,
+for fn in (oo_longs, oo_strings, oo_mixed, ii_ints, float_pair, arity3,
            from_list, wrong_arity_raises, alternating):
     print(fn.__name__, fn(3000))
 print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -2452,19 +2452,77 @@ pub(crate) fn callable_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     ]))
 }
 
+/// The cursor argument shared by every builtin iterator's `__setstate__`.
+/// Python 3.14 reads it with `PyLong_AsSsize_t`, so an `int` (or a subclass) is
+/// the only accepted state — the `__index__` protocol is not consulted — and a
+/// value too wide for a machine word raises `OverflowError`.  PyPy unwraps with
+/// `space.int_w` (`iterobject.py:41`), which does run `__index__`; the
+/// observable behaviour target is 3.14.
+fn iter_setstate_index(state: PyObjectRef) -> Result<i64, PyError> {
+    if state.is_null()
+        || !unsafe {
+            pyre_object::is_int(state) || pyre_object::is_long(state) || pyre_object::is_bool(state)
+        }
+    {
+        return Err(PyError::type_error("an integer is required"));
+    }
+    if unsafe { pyre_object::is_long(state) } {
+        let big = unsafe { pyre_object::longobject::w_long_get_value(state) };
+        if pyre_object::longobject::jit_bigint_to_i64_fits(big) == 0 {
+            return Err(PyError::overflow_error(
+                "Python int too large to convert to C ssize_t",
+            ));
+        }
+    }
+    int_w(state)
+}
+
+/// The live length a `W_SeqIterObject` cursor is clamped against, for the
+/// producers whose `__setstate__` knows one.  The shared `sequenceiterator`
+/// identity reaches its elements through `__getitem__` alone, so it has no
+/// length to clamp with (`iter_setstate`, iterobject.c) and reports `None`;
+/// an out-of-range cursor there is absorbed by `next` raising StopIteration
+/// on the IndexError.
+unsafe fn seq_iter_clamp_length(seq: PyObjectRef) -> Option<i64> {
+    unsafe {
+        if is_str(seq) {
+            Some(pyre_object::unicodeobject::w_str_len(seq) as i64)
+        } else if pyre_object::bytesobject::is_bytes_like(seq) {
+            Some(pyre_object::bytesobject::bytes_like_len(seq) as i64)
+        } else if pyre_object::interp_array::is_array(seq) {
+            Some(pyre_object::interp_array::w_array_len(seq) as i64)
+        } else {
+            None
+        }
+    }
+}
+
 /// `sequenceiterator.__setstate__(index)` — `iterobject.py:40-45
 /// W_AbstractSeqIterObject.descr_setstate`: restore the cursor only while the
-/// sequence is live, clamping a negative index to 0.  There is no upper clamp —
-/// an out-of-range cursor is absorbed by `next` raising StopIteration on the
-/// IndexError.
+/// sequence is live, clamping a negative index to 0.
+///
+/// The producer-specific identities 3.14 splits this payload into each clamp
+/// the cursor to the sequence's *current* length, so a state past the end
+/// pickles as exhausted rather than verbatim; `bytearray_iterator` instead
+/// stores the -1 exhausted sentinel for a negative state, one-way, the way
+/// `list_iterator` does.  PyPy stores every state verbatim except in
+/// `W_FastUnicodeIterObject.descr_setstate` (`iterobject.py:129-140`), which
+/// clamps because it must recompute a byte offset from the cursor.
 pub(crate) fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let mut index = int_w(args[1])?;
+    let mut index = iter_setstate_index(args[1])?;
     unsafe {
-        if pyre_object::w_seq_iter_seq(args[0]).is_null() {
+        let seq = pyre_object::w_seq_iter_seq(args[0]);
+        if seq.is_null() || pyre_object::w_seq_iter_index(args[0]) < 0 {
             return Ok(w_none());
         }
         if index < 0 {
-            index = 0;
+            index = if pyre_object::iterobject::is_bytearray_iter(args[0]) {
+                -1
+            } else {
+                0
+            };
+        } else if let Some(length) = seq_iter_clamp_length(seq) {
+            index = index.min(length);
         }
         pyre_object::w_seq_iter_set_index(args[0], index);
     }
@@ -2486,7 +2544,9 @@ pub(crate) fn seq_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
 pub(crate) fn seq_iter_length_hint_method(args: &[PyObjectRef]) -> PyResult {
     unsafe {
         let seq = pyre_object::w_seq_iter_seq(args[0]);
-        if seq.is_null() {
+        // A negative cursor is `bytearray_iterator`'s exhausted sentinel; it
+        // keeps its source referenced but reports nothing remaining.
+        if seq.is_null() || pyre_object::w_seq_iter_index(args[0]) < 0 {
             return Ok(w_int_new(0));
         }
         if is_instance(seq) && lookup(seq, "__len__").is_none() {
@@ -2523,7 +2583,7 @@ pub(crate) fn list_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
 /// the generic sequence iterator does, and an index past the end is clamped to
 /// the length rather than stored verbatim.
 pub(crate) fn list_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let mut index = int_w(args[1])?;
+    let mut index = iter_setstate_index(args[1])?;
     unsafe {
         let seq = pyre_object::w_list_iter_seq(args[0]);
         if seq.is_null() {
@@ -2576,17 +2636,18 @@ pub(crate) fn tuple_iter_reduce_method(args: &[PyObjectRef]) -> PyResult {
     }
 }
 
+/// `tuple_iterator.__setstate__(index)` — `tupleiter_setstate` clamps the
+/// cursor into `[0, len]`, so a state past the end restores an exhausted
+/// iterator rather than the verbatim cursor PyPy's
+/// `W_AbstractSeqIterObject.descr_setstate` keeps.
 pub(crate) fn tuple_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let mut index = int_w(args[1])?;
+    let mut index = iter_setstate_index(args[1])?;
     unsafe {
-        if pyre_object::w_tuple_iter_seq(args[0]).is_null() {
+        let seq = pyre_object::w_tuple_iter_seq(args[0]);
+        if seq.is_null() {
             return Ok(w_none());
         }
-        // PyPy W_AbstractSeqIterObject.descr_setstate and CPython 3.14's
-        // tuple iterator both clamp a negative cursor to zero.
-        if index < 0 {
-            index = 0;
-        }
+        index = index.clamp(0, pyre_object::w_tuple_len(seq) as i64);
         pyre_object::w_tuple_iter_set_index(args[0], index);
     }
     Ok(w_none())
@@ -2637,7 +2698,7 @@ pub(crate) fn list_reverse_iter_reduce_method(args: &[PyObjectRef]) -> PyResult 
 /// once it walks off the front.  The list outlives exhaustion, so this restores
 /// a spent iterator to a live cursor as well.
 pub(crate) fn list_reverse_iter_setstate_method(args: &[PyObjectRef]) -> PyResult {
-    let mut index = int_w(args[1])?;
+    let mut index = iter_setstate_index(args[1])?;
     unsafe {
         let seq = pyre_object::w_list_reverse_iter_seq(args[0]);
         if seq.is_null() {
@@ -2961,10 +3022,14 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
         pyre_object::gc_roots::pin_root(self_type);
         let self_type_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let seq = pyre_object::functional::w_reversed_get_sequence(self_);
-        if !seq.is_null() {
+        let remaining = pyre_object::functional::w_reversed_get_remaining(self_);
+        // A cursor that has walked off the front is exhausted even while the
+        // sequence is still referenced, so it pickles as `reversed(())` too.
+        // PyPy selects the empty form on the cleared sequence alone and reports
+        // the -1 cursor verbatim for a `__setstate__` that drove it negative.
+        if !seq.is_null() && remaining >= 0 {
             pyre_object::gc_roots::pin_root(seq);
             let seq_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-            let remaining = pyre_object::functional::w_reversed_get_remaining(self_);
             let state = w_tuple_new(vec![pyre_object::gc_roots::shadow_stack_get(seq_slot)]);
             pyre_object::gc_roots::pin_root(state);
             let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -2993,23 +3058,19 @@ pub(crate) fn reversed_reduce_method(args: &[PyObjectRef]) -> PyResult {
 
 /// `reversed.__setstate__(index)` — `functional.py:419-429
 /// descr___setstate__`: set `remaining` then clamp into `[-1, n-1]`
-/// (`n == len(sequence)`, or 0 once exhausted).
+/// (`n == len(sequence)`, or 0 once exhausted).  An already-exhausted cursor
+/// is left alone, so driving it negative is one-way; PyPy re-clamps from any
+/// cursor and lets a later state revive the iterator.
 pub(crate) fn reversed_setstate_method(args: &[PyObjectRef]) -> PyResult {
     let self_ = reversed_receiver(args, "__setstate__")?;
     let state = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-    if state.is_null()
-        || !unsafe {
-            pyre_object::is_int(state) || pyre_object::is_long(state) || pyre_object::is_bool(state)
-        }
-    {
-        return Err(PyError::type_error("an integer is required"));
+    let mut remaining = iter_setstate_index(state)?;
+    if unsafe { pyre_object::functional::w_reversed_get_remaining(self_) } < 0 {
+        return Ok(w_none());
     }
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(self_);
     let self_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    pyre_object::gc_roots::pin_root(state);
-    let state_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let mut remaining = int_w(unsafe { pyre_object::gc_roots::shadow_stack_get(state_slot) })?;
     unsafe {
         let self_ = pyre_object::gc_roots::shadow_stack_get(self_slot);
         let seq = pyre_object::functional::w_reversed_get_sequence(self_);
@@ -14336,12 +14397,14 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             // its writes go through a re-read pointer instead.
             let iter_ptr = obj as *mut pyre_object::W_SeqIterObject;
             let seq = (*iter_ptr).seq;
+            let idx = (*iter_ptr).index;
             // iterobject.py W_SeqIterObject.descr_next — a None (null) seq
             // marks an iterator already exhausted by an earlier IndexError.
-            if seq.is_null() {
+            // A negative cursor is `bytearray_iterator`'s exhausted sentinel,
+            // set by `__setstate__` while the source stays referenced.
+            if seq.is_null() || idx < 0 {
                 return Err(PyError::stop_iteration());
             }
-            let idx = (*iter_ptr).index;
             let item = if is_list(seq) {
                 pyre_object::w_list_getitem(seq, idx)
             } else if is_tuple(seq) {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -1425,8 +1425,9 @@ pub fn range_iter_continues(iter: PyObjectRef) -> Result<bool, PyError> {
             let si = &*(iter as *const W_SeqIterObject);
             // A cleared sequence (exhausted cursor, iterobject.py:90-98) has no
             // more items — a re-iteration of an exhausted iterator stops here
-            // without dereferencing the freed sequence.
-            if si.seq.is_null() {
+            // without dereferencing the freed sequence.  A negative cursor is
+            // `bytearray_iterator`'s exhausted sentinel and keeps its source.
+            if si.seq.is_null() || si.index < 0 {
                 return Ok(false);
             }
             // sequenceiterator re-reads the live sequence length and PyPy's
@@ -1463,8 +1464,9 @@ pub fn range_iter_next_or_null(iter: PyObjectRef) -> Result<PyObjectRef, PyError
             let si = &mut *(iter as *mut W_SeqIterObject);
             // An exhausted cursor cleared its sequence (iterobject.py:90-98
             // `self.w_seq = None`); a re-entry stays exhausted without
-            // dereferencing the freed sequence.
-            if si.seq.is_null() {
+            // dereferencing the freed sequence.  A negative cursor is
+            // `bytearray_iterator`'s exhausted sentinel and keeps its source.
+            if si.seq.is_null() || si.index < 0 {
                 return Ok(PY_NULL);
             }
             let idx = si.index;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -826,10 +826,6 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
         *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
             as *const i64)
     };
-    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
-    if fits_concrete != 0 {
-        return Ok(None);
-    }
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, long, long_type_addr)?;
@@ -871,19 +867,16 @@ pub(crate) fn try_walker_specialize_binary_op_long_int<Sym: WalkSym>(
         walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
     }
 
-    let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
-    let fits = ctx.trace_ctx.call_typed_with_effect(
-        OpCode::CallI,
-        fits_fn,
-        &[raw],
-        &[majit_ir::Type::Ref],
-        majit_ir::Type::Int,
-        majit_metainterp::cannot_raise_effect_info(),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(fits, majit_ir::Value::Int(fits_concrete));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
-
+    // The box needs no preceding fits_int guard. `_make_generic_descr_binop`
+    // and `descr_sub` (longobject.py:304-349) wrap with
+    // `W_LongObject(intop(...))`, and the interpreter arms they model
+    // (`long_add`, `long_sub`, `long_mul`, `long_bitand`, `long_bitor`,
+    // `long_bitxor`) wrap with `w_long_new`. Neither side demotes a
+    // machine-sized result to a `W_IntObject`, so a result that fits is the
+    // same object shape as one that does not, and declining on it left every
+    // `x & 0xff`-shaped operation on the generic residual. The
+    // `is_int(boxed_result_obj)` test above is what catches a path that does
+    // demote.
     let result = crate::helpers::emit_box_long_inline(
         ctx.trace_ctx,
         raw,
@@ -998,9 +991,6 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
             *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
                 as *const i64)
         };
-        if pyre_object::longobject::jit_bigint_fits_int(raw_concrete) != 0 {
-            return Ok(None);
-        }
         Some(raw_concrete)
     } else {
         if unsafe { !pyre_object::is_int(boxed_result_obj) } {
@@ -1058,22 +1048,12 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_div<Sym: WalkSym>(
             if raw.inline_const_to_value().is_none() {
                 walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
             }
-            // `w_long_new` keeps the quotient a `W_LongObject`, so this guard is
-            // not a demotion test: it pins the trace to the payload shape the
-            // inline box was recorded for, exactly as the shift leg does.
-            let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
-            let fits = ctx.trace_ctx.call_typed_with_effect(
-                OpCode::CallI,
-                fits_fn,
-                &[raw],
-                &[majit_ir::Type::Ref],
-                majit_ir::Type::Int,
-                majit_metainterp::cannot_raise_effect_info(),
-            );
-            ctx.trace_ctx
-                .set_opref_concrete(fits, majit_ir::Value::Int(0));
-            walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
-
+            // The box needs no preceding fits_int guard. `_floordiv`/
+            // `_int_floordiv` (longobject.py:409-424) wrap with `newlong` and
+            // `long_floordiv` with `w_long_new`, so the quotient is a
+            // `W_LongObject` whatever its magnitude, and the inline box carries
+            // the payload by pointer — nothing about it varies with the digit
+            // count the guard was testing.
             let boxed = crate::helpers::emit_box_long_inline(
                 ctx.trace_ctx,
                 raw,
@@ -1369,10 +1349,6 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
         *((boxed_result_obj as *const u8).add(pyre_object::longobject::LONG_VALUE_OFFSET)
             as *const i64)
     };
-    let fits_concrete = pyre_object::longobject::jit_bigint_fits_int(raw_concrete);
-    if fits_concrete != 0 {
-        return Ok(None);
-    }
 
     let long_type_addr = &pyre_object::pyobject::LONG_TYPE as *const _ as i64;
     walker_guard_class(ctx, op_pc, lhs, long_type_addr)?;
@@ -1424,19 +1400,13 @@ pub(crate) fn try_walker_specialize_binary_op_long_int_shift<Sym: WalkSym>(
         walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoException, &[])?;
     }
 
-    let fits_fn = pyre_object::longobject::jit_bigint_fits_int as *const ();
-    let fits = ctx.trace_ctx.call_typed_with_effect(
-        OpCode::CallI,
-        fits_fn,
-        &[raw],
-        &[majit_ir::Type::Ref],
-        majit_ir::Type::Int,
-        majit_metainterp::cannot_raise_effect_info(),
-    );
-    ctx.trace_ctx
-        .set_opref_concrete(fits, majit_ir::Value::Int(fits_concrete));
-    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardFalse, &[fits])?;
-
+    // The box needs no preceding fits_int guard: `_int_lshift` wraps with
+    // `W_LongObject(...)` and `_int_rshift` with `newlong` (longobject.py:383,
+    // 402), and `long_lshift`/`long_rshift` both end in `w_long_new`. Neither
+    // demotes a machine-sized result — `newlong` only reaches
+    // `W_SmallLongObject`, which `withsmalllong` leaves off — so declining on
+    // a fitting result put every `x >> 32`-shaped shift back on the generic
+    // residual for no observable difference.
     let result = crate::helpers::emit_box_long_inline(
         ctx.trace_ctx,
         raw,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -1904,59 +1904,13 @@ pub(crate) fn try_walker_specialize_unpack<Sym: WalkSym>(
             // which case this is a no-op; guard here too so a fold that only
             // catches the item reads still proves the layout it loads from.
             walker_guard_specialised_pair_class(ctx, op_pc, seq, spec_type)?;
-            if pair_kind == SpecialisedPairKind::Object {
-                let descr = if int_val == 0 {
-                    crate::descr::specialised_tuple_oo_value0_descr()
-                } else {
-                    crate::descr::specialised_tuple_oo_value1_descr()
-                };
-                // `wraps[i]` is the identity for an object slot, so the field
-                // read is the whole item — no re-boxing, and no `may_force`
-                // execution needed to recover a box identity.
-                let item = crate::state::opimpl_getfield_gc_r(ctx.trace_ctx, seq, descr);
-                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
-                return Ok(Some(()));
-            }
-            // Authentic boxed element supplies the concrete shadow / identity
-            // while the emitted field read and transparent wrapper replace
-            // the residual call in machine code. Fall through if execution
-            // raises or cannot provide that box.
-            let Some(elem_ptr) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+            let Some(item) = walker_emit_specialised_pair_item(
+                ctx, op_pc, seq, pair_kind, int_val, allboxes, call_descr,
+            )?
+            else {
                 return Ok(None);
             };
-            if pair_kind == SpecialisedPairKind::Float {
-                let descr = if int_val == 0 {
-                    crate::descr::specialised_tuple_ff_value0_descr()
-                } else {
-                    crate::descr::specialised_tuple_ff_value1_descr()
-                };
-                let raw =
-                    majit_metainterp::box_trace::getfield_gc_f_pureornot(ctx.trace_ctx, seq, descr);
-                let elem =
-                    unsafe { pyre_object::w_float_get_value(elem_ptr as pyre_object::PyObjectRef) };
-                ctx.trace_ctx
-                    .set_opref_concrete(raw, majit_ir::Value::Float(elem));
-                let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
-                ctx.trace_ctx.set_opref_concrete(
-                    boxed,
-                    majit_ir::Value::Ref(majit_ir::GcRef(elem_ptr as usize)),
-                );
-                write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
-                return Ok(Some(()));
-            }
-            // `ii`: preserve authentic small-int caching / identity.
-            let descr = if int_val == 0 {
-                crate::descr::specialised_tuple_ii_value0_descr()
-            } else {
-                crate::descr::specialised_tuple_ii_value1_descr()
-            };
-            let raw = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, seq, descr);
-            let elem =
-                unsafe { pyre_object::w_int_get_value(elem_ptr as pyre_object::PyObjectRef) };
-            let boxed = walker_box_int(ctx, op_pc, raw, elem)?;
-            ctx.trace_ctx
-                .set_opref_concrete(boxed, box_int_concrete(elem, elem_ptr as i64));
-            write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+            write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
             Ok(Some(()))
         }
         _ => Ok(None),
@@ -1998,6 +1952,84 @@ fn walker_guard_specialised_pair_class<Sym: WalkSym>(
         .heap_cache_mut()
         .class_now_known(seq, spec_type as i64);
     Ok(())
+}
+
+/// Read slot `index` (0 or 1) of an arity-2 tuple specialisation whose class
+/// the caller has already guarded, applying that slot's `wraps[i]`
+/// (`specialisedtupleobject.py:26-27`, and `:134-142 getitem`, which unrolls
+/// `iter_n` to the matching `value%s`).
+///
+/// `Ok(None)` declines: the `ii` / `ff` slots need the authentic box for its
+/// identity, and that execution can fail.
+///
+/// The `ff` arm currently has no producer to serve. Upstream builds `Cls_ff`
+/// from `makespecialisedtuple2` (`specialisedtupleobject.py:178`) and from
+/// `specialized_zip_2_lists` (`:230`); pyre does not port the latter, and
+/// `w_tuple_new` (tupleobject.rs:174-186) sends a plain-float pair to `Cls_oo`
+/// instead so that `(x, x)` keeps the exact `x` object. It is kept because it
+/// is the layout upstream reads, not because a trace reaches it today.
+#[allow(clippy::too_many_arguments)]
+fn walker_emit_specialised_pair_item<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    seq: OpRef,
+    pair_kind: SpecialisedPairKind,
+    index: i64,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+) -> Result<Option<OpRef>, DispatchError> {
+    let first = index == 0;
+    if pair_kind == SpecialisedPairKind::Object {
+        let descr = if first {
+            crate::descr::specialised_tuple_oo_value0_descr()
+        } else {
+            crate::descr::specialised_tuple_oo_value1_descr()
+        };
+        // `wraps[i]` is the identity for an object slot, so the field read is
+        // the whole item — no re-boxing, and no `may_force` execution needed
+        // to recover a box identity.
+        return Ok(Some(crate::state::opimpl_getfield_gc_r(
+            ctx.trace_ctx,
+            seq,
+            descr,
+        )));
+    }
+    // Authentic boxed element supplies the concrete shadow / identity while
+    // the emitted field read and transparent wrapper replace the residual call
+    // in machine code. Fall through if execution raises or cannot provide that
+    // box.
+    let Some(elem_ptr) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    if pair_kind == SpecialisedPairKind::Float {
+        let descr = if first {
+            crate::descr::specialised_tuple_ff_value0_descr()
+        } else {
+            crate::descr::specialised_tuple_ff_value1_descr()
+        };
+        let raw = majit_metainterp::box_trace::getfield_gc_f_pureornot(ctx.trace_ctx, seq, descr);
+        let elem = unsafe { pyre_object::w_float_get_value(elem_ptr as pyre_object::PyObjectRef) };
+        ctx.trace_ctx
+            .set_opref_concrete(raw, majit_ir::Value::Float(elem));
+        let boxed = crate::state::wrapfloat(ctx.trace_ctx, raw);
+        ctx.trace_ctx.set_opref_concrete(
+            boxed,
+            majit_ir::Value::Ref(majit_ir::GcRef(elem_ptr as usize)),
+        );
+        return Ok(Some(boxed));
+    }
+    // `ii`: preserve authentic small-int caching / identity.
+    let descr = if first {
+        crate::descr::specialised_tuple_ii_value0_descr()
+    } else {
+        crate::descr::specialised_tuple_ii_value1_descr()
+    };
+    let raw = crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, seq, descr);
+    let elem = unsafe { pyre_object::w_int_get_value(elem_ptr as pyre_object::PyObjectRef) };
+    let boxed = walker_box_int(ctx, op_pc, raw, elem)?;
+    ctx.trace_ctx
+        .set_opref_concrete(boxed, box_int_concrete(elem, elem_ptr as i64));
+    Ok(Some(boxed))
 }
 
 /// One hop of a `while tb is not None: names.append(tb.tb_frame.f_code.co_name);
@@ -5350,6 +5382,19 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
         );
     }
 
+    // The arity-2 specialisations reach the same `getitem`, but their items
+    // are the inline `value0`/`value1` slots, so they need their own reader —
+    // which is why the gate above is `ob_type == &TUPLE_TYPE` and not
+    // `is_tuple()`. No `w_class` guard: only a specialisation carries its own
+    // `ob_type`, so a tuple subclass (which keeps `&TUPLE_TYPE`) can never
+    // pass the class guard below.
+    if let Some(pair_kind) = specialised_pair_kind(unsafe { (*list_obj).ob_type }) {
+        return try_walker_specialize_subscr_specialised_pair(
+            ctx, op_pc, list_op, key_op, list_obj, key_obj, pair_kind, allboxes, call_descr, dst,
+            dst_bank,
+        );
+    }
+
     // The `dict.lookup` gate.  Both `w_class` checks are load-bearing: a dict
     // SUBCLASS shares `ob_type == &DICT_TYPE` but retags `w_class` and reaches
     // `__missing__` on a miss, and a str SUBCLASS key may override `__hash__` /
@@ -5804,6 +5849,80 @@ pub(crate) fn try_walker_specialize_subscr_tuple<Sym: WalkSym>(
     Ok(Some(()))
 }
 
+/// SUBSCRIPT arm for the arity-2 tuple specialisations
+/// (`specialisedtupleobject.py:134-142 getitem`), the analogue of
+/// [`try_walker_specialize_subscr_tuple`] for a receiver whose items are the
+/// inline `value0` / `value1` slots instead of a `wrappeditems` block.
+///
+/// Upstream `getitem` normalises a negative index against the constant
+/// `typelen` and then runs the unrolled `index == i` chain to pick the slot,
+/// so the recorded slot is pinned here with a single `guard_value` on the
+/// unboxed index: it re-proves both the sign test and the comparison at once,
+/// and a literal subscript makes it constant, which the optimizer drops.
+///
+/// The caller matched `ob_type` against one of the three specialisation
+/// classes, which is also why no `w_class` guard follows: a tuple subclass
+/// instance keeps the canonical `ob_type == &TUPLE_TYPE`, so it can neither
+/// reach this arm nor pass the class guard below.
+///
+/// A slice key, a non-int key, or an out-of-range index falls through to the
+/// generic residual (`Ok(None)`), which raises `IndexError` the way `getitem`
+/// does.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_specialize_subscr_specialised_pair<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    seq_op: OpRef,
+    key_op: OpRef,
+    seq_obj: pyre_object::PyObjectRef,
+    key_obj: pyre_object::PyObjectRef,
+    pair_kind: SpecialisedPairKind,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    const TYPELEN: i64 = 2;
+    // `bool` shares int's `intval`, so it indexes through its own &BOOL_TYPE
+    // guard in the unbox below.
+    let raw_key = unsafe {
+        if !pyre_object::is_int(key_obj) {
+            return Ok(None);
+        }
+        pyre_object::w_int_get_value(key_obj)
+    };
+    let index = if raw_key < 0 {
+        raw_key + TYPELEN
+    } else {
+        raw_key
+    };
+    if !(0..TYPELEN).contains(&index) {
+        return Ok(None);
+    }
+
+    let spec_type = unsafe { (*seq_obj).ob_type };
+    walker_guard_specialised_pair_class(ctx, op_pc, seq_op, spec_type)?;
+
+    let (idx_type, idx_descr) = crate::state::int_or_bool_unbox_type_descr(key_obj);
+    let raw_index = walker_unbox_int_typed(ctx, op_pc, key_op, idx_type, idx_descr)?;
+    ctx.trace_ctx
+        .set_opref_concrete(raw_index, majit_ir::Value::Int(raw_key));
+    let expected = ctx.trace_ctx.const_int(raw_key);
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardValue, &[raw_index, expected])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(raw_index, expected);
+
+    let Some(item) = walker_emit_specialised_pair_item(
+        ctx, op_pc, seq_op, pair_kind, index, allboxes, call_descr,
+    )?
+    else {
+        return Ok(None);
+    };
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, item)?;
+    Ok(Some(()))
+}
+
 /// Builtin `type(x)`:
 ///
 /// ```python
@@ -6137,19 +6256,30 @@ pub(crate) fn try_walker_specialize_builtin_dict_get<Sym: WalkSym>(
     walker_emit_exact_dict_hit(ctx, op.pc, dict_op, r_args[2], dict, hit, dst, 'r')
 }
 
+/// Where the guarded receiver's length comes from — the `length()` body each
+/// layout has upstream.
+#[derive(Clone, Copy)]
+enum BuiltinLenSource {
+    /// `W_ListObject.length()` → `strategy.length` (rlist.py). Carries the
+    /// storage-strategy id the read is guarded on.
+    ListStrategy(i64),
+    /// `W_UnicodeObject.len` → `bh_unicodelen`; no storage strategy.
+    StrField,
+    /// `tupleobject.py` carries no separate length field, so the length is
+    /// `arraylen_gc(wrappeditems)`.
+    TupleArrayLen,
+    /// `specialisedtupleobject.py:54-55 length()` returns the constant
+    /// `typelen`.
+    PairArity,
+}
+
 /// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /
-/// `W_TupleObject`:
+/// `W_TupleObject`, or on an arity-2 tuple specialisation:
 /// lower the opaque `bh_call_fn(len_builtin, PY_NULL, x)` residual to the
 /// inline length read the meta-tracer produces upstream
 /// (descroperation.py `_len`): `guard_value(callable)` +
-/// `guard_class` + exact `w_class` guard + length `getfield_gc_i` +
-/// `wrapint`.  For a list this reads `W_ListObject.length()` →
-/// `strategy.length`, so it additionally emits `guard_value(strategy)`
-/// (rlist.py); for a str it reads the codepoint field directly
-/// (`W_UnicodeObject.len` → `bh_unicodelen`, no storage strategy); for a
-/// tuple it reads `wrappeditems` and applies `arraylen_gc`, matching
-/// `tupleobject.py` where the tuple carries no separate length field. The
-/// exact `w_class` guard is required because a SUBCLASS shares
+/// `guard_class` + exact `w_class` guard + the [`BuiltinLenSource`] read +
+/// `wrapint`.  The exact `w_class` guard is required because a SUBCLASS shares
 /// `ob_type == &LIST_TYPE`/`&STR_TYPE`/`&TUPLE_TYPE` but may override `__len__`
 /// (`baseobjspace::len` dispatches `subclass_special_override`); it
 /// side-exits to the generic residual.
@@ -6185,60 +6315,20 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
     if !pyre_interpreter::builtins::is_builtin_len_function(concrete_callable) {
         return Ok(None);
     }
-    // Exact canonical list / str / tuple only (see the doc comment on the subclass
-    // `__len__` hazard).  `arg_type_addr` / `exact_w_class` pin the guard
-    // target; the booleans select the length path.
-    let (arg_type_addr, exact_w_class, is_str, is_tuple) = unsafe {
-        if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::LIST_TYPE)
-            && std::ptr::eq(
-                (*list_obj).w_class,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
-            )
-        {
-            (
-                &pyre_object::pyobject::LIST_TYPE as *const _ as i64,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE),
-                false,
-                false,
-            )
-        } else if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::STR_TYPE)
-            && std::ptr::eq(
-                (*list_obj).w_class,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::STR_TYPE),
-            )
-        {
-            (
-                &pyre_object::pyobject::STR_TYPE as *const _ as i64,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::STR_TYPE),
-                true,
-                false,
-            )
-        } else if std::ptr::eq((*list_obj).ob_type, &pyre_object::pyobject::TUPLE_TYPE)
-            && std::ptr::eq(
-                (*list_obj).w_class,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
-            )
-        {
-            (
-                &pyre_object::pyobject::TUPLE_TYPE as *const _ as i64,
-                pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE),
-                false,
-                true,
-            )
-        } else {
-            return Ok(None);
-        }
-    };
-    // Length source: str reads the codepoint field directly (no storage
-    // strategy); tuple reads the wrappeditems GcArray header; list resolves
-    // its storage strategy (guarded below). `sid` is `None` for str/tuple.
-    let (sid, concrete_len) = unsafe {
-        if is_str {
-            (None, pyre_object::w_str_len(list_obj))
-        } else if is_tuple {
-            (None, pyre_object::w_tuple_len(list_obj))
-        } else {
-            let concrete_len = pyre_object::w_list_len(list_obj);
+    // Exact canonical list / str / tuple, or one of the arity-2 tuple
+    // specialisations.  `arg_type_addr` pins the `guard_class` target;
+    // `exact_w_class` is the subclass-`__len__` guard (see the doc comment),
+    // absent for a specialisation because only `makespecialisedtuple2` builds
+    // that `ob_type` and always with the canonical tuple `w_class`, so the
+    // class guard alone already excludes every subclass instance.
+    let (arg_type_addr, exact_w_class, len_source, concrete_len) = unsafe {
+        let ob_type = (*list_obj).ob_type;
+        let w_class = (*list_obj).w_class;
+        if std::ptr::eq(ob_type, &pyre_object::pyobject::LIST_TYPE) {
+            let exact = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::LIST_TYPE);
+            if !std::ptr::eq(w_class, exact) {
+                return Ok(None);
+            }
             let sid = if pyre_object::w_list_uses_int_storage(list_obj) {
                 1i64
             } else if pyre_object::w_list_uses_float_storage(list_obj) {
@@ -6249,7 +6339,43 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
                 // Empty-strategy list: no length field to read.
                 return Ok(None);
             };
-            (Some(sid), concrete_len)
+            (
+                &pyre_object::pyobject::LIST_TYPE as *const _ as i64,
+                Some(exact),
+                BuiltinLenSource::ListStrategy(sid),
+                pyre_object::w_list_len(list_obj),
+            )
+        } else if std::ptr::eq(ob_type, &pyre_object::pyobject::STR_TYPE) {
+            let exact = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::STR_TYPE);
+            if !std::ptr::eq(w_class, exact) {
+                return Ok(None);
+            }
+            (
+                &pyre_object::pyobject::STR_TYPE as *const _ as i64,
+                Some(exact),
+                BuiltinLenSource::StrField,
+                pyre_object::w_str_len(list_obj),
+            )
+        } else if std::ptr::eq(ob_type, &pyre_object::pyobject::TUPLE_TYPE) {
+            let exact = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE);
+            if !std::ptr::eq(w_class, exact) {
+                return Ok(None);
+            }
+            (
+                &pyre_object::pyobject::TUPLE_TYPE as *const _ as i64,
+                Some(exact),
+                BuiltinLenSource::TupleArrayLen,
+                pyre_object::w_tuple_len(list_obj),
+            )
+        } else if specialised_pair_kind(ob_type).is_some() {
+            (
+                ob_type as i64,
+                None,
+                BuiltinLenSource::PairArity,
+                pyre_object::w_tuple_len(list_obj),
+            )
+        } else {
+            return Ok(None);
         }
     };
 
@@ -6287,43 +6413,55 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
     ctx.trace_ctx
         .heap_cache_mut()
         .class_now_known(list_op, arg_type_addr);
-    walker_guard_exact_w_class(ctx, op.pc, list_op, exact_w_class)?;
+    if let Some(exact_w_class) = exact_w_class {
+        walker_guard_exact_w_class(ctx, op.pc, list_op, exact_w_class)?;
+    }
     // Length read.  list: guard the storage strategy, then read that
     // strategy's length field (rlist.py inline field for object storage;
     // typed items-block length for int/float storage).  str: a plain
     // codepoint-length getfield (no strategy, `bh_unicodelen`).
-    let raw_len = if let Some(sid) = sid {
-        let strategy = crate::state::opimpl_getfield_gc_i(
+    let raw_len = match len_source {
+        BuiltinLenSource::ListStrategy(sid) => {
+            let strategy = crate::state::opimpl_getfield_gc_i(
+                ctx.trace_ctx,
+                list_op,
+                crate::descr::list_strategy_descr(),
+            );
+            let sid_const = ctx.trace_ctx.const_int(sid);
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardValue, &[strategy, sid_const], 0);
+            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .replace_box(strategy, sid_const);
+            let len_descr = match sid {
+                0 => crate::descr::list_length_descr(),
+                1 => crate::descr::list_int_items_len_descr(),
+                _ => crate::descr::list_float_items_len_descr(),
+            };
+            crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr)
+        }
+        BuiltinLenSource::TupleArrayLen => {
+            let wrappeditems = crate::state::opimpl_getfield_gc_r(
+                ctx.trace_ctx,
+                list_op,
+                crate::descr::tuple_wrappeditems_descr(),
+            );
+            crate::state::opimpl_arraylen_gc(
+                ctx.trace_ctx,
+                wrappeditems,
+                crate::state::pyobject_gcarray_descr(),
+            )
+        }
+        BuiltinLenSource::StrField => crate::state::opimpl_getfield_gc_i(
             ctx.trace_ctx,
             list_op,
-            crate::descr::list_strategy_descr(),
-        );
-        let sid_const = ctx.trace_ctx.const_int(sid);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardValue, &[strategy, sid_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-        ctx.trace_ctx
-            .heap_cache_mut()
-            .replace_box(strategy, sid_const);
-        let len_descr = match sid {
-            0 => crate::descr::list_length_descr(),
-            1 => crate::descr::list_int_items_len_descr(),
-            _ => crate::descr::list_float_items_len_descr(),
-        };
-        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, len_descr)
-    } else if is_tuple {
-        let wrappeditems = crate::state::opimpl_getfield_gc_r(
-            ctx.trace_ctx,
-            list_op,
-            crate::descr::tuple_wrappeditems_descr(),
-        );
-        crate::state::opimpl_arraylen_gc(
-            ctx.trace_ctx,
-            wrappeditems,
-            crate::state::pyobject_gcarray_descr(),
-        )
-    } else {
-        crate::state::opimpl_getfield_gc_i(ctx.trace_ctx, list_op, crate::descr::str_len_descr())
+            crate::descr::str_len_descr(),
+        ),
+        // `specialisedtupleobject.py:54-55 length()` returns the constant
+        // `typelen`; there is no field to read, so the class guard above is
+        // the whole proof and the box below folds to a constant.
+        BuiltinLenSource::PairArity => ctx.trace_ctx.const_int(concrete_len as i64),
     };
     ctx.trace_ctx
         .set_opref_concrete(raw_len, majit_ir::Value::Int(concrete_len as i64));

--- a/pyre/pyre-object/src/iterobject.rs
+++ b/pyre/pyre-object/src/iterobject.rs
@@ -185,6 +185,19 @@ pub unsafe fn is_memory_iter(obj: PyObjectRef) -> bool {
     !obj.is_null() && (*obj).ob_type == &MEMORY_ITER_TYPE as *const PyType
 }
 
+/// `bytearray_iterator` — the one producer-specific `W_SeqIterObject` identity
+/// that carries exhaustion in the cursor: `__setstate__` turns a negative state
+/// into the -1 exhausted sentinel instead of rewinding to the front, and no
+/// later `__setstate__` revives it.  Its immutable siblings (`str`, `bytes`)
+/// and `arrayiterator` clamp a negative state to zero.
+#[inline]
+pub unsafe fn is_bytearray_iter(obj: PyObjectRef) -> bool {
+    if crate::tagged_int::CAN_BE_TAGGED && crate::tagged_int::is_tagged_int(obj) {
+        return false;
+    }
+    !obj.is_null() && (*obj).ob_type == &BYTEARRAY_ITER_TYPE as *const PyType
+}
+
 /// `array.arrayiterator` — carries `__reduce__` / `__setstate__` but, unlike
 /// the str and bytes flavours, no `__length_hint__`.
 #[inline]


### PR DESCRIPTION
Five commits on top of `origin/main`, in two groups.

## Two JIT folds

One folds `long`/`int` arithmetic whose result fits a machine word, so the
mixed-operand shapes stop residualising through the bigint path when the answer
is small. The other folds `len()` and `[i]` on the arity-2 tuple specialisations:
the pair goes virtual, so the allocation disappears.

The subscript fold sits next to main's `dict.lookup` specialisation in
`try_walker_specialize_subscr` — the two gates are disjoint (`ob_type ==
SPECIALISED_TUPLE_{II,FF,OO}` vs `&DICT_TYPE`), and both sit under the canonical
`&TUPLE_TYPE` gate, which is why that gate is `ob_type ==` and not `is_tuple()`.

New parity fixture `subscr_specialised_pair_shapes.py`, plus extensions to
`rbigint_mixed_int_jit.py` and `unpack_specialised_pair_shapes.py`.

`divmod_long_int_pair`'s ceiling tightens to 8x after the fold — headroom, not
sensitivity: the worst ratio measured across platforms is 3.7x, and losing
either fold also moves `guard_failures`, which the jit-stats baselines gate in
both directions. `rbigint_perf_matrix.py` gets a no-argument mode; it read
`sys.argv[1]` unconditionally, which is a permanent crash under
`wasm_check.py`, which passes no argv.

## The iterator `__setstate__` cursor

Nine builtin iterator identities brought in line with the 3.14 oracle. Measured
differences, all fixed:

| | before | 3.14 |
|---|---|---|
| `tuple`/`str`/`bytes`/`bytearray`/`array` `setstate(99)` | stores 99 | clamps to the length |
| `bytearray` `setstate(-5)` | rewinds to 0 | `-1`, exhausted and one-way |
| `reversed` with a negative cursor | reduces to the live form | empty form, no revival |
| every iterator `setstate("x")` | `expected integer, got str object` | `an integer is required` |
| every iterator `setstate(1 << 100)` | `int too large to convert to int` | `Python int too large to convert to C ssize_t` |
| an `__index__` object | accepted | rejected (`PyLong_AsSsize_t` takes int only) |

The clamp reads the **live** length, so growing a `bytearray` after taking its
iterator clamps to the new length. The generic `sequenceiterator` (the
`__getitem__`-only one) does **not** clamp — it cannot know a length, 3.14 agrees,
and `test_iter.test_iter_overflow` depends on it.

The `str` clamp is a port gap: PyPy's `W_FastUnicodeIterObject.descr_setstate`
(`pypy/objspace/std/iterobject.py:129-140`) already has it. The
`tuple`/`bytes`/`bytearray` clamps have no PyPy counterpart and follow the 3.14
target; the comments record which is which.

New parity fixture `iterator_setstate_python314.py` covers all nine identities.

## Verification

Rebuilt from `origin/main` after the rebase, LLBC re-extracted:

- `pyre/check.py` — **ALL PASSED, 3/3 backend runs**: dynasm 389/389,
  cranelift 389/389, wasm 385/385
- `parity_tests/run.py` — 193/193 on cpython 3.14 + dynasm + cranelift
- `cargo check --workspace --all-targets` — clean

## What this branch no longer carries

An earlier revision also reworked the derived pypy perf floor and added the
missing `OK` sentinel to three parity fixtures. #1080 landed both, and its floor
is the better design: `min(1.0, ceiling / 25)` puts the floor at parity and
drops it proportionally only once the ceiling comes within 25x of parity, which
removes the whole population of fixtures whose floor would otherwise sit below
1x — the ones this branch's flat divisor could only get past by relying on
their baseline never arming. #1080 also raises `FLOOR_GATE_MIN_BASELINE_S` from
3x to 10x the execution floor, and rejects a leftover `min-pypy-ratio` header
instead of ignoring it. Those commits are dropped; `check.py` is untouched here.

`divmod_long_int_pair.wasm.jitstats` needed a measurement rather than a merge:
the baseline read 9 before, #1073 re-recorded it to 4, and this branch's fold
had taken it to 6. On the combined tree it measures 4 — the two reductions do
not add — and the wasm leg passes at that value.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iterator state restoration, exhaustion handling, cursor clamping, and invalid-value errors for better Python compatibility.
  - Corrected behavior for bytearray, sequence, tuple, reverse, and array iterators, including exhausted and revived states.

- **Performance**
  - Improved execution of large-integer operations and specialized tuple indexing, unpacking, length checks, and negative-index access.

- **Testing**
  - Added broader compatibility coverage for Python 3.14 iterator behavior, integer operations, tuple access, and unpacking.

- **Documentation**
  - Expanded benchmark usage to run registered cases and report validation checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->