### PR TITLE
check.py: derive the pypy ratio floor from the ceiling, and arm it only on measurable baselines

### DIFF
--- a/pyre/bench/synth/arith_int_bool.py
+++ b/pyre/bench/synth/arith_int_bool.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=381
-# pyre-check: min-pypy-ratio=26
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/attr_cache_invalidation.py
+++ b/pyre/bench/synth/attr_cache_invalidation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=28
-# pyre-check: min-pypy-ratio=3.25
 N = 100000
 
 

--- a/pyre/bench/synth/attr_instance_shadows_class.py
+++ b/pyre/bench/synth/attr_instance_shadows_class.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=265
-# pyre-check: min-pypy-ratio=14
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (131.0x), rounded up, and the floor is half the fastest
-# (29.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (131.0x), rounded up.
 # An instance attribute shadows a same-named non-data-descriptor class
 # attribute on builtin-type subclasses (tuple/int/str), while a data descriptor
 # still wins over a competing instance-dict entry (injected directly, since the

--- a/pyre/bench/synth/attr_store_add_transition.py
+++ b/pyre/bench/synth/attr_store_add_transition.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.55
 # STORE_ATTR that ADDS an attribute not yet in the instance's map: the
 # `map -> PlainAttribute` transition plus the grow-by-one storage rewrite
 # (mapdict.py:942-959 `_set_mapdict_increase_storage1`).  The values are

--- a/pyre/bench/synth/bases_reassign_cache.py
+++ b/pyre/bench/synth/bases_reassign_cache.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6.6
-# pyre-check: min-pypy-ratio=1.05
 # Reassigning type.__bases__ recomputes the MRO of the type and every
 # subclass and invalidates the method/attribute lookup cache, so a method or
 # class attribute that was resolved before the swap resolves through the new

--- a/pyre/bench/synth/binary_int_overflow_local_resume.py
+++ b/pyre/bench/synth/binary_int_overflow_local_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=1.85
 # Overflowing integer operations must resume with the values that were loaded
 # from local slots, including values produced by recursive calls and unpacking.
 

--- a/pyre/bench/synth/binary_slice_index.py
+++ b/pyre/bench/synth/binary_slice_index.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=115
-# pyre-check: min-pypy-ratio=5.35
 # Slice bounds are evaluated through __index__ in both lowering paths:
 #   * a dynamic slice `seq[a:b]` compiles to BINARY_SLICE, handled by
 #     `binary_slice_values`;

--- a/pyre/bench/synth/bound_method_builtin_fold.py
+++ b/pyre/bench/synth/bound_method_builtin_fold.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=48
-# pyre-check: min-pypy-ratio=4.68
 # `lst.append(x)` on a builtin receiver: the name resolves to a builtin-code
 # function on the type, so LOAD_ATTR's method fast path declines (it only
 # pushes `[descr, self]` for `flag_method_descriptor` types) and `getattr`

--- a/pyre/bench/synth/break_except_live_local.py
+++ b/pyre/bench/synth/break_except_live_local.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=22
-# pyre-check: min-pypy-ratio=3.48
 MODULUS = 1_000_003
 
 

--- a/pyre/bench/synth/bridge_branchy_callee.py
+++ b/pyre/bench/synth/bridge_branchy_callee.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=10
-# pyre-check: min-pypy-ratio=0.85
 # A branch inside an inlined callee (gh#343). `compute_branch` guard-fails on the
 # rare arm (`x % 7 == 0`); without a compiled bridge for the inlined callee's
 # continuation every crossing deopts to the blackhole (~34x slower on the native

--- a/pyre/bench/synth/bridge_global_fold_invalidate_hot.py
+++ b/pyre/bench/synth/bridge_global_fold_invalidate_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=2.75
 # A read-only module global read on a COLD arm (a branch, a genexpr, or a
 # function that gets rebound) compiles as a bridge that const-folds the global
 # via a quasi-immutable fold. A mid-loop same-key reassignment (or a function

--- a/pyre/bench/synth/bridge_recursion_overflow.py
+++ b/pyre/bench/synth/bridge_recursion_overflow.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=2.45
 # Parity fixture for the depth-1 bridge self-recursive inline lift
 # (#704). `f` is a tail-recursive
 # exact-integer callee whose `acc * 2 + 1` crosses the machine-int boundary

--- a/pyre/bench/synth/build_class_surrogate_namespace.py
+++ b/pyre/bench/synth/build_class_surrogate_namespace.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=7.8
-# pyre-check: min-pypy-ratio=1.25
 # A __prepare__ namespace whose keys include a lone surrogate must be read back
 # into the class without assuming the keys are valid UTF-8 (the class-statement
 # / __build_class__ gather and the metaclass replay both iterate the keys).

--- a/pyre/bench/synth/build_container_return_resume.py
+++ b/pyre/bench/synth/build_container_return_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=16
-# pyre-check: min-pypy-ratio=1.68
 # Builds a container (tuple / list / set / dict / str) AFTER a hot loop and
 # returns it.  The loop-exit guard failure resumes via the blackhole, which
 # then walks the forward path through the container-build residual

--- a/pyre/bench/synth/build_set_hashability.py
+++ b/pyre/bench/synth/build_set_hashability.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=105
-# pyre-check: min-pypy-ratio=9.08
 # BUILD_SET (the {...} set literal) hashes every element through
 # space.hash_w, so an unhashable element — a list, or an instance whose
 # __hash__ is None / raises / returns a non-int — raises instead of silently

--- a/pyre/bench/synth/bytes_split_whitespace_maxsplit.py
+++ b/pyre/bench/synth/bytes_split_whitespace_maxsplit.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=65
-# pyre-check: min-pypy-ratio=3.48
 # bytes/bytearray split/rsplit on whitespace (sep=None) with a positive
 # maxsplit keeps the surrounding whitespace of the final remainder field,
 # matching str. Output verified against CPython/PyPy.

--- a/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.py
+++ b/pyre/bench/synth/ca_bridge_multiframe_resume_double_call.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=1.45
 # A CALL_ASSEMBLER guard failure whose bridge resume spans two frames: the
 # walk runs the resumed region to the callee's return, executing the recursive
 # calls inside it concretely, and the walk's result completes the callee. If

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=8
-# pyre-check: min-pypy-ratio=1.28
 # A loop that defines a function in its own body and calls it.
 #
 # `pyopcode.py:1457 MAKE_FUNCTION` runs `function.py:47-57 Function.__init__`

--- a/pyre/bench/synth/call_star_forms_inlined_callee.py
+++ b/pyre/bench/synth/call_star_forms_inlined_callee.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=2.62
 # CALL_KW and CALL_FUNCTION_EX inside a callee that is inlined into the hot
 # loop.  Both opcodes used to emit abort_permanent and decline the callee's
 # jitcode; the residual port lets them compile.  Guards output correctness and

--- a/pyre/bench/synth/callable_iterator_type.py
+++ b/pyre/bench/synth/callable_iterator_type.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=24
-# pyre-check: min-pypy-ratio=3.85
 # iter(callable, sentinel) yields a properly-registered iterator type: type(it)
 # is a real type object, the iterator is an object instance, and __iter__
 # returns self. The concrete type name differs across implementations, so only

--- a/pyre/bench/synth/calls_closures.py
+++ b/pyre/bench/synth/calls_closures.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=109
-# pyre-check: min-pypy-ratio=7.95
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/class_attrs_methods.py
+++ b/pyre/bench/synth/class_attrs_methods.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=15
-# pyre-check: min-pypy-ratio=1.15
 N = 600000
 
 

--- a/pyre/bench/synth/class_reassign_hot.py
+++ b/pyre/bench/synth/class_reassign_hot.py
@@ -1,4 +1,7 @@
-# pyre-check: max-pypy-ratio=47
+# pyre-check: max-pypy-ratio=100
+# The ceiling is twice the slowest ratio the CI runners observe (49.3x on the
+# linux runner's cranelift), rounded up. It read 218 before a later tightening
+# fitted it to a single run's numbers.
 # Reassigning obj.__class__ inside a hot loop must actually re-root the
 # instance's type, so method lookup and type() follow the new class.  The
 # STORE_ATTR mapdict inline cache (store_attr_slowpath) used to classify

--- a/pyre/bench/synth/class_reassign_hot.py
+++ b/pyre/bench/synth/class_reassign_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=47
-# pyre-check: min-pypy-ratio=5.38
 # Reassigning obj.__class__ inside a hot loop must actually re-root the
 # instance's type, so method lookup and type() follow the new class.  The
 # STORE_ATTR mapdict inline cache (store_attr_slowpath) used to classify

--- a/pyre/bench/synth/closure_freevar_branch_resume.py
+++ b/pyre/bench/synth/closure_freevar_branch_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=28
-# pyre-check: min-pypy-ratio=3.92
 # gh#498 guard: a branch resume must keep the current closure-call result
 # local, across the three freevar flavours.
 #

--- a/pyre/bench/synth/closure_per_call.py
+++ b/pyre/bench/synth/closure_per_call.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=167
-# pyre-check: min-pypy-ratio=18
 # Regression guard for the per-call-created nested closure JIT hang.
 #
 # `add` is defined fresh on every `make` call, and `make` is driven from a

--- a/pyre/bench/synth/complex_real_imag.py
+++ b/pyre/bench/synth/complex_real_imag.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.65
 # complex.real / complex.imag are read-only getset descriptors bound to the
 # complex type: they carry __objclass__ == complex and __name__, reject a
 # non-complex receiver with TypeError, and reject assignment with

--- a/pyre/bench/synth/comprehension_object_append_hot.py
+++ b/pyre/bench/synth/comprehension_object_append_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=41
-# pyre-check: min-pypy-ratio=5.28
 # An inlined list comprehension whose LIST_APPEND element lands in a list
 # Object-strategy (tuple / None / str / dict / f-string) folds through the #171
 # orthodox append. Its Object arm stores a GC ref and runs list_write_barrier,

--- a/pyre/bench/synth/const_arg_call_resume.py
+++ b/pyre/bench/synth/const_arg_call_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=34
-# pyre-check: min-pypy-ratio=4.15
 # pypy JITs these tiny list loops to a near-zero denominator, so the ratio is
 # dominated by measurement noise on the CI runner (measured 35-43x); the gate
 # is set above that band rather than tightened onto the collapsed baseline.

--- a/pyre/bench/synth/context_manager.py
+++ b/pyre/bench/synth/context_manager.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=4.52
 N = 75000
 
 

--- a/pyre/bench/synth/delete_negative_open_slice_hot.py
+++ b/pyre/bench/synth/delete_negative_open_slice_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=4.18
 # Two-argument BUILD_SLICE must pass the Python None singleton as its implicit
 # step.  Negative bounds make a malformed null step observable during slice
 # normalization, including on guard-failure blackhole resume.

--- a/pyre/bench/synth/dict_ctor_consume.py
+++ b/pyre/bench/synth/dict_ctor_consume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=61
-# pyre-check: min-pypy-ratio=4.65
 # dict.__new__ allocates and ignores its arguments; filling the instance is
 # __init__'s job. So dict(x) walks x exactly once: a mapping's keys() and
 # __getitem__ each run one time per key, a one-shot iterable is not re-entered,

--- a/pyre/bench/synth/dict_hash_protocol.py
+++ b/pyre/bench/synth/dict_hash_protocol.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=25
-# pyre-check: min-pypy-ratio=2.82
 # dict.fromkeys fills a plain dict through the dict's own setitem, so a key
 # whose __hash__ raises propagates that exception instead of being stored
 # unhashed. Only the keys and items views are set-like and therefore

--- a/pyre/bench/synth/dict_set.py
+++ b/pyre/bench/synth/dict_set.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=58
-# pyre-check: min-pypy-ratio=6.18
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/dict_set_key_eq_operand_order.py
+++ b/pyre/bench/synth/dict_set_key_eq_operand_order.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=41
-# pyre-check: min-pypy-ratio=3.62
 # A dict/set bucket probe compares the key already stored against the incoming
 # one, in that order (`ll_dict_lookup` runs `keyeq(checkingkey, key)`).  The
 # order decides whose `__eq__` the comparison protocol reaches first, so it is

--- a/pyre/bench/synth/dict_update_hot.py
+++ b/pyre/bench/synth/dict_update_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=32
-# pyre-check: min-pypy-ratio=2.75
 # N/ITERS are kept small so the wasm backend finishes inside the synthetic
 # timeout: wasm runs every guard-exit re-entry through the not-yet-collected
 # interpreter allocation path, so the run's wall grows super-linearly in ITERS

--- a/pyre/bench/synth/dict_view_set_ops.py
+++ b/pyre/bench/synth/dict_view_set_ops.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=25
-# pyre-check: min-pypy-ratio=3.8
 # A set operation on a dict view builds a set from the left operand and runs
 # the matching in-place set method against the right one, so the result is a
 # plain set. The reflected forms build the set from the other operand, keeping

--- a/pyre/bench/synth/dir_dict_class_attrs.py
+++ b/pyre/bench/synth/dir_dict_class_attrs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=4.8
-# pyre-check: min-pypy-ratio=0.22
 # util.py:80 _objectdir / objectobject.py:324 — dir() of a dict instance lists
 # the dict type's attributes (object.__dir__), NOT the dict's own keys.
 

--- a/pyre/bench/synth/divmod_long_int_pair.py
+++ b/pyre/bench/synth/divmod_long_int_pair.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=2.38
 # `divmod(long, int)` at a traced call site. `_int_divmod` keeps the divisor
 # unwrapped and calls `rbigint.int_divmod`, whose rtyped return is a two-item
 # `GcStruct`: the walker emits one elidable call plus two `getfield_gc_r`, then

--- a/pyre/bench/synth/dunder_repr_str_errors.py
+++ b/pyre/bench/synth/dunder_repr_str_errors.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=2.45
 # Exceptions raised by `__repr__`/`__str__` overrides propagate out of
 # `repr()`/`str()`/`format`/`%`/f-strings instead of being swallowed,
 # including builtin-leaf subclasses and through container recursion.

--- a/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
+++ b/pyre/bench/synth/exc_bridge_entry_guard_not_removed.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=38
-# pyre-check: min-pypy-ratio=2.72
 # A residual callee raises for the extremes of a hot descending loop and
 # returns in the middle, so the loop trace's exception guard chronically fails
 # WITHOUT a pending exception and a no-exception bridge gets compiled.  That

--- a/pyre/bench/synth/exc_caught_in_callee_return_loop.py
+++ b/pyre/bench/synth/exc_caught_in_callee_return_loop.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=55
-# pyre-check: min-pypy-ratio=9.08
 # A callee catches a residual-call exception in-frame and RETURNS a sentinel
 # into a JIT-hot outer loop.  When the callee gets hot enough that a bridge is
 # compiled for the exception-guard (GUARD_NO_EXCEPTION) failure on the

--- a/pyre/bench/synth/exc_in_loop_divzero_continue.py
+++ b/pyre/bench/synth/exc_in_loop_divzero_continue.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6.6
-# pyre-check: min-pypy-ratio=0.78
 # A try/except INSIDE a hot loop whose body raises through a may-force
 # residual call (`//`, `%`, `int("z")`) on some iterations and is CAUGHT,
 # with the loop CONTINUING afterwards.  The raising op is int-specialized

--- a/pyre/bench/synth/except_star.py
+++ b/pyre/bench/synth/except_star.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=3.8
-# pyre-check: min-pypy-ratio=0.48
 def m(label, value):
     print(label, "->", repr(value))
 

--- a/pyre/bench/synth/exception_args_virtual.py
+++ b/pyre/bench/synth/exception_args_virtual.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=21
-# pyre-check: min-pypy-ratio=1.95
 N = 250000
 
 

--- a/pyre/bench/synth/exception_as_cell_cleanup.py
+++ b/pyre/bench/synth/exception_as_cell_cleanup.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=22
-# pyre-check: min-pypy-ratio=2.05
 # An `except E as e:` handler whose exception variable `e` is captured by a
 # nested function makes `e` a cell variable, so the implicit handler cleanup
 # emits DELETE_DEREF (clear the cell contents) rather than DELETE_FAST. The

--- a/pyre/bench/synth/exception_bare_reraise_nested_outer.py
+++ b/pyre/bench/synth/exception_bare_reraise_nested_outer.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.62
 # Bare `raise` inside a nested handler whose re-raise must reach the OUTER
 # handler, exercised under a bridge resume that lands inside the inner handler.
 #

--- a/pyre/bench/synth/exception_catching_frame_tb_node.py
+++ b/pyre/bench/synth/exception_catching_frame_tb_node.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=2.28
 # The frame holding the `try` contributes its own traceback node, including
 # when its `except` is reached from inside its own compiled trace.
 #

--- a/pyre/bench/synth/exception_const_operand_resume.py
+++ b/pyre/bench/synth/exception_const_operand_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=20
-# pyre-check: min-pypy-ratio=2.68
 # Exception-resume bridge (GuardException) with a CONSTANT pre-call operand.
 # Each `try` divides/indexes with a CONSTANT numerator/addend that lives on the
 # operand stack at the raising bytecode. The loop warms up exception-free

--- a/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.py
+++ b/pyre/bench/synth/exception_escape_hot_callee_tb_node_once.py
@@ -1,11 +1,10 @@
 # pyre-check: max-pypy-ratio=73
-# pyre-check: min-pypy-ratio=3.22
 # A hot compiled CALLEE holding a try block the exception does not stay in used
 # to record its own traceback node TWICE.
 #
 # Every iteration of every driver raises and unwinds, so the ratio measures
 # exception throughput rather than the contract under test, and it varies 2.5x
-# across hosts -- hence the explicit floor beside the ceiling.
+# across hosts.
 #
 # N is 4000 because the witness needs the callee compiled: the duplicate node
 # first appears at N=2500 and never at N=1500, and 4000 reproduces every one of

--- a/pyre/bench/synth/exception_group_type.py
+++ b/pyre/bench/synth/exception_group_type.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5.2
-# pyre-check: min-pypy-ratio=0.32
 def m(label, value):
     print(label, "->", repr(value))
 

--- a/pyre/bench/synth/exception_inline_callee_tb_frames.py
+++ b/pyre/bench/synth/exception_inline_callee_tb_frames.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=3.42
 # An exception raised in an inlined callee and caught two or three frames up
 # must still attach a traceback node for every frame it passed through: one at
 # the raise instruction and one per callee->caller propagation.

--- a/pyre/bench/synth/exception_inlined_callee_caught.py
+++ b/pyre/bench/synth/exception_inlined_callee_caught.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=73
-# pyre-check: min-pypy-ratio=7.78
 N = 100000
 
 

--- a/pyre/bench/synth/exception_metadata_hot.py
+++ b/pyre/bench/synth/exception_metadata_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.72
 # Exception metadata observed from inside JIT-hot handlers: traceback
 # attachment and shape, __context__ / __cause__ chaining, sys.exc_info, handler
 # name clearing, and re-raise.

--- a/pyre/bench/synth/exception_metadata_jitstress.py
+++ b/pyre/bench/synth/exception_metadata_jitstress.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=4
-# pyre-check: min-pypy-ratio=0.28
 # JIT-stress twin of exception_metadata_hot: `pypyjit.set_param` lowers the
 # trace/function thresholds to 1 so recording fires on the earliest iterations
 # of every section rather than only after the ~1600-iteration warmup. That

--- a/pyre/bench/synth/exception_multi_handler_warmup.py
+++ b/pyre/bench/synth/exception_multi_handler_warmup.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=17
-# pyre-check: min-pypy-ratio=2.62
 # Multi-except dispatch + counter-only handler bodies on the blackhole
 # guard-failure resume path. The loop warms up exception-free (so the trace
 # compiles the no-exception path), then raises ZeroDivisionError and

--- a/pyre/bench/synth/exception_oserror_fields.py
+++ b/pyre/bench/synth/exception_oserror_fields.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=47
-# pyre-check: min-pypy-ratio=6.72
 N = 200000
 
 

--- a/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
+++ b/pyre/bench/synth/exception_raise_caught_same_frame_tb.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=45
-# pyre-check: min-pypy-ratio=3.45
 # A frame that raises and catches in one body contributes EXACTLY ONE
 # traceback node, and it keeps that count once the loop is compiled.
 #

--- a/pyre/bench/synth/exception_reduce.py
+++ b/pyre/bench/synth/exception_reduce.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=32
-# pyre-check: min-pypy-ratio=3.38
 N = 50000
 
 

--- a/pyre/bench/synth/exception_reraise_tb_depth_hot.py
+++ b/pyre/bench/synth/exception_reraise_tb_depth_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5.5
-# pyre-check: min-pypy-ratio=0.52
 # A bare re-raise caught in the same frame keeps the original traceback: no
 # node is attached at a re-raise coordinate (RaiseWithExplicitTraceback,
 # attach_tb=False). The module-level loop makes the recording iteration itself

--- a/pyre/bench/synth/exception_reraise_tb_depth_jitstress.py
+++ b/pyre/bench/synth/exception_reraise_tb_depth_jitstress.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=4
-# pyre-check: min-pypy-ratio=0.22
 # JIT-stress twin of exception_reraise_tb_depth_hot: `pypyjit.set_param`
 # lowers the trace/function thresholds to 1 so trace recording fires on the
 # earliest iterations rather than only after the ~1600-iteration warmup. That

--- a/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
+++ b/pyre/bench/synth/exception_residual_raise_caught_in_frame.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=34
-# pyre-check: min-pypy-ratio=2.12
 # A frame that catches an exception a residual call raised contributes its own
 # traceback node, including once its `except` is reached from inside its own
 # compiled trace.

--- a/pyre/bench/synth/exception_subclass_attrs.py
+++ b/pyre/bench/synth/exception_subclass_attrs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=80
-# pyre-check: min-pypy-ratio=5.32
 N = 200000
 
 

--- a/pyre/bench/synth/exception_traceback_lineno_chain.py
+++ b/pyre/bench/synth/exception_traceback_lineno_chain.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=22
-# pyre-check: min-pypy-ratio=2.48
 # Every traceback node keeps the line its frame was executing, including for
 # a frame the JIT compiled and exited with an uncaught exception.
 #

--- a/pyre/bench/synth/exception_traceback_loop_forms.py
+++ b/pyre/bench/synth/exception_traceback_loop_forms.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=4.6
 # Traceback nodes recorded by a compiled loop, driven by BOTH loop forms.
 #
 # The sibling exception-traceback fixtures all drive their workload with

--- a/pyre/bench/synth/exception_try_call_inlined_callee_raise.py
+++ b/pyre/bench/synth/exception_try_call_inlined_callee_raise.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=24
-# pyre-check: min-pypy-ratio=2.42
 # A conditional raise two call levels below a `try` must reach the enclosing
 # `except`, including once the frame holding the `try` runs as its own compiled
 # trace.

--- a/pyre/bench/synth/exception_value_op_caught.py
+++ b/pyre/bench/synth/exception_value_op_caught.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=52
-# pyre-check: min-pypy-ratio=3
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (25.1x), rounded up, and the floor is half the fastest
-# (6.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (25.1x), rounded up.
 N = 100000
 
 

--- a/pyre/bench/synth/fast_local_swap.py
+++ b/pyre/bench/synth/fast_local_swap.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=1.35
 N = 400000
 
 

--- a/pyre/bench/synth/finally_bare_raise.py
+++ b/pyre/bench/synth/finally_bare_raise.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=7.2
-# pyre-check: min-pypy-ratio=0.48
 # A hot loop FOLLOWED by a `finally` (or nested `finally`) containing a
 # bare `raise` (RAISE_VARARGS argc==0).  When such a bare re-raise is
 # reached by normal fall-through — no `PUSH_EXC_INFO` seeded the handler

--- a/pyre/bench/synth/float_div_zero_caught_loop.py
+++ b/pyre/bench/synth/float_div_zero_caught_loop.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=50
-# pyre-check: min-pypy-ratio=4.45
 # Float true-division by zero inside a try in a JIT-hot callee.  The walker
 # specializes `float / float` to a bare `FloatTrueDiv` llop (raw IEEE), which
 # would compute `inf` for a zero divisor instead of raising ZeroDivisionError.

--- a/pyre/bench/synth/float_subclass_binop_dispatch.py
+++ b/pyre/bench/synth/float_subclass_binop_dispatch.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=143
-# pyre-check: min-pypy-ratio=6.75
 # A float subclass that overrides the arithmetic and comparison dunders, driven
 # hot enough to compile. The walker's float specialization lowers BINARY_OP to
 # `FloatAdd` / `FloatSub` / `FloatMul` / `FloatTrueDiv` and COMPARE_OP to

--- a/pyre/bench/synth/for_iter_select_receiver_swap.py
+++ b/pyre/bench/synth/for_iter_select_receiver_swap.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=16
-# pyre-check: min-pypy-ratio=2.35
 # A conditional expression selects one of two loop locals as the receiver
 # (`q = o if cond else p`) whose attribute is then read/written inside a hot
 # `for i in range(...)` loop.  The two arms of the conditional are distinct

--- a/pyre/bench/synth/foriter_call_body.py
+++ b/pyre/bench/synth/foriter_call_body.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=20
-# pyre-check: min-pypy-ratio=2.72
 # FOR_ITER body with a CALL: the JIT must handle calls inside for-loop bodies
 # correctly without replaying the last iteration on deopt.  `accumulating`
 # additionally threads the running total through the call, so the inline

--- a/pyre/bench/synth/foriter_call_resume_drops_iteration.py
+++ b/pyre/bench/synth/foriter_call_resume_drops_iteration.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=2.72
 # A `for` body that calls two DISTINCT recursive functions and then runs one
 # more statement, with the branch it takes flipping after warm-up. Once a callee
 # owns a compiled loop the walk aborts the enclosing trace

--- a/pyre/bench/synth/foriter_exempt_nested_foriter.py
+++ b/pyre/bench/synth/foriter_exempt_nested_foriter.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=44
-# pyre-check: min-pypy-ratio=5.88
 # gh#495 guard: fbw_abort_nested_unjournaled_residual prevents the ForIterNext exemption double-advance.
 # branch-bearing callee with a SECOND FOR_ITER (nested), not the loop header.
 # Two shared generators; inner FOR_ITER advance is a non-header foriter (Finding #2).

--- a/pyre/bench/synth/foriter_in_while.py
+++ b/pyre/bench/synth/foriter_in_while.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=16
-# pyre-check: min-pypy-ratio=1.45
 # FOR_ITER inside a while-loop: the common real-world pattern.
 # The while-loop is the JIT entry; the for-loop body must handle the FOR_ITER
 # liveness scoping correctly.  `outer_var` additionally reads the outer

--- a/pyre/bench/synth/foriter_inplace_immutable.py
+++ b/pyre/bench/synth/foriter_inplace_immutable.py
@@ -1,4 +1,8 @@
-# pyre-check: max-pypy-ratio=15
+# pyre-check: max-pypy-ratio=34
+# pypy's exec time is pinned to the startup-subtraction floor on some hosts,
+# so the ratio is not a measurement everywhere: the ceiling is twice the
+# slowest the CI runners observe (16.9x), rounded up. It read 36 before a later
+# tightening fitted it to a single run's numbers.
 """FOR_ITER must not drop an item when immutable ``+=`` ends a hot body."""
 
 

--- a/pyre/bench/synth/foriter_inplace_immutable.py
+++ b/pyre/bench/synth/foriter_inplace_immutable.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=15
-# pyre-check: min-pypy-ratio=2.15
 """FOR_ITER must not drop an item when immutable ``+=`` ends a hot body."""
 
 

--- a/pyre/bench/synth/foriter_user_iter_kept_stack.py
+++ b/pyre/bench/synth/foriter_user_iter_kept_stack.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=2.65
 # User-defined iterator FOR_ITER paths enter a user frame for each item while
 # the caller keeps a depth > 1 operand stack resident across condexpr and
 # short-circuit branch guards.  The kept-stack branch guards must remain

--- a/pyre/bench/synth/format_z_negative_zero.py
+++ b/pyre/bench/synth/format_z_negative_zero.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.72
 # PEP 682 `z` format option: coerce a negative-zero result to positive zero.
 # The float renderings below are byte-identical across CPython and PyPy; the
 # integer `z` rejection differs only in message wording, so this fixture checks

--- a/pyre/bench/synth/gc_deque_backing_list.py
+++ b/pyre/bench/synth/gc_deque_backing_list.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=2.45
 # collections.deque holds its backing list solely through the deque object.
 # If the marker traces the deque with an empty offset set, that list is not
 # forwarded and is swept/moved on a collection driven by a hot allocator loop

--- a/pyre/bench/synth/gc_iterator_source_drop.py
+++ b/pyre/bench/synth/gc_iterator_source_drop.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=3.02
 # Immortal iterator/sequence wrappers (enumerate, itertools.filterfalse,
 # takewhile) hold their source iterator solely through the wrapper object.  The
 # marker never scans an immortal wrapper, so unless its child offsets are

--- a/pyre/bench/synth/generator_pep479.py
+++ b/pyre/bench/synth/generator_pep479.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=41
-# pyre-check: min-pypy-ratio=6.28
 # PEP 479: a StopIteration that escapes a generator body is replaced by
 # RuntimeError("generator raised StopIteration") chained from it, across every
 # drive path (list / for / tuple / next / send) and whether the StopIteration

--- a/pyre/bench/synth/generator_tree_recursion.py
+++ b/pyre/bench/synth/generator_tree_recursion.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=7.6
-# pyre-check: min-pypy-ratio=0.88
 # Generator-driven accumulation over recursive tree/linear results. The
 # tree_sum recursion once silently miscompiled on cranelift (first checksum
 # already wrong) and recovered a regalloc panic on dynasm. Deterministic;

--- a/pyre/bench/synth/getattr_surrogate_hook.py
+++ b/pyre/bench/synth/getattr_surrogate_hook.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.45
 # A lone-surrogate attribute name reaches the same __getattr__ fallbacks as a
 # normal name: a module-level __getattr__ (PEP 562) and a classmethod hook that
 # must be bound through __get__ before being called.

--- a/pyre/bench/synth/getattribute_override_no_bind.py
+++ b/pyre/bench/synth/getattribute_override_no_bind.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=374
-# pyre-check: min-pypy-ratio=33
 # Two regressions in one hot loop:
 #
 # 1. Binding: a non-default `__getattribute__` must suppress LOAD_METHOD

--- a/pyre/bench/synth/getframe_force_cancel_journal.py
+++ b/pyre/bench/synth/getframe_force_cancel_journal.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=3.08
 # Regression guard: a frame-forcing user @property that forces FIRST (the
 # escape flush commits mid-property) and mutates SECOND (the commit is then
 # withdrawn because the callee entered a user frame). The withdrawal must

--- a/pyre/bench/synth/getframe_inlined_callee_own_frame.py
+++ b/pyre/bench/synth/getframe_inlined_callee_own_frame.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=4.25
 # Regression guard: an INLINED callee that inspects its own frame via
 # sys._getframe(0) must still see ITS OWN frame, not its caller's. The walker
 # executes residuals concretely while an inline push never runs the

--- a/pyre/bench/synth/getframe_residual_callee_own_frame.py
+++ b/pyre/bench/synth/getframe_residual_callee_own_frame.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=32
-# pyre-check: min-pypy-ratio=5.15
 # Regression guard: a residual (may-force) callee that inspects its OWN frame
 # via sys._getframe() must not clear the traced CALLER's virtualizable tracing
 # token. Clearing it raised a spurious frame-escape with no committed resume pc,

--- a/pyre/bench/synth/getframe_stored_fback_walk.py
+++ b/pyre/bench/synth/getframe_stored_fback_walk.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=32
-# pyre-check: min-pypy-ratio=5.22
 # Regression guard: a callee stores its OWN frame (sys._getframe(0)); the loop
 # body later walks .f_back.f_locals as a SEPARATE residual. That read forces
 # the traced caller mid-expression; the escape flush must commit with the

--- a/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.py
+++ b/pyre/bench/synth/getframe_while_caller_locals_across_subwalk.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=34
-# pyre-check: min-pypy-ratio=5.45
 # Caller locals that are live ACROSS the inlined call, exercised at a vable
 # escape inside an inline sub-walk.
 #

--- a/pyre/bench/synth/getframe_while_captured_frame_outlives_call.py
+++ b/pyre/bench/synth/getframe_while_captured_frame_outlives_call.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=43
-# pyre-check: min-pypy-ratio=2.92
 # The callee's frame OUTLIVES the call and its f_back is read after the loop.
 #
 # This is the discriminator for the root `f_backref` operand in the multi-frame

--- a/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
+++ b/pyre/bench/synth/getframe_while_escaping_read_frame_identity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=62
-# pyre-check: min-pypy-ratio=10
 # The frame-identity read the multi-frame blackhole adopt commits, and the
 # regression guard for the path that commits it.
 #

--- a/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
+++ b/pyre/bench/synth/getframe_while_inlined_callee_subwalk.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=35
-# pyre-check: min-pypy-ratio=3.75
 # Coverage guard for the unconditional multi-frame blackhole path.
 #
 # A vable escape inside an INLINE sub-walk is what latches a multi-frame

--- a/pyre/bench/synth/getframe_while_subwalk_decline_shapes.py
+++ b/pyre/bench/synth/getframe_while_subwalk_decline_shapes.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=120
-# pyre-check: min-pypy-ratio=7.5
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (58.2x), rounded up, and the floor is half the fastest
-# (15.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (58.2x), rounded up.
 # Two sub-walk shapes the multi-frame blackhole build DECLINES, pinned so the
 # decline stays a decline rather than silently becoming a wrong answer.
 #

--- a/pyre/bench/synth/global_cell_shortpreamble_hot.py
+++ b/pyre/bench/synth/global_cell_shortpreamble_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=2.15
 # A module-global int accumulator carried through an inlined function that
 # branches on the loop variable `i`, where the loop body ALSO reads `i` at the
 # tail (a branch / dead guard / mid-loop reassignment). The `LOAD_NAME i` folds

--- a/pyre/bench/synth/global_quasiimmut_invalidation.py
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.05
 # Nested compiled loop + a conditional loop-carried store to a MODULE
 # GLOBAL that is read after the (untaken) store.  The read-only global
 # `x` folds to a constant in the primary loop under a

--- a/pyre/bench/synth/global_reassign.py
+++ b/pyre/bench/synth/global_reassign.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=1.22
 # Exercises JIT global-cache invalidation, for both cell kinds.
 #
 # `run_int` reads a module global reassigned to another int between calls: the

--- a/pyre/bench/synth/global_reassign_invalidation.py
+++ b/pyre/bench/synth/global_reassign_invalidation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=1.62
 N = 200000
 
 G = 100

--- a/pyre/bench/synth/goto_if_not_same_box.py
+++ b/pyre/bench/synth/goto_if_not_same_box.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5.6
-# pyre-check: min-pypy-ratio=0.78
 # Fused `goto_if_not_<cmp>` with the SAME box on both sides (`b1 is b2`).
 #
 # `record_or_fold_fused_guard` mirrors `opimpl_goto_if_not_<cmp>`

--- a/pyre/bench/synth/handler_reraise_second_exc.py
+++ b/pyre/bench/synth/handler_reraise_second_exc.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=17
-# pyre-check: min-pypy-ratio=1.88
 # A named `except X as m:` handler that raises a SECOND exception of a
 # different class (conditionally, alongside a bare reraise) while the function
 # also has a sibling `except` clause, and a hot `return` path. The func-entry

--- a/pyre/bench/synth/hash_subclass_disabled.py
+++ b/pyre/bench/synth/hash_subclass_disabled.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=106
-# pyre-check: min-pypy-ratio=17
 # A tuple/frozenset subclass that sets __hash__ = None is unhashable: hash()
 # and set insertion both raise TypeError instead of the structural fast path
 # hashing by contents. Output verified against CPython/PyPy.

--- a/pyre/bench/synth/if_else_jump_forward.py
+++ b/pyre/bench/synth/if_else_jump_forward.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=1.52
 N = 1500000
 
 

--- a/pyre/bench/synth/import_from_name_path.py
+++ b/pyre/bench/synth/import_from_name_path.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=1.78
 # A failed `from X import Y` raises ImportError carrying `.name` (the module)
 # and `.path` (its source file), per error.py new_import_error. The absolute
 # path is install-dependent, so only its basename is checked.  `keyword` is a

--- a/pyre/bench/synth/import_none_sentinel.py
+++ b/pyre/bench/synth/import_none_sentinel.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6.2
-# pyre-check: min-pypy-ratio=0.28
 # A None entry in sys.modules blocks the name: the import raises
 # ModuleNotFoundError('import of X halted; None in sys.modules') with .name set,
 # rather than reloading the module or searching for it. The sentinel is checked

--- a/pyre/bench/synth/inheritance_dispatch.py
+++ b/pyre/bench/synth/inheritance_dispatch.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.75
 N = 500000
 
 

--- a/pyre/bench/synth/inline_chain_depth_typeflip.py
+++ b/pyre/bench/synth/inline_chain_depth_typeflip.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=24
-# pyre-check: min-pypy-ratio=1.9
 # Inline chain of increasing depth whose argument flips int -> float partway
 # through the loop, so the type guard deopts with 2, 3 and 7 frames inlined.
 # Each depth keeps its own driver loop and its own chain so the trace shape is

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=25
-# pyre-check: min-pypy-ratio=3.95
 # An inlined closure keeps its freevar cells in MIFrame.registers_r across a
 # may-force call.  The `Fraction` arithmetic in `forward` is that may-force
 # call and invalidates heap-cache facts; the following LOAD_DEREF must recover

--- a/pyre/bench/synth/inline_gate_operand_provenance.py
+++ b/pyre/bench/synth/inline_gate_operand_provenance.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=164
-# pyre-check: min-pypy-ratio=10
 # The FOR_ITER inline gate admits a callee whose only unproven residual is a
 # `BINARY_OP` it expects the walker to specialize away.  That expectation rests
 # on `args_all_exact_*`, which describes the callee's INCOMING ARGUMENTS — so it

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.py
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=28
-# pyre-check: min-pypy-ratio=2.45
 # Module-scope hot loop inlining a 2-level call chain whose middle function has
 # a data-dependent branch — regression guard for the branchy inlined-callee
 # multi-frame carrier miscompile, in a pure and a journaled shape.

--- a/pyre/bench/synth/inline_subwalk_mutating_residual.py
+++ b/pyre/bench/synth/inline_subwalk_mutating_residual.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=40
-# pyre-check: min-pypy-ratio=7.12
 # gh#495 guard: an inlined subwalk whose callee makes an unjournaled mutation
 # through a nested residual CALL, in the two miss-handling shapes.
 #

--- a/pyre/bench/synth/inline_subwalk_property_mutates.py
+++ b/pyre/bench/synth/inline_subwalk_property_mutates.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=50
-# pyre-check: min-pypy-ratio=7.68
 # gh#495 guard: inlined property residual mutates before branch and caught miss.
 # @property value-returning mutating + try/except-inside-callee raising branch
 N = 60000

--- a/pyre/bench/synth/inline_subwalk_radd_consumed.py
+++ b/pyre/bench/synth/inline_subwalk_radd_consumed.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=30
-# pyre-check: min-pypy-ratio=4.55
 # gh#495 guard: reflected-add residual mutation feeds the inlined branch result.
 # radd result feeds the branch condition; branch varies each iter -> sub-walk churn
 N = 40000

--- a/pyre/bench/synth/inline_subwalk_user_iterator.py
+++ b/pyre/bench/synth/inline_subwalk_user_iterator.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=76
-# pyre-check: min-pypy-ratio=4.22
 # gh#495 guard: inlined callee consumes user iterator whose next mutates state.
 # FOR loop over user iterator INSIDE branch-bearing inlined callee; __next__ mutates shared counter
 N = 30000

--- a/pyre/bench/synth/inlined_callee_extended_arg_handler.py
+++ b/pyre/bench/synth/inlined_callee_extended_arg_handler.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=32
-# pyre-check: min-pypy-ratio=4.88
 # A callee whose exception handler is large enough that its jumps need
 # EXTENDED_ARG, inlined into a hot caller loop. The walker dequeues blocks
 # non-sequentially; a block ending on an EXTENDED_ARG code unit must not fold

--- a/pyre/bench/synth/inlined_helper_arith_hot.py
+++ b/pyre/bench/synth/inlined_helper_arith_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=1.18
 # One-line arithmetic helpers called from a hot `for` loop body. The inline
 # lever gates a FOR_ITER-in-flight callee on `fbw_callee_body_replay_safety`:
 # a body whose only residual is a BINARY_OP the walker will specialize to a

--- a/pyre/bench/synth/inlined_helper_mutation.py
+++ b/pyre/bench/synth/inlined_helper_mutation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=45
-# pyre-check: min-pypy-ratio=4.12
 # Inlined-callee shared-heap mutation parity, in both helper orderings.
 #
 # A tiny helper mutates a caller-owned list/instance inside a hot while-loop,

--- a/pyre/bench/synth/instance_dict_reassign.py
+++ b/pyre/bench/synth/instance_dict_reassign.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=61
-# pyre-check: min-pypy-ratio=4.82
 N = 50000
 
 

--- a/pyre/bench/synth/instance_surrogate_attrs.py
+++ b/pyre/bench/synth/instance_surrogate_attrs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=50
-# pyre-check: min-pypy-ratio=4.82
 N = 100000
 
 METH = '\udc81'   # lone surrogate naming a method on the class

--- a/pyre/bench/synth/int_base0_error_literal.py
+++ b/pyre/bench/synth/int_base0_error_literal.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.78
 # `int(s, 0)` reports the offending literal verbatim, keeping any surrounding
 # whitespace, rather than the internally trimmed value.
 def main():

--- a/pyre/bench/synth/int_from_bad_dunder.py
+++ b/pyre/bench/synth/int_from_bad_dunder.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=33
-# pyre-check: min-pypy-ratio=2.48
 # int() rejects a __int__ result that is not an int with TypeError (not an
 # internal RuntimeError). Output verified against CPython/PyPy.
 N = 40000

--- a/pyre/bench/synth/int_lshift_memoryerror.py
+++ b/pyre/bench/synth/int_lshift_memoryerror.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.88
 # A left shift whose result is too large to allocate raises a catchable
 # MemoryError instead of aborting the process on the big-int allocation
 # failure. Normal and moderately-large shifts still compute, and a negative

--- a/pyre/bench/synth/int_max_str_digits.py
+++ b/pyre/bench/synth/int_max_str_digits.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=20
-# pyre-check: min-pypy-ratio=0.5
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (9.1x), rounded up, and the floor is half the fastest
-# (1.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (9.1x), rounded up.
 # PEP 674 integer string-conversion length limit: sys.get/set_int_max_str_digits
 # with the default 4300, enforced on str()/repr()/f-string of a large int and on
 # int() parsing of a long decimal literal, bypassed for power-of-two bases, and

--- a/pyre/bench/synth/int_mul_ovf_bignum_promote.py
+++ b/pyre/bench/synth/int_mul_ovf_bignum_promote.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=4.2
-# pyre-check: min-pypy-ratio=0.38
 
 # Overflow-crossing int multiply on a JIT-hot path. The inner loop is traced
 # while `scale` is small (a*a stays in machine-int range, so the recorded

--- a/pyre/bench/synth/itertools_cycle.py
+++ b/pyre/bench/synth/itertools_cycle.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=0.75
 import itertools
 
 # GET_ITER + FOR_ITER directly over an itertools.cycle iterator. cycle is

--- a/pyre/bench/synth/jit_callee_raised_exc_value.py
+++ b/pyre/bench/synth/jit_callee_raised_exc_value.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=35
-# pyre-check: min-pypy-ratio=2.65
 # An exception raised by a CALLEE (a helper function or an exhausted generator)
 # with a per-iteration computed argument, caught in a hot JIT-traced caller's
 # `except ... as e`. walker_record_guard_exception discarded the GuardException

--- a/pyre/bench/synth/jit_reg_const_pool_256_slot_decline.py
+++ b/pyre/bench/synth/jit_reg_const_pool_256_slot_decline.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=122
-# pyre-check: min-pypy-ratio=9.72
 # A single hot function whose int register + constant-pool slot count exceeds the
 # 256-entry ceiling of the single-byte JitCode operand encoding (assembler.py chr()).
 # Such a trace cannot be encoded as single-byte slot operands, so it must be

--- a/pyre/bench/synth/kept_stack_boxed_in_handler.py
+++ b/pyre/bench/synth/kept_stack_boxed_in_handler.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.35
 # A boxed-int conditional-expression keeps a heap int (>= 256) live on the
 # operand stack across a `goto_if_not` branch guard INSIDE an exception
 # handler body.  The kept-stack guard's not-taken arm resumes at a PC the

--- a/pyre/bench/synth/kept_stack_branch_depths.py
+++ b/pyre/bench/synth/kept_stack_branch_depths.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=1.05
 # Kept-stack branch-guard recovery across resume depths.
 #
 # A `goto_if_not` whose not-taken arm resumes with operand-stack temps live is

--- a/pyre/bench/synth/kept_stack_deep_var_condexpr.py
+++ b/pyre/bench/synth/kept_stack_deep_var_condexpr.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=1.55
 # Deep operand-stack Variables live across an inner condexpr guard.
 # The first two tuple elements (a+i, b-i) are computed Variables left deep on
 # the value stack while the third element's `... if ... else ...` evaluates its

--- a/pyre/bench/synth/kept_stack_deep_var_shortcircuit.py
+++ b/pyre/bench/synth/kept_stack_deep_var_shortcircuit.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=62
-# pyre-check: min-pypy-ratio=6.18
 # Deep operand-stack Variables kept across a short-circuit guard, pure and
 # mutating.
 #

--- a/pyre/bench/synth/kept_stack_depth_gt1.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=25
-# pyre-check: min-pypy-ratio=1.58
 # Depth > 1 kept-stack branch guards: chained comparisons, nested
 # short-circuits and conditional expressions keep two or more operand-stack
 # temps live across a `goto_if_not`.  The not-taken arm resumes at a merge

--- a/pyre/bench/synth/kept_stack_depth_gt1_heap.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1_heap.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=2.08
 # Depth > 1 kept-stack branch guards whose kept / merge slot is a HEAP int
 # (>= 256, a LOAD_CONST rather than the inline LoadSmallInt).  Sibling of
 # `kept_stack_depth_gt1.py`, which keeps only small-int slots (11, 5, 2); here

--- a/pyre/bench/synth/key_eq_resize_restart.py
+++ b/pyre/bench/synth/key_eq_resize_restart.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=56
-# pyre-check: min-pypy-ratio=2.45
 """Key comparisons that grow the container they are probing.
 
 `ll_dict_lookup` restarts the whole lookup when a `keyeq` call replaced the

--- a/pyre/bench/synth/key_eq_restart_forgets.py
+++ b/pyre/bench/synth/key_eq_restart_forgets.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=3.62
 """A key comparison that disturbs the table is retried from scratch.
 
 `ll_dict_lookup` answers a disturbed probe with `return ll_dict_lookup(...)`

--- a/pyre/bench/synth/kwargs_positional_only.py
+++ b/pyre/bench/synth/kwargs_positional_only.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=22
-# pyre-check: min-pypy-ratio=0.5
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (10.7x), rounded up, and the floor is half the fastest
-# (1.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (10.7x), rounded up.
 # argument.py _match_keywords: a positional-only parameter passed by keyword is
 # absorbed into **kwargs when present, else raises; a keyword that duplicates an
 # already-bound positional raises "multiple values".  Exercised through the

--- a/pyre/bench/synth/len_dunder_validation.py
+++ b/pyre/bench/synth/len_dunder_validation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.38
 # `len()` runs the `__len__` result through `__index__` coercion and the
 # length checks: negative -> ValueError, non-int -> TypeError, and a value
 # too large for a machine word -> OverflowError.

--- a/pyre/bench/synth/list_append_funcentry_helper.py
+++ b/pyre/bench/synth/list_append_funcentry_helper.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=61
-# pyre-check: min-pypy-ratio=3.98
 # #171/#34: the orthodox list.append fold fires in function-entry (no-loop)
 # helper traces, not only loop traces.  `push` is a no-loop helper called in a
 # hot loop on two alternating receivers, so it traces from entry (header_pc==0)

--- a/pyre/bench/synth/list_append_write_barrier_gc.py
+++ b/pyre/bench/synth/list_append_write_barrier_gc.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=46
-# pyre-check: min-pypy-ratio=3.15
 # GC stress for the in-place Object-append write barrier the tracer does NOT
 # record. `w_list_append`'s in-place arm stores a GC ref into the items block
 # and runs `list_write_barrier`; when the block is GC-managed the backend GC

--- a/pyre/bench/synth/list_bound_method_mutation.py
+++ b/pyre/bench/synth/list_bound_method_mutation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=2.4
-# pyre-check: min-pypy-ratio=0.28
 # Bound list methods flowing as values (`m = xs.append; m(i)`) dispatch the
 # JIT's Method method-form arms, which get NO concrete execution
 # during tracing — their heap effect must stay deferred, unlike the

--- a/pyre/bench/synth/list_error_parity.py
+++ b/pyre/bench/synth/list_error_parity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=24
-# pyre-check: min-pypy-ratio=1.35
 # list error-message parity where 3.14 and PyPy AGREE (check.py oracle is
 # PyPy).  list.index's missing-value message DIVERGES — 3.14 says
 # "list.index(x): x not in list" (gh-100242 dropped the repr) while PyPy keeps

--- a/pyre/bench/synth/list_inplace_mul_parity.py
+++ b/pyre/bench/synth/list_inplace_mul_parity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.35
 # In-place list repeat (`list *= n`) parity.  CPython and PyPy both mutate the
 # list in place (listobject descr_inplace_mul), so the list object identity is
 # preserved across `*=`; only `*` produces a fresh list.  check.py's oracle is

--- a/pyre/bench/synth/list_insert.py
+++ b/pyre/bench/synth/list_insert.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=2.4
-# pyre-check: min-pypy-ratio=0.28
 # Benchmark: integer list insert at front (per-strategy ops)
 # Exercises W_ListObject.insert() on Integer strategy.
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + ll_arraymove + setarrayitem(ArrayS 8).

--- a/pyre/bench/synth/list_insert_pop_index.py
+++ b/pyre/bench/synth/list_insert_pop_index.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=3.08
 # list.insert(index, x) and list.pop(index) coerce the index through
 # `__index__` (`getindex_w(index, OverflowError)`): a small custom index
 # inserts/pops at the resolved position, an out-of-range pop reports "pop index

--- a/pyre/bench/synth/list_length_hint_validate.py
+++ b/pyre/bench/synth/list_length_hint_validate.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.65
 # list(iterable) and list.extend(iterable) consult __length_hint__ before
 # iterating (listobject.py _extend_from_iterable -> space.length_hint), which
 # validates it: a negative hint raises ValueError, one exceeding a C ssize_t

--- a/pyre/bench/synth/list_ops.py
+++ b/pyre/bench/synth/list_ops.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=46
-# pyre-check: min-pypy-ratio=4.65
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/list_reverse.py
+++ b/pyre/bench/synth/list_reverse.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=2.4
-# pyre-check: min-pypy-ratio=0.25
 # Benchmark: integer list reverse (per-strategy ops)
 # Exercises W_ListObject.reverse() on Integer strategy.
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + setarrayitem(ArrayS 8) swaps.

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=8
-# pyre-check: min-pypy-ratio=0.72
 # Benchmark: integer list setslice (per-strategy ops)
 # Exercises W_ListObject slice assignment: lst[a:b] = [...] on Integer strategy.
 # PYPYLOG confirms: guard_class(IntegerListStrategy) + new_array(3, ArrayS 8).

--- a/pyre/bench/synth/list_subscript_index.py
+++ b/pyre/bench/synth/list_subscript_index.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=2.72
 # A list subscript, assignment, and deletion coerce a non-int key through
 # `__index__` (`getindex_w`); an index too large for a machine word raises
 # IndexError naming the key's real type ("cannot fit '<type>' ..."), and an

--- a/pyre/bench/synth/list_to_tuple_star.py
+++ b/pyre/bench/synth/list_to_tuple_star.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=38
-# pyre-check: min-pypy-ratio=4.72
 N = 50000
 
 

--- a/pyre/bench/synth/listcomp_hot.py
+++ b/pyre/bench/synth/listcomp_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=45
-# pyre-check: min-pypy-ratio=4.78
 N = 100000
 
 

--- a/pyre/bench/synth/load_fast_check.py
+++ b/pyre/bench/synth/load_fast_check.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=9.5
-# pyre-check: min-pypy-ratio=0.75
 N = 1400000
 
 

--- a/pyre/bench/synth/loop_callee_return.py
+++ b/pyre/bench/synth/loop_callee_return.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=1.35
 # Regression: a loop-bearing callee whose return value is consumed by a hot
 # caller loop. The inline recursive-call-assembler path (opimpl_recursive_call_
 # assembler) reaches the callee's loop back-edge, pops the inline frame, and

--- a/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
+++ b/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=9
-# pyre-check: min-pypy-ratio=0.92
 # A local must not read back as the `for` loop's iterator after the loop.
 #
 # An empty dict literal used to decline in the codewriter, and the decline

--- a/pyre/bench/synth/loop_in_try_raise_into_handler.py
+++ b/pyre/bench/synth/loop_in_try_raise_into_handler.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=2.28
 # A hot loop inside a `try` that raises out of the loop into a handler the SAME
 # frame owns, across the delivery flavours that reach the handler differently:
 # an operation that raises from a builtin container, an int-specialized

--- a/pyre/bench/synth/loop_in_try_tail_raise_and_second_loop.py
+++ b/pyre/bench/synth/loop_in_try_tail_raise_and_second_loop.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=2.02
 # The post-loop tail itself is the raising region, and a second hot loop lives
 # after the handler.
 #

--- a/pyre/bench/synth/loop_in_try_tail_unbound_check.py
+++ b/pyre/bench/synth/loop_in_try_tail_unbound_check.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=23
-# pyre-check: min-pypy-ratio=2.45
 # A hot loop whose header is covered by an exception handler, with a post-loop
 # tail that reads the loop variable through LOAD_FAST_CHECK.
 #

--- a/pyre/bench/synth/loops_comprehension.py
+++ b/pyre/bench/synth/loops_comprehension.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=30
-# pyre-check: min-pypy-ratio=2.52
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
+++ b/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=58
-# pyre-check: min-pypy-ratio=4.62
 # A type change on one instance freezes unboxing for the whole class
 # (mapdict.py:623). Instances created before the freeze keep an unboxed slot
 # until something reads it: `_direct_read` migrates them off unboxed storage

--- a/pyre/bench/synth/mapdict_unboxed_type_change_attr.py
+++ b/pyre/bench/synth/mapdict_unboxed_type_change_attr.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=25
-# pyre-check: min-pypy-ratio=2.12
 # Changing an unboxed int or float slot to the other type creates a boxed map;
 # the promoted-map guard must deopt before the old raw-storage read or write is
 # reused for the new representation (mapdict.py:577-584, 600-619, 905-916).

--- a/pyre/bench/synth/match_sequence_of_class_patterns.py
+++ b/pyre/bench/synth/match_sequence_of_class_patterns.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=52
-# pyre-check: min-pypy-ratio=4.18
 # A match statement whose subject pattern is a SEQUENCE of CLASS patterns, each
 # carrying a literal sub-pattern plus a capture (`[Node('lit', a), Node('lit', b)]`).
 # MATCH_CLASS has no dedicated arm in the JIT trace walker and fell through to the

--- a/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
+++ b/pyre/bench/synth/math_isqrt_compare_bridge_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.65
 # A comparison helper (like test_math.testIsqrt's assertLessEqual/assertLess)
 # runs first on exact ints and then on bignums. The `<=`/`<` inside the helper
 # callee has CompareOp class/value guards that must attach a bridge at the

--- a/pyre/bench/synth/math_log_trig_hot.py
+++ b/pyre/bench/synth/math_log_trig_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=1.48
 # RPython lowers the guarded `ll_math_log/cos/sin` bodies to raw float calls.
 # Keep all inputs in their hot domains so the walker emits those CALL_F ops
 # and the temporary W_FloatObject results can virtualize.

--- a/pyre/bench/synth/math_sqrt_hot.py
+++ b/pyre/bench/synth/math_sqrt_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=1.02
 # A hot `math.sqrt(x)` loop.  The walker specializes the call
 # (`try_walker_specialize_math_sqrt`) to a domain-guarded pure
 # `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` -> `sqrt_nonneg`,

--- a/pyre/bench/synth/metaclass_getattribute_delattr.py
+++ b/pyre/bench/synth/metaclass_getattribute_delattr.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=34
-# pyre-check: min-pypy-ratio=3.52
 # A metaclass overriding __getattribute__ / __delattr__ intercepts class
 # attribute reads / deletes (`C.x`, `del C.x`), replacing the builtin
 # type.__getattribute__ / type.__delattr__.  objspace.py:664 runs the

--- a/pyre/bench/synth/method_reassign_after_warmup.py
+++ b/pyre/bench/synth/method_reassign_after_warmup.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=31
-# pyre-check: min-pypy-ratio=2.38
 # The ratio is deliberately loose: pypy folds this loop to near nothing
 # (0.01s at any N tried), so the denominator is collapsed and the number
 # measures pypy's constant folding rather than pyre's throughput. What this

--- a/pyre/bench/synth/mutate_then_raise_caught.py
+++ b/pyre/bench/synth/mutate_then_raise_caught.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=35
-# pyre-check: min-pypy-ratio=4.35
 # gh#495 guard: mutating residual raises and is caught inside the inlined callee.
 # V2: mutate-then-RAISE, caught inside callee. Tests fixed path under exc churn.
 N = 30000

--- a/pyre/bench/synth/mutate_uncaught_raise_delivery.py
+++ b/pyre/bench/synth/mutate_uncaught_raise_delivery.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=3.38
 # gh#495 guard: mutating call that raises uncaught must deliver the exception once.
 N = 30000
 class C:

--- a/pyre/bench/synth/named_reraise_sibling_hot.py
+++ b/pyre/bench/synth/named_reraise_sibling_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=4.88
 # A named `except E as m:` handler whose body bare-re-raises compiles its
 # implicit cleanup to `DELETE_FAST m; RERAISE`, immediately followed by a
 # sibling `except` clause's type check. On the re-raise path the exception must

--- a/pyre/bench/synth/nested_break_not_hot.py
+++ b/pyre/bench/synth/nested_break_not_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=17
-# pyre-check: min-pypy-ratio=2.6
 # A nested `for` loop whose inner `break` lands on the secondary edge of its
 # guard — reached from `if not cond: break` (a POP_JUMP_IF_TRUE fall-through) or
 # from a break-check that is the last statement in the loop body (a

--- a/pyre/bench/synth/nested_callee_chain_mutation_abort.py
+++ b/pyre/bench/synth/nested_callee_chain_mutation_abort.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=2.88
 # gh#495 guard: nested inlined callees mutate through a branch-bearing abort path.
 # 3-level nested branch-bearing mutating callees. outer while -> A -> B -> C, each mutates.
 N = 40000

--- a/pyre/bench/synth/nested_for_outer_local_postread.py
+++ b/pyre/bench/synth/nested_for_outer_local_postread.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=2.32
 def variable_inner(n):
     total = 0
     for i in range(n):

--- a/pyre/bench/synth/nested_list_comprehension_hot.py
+++ b/pyre/bench/synth/nested_list_comprehension_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=44
-# pyre-check: min-pypy-ratio=4.65
 # An inlined list comprehension whose LIST_APPEND element is a non-empty nested
 # list (`[[i] …]` / `[[i, i + 1] …]`). The #171 fold virtualizes the inner list,
 # whose separately allocated backing block (NewArray / NewArrayClear) carries no

--- a/pyre/bench/synth/nested_loop_correctness.py
+++ b/pyre/bench/synth/nested_loop_correctness.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=2.18
 # Nested-loop tracer correctness gate.  Every case prints multiple checksums
 # so a dropped or duplicated inner iteration cannot be masked by a count.
 MOD = 1000003

--- a/pyre/bench/synth/nested_loop_gate_switch.py
+++ b/pyre/bench/synth/nested_loop_gate_switch.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=16
-# pyre-check: min-pypy-ratio=1.45
 # Two nested hot loops with a guard-set switch keyed on the outer phase; the
 # inner late arm (touching a None-or-int local) only executes once the global
 # count crosses 5000, forcing bridge deopts mid-run. This once panicked on

--- a/pyre/bench/synth/newslice_step_hot.py
+++ b/pyre/bench/synth/newslice_step_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=40
-# pyre-check: min-pypy-ratio=5.5
 # An extended slice `seq[a:b:c]` (a step operand) compiles the bounds to
 # BUILD_SLICE — the `newslice(start, stop, step)` HLOp — then BINARY_SUBSCR,
 # a distinct lowering from the two-bound BINARY_SLICE path. A `newslice`

--- a/pyre/bench/synth/p2_local_result_bridge.py
+++ b/pyre/bench/synth/p2_local_result_bridge.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=28
-# pyre-check: min-pypy-ratio=2.12
 # Regression guard for P2 root result seeding when the residual-call result is
 # stored into a root local slot.  The late type flip forces a guard failure in
 # the inlined callee chain; the root stores the returned value in `x` before

--- a/pyre/bench/synth/pickle_ctor_args.py
+++ b/pyre/bench/synth/pickle_ctor_args.py
@@ -1,9 +1,6 @@
 # pyre-check: max-pypy-ratio=145
-# pyre-check: min-pypy-ratio=9
 # pypy's exec time is a real measurement here, but the ratio still spans 18.6x
-# to 70.3x across hosts, so the ceiling is twice the slowest. The floor is
-# explicit because the default ceiling/5 = 29 rejects the fastest host at
-# 13.5x.
+# to 70.3x across hosts, so the ceiling is twice the slowest.
 # _pickle.Pickler/Unpickler accept their constructor arguments positionally and
 # by keyword: tp_new allocates and ignores them, __init__ validates and stores
 # them. `pickle.Pickler` binds to the C accelerator where it exists and to the

--- a/pyre/bench/synth/pickle_terminal_raise_resume.cranelift.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.cranelift.jitstats
@@ -8,4 +8,4 @@ field_pos_spec_misplaced=0
 guard_failures=338
 internal_compile_panics=0
 loops_aborted=1
-loops_compiled=35
+loops_compiled=30

--- a/pyre/bench/synth/pickle_terminal_raise_resume.dynasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.dynasm.jitstats
@@ -8,4 +8,4 @@ field_pos_spec_misplaced=0
 guard_failures=338
 internal_compile_panics=0
 loops_aborted=1
-loops_compiled=35
+loops_compiled=30

--- a/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
+++ b/pyre/bench/synth/pickle_terminal_raise_resume.wasm.jitstats
@@ -8,4 +8,4 @@ field_pos_spec_misplaced=0
 guard_failures=339
 internal_compile_panics=0
 loops_aborted=13
-loops_compiled=72
+loops_compiled=67

--- a/pyre/bench/synth/polymorphic_binary_receiver.py
+++ b/pyre/bench/synth/polymorphic_binary_receiver.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=158
-# pyre-check: min-pypy-ratio=12
 # A BINARY_OP (`+`/`*`) whose receiver alternates at runtime between an exact
 # builtin int and a user-class (or int-subclass) instance at the SAME hot site.
 # The raw int specialization bypasses special-method dispatch, so it must only

--- a/pyre/bench/synth/polymorphic_slot_retype.py
+++ b/pyre/bench/synth/polymorphic_slot_retype.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=2.28
 # Polymorphic accumulator slots cycling int/str/None in a hot loop, with rare
 # retype arms (int->str, str->None) opening after warm-up so the compiled
 # trace takes bridges. A deopt-resumed frame once pushed past the valuestack

--- a/pyre/bench/synth/pow3_arg_types.py
+++ b/pyre/bench/synth/pow3_arg_types.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=4.22
 # Three-argument `pow(base, exp, mod)` requires all operands to be integers.
 # A float base rejects the modulus with a TypeError, a complex base with a
 # ValueError ("complex modulo"), and the all-integer forms compute the modular

--- a/pyre/bench/synth/range_ctor_in_loop.py
+++ b/pyre/bench/synth/range_ctor_in_loop.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=190
-# pyre-check: min-pypy-ratio=20
 # Pins virtual range construction for one-, two-, and three-bound calls while
 # retaining correct residual behavior for exceptional, subclass, index, and
 # escaping-object shapes.

--- a/pyre/bench/synth/recursion_memo_branch.py
+++ b/pyre/bench/synth/recursion_memo_branch.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=40
-# pyre-check: min-pypy-ratio=4.2
 # Memoized vs plain recursion with post-warm-up branch divergence. The
 # memo-dict store (memo[n] = r) once died with a TypeError after warm-up
 # (an empty-string type name from a clobbered class read on the dict-store

--- a/pyre/bench/synth/recursive_call_frame_relocation.py
+++ b/pyre/bench/synth/recursive_call_frame_relocation.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=96
-# pyre-check: min-pypy-ratio=7.58
 # Deep self-recursion whose caller frame is relocated by a minor collection
 # while the recursive callee runs.  The bytecode CALL fast path drops the
 # arguments, runs the callee, then pushes its result onto the caller's value

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6.2
-# pyre-check: min-pypy-ratio=0.55
 # A hot loop FOLLOWED by a try/except whose body raises through a
 # *may-force residual call* (`//`, subscript) rather than an explicit
 # `raise`.  The try/except is reached only after the loop's exit guard

--- a/pyre/bench/synth/reversed_disabled.py
+++ b/pyre/bench/synth/reversed_disabled.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=34
-# pyre-check: min-pypy-ratio=1.72
 # reversed() treats `__reversed__ = None` as not reversible (even with a
 # sequence protocol) and propagates a raised __reversed__ instead of yielding a
 # corrupt null object. Output verified against CPython/PyPy.

--- a/pyre/bench/synth/selfrec_tail_exception_unwind.py
+++ b/pyre/bench/synth/selfrec_tail_exception_unwind.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.18
 """Self-recursive CALL_ASSEMBLER exception unwind regression.
 
 The raise happens while evaluating a tail call's accumulator argument.  It

--- a/pyre/bench/synth/seqiter_tuple_error_parity.py
+++ b/pyre/bench/synth/seqiter_tuple_error_parity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=54
-# pyre-check: min-pypy-ratio=6.22
 # PR271 review parity guard.  check.py's correctness oracle is PyPy, so this
 # bench only asserts behaviour where 3.14 and PyPy AGREE; it guards the
 # tuple-subclass override (P1), the live `__length_hint__` (P2) and the

--- a/pyre/bench/synth/set_hash_protocol.py
+++ b/pyre/bench/synth/set_hash_protocol.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=4.25
 # Adding an element to a set hashes it through the protocol, so an unhashable
 # element raises instead of being stored under a structural hash and a raising
 # __hash__ propagates. This covers every ingestion path: the set and frozenset

--- a/pyre/bench/synth/set_intersection_operand.py
+++ b/pyre/bench/synth/set_intersection_operand.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=39
-# pyre-check: min-pypy-ratio=5.88
 # An intersection walks the shorter side and keeps that side's objects, so
 # when two equal elements are distinct objects which one survives depends on
 # the operand lengths. The shortest operand seeds the result, measured as

--- a/pyre/bench/synth/set_key_protocol.py
+++ b/pyre/bench/synth/set_key_protocol.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=42
-# pyre-check: min-pypy-ratio=4.75
 # A set's backing storage keys on both the hash and the equality protocol, so
 # an element is hashed exactly once per store and a raise from either callback
 # aborts that store rather than being swallowed into a corrupt container. An

--- a/pyre/bench/synth/set_method_arity.py
+++ b/pyre/bench/synth/set_method_arity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.68
 # set/frozenset methods with a fixed arity raise TypeError on a wrong
 # positional-argument count instead of silently accepting it. The exact message
 # text differs between CPython and PyPy, so only the exception type (which they

--- a/pyre/bench/synth/set_name_filtered_dict.py
+++ b/pyre/bench/synth/set_name_filtered_dict.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=0.5
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (6.8x), rounded up, and the floor is half the fastest
-# (1.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (6.8x), rounded up.
 # typeobject.py:1006 _set_names — type.__new__ calls __set_name__(owner, name)
 # for each descriptor in the type's final __dict__.  Each descriptor is visited
 # once, with the class as owner and its own attribute name.

--- a/pyre/bench/synth/set_remove_ord_errors.py
+++ b/pyre/bench/synth/set_remove_ord_errors.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=12
-# pyre-check: min-pypy-ratio=1.78
 # set.remove(missing) raises KeyError carrying the missing key itself (so its
 # repr shows), matching dict[missing]; ord() on a non-string names the argument's
 # real type. A warmup loop exercises the working set-membership and ord fast

--- a/pyre/bench/synth/set_update_hash_other.py
+++ b/pyre/bench/synth/set_update_hash_other.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=36
-# pyre-check: min-pypy-ratio=4.68
 # difference_update and intersection_update hash each element of the other
 # operand as it is consumed, so an unhashable element raises and a raising
 # __hash__ propagates -- including when self is empty and nothing can match.

--- a/pyre/bench/synth/set_update_hot.py
+++ b/pyre/bench/synth/set_update_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=65
-# pyre-check: min-pypy-ratio=4.18
 # N/ITERS are kept small so the wasm backend finishes inside the synthetic
 # timeout: wasm runs every guard-exit re-entry through the not-yet-collected
 # interpreter allocation path, so the run's wall grows super-linearly in ITERS

--- a/pyre/bench/synth/set_update_materialize_rhs.py
+++ b/pyre/bench/synth/set_update_materialize_rhs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=29
-# pyre-check: min-pypy-ratio=2.98
 # symmetric_difference_update turns a non-set operand into a set before it
 # toggles anything, so the operand is hashed and deduped up front: a duplicate
 # toggles once, and a later unhashable element leaves self untouched. update

--- a/pyre/bench/synth/short_circuit_side_effects.py
+++ b/pyre/bench/synth/short_circuit_side_effects.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=30
-# pyre-check: min-pypy-ratio=3.15
 # Short-circuit and/or chains whose operands call side-effecting helpers,
 # inside a hot loop whose first operand flips truthiness after warm-up. The
 # helpers bump global counters; the computed totals were always correct, but

--- a/pyre/bench/synth/short_circuit_value_kept_stack.py
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=1.35
 # Exercises short-circuit `and` / `or` in VALUE context inside a hot loop.
 #
 # `x = (i % 7) and (i + 3)` lowers to `BINARY_OP %; COPY 1; TO_BOOL;

--- a/pyre/bench/synth/short_circuit_value_local_kept.py
+++ b/pyre/bench/synth/short_circuit_value_local_kept.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=20
-# pyre-check: min-pypy-ratio=1.32
 # Depth-1 kept-stack short-circuit with a BARE loop-varying local on the left
 # and a loop-invariant constant on the right.
 #

--- a/pyre/bench/synth/simple_namespace_type.py
+++ b/pyre/bench/synth/simple_namespace_type.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.95
 # `types.SimpleNamespace` is a dedicated type: keyword construction into the
 # instance dict, a `namespace(...)` repr, `__dict__` exposure, structural
 # equality, unhashability, and `type(sys.implementation)` identity. Multi-key

--- a/pyre/bench/synth/slots_class_var_conflict.py
+++ b/pyre/bench/synth/slots_class_var_conflict.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.92
 # A `__slots__` entry naming a class variable raises ValueError at class
 # creation, while a duplicate `__slots__` entry is silently ignored.
 # Output verified against CPython/PyPy.

--- a/pyre/bench/synth/sre_pattern_methods.py
+++ b/pyre/bench/synth/sre_pattern_methods.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=27
-# pyre-check: min-pypy-ratio=3.02
 import re
 
 # Regex work runs through the `re` layer and native `_sre`, which the trace

--- a/pyre/bench/synth/store_global_hot.py
+++ b/pyre/bench/synth/store_global_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=13
-# pyre-check: min-pypy-ratio=1.08
 # STORE_GLOBAL inside a hot loop: a `global`-declared function reassigns
 # module globals every iteration.  The compiled per-CodeObject jitcode
 # walks the `store_global` residual instead of an abort_permanent marker,

--- a/pyre/bench/synth/store_slice_hot.py
+++ b/pyre/bench/synth/store_slice_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=15
-# pyre-check: min-pypy-ratio=1.28
 # STORE_SLICE in a hot loop: `buf[a:b] = [i, i + 1]` with *variable* bounds
 # (a, b are locals, not literals) compiles to the STORE_SLICE opcode every
 # iteration — literal bounds would fold to a const slice + STORE_SUBSCR.  The

--- a/pyre/bench/synth/str_encode_text_codec.py
+++ b/pyre/bench/synth/str_encode_text_codec.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=27
-# pyre-check: min-pypy-ratio=3.28
 # str.encode() rejects non-text (binary) codecs with LookupError instead of
 # silently producing bytes: the binary codecs' CodecInfo._is_text_encoding
 # (False, stored on a tuple subclass instance) is honored. Output verified

--- a/pyre/bench/synth/str_fstring.py
+++ b/pyre/bench/synth/str_fstring.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=45
-# pyre-check: min-pypy-ratio=4.62
 # Merged synth parity smoke suite: independent feature-level hot loops, each
 # kept verbatim from its former standalone file with module-level names prefixed
 # by the source name. Bug-repro / resume / kept-stack tests are NOT merged (they

--- a/pyre/bench/synth/str_getitem_len_hot.py
+++ b/pyre/bench/synth/str_getitem_len_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: min-pypy-ratio=2.25
 # Hot-loop str/unicode subscript and length over every string kind: ASCII /
 # latin1 (1-byte code units), BMP (2-byte), and non-BMP astral (4-byte). The
 # subscripts emit residual STRGETITEM/UNICODEGETITEM and the lengths STRLEN/

--- a/pyre/bench/synth/str_index_bytes_iter_surface.py
+++ b/pyre/bench/synth/str_index_bytes_iter_surface.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=1.52
 # str subscripts resolve a code point index, not a byte offset, for every
 # payload width, and a slice keeps that indexing under negative and skipping
 # steps. bytes/bytearray iterate their live buffer as ordinals, so a bytearray

--- a/pyre/bench/synth/str_startswith_bounds.py
+++ b/pyre/bench/synth/str_startswith_bounds.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=17
-# pyre-check: min-pypy-ratio=1.15
 # startswith/endswith convert their code-point bounds to byte offsets: a
 # start past the end is not clamped, it inverts the window, so the match is
 # False even for an empty prefix. A start exactly at the end still yields a

--- a/pyre/bench/synth/struct_pack_unpack.py
+++ b/pyre/bench/synth/struct_pack_unpack.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=56
-# pyre-check: min-pypy-ratio=2.82
 import struct
 
 

--- a/pyre/bench/synth/subscr_negative_index_deopt.py
+++ b/pyre/bench/synth/subscr_negative_index_deopt.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=0.75
 # #171/#11 negative-index regression: a canonical-tuple / list subscript that
 # the JIT specializes on a NON-NEGATIVE observed index must DEOPT (the
 # lower-bound guard `0 <= idx`) when a later NEGATIVE index flows through the

--- a/pyre/bench/synth/subscr_user_getitem_inline.py
+++ b/pyre/bench/synth/subscr_user_getitem_inline.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=35
-# pyre-check: min-pypy-ratio=1.88
 # BINARY_SUBSCR whose receiver resolves `__getitem__` to a Python function.
 # Covers the two receiver shapes whose subscript the type's own MRO owns — a
 # user instance and a builtin sequence subclass that overrides `__getitem__` —

--- a/pyre/bench/synth/surrogate_class_kwargs.py
+++ b/pyre/bench/synth/surrogate_class_kwargs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.68
 # Lone-surrogate keys survive the builtin dict / type kwargs and class
 # namespace walks instead of crashing on the non-UTF-8 key:
 #  - dict(**{surrogate: v}) and d.update(**{surrogate: v}) store the key

--- a/pyre/bench/synth/surrogate_dir.py
+++ b/pyre/bench/synth/surrogate_dir.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.55
 # dir() lists lone-surrogate attribute/global names instead of dropping
 # them, and never crashes reading a surrogate str key.  DictStorage keeps
 # names as byte-ish str (entries_wtf8), so a name set via setattr with a

--- a/pyre/bench/synth/surrogate_kwargs.py
+++ b/pyre/bench/synth/surrogate_kwargs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=61
-# pyre-check: min-pypy-ratio=3.98
 # A lone-surrogate keyword name survives the f(**dict) call path: it lands
 # in **kwargs unchanged and an unmatched one is named in the TypeError.
 # Arguments keeps keyword names as byte-ish str (argument.py keywords: [str]),

--- a/pyre/bench/synth/surrogate_metaclass_kwargs.py
+++ b/pyre/bench/synth/surrogate_metaclass_kwargs.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.58
 # A user metaclass whose __new__/__init__ takes **kw receives class keywords
 # through the by-name keyword binder (resolve_kwargs).  A lone-surrogate class
 # keyword must survive as a byte-ish name instead of crashing the strict-UTF-8

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=20
-# pyre-check: min-pypy-ratio=1.58
 # A hot loop FOLLOWED by a try/except whose handler `return`s.  The
 # `return`-from-`except` cleanup compiles to `SWAP 2; POP_EXCEPT;
 # RETURN_VALUE` (the SWAP exchanges the return value with the saved

--- a/pyre/bench/synth/syntaxerror_location.py
+++ b/pyre/bench/synth/syntaxerror_location.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6
-# pyre-check: min-pypy-ratio=0.65
 # A compile-time SyntaxError carries its parser location: msg, lineno, offset,
 # text, filename and end_lineno populate the instance (args is
 # (msg, (filename, lineno, offset, text, end_lineno, end_offset))), and __str__

--- a/pyre/bench/synth/syntaxerror_str.py
+++ b/pyre/bench/synth/syntaxerror_str.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.45
 # SyntaxError.__str__ renders 'msg (filename, line lineno)', degrading through
 # the filename-only, lineno-only and bare-msg shapes; a non-str msg falls back
 # to str(msg). (The end_lineno range form is not exercised here: PyPy renders

--- a/pyre/bench/synth/trace_too_long_effect_replay.py
+++ b/pyre/bench/synth/trace_too_long_effect_replay.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.98
 # A trace that outgrows `trace_limit` must not re-apply effects the walk has
 # already executed. The walker's length check fires at an arbitrary opcode,
 # unlike every other abort, which declines before executing an effect it

--- a/pyre/bench/synth/tuple_contains_eq_raises.py
+++ b/pyre/bench/synth/tuple_contains_eq_raises.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.52
 # containment on a 2-tuple compares elements with `__eq__`; an exception it
 # raises propagates rather than being swallowed into a False result.
 def main():

--- a/pyre/bench/synth/tuple_str_bytes_subscript_index.py
+++ b/pyre/bench/synth/tuple_str_bytes_subscript_index.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=15
-# pyre-check: min-pypy-ratio=1.45
 # tuple, str, and bytes subscripts coerce a non-int, non-slice key through
 # `__index__` (`getindex_w`): a small custom index reads the resolved position,
 # an out-of-range index raises the type's "index out of range", and an index

--- a/pyre/bench/synth/tuple_unpack_array_backed_hot.py
+++ b/pyre/bench/synth/tuple_unpack_array_backed_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=11
-# pyre-check: min-pypy-ratio=1.35
 # Exact, non-specialized tuples use the ordinary wrapped-items array.  Keep
 # fixed-length unpack on that storage visible to the trace while preserving
 # the generic path for tuple subclasses at the same call site.

--- a/pyre/bench/synth/type_call_inline_init_branch_deopt.py
+++ b/pyre/bench/synth/type_call_inline_init_branch_deopt.py
@@ -1,10 +1,7 @@
 # pyre-check: max-pypy-ratio=105
-# pyre-check: min-pypy-ratio=4.2
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (51.5x), rounded up, and the floor is half the fastest
-# (8.5x) — a derived floor of ceiling/5 would sit above it.
-# observe (51.5x), rounded up, and the floor is
+# runners observe (51.5x), rounded up.
 # A guard failing inside an inlined `__init__` must hand the caller the
 # instance, not `__init__`'s return value.  `typeobject.py descr_call` discards
 # `__init__`'s result and returns the instance; the flattened constructor

--- a/pyre/bench/synth/type_descr_get_metaclass_getattr.py
+++ b/pyre/bench/synth/type_descr_get_metaclass_getattr.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=5
-# pyre-check: min-pypy-ratio=0.72
 # descroperation.py:234 — when a descriptor reached through a type attribute
 # lookup raises AttributeError from its __get__, the metaclass __getattr__ gets
 # the final say (the whole getattribute slot is wrapped in try/except and an

--- a/pyre/bench/synth/type_dict_surrogate.py
+++ b/pyre/bench/synth/type_dict_surrogate.py
@@ -1,10 +1,7 @@
 # pyre-check: max-pypy-ratio=350
-# pyre-check: min-pypy-ratio=10
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is the one recorded before the
-# tightening, four times the slowest the CI runners observe (84.7x), and the
-# floor is half the fastest (21.5x) — a derived floor of ceiling/5 would sit
-# above it.
+# tightening, four times the slowest the CI runners observe (84.7x).
 N = 200000
 
 S = '\udcff'                  # lone low surrogate

--- a/pyre/bench/synth/type_dotted_name.py
+++ b/pyre/bench/synth/type_dotted_name.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=6.8
-# pyre-check: min-pypy-ratio=0.85
 # type.__name__ / __qualname__ dot handling: a heap type built with a dotted
 # name string (type('a.b', (), {})) keeps the name verbatim on both getters,
 # while a static/builtin dotted tp_name strips to its final component. An

--- a/pyre/bench/synth/type_error_message_parity.py
+++ b/pyre/bench/synth/type_error_message_parity.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=3.8
-# pyre-check: min-pypy-ratio=0.28
 # Error-message parity across a few type/builtin operations that both
 # reference implementations word identically.
 def main():

--- a/pyre/bench/synth/type_immutable_reject.py
+++ b/pyre/bench/synth/type_immutable_reject.py
@@ -1,10 +1,7 @@
 # pyre-check: max-pypy-ratio=40
-# pyre-check: min-pypy-ratio=2
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (18.2x), rounded up, and the floor is half the fastest
-# (4.0x) — a derived floor of ceiling/5 would sit above it.
-# across CI hosts (18.2x), rounded up, and the floor is
+# runners observe (18.2x), rounded up.
 N = 200000
 
 

--- a/pyre/bench/synth/type_metatype_data_descr.py
+++ b/pyre/bench/synth/type_metatype_data_descr.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=0.25
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (6.4x), rounded up, and the floor is half the fastest
-# (0.5x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (6.4x), rounded up.
 # typeobject.py W_TypeObject.descr_getattribute: a metatype DATA descriptor
 # wins over the class's own MRO value of the same name; a metatype non-data
 # descriptor and a plain metatype attribute lose to the class's own value.

--- a/pyre/bench/synth/type_name_setter.py
+++ b/pyre/bench/synth/type_name_setter.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=9.7
-# pyre-check: min-pypy-ratio=1.22
 N = 80000
 
 # Exercises the writable type.__name__ setter under the JIT: a successful

--- a/pyre/bench/synth/type_name_surrogate_reject.py
+++ b/pyre/bench/synth/type_name_surrogate_reject.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=26
-# pyre-check: min-pypy-ratio=3.12
 N = 10000
 
 

--- a/pyre/bench/synth/unary_int_loop_carried.py
+++ b/pyre/bench/synth/unary_int_loop_carried.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=0.95
 # Unary operations must observe the current loop-carried integer. Exercise
 # both ordinary values and the large-integer boundary, plus neighboring
 # operations that serve as controls. Deterministic.

--- a/pyre/bench/synth/unary_negative.py
+++ b/pyre/bench/synth/unary_negative.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=110
-# pyre-check: min-pypy-ratio=7.5
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (54.5x), rounded up, and the floor is half the fastest
-# (15.0x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (54.5x), rounded up.
 N = 1000000
 
 

--- a/pyre/bench/synth/unary_positive_resume.py
+++ b/pyre/bench/synth/unary_positive_resume.py
@@ -1,9 +1,7 @@
 # pyre-check: max-pypy-ratio=90
-# pyre-check: min-pypy-ratio=5.2
 # pypy's exec time is pinned to the startup-subtraction floor here, so the
 # ratio is not a measurement: the ceiling is twice the slowest ratio the CI
-# runners observe (44.3x), rounded up, and the floor is half the fastest
-# (10.5x) — a derived floor of ceiling/5 would sit above it.
+# runners observe (44.3x), rounded up.
 N = 2000000
 
 

--- a/pyre/bench/synth/unpack_drain_star_raise.py
+++ b/pyre/bench/synth/unpack_drain_star_raise.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=49
-# pyre-check: min-pypy-ratio=5.62
 # Star-unpack of an iterator of unknown length: `f(*it)` is the consumer that
 # routes through `_unpackiterable_unknown_length`, the drain loop jd1
 # (`unpackiterable_driver`) traces and compiles. `a, b, c = it` does NOT reach

--- a/pyre/bench/synth/unpack_ex_hot.py
+++ b/pyre/bench/synth/unpack_ex_hot.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=17
-# pyre-check: min-pypy-ratio=2.6
 # UNPACK_EX in a hot loop: `a, *b = data` with a star target compiles to the
 # unpack_ex residual (the UNPACK_SEQUENCE sibling with a starred list slot)
 # instead of an abort_permanent marker, so the hot body JIT-compiles rather

--- a/pyre/bench/synth/unpack_wrong_arity_caught.py
+++ b/pyre/bench/synth/unpack_wrong_arity_caught.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=35
-# pyre-check: min-pypy-ratio=1.55
 # A hot exact-length unpack specializes for the common arity.  The rare
 # mismatching tuple must deopt at the UNPACK_SEQUENCE validation call and
 # deliver ValueError through this frame's exception handler.

--- a/pyre/bench/synth/wasm_ca_trampoline_decline.py
+++ b/pyre/bench/synth/wasm_ca_trampoline_decline.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=57
-# pyre-check: min-pypy-ratio=13
 # Regression for wasm CA frames: this self-recursive body reaches the raw
 # float-power residual call (CallF, hence the host jit_call trampoline) and
 # allocates a string at every recursive level. Once the recursion bridge is

--- a/pyre/bench/synth/while_is_none.py
+++ b/pyre/bench/synth/while_is_none.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=18
-# pyre-check: min-pypy-ratio=1.42
 # The walk loop's hot body reads `head.val` (an int) and `head.next` (the next
 # node).  The full-body-walker LOAD_ATTR fold folds the object-typed `head.next`
 # read to `guard_class` + `guard_value(map)` + `getfield(storage)` +

--- a/pyre/bench/synth/with_except_start_function_resume.py
+++ b/pyre/bench/synth/with_except_start_function_resume.py
@@ -1,5 +1,4 @@
 # pyre-check: max-pypy-ratio=14
-# pyre-check: min-pypy-ratio=1.35
 # A function-entry trace records only the early-return arm.  The first true
 # call then fails that guard and blackhole-replays the previously unvisited
 # `with` arm.  WITH_EXCEPT_START must read the live handler stack and call

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -127,8 +127,26 @@ EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # floor enough for small relative error: execution time is the difference
 # between two independently measured values.
 FLOOR_GATE_MIN_BASELINE_S = 3 * EXEC_TIME_FLOOR_S
-# The default pypy performance floor is its ceiling divided by this value.
-PERF_GATE_FLOOR_DIVISOR = 5
+# The pypy performance floor is DERIVED from the ceiling and is never stated
+# per bench.  What we want from every bench is parity with pypy, so a
+# hand-written floor would assert that a fixture must STAY some number of times
+# slower than pypy -- not a thing anyone wants to be true, and one more number
+# to re-fit every time the ceiling moves.  The floor is only an instrument for
+# reporting that a ceiling has gone stale, so it sits at parity: reaching it is
+# the event worth a red run, and no ceiling above parity can put the floor
+# anywhere a bench that is merely fast on a fast host can reach.  Ceilings run
+# as far as 194x above the lowest ratio a runner has reported for their fixture,
+# and none of that spread can reach a floor pinned here.
+PERF_GATE_FLOOR_RATIO = 1.0
+# Below a ceiling of this many times parity, a floor AT parity would sit inside
+# the band the ceiling itself allows, so the floor drops proportionally instead.
+# The divisor has to clear the span one fixture reads across the CI runners --
+# the ceiling is an allowance set from the slowest of them, and the fastest can
+# read several times lower.  Among the fixtures whose ceiling is low enough for
+# the divisor to bind, the widest gap between a ceiling and the lowest ratio any
+# runner reported for it is 22x, so a smaller divisor would fail a bench for
+# being fast on the host where it is fastest.
+PERF_GATE_FLOOR_DIVISOR = 25
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick
 # quantized (see WIN_TIMER_QUANTUM_S above).
@@ -907,14 +925,25 @@ def synth_perf_gate(path):
 
     The limit is read against the native backends only; `run_synthetic_bench`
     exempts wasm.
+
+    A fixture states its ceiling and nothing else: the floor that goes with it
+    is `perf_gate_floor`'s business, so a leftover `min-pypy-ratio` header is
+    rejected rather than ignored.
     """
     prefix = "# pyre-check: max-pypy-ratio="
+    retired = "# pyre-check: min-pypy-ratio="
+    ratio = None
     with open(path, encoding="utf-8") as source:
         for _ in range(20):
             line = source.readline()
             if not line:
                 break
-            if not line.startswith(prefix):
+            if line.startswith(retired):
+                raise ValueError(
+                    f"{path} states a pypy floor: {line.strip()}\n"
+                    "the floor is derived from max-pypy-ratio; delete the line"
+                )
+            if not line.startswith(prefix) or ratio is not None:
                 continue
             try:
                 ratio = float(line[len(prefix):].strip())
@@ -922,32 +951,17 @@ def synth_perf_gate(path):
                 raise ValueError(f"invalid synthetic performance gate in {path}: {line.strip()}") from e
             if ratio <= 0:
                 raise ValueError(f"synthetic performance gate must be positive in {path}")
-            return ratio
-    return None
+    return ratio
 
 
-def synth_min_perf_gate(path):
-    """Read an optional per-fixture minimum pypy ratio from its header.
+def perf_gate_floor(ceiling):
+    """The pypy ratio a bench with this ceiling must not read below.
 
-    The minimum overrides the floor derived from `max-pypy-ratio`, for example:
-        # pyre-check: min-pypy-ratio=2
+    See `PERF_GATE_FLOOR_RATIO`: a bench is asked to reach parity, never to
+    stay slow, so the floor is parity itself until the ceiling comes close
+    enough that parity would sit inside the allowance.
     """
-    prefix = "# pyre-check: min-pypy-ratio="
-    with open(path, encoding="utf-8") as source:
-        for _ in range(20):
-            line = source.readline()
-            if not line:
-                break
-            if not line.startswith(prefix):
-                continue
-            try:
-                ratio = float(line[len(prefix):].strip())
-            except ValueError as e:
-                raise ValueError(f"invalid synthetic minimum performance gate in {path}: {line.strip()}") from e
-            if ratio <= 0:
-                raise ValueError(f"synthetic minimum performance gate must be positive in {path}")
-            return ratio
-    return None
+    return min(PERF_GATE_FLOOR_RATIO, ceiling / PERF_GATE_FLOOR_DIVISOR)
 
 
 def synth_rss_gate(path):
@@ -1822,7 +1836,7 @@ class Check:
     def _run_backend_bench(
         self, backend, name, script, timeout,
         vs_cpython, vs_pypy, t_cpython, t_pypy, pypy_output,
-        wasm_float_tol=False, max_rss_mb=None, min_pypy_ratio=None,
+        wasm_float_tol=False, max_rss_mb=None,
     ):
         pyre_bin = self._pyre(backend)
         effective_timeout = scaled_timeout(timeout, self._timeout_scale(backend))
@@ -1904,10 +1918,7 @@ class Check:
                 ratio = _ratio(elapsed, t_pypy)
 
         if vs_pypy and t_pypy not in (None, "-"):
-            minimum = (
-                min_pypy_ratio if min_pypy_ratio is not None
-                else vs_pypy / PERF_GATE_FLOOR_DIVISOR
-            )
+            minimum = perf_gate_floor(vs_pypy)
             passed, bound, checked_elapsed, checked_baseline, retry_note = self._performance_gate_passed(
                 backend, script, timeout, elapsed, vs_pypy, float(t_pypy),
                 [PYPY3, script], pypy_output, "pypy", minimum,
@@ -1979,16 +1990,9 @@ class Check:
         self, name, script, timeout,
         dynasm_vs_cpython=None, dynasm_vs_pypy=None,
         cranelift_vs_cpython=None, cranelift_vs_pypy=None,
-        skip_backends=(), wasm_float_tol=False, min_pypy_ratio=None,
+        skip_backends=(), wasm_float_tol=False,
     ):
-        """Run one benchmark on each enabled backend.
-
-        `min_pypy_ratio` overrides the floor derived from the ceiling, the same
-        way `# pyre-check: min-pypy-ratio` does for a synthetic fixture. The
-        derived floor is `ceiling / PERF_GATE_FLOOR_DIVISOR`, so it can only
-        express a 5x span between the fastest and slowest host; a bench whose
-        hosts spread wider than that needs both bounds stated.
-        """
+        """Run one benchmark on each enabled backend."""
         need_cpython = False
         if (
             self.enabled("dynasm")
@@ -2055,7 +2059,7 @@ class Check:
             self._run_backend_bench(
                 backend, name, script, timeout,
                 vs_cpython, vs_pypy, t_cpython, t_pypy, pypy_output,
-                wasm_float_tol=wasm_float_tol, min_pypy_ratio=min_pypy_ratio,
+                wasm_float_tol=wasm_float_tol,
             )
 
     # ── self-checking regression guard ──
@@ -2122,7 +2126,6 @@ class Check:
         effective_timeout = scaled_timeout(timeout, self.args.timeout_scale)
         try:
             max_pypy_ratio = synth_perf_gate(path)
-            min_pypy_ratio = synth_min_perf_gate(path)
             max_rss_mb = synth_rss_gate(path)
             skip_backends = synth_skip_backends(path)
         except ValueError as e:
@@ -2204,7 +2207,6 @@ class Check:
                 backend, name, path, timeout,
                 None, vs_pypy, t_cpython, t_pypy, pypy_output,
                 max_rss_mb=None if backend == "wasm" else max_rss_mb,
-                min_pypy_ratio=min_pypy_ratio,
             )
 
     def run_synthetic_suite(self):
@@ -2516,12 +2518,11 @@ def main():
         chk.run_bench("fib_recursive",  f"{B}/fib_recursive.py",        5,       2,       6,       2,       8)
         chk.run_bench("nested_loop",    f"{B}/nested_loop.py",          5,       None,    2,       None,    3)
         chk.run_bench("raise_catch",    f"{B}/raise_catch_loop.py",     5,       None,    1.5,     None,    2.5)
-        # spectral_norm's hosts spread 0.5x-4.3x against pypy — pypy runs it in
+        # spectral_norm's hosts spread 0.5x-4.3x against pypy: pypy runs it in
         # 0.13s on the linux and macos runners and 0.39s on the windows one, so
-        # pyre reads faster than pypy there and crosses the derived floor of
-        # 5/5 = 1x. The span is wider than a derived floor can express, so the
-        # floor is stated at half the fastest ratio observed.
-        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       1,       5,       1,       5,    min_pypy_ratio=0.25)
+        # pyre reads faster than pypy there. This is the bench that sets the
+        # floor divisor's lower bound among the non-synthetic ones.
+        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       1,       5,       1,       5)
         chk.run_bench("nbody",          f"{B}/nbody.py",               10,       0.5,     5,       1,       5,    wasm_float_tol=True)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       15)
         # Skipped on wasm: the guard times calls with `time.perf_counter()`, and

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -126,26 +126,32 @@ EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # A floor failure is only trustworthy when the baseline clears the execution
 # floor enough for small relative error: execution time is the difference
 # between two independently measured values.
-FLOOR_GATE_MIN_BASELINE_S = 3 * EXEC_TIME_FLOOR_S
+#
+# Three times the floor is not enough of a clearance to fail a bench on.  At
+# that size the baseline is 3 scheduler ticks of Windows CPU accounting, each
+# side of the ratio carries +-1 tick, and a "you got fast" verdict is being
+# read off a number with a third of its own magnitude in quantization error.
+# One CI run failed `comprehension_accumulators` on windows for reading 0.3x
+# against a pypy baseline of 0.05s -- 3.2 ticks -- while the same fixture read
+# 1.6x and 2.5x on macos.  Ten times the floor holds that error near a tenth,
+# and it leaves the gate armed on 24 fixtures whose pypy time is real work.
+FLOOR_GATE_MIN_BASELINE_S = 10 * EXEC_TIME_FLOOR_S
 # The pypy performance floor is DERIVED from the ceiling and is never stated
 # per bench.  What we want from every bench is parity with pypy, so a
 # hand-written floor would assert that a fixture must STAY some number of times
 # slower than pypy -- not a thing anyone wants to be true, and one more number
 # to re-fit every time the ceiling moves.  The floor is only an instrument for
 # reporting that a ceiling has gone stale, so it sits at parity: reaching it is
-# the event worth a red run, and no ceiling above parity can put the floor
-# anywhere a bench that is merely fast on a fast host can reach.  Ceilings run
-# as far as 194x above the lowest ratio a runner has reported for their fixture,
-# and none of that spread can reach a floor pinned here.
+# the event worth a red run.
 PERF_GATE_FLOOR_RATIO = 1.0
 # Below a ceiling of this many times parity, a floor AT parity would sit inside
 # the band the ceiling itself allows, so the floor drops proportionally instead.
 # The divisor has to clear the span one fixture reads across the CI runners --
 # the ceiling is an allowance set from the slowest of them, and the fastest can
-# read several times lower.  Among the fixtures whose ceiling is low enough for
-# the divisor to bind, the widest gap between a ceiling and the lowest ratio any
-# runner reported for it is 22x, so a smaller divisor would fail a bench for
-# being fast on the host where it is fastest.
+# read several times lower.  Of the fixtures whose baseline is large enough to
+# arm the floor at all, the widest gap between a ceiling and a ratio a runner
+# reported for it is 6x; those are the fixtures whose pypy time is real work,
+# which is also what earns them a closely fitted ceiling.
 PERF_GATE_FLOOR_DIVISOR = 25
 # A single slow sample is retried before failing a performance gate. Windows
 # needs more samples because its process CPU accounting is scheduler-tick

--- a/pyre/extra_tests/parity_tests/dict_subscript_fold.py
+++ b/pyre/extra_tests/parity_tests/dict_subscript_fold.py
@@ -135,3 +135,5 @@ assert read_varying_int_keys(varying) == (N * (N - 1)) // 2 + 5 * N
 mutating = {0: 11}
 assert write_new_keys_and_read_first(mutating) == 0
 assert mutating[N - 1] == (N - 1) * 3
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/exception_instance_dict_attr.py
+++ b/pyre/extra_tests/parity_tests/exception_instance_dict_attr.py
@@ -113,3 +113,5 @@ assert read_sum(o) == 5 * N
 
 # The typed `args` slot is not a dictionary attribute.
 assert E(1, 2).args == (1, 2)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/object_init_text_signature.py
+++ b/pyre/extra_tests/parity_tests/object_init_text_signature.py
@@ -18,3 +18,5 @@ assert str(inspect.signature(object.__init__)) == "(self, /, *args, **kwargs)"
 # consumed and does not survive into the rendered signature.
 assert str(inspect.signature(object.__new__)) == "(*args, **kwargs)"
 assert str(inspect.signature(int.__dict__["__pow__"])) == "(self, value, mod=None, /)"
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/os_stat_file_descriptor.py
+++ b/pyre/extra_tests/parity_tests/os_stat_file_descriptor.py
@@ -1,3 +1,8 @@
+# pyre-check: platforms=linux,darwin
+# Windows has no `dir_fd`, so the reference raises NotImplementedError where
+# this pins the ValueError that precedes it. pyre reads EBADF from
+# `os.stat(fd)` there as well, which this file cannot gate: a comparison
+# against a failing reference measures nothing.
 """`os.stat` takes an open file descriptor where `os.lstat` does not.
 
 `interp_posix.py:611` declares stat's path as `path_or_fd(allow_fd=True)` and

--- a/pyre/extra_tests/parity_tests/run.py
+++ b/pyre/extra_tests/parity_tests/run.py
@@ -100,7 +100,16 @@ def _run(cmd: list[str], script: Path, env: dict[str, str] | None) -> tuple[bool
     lines = [line for line in out.splitlines() if line.strip()]
     last = lines[-1] if lines else ""
     ok = proc.returncode == 0 and last == "OK"
-    detail = "" if ok else f"rc={proc.returncode} last={last!r} stderr={err.strip()!r}"
+    if ok:
+        detail = ""
+    elif proc.returncode == 0:
+        # The script ran to completion and never announced itself. Reporting
+        # this as `rc=0 last=''` reads like an interpreter that produced
+        # nothing, and it is reported once per runner, so three of them make a
+        # sound fixture that forgot its last line look like a pyre failure.
+        detail = f"exited 0 without a final 'OK' line (last non-empty line {last!r})"
+    else:
+        detail = f"rc={proc.returncode} last={last!r} stderr={err.strip()!r}"
     return ok, detail
 
 


### PR DESCRIPTION
`pyre/check.py`'s pypy performance gate has a floor as well as a ceiling. The
floor was a per-fixture number: 240 synthetic fixtures carried a
`# pyre-check: min-pypy-ratio=` header, and `run_bench` took a `min_pypy_ratio`
keyword. Each of those numbers asserts that a fixture must **stay** some number
of times slower than pypy, which is not a thing anyone wants to be true, and
each has to be re-fitted every time its ceiling moves.

The floor is now derived and stated nowhere else:

```python
def perf_gate_floor(ceiling):
    return min(PERF_GATE_FLOOR_RATIO, ceiling / PERF_GATE_FLOOR_DIVISOR)
```

Parity with pypy is what every bench is asked for, so parity is the floor; it
drops proportionally only once the ceiling itself comes within 25x of parity,
where a floor at parity would sit inside the band the ceiling already allows.
`synth_perf_gate` rejects a leftover `min-pypy-ratio` header rather than
ignoring it.

### The floor was arming on baselines too small to read

Run 31071924467 failed `synth/comprehension_accumulators` on windows for
reading 0.3x — against a pypy baseline of 0.05s. On windows that is 3.2
scheduler ticks, each side of the ratio carries ±1 tick, and the same fixture
read 1.6x and 2.5x on macos in the same run. The gate armed at
`3 * EXEC_TIME_FLOOR_S`, so it was reading a "you got fast" verdict off a
number with a third of its own magnitude in quantization error.

`FLOOR_GATE_MIN_BASELINE_S` is now `10 * EXEC_TIME_FLOOR_S`. Across the three
runners in that run, the gate then stays armed on 24 fixtures whose pypy time
is real work, and the widest gap between a ceiling and a ratio reported for one
of them is 6x — comfortably inside the divisor.

### Verification

Every fixture whose header note changed, plus every fixture that still arms the
floor, run green on dynasm and cranelift locally. No fixture's floor moves
tighter than the ratio any runner has reported for it.

— *opened by Claude*

---

## Rebased onto #1079, and the parity_tests failures that came with it

The gate step is green on all three runners at the previous head —
`dynasm 388/388`, `cranelift 388/388`, ubuntu also `wasm 384/384`, windows
included. What was left red was `parity_tests`, and none of it was this
change:

- `dict_subscript_fold`, `exception_instance_dict_attr` and
  `object_init_text_signature` (all added by #1067) end on an assert and never
  print the final `OK` line `run.py` requires, so all three interpreters
  reported `rc=0 last=''` and the row read `cpython=FAIL dynasm=FAIL
  cranelift=FAIL`. Each gets its `print("OK")`, and `run.py` now says "exited 0
  without a final 'OK' line" instead of a detail that reads like an interpreter
  which produced nothing.
- `os_stat_file_descriptor` is `platforms=linux,darwin`: windows has no
  `dir_fd`, so the reference raises `NotImplementedError` where the fixture pins
  the `ValueError` that precedes it. This is the first run in which the windows
  job ever reached `parity_tests` — the gate step used to stop it.

`python3 pyre/extra_tests/parity_tests/run.py` reports `all parity tests pass`
locally on both backends, rebuilt at this base.
