### PR TITLE
jit: relocate a bridge's target tokens, and name the FOR_ITER deferred-admit call boundary

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -35,6 +35,13 @@ const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers:
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
+/// A LABEL publishes an in-buffer offset and only becomes an absolute address
+/// in `fixup_target_tokens`; 0 means its target was never compiled.  The first
+/// page is never mapped, so any value below it is one of those two and can only
+/// be a wild branch.  Dynasm bakes the immediate at codegen, so it cannot be
+/// repaired later.
+const MIN_RELOCATED_JUMP_TARGET: usize = 4096;
+
 /// Bytes the trace entry frame reserves: the frame-pointer/link pair, the
 /// callee-saved registers the trace body clobbers, and the thread-local base
 /// slot. The prologue, the stack-overflow early return and the epilogue must
@@ -353,6 +360,10 @@ pub struct AssemblerARM64<'a> {
     /// landed outside `b.cond`'s forward reach.  Read by `check_guard_reach`.
     guard_reach_violations: Vec<(usize, usize)>,
 
+    /// First cross-buffer JUMP whose target still points into an assembler
+    /// buffer instead of executable memory.
+    unrelocated_jump_target: Option<(usize, usize)>,
+
     /// x86/assembler.py:93 target_tokens_currently_compiling parity.
     /// Keyed by descriptor pointer identity (PyPy uses Python `is`).
     target_tokens_currently_compiling: IndexMap<usize, DynamicLabel>,
@@ -553,6 +564,7 @@ impl<'a> AssemblerARM64<'a> {
             long_guard_branch: false,
             short_guard_branch_offsets: IndexMap::new(),
             guard_reach_violations: Vec::new(),
+            unrelocated_jump_target: None,
             target_tokens_currently_compiling: IndexMap::new(),
             compiled_target_tokens: Vec::new(),
             vtable_offset,
@@ -1851,6 +1863,49 @@ impl<'a> AssemblerARM64<'a> {
         gcmap
     }
 
+    /// `aarch64/assembler.py:1087 fixup_target_tokens`.
+    /// A LABEL assembled inside a bridge is a jump target for later traces exactly like a loop's.
+    fn fixup_target_tokens(tokens: Vec<majit_ir::DescrRef>, frame_depth: usize, rawstart: usize) {
+        for descr in tokens {
+            if let Some(loop_descr) = descr.as_loop_target_descr() {
+                // assembler.py:1167-1171 reads the target loop's
+                // `frame_info.jfi_frame_depth` at a cross-loop JUMP; publish
+                // this loop's full frame depth so a later trace's JUMP can
+                // size its frame for this target.  Carries the depth grown by
+                // `_assemble` for this loop's own onward JUMP.
+                //
+                // Store the companion `target_frame_depth` BEFORE the
+                // `ll_loop_code` gate (both Release stores): a reader
+                // Acquire-loads `ll_loop_code` and only reads
+                // `target_frame_depth` once the gate is non-zero, so the depth
+                // must become visible first — otherwise the reader pairs the
+                // new code pointer with a stale 0 depth and bypasses the
+                // frame-capacity check (descr.rs set_dispatch_target ordering
+                // contract).  Dynasm ignores `label_block_id` (descr.rs:1236 —
+                // it bakes the LABEL address straight into `ll_loop_code`), so
+                // that companion is not published here.
+                let old = loop_descr.ll_loop_code();
+                let new = old + rawstart;
+                loop_descr.set_target_frame_depth(frame_depth);
+                loop_descr.set_ll_loop_code(new);
+                if majit_ir::debug::have_debug_prints() {
+                    majit_ir::debug::debug_print(&format!(
+                        "[dynasm] fixup_target_tokens: ll_loop_code {old} -> {new:#x}"
+                    ));
+                }
+            }
+        }
+    }
+
+    fn check_unrelocated_jump_target(&self) -> Result<(), BackendError> {
+        let Some((target, descr)) = self.unrelocated_jump_target else {
+            return Ok(());
+        };
+        Err(BackendError::CompilationFailed(format!(
+            "cross-buffer JUMP target {target:#x} for descr {descr:#x} is not a relocated executable address"
+        )))
+    }
+
     // ----------------------------------------------------------------
     // assembler.py:501 assemble_loop
     // ----------------------------------------------------------------
@@ -1872,6 +1927,7 @@ impl<'a> AssemblerARM64<'a> {
         self.self_entry_label = Some(entry_label);
         let entry = self.mc.offset();
         self._assemble(true)?;
+        self.check_unrelocated_jump_target()?;
 
         // regalloc sets fail_arg_locs in append_guard_token_with_faillocs.
         // No allocate_unmapped_fail_arg_slots needed.
@@ -1881,6 +1937,8 @@ impl<'a> AssemblerARM64<'a> {
         self.check_guard_reach()?;
 
         // assembler.py:556 materialize_loop — finalize to executable memory
+        let tokens = std::mem::take(&mut self.compiled_target_tokens);
+        let frame_depth = self.frame_depth;
         let buffer = self
             .mc
             .finalize()
@@ -1899,28 +1957,7 @@ impl<'a> AssemblerARM64<'a> {
         // trampoline. The JIT code loads from this pointer at runtime.
         unsafe { *self.self_entry_addr_ptr = rawstart + entry.0 };
 
-        for descr in &self.compiled_target_tokens {
-            if let Some(loop_descr) = descr.as_loop_target_descr() {
-                // assembler.py:1167-1171 reads the target loop's
-                // `frame_info.jfi_frame_depth` at a cross-loop JUMP; publish
-                // this loop's full frame depth so a later trace's JUMP can
-                // size its frame for this target.  Carries the depth grown by
-                // `_assemble` for this loop's own onward JUMP.
-                //
-                // Store the companion `target_frame_depth` BEFORE the
-                // `ll_loop_code` gate (both Release stores): a reader
-                // Acquire-loads `ll_loop_code` and only reads
-                // `target_frame_depth` once the gate is non-zero, so the depth
-                // must become visible first — otherwise the reader pairs the
-                // new code pointer with a stale 0 depth and bypasses the
-                // frame-capacity check (descr.rs set_dispatch_target ordering
-                // contract).  Dynasm ignores `label_block_id` (descr.rs:1236 —
-                // it bakes the LABEL address straight into `ll_loop_code`), so
-                // that companion is not published here.
-                loop_descr.set_target_frame_depth(self.frame_depth);
-                loop_descr.set_ll_loop_code(loop_descr.ll_loop_code() + rawstart);
-            }
-        }
+        Self::fixup_target_tokens(tokens, frame_depth, rawstart);
 
         // Position is the canonical fail_index identity (matching
         // `llsupport/assembler.py`'s `_allgcrefs` index — PyPy does not
@@ -2037,9 +2074,12 @@ impl<'a> AssemblerARM64<'a> {
         // assembler.py:641 prepare_bridge
         let entry = self.mc.offset();
         self._assemble(false)?;
+        self.check_unrelocated_jump_target()?;
         let stub_offsets = self.write_pending_failure_recoveries();
         self.check_guard_reach()?;
 
+        let tokens = std::mem::take(&mut self.compiled_target_tokens);
+        let frame_depth = self.frame_depth;
         let buffer = self
             .mc
             .finalize()
@@ -2052,6 +2092,7 @@ impl<'a> AssemblerARM64<'a> {
         // `_check_frame_depth` depth placeholder with the final absolute
         // frame depth (max of loop/bridge), now known post-finalize.
         Self::patch_stack_checks(self.frame_depth, rawstart, &self.frame_depth_to_patch);
+        Self::fixup_target_tokens(tokens, frame_depth, rawstart);
 
         if crate::majit_dump_enabled() {
             let code = unsafe { std::slice::from_raw_parts(rawstart as *const u8, buffer.len()) };
@@ -2108,6 +2149,7 @@ impl<'a> AssemblerARM64<'a> {
         let ops: &'a [Op] = self.operations;
         self.short_guard_branch_offsets.clear();
         self.guard_reach_violations.clear();
+        self.unrelocated_jump_target = None;
         // A guard's `b.cond` has to reach a stub that is written after the
         // whole body, so the budget is the body plus every stub — not the body
         // alone.  `const_stores` makes a stub grow independently of the
@@ -3131,18 +3173,22 @@ impl<'a> AssemblerARM64<'a> {
                     .and_then(|k| self.target_tokens_currently_compiling.get(&k).copied())
                 {
                     dynasm!(self.mc ; .arch aarch64 ; b =>label);
-                } else if let Some(target) = jump_descr.map(|descr| descr.ll_loop_code()) {
+                } else if let (Some(descr_ref), Some(descr)) = (descr_arc.as_ref(), jump_descr) {
+                    let target = descr.ll_loop_code();
                     // External JUMP: direct branch to target loop code.
                     // assembler.py:2461 mc.JMP(imm(target))
                     // Use x16 (IP0 scratch) to avoid clobbering remap'd regs.
                     // assembler.py:1167-1171 `_assemble`: record the target
                     // loop's frame depth so this trace's frame grows to fit it.
-                    if let Some(descr) = jump_descr {
+                    if target < MIN_RELOCATED_JUMP_TARGET {
+                        self.unrelocated_jump_target =
+                            Some((target, majit_ir::descr_identity(descr_ref)));
+                    } else {
                         self.jump_target_frame_depth =
                             self.jump_target_frame_depth.max(descr.target_frame_depth());
+                        self.emit_mov_imm64(16, target as i64);
+                        dynasm!(self.mc ; .arch aarch64 ; br x16);
                     }
-                    self.emit_mov_imm64(16, target as i64);
-                    dynasm!(self.mc ; .arch aarch64 ; br x16);
                 }
             }
             OpCode::Finish => {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -64,6 +64,13 @@ const X86_FLOAT_REGS: [crate::regloc::RegLoc; 8] = [
     crate::regloc::RegLoc::new(7, true),
 ];
 
+/// A LABEL publishes an in-buffer offset and only becomes an absolute address
+/// in `fixup_target_tokens`; 0 means its target was never compiled.  The first
+/// page is never mapped, so any value below it is one of those two and can only
+/// be a wild branch.  Dynasm bakes the immediate at codegen, so it cannot be
+/// repaired later.
+const MIN_RELOCATED_JUMP_TARGET: usize = 4096;
+
 /// Resolved argument: either a frame slot (frame-pointer-relative offset) or a constant.
 enum ResolvedArg {
     /// Frame-pointer-relative byte offset: [rbp + offset] on x64, [x29, #offset] on aarch64.
@@ -800,6 +807,9 @@ pub struct Assembler386<'a> {
     /// Keyed by descriptor pointer identity (PyPy uses Python `is`).
     target_tokens_currently_compiling: IndexMap<usize, DynamicLabel>,
     compiled_target_tokens: Vec<majit_ir::DescrRef>,
+    /// First cross-buffer JUMP whose target still points into an assembler
+    /// buffer instead of executable memory.
+    unrelocated_jump_target: Option<(usize, usize)>,
     /// llmodel.py:64-69 self.vtable_offset — typeptr field byte offset.
     /// `None` corresponds to RPython's gcremovetypeptr config.
     vtable_offset: Option<usize>,
@@ -1024,6 +1034,7 @@ impl<'a> Assembler386<'a> {
             guard_success_cc: None,
             target_tokens_currently_compiling: IndexMap::new(),
             compiled_target_tokens: Vec::new(),
+            unrelocated_jump_target: None,
             vtable_offset,
             classptr_to_typeid,
             guard_gc_type_info,
@@ -2504,6 +2515,49 @@ impl<'a> Assembler386<'a> {
         gcmap
     }
 
+    /// `x86/assembler.py:990 fixup_target_tokens`.
+    /// A LABEL assembled inside a bridge is a jump target for later traces exactly like a loop's.
+    fn fixup_target_tokens(tokens: Vec<majit_ir::DescrRef>, frame_depth: usize, rawstart: usize) {
+        for descr in tokens {
+            if let Some(loop_descr) = descr.as_loop_target_descr() {
+                // assembler.py:1003-1008 reads the target loop's
+                // `frame_info.jfi_frame_depth` at a cross-loop JUMP; publish
+                // this loop's full frame depth so a later trace's JUMP can
+                // size its frame for this target.  Carries the depth grown by
+                // `_assemble` for this loop's own onward JUMP.
+                //
+                // Store the companion `target_frame_depth` BEFORE the
+                // `ll_loop_code` gate (both Release stores): a reader
+                // Acquire-loads `ll_loop_code` and only reads
+                // `target_frame_depth` once the gate is non-zero, so the depth
+                // must become visible first — otherwise the reader pairs the
+                // new code pointer with a stale 0 depth and bypasses the
+                // frame-capacity check (descr.rs set_dispatch_target ordering
+                // contract).  Dynasm ignores `label_block_id` (descr.rs:1236 —
+                // it bakes the LABEL address straight into `ll_loop_code`), so
+                // that companion is not published here.
+                let old = loop_descr.ll_loop_code();
+                let new = old + rawstart;
+                loop_descr.set_target_frame_depth(frame_depth);
+                loop_descr.set_ll_loop_code(new);
+                if majit_ir::debug::have_debug_prints() {
+                    majit_ir::debug::debug_print(&format!(
+                        "[dynasm] fixup_target_tokens: ll_loop_code {old} -> {new:#x}"
+                    ));
+                }
+            }
+        }
+    }
+
+    fn check_unrelocated_jump_target(&self) -> Result<(), BackendError> {
+        let Some((target, descr)) = self.unrelocated_jump_target else {
+            return Ok(());
+        };
+        Err(BackendError::CompilationFailed(format!(
+            "cross-buffer JUMP target {target:#x} for descr {descr:#x} is not a relocated executable address"
+        )))
+    }
+
     // ----------------------------------------------------------------
     // assembler.py:501 assemble_loop
     // ----------------------------------------------------------------
@@ -2525,6 +2579,7 @@ impl<'a> Assembler386<'a> {
         self.self_entry_label = Some(entry_label);
         let entry = self.mc.offset();
         self._assemble(true)?;
+        self.check_unrelocated_jump_target()?;
 
         // regalloc sets fail_arg_locs in append_guard_token_with_faillocs.
         // No allocate_unmapped_fail_arg_slots needed.
@@ -2533,6 +2588,8 @@ impl<'a> Assembler386<'a> {
         let stub_offsets = self.write_pending_failure_recoveries();
 
         // assembler.py:556 materialize_loop — finalize to executable memory
+        let tokens = std::mem::take(&mut self.compiled_target_tokens);
+        let frame_depth = self.frame_depth;
         let buffer = self
             .mc
             .finalize()
@@ -2553,28 +2610,7 @@ impl<'a> Assembler386<'a> {
         // trampoline. The JIT code loads from this pointer at runtime.
         unsafe { *self.self_entry_addr_ptr = rawstart + entry.0 };
 
-        for descr in &self.compiled_target_tokens {
-            if let Some(loop_descr) = descr.as_loop_target_descr() {
-                // assembler.py:1003-1008 reads the target loop's
-                // `frame_info.jfi_frame_depth` at a cross-loop JUMP; publish
-                // this loop's full frame depth so a later trace's JUMP can
-                // size its frame for this target.  Carries the depth grown by
-                // `_assemble` for this loop's own onward JUMP.
-                //
-                // Store the companion `target_frame_depth` BEFORE the
-                // `ll_loop_code` gate (both Release stores): a reader
-                // Acquire-loads `ll_loop_code` and only reads
-                // `target_frame_depth` once the gate is non-zero, so the depth
-                // must become visible first — otherwise the reader pairs the
-                // new code pointer with a stale 0 depth and bypasses the
-                // frame-capacity check (descr.rs set_dispatch_target ordering
-                // contract).  Dynasm ignores `label_block_id` (descr.rs:1236 —
-                // it bakes the LABEL address straight into `ll_loop_code`), so
-                // that companion is not published here.
-                loop_descr.set_target_frame_depth(self.frame_depth);
-                loop_descr.set_ll_loop_code(loop_descr.ll_loop_code() + rawstart);
-            }
-        }
+        Self::fixup_target_tokens(tokens, frame_depth, rawstart);
 
         // Position is the canonical fail_index identity (matching
         // `llsupport/assembler.py`'s `_allgcrefs` index — PyPy does not
@@ -2684,8 +2720,11 @@ impl<'a> Assembler386<'a> {
         // assembler.py:641 prepare_bridge
         let entry = self.mc.offset();
         self._assemble(false)?;
+        self.check_unrelocated_jump_target()?;
         let stub_offsets = self.write_pending_failure_recoveries();
 
+        let tokens = std::mem::take(&mut self.compiled_target_tokens);
+        let frame_depth = self.frame_depth;
         let buffer = self
             .mc
             .finalize()
@@ -2700,6 +2739,7 @@ impl<'a> Assembler386<'a> {
         // patch rewrites the placeholder `0xffffff` immediate(s) so the
         // CMP at bridge entry reflects the bridge's true requirement.
         Self::patch_stack_checks(self.frame_depth, rawstart, &self.frame_depth_to_patch);
+        Self::fixup_target_tokens(tokens, frame_depth, rawstart);
 
         if crate::majit_dump_enabled() {
             let code = unsafe { std::slice::from_raw_parts(rawstart as *const u8, buffer.len()) };
@@ -2754,6 +2794,7 @@ impl<'a> Assembler386<'a> {
     fn _assemble(&mut self, emit_prologue: bool) -> Result<(), BackendError> {
         let inputargs: &'a [InputArg] = self.inputargs;
         let ops: &'a [Op] = self.operations;
+        self.unrelocated_jump_target = None;
         if emit_prologue {
             self._call_header(inputargs);
         } else {
@@ -4126,7 +4167,8 @@ impl<'a> Assembler386<'a> {
                     .and_then(|k| self.target_tokens_currently_compiling.get(&k).copied())
                 {
                     dynasm!(self.mc ; .arch x64 ; jmp =>label);
-                } else if let Some(target) = jump_descr.map(|descr| descr.ll_loop_code()) {
+                } else if let (Some(descr_ref), Some(descr)) = (descr_arc.as_ref(), jump_descr) {
+                    let target = descr.ll_loop_code();
                     // External JUMP: direct JMP to target loop code.
                     // assembler.py:2461 mc.JMP(imm(target)) — PyPy's
                     // `LocationCodeBuilder._addr_as_reg_offset` (regloc.py:204)
@@ -4141,16 +4183,19 @@ impl<'a> Assembler386<'a> {
                     // expecting a class pointer.
                     // assembler.py:1003-1008 `_assemble`: record the target
                     // loop's frame depth so this trace's frame grows to fit it.
-                    if let Some(descr) = jump_descr {
+                    if target < MIN_RELOCATED_JUMP_TARGET {
+                        self.unrelocated_jump_target =
+                            Some((target, majit_ir::descr_identity(descr_ref)));
+                    } else {
                         self.jump_target_frame_depth =
                             self.jump_target_frame_depth.max(descr.target_frame_depth());
+                        let addr = target as i64;
+                        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
+                        dynasm!(self.mc ; .arch x64
+                            ; mov Rq(scratch), QWORD addr
+                            ; jmp Rq(scratch)
+                        );
                     }
-                    let addr = target as i64;
-                    let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
-                    dynasm!(self.mc ; .arch x64
-                        ; mov Rq(scratch), QWORD addr
-                        ; jmp Rq(scratch)
-                    );
                 }
             }
             OpCode::Finish => {

--- a/pyre/extra_tests/parity_tests/jit_retrace_nested_loop_bridge_label.py
+++ b/pyre/extra_tests/parity_tests/jit_retrace_nested_loop_bridge_label.py
@@ -1,0 +1,38 @@
+"""A retrace whose LABEL is assembled inside a bridge is branched to correctly.
+
+A retrace is attached to a guard, so it is assembled through the bridge path and
+carries its own LABEL. That LABEL publishes an in-buffer offset that only becomes
+an absolute address when the target tokens are fixed up; a later trace closing
+onto the same token reads the field and bakes it as a branch target. Skipping the
+fixup on the bridge path made that branch jump to the raw offset.
+
+The inner loop's accumulator flips int -> float partway through the outer loop,
+which is what asks for the retrace.
+"""
+
+try:
+    import pypyjit
+except ImportError:
+    pass
+else:
+    pypyjit.set_param("retrace_limit=5")
+
+
+def accumulate(outer, inner):
+    total = 0
+    o = 0
+    while o < outer:
+        j = 0
+        while j < inner:
+            if o > 200:
+                total = total + 0.5
+            else:
+                total = total + 1
+            j += 1
+        o += 1
+    return total
+
+
+assert accumulate(600, 100) == 40050.0
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/jit_subscr_getitem_inline_keeps_its_index.py
+++ b/pyre/extra_tests/parity_tests/jit_subscr_getitem_inline_keeps_its_index.py
@@ -1,0 +1,21 @@
+"""A user `__getitem__` inlined from BINARY_OP keeps its own index operand.
+
+The FOR_ITER deferred-inline gate used to admit this inline because it carried
+no `arg_class_guard`, which stood for "entered from a CALL the abort rewind can
+name". `obj[key]` enters from BINARY_OP instead, so a deferred abort resumed one
+operand short and the subscript index was replaced at runtime by an unrelated
+live Ref — here the enclosing generator's iterator, which surfaced as
+
+    TypeError: list indices must be integers or slices, not list_iterator
+
+from `re._parser.SubPattern.__getitem__`. JIT-only; `PYRE_NO_JIT=1` always
+passed.
+"""
+
+import re
+
+pattern = re.compile("|".join("%d" % x for x in range(10000)))
+assert pattern.match("9999") is not None
+assert pattern.match("beef") is None
+
+print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9697,6 +9697,10 @@ pub unsafe fn type_name_obj_fast_path(w_obj: PyObjectRef) -> Option<(PyObjectRef
 /// metatype data descriptor, a missing class-MRO value, or any value with a
 /// descriptor protocol declines.
 ///
+/// This is the `:820-822` arm, and [`type_name_obj_fast_path`] is the
+/// `:814-819` one: a name the metatype answers with a data descriptor — which
+/// is what `__name__` is — is refused here and folded there instead.
+///
 /// The value type must additionally be a non-heap builtin type.  Its namespace
 /// cannot be mutated from Python and it cannot be the target of a `__class__`
 /// assignment, so an absent `__get__` remains absent for the life of the trace.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1811,6 +1811,7 @@ pub(crate) fn try_walker_inline_user_call<Sym: WalkSym>(
         has_closure,
         None,
         None,
+        true,
         false,
         None,
     )
@@ -2607,6 +2608,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     has_closure: bool,
     exception_receiver_guard: Option<ExceptionInlineReceiverGuard>,
     arg_class_guard: Option<ArgClassGuard>,
+    entry_is_call_boundary: bool,
     require_str_result: bool,
     constructor_result: Option<(OpRef, ConcreteValue)>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
@@ -2965,14 +2967,21 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             CalleeReplaySafety::Clean => true,
             CalleeReplaySafety::DeferredCall => {
                 // The deferred promise rests on the abort REWINDING to the
-                // enclosing CALL and re-executing it from scratch.  A binop
-                // dunder dispatch (the only entry carrying an
-                // `arg_class_guard`) reaches this lever from a `BINARY_OP`
-                // instead, and that opcode is not a call boundary the rewind
-                // can name: the flush resumes one operand short and the whole
-                // iteration's contribution is dropped, silently.  A `Clean`
-                // body is still admitted from there — it has nothing that can
-                // abort.
+                // enclosing CALL and re-executing it from scratch, so the
+                // entry has to be a boundary the rewind can name.  What
+                // decides that is the entry opcode's stack effect rather than
+                // whether it is spelled CALL: one that merely peeks its
+                // operands re-executes from the stack it already had.  A
+                // `BINARY_OP` or `COMPARE_OP` entry is not: the flush resumes
+                // one operand short and the whole iteration's contribution is
+                // dropped, silently — the subscript inline observed its index
+                // operand replaced by an unrelated live Ref.  Each caller
+                // states this directly in `entry_is_call_boundary`; the older
+                // `arg_class_guard.is_none()` proxy stood for the same
+                // property and rotted, because the `obj[key]` inline enters
+                // from `BINARY_OP` while passing no `arg_class_guard`.  A
+                // `Clean` body is still admitted from there — it has nothing
+                // that can abort.
                 //
                 // The widened method-form surface — an unbound callee whose
                 // body reads `self.attr` — was admitted here only once the
@@ -2995,7 +3004,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 // entry or skip the handler cleanup.  Keep handler-bearing
                 // bodies on the residual path unless this scan proves them
                 // clean.
-                foriter_deferred_admit = arg_class_guard.is_none()
+                foriter_deferred_admit = entry_is_call_boundary
                     && !body_facts.owns_loop_header
                     && !pyre_interpreter::code_has_for_iter(callee_code)
                     && !body_facts.has_exception_table
@@ -4987,6 +4996,7 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
         has_closure,
         None,
         None,
+        true,
         // `__init__` bodies are `self.x = ...` stores; the sub-walk folds them
         // to slot writes on the fresh instance exactly as the property-setter
         // route folds its own.
@@ -5142,6 +5152,7 @@ pub(crate) fn try_walker_inline_exception_string_override<Sym: WalkSym>(
         Some((r_args[2], concrete_receiver, w_class, version_tag)),
         None,
         true,
+        true,
         None,
     )?
     else {
@@ -5279,6 +5290,7 @@ pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
         has_closure,
         Some((r_args[2], concrete_receiver, w_type, version_tag)),
         None,
+        true,
         false,
         None,
     )?
@@ -5464,6 +5476,9 @@ pub(crate) fn try_walker_inline_property_get<Sym: WalkSym>(
         has_closure,
         Some((obj, concrete_obj, w_type, version_tag)),
         None,
+        // LOAD_ATTR is not a CALL either, but this entry is left admitted
+        // as it was: only the subscript one below has a witness.
+        true,
         // Getter bodies commonly read `self._slot` — a LOAD_ATTR the method-form
         // support gate would otherwise reject; the sub-walk folds it to a slot
         // read (same allowance the exception `__str__`/`__repr__` override uses).
@@ -5570,6 +5585,8 @@ pub(crate) fn try_walker_inline_property_set<Sym: WalkSym>(
         has_closure,
         Some((obj, concrete_obj, w_type, version_tag)),
         None,
+        // STORE_ATTR, same standing as the getter above.
+        true,
         false,
         None,
     )
@@ -5677,6 +5694,10 @@ pub(crate) fn try_walker_inline_subscr_getitem<Sym: WalkSym>(
         has_closure,
         Some((obj, concrete_obj, w_type, version_tag)),
         None,
+        // `obj[key]` enters from BINARY_OP, which the abort rewind cannot
+        // name.  This is the entry the retired `arg_class_guard.is_none()`
+        // proxy admitted by mistake.
+        false,
         false,
         None,
     )
@@ -5783,10 +5804,12 @@ pub(crate) fn try_walker_specialize_seqiter_getitem_next<Sym: WalkSym>(
     // is what makes that necessary: `RaiseVarargs` classifies as a deferred
     // residual, so a cursor body that ends on one would otherwise never be
     // served.  The deferred promise holds here — a residual the lever cannot
-    // inline aborts before executing and denies the callee — and the one shape
-    // the shared FOR_ITER gate withholds it from, a `BINARY_OP` dunder entry
-    // carrying an `arg_class_guard`, cannot reach this route: the entry is a
-    // FOR_ITER whose only operand is the iterator.
+    // inline aborts before executing and denies the callee.  This route's own
+    // entry is a FOR_ITER, which is not a CALL, and it still passes
+    // `entry_is_call_boundary: true`: `opcode_for_iter` peeks its single
+    // iterator operand where `opcode_binary_op` pops both of its own, so the
+    // rewind re-executes this entry from the stack it already had and the
+    // boundary is nameable.
     if !matches!(
         replay_safety,
         CalleeReplaySafety::Clean | CalleeReplaySafety::DeferredCall
@@ -5868,6 +5891,9 @@ pub(crate) fn try_walker_specialize_seqiter_getitem_next<Sym: WalkSym>(
         has_closure,
         Some((seq_op, seq, w_type, version_tag)),
         None,
+        // FOR_ITER, not a CALL, but a peeking entry the rewind can re-execute —
+        // the replay-safety note above states why that is what the gate asks.
+        true,
         false,
         None,
     );
@@ -6076,6 +6102,7 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
         Some((lhs, concrete_lhs, w_class, version_tag)),
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
         false,
+        false,
         None,
     )?
     else {
@@ -6230,6 +6257,7 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         has_closure,
         Some((lhs, concrete_lhs, w_class, version_tag)),
         Some((rhs, concrete_rhs, w_typ_r.as_ptr())),
+        false,
         false,
         None,
     )?

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3345,6 +3345,10 @@ pub(crate) fn try_walker_specialize_load_type_name_attr<Sym: WalkSym>(
 /// subclasses, so the one receiver pin covers reassignment or deletion on any
 /// base class as well.
 ///
+/// A name the metatype answers with a data descriptor is refused by the oracle,
+/// so `__name__` never reaches here — [`try_walker_specialize_load_type_name_attr`]
+/// is its fold, and the two cover the disjoint arms of `descr_getattribute`.
+///
 /// The name needs no operand guard: the codewriter baked its `co_names` index
 /// into the residual.  This read-only, present-attribute fold cannot raise, so
 /// unlike the classmethod method-load fold it is safe inside an inlined callee


### PR DESCRIPTION
Rebased onto `main` (#1089). **Three commits, down from nine** — #1101 merged an
earlier head of this branch, so six of the commits this PR used to carry are
already in `main`. Replaying them produced duplicate definitions rather than
conflicts, which is how they were identified; the two that remain are the
wrong-code fixes, plus one doc commit whose code also landed in #1101.

No `.jitstats` baseline is touched. 7 files, 255/69.

## `jit`: relocate a bridge's target tokens, and refuse a cross-buffer JUMP to an unrelocated target

`assemble_bridge` never ran the `compiled_target_tokens` relocation that
`assemble_loop` inlined, so a LABEL assembled inside a bridge left its
`ll_loop_code` holding the in-buffer offset it was given at emission. A retrace
is attached to a guard, so it is assembled through the bridge path and carries
its own LABEL; a later trace closing onto that token missed
`target_tokens_currently_compiling`, read the field, and baked the offset as an
absolute branch target — `br x16` with 0x1fc, a deterministic SIGSEGV on a
nested loop whose inner accumulator changes type.

The relocation is extracted into `fixup_target_tokens` and called from both
assemble paths, matching `aarch64/assembler.py:1087` (called at `:98` and
`:213`) and `x86/assembler.py:990` (`:612`, `:706`). Both dynasm backends had
the omission; cranelift publishes an absolute address instead and is
unaffected. The list is consumed, so a token cannot be relocated twice.

A cross-buffer JUMP whose target is below the first page now fails the compile
rather than emitting the branch. Dynasm bakes the immediate at codegen, so
neither 0 (target never compiled) nor an unrelocated offset can be repaired
later; both are always wild branches.

`jit_retrace_nested_loop_bridge_label` SIGSEGVs before this change.

## `jit`: name the FOR_ITER deferred-admit call-boundary property instead of inferring it

The `CalleeReplaySafety::DeferredCall` arm admitted a callee when
`arg_class_guard.is_none()`, standing in for "the entry is a CALL the abort
rewind can name". The arm's comment justified the proxy by asserting a binop
dunder dispatch was the only entry carrying an `arg_class_guard`. It is not:
`try_walker_inline_subscr_getitem` enters from `BINARY_OP` and passes no
`arg_class_guard`, so `obj[key]` was admitted and resumed one operand short —
the subscript index was replaced at runtime by an unrelated live Ref, failing
`test.test_re` in CI with

    TypeError: list indices must be integers or slices, not list_iterator

`try_walker_inline_resolved_user_call` now takes an explicit
`entry_is_call_boundary`. Every call site was audited against the old
predicate's value; `try_walker_inline_subscr_getitem` is the only behaviour
change (`true` → `false`).

What the gate asks is the entry opcode's stack effect, not the spelling: an
entry that only peeks re-executes from the stack the rewind already has.
`opcode_for_iter` peeks its single iterator operand where `opcode_binary_op`
pops both of its own, and the FOR_ITER call site carries that reason rather
than a reference to the property routes. The two attribute entries reach their
stack discipline through `load_attr_cached` / `store_attr_cached`, which this
audit did not follow, so they keep the standing they had and say so.

`jit_subscr_getitem_inline_keeps_its_index` raises that TypeError before this
change and is JIT-only.

## `jit`: name which descr_getattribute arm each type-attribute fold covers

The folds landed in #1101; what remains is the cross-reference. The two folds
cover `typeobject.py:814-819` (the metatype-data-descriptor arm `__name__`
resolves through) and `:820-822` (the class-MRO-value arm), and each doc
comment now names its own arm and points at the other.

## Verification

The full gate was run green on this content, but **at an earlier SHA**:

| | measured | pushed here |
|---|---|---|
| head | `790ec11add2` | `4a3ab98b49a` |
| base | `d98cd907410` | `392da6eb9e3` |

```
parity suite          all parity tests pass  (221 scripts)
check.py dynasm       ALL PASSED  410/410
check.py cranelift    ALL PASSED  410/410
check.py wasm         ALL PASSED  406/406
```

`SNAPDIFF` 0, `jit-stats regressed` 0; the last two backends ran at load 6-10,
so they are not load-faked. Since then the branch was replayed onto a base that
moved by two commits / 2657 lines (#1110, #1089), touching
`jitcode_dispatch/specialize.rs` and `mod.rs` among others, and one
comment-only amend was added. The three commits replayed without conflict and
the net diff is unchanged apart from those comments, but the numbers above
describe the older SHA — CI on this head is what gates it.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JIT handling for cross-buffer jumps on AArch64 and x86, preventing invalid compilations and improving diagnostics.
  - Fixed deferred inline-call handling for iteration, binary operations, comparisons, subscripting, and related operations.
  - Improved retracing through nested-loop bridges and preserved subscript indices during deferred recovery.
  - Clarified handling of type names and metatype attributes for more consistent behavior.

- **Tests**
  - Added regression coverage for nested-loop retracing and inlined subscription operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->