### PR TITLE
time clock parity (thread_time, get_clock_info resolution) + JIT unary int folds + long-subclass unary pos

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -758,6 +758,19 @@ pub enum PyreHelperKind {
     /// A `bool` (`+True` is int `1`, not identity) and every non-int operand
     /// fall through to the generic residual so their `__pos__` still runs.
     UnaryPositive,
+    /// `bh_unary_negative_fn(value)` — the `UNARY_NEGATIVE` helper
+    /// (`opcode_ops::unary_negative_value` → `space.neg`).  The full-body
+    /// walker folds a provably-exact-int operand to `IntSubOvf(0, value)`
+    /// behind a `guard_class INT`; a bool / subclass / non-int operand, and an
+    /// `INT_MIN` value (whose negation is the `2**63` long), fall through to
+    /// the generic residual.
+    UnaryNegative,
+    /// `bh_unary_invert_fn(value)` — the `UNARY_INVERT` helper
+    /// (`opcode_ops::unary_invert_value` → `space.invert`).  The full-body
+    /// walker folds a provably-exact-int operand to `IntInvert(value)` behind a
+    /// `guard_class INT` (`~x` always fits an int, so no overflow guard); a
+    /// bool / subclass / non-int operand falls through to the generic residual.
+    UnaryInvert,
     /// `bh_unpack_sequence_fn(count, seq)` — the UNPACK_SEQUENCE validator
     /// emitted by the codewriter UNPACK_SEQUENCE arm.  Validates the exact
     /// length and returns the normalized tuple.  The full-body walker

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -749,6 +749,15 @@ pub enum PyreHelperKind {
     /// + `int_is_true`, eliding the `CALL_MAY_FORCE` (and its
     /// `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the generic residual emits.
     Truth,
+    /// `bh_unary_positive_fn(value)` — the CALL_INTRINSIC_1 UNARY_POSITIVE
+    /// helper (`opcode_ops::unary_positive_value` → `space.pos`).  `int.__pos__`
+    /// returns an exact int unchanged, so the full-body walker recognises this
+    /// tag to fold a provably-int operand to the operand itself behind a
+    /// `guard_class INT`, eliding the `CALL_MAY_FORCE` (and its
+    /// `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the generic residual emits.
+    /// A `bool` (`+True` is int `1`, not identity) and every non-int operand
+    /// fall through to the generic residual so their `__pos__` still runs.
+    UnaryPositive,
     /// `bh_unpack_sequence_fn(count, seq)` — the UNPACK_SEQUENCE validator
     /// emitted by the codewriter UNPACK_SEQUENCE arm.  Validates the exact
     /// length and returns the normalized tuple.  The full-body walker

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1089,6 +1089,11 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // 159 as a bare `with_gc_ptrs` id and carries no vtable of its own.
         subclass_range_alias(160, typed::<crate::module::_io::W_BytesIO>()),
         subclass_range_alias(161, typed::<crate::module::_io::W_StringIO>()),
+        // `posix.DirEntry` — `allocate_stable` type registered right after
+        // `W_StringIO` in `build_gc`, before the bare twister id.  `posix` is
+        // compiled out on wasm32 (`module/mod.rs:91`), so this alias is too.
+        #[cfg(not(target_arch = "wasm32"))]
+        subclass_range_alias(162, typed::<crate::module::posix::W_DirEntry>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/_random/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_random/mod.rs
@@ -20,23 +20,37 @@ const MAGIC_CONSTANT_B: u32 = 19650218;
 const MAGIC_CONSTANT_C: u32 = 1664525;
 const MAGIC_CONSTANT_D: u32 = 1566083941;
 
-pub(crate) struct Random {
+/// `rrandom.py:23 class Random` is an ordinary instance that
+/// `interp_random.py:21` allocates on its own — `self._rnd = rrandom.Random()`
+/// — so the twister lives *behind* a reference rather than inside its holder.
+/// Keeping that shape is what makes the holder's `self.rnd` field readable:
+/// borrowing an inline aggregate field has no IR spelling, and the front-end's
+/// `&x ≡ x` model would hand `genrand32` the first word of `state` where its
+/// address was meant.  It owns no object references, so the collector forwards
+/// nothing but its header.
+#[crate::pyre_class("_random._mersenne_twister", static_name = "MERSENNE_TWISTER")]
+pub struct Random {
     state: [u32; N],
     index: usize,
 }
 
-impl Default for Random {
-    fn default() -> Self {
-        let mut rnd = Random {
+impl Random {
+    /// `rrandom.Random.__init__` — a fresh state run through `init_genrand(0)`.
+    fn new_instance() -> PyObjectRef {
+        let obj = Random::allocate_stable(Random {
+            ob: PyObject {
+                ob_type: std::ptr::null(),
+                w_class: std::ptr::null_mut(),
+            },
             state: [0; N],
             index: 0,
-        };
-        rnd.init_genrand(0);
-        rnd
+        });
+        Random::from_obj(obj)
+            .expect("a freshly allocated twister has the Random layout")
+            .init_genrand(0);
+        obj
     }
-}
 
-impl Random {
     fn init_genrand(&mut self, s: u32) {
         let mt = &mut self.state;
         mt[0] = s;
@@ -128,7 +142,18 @@ pub struct W_Random {
     /// `_random.Random` itself simply retains the empty/null state.
     pub map: *const u8,
     pub storage: *mut pyre_object::object_array::ItemsBlock,
-    rnd: Random,
+    /// `interp_random.py:21 self._rnd = rrandom.Random()` — the reference to a
+    /// separately allocated generator.  `random_object_custom_trace` forwards
+    /// it: the mapdict-prefix trace this class shares knows only `w_class`,
+    /// `storage` and the boxed attribute slots.
+    pub rnd: PyObjectRef,
+}
+
+impl W_Random {
+    /// The generator behind `self._rnd`.
+    fn rnd(&self) -> &'static mut Random {
+        Random::from_obj(self.rnd).expect("_random.Random holds a Mersenne Twister")
+    }
 }
 
 // `has_mapdict_storage` admits a `_random.Random` to the shared mapdict path,
@@ -173,18 +198,27 @@ impl W_Random {
         pyre_object::gc_roots::pin_root(w_anything);
         let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 2;
         let seed_slot = cls_slot + 1;
-        let obj = W_Random::allocate_stable(W_Random::default());
+        // `interp_random.py:21` builds the generator before anything can reach
+        // it through the wrapper, so each allocation has to hold the previous
+        // one down: the twister across the wrapper's allocation, the wrapper
+        // across `seed`'s.
+        pyre_object::gc_roots::pin_root(Random::new_instance());
+        let rnd_slot = seed_slot + 1;
+        pyre_object::gc_roots::pin_root(W_Random::allocate_stable(W_Random::default()));
+        let obj_slot = rnd_slot + 1;
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         crate::typedef::tag_subclass_instance(obj, unsafe {
             pyre_object::gc_roots::shadow_stack_get(cls_slot)
         });
         let random = W_Random::from_obj(obj)
             .expect("a freshly allocated _random.Random has the Random layout");
+        random.rnd = pyre_object::gc_roots::shadow_stack_get(rnd_slot);
         random.seed(pyre_object::gc_roots::shadow_stack_get(seed_slot))?;
-        Ok(obj)
+        Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot))
     }
 
     fn random(&mut self) -> f64 {
-        self.rnd.random()
+        self.rnd().random()
     }
 
     fn seed(
@@ -219,16 +253,17 @@ impl W_Random {
         // Split into little-endian 32-bit chunks.
         let (_sign, key) = n.to_u32_digits();
         let key = if key.is_empty() { vec![0u32] } else { key };
-        self.rnd.init_by_array(&key);
+        self.rnd().init_by_array(&key);
         Ok(())
     }
 
     fn getstate(&self) -> PyObjectRef {
+        let rnd = self.rnd();
         let mut state: Vec<PyObjectRef> = Vec::with_capacity(N + 1);
         for i in 0..N {
-            state.push(w_int_new(self.rnd.state[i] as i64));
+            state.push(w_int_new(rnd.state[i] as i64));
         }
-        state.push(w_int_new(self.rnd.index as i64));
+        state.push(w_int_new(rnd.index as i64));
         w_tuple_new(state)
     }
 
@@ -267,8 +302,9 @@ impl W_Random {
             if index < 0 || index > N as i64 {
                 crate::bail_value_error!("invalid state");
             }
-            self.rnd.state = new_state;
-            self.rnd.index = index as usize;
+            let rnd = self.rnd();
+            rnd.state = new_state;
+            rnd.index = index as usize;
         }
         Ok(())
     }
@@ -283,7 +319,7 @@ impl W_Random {
         }
         if k < 32 {
             // fits an int, skip the bytes-to-long dance
-            let r = self.rnd.genrand32() >> (32 - k);
+            let r = self.rnd().genrand32() >> (32 - k);
             return Ok(w_int_new(r as i64));
         }
         let nbytes = usize::try_from(((k - 1) / 32 + 1) * 4)
@@ -293,7 +329,7 @@ impl W_Random {
             .try_reserve_exact(nbytes)
             .map_err(|_| crate::PyError::memory_error(""))?;
         while k > 0 {
-            let mut r = self.rnd.genrand32();
+            let mut r = self.rnd().genrand32();
             if k < 32 {
                 r >>= 32 - k;
             }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -23,6 +23,27 @@ struct ApplevelForkCallbacks {
     child_w: Vec<usize>,
 }
 
+/// `posix.DirEntry` — native layout `[PyObject | w_name | w_path | w_stat |
+/// w_lstat | dir_fd]`, matching `interp_scandir.py W_DirEntry`: the name and
+/// full path plus the cached `stat` (`follow_symlinks=True`) and `lstat`
+/// (`follow_symlinks=False`) results.  `w_stat`/`w_lstat` are `PY_NULL` until
+/// first requested, so `entry.stat()` re-fetches once and then returns the
+/// same object, and `is_dir`/`is_file`/`inode` share the same on-demand stat.
+/// `dir_fd` is the descriptor a `scandir(fd)` handed the entry (`-1` for a
+/// name), which its own stat resolves the bare `name` against — the native
+/// counterpart of `self.scandir_iterator.orig_fd`.
+/// The layout carries no instance dict; `name`/`path` are read-only getset
+/// descriptors, so the type is not instantiable and not acceptable as a base.
+#[crate::pyre_class("posix.DirEntry")]
+#[derive(Default)]
+pub struct W_DirEntry {
+    pub w_name: PyObjectRef,
+    pub w_path: PyObjectRef,
+    pub w_stat: PyObjectRef,
+    pub w_lstat: PyObjectRef,
+    pub dir_fd: i32,
+}
+
 static APPLEVEL_FORK_CALLBACKS: LazyLock<Mutex<ApplevelForkCallbacks>> =
     LazyLock::new(|| Mutex::new(ApplevelForkCallbacks::default()));
 // PyPy's GIL serializes concurrent fork entry.  Pyre is free-threaded, so the
@@ -3656,9 +3677,21 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     type PyObjectRef = pyre_object::PyObjectRef;
 
     fn dir_entry_path(self_obj: PyObjectRef) -> Result<(PyObjectRef, Vec<u8>), crate::PyError> {
-        let p = crate::baseobjspace::getattr_str(self_obj, "path")?;
-        let path = extract_path(p)?;
-        Ok((p, path))
+        let de = W_DirEntry::from_obj(self_obj)
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        let path = extract_path(de.w_path)?;
+        Ok((de.w_path, path))
+    }
+    fn dir_entry_get_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        // GetSetProperty get: `(descriptor, w_obj)` — the entry is `args[1]`.
+        let de = W_DirEntry::from_obj(args[1])
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        Ok(de.w_name)
+    }
+    fn dir_entry_get_path(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let de = W_DirEntry::from_obj(args[1])
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        Ok(de.w_path)
     }
     /// The descriptor the `scandir` that produced this entry was handed, or
     /// `-1` where it was given a name instead. An entry from a descriptor
@@ -3666,8 +3699,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// prefix empty — so its own stat calls have to resolve the name against
     /// that descriptor rather than against the process's working directory.
     fn dir_entry_dir_fd(self_obj: PyObjectRef) -> Result<i32, crate::PyError> {
-        let w = crate::baseobjspace::getattr_str(self_obj, "_dir_fd")?;
-        Ok(crate::baseobjspace::int_w(w)? as i32)
+        let de = W_DirEntry::from_obj(self_obj)
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        Ok(de.dir_fd)
     }
     /// `rposix_stat.fstatat(name, dirfd, follow)` — the call
     /// `interp_scandir.py:252-254,297-299` makes for exactly that reason. The
@@ -3807,14 +3841,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             Ok(pyre_object::w_int_new(ino))
         }
     }
-    fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let (w_path, path) = dir_entry_path(args[0])?;
-        let follow = dir_entry_follow(args)?;
+    /// Fetch a fresh `stat` (`follow=true`) / `lstat` (`follow=false`) result —
+    /// the uncached path shared by `dir_entry_stat`'s cache miss.  `dir_fd` is
+    /// the descriptor the entry's `scandir` was handed (or `-1`); a real one
+    /// resolves the entry's bare `name` through `fstatat`.
+    fn dir_entry_fetch_stat(
+        w_path: PyObjectRef,
+        path: &[u8],
+        follow: bool,
+        dir_fd: i32,
+    ) -> Result<PyObjectRef, crate::PyError> {
         #[cfg(all(unix, not(feature = "sandbox")))]
         {
-            let dir_fd = dir_entry_dir_fd(args[0])?;
             if dir_fd != -1 {
-                let st = dir_entry_stat_at(&path, dir_fd, follow)
+                let st = dir_entry_stat_at(path, dir_fd, follow)
                     .map_err(|errno| errno_err_with_filename(errno, w_path))?;
                 #[cfg(target_os = "macos")]
                 let st_flags = st.st_flags;
@@ -3826,9 +3866,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 ));
             }
         }
+        #[cfg(not(all(unix, not(feature = "sandbox"))))]
+        let _ = dir_fd;
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         {
-            return match win_stat_fields(&path, follow) {
+            return match win_stat_fields(path, follow) {
                 Ok(fields) => Ok(stat_result_from_fields(&fields, 0)),
                 Err(e) => Err(fs_err_with_filename(e, w_path)),
             };
@@ -3836,14 +3878,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
         {
             let meta = if follow {
-                host_fs::metadata(path_from_bytes(&path).as_ref())
+                host_fs::metadata(path_from_bytes(path).as_ref())
             } else {
-                host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
+                host_fs::symlink_metadata(path_from_bytes(path).as_ref())
             };
             match meta {
                 Ok(m) => {
                     #[cfg(all(target_os = "macos", not(feature = "sandbox")))]
-                    let st_flags = macos_path_st_flags(&path, follow);
+                    let st_flags = macos_path_st_flags(path, follow);
                     #[cfg(not(all(target_os = "macos", not(feature = "sandbox"))))]
                     let st_flags = 0u32;
                     Ok(make_stat_result(&m, st_flags))
@@ -3852,15 +3894,50 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }
         }
     }
+    /// `interp_scandir.py get_stat` — `follow_symlinks=True` caches into
+    /// `w_stat`, `False` into `w_lstat`, so a repeated call returns the same
+    /// object.  Only a successful fetch is cached; an error re-raises on each
+    /// call.  The entry never moves (`allocate_stable`), so the raw receiver
+    /// stays valid across the fetch's allocation.
+    fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let self_obj = args[0];
+        let follow = dir_entry_follow(args)?;
+        {
+            let de = W_DirEntry::from_obj(self_obj)
+                .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+            let cached = if follow { de.w_stat } else { de.w_lstat };
+            if !cached.is_null() {
+                return Ok(cached);
+            }
+        }
+        let dir_fd = dir_entry_dir_fd(self_obj)?;
+        let (w_path, path) = dir_entry_path(self_obj)?;
+        let result = dir_entry_fetch_stat(w_path, &path, follow, dir_fd)?;
+        let de = W_DirEntry::from_obj(self_obj)
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        if follow {
+            de.w_stat = result;
+        } else {
+            de.w_lstat = result;
+        }
+        // `result` may be a nursery object stored into the stable entry; join
+        // the remembered set so the next minor collection forwards it.
+        unsafe { pyre_object::gc_hook::try_gc_write_barrier(self_obj as *mut u8) };
+        Ok(result)
+    }
     fn dir_entry_fspath(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        crate::baseobjspace::getattr_str(args[0], "path")
+        let de = W_DirEntry::from_obj(args[0])
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?;
+        Ok(de.w_path)
     }
     /// `posixmodule.c DirEntry_repr` — `"<DirEntry %R>"`, so the name is
     /// rendered by its own `repr`.  That keeps `os.scandir(b'.')`'s bytes
     /// name spelled `b'…'` and lets a name whose bytes have no UTF-8 form
     /// keep the lone surrogate `fs_name_obj` decoded it to.
     fn dir_entry_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let name = crate::baseobjspace::getattr_str(args[0], "name")?;
+        let name = W_DirEntry::from_obj(args[0])
+            .ok_or_else(|| crate::PyError::type_error("expected a 'posix.DirEntry' object"))?
+            .w_name;
         let mut out = rustpython_wtf8::Wtf8Buf::new();
         out.push_str("<DirEntry ");
         out.push_wtf8(&unsafe { crate::py_repr_wtf8(name)? });
@@ -3890,48 +3967,77 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // builtin name into a `__module__` entry, so `type(e).__module__`
             // reports `posix` and every type-name-bearing error message is
             // spelled the way the typedef spells it.
-            let tp = crate::typedef::make_builtin_type("posix.DirEntry", |ns| {
-                for (name, f) in [
-                    ("is_dir", dir_entry_is_dir as crate::gateway::BuiltinCodeFn),
-                    ("is_file", dir_entry_is_file),
-                    ("is_symlink", dir_entry_is_symlink),
-                    ("is_junction", dir_entry_is_junction),
-                    ("inode", dir_entry_inode),
-                    ("stat", dir_entry_stat),
-                    ("__fspath__", dir_entry_fspath),
-                    ("__repr__", dir_entry_repr),
-                    ("__reduce_ex__", dir_entry_reduce_ex),
-                ] {
+            // The native `W_DirEntry` layout backs the type; `name`/`path` are
+            // read-only getset descriptors over the inline fields, so instances
+            // carry no `__dict__` (matching a `W_DirEntry` typedef with no
+            // `makedict`).
+            let tp = crate::typedef::make_builtin_type_with_layout(
+                "posix.DirEntry",
+                |ns| {
+                    for (name, getter) in [
+                        ("name", dir_entry_get_name as crate::gateway::BuiltinCodeFn),
+                        ("path", dir_entry_get_path),
+                    ] {
+                        unsafe {
+                            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                                ns,
+                                name,
+                                crate::typedef::make_getset_descriptor_named(
+                                    crate::gateway::make_builtin_function_with_arity(
+                                        name, getter, 2,
+                                    ),
+                                    name,
+                                ),
+                            )
+                        };
+                    }
+                    for (name, f) in [
+                        ("is_dir", dir_entry_is_dir as crate::gateway::BuiltinCodeFn),
+                        ("is_file", dir_entry_is_file),
+                        ("is_symlink", dir_entry_is_symlink),
+                        ("is_junction", dir_entry_is_junction),
+                        ("inode", dir_entry_inode),
+                        ("stat", dir_entry_stat),
+                        ("__fspath__", dir_entry_fspath),
+                        ("__repr__", dir_entry_repr),
+                        ("__reduce_ex__", dir_entry_reduce_ex),
+                    ] {
+                        unsafe {
+                            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                                ns,
+                                name,
+                                crate::make_builtin_function(name, f),
+                            )
+                        };
+                    }
+                    // CPython 3.14 Modules/posixmodule.c DirEntry_methods —
+                    // Py_GenericAlias with METH_CLASS.
                     unsafe {
-                        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                        pyre_object::w_dict_setitem_str(
                             ns,
-                            name,
-                            crate::make_builtin_function(name, f),
+                            "__class_getitem__",
+                            pyre_object::function::w_classmethod_new(crate::make_builtin_function(
+                                "__class_getitem__",
+                                crate::_pypy_generic_alias::generic_alias_class_getitem,
+                            )),
                         )
                     };
-                }
-                // CPython 3.14 Modules/posixmodule.c DirEntry_methods —
-                // Py_GenericAlias with METH_CLASS.
-                unsafe {
-                    pyre_object::w_dict_setitem_str(
-                        ns,
-                        "__class_getitem__",
-                        pyre_object::function::w_classmethod_new(crate::make_builtin_function(
-                            "__class_getitem__",
-                            crate::_pypy_generic_alias::generic_alias_class_getitem,
-                        )),
-                    )
-                };
-            });
-            unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+                },
+                crate::typedef::w_object(),
+                <W_DirEntry as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
+            );
+            pyre_object::pyobject::set_instantiate(
+                unsafe { &*<W_DirEntry as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE },
+                tp,
+            );
             // `interp_scandir.py:468-487` declares no `__new__` on the typedef
             // and `:487` sets `acceptable_as_base_class = False`; `typedef.py:55
             // acceptable_as_base_class = '__new__' in rawdict` is the rule, and
             // `typedef.py:754 assert not PyFrame.typedef.acceptable_as_base_class
             // # no __new__` is the same shape typedef.rs:534-539 already ports.
-            // `scandir_fn` below allocates entries with
-            // `pyre_object::w_instance_new`, which never enters `type.__call__`,
-            // so the producer is untouched by the instantiation gate.
+            // `scandir_fn` below allocates entries with `W_DirEntry::
+            // allocate_stable`, which never enters `type.__call__`, so the
+            // producer is untouched by the instantiation gate.
             unsafe {
                 pyre_object::typeobject::w_type_set_disallow_instantiation(tp);
                 pyre_object::typeobject::w_type_set_acceptable_as_base_class(tp, false);
@@ -4000,6 +4106,32 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }) as PyObjectRef
     }
 
+    /// Allocate one `W_DirEntry` and append it to `list` (pinned at `list_slot`
+    /// on the shadow stack).  Each string is pinned before the next allocation
+    /// so a moving collection during `allocate_stable` forwards it; the entry
+    /// is stable but its young strings join the remembered set.  `dir_fd` is the
+    /// descriptor the entry resolves its own `name` against, or `-1`.
+    fn scandir_push_entry(
+        list_slot: usize,
+        bytes_mode: bool,
+        name: &[u8],
+        full: &[u8],
+        dir_fd: i32,
+    ) {
+        let _entry_scope = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, name));
+        pyre_object::gc_roots::pin_root(fs_name_obj(bytes_mode, full));
+        pyre_object::gc_roots::pin_root(W_DirEntry::allocate_stable(W_DirEntry::default()));
+        let obj = pyre_object::gc_roots::shadow_stack_get(base + 2);
+        let de = W_DirEntry::from_obj(obj).expect("freshly allocated posix.DirEntry");
+        de.w_name = pyre_object::gc_roots::shadow_stack_get(base);
+        de.w_path = pyre_object::gc_roots::shadow_stack_get(base + 1);
+        de.dir_fd = dir_fd;
+        unsafe { pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8) };
+        let list = pyre_object::gc_roots::shadow_stack_get(list_slot);
+        unsafe { pyre_object::w_list_append(list, obj) };
+    }
     fn scandir_fn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // One resolution yields both the path and its bytes-ness, so
         // `__fspath__` runs exactly once. The omitted argument is the same
@@ -4010,64 +4142,64 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         let bytes_mode = unsafe { resolved.is_bytes() };
         let path = resolved.as_bytes.as_slice();
         let w_path = || resolved.w_path();
+        // Initialise the DirEntry type (`set_instantiate`) before allocating
+        // any entry of it.
+        let _ = dir_entry_type();
         let list = pyre_object::w_list_new(Vec::new());
-        // Every entry records the descriptor it must resolve its own name
-        // against, which is `-1` for the entries a name produced.
-        let mut entry_dir_fd = -1i32;
+        // The entries are `allocate_stable` (non-nursery) objects, but a stable
+        // allocation can still drive a moving collection over a large listing,
+        // so `list` and each per-entry temporary live on the shadow stack.
+        let _list_scope = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(list);
+        let list_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        // A `scandir(fd)` lists through the descriptor and every entry records
+        // it (`-1` for the entries a name produced), so its own stat resolves
+        // the bare name against that descriptor.
         #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
         let from_fd = Some(resolved.as_fd).filter(|&fd| fd != -1);
         #[cfg(not(all(unix, feature = "host_env", not(feature = "sandbox"))))]
         let from_fd: Option<i32> = None;
-        if let Some(fd) = from_fd {
-            entry_dir_fd = fd;
+        match from_fd {
             #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
-            for name in
-                fdlistdir(fd).map_err(|errno| errno_err_with_filename(errno, w_path()))?
-            {
+            Some(fd) => {
                 // `interp_scandir.py:50` leaves the path prefix empty for a
-                // descriptor — there is no directory name to join — so an
-                // entry's `path` is its bare name, and a descriptor is not
-                // `bytes`, so both come back as `str`.
-                let w_name = fs_name_obj(false, &name);
-                let de = pyre_object::w_instance_new(dir_entry_type());
-                let _ = crate::baseobjspace::setattr_str(de, "name", w_name);
-                let _ = crate::baseobjspace::setattr_str(de, "path", w_name);
-                let _ = crate::baseobjspace::setattr_str(
-                    de,
-                    "_dir_fd",
-                    pyre_object::w_int_new(i64::from(fd)),
-                );
-                unsafe { pyre_object::w_list_append(list, de) };
+                // descriptor — there is no directory to join — so an entry's
+                // `path` is its bare `name`, and a descriptor is not `bytes`,
+                // so both come back as `str`.
+                for name in
+                    fdlistdir(fd).map_err(|errno| errno_err_with_filename(errno, w_path()))?
+                {
+                    scandir_push_entry(list_slot, false, &name, &name, fd);
+                }
             }
-        } else {
-            let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
-                .map_err(|e| fs_err_with_filename(e, w_path()))?;
-            for entry in entries {
-                let entry = entry.map_err(|e| fs_err_with_filename(e, w_path()))?;
-                let name = entry.file_name();
-                let full = entry.path().into_os_string();
-                let de = pyre_object::w_instance_new(dir_entry_type());
-                let _ = crate::baseobjspace::setattr_str(
-                    de,
-                    "name",
-                    fs_name_obj(bytes_mode, name.as_encoded_bytes()),
-                );
-                let _ = crate::baseobjspace::setattr_str(
-                    de,
-                    "path",
-                    fs_name_obj(bytes_mode, full.as_encoded_bytes()),
-                );
-                let _ = crate::baseobjspace::setattr_str(
-                    de,
-                    "_dir_fd",
-                    pyre_object::w_int_new(i64::from(entry_dir_fd)),
-                );
-                unsafe { pyre_object::w_list_append(list, de) };
+            _ => {
+                let entries = host_fs::read_dir(path_from_bytes(path).as_ref())
+                    .map_err(|e| fs_err_with_filename(e, w_path()))?;
+                for entry in entries {
+                    let entry = entry.map_err(|e| fs_err_with_filename(e, w_path()))?;
+                    let name = entry.file_name();
+                    let full = entry.path().into_os_string();
+                    scandir_push_entry(
+                        list_slot,
+                        bytes_mode,
+                        name.as_encoded_bytes(),
+                        full.as_encoded_bytes(),
+                        -1,
+                    );
+                }
             }
         }
-        let it = pyre_object::w_instance_new(scandir_iter_type());
+        // Pin the iterator so the `_entries`/`_index` setattr allocations cannot
+        // strand it, re-reading `it`/`list` from their slots after each.
+        pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(scandir_iter_type()));
+        let it_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let it = pyre_object::gc_roots::shadow_stack_get(it_slot);
+        let list = pyre_object::gc_roots::shadow_stack_get(list_slot);
         let _ = crate::baseobjspace::setattr_str(it, "_entries", list);
+        let it = pyre_object::gc_roots::shadow_stack_get(it_slot);
         let _ = crate::baseobjspace::setattr_str(it, "_index", pyre_object::w_int_new(0));
+        let it = pyre_object::gc_roots::shadow_stack_get(it_slot);
+        drop(_list_scope);
         Ok(it)
     }
     crate::module_ns_store(

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -3374,6 +3374,47 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         }
     }
 
+    /// The Windows counterpart of `stat_fields_from_libc`.  `win32_xstat` and
+    /// `fstat` fill the same `StatStruct`, so routing both entry points
+    /// through it is what lets a name and a descriptor for one file report one
+    /// identity — `st_ino`/`st_dev` were previously reported as 0 from a path,
+    /// which made every file look like every other one.
+    ///
+    /// `st_ctime` carries the creation time, which is the value the field has
+    /// always held here; `StatStruct` keeps that under `st_birthtime` and
+    /// leaves its own `st_ctime` at zero.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    fn stat_fields_from_statstruct(
+        st: &rustpython_host_env::fileutils::StatStruct,
+    ) -> StatFields {
+        StatFields {
+            mode: st.st_mode as i64,
+            ino: st.st_ino as i64,
+            dev: st.st_dev as i64,
+            nlink: st.st_nlink as i64,
+            uid: st.st_uid as i64,
+            gid: st.st_gid as i64,
+            size: st.st_size as i64,
+            atime: st.st_atime as i64,
+            mtime: st.st_mtime as i64,
+            ctime: st.st_birthtime as i64,
+            atime_ns: st.st_atime as i64 * 1_000_000_000 + st.st_atime_nsec as i64,
+            mtime_ns: st.st_mtime as i64 * 1_000_000_000 + st.st_mtime_nsec as i64,
+            ctime_ns: st.st_birthtime as i64 * 1_000_000_000 + st.st_birthtime_nsec as i64,
+        }
+    }
+
+    /// `win32_xstat` for a byte path.  `os.stat`, `DirEntry.stat` and
+    /// `DirEntry.inode` all go through here so that one file has one identity
+    /// however it was reached; reaching only some of them would leave
+    /// `entry.inode()` and `os.stat(entry.path).st_ino` disagreeing.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    fn win_stat_fields(path: &[u8], follow_symlinks: bool) -> std::io::Result<StatFields> {
+        let os_path = os_str_from_bytes(path);
+        rustpython_host_env::nt::win32_xstat(&os_path, follow_symlinks)
+            .map(|st| stat_fields_from_statstruct(&st))
+    }
+
     /// Where the `host_env::posix`-backed implementations below are compiled.
     /// Elsewhere those names are the noop placeholders registered near the top
     /// of this function, which cannot serve a descriptor.
@@ -3564,7 +3605,22 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             .map_err(|e| crate::host_seam::seam_os_err_with_filename(e, path.w_path()))?;
             return Ok(make_stat_result_from_statbuf(&buf));
         }
-        #[cfg(not(feature = "sandbox"))]
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            return match win_stat_fields(&path.as_bytes, follow_symlinks) {
+                Ok(fields) => Ok(stat_result_from_fields(&fields, 0)),
+                Err(e) => Err(fs_err_with_filename2(
+                    e,
+                    2,
+                    path.w_path(),
+                    pyre_object::PY_NULL,
+                )),
+            };
+        }
+        #[cfg(all(
+            not(feature = "sandbox"),
+            not(all(windows, feature = "host_env"))
+        ))]
         {
             let meta = if follow_symlinks {
                 host_fs::metadata(path_from_bytes(&path.as_bytes).as_ref())
@@ -3725,19 +3781,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 return Ok(pyre_object::w_int_new(st.st_ino as i64));
             }
         }
-        let meta = host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
-            .map_err(|e| fs_err_with_filename(e, w_path))?;
-        #[cfg(unix)]
-        let ino = {
-            use std::os::unix::fs::MetadataExt;
-            meta.ino() as i64
-        };
-        #[cfg(not(unix))]
-        let ino = {
-            let _ = &meta;
-            0i64
-        };
-        Ok(pyre_object::w_int_new(ino))
+        // `posixmodule.c DirEntry_inode` reads the same file index `os.stat`
+        // reports, so the 0 this used to answer with on Windows disagreed with
+        // `os.stat(entry.path).st_ino`.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            let fields =
+                win_stat_fields(&path, false).map_err(|e| fs_err_with_filename(e, w_path))?;
+            return Ok(pyre_object::w_int_new(fields.ino));
+        }
+        #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
+        {
+            let meta = host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
+                .map_err(|e| fs_err_with_filename(e, w_path))?;
+            #[cfg(unix)]
+            let ino = {
+                use std::os::unix::fs::MetadataExt;
+                meta.ino() as i64
+            };
+            #[cfg(not(unix))]
+            let ino = {
+                let _ = &meta;
+                0i64
+            };
+            Ok(pyre_object::w_int_new(ino))
+        }
     }
     fn dir_entry_stat(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (w_path, path) = dir_entry_path(args[0])?;
@@ -3758,20 +3826,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 ));
             }
         }
-        let meta = if follow {
-            host_fs::metadata(path_from_bytes(&path).as_ref())
-        } else {
-            host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
-        };
-        match meta {
-            Ok(m) => {
-                #[cfg(all(target_os = "macos", not(feature = "sandbox")))]
-                let st_flags = macos_path_st_flags(&path, follow);
-                #[cfg(not(all(target_os = "macos", not(feature = "sandbox"))))]
-                let st_flags = 0u32;
-                Ok(make_stat_result(&m, st_flags))
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            return match win_stat_fields(&path, follow) {
+                Ok(fields) => Ok(stat_result_from_fields(&fields, 0)),
+                Err(e) => Err(fs_err_with_filename(e, w_path)),
+            };
+        }
+        #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
+        {
+            let meta = if follow {
+                host_fs::metadata(path_from_bytes(&path).as_ref())
+            } else {
+                host_fs::symlink_metadata(path_from_bytes(&path).as_ref())
+            };
+            match meta {
+                Ok(m) => {
+                    #[cfg(all(target_os = "macos", not(feature = "sandbox")))]
+                    let st_flags = macos_path_st_flags(&path, follow);
+                    #[cfg(not(all(target_os = "macos", not(feature = "sandbox"))))]
+                    let st_flags = 0u32;
+                    Ok(make_stat_result(&m, st_flags))
+                }
+                Err(e) => Err(fs_err_with_filename(e, w_path)),
             }
-            Err(e) => Err(fs_err_with_filename(e, w_path)),
         }
     }
     fn dir_entry_fspath(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/posix/mod.rs
+++ b/pyre/pyre-interpreter/src/module/posix/mod.rs
@@ -5,3 +5,5 @@
 //! exercises.  The shared `stat_result` builtin type lives here too.
 
 crate::pyre_module_init!(interp_posix);
+
+pub use interp_posix::W_DirEntry;

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -283,7 +283,8 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         )));
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(name_obj) };
-    let (implementation, monotonic, adjustable) = match name.as_str().unwrap_or_default() {
+    let name_str = name.as_str().unwrap_or_default();
+    let (implementation, monotonic, adjustable) = match name_str {
         "time" => ("clock_gettime(CLOCK_REALTIME)", false, true),
         "monotonic" | "perf_counter" => {
             #[cfg(target_os = "macos")]
@@ -319,8 +320,89 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     crate::baseobjspace::setattr_str(info, "implementation", w_str_new(implementation))?;
     crate::baseobjspace::setattr_str(info, "monotonic", w_bool_from(monotonic))?;
     crate::baseobjspace::setattr_str(info, "adjustable", w_bool_from(adjustable))?;
-    crate::baseobjspace::setattr_str(info, "resolution", floatobject::w_float_new(1.0e-9))?;
+    crate::baseobjspace::setattr_str(
+        info,
+        "resolution",
+        floatobject::w_float_new(get_clock_info_resolution(name_str)),
+    )?;
     Ok(w_none())
+}
+
+/// A clock `Duration` in seconds the way `_timespec_to_seconds` computes it —
+/// `sec + nsec * 1e-9`.  `Duration::as_secs_f64` divides the nanoseconds by 1e9
+/// instead, which rounds one ULP off from CPython for sub-microsecond ticks
+/// (`1000 * 1e-9` != `1000 / 1e9`), so `get_clock_info().resolution` and
+/// `clock_getres()` would otherwise disagree with the reference in the last bit.
+#[cfg(all(unix, feature = "host_env", not(target_os = "redox")))]
+fn clock_seconds_from_duration(d: std::time::Duration) -> f64 {
+    d.as_secs() as f64 + f64::from(d.subsec_nanos()) * 1e-9
+}
+
+/// Resolution of the mach clock backing `monotonic`/`perf_counter` on macOS:
+/// one `mach_absolute_time` tick is `numer/denom` nanoseconds
+/// (`_PyTime_GetMonotonicClockWithInfo` reports the same).  `clock_getres` is
+/// deliberately not used — `clock_getres(CLOCK_MONOTONIC)` reports the coarser
+/// system tick (1µs), not the finer timebase rate.  Dividing by the
+/// exactly-representable `1e9` (rather than multiplying by `1e-9`) reproduces
+/// the reference value bit-for-bit for a non-integer timebase like `125/3`.
+#[cfg(all(target_os = "macos", feature = "host_env"))]
+#[allow(deprecated)] // libc's mach_timebase_info fields moved to the `mach2` crate; one read is not worth a new dependency.
+fn mach_timebase_resolution_seconds() -> f64 {
+    let mut tb = ::libc::mach_timebase_info { numer: 0, denom: 0 };
+    // SAFETY: fills an owned, zeroed struct; the call has no other effect.
+    if unsafe { ::libc::mach_timebase_info(&mut tb) } == 0 && tb.denom != 0 {
+        return (f64::from(tb.numer) / f64::from(tb.denom)) / 1e9;
+    }
+    1.0e-9
+}
+
+/// The `resolution` value `time.get_clock_info(name)` reports.
+///
+/// `clock_getres(clk_id)` for every clock-backed source — `time`,
+/// `process_time`, `thread_time`, and `monotonic`/`perf_counter` off macOS —
+/// with a 1e-9 fallback when the clock is unreadable, mirroring the
+/// `_process_time_impl`/`_thread_time_impl` `clock_getres` paths.  On macOS
+/// `monotonic`/`perf_counter` run on `mach_absolute_time`, whose resolution is
+/// the timebase rate rather than `clock_getres(CLOCK_MONOTONIC)`.
+#[cfg(all(unix, feature = "host_env", not(target_os = "redox")))]
+fn get_clock_info_resolution(name: &str) -> f64 {
+    #[cfg(target_os = "macos")]
+    {
+        if matches!(name, "monotonic" | "perf_counter") {
+            return mach_timebase_resolution_seconds();
+        }
+    }
+    let clk = match name {
+        "time" => host_time::ClockId::CLOCK_REALTIME,
+        "monotonic" | "perf_counter" => host_time::ClockId::CLOCK_MONOTONIC,
+        #[cfg(not(any(
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "solaris",
+            target_os = "openbsd",
+            target_os = "wasi",
+        )))]
+        "process_time" => host_time::ClockId::CLOCK_PROCESS_CPUTIME_ID,
+        #[cfg(not(any(
+            target_os = "illumos",
+            target_os = "netbsd",
+            target_os = "solaris",
+            target_os = "openbsd",
+            target_os = "redox",
+        )))]
+        "thread_time" => host_time::ClockId::CLOCK_THREAD_CPUTIME_ID,
+        _ => return 1.0e-9,
+    };
+    host_time::clock_getres(clk)
+        .map(clock_seconds_from_duration)
+        .unwrap_or(1.0e-9)
+}
+
+/// Without a host `clock_getres` (non-Unix, no `host_env`, or redox), report the
+/// nanosecond representation resolution every pyre clock carries internally.
+#[cfg(not(all(unix, feature = "host_env", not(target_os = "redox"))))]
+fn get_clock_info_resolution(_name: &str) -> f64 {
+    1.0e-9
 }
 
 /// Process CPU time (kernel + user) as nanoseconds.
@@ -593,7 +675,7 @@ pub fn clock_getres(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             format!("clock_getres: {e}"),
         )
     })?;
-    Ok(floatobject::w_float_new(d.as_secs_f64()))
+    Ok(floatobject::w_float_new(clock_seconds_from_duration(d)))
 }
 
 // ── libc tm helpers ──────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -296,12 +296,15 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             }
         }
         "process_time" => ("clock_gettime(CLOCK_PROCESS_CPUTIME_ID)", true, false),
-        // `interp_time.py:926` gates `thread_time` on HAS_THREAD_TIME; expose it
-        // only where the platform carries CLOCK_THREAD_CPUTIME_ID (the same
-        // clocks mod.rs registers the constant for), otherwise it falls through
-        // to the "unknown clock" ValueError.
+        // `interp_time.py:926` gates `thread_time` on HAS_THREAD_TIME; describe
+        // it only where the platform carries CLOCK_THREAD_CPUTIME_ID and the
+        // host clock is wired (the exact gate under which mod.rs registers the
+        // `thread_time` function), so the report never names a clock whose
+        // function is absent; otherwise fall through to the "unknown clock"
+        // ValueError.
         #[cfg(all(
             unix,
+            feature = "host_env",
             not(any(
                 target_os = "illumos",
                 target_os = "netbsd",
@@ -373,6 +376,77 @@ pub fn process_time(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 pub fn process_time_ns(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let _ = args;
     Ok(w_int_new(process_time_nanos()? as i64))
+}
+
+/// Thread CPU time (kernel + user) for the calling thread as nanoseconds.
+///
+/// `clock_gettime(CLOCK_THREAD_CPUTIME_ID)` is the sole source, matching
+/// `_thread_time_impl`.  Unlike [`process_time_nanos`] there is no
+/// `getrusage`/`times` fallback: those report process-wide CPU time, not the
+/// calling thread's, so deriving thread time from them would be wrong.  An
+/// unreadable clock raises OSError rather than reporting a bogus value.
+///
+/// This reads the clock directly rather than through the `clock()` seam op
+/// (which is the process-CPU `ll_time_clock` analog): `_thread_time_impl` reads
+/// `c_clock_gettime` directly, `time.clock_gettime` already does the same, and
+/// `clock_gettime` is on the sandbox seccomp allowlist, so a sandbox build
+/// reads its own thread clock without a controller round-trip.
+#[cfg(all(
+    unix,
+    feature = "host_env",
+    not(any(
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "openbsd",
+        target_os = "redox",
+    ))
+))]
+fn thread_time_nanos() -> Result<i128, crate::PyError> {
+    host_time::clock_gettime(host_time::ClockId::CLOCK_THREAD_CPUTIME_ID)
+        .map(|d| d.as_nanos() as i128)
+        .map_err(|e| {
+            crate::PyError::os_error_with_errno(
+                e.raw_os_error().unwrap_or(0),
+                format!("clock_gettime: {e}"),
+            )
+        })
+}
+
+/// time.thread_time() → float
+///
+/// Thread time for profiling: sum of the kernel and user-space CPU time.
+#[cfg(all(
+    unix,
+    feature = "host_env",
+    not(any(
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "openbsd",
+        target_os = "redox",
+    ))
+))]
+pub fn thread_time(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let _ = args;
+    Ok(floatobject::w_float_new(thread_time_nanos()? as f64 * 1e-9))
+}
+
+/// time.thread_time_ns() → int
+#[cfg(all(
+    unix,
+    feature = "host_env",
+    not(any(
+        target_os = "illumos",
+        target_os = "netbsd",
+        target_os = "solaris",
+        target_os = "openbsd",
+        target_os = "redox",
+    ))
+))]
+pub fn thread_time_ns(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let _ = args;
+    Ok(w_int_new(thread_time_nanos()? as i64))
 }
 
 /// time.clock_gettime(clk_id) → float seconds

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -296,6 +296,21 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             }
         }
         "process_time" => ("clock_gettime(CLOCK_PROCESS_CPUTIME_ID)", true, false),
+        // `interp_time.py:926` gates `thread_time` on HAS_THREAD_TIME; expose it
+        // only where the platform carries CLOCK_THREAD_CPUTIME_ID (the same
+        // clocks mod.rs registers the constant for), otherwise it falls through
+        // to the "unknown clock" ValueError.
+        #[cfg(all(
+            unix,
+            not(any(
+                target_os = "illumos",
+                target_os = "netbsd",
+                target_os = "solaris",
+                target_os = "openbsd",
+                target_os = "redox",
+            ))
+        ))]
+        "thread_time" => ("clock_gettime(CLOCK_THREAD_CPUTIME_ID)", true, false),
         _ => return Err(crate::PyError::value_error("unknown clock")),
     };
     crate::baseobjspace::setattr_str(info, "implementation", w_str_new(implementation))?;

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -88,8 +88,17 @@ crate::py_module! {
                 target_os = "openbsd",
                 target_os = "redox",
             )))]
-            crate::module_ns_store(ns, "CLOCK_THREAD_CPUTIME_ID",
-                pyre_object::w_int_new(libc::CLOCK_THREAD_CPUTIME_ID as i64));
+            {
+                crate::module_ns_store(ns, "CLOCK_THREAD_CPUTIME_ID",
+                    pyre_object::w_int_new(libc::CLOCK_THREAD_CPUTIME_ID as i64));
+                // thread_time reads CLOCK_THREAD_CPUTIME_ID, so it is exposed on
+                // exactly the platforms that carry the constant — the same gate
+                // `_get_time_info` uses for its "thread_time" arm.
+                crate::module_ns_store(ns, "thread_time",
+                    crate::make_builtin_function_with_arity("thread_time", t::thread_time, 0));
+                crate::module_ns_store(ns, "thread_time_ns",
+                    crate::make_builtin_function_with_arity("thread_time_ns", t::thread_time_ns, 0));
+            }
         }
         // `Module.startup` calls `_init_timezone`, and exposes `tzset` on
         // every POSIX build.  Both read host timezone state ($TZ,

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -776,6 +776,11 @@ fn bigint_neg(a: &BigInt) -> BigInt {
 }
 
 #[majit_macros::elidable]
+fn bigint_clone(a: &BigInt) -> BigInt {
+    a.clone()
+}
+
+#[majit_macros::elidable]
 fn bigint_invert(a: &BigInt) -> BigInt {
     a.invert()
 }
@@ -5188,10 +5193,17 @@ pub fn pos(a: PyObjectRef) -> PyResult {
         }
         if is_long(a) {
             // intobject.py:182-191 `_self_unaryop('pos')` delegates to
-            // `self.int(space)`, and W_LongObject.int returns `self` for the
-            // exact builtin representation.  Do not allocate another wrapper
-            // or shallow-cloned rbigint payload for unary plus.
-            return Ok(a);
+            // `self.int(space)`, which returns `self` only for the exact
+            // builtin representation.  A subclass returns a plain-int copy
+            // (long_pos: exact → self, else `_PyLong_Copy`), so leaking the
+            // subclass instance would be wrong; an exact long returns `self`
+            // without allocating another wrapper or shallow-cloned payload.
+            if pyre_object::is_exact_builtin_instance(a) {
+                return Ok(a);
+            }
+            return Ok(pyre_object::longobject::w_long_new_fresh_rbigint_handle(
+                bigint_clone(w_long_get_value(a)),
+            ));
         }
         if is_float(a) {
             return Ok(w_float_new(w_float_get_value(a)));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4806,8 +4806,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryPositive
-        && try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)?
-            .is_some()
+        && try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4796,6 +4796,22 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         }
     }
 
+    // #61: UNARY_POSITIVE `+int` identity fold.  The object-space `pos` on an
+    // exact int returns the operand unchanged, so a provably-int operand folds
+    // to the operand box itself behind a `GUARD_CLASS INT`, eliding the
+    // `CALL_MAY_FORCE` (and its `GUARD_NOT_FORCED` / `GUARD_NO_EXCEPTION`) the
+    // generic residual emits.  A bool (`+True` is int `1`) / non-int operand
+    // declines to the generic leg so its `__pos__` still runs.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && r_args.len() == 1
+        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryPositive
+        && try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)?
+            .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // #62: specialize STORE_SUBSCR `list[int] = value` (int / float storage,
     // in-bounds, type-matching) to the walker-native `setarrayitem_raw` form,
     // eliding the `CALL_MAY_FORCE` that would force the virtualizable every

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4812,6 +4812,39 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // #61: UNARY_NEGATIVE `-int` fold.  `-x` is `0 - x`; the fold emits
+    // `IntSubOvf(0, x)` behind a `GUARD_CLASS INT` (reusing the binary-sub
+    // overflow discipline), eliding the `CALL_MAY_FORCE`.  A bool / subclass /
+    // non-int, and an `INT_MIN` value (whose negation is the `2**63` long),
+    // decline to the generic leg.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && r_args.len() == 1
+        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryNegative
+        && try_walker_specialize_unary_negative_int(
+            ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
+        )?
+        .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
+    // #61: UNARY_INVERT `~int` fold.  `~x` always fits an int, so the fold
+    // emits a plain `IntInvert` behind a `GUARD_CLASS INT` (no overflow guard),
+    // eliding the `CALL_MAY_FORCE`.  A bool / subclass / non-int operand
+    // declines to the generic leg.
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && r_args.len() == 1
+        && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryInvert
+        && try_walker_specialize_unary_invert_int(
+            ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
+        )?
+        .is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // #62: specialize STORE_SUBSCR `list[int] = value` (int / float storage,
     // in-bounds, type-matching) to the walker-native `setarrayitem_raw` form,
     // eliding the `CALL_MAY_FORCE` that would force the virtualizable every

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -371,6 +371,44 @@ pub(crate) fn try_walker_specialize_truth_bool<Sym: WalkSym>(
     Ok(Some(truth))
 }
 
+/// #61: walker-native identity fold for the `UNARY_POSITIVE` residual
+/// (oopspec [`majit_ir::PyreHelperKind::UnaryPositive`]).  The object-space
+/// `pos` on an exact int returns the operand unchanged, so a concrete non-bool
+/// `W_IntObject` operand folds to the operand box itself behind the same guard
+/// prefix the truth / binary int folds emit (a low-bit tag test for a tagged
+/// immediate, `GUARD_CLASS INT` for a heap box).  The unboxed raw is discarded
+/// (DCE): the result is the box, not its `intval`.
+///
+/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
+/// `Continue`); `Ok(None)` for a bool (`+True` is int `1`, not identity) or a
+/// non-int operand — the caller then falls through to the generic
+/// `CallMayForce` residual so a user / subclass `__pos__` still runs.
+pub(crate) fn try_walker_specialize_unary_positive_int<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(obj) = walker_concrete_ref_object(ctx, operand) else {
+        return Ok(None);
+    };
+    // `+x` is identity only for an EXACT int: a bool carries `BOOL_TYPE` (its
+    // `+` yields int `1`) and an int subclass may override `__pos__`, so both
+    // decline to the generic residual.
+    // SAFETY: `obj` is a live concrete `PyObjectRef` from the walker shadow.
+    if unsafe { !pyre_object::is_int(obj) || pyre_object::is_bool(obj) } {
+        return Ok(None);
+    }
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    // Emit the guard prefix (`GUARD_CLASS INT` / tag test) so a later non-int
+    // arrival deopts; the returned raw is unused because the result is the
+    // operand box itself.
+    let _ = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, operand)?;
+    Ok(Some(()))
+}
+
 /// #57: walker-native speculative int specialization for the `BINARY_OP`
 /// helper residual_call (oopspec `BinaryOp`).  Re-derives
 /// the former int fast path's structure (`guard_class` + `getfield_gc_i` per

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -380,9 +380,10 @@ pub(crate) fn try_walker_specialize_truth_bool<Sym: WalkSym>(
 /// (DCE): the result is the box, not its `intval`.
 ///
 /// Returns `Ok(Some(()))` when the fold was emitted (caller returns
-/// `Continue`); `Ok(None)` for a bool (`+True` is int `1`, not identity) or a
-/// non-int operand — the caller then falls through to the generic
-/// `CallMayForce` residual so a user / subclass `__pos__` still runs.
+/// `Continue`); `Ok(None)` for a bool (`+True` is int `1`, not identity), a
+/// numeric subclass, or a non-int operand — the caller then falls through to
+/// the generic `CallMayForce` residual so a subclass / user `__pos__` still
+/// runs.
 pub(crate) fn try_walker_specialize_unary_positive_int<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
@@ -393,11 +394,20 @@ pub(crate) fn try_walker_specialize_unary_positive_int<Sym: WalkSym>(
     let Some(obj) = walker_concrete_ref_object(ctx, operand) else {
         return Ok(None);
     };
-    // `+x` is identity only for an EXACT int: a bool carries `BOOL_TYPE` (its
-    // `+` yields int `1`) and an int subclass may override `__pos__`, so both
-    // decline to the generic residual.
+    // `+x` is identity only for an EXACT builtin int.  A bool shares the
+    // `intval` but `+True` is int `1`, not identity.  A numeric subclass keeps
+    // the builtin `ob_type` (its Python class lives in `w_class`), so the
+    // `GUARD_CLASS INT` below reads `ob_type` and would NOT catch it at
+    // runtime — forwarding the operand would return the subclass instead of
+    // the plain int its `__pos__` yields.  Both decline to the generic
+    // residual.  Mirrors the `is_exact_builtin_instance` gate in
+    // `walker_int_specialization_operands`.
     // SAFETY: `obj` is a live concrete `PyObjectRef` from the walker shadow.
-    if unsafe { !pyre_object::is_int(obj) || pyre_object::is_bool(obj) } {
+    if unsafe {
+        !pyre_object::is_int(obj)
+            || pyre_object::is_bool(obj)
+            || !pyre_object::is_exact_builtin_instance(obj)
+    } {
         return Ok(None);
     }
     let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
@@ -406,6 +416,117 @@ pub(crate) fn try_walker_specialize_unary_positive_int<Sym: WalkSym>(
     // operand box itself.
     let _ = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, operand)?;
+    Ok(Some(()))
+}
+
+/// Shared gate for the `UNARY_NEGATIVE` / `UNARY_INVERT` int folds: the operand
+/// must be a concrete EXACT builtin non-bool `W_IntObject`.  A bool unboxes
+/// through its own `&BOOL_TYPE` guard (declined here for simplicity — `-True` /
+/// `~True` stay on the residual), and a numeric subclass keeps the builtin
+/// `ob_type` so the `GUARD_CLASS INT` the fold emits would not catch it at
+/// runtime.  Returns the concrete `intval` on success.  Mirrors the
+/// `is_exact_builtin_instance` gate in `walker_int_specialization_operands`.
+fn walker_unary_int_operand<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    operand: OpRef,
+) -> Option<i64> {
+    let obj = walker_concrete_ref_object(ctx, operand)?;
+    // SAFETY: `obj` is a live concrete `PyObjectRef` from the walker shadow.
+    unsafe {
+        if !pyre_object::is_int(obj)
+            || pyre_object::is_bool(obj)
+            || !pyre_object::is_exact_builtin_instance(obj)
+        {
+            return None;
+        }
+        Some(pyre_object::w_int_get_value(obj))
+    }
+}
+
+/// #61: walker-native int specialization for the `UNARY_NEGATIVE` residual
+/// (oopspec [`majit_ir::PyreHelperKind::UnaryNegative`]).  `-x` on an exact
+/// int is `0 - x`; the object-space `neg` promotes only `-INT_MIN` to a
+/// `W_LongObject` (`intobject.py:628` `descr_neg` → `_make_ovf2long`).  Since
+/// majit has no overflow-checked unary negate, the fold expresses `-x` as
+/// `IntSubOvf(0, x)` behind a `GUARD_CLASS INT`, reusing the binary-sub
+/// overflow discipline: a record value of `INT_MIN` declines (the residual
+/// builds the `2**63` long), and any other record value emits a
+/// `GUARD_NO_OVERFLOW` so an `INT_MIN` arrival on the reused trace deopts to
+/// the residual rather than wrapping back to `INT_MIN`.
+///
+/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
+/// `Continue`); `Ok(None)` for a bool / subclass / non-int / `INT_MIN`
+/// operand, or when the residual result box is unavailable.
+pub(crate) fn try_walker_specialize_unary_negative_int<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(x) = walker_unary_int_operand(ctx, operand) else {
+        return Ok(None);
+    };
+    // `0 - INT_MIN` overflows i64 → `2**63` long; let the residual build it.
+    if x == i64::MIN {
+        return Ok(None);
+    }
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let x_raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
+    let zero_raw = ctx.trace_ctx.const_int(0);
+    let result_value = 0i64.wrapping_sub(x);
+    let raw_result = ctx
+        .trace_ctx
+        .record_op(OpCode::IntSubOvf, &[zero_raw, x_raw]);
+    ctx.trace_ctx
+        .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
+    walker_emit_guard_with_snapshot(ctx, op_pc, OpCode::GuardNoOverflow, &[])?;
+    let boxed = walker_box_int(ctx, op_pc, raw_result, result_value)?;
+    ctx.trace_ctx
+        .set_opref_concrete(boxed, box_int_concrete(result_value, boxed_result_i64));
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
+    Ok(Some(()))
+}
+
+/// #61: walker-native int specialization for the `UNARY_INVERT` residual
+/// (oopspec [`majit_ir::PyreHelperKind::UnaryInvert`]).  `~x` on an exact int
+/// is `!x`, which always fits an i64 (`~INT_MIN == INT_MAX`, `~INT_MAX ==
+/// INT_MIN`), so `descr_invert` never promotes to a long: the fold emits a
+/// plain `IntInvert` behind a `GUARD_CLASS INT`, with no overflow guard.
+///
+/// Returns `Ok(Some(()))` when the fold was emitted (caller returns
+/// `Continue`); `Ok(None)` for a bool / subclass / non-int operand, or when
+/// the residual result box is unavailable.
+pub(crate) fn try_walker_specialize_unary_invert_int<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    operand: OpRef,
+    allboxes: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<()>, DispatchError> {
+    let Some(x) = walker_unary_int_operand(ctx, operand) else {
+        return Ok(None);
+    };
+    let Some(boxed_result_i64) = walker_execute_may_force_boxed(ctx, allboxes, call_descr) else {
+        return Ok(None);
+    };
+    let int_type_addr = &pyre_object::pyobject::INT_TYPE as *const _ as i64;
+    let x_raw = walker_unbox_int(ctx, op_pc, operand, int_type_addr)?;
+    let result_value = !x;
+    let raw_result = ctx.trace_ctx.record_op(OpCode::IntInvert, &[x_raw]);
+    ctx.trace_ctx
+        .set_opref_concrete(raw_result, majit_ir::Value::Int(result_value));
+    let boxed = walker_box_int(ctx, op_pc, raw_result, result_value)?;
+    ctx.trace_ctx
+        .set_opref_concrete(boxed, box_int_concrete(result_value, boxed_result_i64));
+    write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, boxed)?;
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -3488,6 +3488,20 @@ fn build_gc() -> Box<MiniMarkGC> {
         <pyre_interpreter::module::_io::W_StringIO
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // `posix.DirEntry`: four inline GC edges (`w_name`/`w_path` and the cached
+    // `w_stat`/`w_lstat`, the latter two NULL until first requested).  Appended
+    // after the last vtable-bearing object (`W_StringIO`) so no established GC
+    // id moves; only the trailing bare-`with_gc_ptrs` ids (twister, leaf
+    // storage boxes) shift, and those carry no census alias.  `posix` is
+    // compiled out on wasm32, so this registration and its census aliases are
+    // gated to match.
+    #[cfg(not(target_arch = "wasm32"))]
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::posix::W_DirEntry
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // `rrandom.Random` — the Mersenne Twister `interp_random.py:21` allocates
     // beside its holder. Like W_DequeBlock it is GC-managed without being an
     // rclass.OBJECT subclass and has no Python-visible vtable, so it takes a

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -761,6 +761,18 @@ unsafe fn object_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut maj
     );
 }
 
+/// Custom trace for `_random.Random`.  It carries the mapdict prefix like any
+/// other native-layout subclassable object, *and* the reference
+/// `interp_random.py:21` keeps to its own generator (`self._rnd =
+/// rrandom.Random()`).  The shared prefix trace knows nothing of that field, so
+/// forward it here as well — the twister is reachable through nothing else, and
+/// the wrapper keeps answering `random()` through it after a collection.
+unsafe fn random_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    unsafe { object_object_custom_trace(obj_addr, f) };
+    let inst = unsafe { &mut *(obj_addr as *mut pyre_interpreter::module::_random::W_Random) };
+    f(std::ptr::addr_of_mut!(inst.rnd) as *mut majit_ir::GcRef);
+}
+
 /// Custom trace for `W_ModuleDictObject`
 /// (`dictmultiobject.py:328 W_ModuleDictObject`).
 ///
@@ -2662,7 +2674,8 @@ fn build_gc() -> Box<MiniMarkGC> {
     // PyPy's `allocate_instance(W_Random, w_subtype)` composes
     // `MapdictStorageMixin` into Python subclasses. `W_Random` therefore has
     // the same `[PyObject | map | storage]` prefix as `W_ObjectObject` and
-    // needs the same custom trace for boxed attributes. Register it in the
+    // needs the same custom trace for boxed attributes — plus its own `rnd`
+    // edge, which `random_object_custom_trace` adds on top. Register it in the
     // original slot so every later type id remains stable.
     {
         let descr = <pyre_interpreter::module::_random::W_Random
@@ -2670,7 +2683,7 @@ fn build_gc() -> Box<MiniMarkGC> {
         let tid = gc.register_type(TypeInfo::object_subclass_with_custom_trace(
             descr.object_size,
             object_tid,
-            object_object_custom_trace,
+            random_object_custom_trace,
         ));
         if descr.gc_type_id.is_unassigned() {
             descr.gc_type_id.set(tid);
@@ -3475,6 +3488,18 @@ fn build_gc() -> Box<MiniMarkGC> {
         <pyre_interpreter::module::_io::W_StringIO
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // `rrandom.Random` — the Mersenne Twister `interp_random.py:21` allocates
+    // beside its holder. Like W_DequeBlock it is GC-managed without being an
+    // rclass.OBJECT subclass and has no Python-visible vtable, so it takes a
+    // bare `with_gc_ptrs` id rather than a `register_pyre_class` one. Appended
+    // at the tail so no established id moves.
+    let twister_descr = <pyre_interpreter::module::_random::Random
+        as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+    let twister_tid = gc.register_type(TypeInfo::with_gc_ptrs(
+        twister_descr.object_size,
+        twister_descr.ptr_offsets.to_vec(),
+    ));
+    twister_descr.gc_type_id.set(twister_tid);
     // ── GC-root registration completeness oracle ─────────────────────────
     // Every `#[pyre_class]` type appends its descriptor to the whole-program
     // `PYRE_CLASS_DESCRIPTORS` slice.  A type with inline managed children

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -6171,7 +6171,7 @@ where
         ctx.unary_negative_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::PyreHelperKind::UnaryNegative,
         dst_reg,
     ))
 }
@@ -6207,7 +6207,7 @@ where
         ctx.unary_invert_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::PyreHelperKind::UnaryInvert,
         dst_reg,
     ))
 }

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -6243,7 +6243,7 @@ where
         ctx.unary_positive_fn_idx,
         vec![value],
         CallFlavor::MayForce,
-        majit_ir::PyreHelperKind::None,
+        majit_ir::PyreHelperKind::UnaryPositive,
         dst_reg,
     ))
 }

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -637,6 +637,11 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     (160, Some(0)),
     // `_io.StringIO` follows `_io.BytesIO` at the append-only tail.
     (161, Some(0)),
+    // `posix.DirEntry` follows `_io.StringIO`, before the bare twister id.
+    // `posix` is compiled out on wasm32, so its object-hierarchy slot is too,
+    // keeping this census consistent with `build_gc`'s gated registration.
+    #[cfg(not(target_arch = "wasm32"))]
+    (162, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every


### PR DESCRIPTION
This branch bundles this cycle's CPython-3.14 parity and JIT-correctness work. Each commit is self-contained, verified on macOS against a CPython 3.14 oracle; the JIT commits also want the full dynasm/cranelift/wasm CI treatment this PR triggers.

## `time` module parity (CPython 3.14)

- **`_get_time_info` `thread_time` clock** — describe `thread_time` where the platform carries `CLOCK_THREAD_CPUTIME_ID` (the gate under which the function is registered), so the report never names a clock whose function is absent.
- **`time.thread_time()` / `time.thread_time_ns()`** — read `clock_gettime(CLOCK_THREAD_CPUTIME_ID)` directly (the sole source, mirroring `_thread_time_impl`; no `getrusage`/`times` fallback because those are process-wide). Reads the clock like `time.clock_gettime` rather than the process-CPU `clock()` seam op, so a sandbox build reads its own thread clock (`clock_gettime` is on the seccomp allowlist). Unix subset only (matches PyPy's `HAS_THREAD_TIME`).
- **`get_clock_info(name).resolution`** — was a fixed `1e-9` for every clock; now the actual per-clock resolution: `clock_getres(clk_id)` for `time`/`process_time`/`thread_time` and `monotonic`/`perf_counter` off macOS, and the mach timebase (`numer/denom / 1e9`) for macOS `monotonic`/`perf_counter` (which run on `mach_absolute_time`). Durations convert as `sec + nsec*1e-9` (the `_timespec_to_seconds` form), matching CPython bit-for-bit; `clock_getres()` routes through the same conversion. Verified identical to CPython 3.14 for all five clocks.

## JIT: trace-time int specialization for unary ops

- Fold `UNARY_POSITIVE`/`UNARY_NEGATIVE`/`UNARY_INVERT` on exact builtin ints at trace time (previously all three lowered to symmetric `MayForce` residuals). `pos` = forward the operand, `neg` = `IntSubOvf(0, x)` + `GuardNoOverflow` (majit has no `IntNegOvf`; the guard preserves the `INT_MIN` deopt-to-long), `invert` = `IntInvert`.
- Gated on `is_exact_builtin_instance` at record time: a numeric subclass keeps the builtin `ob_type`, so `guard_class(INT)` would pass for it — forwarding the operand there miscompiles `+Subclass(x)`. Verified against a hot-loop subclass fixture and INT_MIN edges.

## descroperation: unary `pos` on a long subclass

- `+BigSubclass(10**30)` returned the subclass instance; CPython `long_pos` returns a plain-int copy for a non-exact long (exact → self). Gate on `is_exact_builtin_instance` and copy otherwise. (`neg`/`invert` already allocate a fresh plain long, so they were unaffected.)

## Verification

- `time` parity: fixture output diffs identically against CPython 3.14 (`get_clock_info` resolution for all clocks; `thread_time` presence/type/monotonicity; OSError on unreadable clock).
- JIT folds: correctness fixtures (int/bool subclasses, INT_MIN, deopt-to-long) pass and the folds fire (`IntSubOvf`/`GuardNoOverflow` emitted, `call_may_force=0`); re-verified on fresh LLBC.
- Codex parity review of the diff: no regressions (the one flagged `pos` item was refuted by the CPython-3.14 oracle — `long_pos` does not call `__int__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `time.thread_time()` and `time.thread_time_ns()` on supported Unix platforms.
  * Added native `posix.DirEntry` support for directory scanning, including cached file metadata and consistent Windows file identity information.
  * Improved `DirEntry.name` and `DirEntry.path` as read-only attributes.

* **Performance**
  * Improved JIT handling of unary integer operations such as positive, negative, and bitwise inversion.

* **Compatibility**
  * Improved random generator allocation, state handling, and garbage-collection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->