### PR TITLE
jit: clear the residual-callee walls under the call_function_impl_result hub

### DIFF
--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2524,7 +2524,11 @@ impl Bookkeeper {
             // still has RPython's one-GC-reference shape.  Match the
             // `BigInt.from` builtin analyzer and foreign-method cutover:
             // retain a classdef-less `SomeInstance`, never lattice bottom.
-            "BigInt" => {
+            // A function pointer is a one-word code pointer, so it shares
+            // that shell: an optional function pointer then joins with None
+            // as a nullable pointer instead of collapsing to `SomeNone`,
+            // which blocks every read on the field.
+            "BigInt" | "fn" => {
                 return SomeValue::Instance(super::model::SomeInstance::new(
                     None,
                     false,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2134,6 +2134,21 @@ impl Bookkeeper {
         // (`valuetype_to_someshell(Ref) -> SomeInstance(classdef=None)`), which
         // `generalize_attr` can only widen, so a reference-typed tuple element
         // stays classdef-less however precisely its writers are annotated.
+        let filtered_nullable_fields: Vec<String> = {
+            if !majit_ir::descr::is_shaped_tuple_name(n) {
+                Vec::new()
+            } else {
+                let guard = self.pyre_struct_fields.borrow();
+                guard
+                    .as_ref()
+                    .and_then(|r| r.fields.get(n))
+                    .into_iter()
+                    .flat_map(|fields| fields.iter())
+                    .filter(|(_, ty)| is_nullable_sum_spelling(ty))
+                    .map(|(name, _)| name.clone())
+                    .collect()
+            }
+        };
         let mut fields: Vec<(String, String)> = {
             let guard = self.pyre_struct_fields.borrow();
             match guard.as_ref().and_then(|r| {
@@ -2205,6 +2220,32 @@ impl Bookkeeper {
         }
         let host = self.intern_class_by_qualname(n);
         let classdef = self.getuniqueclassdef(&host)?;
+        // The constructor materializes the nullable sum variant in each
+        // filtered tuple field.  `register_struct_fields` may already have
+        // seeded that same slot with the untyped Ref force shell, but the
+        // constructor's `generalize_attr` must start from lattice bottom or
+        // the classless shell wins the union and discards the variant
+        // ClassDef.  Reset ONLY rows removed by the nullable-sum retain;
+        // real annotation flow remains monotonic.
+        if !filtered_nullable_fields.is_empty() {
+            let mut classdef_mut = classdef.borrow_mut();
+            for field_name in &filtered_nullable_fields {
+                let Some(attr) = classdef_mut.attrs.get_mut(field_name) else {
+                    continue;
+                };
+                let is_untyped_force_shell = matches!(
+                    &attr.s_value,
+                    SomeValue::Instance(inst)
+                        if inst.classdef.is_none()
+                            && !inst.can_be_none
+                            && inst.flags.is_empty()
+                            && inst.base.const_box.is_none()
+                );
+                if is_untyped_force_shell {
+                    attr.s_value = SomeValue::Impossible;
+                }
+            }
+        }
         for (field_name, field_ty) in &fields {
             if field_name == "__class__" {
                 continue;
@@ -6341,6 +6382,112 @@ mod tests {
             "varnames must project to SomeList, got {:?}",
             varnames.s_value
         );
+    }
+
+    #[test]
+    fn shaped_tuple_nullable_rows_keep_variant_classdefs_after_constructor_setattr() {
+        use crate::annotator::classdesc::ClassDef;
+        use crate::annotator::model::{SomeInstance, SomeValue};
+        use crate::front::StructFieldRegistry;
+
+        let bk = bk();
+        let tuple = "Tuple<Option<Vec<*mut PyObject>>,Result<Vec<*mut PyObject>,PyErr>>";
+        crate::annotator::classdesc::register_struct_fields(
+            tuple,
+            &[
+                ("__pos_0".to_string(), crate::model::ValueType::Ref(None)),
+                ("__pos_1".to_string(), crate::model::ValueType::Ref(None)),
+            ],
+        );
+        let mut reg = StructFieldRegistry::default();
+        reg.fields.insert(
+            tuple.to_string(),
+            vec![
+                (
+                    "__pos_0".to_string(),
+                    "Option<Vec<*mut PyObject>>".to_string(),
+                ),
+                (
+                    "__pos_1".to_string(),
+                    "Result<Vec<*mut PyObject>,PyErr>".to_string(),
+                ),
+            ],
+        );
+        reg.fields.insert(
+            "Option<Vec<*mut PyObject>>".to_string(),
+            vec![("__discriminant".to_string(), "i64".to_string())],
+        );
+        reg.fields.insert(
+            "Option<Vec<*mut PyObject>>::Some".to_string(),
+            vec![("__pos_0".to_string(), "Vec<*mut PyObject>".to_string())],
+        );
+        reg.fields.insert(
+            "Result<Vec<*mut PyObject>,PyErr>".to_string(),
+            vec![("__discriminant".to_string(), "i64".to_string())],
+        );
+        reg.fields.insert(
+            "Result<Vec<*mut PyObject>,PyErr>::Ok".to_string(),
+            vec![("__pos_0".to_string(), "Vec<*mut PyObject>".to_string())],
+        );
+        bk.set_pyre_struct_fields(Rc::new(reg));
+
+        let tuple_host = bk.intern_class_by_qualname(tuple);
+        let tuple_cd = bk.getuniqueclassdef(&tuple_host).expect("tuple classdef");
+        {
+            let attrs = tuple_cd.borrow();
+            for field in ["__pos_0", "__pos_1"] {
+                let value = &attrs.attrs.get(field).expect("tuple field").s_value;
+                assert!(
+                    matches!(value, SomeValue::Instance(inst)
+                    if inst.classdef.is_none() && !inst.can_be_none
+                        && inst.flags.is_empty() && inst.base.const_box.is_none()),
+                    "{field} pre-seed must be untyped force shell, got {value:?}"
+                );
+                eprintln!("probe {field} after force seeding, before projection: {value:?}");
+            }
+        }
+        bk.project_struct_rows(tuple).expect("tuple rows project");
+        {
+            let attrs = tuple_cd.borrow();
+            for field in ["__pos_0", "__pos_1"] {
+                assert!(
+                    matches!(
+                        attrs.attrs.get(field).expect("tuple field").s_value,
+                        SomeValue::Impossible
+                    ),
+                    "{field} filtered row must reset its force shell before setattr"
+                );
+            }
+        }
+
+        let some_cd = bk
+            .getuniqueclassdef_for_enum_variant("Option<Vec<*mut PyObject>>", "Some")
+            .expect("Option::Some");
+        let ok_cd = bk
+            .getuniqueclassdef_for_enum_variant("Result<Vec<*mut PyObject>,PyErr>", "Ok")
+            .expect("Result::Ok");
+        for (field, classdef) in [("__pos_0", some_cd.clone()), ("__pos_1", ok_cd.clone())] {
+            ClassDef::generalize_attr(
+                &tuple_cd,
+                field,
+                Some(SomeValue::Instance(SomeInstance::new(
+                    Some(classdef),
+                    false,
+                    std::collections::BTreeMap::new(),
+                ))),
+            )
+            .expect("constructor setattr");
+        }
+        let attrs = tuple_cd.borrow();
+        for (field, expected) in [("__pos_0", some_cd), ("__pos_1", ok_cd)] {
+            let value = &attrs.attrs.get(field).expect("tuple field").s_value;
+            eprintln!("probe {field} after constructor setattr: {value:?}");
+            assert!(
+                matches!(value, SomeValue::Instance(inst)
+                if inst.classdef.as_ref().is_some_and(|cd| Rc::ptr_eq(cd, &expected))),
+                "{field} must retain variant ClassDef, got {value:?}"
+            );
+        }
     }
 
     /// Fixture for the methods-on-classdef capability that `dyn Trait`

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -2125,17 +2125,43 @@ impl Bookkeeper {
         // Strip the `<…>` argument span so the lookup resolves under the
         // template key — matching `StructFieldRegistry::lookup_fields`,
         // which the bare-`reg.fields.get` here bypasses.
+        //
+        // A per-shape tuple (`Tuple<FrameDebugData>`) is the exception: it has
+        // no template — `register_tuple_shape_rows` registers its concrete
+        // element spellings under the full shaped key, and stripping would
+        // look up a bare `Tuple` that carries no rows.  Without the exact
+        // lookup every `__pos_N` keeps the untyped FORCE shell
+        // (`valuetype_to_someshell(Ref) -> SomeInstance(classdef=None)`), which
+        // `generalize_attr` can only widen, so a reference-typed tuple element
+        // stays classdef-less however precisely its writers are annotated.
         let mut fields: Vec<(String, String)> = {
             let guard = self.pyre_struct_fields.borrow();
             match guard.as_ref().and_then(|r| {
-                r.fields
-                    .get(majit_ir::descr::strip_generic_args(n).as_ref())
-                    .cloned()
+                if majit_ir::descr::is_shaped_tuple_name(n) {
+                    r.fields.get(n).cloned()
+                } else {
+                    r.fields
+                        .get(majit_ir::descr::strip_generic_args(n).as_ref())
+                        .cloned()
+                }
             }) {
                 Some(f) => f,
                 None => return Ok(()),
             }
         };
+        if majit_ir::descr::is_shaped_tuple_name(n) {
+            // Every `__pos_N` of a shaped tuple is written by the frontend's
+            // own constructor sequence (`simple_call(<host Tuple<…>>)` then one
+            // `setattr` per element), so a projected row has to agree with the
+            // value that sequence produces.  A sum-typed element does not: the
+            // constructor materializes a variant INSTANCE, while
+            // `project_pyre_field_type` models the spelling as the nullable
+            // payload — `Option<Vec<*mut PyObject>>` projects to list-or-none
+            // and then fails `generalize_attr` against
+            // `Instance(Option<Vec<*mut PyObject>>::None)`.  Leave those rows
+            // to the constructor.
+            fields.retain(|(_, ty)| !is_nullable_sum_spelling(ty));
+        }
         // A per-instantiation variant carries concrete payload rows keyed
         // under its full `<…>`-suffixed spelling
         // (`Option<*mut PyObject>::Some` → `__pos_0: *mut PyObject`,
@@ -3683,6 +3709,23 @@ fn collect_referenced_struct_names(
     if reg.fields.contains_key(stripped) {
         out.push(stripped.to_string());
     }
+}
+
+/// Whether a field-type spelling names a sum type that
+/// [`Bookkeeper::project_pyre_field_type`] models as its *payload* plus
+/// `None` — the nullable-pointer shape (`Option<Vec<T>>` → list-or-none).
+/// That model describes a field lowered to one nullable word; it does NOT
+/// describe a slot the frontend fills with a materialized variant instance
+/// (`simple_call(<host Option<Vec<*mut PyObject>>::None>)`), whose
+/// annotation is `Instance(Option<…>::None)` and cannot union with the
+/// payload.
+fn is_nullable_sum_spelling(field_ty: &str) -> bool {
+    let t = field_ty
+        .trim()
+        .trim_start_matches('&')
+        .trim_start_matches("mut ")
+        .trim();
+    strip_generic_one(t, "Option<").is_some() || strip_generic_one(t, "Result<").is_some()
 }
 
 /// Strip `Wrapper<` prefix and matching `>` suffix from a type string,

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -384,7 +384,8 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         longlong2float_analyzer,
     );
     // Foreign Rust container constructors — `Vec::new` /
-    // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
+    // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new` /
+    // `Box::new_uninit`.
     // Each returns the classdef-less opaque `SomeInstance` shell (twin
     // `bigint_from`), retiring the "no analyser registered" wall the
     // two-phase prepass hits when residualizing bodies that build these
@@ -396,6 +397,18 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     analyzer_for(&mut reg, "vec.Vec.with_capacity", foreign_container_ctor);
     analyzer_for(&mut reg, "indexmap.IndexMap.new", foreign_container_ctor);
     analyzer_for(&mut reg, "Box.new", foreign_container_ctor);
+    // `Box::new_uninit() -> Box<MaybeUninit<T>>` returns the same foreign,
+    // opaque allocation shell as `Box::new`; this retires the
+    // `boxed.Box.new_uninit` no-analyser wall.
+    analyzer_for(&mut reg, "boxed.Box.new_uninit", foreign_container_ctor);
+    // `Box::into_raw(Box<T>) -> *mut T` preserves the allocation represented
+    // by its argument, so its analyser passes that annotation through.  The
+    // pointer and box denote one allocation; re-minting an opaque shell would
+    // discard a class already established by the producer, while
+    // `project_pyre_field_type` already folds a raw pointer to its pointee
+    // shell.  Both host spellings retire the corresponding no-analyser wall.
+    analyzer_for(&mut reg, "Box.into_raw", box_into_raw);
+    analyzer_for(&mut reg, "boxed.Box.into_raw", box_into_raw);
     // `<[T]>::into_vec` producer — returns a fresh `Vec<T>`, the same
     // opaque container shell as `Vec::new`.
     analyzer_for(
@@ -1574,11 +1587,36 @@ fn foreign_container_ctor(
     _args_s: &[Option<SomeValue>],
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
-    Ok(SomeValue::Instance(SomeInstance::new(
+    Ok(foreign_opaque_instance())
+}
+
+/// The classdef-less `SomeInstance` every foreign-opaque analyser answers —
+/// the GcRef shell `annotation_state::ref_fallback_instance` gives an
+/// unregistered host-struct pointee, projecting to `ValueType::Ref(None)`.
+fn foreign_opaque_instance() -> SomeValue {
+    SomeValue::Instance(SomeInstance::new(
         None,
         false,
         std::collections::BTreeMap::new(),
-    )))
+    ))
+}
+
+/// Analyzer for `Box::into_raw(Box<T>) -> *mut T`.  The raw pointer and the
+/// consumed box denote the same allocation, so pass through the argument's
+/// annotation rather than minting a fresh opaque shell.  This preserves any
+/// class established by the box's producer; `project_pyre_field_type` already
+/// folds a raw pointer to its pointee shell.  An absent argument annotation
+/// falls back to the classdef-less foreign shell, retiring the
+/// `Box.into_raw` / `boxed.Box.into_raw` no-analyser walls.
+fn box_into_raw(
+    _bk: &Rc<Bookkeeper>,
+    args_s: &[Option<SomeValue>],
+    _kwds: &HashMap<String, Option<SomeValue>>,
+) -> Result<SomeValue, AnnotatorError> {
+    Ok(args_s
+        .first()
+        .and_then(Clone::clone)
+        .unwrap_or_else(foreign_opaque_instance))
 }
 
 /// Analyzer for the `majit_metainterp` crate's `pub fn -> bool` flag

--- a/majit/majit-translate/src/annotator/builtin.rs
+++ b/majit/majit-translate/src/annotator/builtin.rs
@@ -384,8 +384,7 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
         longlong2float_analyzer,
     );
     // Foreign Rust container constructors — `Vec::new` /
-    // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new` /
-    // `Box::new_uninit`.
+    // `Vec::with_capacity` / `indexmap::IndexMap::new` / `Box::new`.
     // Each returns the classdef-less opaque `SomeInstance` shell (twin
     // `bigint_from`), retiring the "no analyser registered" wall the
     // two-phase prepass hits when residualizing bodies that build these
@@ -397,18 +396,6 @@ fn register_builtins() -> HashMap<String, BuiltinAnalyzer> {
     analyzer_for(&mut reg, "vec.Vec.with_capacity", foreign_container_ctor);
     analyzer_for(&mut reg, "indexmap.IndexMap.new", foreign_container_ctor);
     analyzer_for(&mut reg, "Box.new", foreign_container_ctor);
-    // `Box::new_uninit() -> Box<MaybeUninit<T>>` returns the same foreign,
-    // opaque allocation shell as `Box::new`; this retires the
-    // `boxed.Box.new_uninit` no-analyser wall.
-    analyzer_for(&mut reg, "boxed.Box.new_uninit", foreign_container_ctor);
-    // `Box::into_raw(Box<T>) -> *mut T` preserves the allocation represented
-    // by its argument, so its analyser passes that annotation through.  The
-    // pointer and box denote one allocation; re-minting an opaque shell would
-    // discard a class already established by the producer, while
-    // `project_pyre_field_type` already folds a raw pointer to its pointee
-    // shell.  Both host spellings retire the corresponding no-analyser wall.
-    analyzer_for(&mut reg, "Box.into_raw", box_into_raw);
-    analyzer_for(&mut reg, "boxed.Box.into_raw", box_into_raw);
     // `<[T]>::into_vec` producer — returns a fresh `Vec<T>`, the same
     // opaque container shell as `Vec::new`.
     analyzer_for(
@@ -1587,36 +1574,11 @@ fn foreign_container_ctor(
     _args_s: &[Option<SomeValue>],
     _kwds: &HashMap<String, Option<SomeValue>>,
 ) -> Result<SomeValue, AnnotatorError> {
-    Ok(foreign_opaque_instance())
-}
-
-/// The classdef-less `SomeInstance` every foreign-opaque analyser answers —
-/// the GcRef shell `annotation_state::ref_fallback_instance` gives an
-/// unregistered host-struct pointee, projecting to `ValueType::Ref(None)`.
-fn foreign_opaque_instance() -> SomeValue {
-    SomeValue::Instance(SomeInstance::new(
+    Ok(SomeValue::Instance(SomeInstance::new(
         None,
         false,
         std::collections::BTreeMap::new(),
-    ))
-}
-
-/// Analyzer for `Box::into_raw(Box<T>) -> *mut T`.  The raw pointer and the
-/// consumed box denote the same allocation, so pass through the argument's
-/// annotation rather than minting a fresh opaque shell.  This preserves any
-/// class established by the box's producer; `project_pyre_field_type` already
-/// folds a raw pointer to its pointee shell.  An absent argument annotation
-/// falls back to the classdef-less foreign shell, retiring the
-/// `Box.into_raw` / `boxed.Box.into_raw` no-analyser walls.
-fn box_into_raw(
-    _bk: &Rc<Bookkeeper>,
-    args_s: &[Option<SomeValue>],
-    _kwds: &HashMap<String, Option<SomeValue>>,
-) -> Result<SomeValue, AnnotatorError> {
-    Ok(args_s
-        .first()
-        .and_then(Clone::clone)
-        .unwrap_or_else(foreign_opaque_instance))
+    )))
 }
 
 /// Analyzer for the `majit_metainterp` crate's `pub fn -> bool` flag

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2087,6 +2087,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
             || !lo.option_try_sites.is_empty()
+            || !lo.slice_index_minusone_sites.is_empty()
         {
             // The exception-link transforms run on a simplified graph,
             // as exceptiontransform.py does (graphs reach it after
@@ -2099,6 +2100,12 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             simplify_lowered_graph(&mut lo.graph, struct_field_attrs);
         }
         let mut tail_forwarded_returns = 0usize;
+        if !lo.slice_index_minusone_sites.is_empty() {
+            crate::front::slice_index::rewire_slice_index_minusone_sites(
+                &mut lo.graph,
+                &lo.slice_index_minusone_sites,
+            );
+        }
         if !lo.result_exc_call_results.is_empty() {
             let outcome = crate::front::result_exc::rewire_result_exc_call_sites(
                 &mut lo.graph,
@@ -2805,6 +2812,9 @@ struct Lowering<'a> {
     /// `front::range_iter` post-pass synthesizes so the `next`-diamond folds
     /// the loop (see [`crate::front::range_iter::RangeNewSite`]).
     range_iter_new_sites: Vec<crate::front::range_iter::RangeNewSite>,
+    /// RangeTo aggregates retained as candidates for the exact MinusOne
+    /// slice-index recognizer; general RangeTo remains dormant.
+    slice_index_minusone_sites: Vec<crate::front::slice_index::SliceIndexMinusOneSite>,
     /// `RangeInclusive::contains(&self, &x)` call sites paired with the
     /// `new` sites above by the `front::range_contains` post-pass (see
     /// [`crate::front::range_contains::RangeContainsSite`]).
@@ -3030,6 +3040,7 @@ impl<'a> Lowering<'a> {
             saturating_sub_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
+            slice_index_minusone_sites: Vec::new(),
             range_contains_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
@@ -4733,6 +4744,17 @@ impl<'a> Lowering<'a> {
                             start: arg_vars[0].clone(),
                             end: arg_vars[1].clone(),
                         });
+                }
+                if owner_path.as_slice() == ["core", "ops", "range"]
+                    && ctor_name == "RangeTo"
+                    && arg_vars.len() == 1
+                {
+                    self.slice_index_minusone_sites.push(
+                        crate::front::slice_index::SliceIndexMinusOneSite {
+                            range_result: res.clone(),
+                            end: arg_vars[0].clone(),
+                        },
+                    );
                 }
                 // NOTE: RangeFrom and RangeTo capture are DORMANT. Their
                 // rewrites plant `getslice`, which has no blackhole handler.

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4650,10 +4650,6 @@ impl<'a> Lowering<'a> {
                 // Resolve operand Variables up front; they flow into the
                 // synthesised FieldWrite chain rather than the ctor's
                 // arg list.
-                let rangeto_end_is_unsigned = operands
-                    .first()
-                    .and_then(operand_tyref)
-                    .is_some_and(|ty| tyref_to_value_type(ty, self.llbc) == ValueType::Unsigned);
                 let mut arg_vars: Vec<Variable> = Vec::with_capacity(operands.len());
                 for op in operands {
                     arg_vars.push(self.resolve_operand(mir_bb, op)?);
@@ -4758,7 +4754,6 @@ impl<'a> Lowering<'a> {
                         crate::front::slice_index::SliceIndexRangeToSite {
                             range_result: res.clone(),
                             end: arg_vars[0].clone(),
-                            end_is_unsigned: rangeto_end_is_unsigned,
                         },
                     );
                 }
@@ -23252,63 +23247,6 @@ mod tests {
         );
     }
 
-    /// Real-LLBC anchor for the `usize` stop in
-    /// `split_builtin_kwargs`'s `&args[..args.len() - 1]`. Rust's checked
-    /// MIR represents the subtraction destination as `(usize, bool)`, while
-    /// the graph deliberately collapses its `.0` projection to the scalar
-    /// arithmetic result. That scalar must retain the tuple's `usize`
-    /// element type so annotation learns it is unsigned/non-negative.
-    #[test]
-    #[ignore]
-    fn split_builtin_kwargs_getslice_stop_is_unsigned() {
-        use crate::model::{OpKind, ValueType};
-        let path = concat!(
-            env!("CARGO_MANIFEST_DIR"),
-            "/../../build/llbc/pyre-interpreter.ullbc"
-        );
-        let llbc = Llbc::load(path).expect("load real LLBC");
-        let graph = super::lower_function(&llbc, "split_builtin_kwargs")
-            .expect("lower split_builtin_kwargs");
-        let stop = graph
-            .blocks
-            .iter()
-            .flat_map(|b| b.operations.iter())
-            .find_map(|space_op| match (&space_op.result, &space_op.kind) {
-                (
-                    Some(result),
-                    OpKind::BinOp {
-                        result_ty: ValueType::Unsigned,
-                        op,
-                        ..
-                    },
-                ) if op == "sub" => Some(result.clone()),
-                _ => None,
-            })
-            .expect("RangeTo end must retain an unsigned subtraction");
-        let producer = graph
-            .blocks
-            .iter()
-            .flat_map(|b| b.operations.iter())
-            .find(|op| {
-                op.result
-                    .as_ref()
-                    .is_some_and(|result| result.id() == stop.id())
-            })
-            .expect("getslice stop producer");
-        assert!(
-            matches!(
-                &producer.kind,
-                OpKind::BinOp {
-                    op,
-                    result_ty: ValueType::Unsigned,
-                    ..
-                } if op == "sub"
-            ),
-            "usize stop producer must be an unsigned subtraction, got {:?}",
-            producer.kind
-        );
-    }
-
     /// Real-LLBC anchor for the `Option::is_some_and` closure-select fold:
     /// `is_mmap` is `type(obj).is_some_and(|tp| ptr::eq(tp.as_ptr(),
     /// mmap_type()))`.  After the `option_closure_select` post-pass there must
@@ -23951,8 +23889,9 @@ mod tests {
         );
     }
 
-    /// Array slicing uses the general RangeTo lever; mutable indexing remains
-    /// residual because it writes through a view.
+    /// Array slicing keeps the residual RangeTo path because the general stop
+    /// has no length proof; mutable indexing is likewise residual because it
+    /// writes through a view.
     #[test]
     #[ignore]
     fn call_function_impl_result_has_no_residual_array_index() {
@@ -23964,16 +23903,19 @@ mod tests {
         let llbc = Llbc::load(path).expect("load real LLBC");
         let graph = super::lower_function(&llbc, "call_function_impl_result")
             .expect("lower call_function_impl_result");
-        assert!(!graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
-            matches!(
-                &op.kind,
-                OpKind::Call {
-                    target: crate::model::CallTarget::FunctionPath { segments },
-                    ..
-                } if segments
-                    == &["core", "array", "<Impl>", "index"]
-                        .map(str::to_string)
-            )
-        }));
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: crate::model::CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments
+                        == &["core", "array", "<Impl>", "index"]
+                            .map(str::to_string)
+                )
+            }),
+            "general RangeTo array index remains residual"
+        );
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -10939,8 +10939,11 @@ impl<'a> Lowering<'a> {
     /// exact derivation — a `Str`/`Float`/`Ref`/nested-enum payload keys the
     /// suffixed root identically on both sides.  The one deviation is
     /// [`crate::front::checked_arith_uint`], which mints a BARE `Option` root
-    /// for its `Int`/`Unsigned` payload; an integer-payload `Option` therefore
-    /// stays bare here to match it.  A niche `Option<NonNull>` has no aggregate
+    /// for its `Option<usize>`; an UNSIGNED-payload `Option` therefore stays
+    /// bare here to match it.  A SIGNED one must not: the bare root carries a
+    /// single `__pos_0`, so a signed producer joining it unions `int` with
+    /// `r_uint`, which cannot be proved to share a signedness.  A niche
+    /// `Option<NonNull>` has no aggregate
     /// `__discriminant` / `__pos_0` (the arms use a pointer null-test and an
     /// identity payload), so its owners are never read — keep them bare, which
     /// also mirrors [`Self::resolve_bool_then_option_dest`]'s own aggregate
@@ -10950,9 +10953,7 @@ impl<'a> Lowering<'a> {
         recv_ty: &TyRef,
     ) -> Option<(String, String, ValueType)> {
         let payload_ty = self.tyref_option_payload_value_type(recv_ty)?;
-        if matches!(payload_ty, ValueType::Int | ValueType::Unsigned)
-            || self.tyref_is_niche_option_ptr(recv_ty)
-        {
+        if matches!(payload_ty, ValueType::Unsigned) || self.tyref_is_niche_option_ptr(recv_ty) {
             let def_id = self.tyref_adt_def_id(recv_ty)?;
             let td = self.llbc.type_by_id(def_id)?;
             let option_owner = td.item_meta.name_path();
@@ -11453,11 +11454,31 @@ impl<'a> Lowering<'a> {
             | ClosureCombinator::IsSomeAnd => tyref_to_value_type(dest_ty, self.llbc),
         };
         let niche = self.tyref_is_niche_option_ptr(recv_ty);
+        // `map`/`and_then` BUILD their result `Option<U>`; the other combinators
+        // build none.  `U` is the dest payload, not the receiver's `T`, so the
+        // built variant must key the dest's own classdef — otherwise two `map`s
+        // over the same receiver type with different closure results share one
+        // `__pos_0` slot, the collision `recognize_from_size_align_ok_site`
+        // documents at its own site.  `resolve_option_consumer_owners` is the
+        // derivation every downstream reader of the built value (`unwrap_or`,
+        // `?`, `expect`) uses, so producing anything else payload-erases the
+        // read; a dest that is not a resolvable `Option` declines the whole
+        // rewrite and leaves the residual call.
+        let (result_option_owner, result_some_owner, result_niche) = match kind {
+            ClosureCombinator::Map | ClosureCombinator::AndThen => {
+                let (owner, some, _payload) = self.resolve_option_consumer_owners(dest_ty)?;
+                (owner, some, self.tyref_is_niche_option_ptr(dest_ty))
+            }
+            _ => (option_owner.clone(), some_owner.clone(), niche),
+        };
         Some(crate::front::option_closure_select::ClosureSelectSite {
             kind,
             result_var: result_var.clone(),
             option_owner,
             some_owner,
+            result_option_owner,
+            result_some_owner,
+            result_niche,
             call_once_owner,
             payload_ty,
             call_result_ty,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4457,33 +4457,34 @@ impl<'a> Lowering<'a> {
                 let v = self.resolve_place(mir_bb, place)?;
                 Ok((None, v))
             }
-            // `Repeat(elem, ty, count)` — `[v; N]` literal. Modeled as
-            // a synthetic Call so the IR shape stays uniform; downstream
-            // consumers see a 1-arg array construction call.
+            // `Repeat(elem, ty, count)` — `[v; N]` literal. The decodable
+            // shape follows upstream `transform.py:36-50` and
+            // `rlist.py:346-351`: `newlist(fill)` followed by
+            // `mul(list, count)`, which the transform pass collapses to
+            // `alloc_and_set(count, fill)`.
             //
-            // `__array_repeat` is deliberately unregistered: an array-repeat
-            // graph annotate-fails on it and falls back to the legacy
-            // walker. The transparent `Array` ctor the `Rvalue::Aggregate`
-            // array arm uses is NOT a substitute here — that arm materialises
-            // its elements through an explicit `__pos_N` `FieldWrite` chain,
-            // whereas a `Repeat` carries a count and a single fill and no
-            // per-slot writes, so an `Array` ctor would leave the value with
-            // no element representation and no length. The ctor does not
-            // zero-fill either: a zero-arg `Array` ctor matches no jtransform
-            // arm (only the zero-arg `Tuple` unit collapses to a null ref,
-            // `jtransform.rs`), so it would residualise as an unlowerable
-            // `symbolic_fnaddr` rather than a `new_array_clear`.
-            Rvalue::Repeat(elem, _ty, _count) => {
+            // `__array_repeat` remains deliberately unregistered for the
+            // fallback shape when Charon supplies a const-generic reference
+            // that cannot be decoded. In that case the old 1-arg call is
+            // preserved verbatim and the graph follows its existing legacy
+            // walker path. The transparent `Array` ctor is not equivalent:
+            // `Repeat` carries one fill value and a count, not per-slot
+            // `__pos_N` writes.
+            Rvalue::Repeat(elem, _ty, count) => {
                 let arg = self.resolve_operand(mir_bb, elem)?;
                 let res = self
                     .graph
                     .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                let args = match self.emit_constant(mir_bb, &count) {
+                    Ok(count) => vec![arg, count],
+                    Err(_) => vec![arg],
+                };
                 Ok((
                     Some(OpKind::Call {
                         target: CallTarget::FunctionPath {
                             segments: vec!["__array_repeat".to_string()],
                         },
-                        args: vec![arg],
+                        args,
                         result_ty: ValueType::Int,
                     }),
                     res,

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11491,7 +11491,8 @@ impl<'a> Lowering<'a> {
     }
 
     /// `true` when `ty` is a niche-optimised `Option<NonNull<T>>`,
-    /// `Option<&mut T>`, or `Option<&T>` with a thin (Sized) ADT pointee.
+    /// `Option<fn(..)>`, `Option<&mut T>`, or `Option<&T>` with a thin
+    /// (Sized) ADT pointee.
     /// Rust encodes each in ONE pointer
     /// word (`None` = null, `Some(p)` = the non-null pointer), so
     /// `Discriminant` on it is a pointer-null test (`base != null`) and the
@@ -11551,6 +11552,12 @@ impl<'a> Lowering<'a> {
             return false;
         };
         if type_node_is_mut_ref(payload, self.llbc) {
+            return true;
+        }
+        // A function pointer is one word, and `Option<fn(..)>` represents
+        // `None` as the null pointer.  The payload therefore aliases the
+        // base pointer directly and carries no metadata word.
+        if type_node_is_fn_ptr(payload, self.llbc) {
             return true;
         }
         // A shared reference `&T` is equally a one-word null-pointer niche
@@ -15622,6 +15629,33 @@ fn type_node_is_mut_ref<'l>(mut node: &'l serde_json::Value, llbc: &'l Llbc) -> 
             .and_then(|arr| arr.get(2))
             .and_then(serde_json::Value::as_str)
             .is_some_and(|kind| kind.to_ascii_lowercase().contains("mut"));
+    }
+    false
+}
+
+/// Whether a Charon type node's top-level constructor is a function pointer,
+/// after following serialization indirections.
+fn type_node_is_fn_ptr<'l>(mut node: &'l serde_json::Value, llbc: &'l Llbc) -> bool {
+    for _ in 0..24 {
+        let Some(obj) = node.as_object() else {
+            return false;
+        };
+        if let Some(id) = obj.get("Deduplicated").and_then(serde_json::Value::as_u64) {
+            let Some(body) = llbc.dedup_body(id) else {
+                return false;
+            };
+            node = body;
+            continue;
+        }
+        if let Some(arr) = obj
+            .get("HashConsedValue")
+            .and_then(serde_json::Value::as_array)
+            && arr.len() == 2
+        {
+            node = &arr[1];
+            continue;
+        }
+        return obj.get("FnPtr").is_some();
     }
     false
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2087,7 +2087,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
             || !lo.option_try_sites.is_empty()
-            || !lo.slice_index_minusone_sites.is_empty()
+            || !lo.slice_index_rangeto_sites.is_empty()
         {
             // The exception-link transforms run on a simplified graph,
             // as exceptiontransform.py does (graphs reach it after
@@ -2100,10 +2100,10 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             simplify_lowered_graph(&mut lo.graph, struct_field_attrs);
         }
         let mut tail_forwarded_returns = 0usize;
-        if !lo.slice_index_minusone_sites.is_empty() {
-            crate::front::slice_index::rewire_slice_index_minusone_sites(
+        if !lo.slice_index_rangeto_sites.is_empty() {
+            crate::front::slice_index::rewire_slice_index_rangeto_sites(
                 &mut lo.graph,
-                &lo.slice_index_minusone_sites,
+                &lo.slice_index_rangeto_sites,
             );
         }
         if !lo.result_exc_call_results.is_empty() {
@@ -2812,9 +2812,10 @@ struct Lowering<'a> {
     /// `front::range_iter` post-pass synthesizes so the `next`-diamond folds
     /// the loop (see [`crate::front::range_iter::RangeNewSite`]).
     range_iter_new_sites: Vec<crate::front::range_iter::RangeNewSite>,
-    /// RangeTo aggregates retained as candidates for the exact MinusOne
-    /// slice-index recognizer; general RangeTo remains dormant.
-    slice_index_minusone_sites: Vec<crate::front::slice_index::SliceIndexMinusOneSite>,
+    /// RangeTo aggregates retained as candidates for the slice-index
+    /// recognizer. The end's unsigned coloring is captured from MIR here,
+    /// before the operand can become a block inputarg.
+    slice_index_rangeto_sites: Vec<crate::front::slice_index::SliceIndexRangeToSite>,
     /// `RangeInclusive::contains(&self, &x)` call sites paired with the
     /// `new` sites above by the `front::range_contains` post-pass (see
     /// [`crate::front::range_contains::RangeContainsSite`]).
@@ -3040,7 +3041,7 @@ impl<'a> Lowering<'a> {
             saturating_sub_sites: Vec::new(),
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
-            slice_index_minusone_sites: Vec::new(),
+            slice_index_rangeto_sites: Vec::new(),
             range_contains_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
@@ -4649,6 +4650,10 @@ impl<'a> Lowering<'a> {
                 // Resolve operand Variables up front; they flow into the
                 // synthesised FieldWrite chain rather than the ctor's
                 // arg list.
+                let rangeto_end_is_unsigned = operands
+                    .first()
+                    .and_then(operand_tyref)
+                    .is_some_and(|ty| tyref_to_value_type(ty, self.llbc) == ValueType::Unsigned);
                 let mut arg_vars: Vec<Variable> = Vec::with_capacity(operands.len());
                 for op in operands {
                     arg_vars.push(self.resolve_operand(mir_bb, op)?);
@@ -4749,24 +4754,16 @@ impl<'a> Lowering<'a> {
                     && ctor_name == "RangeTo"
                     && arg_vars.len() == 1
                 {
-                    self.slice_index_minusone_sites.push(
-                        crate::front::slice_index::SliceIndexMinusOneSite {
+                    self.slice_index_rangeto_sites.push(
+                        crate::front::slice_index::SliceIndexRangeToSite {
                             range_result: res.clone(),
                             end: arg_vars[0].clone(),
+                            end_is_unsigned: rangeto_end_is_unsigned,
                         },
                     );
                 }
-                // NOTE: RangeFrom and RangeTo capture are DORMANT. Their
-                // rewrites plant `getslice`, which has no blackhole handler.
-                // RangeFrom first exposed this when a graph dropped to the
-                // legacy walker with an uncolored Void stop. Activating
-                // RangeTo later exposed bare `getslice/rii>r` in both
-                // `split_builtin_kwargs` and `do_warn_explicit`: both stops
-                // are `args.len() - 1`, statically unsigned but not constant.
-                // The recognizer's const-nonnegative gate declines them; both
-                // captures remain disabled until the codewriter is guaranteed
-                // to consume the rtyped graph where `rtype_getslice` has
-                // replaced the op.
+                // RangeFrom alone stays dormant: its Void ConstNone stop has
+                // no regalloc coloring on the legacy-walker path.
                 // Surface every operand through a separate FieldWrite so
                 // the field-to-value binding survives into the
                 // codewriter / annotator.  Field names default to
@@ -23276,11 +23273,18 @@ mod tests {
             .blocks
             .iter()
             .flat_map(|b| b.operations.iter())
-            .find_map(|op| match &op.kind {
-                OpKind::GetSlice { args } => args.get(2).cloned(),
+            .find_map(|space_op| match (&space_op.result, &space_op.kind) {
+                (
+                    Some(result),
+                    OpKind::BinOp {
+                        result_ty: ValueType::Unsigned,
+                        op,
+                        ..
+                    },
+                ) if op == "sub" => Some(result.clone()),
                 _ => None,
             })
-            .expect("RangeTo rewrite must emit getslice stop");
+            .expect("RangeTo end must retain an unsigned subtraction");
         let producer = graph
             .blocks
             .iter()
@@ -23945,5 +23949,31 @@ mod tests {
             "Option<&Wtf8> is a fat-ref DST option and must not niche-fold to a \
              pointer-null test (no null_mut discriminant)"
         );
+    }
+
+    /// Array slicing uses the general RangeTo lever; mutable indexing remains
+    /// residual because it writes through a view.
+    #[test]
+    #[ignore]
+    fn call_function_impl_result_has_no_residual_array_index() {
+        use crate::model::OpKind;
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "call_function_impl_result")
+            .expect("lower call_function_impl_result");
+        assert!(!graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+            matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: crate::model::CallTarget::FunctionPath { segments },
+                    ..
+                } if segments
+                    == &["core", "array", "<Impl>", "index"]
+                        .map(str::to_string)
+            )
+        }));
     }
 }

--- a/majit/majit-translate/src/front/option_closure_select.rs
+++ b/majit/majit-translate/src/front/option_closure_select.rs
@@ -71,12 +71,24 @@ pub(crate) struct ClosureSelectSite {
     pub kind: ClosureCombinator,
     /// The combinator call result — locates block A.
     pub result_var: Variable,
-    /// The `Option` enum root `name_path` — the `__discriminant` field owner
-    /// (both the receiver read and any built `Some`/`None`).
+    /// The receiver `Option` enum root `name_path` — the `__discriminant` field
+    /// owner for the receiver read.
     pub option_owner: String,
-    /// The `Option::Some` variant `name_path` — the `__pos_0` payload field
-    /// owner (the receiver read and any built `Some`).
+    /// The receiver `Option::Some` variant `name_path` — the `__pos_0` payload
+    /// field owner for the receiver read.
     pub some_owner: String,
+    /// The `Option` enum root `name_path` of the result the rewrite BUILDS —
+    /// `map`'s `Some(U)` and `map`/`and_then`'s `None`.  `map`'s result is
+    /// `Option<U>` for a closure `T -> U`, so it keys a different classdef than
+    /// the receiver's `Option<T>`: sharing one would put two closures' results
+    /// in one `__pos_0` slot.
+    pub result_option_owner: String,
+    /// The `Option::Some` variant `name_path` of the built result — the
+    /// `__pos_0` payload field owner of `map`'s `Some(U)`.
+    pub result_some_owner: String,
+    /// True when the BUILT result is a niche `Option` — `Some(x)` is then `x`
+    /// itself and `None` is null, the produce-side mirror of `niche`.
+    pub result_niche: bool,
     /// The closure env ADT `name_path` — the `call_once` inherent-method owner.
     pub call_once_owner: String,
     /// The receiver `Option`'s payload `T` projected to a [`ValueType`] — the
@@ -253,14 +265,26 @@ fn rewire_one_closure_select_site(
                 &site.args_tuple_suffix,
             );
             match site.kind {
-                // `map` wraps the closure result back into `Some(U)`.
-                ClosureCombinator::Map => emit_option_variant(
-                    graph,
-                    then_bb,
-                    &site.option_owner,
-                    1,
-                    Some((&site.some_owner, call_result, site.call_result_ty.clone())),
-                ),
+                // `map` wraps the closure result back into `Some(U)` — except
+                // that a niche `Option` is a one-word pointer with no aggregate
+                // `__discriminant` / `__pos_0`, where `Some(x)` is `x` itself.
+                ClosureCombinator::Map => {
+                    if site.result_niche {
+                        call_result
+                    } else {
+                        emit_option_variant(
+                            graph,
+                            then_bb,
+                            &site.result_option_owner,
+                            1,
+                            Some((
+                                &site.result_some_owner,
+                                call_result,
+                                site.call_result_ty.clone(),
+                            )),
+                        )
+                    }
+                }
                 // `and_then`'s closure already returns `Option<U>`;
                 // `is_some_and`'s already returns the `bool`.
                 _ => call_result,
@@ -282,7 +306,13 @@ fn rewire_one_closure_select_site(
     let else_value = match site.kind {
         // `map`/`and_then` build a fresh `None`.
         ClosureCombinator::Map | ClosureCombinator::AndThen => {
-            emit_option_variant(graph, else_bb, &site.option_owner, 0, None)
+            // A niche `Option` is a one-word pointer with no aggregate
+            // `__discriminant` / `__pos_0`: `None` is null.
+            if site.result_niche {
+                graph.push_null_mut_ptr(else_bb)
+            } else {
+                emit_option_variant(graph, else_bb, &site.result_option_owner, 0, None)
+            }
         }
         // `is_some_and` yields the constant `false` — no closure, no `Option`.
         ClosureCombinator::IsSomeAnd => {
@@ -467,6 +497,9 @@ mod tests {
             call_result_ty: ValueType::Int,
             args_tuple_suffix: String::new(),
             niche: false,
+            result_option_owner: "core::option::Option".into(),
+            result_some_owner: "core::option::Option::Some".into(),
+            result_niche: false,
         }
     }
 

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -1,6 +1,6 @@
 //! `&s[k..]` / `&s[..k]` sub-slice indexes → orthodox `getslice` copies.
 //!
-//! ## Status: RangeTo and RangeFrom dormant
+//! ## Status: RangeFrom dormant
 //!
 //! These recognizers are CAPSTONES, not independently wired primitives. The
 //! RangeFrom arm is built and unit-tested but is not captured or invoked from
@@ -9,19 +9,20 @@
 //! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
 //! dropped to the legacy walker.
 //!
-//! RangeTo's primary blocker is semantic: Rust's `&s[..end]` panics when
-//! `end > s.len()`, but `build_ll_listslice_startstop_helper_graph` clamps an
-//! oversized stop to the list length and returns the whole slice
-//! (`translator/rtyper/rlist.rs:3563-3576`). Until lowering can prove
-//! `end <= len`, emitting `getslice(s, 0, end)` would turn an interpreter
-//! failure into success. Its secondary blocker is non-negativity: activating
-//! RangeTo previously emitted bare `getslice/rii>r` from
-//! `split_builtin_kwargs` and `do_warn_explicit`; both stops are
-//! `args.len() - 1`, statically unsigned but not constant. An unsigned gate
-//! would admit those measured failures, while the constant-nonnegative gate
-//! declines them. The upper-bound proof is still missing, so both capture
-//! arms remain dormant and leave the original residual ctor + call chain
-//! untouched.
+//! RangeTo is sound because the clamp is upstream, not a pyre deviation:
+//! `ll_listslice_startstop` (`rpython/rtyper/rlist.py:893-903`) clamps
+//! `stop > length`, matching Python's defined `s[:n]` behavior. The frontend
+//! also strips Rust's own range checks: `TermKind::Assert` branches
+//! unconditionally to success, citing `backendopt/removeassert.py`, because
+//! those checks have no Python-observable meaning. A clamping `getslice` is
+//! strictly more defined than that stripped bounds check. The real remaining
+//! requirement is a non-negative (unsigned) end.
+//!
+//! The earlier failure was an unwired frontend `getslice` planted before a
+//! graph fell through the legacy walker. RangeTo now uses an unregistered
+//! synthetic call, expanded only by the rtyper flowspace adapter, so no
+//! frontend `getslice` is planted. RangeFrom alone stays dormant because its
+//! Void `ConstNone` stop has no regalloc coloring on that path.
 #![allow(dead_code)]
 //!
 //! ## Positioning
@@ -100,13 +101,7 @@ pub(crate) struct SliceIndexRangeFromSite {
 pub(crate) struct SliceIndexRangeToSite {
     pub range_result: Variable,
     pub end: Variable,
-}
-
-/// A RangeTo candidate accepted only for the proven `slice.len() - 1` form.
-#[derive(Clone)]
-pub(crate) struct SliceIndexMinusOneSite {
-    pub range_result: Variable,
-    pub end: Variable,
+    pub end_is_unsigned: bool,
 }
 
 /// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
@@ -136,21 +131,16 @@ pub(crate) fn rewire_slice_index_rangefrom_sites(
     rewritten
 }
 
-/// Rewrite captured `RangeTo { end }` indexes into
-/// `getslice(slice, 0, end)` (`SliceKind::StartStop`). Production capture must
-/// remain dormant until it can prove `end <= slice.len()`; the StartStop
-/// helper clamps instead of preserving Rust's out-of-bounds panic.
+/// Rewrite captured `RangeTo { end }` indexes through the synthetic-call
+/// channel. MinusOne is selected after locating the consuming call; otherwise
+/// only an end captured as unsigned admits the general RangeTo rewrite.
 pub(crate) fn rewire_slice_index_rangeto_sites(
     graph: &mut FunctionGraph,
     sites: &[SliceIndexRangeToSite],
 ) -> usize {
     let mut rewritten = 0;
     for site in sites {
-        match rewire_one_slice_index_site(
-            graph,
-            &site.range_result,
-            SliceIndexBounds::RangeTo { end: &site.end },
-        ) {
+        match rewire_one_slice_index_rangeto_site(graph, site) {
             Ok(()) => rewritten += 1,
             Err(_decline) => {
                 // Leave the residual chain intact so legacy keeps its prior
@@ -161,33 +151,51 @@ pub(crate) fn rewire_slice_index_rangeto_sites(
     rewritten
 }
 
-/// Rewrite only `slice[..slice.len() - 1]`. The synthetic call is expanded
-/// by the annotation-side flowspace adapter, so it cannot leak to the legacy
-/// walker as an unwired frontend `getslice` op.
-pub(crate) fn rewire_slice_index_minusone_sites(
-    graph: &mut FunctionGraph,
-    sites: &[SliceIndexMinusOneSite],
-) -> usize {
-    let mut rewritten = 0;
-    for site in sites {
-        if rewire_one_slice_index_site(
-            graph,
-            &site.range_result,
-            SliceIndexBounds::MinusOne { end: &site.end },
-        )
-        .is_ok()
-        {
-            rewritten += 1;
-        }
-    }
-    rewritten
-}
-
 #[derive(Clone, Copy)]
 enum SliceIndexBounds<'a> {
-    RangeFrom { start: &'a Variable },
-    RangeTo { end: &'a Variable },
-    MinusOne { end: &'a Variable },
+    RangeFrom {
+        start: &'a Variable,
+    },
+    RangeTo {
+        end: &'a Variable,
+        end_is_unsigned: bool,
+    },
+    MinusOne {
+        end: &'a Variable,
+    },
+}
+
+fn rewire_one_slice_index_rangeto_site(
+    graph: &mut FunctionGraph,
+    site: &SliceIndexRangeToSite,
+) -> Result<(), String> {
+    let range = &site.range_result;
+    let slice = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .find_map(|op| {
+            let OpKind::Call { args, .. } = &op.kind else {
+                return None;
+            };
+            (is_slice_range_index_call(&op.kind) && args.len() == 2 && args[1] == *range)
+                .then(|| args[0].clone())
+        })
+        .ok_or_else(|| format!("{}: no RangeTo index consumer", graph.name))?;
+    let bounds = if minus_one_end_matches(graph, &site.end, &slice) {
+        SliceIndexBounds::MinusOne { end: &site.end }
+    } else if site.end_is_unsigned {
+        SliceIndexBounds::RangeTo {
+            end: &site.end,
+            end_is_unsigned: true,
+        }
+    } else {
+        return Err(format!(
+            "{}: RangeTo end is not unsigned — declining",
+            graph.name
+        ));
+    };
+    rewire_one_slice_index_site(graph, range, bounds)
 }
 
 fn rewire_one_slice_index_site(
@@ -269,14 +277,15 @@ fn rewire_one_slice_index_site(
                 ));
             }
         }
-        SliceIndexBounds::RangeTo { end } => {
+        SliceIndexBounds::RangeTo {
+            end,
+            end_is_unsigned,
+        } => {
             if !graph_defines(graph, end) {
                 return Err(format!("{name}: RangeTo end is not defined in the graph"));
             }
-            if !bound_is_const_nonneg(graph, end) {
-                return Err(format!(
-                    "{name}: RangeTo end is not a non-negative constant — declining"
-                ));
+            if !end_is_unsigned {
+                return Err(format!("{name}: RangeTo end is not unsigned — declining"));
             }
         }
         SliceIndexBounds::MinusOne { end } => {
@@ -293,12 +302,12 @@ fn rewire_one_slice_index_site(
 
     // --- All structural validation passed; mutate the graph. ---
 
-    // 4. Remove the range construction only for the RangeFrom / ordinary
-    //    RangeTo rewrites. MinusOne leaves the ctor and its FieldWrite in
+    // 4. Remove the range construction only for the RangeFrom rewrites.
+    // MinusOne and general RangeTo leave the ctor and its FieldWrite in
     //    place: the range can be carried by a block link without being read
     //    by an operation, and sweeping its sole defining ctor would orphan
     //    that link-carried value.
-    if !matches!(bounds, SliceIndexBounds::MinusOne { .. }) {
+    if matches!(bounds, SliceIndexBounds::RangeFrom { .. }) {
         for b in &mut graph.blocks {
             b.operations.retain(|op| {
                 let is_field_write =
@@ -317,10 +326,7 @@ fn rewire_one_slice_index_site(
     }
 
     // 5. Replace the residual `slice::index` call (re-located by result
-    //    identity — the sweeps above shifted op indices) with
-    //    `getslice(slice, start, None)`. The `None` stop is a fresh
-    //    `ConstNone` op inserted immediately before the getslice so its result
-    //    Variable is defined in the same block.
+    //    identity — the sweeps above shifted op indices).
     let (rb, ri) = graph
         .blocks
         .iter()
@@ -346,31 +352,46 @@ fn rewire_one_slice_index_site(
             },
         };
     } else {
-        let synthetic_bound = graph.alloc_value_var();
-        let (args, synthetic_kind) = match bounds {
-            SliceIndexBounds::RangeFrom { start } => (
-                vec![slice, start.clone(), synthetic_bound.clone()],
-                OpKind::ConstNone,
-            ),
-            SliceIndexBounds::RangeTo { end } => (
-                vec![slice, synthetic_bound.clone(), end.clone()],
-                OpKind::ConstInt(0),
-            ),
+        match bounds {
+            SliceIndexBounds::RangeFrom { start } => {
+                let synthetic_bound = graph.alloc_value_var();
+                graph.blocks[rb].operations[ri] = SpaceOperation {
+                    result: Some(index_result),
+                    kind: OpKind::GetSlice {
+                        args: vec![slice, start.clone(), synthetic_bound.clone()],
+                    },
+                };
+                graph.blocks[rb].operations.insert(
+                    ri,
+                    SpaceOperation {
+                        result: Some(synthetic_bound),
+                        kind: OpKind::ConstNone,
+                    },
+                );
+            }
+            SliceIndexBounds::RangeTo { .. } => {
+                graph.blocks[rb].operations[ri] = SpaceOperation {
+                    result: Some(index_result),
+                    kind: OpKind::Call {
+                        target: CallTarget::FunctionPath {
+                            segments: vec!["__getslice_rangeto".to_string()],
+                        },
+                        args: vec![slice, bounds_end(&bounds).clone()],
+                        result_ty: index_result_ty,
+                    },
+                };
+            }
             SliceIndexBounds::MinusOne { .. } => unreachable!(),
-        };
-        graph.blocks[rb].operations[ri] = SpaceOperation {
-            result: Some(index_result),
-            kind: OpKind::GetSlice { args },
-        };
-        graph.blocks[rb].operations.insert(
-            ri,
-            SpaceOperation {
-                result: Some(synthetic_bound),
-                kind: synthetic_kind,
-            },
-        );
+        }
     }
     Ok(())
+}
+
+fn bounds_end<'a>(bounds: &'a SliceIndexBounds<'a>) -> &'a Variable {
+    match bounds {
+        SliceIndexBounds::RangeTo { end, .. } | SliceIndexBounds::MinusOne { end } => end,
+        SliceIndexBounds::RangeFrom { .. } => unreachable!(),
+    }
 }
 
 /// `end = sub(ArrayLen(slice), 1)` is the only RangeTo shape whose stop is
@@ -422,11 +443,15 @@ fn is_slice_range_index_call(kind: &OpKind) -> bool {
 /// path `core::slice::index::<Impl>::index`.
 fn slice_index_segments_match(segments: &[String]) -> bool {
     let n = segments.len();
-    n >= 3
-        && segments[n - 1] == "index"
-        && segments[n - 2] == "<Impl>"
+    if n < 4 || segments.first().map(String::as_str) != Some("core") {
+        return false;
+    }
+    let slice_impl = n >= 5
+        && segments[n - 4] == "slice"
         && segments[n - 3] == "index"
-        && segments.first().map(String::as_str) == Some("core")
+        && segments[n - 2] == "<Impl>";
+    let array_impl = segments[n - 3] == "array" && segments[n - 2] == "<Impl>";
+    segments[n - 1] == "index" && (slice_impl || array_impl)
 }
 
 /// `true` when the `RangeFrom` value is consumed by EXACTLY its own
@@ -792,12 +817,13 @@ mod tests {
         // operation there — precisely the shape that must not orphan it.
         g.set_goto(a, b, vec![sub, range.clone()]);
 
-        let site = SliceIndexMinusOneSite {
+        let site = SliceIndexRangeToSite {
             range_result: range.clone(),
             end,
+            end_is_unsigned: true,
         };
         assert_eq!(
-            rewire_slice_index_minusone_sites(&mut g, &[site]),
+            rewire_slice_index_rangeto_sites(&mut g, &[site]),
             1,
             "the MinusOne slice::index site is rewritten"
         );
@@ -842,7 +868,20 @@ mod tests {
         let mut g = FunctionGraph::new("test_slice_index_rangeto");
         let a = g.startblock;
         let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
-        let end = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let end_base = g.push_op_var(a, OpKind::ConstInt(7), true).unwrap();
+        let end_one = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "add".into(),
+                    lhs: end_base,
+                    rhs: end_one,
+                    result_ty: ValueType::Unsigned,
+                },
+                true,
+            )
+            .unwrap();
         let range = g
             .push_op_var(
                 a,
@@ -878,39 +917,38 @@ mod tests {
         let site = SliceIndexRangeToSite {
             range_result: range.clone(),
             end: end.clone(),
+            end_is_unsigned: true,
         };
         assert_eq!(rewire_slice_index_rangeto_sites(&mut g, &[site]), 1);
-        crate::model::prune_dead_phis(&mut g);
-
-        assert_eq!(g.block(b).inputargs, vec![b_args[0].clone()]);
-        assert_eq!(g.block(a).exits[0].args.len(), 1);
-        assert_ne!(
-            g.block(a).exits[0].args[0].as_variable(),
-            Some(&range),
-            "orphan RangeTo link arg must be removed"
-        );
-
-        let getslice = g
+        let marker = g
             .blocks
             .iter()
             .flat_map(|blk| &blk.operations)
             .find_map(|op| match &op.kind {
-                OpKind::GetSlice { args } => Some(args),
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    args,
+                    ..
+                } if segments == &["__getslice_rangeto".to_string()] => Some(args),
                 _ => None,
             })
-            .expect("RangeTo index becomes getslice");
-        assert_eq!(getslice[0], slice);
-        assert_eq!(getslice[2], end);
-        let start = &getslice[1];
-        assert!(g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
-            op.result.as_ref() == Some(start) && matches!(&op.kind, OpKind::ConstInt(0))
-        }));
+            .expect("RangeTo index becomes synthetic getslice marker");
+        assert_eq!(marker, &[slice, end]);
         assert!(
-            !g.blocks
-                .iter()
-                .flat_map(|blk| &blk.operations)
-                .any(|op| is_slice_range_index_call(&op.kind))
+            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+                is_slice_range_index_call(&op.kind) == false && op.result.as_ref() == Some(&range)
+            }),
+            "RangeTo ctor remains defined for link-carried aliases"
         );
+        for block in &g.blocks {
+            for link in &block.exits {
+                for arg in &link.args {
+                    if let LinkArg::Value(var) = arg {
+                        assert!(graph_defines(&g, var), "dangling link arg {var:?}");
+                    }
+                }
+            }
+        }
     }
 
     /// A RangeTo whose end is computed at runtime declines even when its Rust
@@ -930,7 +968,7 @@ mod tests {
                     op: "sub".into(),
                     lhs: len,
                     rhs: one,
-                    result_ty: ValueType::Unsigned,
+                    result_ty: ValueType::Int,
                 },
                 true,
             )
@@ -968,6 +1006,7 @@ mod tests {
         let site = SliceIndexRangeToSite {
             range_result: range,
             end,
+            end_is_unsigned: false,
         };
         assert_eq!(
             rewire_slice_index_rangeto_sites(&mut g, &[site]),
@@ -988,6 +1027,23 @@ mod tests {
                 .any(|op| matches!(&op.kind, OpKind::GetSlice { .. })),
             "no getslice is planted on decline"
         );
+    }
+
+    #[test]
+    fn range_to_rejects_index_mut_and_accepts_array_index() {
+        assert!(!slice_index_segments_match(&[
+            "core".into(),
+            "slice".into(),
+            "index".into(),
+            "<Impl>".into(),
+            "index_mut".into(),
+        ]));
+        assert!(slice_index_segments_match(&[
+            "core".into(),
+            "array".into(),
+            "<Impl>".into(),
+            "index".into(),
+        ]));
     }
 
     /// A RangeFrom whose start is a RUNTIME value (not a const) declines: a

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -102,6 +102,13 @@ pub(crate) struct SliceIndexRangeToSite {
     pub end: Variable,
 }
 
+/// A RangeTo candidate accepted only for the proven `slice.len() - 1` form.
+#[derive(Clone)]
+pub(crate) struct SliceIndexMinusOneSite {
+    pub range_result: Variable,
+    pub end: Variable,
+}
+
 /// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
 /// residual `slice::index` call into an orthodox `getslice(slice, start,
 /// None)` op. Fail-safe: a site that does not match the expected single-
@@ -154,10 +161,33 @@ pub(crate) fn rewire_slice_index_rangeto_sites(
     rewritten
 }
 
+/// Rewrite only `slice[..slice.len() - 1]`. The synthetic call is expanded
+/// by the annotation-side flowspace adapter, so it cannot leak to the legacy
+/// walker as an unwired frontend `getslice` op.
+pub(crate) fn rewire_slice_index_minusone_sites(
+    graph: &mut FunctionGraph,
+    sites: &[SliceIndexMinusOneSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        if rewire_one_slice_index_site(
+            graph,
+            &site.range_result,
+            SliceIndexBounds::MinusOne { end: &site.end },
+        )
+        .is_ok()
+        {
+            rewritten += 1;
+        }
+    }
+    rewritten
+}
+
 #[derive(Clone, Copy)]
 enum SliceIndexBounds<'a> {
     RangeFrom { start: &'a Variable },
     RangeTo { end: &'a Variable },
+    MinusOne { end: &'a Variable },
 }
 
 fn rewire_one_slice_index_site(
@@ -172,7 +202,7 @@ fn rewire_one_slice_index_site(
     //    value as its `range` operand (args[1]). Capture its `slice` operand
     //    (args[0]) and result; the position is re-found after the sweeps
     //    below, since removing the ctor / FieldWrite shifts op indices.
-    let (slice, index_result) = graph
+    let (slice, index_result, index_result_ty) = graph
         .blocks
         .iter()
         .find_map(|b| {
@@ -187,7 +217,10 @@ fn rewire_one_slice_index_site(
                     return None;
                 }
                 let result = op.result.as_ref()?;
-                Some((args[0].clone(), result.clone()))
+                let OpKind::Call { result_ty, .. } = &op.kind else {
+                    unreachable!()
+                };
+                Some((args[0].clone(), result.clone(), result_ty.clone()))
             })
         })
         .ok_or_else(|| format!("{name}: no slice::index call consumes the RangeFrom value"))?;
@@ -246,29 +279,41 @@ fn rewire_one_slice_index_site(
                 ));
             }
         }
+        SliceIndexBounds::MinusOne { end } => {
+            if !graph_defines(graph, end) {
+                return Err(format!("{name}: MinusOne end is not defined in the graph"));
+            }
+            if !minus_one_end_matches(graph, end, &slice) {
+                return Err(format!(
+                    "{name}: RangeTo end is not sub(ArrayLen(slice), 1) — declining"
+                ));
+            }
+        }
     }
 
     // --- All structural validation passed; mutate the graph. ---
 
-    // 4. Remove every `start` `FieldWrite` on the `RangeFrom` value and the
-    //    `SyntheticTransparentCtor` producing it. After the rewrite `range` is
-    //    dead (the gate proved the index call is its only non-construction
-    //    consumer), so a surviving `setattr("start")` or ctor would wall on a
-    //    value nothing reads.
-    for b in &mut graph.blocks {
-        b.operations.retain(|op| {
-            let is_field_write =
-                matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == &range);
-            let is_ctor = op.result.as_ref() == Some(&range)
-                && matches!(
-                    &op.kind,
-                    OpKind::Call {
-                        target: CallTarget::SyntheticTransparentCtor { .. },
-                        ..
-                    }
-                );
-            !(is_field_write || is_ctor)
-        });
+    // 4. Remove the range construction only for the RangeFrom / ordinary
+    //    RangeTo rewrites. MinusOne leaves the ctor and its FieldWrite in
+    //    place: the range can be carried by a block link without being read
+    //    by an operation, and sweeping its sole defining ctor would orphan
+    //    that link-carried value.
+    if !matches!(bounds, SliceIndexBounds::MinusOne { .. }) {
+        for b in &mut graph.blocks {
+            b.operations.retain(|op| {
+                let is_field_write =
+                    matches!(&op.kind, OpKind::FieldWrite { base, .. } if base == &range);
+                let is_ctor = op.result.as_ref() == Some(&range)
+                    && matches!(
+                        &op.kind,
+                        OpKind::Call {
+                            target: CallTarget::SyntheticTransparentCtor { .. },
+                            ..
+                        }
+                    );
+                !(is_field_write || is_ctor)
+            });
+        }
     }
 
     // 5. Replace the residual `slice::index` call (re-located by result
@@ -289,29 +334,72 @@ fn rewire_one_slice_index_site(
                 .map(|oi| (bi, oi))
         })
         .ok_or_else(|| format!("{name}: slice::index op vanished before rewrite"))?;
-    let synthetic_bound = graph.alloc_value_var();
-    let (args, synthetic_kind) = match bounds {
-        SliceIndexBounds::RangeFrom { start } => (
-            vec![slice, start.clone(), synthetic_bound.clone()],
-            OpKind::ConstNone,
-        ),
-        SliceIndexBounds::RangeTo { end } => (
-            vec![slice, synthetic_bound.clone(), end.clone()],
-            OpKind::ConstInt(0),
-        ),
-    };
-    graph.blocks[rb].operations[ri] = SpaceOperation {
-        result: Some(index_result),
-        kind: OpKind::GetSlice { args },
-    };
-    graph.blocks[rb].operations.insert(
-        ri,
-        SpaceOperation {
-            result: Some(synthetic_bound),
-            kind: synthetic_kind,
-        },
-    );
+    if let SliceIndexBounds::MinusOne { .. } = bounds {
+        graph.blocks[rb].operations[ri] = SpaceOperation {
+            result: Some(index_result),
+            kind: OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__getslice_minusone".to_string()],
+                },
+                args: vec![slice],
+                result_ty: index_result_ty,
+            },
+        };
+    } else {
+        let synthetic_bound = graph.alloc_value_var();
+        let (args, synthetic_kind) = match bounds {
+            SliceIndexBounds::RangeFrom { start } => (
+                vec![slice, start.clone(), synthetic_bound.clone()],
+                OpKind::ConstNone,
+            ),
+            SliceIndexBounds::RangeTo { end } => (
+                vec![slice, synthetic_bound.clone(), end.clone()],
+                OpKind::ConstInt(0),
+            ),
+            SliceIndexBounds::MinusOne { .. } => unreachable!(),
+        };
+        graph.blocks[rb].operations[ri] = SpaceOperation {
+            result: Some(index_result),
+            kind: OpKind::GetSlice { args },
+        };
+        graph.blocks[rb].operations.insert(
+            ri,
+            SpaceOperation {
+                result: Some(synthetic_bound),
+                kind: synthetic_kind,
+            },
+        );
+    }
     Ok(())
+}
+
+/// `end = sub(ArrayLen(slice), 1)` is the only RangeTo shape whose stop is
+/// proven against this receiver's length. `ArrayLen` and plain `sub` are the
+/// measured post-lowering forms (`front/mir.rs:14603`).
+fn minus_one_end_matches(graph: &FunctionGraph, end: &Variable, slice: &Variable) -> bool {
+    let Some((lhs, rhs)) = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .find_map(|op| match (&op.result, &op.kind) {
+            (Some(result), OpKind::BinOp { op, lhs, rhs, .. }) if result == end && op == "sub" => {
+                Some((lhs.clone(), rhs.clone()))
+            }
+            _ => None,
+        })
+    else {
+        return false;
+    };
+    let has_len = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+        op.result.as_ref() == Some(&lhs)
+            && matches!(&op.kind, OpKind::ArrayLen { base, .. } if base == slice)
+    });
+    let has_one = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .any(|op| op.result.as_ref() == Some(&rhs) && matches!(&op.kind, OpKind::ConstInt(1)));
+    has_len && has_one
 }
 
 /// `true` when `kind` is a residual `core::slice::index::<Impl>::index` call —
@@ -607,6 +695,144 @@ mod tests {
                 op.result.as_ref() == Some(stop) && matches!(&op.kind, OpKind::ConstNone)
             });
         assert!(stop_is_const_none, "arg2 = ConstNone (StartOnly stop)");
+    }
+
+    #[test]
+    fn minus_one_recognizer_requires_same_slice_array_len() {
+        let mut g = FunctionGraph::new("minus_one_recognizer");
+        let b = g.startblock;
+        let slice = g.push_op_var(b, OpKind::ConstInt(0), true).unwrap();
+        let other = g.push_op_var(b, OpKind::ConstInt(0), true).unwrap();
+        let len = g
+            .push_op_var(
+                b,
+                OpKind::ArrayLen {
+                    base: slice.clone(),
+                    array_type_id: None,
+                    nolength: false,
+                },
+                true,
+            )
+            .unwrap();
+        let one = g.push_op_var(b, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                b,
+                OpKind::BinOp {
+                    op: "sub".into(),
+                    lhs: len,
+                    rhs: one,
+                    result_ty: ValueType::Unsigned,
+                },
+                true,
+            )
+            .unwrap();
+        assert!(minus_one_end_matches(&g, &end, &slice));
+        assert!(!minus_one_end_matches(&g, &end, &other));
+    }
+
+    #[test]
+    fn rewrite_minusone_keeps_link_carried_range_defined() {
+        let mut g = FunctionGraph::new("test_slice_index_minusone_link");
+        let a = g.startblock;
+        let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
+        let len = g
+            .push_op_var(
+                a,
+                OpKind::ArrayLen {
+                    base: slice.clone(),
+                    array_type_id: None,
+                    nolength: false,
+                },
+                true,
+            )
+            .unwrap();
+        let one = g.push_op_var(a, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                a,
+                OpKind::BinOp {
+                    op: "sub".into(),
+                    lhs: len,
+                    rhs: one,
+                    result_ty: ValueType::Unsigned,
+                },
+                true,
+            )
+            .unwrap();
+        let range = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: rangeto_ctor_target(),
+                    args: Vec::new(),
+                    result_ty: ValueType::Ref(Some("core::ops::range::RangeTo".into())),
+                },
+                true,
+            )
+            .unwrap();
+        g.block_mut(a).operations.push(SpaceOperation {
+            result: None,
+            kind: end_field_write(&range, &end),
+        });
+        let sub = g
+            .push_op_var(
+                a,
+                OpKind::Call {
+                    target: slice_index_call_target(),
+                    args: vec![slice, range.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+                true,
+            )
+            .unwrap();
+        let (b, _b_args) = g.create_block_with_arg_vars(2);
+        g.set_return(b, None);
+        // The RangeTo value is carried to the successor but never read by an
+        // operation there — precisely the shape that must not orphan it.
+        g.set_goto(a, b, vec![sub, range.clone()]);
+
+        let site = SliceIndexMinusOneSite {
+            range_result: range.clone(),
+            end,
+        };
+        assert_eq!(
+            rewire_slice_index_minusone_sites(&mut g, &[site]),
+            1,
+            "the MinusOne slice::index site is rewritten"
+        );
+        assert!(
+            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::SyntheticTransparentCtor { .. },
+                        ..
+                    }
+                ) && op.result.as_ref() == Some(&range)
+            }),
+            "RangeTo ctor survives MinusOne rewrite"
+        );
+        assert!(
+            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
+                matches!(&op.kind, OpKind::FieldWrite { base, field, .. }
+                    if base == &range && field.name == "end")
+            }),
+            "RangeTo end FieldWrite survives MinusOne rewrite"
+        );
+
+        for block in &g.blocks {
+            for link in &block.exits {
+                for arg in &link.args {
+                    if let LinkArg::Value(var) = arg {
+                        assert!(
+                            graph_defines(&g, var),
+                            "link arg {var:?} must remain defined after MinusOne rewrite"
+                        );
+                    }
+                }
+            }
+        }
     }
 
     /// `&s[..k]` uses the existing StartStop contract: a synthetic constant

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -9,20 +9,20 @@
 //! `pyre_interpreter::module::_io::buffered_rwpair::<Impl>::readinto` graph
 //! dropped to the legacy walker.
 //!
-//! RangeTo is sound because the clamp is upstream, not a pyre deviation:
-//! `ll_listslice_startstop` (`rpython/rtyper/rlist.py:893-903`) clamps
-//! `stop > length`, matching Python's defined `s[:n]` behavior. The frontend
-//! also strips Rust's own range checks: `TermKind::Assert` branches
+//! The `ll_listslice_startstop` clamp (`rpython/rtyper/rlist.py:893-903`)
+//! repairs the oversized result of an unsigned `len - 1` wrap. The MinusOne
+//! shape is admitted because `len - 1 <= len` is proven for this receiver;
+//! a general RangeTo stop has no `end <= len` proof and is declined. The
+//! frontend also strips Rust's own range checks: `TermKind::Assert` branches
 //! unconditionally to success, citing `backendopt/removeassert.py`, because
-//! those checks have no Python-observable meaning. A clamping `getslice` is
-//! strictly more defined than that stripped bounds check. The real remaining
-//! requirement is a non-negative (unsigned) end.
+//! those checks have no Python-observable meaning.
 //!
 //! The earlier failure was an unwired frontend `getslice` planted before a
-//! graph fell through the legacy walker. RangeTo now uses an unregistered
-//! synthetic call, expanded only by the rtyper flowspace adapter, so no
-//! frontend `getslice` is planted. RangeFrom alone stays dormant because its
-//! Void `ConstNone` stop has no regalloc coloring on that path.
+//! graph fell through the legacy walker. The admitted MinusOne path uses an
+//! unregistered synthetic call, expanded only by the rtyper flowspace
+//! adapter, so no frontend `getslice` is planted. RangeFrom alone stays
+//! dormant because its Void `ConstNone` stop has no regalloc coloring on that
+//! path.
 #![allow(dead_code)]
 //!
 //! ## Positioning
@@ -79,7 +79,7 @@
 //! gate that no dropped graph carries a bare `getslice`.
 
 use crate::flowspace::model::Variable;
-use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation};
+use crate::model::{CallTarget, FunctionGraph, LinkArg, OpKind, SpaceOperation, ValueType};
 
 /// A recognized `RangeFrom { start }` aggregate feeding a residual
 /// `core::slice::index::<Impl>::index(slice, range)` call, captured during
@@ -101,7 +101,6 @@ pub(crate) struct SliceIndexRangeFromSite {
 pub(crate) struct SliceIndexRangeToSite {
     pub range_result: Variable,
     pub end: Variable,
-    pub end_is_unsigned: bool,
 }
 
 /// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
@@ -132,8 +131,7 @@ pub(crate) fn rewire_slice_index_rangefrom_sites(
 }
 
 /// Rewrite captured `RangeTo { end }` indexes through the synthetic-call
-/// channel. MinusOne is selected after locating the consuming call; otherwise
-/// only an end captured as unsigned admits the general RangeTo rewrite.
+/// channel. Only the MinusOne shape has a proven stop bound.
 pub(crate) fn rewire_slice_index_rangeto_sites(
     graph: &mut FunctionGraph,
     sites: &[SliceIndexRangeToSite],
@@ -153,16 +151,8 @@ pub(crate) fn rewire_slice_index_rangeto_sites(
 
 #[derive(Clone, Copy)]
 enum SliceIndexBounds<'a> {
-    RangeFrom {
-        start: &'a Variable,
-    },
-    RangeTo {
-        end: &'a Variable,
-        end_is_unsigned: bool,
-    },
-    MinusOne {
-        end: &'a Variable,
-    },
+    RangeFrom { start: &'a Variable },
+    MinusOne { end: &'a Variable },
 }
 
 fn rewire_one_slice_index_rangeto_site(
@@ -184,14 +174,9 @@ fn rewire_one_slice_index_rangeto_site(
         .ok_or_else(|| format!("{}: no RangeTo index consumer", graph.name))?;
     let bounds = if minus_one_end_matches(graph, &site.end, &slice) {
         SliceIndexBounds::MinusOne { end: &site.end }
-    } else if site.end_is_unsigned {
-        SliceIndexBounds::RangeTo {
-            end: &site.end,
-            end_is_unsigned: true,
-        }
     } else {
         return Err(format!(
-            "{}: RangeTo end is not unsigned — declining",
+            "{}: RangeTo stop has no proof that end <= slice length — declining",
             graph.name
         ));
     };
@@ -260,10 +245,9 @@ fn rewire_one_slice_index_site(
     //     `getslice/rii>r` from `split_builtin_kwargs` and
     //     `do_warn_explicit`; both measured ends were `args.len() - 1`,
     //     statically unsigned but not constant, so an unsigned-only gate would
-    //     not decline them. Even a non-negative constant must not be wired in
-    //     production without the primary `end <= slice.len()` proof: the
-    //     StartStop helper clamps an oversized stop (`rlist.rs:3563-3576`),
-    //     whereas Rust indexing panics.
+    //     not decline them. A general RangeTo stop also lacks the primary
+    //     `end <= slice.len()` proof: the StartStop helper clamps an oversized
+    //     stop (`rlist.rs:3563-3576`), whereas Rust indexing panics.
     match bounds {
         SliceIndexBounds::RangeFrom { start } => {
             if !graph_defines(graph, start) {
@@ -275,17 +259,6 @@ fn rewire_one_slice_index_site(
                 return Err(format!(
                     "{name}: RangeFrom start is not a non-negative constant — declining"
                 ));
-            }
-        }
-        SliceIndexBounds::RangeTo {
-            end,
-            end_is_unsigned,
-        } => {
-            if !graph_defines(graph, end) {
-                return Err(format!("{name}: RangeTo end is not defined in the graph"));
-            }
-            if !end_is_unsigned {
-                return Err(format!("{name}: RangeTo end is not unsigned — declining"));
             }
         }
         SliceIndexBounds::MinusOne { end } => {
@@ -303,7 +276,7 @@ fn rewire_one_slice_index_site(
     // --- All structural validation passed; mutate the graph. ---
 
     // 4. Remove the range construction only for the RangeFrom rewrites.
-    // MinusOne and general RangeTo leave the ctor and its FieldWrite in
+    // MinusOne leaves the ctor and its FieldWrite in
     //    place: the range can be carried by a block link without being read
     //    by an operation, and sweeping its sole defining ctor would orphan
     //    that link-carried value.
@@ -369,43 +342,31 @@ fn rewire_one_slice_index_site(
                     },
                 );
             }
-            SliceIndexBounds::RangeTo { .. } => {
-                graph.blocks[rb].operations[ri] = SpaceOperation {
-                    result: Some(index_result),
-                    kind: OpKind::Call {
-                        target: CallTarget::FunctionPath {
-                            segments: vec!["__getslice_rangeto".to_string()],
-                        },
-                        args: vec![slice, bounds_end(&bounds).clone()],
-                        result_ty: index_result_ty,
-                    },
-                };
-            }
             SliceIndexBounds::MinusOne { .. } => unreachable!(),
         }
     }
     Ok(())
 }
 
-fn bounds_end<'a>(bounds: &'a SliceIndexBounds<'a>) -> &'a Variable {
-    match bounds {
-        SliceIndexBounds::RangeTo { end, .. } | SliceIndexBounds::MinusOne { end } => end,
-        SliceIndexBounds::RangeFrom { .. } => unreachable!(),
-    }
-}
-
 /// `end = sub(ArrayLen(slice), 1)` is the only RangeTo shape whose stop is
-/// proven against this receiver's length. `ArrayLen` and plain `sub` are the
-/// measured post-lowering forms (`front/mir.rs:14603`).
+/// proven against this receiver's length, and only its unsigned form has the
+/// required wraparound semantics. `ArrayLen` and plain `sub` are the measured
+/// post-lowering forms (`front/mir.rs:14603`).
 fn minus_one_end_matches(graph: &FunctionGraph, end: &Variable, slice: &Variable) -> bool {
     let Some((lhs, rhs)) = graph
         .blocks
         .iter()
         .flat_map(|b| &b.operations)
         .find_map(|op| match (&op.result, &op.kind) {
-            (Some(result), OpKind::BinOp { op, lhs, rhs, .. }) if result == end && op == "sub" => {
-                Some((lhs.clone(), rhs.clone()))
-            }
+            (
+                Some(result),
+                OpKind::BinOp {
+                    op,
+                    lhs,
+                    rhs,
+                    result_ty: ValueType::Unsigned,
+                },
+            ) if result == end && op == "sub" => Some((lhs.clone(), rhs.clone())),
             _ => None,
         })
     else {
@@ -757,6 +718,38 @@ mod tests {
     }
 
     #[test]
+    fn minus_one_recognizer_requires_unsigned_subtraction() {
+        let mut g = FunctionGraph::new("minus_one_recognizer_signed");
+        let b = g.startblock;
+        let slice = g.push_op_var(b, OpKind::ConstInt(0), true).unwrap();
+        let len = g
+            .push_op_var(
+                b,
+                OpKind::ArrayLen {
+                    base: slice.clone(),
+                    array_type_id: None,
+                    nolength: false,
+                },
+                true,
+            )
+            .unwrap();
+        let one = g.push_op_var(b, OpKind::ConstInt(1), true).unwrap();
+        let end = g
+            .push_op_var(
+                b,
+                OpKind::BinOp {
+                    op: "sub".into(),
+                    lhs: len,
+                    rhs: one,
+                    result_ty: ValueType::Int,
+                },
+                true,
+            )
+            .unwrap();
+        assert!(!minus_one_end_matches(&g, &end, &slice));
+    }
+
+    #[test]
     fn rewrite_minusone_keeps_link_carried_range_defined() {
         let mut g = FunctionGraph::new("test_slice_index_minusone_link");
         let a = g.startblock;
@@ -820,7 +813,6 @@ mod tests {
         let site = SliceIndexRangeToSite {
             range_result: range.clone(),
             end,
-            end_is_unsigned: true,
         };
         assert_eq!(
             rewire_slice_index_rangeto_sites(&mut g, &[site]),
@@ -864,7 +856,7 @@ mod tests {
     /// `&s[..k]` uses the existing StartStop contract: a synthetic constant
     /// zero start and the aggregate's real `end` value as stop.
     #[test]
-    fn rewrite_lifts_rangeto_index_to_getslice() {
+    fn rewrite_declines_general_rangeto_without_length_proof() {
         let mut g = FunctionGraph::new("test_slice_index_rangeto");
         let a = g.startblock;
         let slice = g.push_op_var(a, OpKind::ConstInt(0), true).unwrap();
@@ -917,28 +909,14 @@ mod tests {
         let site = SliceIndexRangeToSite {
             range_result: range.clone(),
             end: end.clone(),
-            end_is_unsigned: true,
         };
-        assert_eq!(rewire_slice_index_rangeto_sites(&mut g, &[site]), 1);
-        let marker = g
-            .blocks
-            .iter()
-            .flat_map(|blk| &blk.operations)
-            .find_map(|op| match &op.kind {
-                OpKind::Call {
-                    target: CallTarget::FunctionPath { segments },
-                    args,
-                    ..
-                } if segments == &["__getslice_rangeto".to_string()] => Some(args),
-                _ => None,
-            })
-            .expect("RangeTo index becomes synthetic getslice marker");
-        assert_eq!(marker, &[slice, end]);
+        assert_eq!(rewire_slice_index_rangeto_sites(&mut g, &[site]), 0);
         assert!(
-            g.blocks.iter().flat_map(|blk| &blk.operations).any(|op| {
-                is_slice_range_index_call(&op.kind) == false && op.result.as_ref() == Some(&range)
-            }),
-            "RangeTo ctor remains defined for link-carried aliases"
+            g.blocks
+                .iter()
+                .flat_map(|blk| &blk.operations)
+                .any(|op| { is_slice_range_index_call(&op.kind) }),
+            "general RangeTo remains residual"
         );
         for block in &g.blocks {
             for link in &block.exits {
@@ -951,9 +929,8 @@ mod tests {
         }
     }
 
-    /// A RangeTo whose end is computed at runtime declines even when its Rust
-    /// type is unsigned. The measured `args.len() - 1` sites have this shape
-    /// and produced bare unwired `getslice/rii>r` when admitted.
+    /// A RangeTo whose end is computed at runtime declines. The measured
+    /// `args.len() - 1` sites have this shape and have no length proof.
     #[test]
     fn rewrite_declines_runtime_end() {
         let mut g = FunctionGraph::new("test_slice_index_rangeto_runtime");
@@ -1006,7 +983,6 @@ mod tests {
         let site = SliceIndexRangeToSite {
             range_result: range,
             end,
-            end_is_unsigned: false,
         };
         assert_eq!(
             rewire_slice_index_rangeto_sites(&mut g, &[site]),

--- a/majit/majit-translate/src/tool/error.rs
+++ b/majit/majit-translate/src/tool/error.rs
@@ -246,6 +246,53 @@ pub fn offset2lineno(code: &HostCode, stopat: i64) -> u32 {
     line
 }
 
+/// Upstream falls back to `['no source!']` when a graph carries no Python
+/// source, which is every MIR-built pyre graph — so the listing that upstream
+/// prints around the failing operation is always empty here.  Print the
+/// block's inputargs and operations instead: without them a record names the
+/// failing op but never the op that PRODUCED its receiver, which is the one
+/// piece of context a classdef-less / blocked-block diagnosis needs.
+fn no_source_lines(
+    g: &std::cell::Ref<'_, crate::flowspace::model::FunctionGraph>,
+    block: Option<&BlockRef>,
+) -> Vec<String> {
+    /// Bound the listing: a blocked op's producer is normally a few ops away,
+    /// and an unbounded dump would multiply the size of every record.
+    const MAX_OPS: usize = 40;
+    let mut out = vec!["no source!".to_string()];
+    if let Some(b) = block {
+        let b = b.borrow();
+        out.push(format!(
+            "  block inputargs: [{}]",
+            b.inputargs
+                .iter()
+                .map(|v| format!("{v}"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        ));
+        for (i, op) in b.operations.iter().take(MAX_OPS).enumerate() {
+            out.push(format!("  op[{i}] {op}"));
+        }
+        if b.operations.len() > MAX_OPS {
+            out.push(format!(
+                "  … {} more operation(s)",
+                b.operations.len() - MAX_OPS
+            ));
+        }
+    }
+    out.push(format!(
+        "  startblock inputargs: [{}]",
+        g.startblock
+            .borrow()
+            .inputargs
+            .iter()
+            .map(|v| format!("{v}"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    ));
+    out
+}
+
 /// RPython `source_lines1(graph, block, operindex, offset=None,
 ///                          long=False, show_lines_of_code=SHOW_DEFAULT_LINES_OF_CODE)`
 /// (error.py:18-61).
@@ -310,23 +357,23 @@ pub fn source_lines1(
     // upstream: `source = graph.source`; attribute absent → ['no source!'].
     let source = match g.source() {
         Ok(s) => s,
-        Err(_) => return vec!["no source!".into()],
+        Err(_) => return no_source_lines(&g, block),
     };
     let filename = match g.filename() {
         Ok(s) => s,
-        Err(_) => return vec!["no source!".into()],
+        Err(_) => return no_source_lines(&g, block),
     };
     let startline = match g.startline() {
         Ok(n) => n,
-        Err(_) => return vec!["no source!".into()],
+        Err(_) => return no_source_lines(&g, block),
     };
     let func = match &g.func {
         Some(f) => f,
-        None => return vec!["no source!".into()],
+        None => return no_source_lines(&g, block),
     };
     let code = match func.code.as_deref() {
         Some(c) => c,
-        None => return vec!["no source!".into()],
+        None => return no_source_lines(&g, block),
     };
     let graph_lines: Vec<&str> = source.split('\n').collect();
 

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -2974,9 +2974,12 @@ fn drive_subject(
     // dont_simplify_again=False)` (rtyper.py:178-189):
     //
     //   1. `if not dont_simplify_again: self.annotator.simplify()`
-    //      — pyre per-subject flow does not run annotator-wide
-    //        simplify; the subject was lifted via the adapter and
-    //        its block list is already in canonical shape.
+    //      — pyre per-subject flow keeps the annotator-wide
+    //        simplification and extra-pass work skipped: the subject was
+    //        lifted via the adapter and its block list is already in
+    //        canonical shape.  `transform_allocate` is applied per block
+    //        immediately before specialization instead (see
+    //        `specialize_block`).
     //   2. `self.exceptiondata.finish(self)` — hoisted into
     //      `PyreCallRegistry::ensure_session` so it runs **once** at
     //      session start (idempotent — `getclassrepr` is cached on
@@ -3746,6 +3749,7 @@ pub(crate) fn dual_gate_outcome_from_cache(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::flowspace::model::BlockKey;
     use crate::model::{Block, BlockId, LinkArg, ValueType};
     use crate::translator::rtyper::legacy_annotator::setbinding;
 
@@ -4958,6 +4962,161 @@ mod tests {
     }
 
     #[test]
+    fn cutover_repeat_runs_transform_allocate_before_rtype() {
+        let _lock = anchor_lock();
+        let mut graph = LegacyGraph::new("cutover_repeat_alloc_and_set");
+        let vars = mint_vars(&mut graph, 4);
+        let fill = vars[1].clone();
+        let count = vars[2].clone();
+        let result = vars[3].clone();
+        let startblock = Block {
+            id: graph.startblock,
+            inputargs: block_inputargs(&vars, &[1, 2]),
+            operations: vec![crate::model::SpaceOperation {
+                result: Some(result.clone()),
+                kind: crate::model::OpKind::Call {
+                    target: crate::model::CallTarget::FunctionPath {
+                        segments: vec!["__array_repeat".into()],
+                    },
+                    args: vec![fill.clone(), count.clone()],
+                    result_ty: ValueType::Int,
+                },
+            }],
+            exitswitch: None,
+            exits: vec![link_to_returnblock(
+                vec![LinkArg::Value(result.clone())],
+                graph.returnblock,
+            )],
+            framestate: None,
+            dead: false,
+        };
+        let returnblock = Block {
+            id: graph.returnblock,
+            inputargs: block_inputargs(&vars, &[3]),
+            operations: vec![],
+            exitswitch: None,
+            exits: vec![],
+            framestate: None,
+            dead: false,
+        };
+        graph.blocks = vec![startblock, returnblock];
+        setbinding(&fill, ValueType::Int);
+        setbinding(&count, ValueType::Int);
+
+        let registry = crate::translator::rtyper::pyre_call_registry::PyreCallRegistry::new(
+            Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
+        );
+        let (flow_graph, _, _, _) = drive_subject(&graph, &registry, /* do_rtype = */ false)
+            .expect("repeat subject must annotate and transform");
+        let transformed_ops: Vec<String> = flow_graph
+            .borrow()
+            .iterblocks()
+            .into_iter()
+            .flat_map(|block| block.borrow().operations.clone())
+            .map(|op| op.opname)
+            .collect();
+        eprintln!(
+            "[cutover_repeat_runs_transform_allocate_before_rtype] before={transformed_ops:?}"
+        );
+        assert!(
+            transformed_ops.iter().any(|name| name == "mul"),
+            "cutover must leave mul until per-block specialization, got {transformed_ops:?}"
+        );
+        assert!(
+            transformed_ops.iter().all(|name| name != "alloc_and_set"),
+            "cutover must not run graph transforms during annotation, got {transformed_ops:?}"
+        );
+
+        let (_, rtyper) = registry.ensure_session().expect("session must remain live");
+        let startblock = flow_graph.borrow().startblock.clone();
+        let direct_before = startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| op.opname.clone())
+            .collect::<Vec<_>>();
+        eprintln!(
+            "[cutover_repeat_runs_transform_allocate_before_rtype] direct_before={direct_before:?}"
+        );
+        assert!(
+            direct_before.iter().any(|name| name == "mul"),
+            "direct specialize_block fixture must start with mul: {direct_before:?}"
+        );
+        rtyper
+            .specialize_block(&startblock)
+            .expect("direct specialize_block must transform and rtype the start block");
+        let direct_after = startblock
+            .borrow()
+            .operations
+            .iter()
+            .map(|op| format!("{op:?}"))
+            .collect::<Vec<_>>();
+        eprintln!(
+            "[cutover_repeat_runs_transform_allocate_before_rtype] direct_after={direct_after:?}"
+        );
+        assert!(
+            direct_after.iter().any(|op| op.contains("alloc_and_set")),
+            "direct specialize_block must run transform_allocate before rtyping: {direct_after:?}"
+        );
+        rtyper.mark_already_seen(&startblock);
+        rtyper
+            .specialize_more_blocks()
+            .expect("transformed repeat must rtype");
+        let rtyped_output = flow_graph
+            .borrow()
+            .iterblocks()
+            .into_iter()
+            .flat_map(|block| block.borrow().operations.clone())
+            .map(|op| format!("{op:?}"))
+            .collect::<Vec<_>>();
+        eprintln!(
+            "[cutover_repeat_runs_transform_allocate_before_rtype] after={rtyped_output:?}"
+        );
+        assert!(
+            rtyped_output.iter().any(|op| op.contains("alloc_and_set")),
+            "rtyped repeat output must retain alloc_and_set identity: {rtyped_output:?}"
+        );
+        assert!(
+            rtyped_output
+                .iter()
+                .all(|op| !op.contains("opname: \"mul\"")),
+            "rtyped repeat output must contain no mul: {rtyped_output:?}"
+        );
+    }
+
+    #[test]
+    fn cutover_blocked_subject_block_is_excluded_from_per_block_transform() {
+        let _lock = anchor_lock();
+        // A blocked block is represented by `annotated[key] = None`, just as
+        // in the subject drive. It must never enter the per-block transform
+        // or rtyper walk; the subject guard aborts before specialization.
+        let blocked = crate::flowspace::model::Block::shared(vec![]);
+        let ann = crate::annotator::annrpython::RPythonAnnotator::new(None, None, None, false);
+        ann.annotated
+            .borrow_mut()
+            .insert(BlockKey::of(&blocked), None);
+        ann.all_blocks
+            .borrow_mut()
+            .insert(BlockKey::of(&blocked), blocked.clone());
+
+        let raw_subject_blocks = vec![blocked];
+        let annotated = ann.annotated.borrow();
+        let subject_blocks: Vec<_> = raw_subject_blocks
+            .into_iter()
+            .filter(|block| matches!(annotated.get(&BlockKey::of(block)), Some(Some(_))))
+            .collect();
+        drop(annotated);
+        crate::translator::transform::transform_allocate(&ann, &subject_blocks);
+        eprintln!(
+            "[cutover_blocked_subject_block_is_excluded_from_per_block_transform] {:?}",
+            subject_blocks
+                .iter()
+                .map(|block| BlockKey::of(block).as_usize())
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
     fn cachedgraph_hit_registers_callee_graph_into_translator_graphs() {
         let _lock = anchor_lock();
         // Keystone linkage: after a real caller -> callee specialize,
@@ -4977,26 +5136,27 @@ mod tests {
         // `translator.graphs`, graphanalyze.rs) instead of falling to
         // `top_result()`.
         let mut graph = LegacyGraph::new("call_resolved");
-        let vars = mint_vars(&mut graph, 3);
-        let inputargs = block_inputargs(&vars, &[1]);
+        let vars = mint_vars(&mut graph, 4);
+        let inputargs = block_inputargs(&vars, &[1, 2]);
         let v1_var = vars[1].clone();
         let v2_var = vars[2].clone();
+        let v3_var = vars[3].clone();
         let startblock = Block {
             id: graph.startblock,
             inputargs,
             operations: vec![crate::model::SpaceOperation {
-                result: Some(v2_var.clone()),
+                result: Some(v3_var.clone()),
                 kind: crate::model::OpKind::Call {
                     target: crate::model::CallTarget::FunctionPath {
                         segments: vec!["foo".into()],
                     },
-                    args: vec![v1_var.clone()],
-                    result_ty: ValueType::Int,
+                    args: vec![v1_var.clone(), v2_var.clone()],
+                    result_ty: ValueType::Unknown,
                 },
             }],
             exitswitch: None,
             exits: vec![link_to_returnblock(
-                vec![LinkArg::Value(v2_var.clone())],
+                vec![LinkArg::Value(v3_var.clone())],
                 graph.returnblock,
             )],
             dead: false,
@@ -5004,7 +5164,7 @@ mod tests {
         };
         let returnblock = Block {
             id: graph.returnblock,
-            inputargs: block_inputargs(&vars, &[2]),
+            inputargs: block_inputargs(&vars, &[3]),
             operations: vec![],
             exitswitch: None,
             exits: vec![],
@@ -5024,16 +5184,27 @@ mod tests {
         // `base.bookkeeper` is the bookkeeper `ensure_session` attaches
         // the annotator to.
         let mut callee_graph = LegacyGraph::new("foo");
-        let callee_vars = mint_vars(&mut callee_graph, 11);
-        let foo_inputargs = block_inputargs(&callee_vars, &[10]);
+        let callee_vars = mint_vars(&mut callee_graph, 13);
+        let foo_inputargs = block_inputargs(&callee_vars, &[10, 11]);
         let foo_v10_var = callee_vars[10].clone();
+        let foo_v11_var = callee_vars[11].clone();
+        let foo_v12_var = callee_vars[12].clone();
         let foo_start = Block {
             id: callee_graph.startblock,
             inputargs: foo_inputargs,
-            operations: vec![],
+            operations: vec![crate::model::SpaceOperation {
+                result: Some(foo_v12_var.clone()),
+                kind: crate::model::OpKind::Call {
+                    target: crate::model::CallTarget::FunctionPath {
+                        segments: vec!["__array_repeat".into()],
+                    },
+                    args: vec![foo_v10_var.clone(), foo_v11_var.clone()],
+                    result_ty: ValueType::Ref(None),
+                },
+            }],
             exitswitch: None,
             exits: vec![link_to_returnblock(
-                vec![LinkArg::Value(foo_v10_var.clone())],
+                vec![LinkArg::Value(foo_v12_var.clone())],
                 callee_graph.returnblock,
             )],
             dead: false,
@@ -5041,7 +5212,7 @@ mod tests {
         };
         let foo_return = Block {
             id: callee_graph.returnblock,
-            inputargs: block_inputargs(&callee_vars, &[10]),
+            inputargs: block_inputargs(&callee_vars, &[12]),
             operations: vec![],
             exitswitch: None,
             exits: vec![],
@@ -5054,9 +5225,14 @@ mod tests {
             std::rc::Rc::new(crate::annotator::bookkeeper::Bookkeeper::new()),
         );
         setbinding(&foo_v10_var, ValueType::Int);
+        setbinding(&foo_v11_var, ValueType::Int);
         let pygraph = lift_callee_to_pygraph(
             &callee_graph,
-            crate::flowspace::argument::Signature::new(vec!["x".to_string()], None, None),
+            crate::flowspace::argument::Signature::new(
+                vec!["x".to_string(), "n".to_string()],
+                None,
+                None,
+            ),
             &leaf_registry,
         )
         .expect("leaf callee must lift to PyGraph");
@@ -5081,7 +5257,11 @@ mod tests {
         let callee_graph_ref = pygraph.graph.clone();
         registry.register_callee(
             crate::translator::rtyper::pyre_call_registry::FunctionPathKey::from_segments(["foo"]),
-            crate::flowspace::argument::Signature::new(vec!["x".to_string()], None, None),
+            crate::flowspace::argument::Signature::new(
+                vec!["x".to_string(), "n".to_string()],
+                None,
+                None,
+            ),
             pygraph,
         );
 
@@ -5089,6 +5269,23 @@ mod tests {
         setbinding(&v2_var, ValueType::Int);
         specialize_legacy_graph_with_registry_returning_value_to_var(&graph, &registry)
             .expect("cache pre-fill must let the leaf Call resolve end-to-end");
+
+        let callee_ops: Vec<String> = callee_graph_ref
+            .borrow()
+            .iterblocks()
+            .into_iter()
+            .flat_map(|block| block.borrow().operations.clone())
+            .map(|op| format!("{op:?}"))
+            .collect();
+        eprintln!("[cachedgraph_hit_registers_callee_graph_into_translator_graphs] {callee_ops:?}");
+        assert!(
+            callee_ops.iter().any(|op| op.contains("alloc_and_set")),
+            "callee-lifted repeat must transform to alloc_and_set: {callee_ops:?}"
+        );
+        assert!(
+            callee_ops.iter().all(|op| !op.contains("opname: \"mul\"")),
+            "callee-lifted repeat must contain no mul: {callee_ops:?}"
+        );
 
         // `ensure_session` ran inside the specialize and wired the
         // annotator backlink onto the registry's shared bookkeeper

--- a/majit/majit-translate/src/translator/rtyper/cutover.rs
+++ b/majit/majit-translate/src/translator/rtyper/cutover.rs
@@ -5069,9 +5069,7 @@ mod tests {
             .flat_map(|block| block.borrow().operations.clone())
             .map(|op| format!("{op:?}"))
             .collect::<Vec<_>>();
-        eprintln!(
-            "[cutover_repeat_runs_transform_allocate_before_rtype] after={rtyped_output:?}"
-        );
+        eprintln!("[cutover_repeat_runs_transform_allocate_before_rtype] after={rtyped_output:?}");
         assert!(
             rtyped_output.iter().any(|op| op.contains("alloc_and_set")),
             "rtyped repeat output must retain alloc_and_set identity: {rtyped_output:?}"

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -815,6 +815,24 @@ fn is_vec_ctor_segments(segments: &[String]) -> bool {
         && (segments[2] == "with_capacity" || segments[2] == "new")
 }
 
+/// `alloc::vec::from_elem(elem, count)` (Rust MIR `vec![elem; count]`) —
+/// the repeated resizable-list constructor.  Routed in [`translate_op`] to
+/// `newlist(elem)` + `mul(list, count)`, the same `[a] * b` shape that
+/// `transform_allocate` (`transform.py:36-50`) collapses to
+/// `alloc_and_set` and `rtype_alloc_and_set` (`rlist.py:346-351`) lowers
+/// through `ll_alloc_and_set` (`rlist.py:487`).
+///
+/// Charon emits this call as `alloc::vec::from_elem`, while the constructor
+/// recognizer above omits the foreign crate prefix. Match the trailing
+/// `vec::from_elem` spelling defensively, but require the exact two-argument
+/// `(elem, count)` shape.
+fn is_vec_from_elem_segments(segments: &[String], arg_count: usize) -> bool {
+    segments.len() >= 2
+        && segments[segments.len() - 2] == "vec"
+        && segments[segments.len() - 1] == "from_elem"
+        && arg_count == 2
+}
+
 /// `Vec::push(l, item)` (Rust MIR `vec::Vec::push`) — the resizable-list
 /// append. Routed to the resized `ListRepr.rtype_method("append")`
 /// (`rlist.py:185`) via the `getattr(recv, "append") + simple_call` method
@@ -934,8 +952,11 @@ pub(crate) fn op_canraise(kind: &OpKind) -> bool {
         // Matched before the general `Call` arm.
         OpKind::Call {
             target: crate::model::CallTarget::FunctionPath { segments },
+            args,
             ..
-        } if is_vec_ctor_segments(segments) => false,
+        } if is_vec_ctor_segments(segments) || is_vec_from_elem_segments(segments, args.len()) => {
+            false
+        }
         // `[__iter_next]` (`front::iter_next`) lowers to the raising
         // flowspace `next` op (`operation.rs` `OpKind::Next.can_only_throw
         // = [StopIteration, RuntimeError]`).  Matched before the general
@@ -1898,6 +1919,22 @@ pub fn translate_op(
                     // dropped — see [`is_vec_ctor_segments`].
                     if is_vec_ctor_segments(segments) {
                         return Ok(vec![FlowspaceOp::new("newlist", vec![], result)]);
+                    }
+                    // `vec![elem; count]` lowers (in Rust MIR) to a call to
+                    // `alloc::vec::from_elem(elem, count)`. Emit the same
+                    // `newlist(elem)` + `mul(list, count)` shape as the
+                    // `__array_repeat` synthetic above; see
+                    // [`is_vec_from_elem_segments`] for the upstream
+                    // `transform_allocate` / `rtype_alloc_and_set` path.
+                    if is_vec_from_elem_segments(segments, arg_hls.len()) {
+                        let mut iter = arg_hls.into_iter();
+                        let fill = iter.next().expect("from_elem fill arg");
+                        let count = iter.next().expect("from_elem count arg");
+                        let list = Hlvalue::Variable(Variable::new());
+                        return Ok(vec![
+                            FlowspaceOp::new("newlist", vec![fill], list.clone()),
+                            FlowspaceOp::new("mul", vec![list, count], result),
+                        ]);
                     }
                     // `Vec::push(recv, item)` lowers (in Rust MIR) to a call
                     // to `vec::Vec::push`. Emit the *method* shape
@@ -4730,6 +4767,62 @@ mod tests {
         assert_eq!(translated[1].args[0], translated[0].result);
         assert_eq!(translated[1].args[1], count);
         assert_eq!(translated[1].result, result);
+    }
+
+    /// The frontend cannot see the adapter's expansion: `lower_function`
+    /// still contains the raw `alloc::vec::from_elem` call, while the
+    /// flowspace graph must carry `newlist` + `mul` instead.  This real-LLBC
+    /// anchor therefore runs both stages and checks the adapter output.
+    #[test]
+    #[ignore]
+    fn bind_kwargs_to_signature_has_no_residual_vec_from_elem_after_adaptation() {
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = majit_charon_reader::Llbc::load(path).expect("load real LLBC");
+        let legacy = crate::front::mir::lower_function(&llbc, "bind_kwargs_to_signature")
+            .expect("lower bind_kwargs_to_signature");
+        let raw_from_elem = legacy
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: crate::model::CallTarget::FunctionPath { segments },
+                        ..
+                    } if is_vec_from_elem_segments(segments, 2)
+                )
+            })
+            .count();
+        assert!(raw_from_elem > 0, "fixture must contain vec::from_elem");
+
+        let var_map = build_value_to_variable_map(&legacy);
+        let value_map = build_value_to_hlvalue_map(&legacy, &var_map);
+        let registry = empty_call_registry();
+        let expansions = legacy
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: crate::model::CallTarget::FunctionPath { segments },
+                        ..
+                    } if is_vec_from_elem_segments(segments, 2)
+                )
+            })
+            .map(|op| translate_op(op, &value_map, &registry).expect("adapt from_elem"))
+            .collect::<Vec<_>>();
+        assert!(!expansions.is_empty());
+        for translated in expansions {
+            assert_eq!(translated.len(), 2);
+            assert_eq!(translated[0].opname, "newlist");
+            assert_eq!(translated[1].opname, "mul");
+        }
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1593,6 +1593,21 @@ pub fn translate_op(
                             result,
                         )]);
                     }
+                    if segments.as_slice() == ["__getslice_rangeto"] && arg_hls.len() == 2 {
+                        // slice, end -> getslice(slice, 0, end)
+                        let mut args = arg_hls.into_iter();
+                        let slice = args.next().expect("slice arg");
+                        let end = args.next().expect("RangeTo end arg");
+                        return Ok(vec![FlowspaceOp::new(
+                            "getslice",
+                            vec![
+                                slice,
+                                Hlvalue::Constant(Constant::new(ConstValue::Int(0))),
+                                end,
+                            ],
+                            result,
+                        )]);
+                    }
                     // `[v; N]` array literal.  `front::mir` lowers
                     // `Rvalue::Repeat` to the `__array_repeat` synthetic
                     // carrying `(fill, count)` whenever the count decodes.
@@ -4749,6 +4764,40 @@ mod tests {
             translated[0].args[2],
             Hlvalue::Constant(Constant::new(ConstValue::Int(-1)))
         );
+        assert_eq!(translated[0].result, result);
+    }
+
+    #[test]
+    fn translate_op_getslice_rangeto_expands_after_annotation() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_getslice_rangeto_fixture");
+        let vars = mint_vars(&mut graph, 3);
+        let slice = Hlvalue::Variable(Variable::new());
+        let end = Hlvalue::Variable(Variable::new());
+        let result = Hlvalue::Variable(Variable::new());
+        value_map.insert(vars[0].clone(), slice.clone());
+        value_map.insert(vars[1].clone(), end.clone());
+        value_map.insert(vars[2].clone(), result.clone());
+        let op = SpaceOperation {
+            result: Some(vars[2].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["__getslice_rangeto".into()],
+                },
+                args: vec![vars[0].clone(), vars[1].clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("RangeTo marker must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "getslice");
+        assert_eq!(translated[0].args[0], slice);
+        assert_eq!(
+            translated[0].args[1],
+            Hlvalue::Constant(Constant::new(ConstValue::Int(0)))
+        );
+        assert_eq!(translated[0].args[2], end);
         assert_eq!(translated[0].result, result);
     }
 

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1567,6 +1567,32 @@ pub fn translate_op(
                     if let Some(opname) = nonraising_core_bridge_opname(segments, arg_hls.len()) {
                         return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
                     }
+                    // `slice[..slice.len() - 1]` is emitted by
+                    // `front::slice_index` as an unregistered marker rather
+                    // than frontend `getslice`/`ConstInt` ops.  The marker is
+                    // expanded here, after annotation, to the upstream
+                    // `getslice(slice, 0, -1)` contract.  This mirrors the
+                    // frontend/adapter split used by `__array_repeat`: an
+                    // untyped graph falling to the legacy walker retains an
+                    // ordinary residual call and cannot carry an unwired
+                    // `getslice` op to the assembler.
+                    //
+                    // Upstream: `decompose_slice_args` (`rtyper.rs:2798`)
+                    // selects `SliceKind::MinusOne` for annotated constants
+                    // `0` and `-1`, then `rlist.py:906-911` calls
+                    // `ll_listslice_minusone` (asserting, not clamping).
+                    if segments.as_slice() == ["__getslice_minusone"] && arg_hls.len() == 1 {
+                        let slice = arg_hls.into_iter().next().expect("slice arg");
+                        return Ok(vec![FlowspaceOp::new(
+                            "getslice",
+                            vec![
+                                slice,
+                                Hlvalue::Constant(Constant::new(ConstValue::Int(0))),
+                                Hlvalue::Constant(Constant::new(ConstValue::Int(-1))),
+                            ],
+                            result,
+                        )]);
+                    }
                     // `[v; N]` array literal.  `front::mir` lowers
                     // `Rvalue::Repeat` to the `__array_repeat` synthetic
                     // carrying `(fill, count)` whenever the count decodes.
@@ -4689,6 +4715,41 @@ mod tests {
         assert_eq!(translated[1].args[0], translated[0].result);
         assert_eq!(translated[1].args[1], count);
         assert_eq!(translated[1].result, result);
+    }
+
+    #[test]
+    fn translate_op_getslice_minusone_expands_after_annotation() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_getslice_minusone_fixture");
+        let vars = mint_vars(&mut graph, 2);
+        let slice = Hlvalue::Variable(Variable::new());
+        let result = Hlvalue::Variable(Variable::new());
+        value_map.insert(vars[0].clone(), slice.clone());
+        value_map.insert(vars[1].clone(), result.clone());
+        let op = SpaceOperation {
+            result: Some(vars[1].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["__getslice_minusone".into()],
+                },
+                args: vec![vars[0].clone()],
+                result_ty: ValueType::Ref(None),
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("minus-one marker must lower");
+        assert_eq!(translated.len(), 1);
+        assert_eq!(translated[0].opname, "getslice");
+        assert_eq!(translated[0].args[0], slice);
+        assert_eq!(
+            translated[0].args[1],
+            Hlvalue::Constant(Constant::new(ConstValue::Int(0)))
+        );
+        assert_eq!(
+            translated[0].args[2],
+            Hlvalue::Constant(Constant::new(ConstValue::Int(-1)))
+        );
+        assert_eq!(translated[0].result, result);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1567,6 +1567,42 @@ pub fn translate_op(
                     if let Some(opname) = nonraising_core_bridge_opname(segments, arg_hls.len()) {
                         return Ok(vec![FlowspaceOp::new(opname, arg_hls, result)]);
                     }
+                    // `[v; N]` array literal.  `front::mir` lowers
+                    // `Rvalue::Repeat` to the `__array_repeat` synthetic
+                    // carrying `(fill, count)` whenever the count decodes.
+                    // Expand it into the `[a] * b` shape upstream builds —
+                    // `newlist(a)` then `mul(list, b)` — which
+                    // `transform_allocate` (transform.py:36-50) collapses
+                    // into `alloc_and_set(b, a)`, the operation
+                    // `rtype_alloc_and_set` (rlist.py:346-351) lowers
+                    // through `ll_alloc_and_set` (rlist.py:487) to
+                    // `_ll_alloc_and_clear` / `_ll_alloc_and_set_nonnull`.
+                    //
+                    // The list must be `mul`'s arg 0: `transform_allocate`
+                    // matches on `op.args[0] in length1_lists` and reads the
+                    // count back out of `op.args[1]`, which is the order
+                    // `rtype_alloc_and_set` then consumes as
+                    // `hop.inputargs(Signed, r_list.item_repr)`.  Upstream's
+                    // `pairtype(SomeInteger, SomeList).mul` (binaryop.py:657)
+                    // exists but `transform_allocate` does not match it.
+                    // Both ops go out together so they share a block, which
+                    // is the scope `transform_allocate` scans.
+                    //
+                    // Emitting here rather than in `front::mir` is
+                    // deliberate: this adapter is only reached on the way to
+                    // the rtyper, so neither op can survive on a graph that
+                    // fell back to the legacy walker.
+                    if segments.len() == 1 && segments[0] == "__array_repeat" && arg_hls.len() == 2
+                    {
+                        let mut iter = arg_hls.into_iter();
+                        let fill = iter.next().expect("array repeat fill arg");
+                        let count = iter.next().expect("array repeat count arg");
+                        let list = Hlvalue::Variable(Variable::new());
+                        return Ok(vec![
+                            FlowspaceOp::new("newlist", vec![fill], list.clone()),
+                            FlowspaceOp::new("mul", vec![list, count], result),
+                        ]);
+                    }
                     // `[__iter_next]` (`front::iter_next`) → the raising
                     // flowspace `next` op (`operation.rs` `OpKind::Next`,
                     // `can_only_throw = [StopIteration, RuntimeError]`).  The
@@ -4620,6 +4656,39 @@ mod tests {
         // `__name__`, mirroring upstream `func.__name__` (the leaf
         // identifier, not the dotted module path).
         assert_eq!(host.qualname(), "b");
+    }
+
+    #[test]
+    fn translate_op_array_repeat_expands_to_newlist_then_mul() {
+        let mut value_map: HashMap<Variable, Hlvalue> = HashMap::new();
+        let mut graph = LegacyGraph::new("translate_op_array_repeat_fixture");
+        let vars = mint_vars(&mut graph, 4);
+        let fill = Hlvalue::Variable(Variable::new());
+        let count = Hlvalue::Variable(Variable::new());
+        let result = Hlvalue::Variable(Variable::new());
+        value_map.insert(vars[1].clone(), fill.clone());
+        value_map.insert(vars[2].clone(), count.clone());
+        value_map.insert(vars[3].clone(), result.clone());
+
+        let op = SpaceOperation {
+            result: Some(vars[3].clone()),
+            kind: OpKind::Call {
+                target: crate::model::CallTarget::FunctionPath {
+                    segments: vec!["__array_repeat".into()],
+                },
+                args: vec![vars[1].clone(), vars[2].clone()],
+                result_ty: ValueType::Int,
+            },
+        };
+        let translated = translate_op(&op, &value_map, &empty_call_registry())
+            .expect("two-arg __array_repeat must lower");
+        assert_eq!(translated.len(), 2);
+        assert_eq!(translated[0].opname, "newlist");
+        assert_eq!(translated[0].args, vec![fill.clone()]);
+        assert_eq!(translated[1].opname, "mul");
+        assert_eq!(translated[1].args[0], translated[0].result);
+        assert_eq!(translated[1].args[1], count);
+        assert_eq!(translated[1].result, result);
     }
 
     #[test]

--- a/majit/majit-translate/src/translator/rtyper/rtyper.rs
+++ b/majit/majit-translate/src/translator/rtyper/rtyper.rs
@@ -1692,6 +1692,23 @@ impl RPythonTyper {
     /// annrpython) skips the fixed_graphs update to match upstream's
     /// defensive behavior when `graph.getreturnvar()` would crash.
     pub fn specialize_block(self: &Rc<Self>, block: &BlockRef) -> Result<(), TyperError> {
+        // RPython `transform.py:36-50` applies `transform_allocate`
+        // as part of `default_extra_passes` (`transform.py:246-251`)
+        // after whole-program annotation.  Pyre's cutover annotates
+        // incrementally, so the whole-program `transform_graph`
+        // cannot be applied to a partial block subset here.  This
+        // pass is the only extra pass required by the rtyper for
+        // correctness (`rtype_alloc_and_set`, `rlist.py:346-351`,
+        // consumes its output); it is a local, idempotent block
+        // rewrite and is therefore safe immediately before
+        // specialization.  The remaining three extra passes are
+        // optimizations and remain unavailable on this path.
+        let ann = self
+            .annotator
+            .upgrade()
+            .expect("RPythonTyper.annotator weak reference dropped");
+        crate::translator::transform::transform_allocate(&ann, std::slice::from_ref(block));
+
         let graph: GraphRef = {
             let ann = self
                 .annotator

--- a/majit/majit-translate/tests/test_mir_frontend.rs
+++ b/majit/majit-translate/tests/test_mir_frontend.rs
@@ -660,9 +660,16 @@ fn bool_then_some_lifts_to_short_circuit_diamond() {
 /// `Try::branch(opt)` / `ControlFlow` diamond into a direct switch on
 /// `opt.__discriminant`: `Some` extracts `opt.__pos_0` and continues,
 /// `None` builds a normal `None` return value.
+///
+/// The owners are the per-instantiation `Option<i64>` root, not the bare
+/// template: the fixture's own `Some(v + addend)` writes `__pos_0` under the
+/// suffixed root, so a bare read would take the payload off a different
+/// classdef than the one the producer wrote.
 #[test]
 fn option_question_mark_lifts_to_direct_option_switch() {
     use majit_translate::model::{CallTarget, ExitCase, ExitSwitch, OpKind};
+    const OPTION_ROOT: &str = "core::option::Option<i64>";
+    const SOME_ROOT: &str = "core::option::Option<i64>::Some";
     let llbc = load_corpus();
     let graph = lower_function(llbc, "option_question_mark").expect("lowering");
 
@@ -686,20 +693,20 @@ fn option_question_mark_lifts_to_direct_option_switch() {
                 } if name == "branch" => residual_branch += 1,
                 OpKind::FieldRead { field, .. }
                     if field.name == "__discriminant"
-                        && field.owner_root.as_deref() == Some("core::option::Option") =>
+                        && field.owner_root.as_deref() == Some(OPTION_ROOT) =>
                 {
                     option_disc_read = op.result.clone();
                 }
                 OpKind::FieldRead { field, .. }
                     if field.name == "__pos_0"
-                        && field.owner_root.as_deref() == Some("core::option::Option::Some") =>
+                        && field.owner_root.as_deref() == Some(SOME_ROOT) =>
                 {
                     some_payload_reads += 1;
                 }
                 OpKind::ConstInt(d) => last_disc = Some(*d),
                 OpKind::FieldWrite { field, .. }
                     if field.name == "__discriminant"
-                        && field.owner_root.as_deref() == Some("core::option::Option") =>
+                        && field.owner_root.as_deref() == Some(OPTION_ROOT) =>
                 {
                     if last_disc == Some(0) {
                         none_ctor += 1;

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2348,7 +2348,10 @@ pub(crate) fn bind_kwargs_to_signature(
     let varkw_slot = varargs_slot + usize::from(has_varargs);
     if has_varkw {
         roots.pin_root(pyre_object::w_dict_new_kwargs());
-        for (i, (key, _)) in extra_kwargs.iter().enumerate() {
+        // The index loop lowers to direct element loads; iterator adapters are residual calls.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..extra_kwargs.len() {
+            let key = &extra_kwargs[i].0;
             unsafe {
                 // The key allocation runs first: as the second argument it
                 // would be evaluated after the receiver, handing
@@ -2358,9 +2361,11 @@ pub(crate) fn bind_kwargs_to_signature(
             }
         }
     }
-    let mut result: Vec<PyObjectRef> = (0..result.len())
-        .map(|i| roots.get(result_slot + i))
-        .collect();
+    let result_len = result.len();
+    let mut result: Vec<PyObjectRef> = Vec::with_capacity(result_len);
+    for i in 0..result_len {
+        result.push(roots.get(result_slot + i));
+    }
     if has_varargs {
         result.push(roots.get(varargs_slot));
     }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3190,12 +3190,14 @@ pub fn call_function_impl_result(
     let mut inline_args = [PY_NULL; INLINE_ARGS];
     let mut wide_args = Vec::new();
     let args = if args.len() <= INLINE_ARGS {
-        for (i, slot) in inline_args[..args.len()].iter_mut().enumerate() {
-            *slot = _roots.get(root_base + 1 + i);
+        // The index loop lowers to `setarrayitem`; iterator adapters are residual calls.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..args.len() {
+            inline_args[i] = _roots.get(root_base + 1 + i);
         }
         &inline_args[..args.len()]
     } else {
-        wide_args.reserve_exact(args.len());
+        wide_args = Vec::with_capacity(args.len());
         for i in 0..args.len() {
             wide_args.push(_roots.get(root_base + 1 + i));
         }
@@ -3294,9 +3296,10 @@ pub fn call_function_impl_result(
             // have been updated to forwarded addresses; reconstruct the
             // argument view before recursively dispatching the bound call.
             let current_callable = pyre_object::gc_roots::shadow_stack_get(root_base);
-            let current_args: Vec<PyObjectRef> = (0..args.len())
-                .map(|i| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i))
-                .collect();
+            let mut current_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
+            for i in 0..args.len() {
+                current_args.push(pyre_object::gc_roots::shadow_stack_get(root_base + 1 + i));
+            }
             if prepend_receiver {
                 let mut call_args = Vec::with_capacity(1 + current_args.len());
                 call_args.push(current_callable);

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -328,8 +328,8 @@ impl RootScope {
     /// [`push_roots`] so the API surface stays uniform across phases.
     #[inline]
     fn new() -> Self {
-        let (save_point, stack_slot) =
-            with_shadow_stack(|stack| (stack.len(), stack as *const RootStack));
+        let stack_slot = shadow_stack_cell();
+        let save_point = shadow_stack_cell_len(stack_slot);
         Self {
             save_point,
             stack_slot,
@@ -445,9 +445,7 @@ impl Drop for RootScope {
         assert_shadow_stack_not_walking();
         // `truncate` is a no-op if `save_point >= len()`, which is
         // the steady-state case for an empty bracket.
-        // SAFETY: `stack_slot` is this thread's root-stack cell; `_not_send`
-        // keeps the bracket on the thread that resolved it.
-        unsafe { (*self.stack_slot).truncate(self.save_point) };
+        shadow_stack_cell_truncate(self.stack_slot, self.save_point);
     }
 }
 
@@ -592,6 +590,28 @@ pub fn normalize_roots(base: usize, len: usize) {
 #[majit_macros::dont_look_inside]
 pub fn shadow_stack_len() -> usize {
     with_shadow_stack(RootStack::len)
+}
+
+/// The thread's root-stack cell.  The JIT residualises the resolution instead
+/// of tracing into it (`@dont_look_inside`, `rlib/jit.py:139`), the
+/// `shadow_stack_len` twin.
+#[majit_macros::dont_look_inside]
+fn shadow_stack_cell() -> *const RootStack {
+    with_shadow_stack(|stack| stack as *const RootStack)
+}
+
+#[majit_macros::dont_look_inside]
+fn shadow_stack_cell_len(cell: *const RootStack) -> usize {
+    // SAFETY: `cell` is this thread's root-stack cell, and `_not_send` keeps
+    // the bracket on the thread that resolved it.
+    unsafe { (*cell).len() }
+}
+
+#[majit_macros::dont_look_inside]
+fn shadow_stack_cell_truncate(cell: *const RootStack, len: usize) {
+    // SAFETY: `cell` is this thread's root-stack cell, and `_not_send` keeps
+    // the bracket on the thread that resolved it.
+    unsafe { (*cell).truncate(len) };
 }
 
 /// Read a single shadow-stack slot by index, panicking if the index


### PR DESCRIPTION
Sixteen changes that let the rtyper prepass lift graphs it previously declined. Each was chosen by measuring the prepass census — three streams (`PREPASS phaseA fail`, `PREPASS phaseB fail`, `PYRE_RTYPER skip`) plus the innermost-blocker histogram — and adjudicating on the failing-subject **set**, not the totals.

## Measurement

Both sides pinned to the same merge-base, same corpus generation, `HEAD` never moved during either run. The control is branch-free: the working tree is reverted to the merge-base with `git checkout <base> -- .`, the LLBC corpus re-extracted, and the census re-run.

| stream | base | branch | delta |
|---|---|---|---|
| phaseA (annotation) | 1318 | **1288** | **−30** |
| phaseB (rtyper) | 5 | **5** | **0** |
| `PYRE_RTYPER skip` (does the graph lift) | 1322 | **1293** | **−29** |

**0 newly-failing subjects on all three streams.** 29 graphs lift that did not before, and none stopped lifting.

Innermost-blocker histogram: `core::slice::index::<Impl>::index` 188 → 30, `__array_repeat` 124 → 0, `pyre_object::gc_roots::ROOT_STACK` 102 → 0, `alloc::vec::from_elem` 8 → 0.

The `(no registry leaf)` bucket grows 152 → 219, which is the standard alarm for a cause-change, so it was read out rather than assumed: every class in it already existed in the base (`err/other` 49→86, `panic/unionerror` 24→51, `panic/other` 17→27, while `classdef-less` 49→45 and `err/unionerror` 13→10 both *shrank*), no new class appeared, and sampled records show the same subjects annotating *past* a cleared hub hop and stopping at their own next wall.

> Both numbers above were taken at merge-base `b99bf57bde4`. The branch has since been rebased onto `128590c675f`, which carries 20 changed `pyre/**/*.rs` files and therefore a different corpus. A two-sided re-measurement at the current base is running; this table will be replaced with it.

## majit-translate

| commit | change |
|---|---|
| `af6f9b30214` | dump the block's operations when a graph has no Python source |
| `051dc129c02` | look up a shaped tuple's rows under its full key in `project_struct_rows` |
| `ac9991b66d7` | model `Option<fn(..)>` as the null-pointer niche it is |
| `220295718e4` | build `Option::map`'s result under the destination's classdef |
| `4ab02eb17e6` | lower `[v; N]` to the `newlist`+`mul` shape `transform_allocate` collapses |
| `aba1e91f0e9` | route `slice[..len-1]` to the `MinusOne` `getslice` through a synthetic call |
| `7c2fd2824e1` | run `transform_allocate` on every block before it is specialized |
| `98919d7f665` | expand `alloc::vec::from_elem` into the `newlist`+`mul` repeat shape |
| `e1fc067eae2` | decline the general `RangeTo` fold; gate `MinusOne` on an unsigned `sub` |
| `b4e4cd77d37` | reset a filtered shaped-tuple row's force shell before the constructor writes it |

The slice folds and the `vec!` levers use the **synthetic-call channel**: `front/` passes rewrite `crate::model::OpKind`, which `codewriter/assembler.rs` also consumes, so an unwired frontend op can leak to the assembler. `flowspace_adapter::translate_op` instead produces string-named `FlowspaceOp`s that only the annotator and rtyper see. So `front/` recognises the pattern and emits a synthetic *unregistered* `OpKind::Call`, and the adapter expands it.

### `7c2fd2824e1` is a prepass-lifecycle fix, and it is the reason the `vec!` levers are sound

`newlist(a)` + `mul(list, b)` was reaching the rtyper unrewritten and failing with `pair(rtype_mul) not implemented for (FixedSizeListRepr, IntegerRepr)`. `transform_allocate` (`transform.py:36-50`) is reachable only through `transform_graph` ← `RPythonAnnotator::simplify` ← `RPythonTyper::specialize` with `dont_simplify_again == false`, and every production caller passes `true` — so none of `default_extra_passes` ran on this path at all.

The whole-program `transform_graph` cannot simply be called here: its `transform_dead_code` / `transform_dead_op_vars` halves compute liveness over the subset they are handed. Upstream hands them the complete set once, after whole-program annotation; pyre's cutover annotates incrementally, so any subset is partial, and applying it per subject deletes the defining operation of a variable a not-yet-annotated block still uses (measured: phaseA 1284 → 1677, dominated by `variable ... used before definition`).

`transform_allocate` is a local, idempotent, single-block rewrite and is the only one of the four the rtyper depends on for correctness — `rtype_alloc_and_set` (`rlist.py:346-351`) exists to consume its output. It runs at the top of `specialize_block`, which covers the `specialize_more_blocks` loop, the two-phase whole-program pass that calls `specialize_block` directly, and graphs lifted through `lift_callee_to_pygraph`, whose blocks never pass through `drive_subject`. The other three extra passes remain unavailable on this path, and the comment says so.

### `90aeacb8bb7` and `b20a9267960` cancel

The `Box::new_uninit` / `Box::into_raw` annotator registrations let three allocation graphs past annotation, where they then failed the rtyper with `don't know about built-in function <host Box.new>` — `findbltintyper` (`rbuiltin.py:73-83`) has no typer for the `Box.*` host callables, and `Box.new` carries an analyser without one on `main` already.

A/B with the registrations as the only difference: phaseA 1284 → 1287, phaseB 8 → 5, **skip 1292 → 1292**. The skip stream is identical, so no graph lifts either way — the registrations only move three failures from phaseA to phaseB. Reverted; the net diff of this branch does not touch `annotator/builtin.rs`.

## pyre

The frontend models RPython's operation set — index loops, `list.append`, `range`, `@dont_look_inside` residual helpers. Rust constructs with no RPython counterpart become unregistered residual callees and stop a graph from lifting. Both commits are spelling changes with identical semantics.

* `7730a46a9d8` — `call_function_impl_result`'s `iter_mut().enumerate()`, `.map().collect()` and `Vec::reserve_exact` become index loops and `Vec::with_capacity` + `push`; `RootScope::new` no longer reaches `ROOT_STACK` from traced code, with `shadow_stack_cell{,_len,_truncate}` joining the existing `#[dont_look_inside]` accessor family (one TLS resolution per bracket, as before).
* `031ecec1730` — the same two loop spellings in `bind_kwargs_to_signature`. The `unsafe` block's contents and evaluation order, the `push_roots` bracket and its slot arithmetic are unchanged.

`push_roots` / `RootScope::new` still cannot themselves be `#[dont_look_inside]`: `emit_helper_call_target_fn` gives every residual helper an all-`i64` ABI, and a two-word by-value `RootScope` has no encoding. That blocker is real and is left in place.

## Review round

Two reviewer findings were confirmed against the source and fixed. Both were defects in this branch's own commits.

**`e1fc067eae2` — the general `RangeTo` fold had no `end <= len` proof.** It fired whenever the end was unsigned, but unsigned proves `end >= 0`, not `end <= slice.len()`. For a traced `&slice[..end]` with `end > len`, Rust's `SliceIndex::index` panics while `__getslice_rangeto` expands to `ll_listslice_startstop`, which clamps and returns the whole slice — the two disagree on a reachable input. The argument that enabled the arm (that `s[:n]` with `n > len(s)` is defined) applied Python's slicing semantics to a graph whose source semantics are Rust's; `rewire_one_slice_index_site` already documented the requirement it violated. Only `MinusOne` is admitted now, whose `end = len - 1` is a real proof against the receiver's own length.

The same commit gates `minus_one_end_matches` on an unsigned `sub`. It matched any `sub` producing the end, and the dispatcher tested it *before* the unsigned gate, so a signed `sub(ArrayLen(slice), 1)` took the `MinusOne` path. `ll_listslice_startstop` (`rlist.py:893-903`) clamps only `stop > length`; `stop < start` is an `ll_assert`, a no-op in a release translation — so on an empty slice a signed `len - 1` reaches `ll_newlist` with `newlength = -1`, while the unsigned wrap the clamp does repair.

Census after the decline: all three streams and their subject sets **identical**, with no subject moving in either direction. The general `RangeTo` arm was contributing nothing while carrying the divergence.

**`b4e4cd77d37` — a filtered shaped-tuple row kept its force shell.** `project_struct_rows` drops nullable-sum rows so the constructor's materialized variant is not generalized against the nullable-payload spelling; dropping the row also skipped the force-shell replacement loop, so a slot already seeded with the untyped `FORCE_ATTRIBUTES` shell kept it, and the constructor's `setattr` unioned the variant against that classless shell, which wins. Probed before and after: `__pos_0` / `__pos_1` of a shaped tuple holding `Option<Vec<*mut PyObject>>` and `Result<Vec<*mut PyObject>, PyErr>` still held the classdef-less shell after `setattr`; they now carry the `Some` and `Ok` classdefs.

This one is invisible to the census — it degrades an annotation rather than failing it, so the regression test is the evidence, not the three streams.

A third finding (`and_then` returning a non-niche `Option<usize>` merging different classdefs) is not actionable as written: `resolve_option_consumer_owners` returns the bare owner by early return for every unsigned or niche payload, and that carve-out is a documented convention shared with `front::checked_arith_uint`, so the per-instantiation spelling the finding assumes does not arise. Four further findings referenced `SliceIndexBounds::RangeTo`, `end_is_unsigned` and two anchor names that `e1fc067eae2` removed outright.

Seven findings remain open — test and documentation quality, including three tests that pass without exercising what they guard. They are queued, not dismissed.

## Method note

Hubs were closed by enumerating their **complete** callee set rather than iterating walls one at a time — the census is fail-fast and reports only the first wall, which is how `bind_kwargs_to_signature` looked like a one-wall graph when it had four.

Three defects on this branch were caught by the census alone while the test gate stayed green, and one change passed three new anchors while being a **production no-op** — its anchors exercised `specialize_more_blocks` while the prepass reaches `specialize_block` directly.

## Gate

`cargo test --all --no-default-features --features dynasm` — 101 suites, 7510 passed, 0 failed. `cargo fmt --check` and `git diff --check` clean.

Note: `jit_fnaddr::tests::registered_paths_sharing_an_address_are_alias_spellings` fails intermittently on a clean tree too (the linker folds two trivially identical functions; the colliding pair differs run to run).

— *updated by Claude*
