### PR TITLE
jit: resolve a walk's coordinates from the frame and operand offset that produced them; gate the vendored CPython suite

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -8,6 +8,8 @@ import argparse
 import difflib
 import math
 import os
+import platform
+import re
 import shutil
 import statistics
 import struct
@@ -143,6 +145,17 @@ WIN_NATIVE_TIMEOUT_SCALE = 2.0
 
 BENCH_DIR = "pyre/bench"
 SYNTHETIC_BENCH_DIR = "pyre/bench/synth"
+CPYTHON_SUITE_BASELINE = "pyre/cpython_tests/baseline.json"
+# The baseline holds one verdict per module per backend, and dynasm emits
+# arch-specific code, so a verdict only compares against the host it was
+# observed on. `.github/workflows/pyre-ci.yml` pins its CPython suite job to
+# `macos-latest` for the same reason.
+CPYTHON_SUITE_BASELINE_HOST = ("darwin", "arm64")
+# Per module, matching the CI job. `test.test_asyncio` alone needs ~2m47s of
+# wall time, so a smaller per-module limit turns a slow module into a fake
+# regression.
+CPYTHON_SUITE_MODULE_TIMEOUT_S = 300
+CPYTHON_SUITE_TIMEOUT_S = 2400
 SNAP_DIR = "pyre/check.snap"
 BENCH_COMPARE_BUFFER_S = 0.005
 # Windows process CPU accounting advances in scheduler ticks (normally 1/64 s).
@@ -2374,6 +2387,79 @@ class Check:
             print(f"{green('PASS')}  {elapsed:.2f}s")
             self._append_comparison(backend, name, "-", "-", f"{elapsed:.2f}s")
 
+    # ── vendored CPython suite ──
+
+    def run_cpython_suite(self):
+        """Gate the vendored CPython test suite against its recorded baseline.
+
+        Every other stage in this file runs code we wrote, so it can only
+        catch a defect in a shape somebody already thought of.  This one runs
+        CPython's own tests, and it is the stage that reports a JIT miscompile
+        nobody wrote a fixture for: `test.test_datetime` failed on a
+        specialised-pair subscript fold while the whole synthetic corpus and
+        every parity fixture stayed green.
+
+        The baseline records one verdict per module per backend, observed on
+        darwin-arm64, and dynasm's codegen is arch-specific -- so the
+        comparison only means anything there, which is also why the CI job
+        pins `runs-on: macos-latest`.  On any other host the stage reports
+        that it did not run instead of counting as a pass.
+        """
+        name = "cpython-suite"
+        backend = "dynasm"
+        print(f"  {name}")
+        if not self.enabled(backend):
+            sys.stdout.write(f"    {backend:<10s}")
+            print(dim("skip (backend not enabled)"))
+            self._append_comparison(backend, name, "-", "-", "skip")
+            return
+        host = (sys.platform, platform.machine())
+        if host != CPYTHON_SUITE_BASELINE_HOST:
+            sys.stdout.write(f"    {backend:<10s}")
+            print(dim(
+                f"skip (baseline observed on {'-'.join(CPYTHON_SUITE_BASELINE_HOST)}, "
+                f"host is {'-'.join(host)})"
+            ))
+            self._append_comparison(backend, name, "-", "-", "skip")
+            return
+        sys.stdout.write(f"    {backend:<10s}")
+        sys.stdout.flush()
+        output, elapsed, code, stderr = run_timed(
+            [
+                PYTHON3, str(Path(__file__).parent / "cpython_tests" / "run.py"),
+                "--binary", str(self._pyre(backend)),
+                "--baseline", str(CPYTHON_SUITE_BASELINE),
+                "--jobs", str(max(1, (os.cpu_count() or 4) - 1)),
+                "--timeout", str(CPYTHON_SUITE_MODULE_TIMEOUT_S),
+            ],
+            timeout_s=CPYTHON_SUITE_TIMEOUT_S,
+            env=pyre_env(),
+        )
+        # `N to run,` rather than the runner's own "no regressions": a
+        # selection that came out empty prints every counter as zero and
+        # still exits 0, which reads as a pass and tests nothing.
+        selected = re.search(r"^(\d+) to run,", output, re.M)
+        if code == 124:
+            detail = f"timeout (>{CPYTHON_SUITE_TIMEOUT_S}s)"
+        elif selected is None:
+            detail = "runner printed no selection line"
+        elif selected.group(1) == "0":
+            detail = "selected 0 modules"
+        elif code != 0:
+            regressions = re.findall(r"^  - (\S+): (.*)$", output, re.M)
+            detail = "; ".join(f"{m} {d}" for m, d in regressions) or f"exit {code}"
+        else:
+            detail = ""
+        if detail:
+            self._record(backend, False, name, detail)
+            print(f"{red('FAIL')}  {detail}")
+            _dump_failed_run(output, stderr)
+            self._append_comparison(backend, name, "-", "-", "FAIL")
+            return
+        self._record(backend, True, name, "")
+        print(f"{green('PASS')}  {selected.group(1)} modules, {elapsed:.0f}s")
+        self._append_comparison(backend, name, "-", "-", f"{elapsed:.0f}s")
+
     # ── synthetic parity suite ──
 
     def run_synthetic_bench(self, path, timeout):
@@ -2707,6 +2793,11 @@ def parse_args():
         help="skip pyre/bench/synth feature-parity benchmarks",
     )
     parser.add_argument(
+        "--no-cpython-suite",
+        action="store_true",
+        help="skip the vendored CPython suite gate (pyre/cpython_tests)",
+    )
+    parser.add_argument(
         "--synthetic-only",
         action="store_true",
         help="run only pyre/bench/synth feature-parity benchmarks",
@@ -2888,6 +2979,11 @@ def main():
     if not args.no_synthetic:
         print()
         chk.run_synthetic_suite()
+
+    if not args.no_cpython_suite and not args.synthetic_only:
+        print()
+        print(bold("vendored CPython suite"))
+        chk.run_cpython_suite()
 
     rc = chk.print_summary()
     sys.exit(rc)

--- a/pyre/extra_tests/parity_tests/inline_callee_locals_across_guard.py
+++ b/pyre/extra_tests/parity_tests/inline_callee_locals_across_guard.py
@@ -1,0 +1,82 @@
+# Locals of an inlined callee must survive a guard that fails inside the
+# callee's own body.  A callee's `LOAD_FAST`/`STORE_FAST` lower to
+# `getarrayitem_vable_*`/`setarrayitem_vable_*` on its own frame array, and the
+# split between the `locals_cells_stack_w` prefix and the operand-stack region
+# is that frame's own local count.  Both shapes are covered: a callee with MORE
+# locals than its caller (a `STORE_FAST` mistaken for an operand-stack push
+# folds away, and the resumed frame reads the slot back as NULL) and one with
+# FEWER (an operand-stack cell mistaken for a local).
+#
+# The guard is an attribute read off a receiver whose class alternates between
+# rounds, so every round after the first resumes inside the callee.
+
+N = 400
+ROUNDS = 60
+
+
+class Shape:
+    def __init__(self, v):
+        self.v = v
+
+
+class Other:
+    def __init__(self, v):
+        self.v = v
+
+
+def sink(a, b, c):
+    return (a * 7 + b * 3 + c) % 1000003
+
+
+def wide_callee(o, k):
+    # Six locals — more than `narrow_driver` has.  `t0`/`t2` are stored before
+    # the guarded `o.v` read and consumed after it.
+    t0 = k * 2 + 1
+    t1 = t0 + 5
+    t2 = t1 * 3
+    v = o.v
+    return sink(t0, t2, v)
+
+
+def narrow_driver(n, o):
+    acc = 0
+    for i in range(n):
+        acc = (acc + wide_callee(o, i)) % 1000003
+    return acc
+
+
+def narrow_callee(o):
+    # Two locals — fewer than `wide_driver` has.
+    v = o.v
+    return (v, v + 1, v + 2)
+
+
+def wide_driver(n, o):
+    a = 0
+    b = 1
+    c = 2
+    d = 3
+    e = 4
+    f = 5
+    g = 6
+    acc = 0
+    for i in range(n):
+        x, y, z = narrow_callee(o)
+        acc = (acc + x + y + z + a + b + c + d + e + f + g + i) % 1000003
+    return acc
+
+
+# sum over i in 0..N-1 of (32 * i + 72), taken mod 1000003
+NARROW_EXPECTED = (32 * (N * (N - 1) // 2) + 72 * N) % 1000003
+# per iteration: (11 + 12 + 13) + (0 + 1 + ... + 6) + i
+WIDE_EXPECTED = ((36 + 21) * N + N * (N - 1) // 2) % 1000003
+
+warm = Shape(11)
+flip = Other(11)
+
+for round_ in range(ROUNDS):
+    for receiver in (warm, flip):
+        assert narrow_driver(N, receiver) == NARROW_EXPECTED
+        assert wide_driver(N, receiver) == WIDE_EXPECTED
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/iterator_setstate_python314.py
+++ b/pyre/extra_tests/parity_tests/iterator_setstate_python314.py
@@ -9,6 +9,7 @@ sequence reject every later state once it goes negative.
 """
 
 import array
+import sys
 
 
 def check(condition, message):
@@ -20,6 +21,13 @@ def state(it):
     """The cursor `__reduce__` pickles, or EXHAUSTED for the empty form."""
     reduced = it.__reduce__()
     return reduced[2] if len(reduced) > 2 else "EXHAUSTED"
+
+
+def restored(make, index):
+    """The cursor `__setstate__(index)` leaves on a fresh iterator."""
+    it = make()
+    it.__setstate__(index)
+    return state(it)
 
 
 def remaining(it):
@@ -162,13 +170,23 @@ for label, make in makers:
                   label + " rejects a non-integer state: " + str(exc))
         else:
             raise AssertionError(label + " accepted a non-integer state")
-    try:
-        make().__setstate__(1 << 100)
-    except OverflowError as exc:
-        check(str(exc) == "Python int too large to convert to C ssize_t",
-              label + " overflow message: " + str(exc))
-    else:
-        raise AssertionError(label + " accepted an oversized state")
+    for oversized in (1 << 100, sys.maxsize + 1, -sys.maxsize - 2):
+        try:
+            make().__setstate__(oversized)
+        except OverflowError as exc:
+            check(str(exc) == "Python int too large to convert to C ssize_t",
+                  label + " overflow message: " + str(exc))
+        else:
+            raise AssertionError(label + " accepted an oversized state")
+    # The two extremes that do fit are accepted, and land where any other value
+    # of their sign lands: the cursor is what gets clamped, not the width of the
+    # incoming int.  The generic iterator is the exception on the positive side,
+    # having no length to clamp against (`seq_iter_clamp_length`).
+    check(restored(make, -sys.maxsize - 1) == restored(make, -1),
+          label + " accepts the smallest cursor")
+    check(restored(make, sys.maxsize)
+          == (sys.maxsize if label == "generic" else restored(make, 99)),
+          label + " accepts the largest cursor")
     it = make()
     it.__setstate__(MyInt(1))
     check(state(it) == 1, label + " accepts an int subclass")

--- a/pyre/extra_tests/parity_tests/nested_inline_caller_lineno.py
+++ b/pyre/extra_tests/parity_tests/nested_inline_caller_lineno.py
@@ -1,0 +1,47 @@
+# The line number a frame reports while a residual runs inside a call chain
+# that was inlined more than one level deep.
+#
+# A residual executed inside an inlined callee temporarily publishes
+# `last_instr` onto the outer traced frame, so that a frame reader running
+# during the call (`sys._getframe().f_lineno`, a warning's registry key, a
+# traceback) sees the line the call was made from rather than whatever the last
+# resume point left behind.  That coordinate is derived from the CALL
+# instruction's JitCode offset, which indexes the outer frame's JitCode only
+# while the walk is that frame's own.  One level down, the offset belongs to the
+# intermediate callee, and mapping it through the outer frame's pc tables names
+# whatever line that byte happens to land on — here the `def` line's body start
+# instead of the call.
+#
+# `driver` runs the traced loop, inlines `mid`, which inlines `leaf`; the
+# `sys._getframe` residual inside `leaf` is what publishes the coordinate.  The
+# loop collects every line `driver` reports across the run, so a single wrong
+# iteration is caught: the set must hold exactly the one call line.
+
+import sys
+
+N = 3000
+
+
+def leaf(k):
+    # Frame depths: 0 = leaf, 1 = mid, 2 = driver.
+    return sys._getframe(2).f_lineno
+
+
+def mid(k):
+    return leaf(k)
+
+
+def driver(n):
+    seen = set()
+    i = 0
+    while i < n:
+        seen.add(mid(i))  # <-- the only line `driver` may ever report
+        i += 1
+    return sorted(seen)
+
+
+CALL_LINE = driver.__code__.co_firstlineno + 4
+observed = driver(N)
+assert observed == [CALL_LINE], (CALL_LINE, observed)
+
+print("OK")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -1223,7 +1223,10 @@ pub(crate) fn drive_bridge_frame_subwalk<Sym: WalkSym>(
 
     let outcome = {
         let mut sub_wc = WalkContext {
-            callee_shadow: Some(Default::default()),
+            callee_shadow: Some(super::CalleeLocalsShadow {
+                code_ptr: callee_pjc.code_ptr,
+                ..Default::default()
+            }),
             inline_callee_consts: Some(consts),
             fbw_mode: FbwWalkMode {
                 snapshot_sym: root_sym_ptr,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -147,9 +147,9 @@ pub(crate) fn inflight_foriter_body_pc(body: InflightForiterBody) -> Option<usiz
     match body {
         InflightForiterBody::Py(body_pc) => Some(body_pc),
         InflightForiterBody::Jit {
-            outer_jitcode_index,
+            jitcode_index,
             op_pc,
-        } => crate::state::pyjitcode_for_jitcode_index(outer_jitcode_index as i32).map(|jc| {
+        } => crate::state::pyjitcode_for_jitcode_index(jitcode_index).map(|jc| {
             crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.metadata, op_pc) as usize + 1
         }),
     }
@@ -157,10 +157,29 @@ pub(crate) fn inflight_foriter_body_pc(body: InflightForiterBody) -> Option<usiz
 
 /// Capture the native coordinates that identify a `for_iter_next` residual.
 /// The Python continue-arm fallthrough is intentionally not derived here.
+///
+/// `op_pc` is an offset into the JitCode the walk is currently executing, so
+/// the identity paired with it must be that JitCode's.  Inside an inline
+/// sub-walk that is the callee's ([`InlineCalleeConsts::jitcode_index`], the
+/// same resolution `build_multi_frame_miframe` applies to its innermost
+/// frame); `fbw_mode.snapshot_sym` still names the outer portal.  Pairing the
+/// portal with a callee offset invents a coordinate: `inflight_foriter_body_pc`
+/// resolves it through the CALLER's pc tables and answers with a Python pc that
+/// belongs to neither loop, so a callee loop's item is stashed under an
+/// identity no resume coordinate can match, and a caller loop that happens to
+/// resolve to the same pc has its own in-flight entry truncated away and
+/// replaced by the callee's item.
 pub(crate) fn fbw_foriter_body_from_op_pc<Sym: WalkSym>(
-    snapshot_sym: *const Sym,
+    ctx: &WalkContext<'_, '_, Sym>,
     op_pc: usize,
 ) -> Option<InflightForiterBody> {
+    if let Some(consts) = ctx.inline_callee_consts {
+        return Some(InflightForiterBody::Jit {
+            jitcode_index: consts.jitcode_index,
+            op_pc,
+        });
+    }
+    let snapshot_sym = ctx.fbw_mode.snapshot_sym;
     if snapshot_sym.is_null() {
         return None;
     }
@@ -171,7 +190,7 @@ pub(crate) fn fbw_foriter_body_from_op_pc<Sym: WalkSym>(
         return None;
     }
     Some(InflightForiterBody::Jit {
-        outer_jitcode_index: unsafe { (*sym.jitcode()).index as u32 },
+        jitcode_index: unsafe { (*sym.jitcode()).index as i32 },
         op_pc,
     })
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4212,7 +4212,10 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     };
     let (callee_outcome, callee_class_of_last_exc_is_const) = {
         let mut sub_wc = WalkContext {
-            callee_shadow: Some(Default::default()),
+            callee_shadow: Some(super::CalleeLocalsShadow {
+                code_ptr: raw_callee_code,
+                ..Default::default()
+            }),
             // Path-1: resolve scalar static-field reads off this callee's own
             // unseeded portal frame to its compile-time constants.
             inline_callee_consts: Some(inline_consts),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -4094,6 +4094,18 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
     // the CALL site but stamping the walk-entry header desyncs the two windows
     // (count-mismatch assert / wrong slot layout), so carry the box coordinate
     // to the header alongside the boxes.
+    // The coordinate published onto the outer portal frame's `last_instr`
+    // while a residual runs inside the callee.  `op.pc` indexes the snapshot
+    // sym's jitcode only while the walk is the portal's own; one level down it
+    // is the INTERMEDIATE callee's offset, and mapping it through the portal's
+    // pc tables stamps whatever py_pc that byte happens to land on onto a frame
+    // that is still paused at the CALL the outermost sub-walk entered under —
+    // which is exactly what the inherited coordinate already names.
+    let inherited_caller_py_pc = if ctx.fbw_mode.inline_subwalk {
+        ctx.fbw_mode.inline_caller_py_pc
+    } else {
+        inline_caller_py_pc_from_snapshot(ctx, op.pc)
+    };
     let (
         inline_outer_active_boxes,
         inline_outer_entry_py_pc,
@@ -4108,7 +4120,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                 ctx.entry_py_pc,
                 ctx.outer_jitcode_index,
                 ctx.outer_resume_marker_jit_pc,
-                inline_caller_py_pc_from_snapshot(ctx, op.pc).or(ctx.fbw_mode.inline_caller_py_pc),
+                inherited_caller_py_pc,
             )
         } else {
             let sym = unsafe { &*sym_ptr };
@@ -4118,8 +4130,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     ctx.entry_py_pc,
                     ctx.outer_jitcode_index,
                     ctx.outer_resume_marker_jit_pc,
-                    inline_caller_py_pc_from_snapshot(ctx, op.pc)
-                        .or(ctx.fbw_mode.inline_caller_py_pc),
+                    inherited_caller_py_pc,
                 )
             } else {
                 // Liveness coordinate is the CALL op's own (jitcode index,
@@ -4185,7 +4196,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
             ctx.entry_py_pc,
             ctx.outer_jitcode_index,
             ctx.outer_resume_marker_jit_pc,
-            inline_caller_py_pc_from_snapshot(ctx, op.pc).or(ctx.fbw_mode.inline_caller_py_pc),
+            inherited_caller_py_pc,
         )
     };
     // `executioncontext.py:88 enter` — emitted here, past every decline gate,
@@ -5832,7 +5843,7 @@ pub(crate) fn try_walker_specialize_seqiter_getitem_next<Sym: WalkSym>(
         return Ok(None);
     }
 
-    let body_coord = fbw_foriter_body_from_op_pc(ctx.fbw_mode.snapshot_sym, op.pc)
+    let body_coord = fbw_foriter_body_from_op_pc(ctx, op.pc)
         .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
     fbw_foriter_inflight_mark_attempt(body_coord);
     let pre_emit_pos = ctx.trace_ctx.get_trace_position();

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -5639,12 +5639,12 @@ enum InflightForiterBody {
     /// Legacy entry-PC fallback for a per-opcode walk or fixture with no
     /// full-body JitCode coordinate.
     Py(usize),
-    /// The outer Python JitCode identity and the `for_iter_next` residual's
-    /// own JitCode pc. The body fallthrough is derived only at a match point.
-    Jit {
-        outer_jitcode_index: u32,
-        op_pc: usize,
-    },
+    /// The `for_iter_next` residual's own JitCode pc plus the identity of the
+    /// JitCode that pc indexes — the inlined callee's inside a sub-walk, the
+    /// outer portal's otherwise.  The body fallthrough is derived only at a
+    /// match point.  Negative when the identity is unresolvable, which
+    /// `inflight_foriter_body_pc` reports as no coordinate at all.
+    Jit { jitcode_index: i32, op_pc: usize },
 }
 
 #[derive(Clone, Copy)]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -413,6 +413,14 @@ pub struct CalleeLocalsShadow {
     /// `f_locals` or `sys._getframe` — and must not be folded away; the operand
     /// -stack region above `nlocals` is not reachable that way and still folds.
     pub frame_materialized: bool,
+    /// `CodeObject` of THIS inline level's frame.
+    ///
+    /// A `getarrayitem_vable_*` / `setarrayitem_vable_*` slot indexes the frame
+    /// the op names, and a Python pc reached inside a sub-walk indexes that
+    /// frame's bytecode — both are the callee's, not the outer portal frame the
+    /// `fbw_mode.snapshot_sym` describes.  Null when the level did not resolve
+    /// a callee code object.
+    pub code_ptr: *const pyre_interpreter::CodeObject,
 }
 
 impl Default for CalleeLocalsShadow {
@@ -424,6 +432,7 @@ impl Default for CalleeLocalsShadow {
             concrete_frame: 0,
             frame_box: OpRef::NONE,
             frame_materialized: false,
+            code_ptr: std::ptr::null(),
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2980,7 +2980,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // exhaustion arm) still records the completion; a successful attempt
     // replaces the entry with a fresh one anyway.
     if helper == majit_ir::PyreHelperKind::ForIterNext {
-        let body = fbw_foriter_body_from_op_pc(ctx.fbw_mode.snapshot_sym, op_pc)
+        let body = fbw_foriter_body_from_op_pc(ctx, op_pc)
             .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
         fbw_foriter_inflight_mark_attempt(body);
     }
@@ -3543,7 +3543,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                 // body and deliver to the wrong pc.  The fallback (no outer
                 // full-body sym / metadata) keeps the entry coordinate, which
                 // is correct for the loop-header FOR_ITER.
-                let body = fbw_foriter_body_from_op_pc(ctx.fbw_mode.snapshot_sym, op_pc)
+                let body = fbw_foriter_body_from_op_pc(ctx, op_pc)
                     .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
                 fbw_foriter_inflight_capture(result_i64 as usize as pyre_object::PyObjectRef, body);
                 // #73/#267: the item lands on the operand-stack TOS through the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -11186,7 +11186,7 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
 
     // A new consume attempt completes the prior in-flight iteration before
     // this irreversible concrete advance, matching the residual executor.
-    let body = fbw_foriter_body_from_op_pc(ctx.fbw_mode.snapshot_sym, op_pc)
+    let body = fbw_foriter_body_from_op_pc(ctx, op_pc)
         .unwrap_or_else(|| InflightForiterBody::Py(ctx.entry_py_pc() as usize + 1));
     fbw_foriter_inflight_mark_attempt(body);
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -12437,3 +12437,82 @@ fn ref_var_list_offset_follows_the_argcodes_not_a_fixed_byte() {
     let op = crate::jitcode_runtime::decode_op_at(&code, 0).expect("must decode");
     assert_eq!(ref_var_list_operand_offset(&code, &op), None);
 }
+
+#[test]
+fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
+    // The in-flight FOR_ITER coordinate pairs a `for_iter_next` residual's own
+    // JitCode offset with a JitCode identity, and
+    // `inflight_foriter_body_pc` resolves the pair through THAT jitcode's pc
+    // tables.  Inside an inline sub-walk the offset is the callee's, so the
+    // identity must be the callee's too — `fbw_mode.snapshot_sym` still names
+    // the outer portal.
+    //
+    // A null `snapshot_sym` is the discriminating fixture: it is the one input
+    // for which the portal arm can produce nothing at all, so a returned
+    // identity can only have come from `inline_callee_consts`.  The callee arm
+    // returns before the sym is read, so a live portal can never outrank it.
+    let mut tc = fresh_trace_ctx();
+    let descr_pool: Vec<DescrRef> = Vec::new();
+    let session = std::cell::RefCell::new(WalkSession::default());
+    let callee_index = 4242;
+    let mut wc = WalkContext {
+        callee_shadow: None,
+        inline_callee_consts: None,
+        fbw_mode: test_fbw_mode(),
+        session: &session,
+        registers_r: &mut [],
+        registers_i: &mut [],
+        registers_f: &mut [],
+        concrete_registers_r: &mut [],
+        concrete_registers_i: &mut [],
+        descr_refs: &descr_pool,
+        raw_descrs: RawDescrPool::Global,
+        is_authoritative_executor: false,
+        trace_ctx: &mut tc,
+        is_top_level: true,
+        sub_jitcode_lookup: &no_sub_jitcodes,
+        last_exc_value: None,
+        last_exc_value_concrete: ConcreteValue::Null,
+        entry_py_pc: EntryPyPc::Py(0),
+        outer_resume_marker_jit_pc: None,
+        outer_jitcode_index: 0,
+        outer_active_boxes: Vec::new(),
+        store_subscr_fn_addr: None,
+        pending_guard_snapshot_error: None,
+        vstack_boxes: Vec::new(),
+        vstack_depth: 0,
+        vstack_cur_pypc: 0,
+        vstack_valid: false,
+        vstack_last_ref: OpRef::NONE,
+        vstack_reorder_ceiling: u32::MAX,
+        vstack_reorder_saved: None,
+        vstack_handler_landing_py: None,
+        live_before_jit_pc: usize::MAX,
+        live_after_jit_pc: usize::MAX,
+    };
+    assert!(
+        wc.fbw_mode.snapshot_sym.is_null(),
+        "fixture premise: no portal identity is available",
+    );
+    assert!(
+        fbw_foriter_body_from_op_pc(&wc, 96).is_none(),
+        "with neither a callee nor a portal there is no coordinate to record",
+    );
+
+    wc.inline_callee_consts = Some(InlineCalleeConsts {
+        w_globals: 0,
+        w_code: 0,
+        jitcode_index: callee_index,
+    });
+    wc.fbw_mode.inline_subwalk = true;
+    match fbw_foriter_body_from_op_pc(&wc, 96) {
+        Some(InflightForiterBody::Jit {
+            jitcode_index,
+            op_pc,
+        }) => {
+            assert_eq!(jitcode_index, callee_index, "identity must be the callee's");
+            assert_eq!(op_pc, 96, "offset must be recorded verbatim");
+        }
+        other => panic!("expected the callee's Jit coordinate, got {other:?}"),
+    }
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -638,12 +638,22 @@ fn folded_store_is_observable_local<Sym: WalkSym>(
 }
 
 /// `CodeObject` of the frame a vable op names — the callee's inside an inline
-/// sub-walk, the outer portal frame's otherwise.
+/// sub-walk that owns a [`CalleeLocalsShadow`], the outer portal frame's
+/// otherwise.
+///
+/// Shadow ownership, not `fbw_mode.inline_subwalk`, is the discriminant: the
+/// flag is also set for a canonical-helper descent (`run_sub_jitcode_walk`)
+/// and for a recursive root closure driven through the same entry, neither of
+/// which resolves a callee shadow.  Those walk the frame the outer sym already
+/// describes, so keying off the flag would leave them with no frame at all.
 fn active_frame_code<'a, Sym: WalkSym>(
     ctx: &'a WalkContext<'_, '_, Sym>,
 ) -> Option<&'a pyre_interpreter::CodeObject> {
-    let code_ptr = if ctx.fbw_mode.inline_subwalk {
-        ctx.callee_shadow.as_ref()?.code_ptr
+    // A resolved shadow is authoritative: falling back to the outer sym when
+    // its `code_ptr` is unset would answer with the CALLER's frame, the exact
+    // misattribution `active_frame_nlocals` exists to prevent.
+    let code_ptr = if let Some(shadow) = ctx.callee_shadow.as_ref() {
+        shadow.code_ptr
     } else {
         let sym = ctx.fbw_mode.snapshot_sym;
         if sym.is_null() {
@@ -676,10 +686,13 @@ fn active_frame_code<'a, Sym: WalkSym>(
 /// callee then read them back as NULL from the reconstructed frame — the next
 /// call in the callee arrived one positional argument short.
 fn active_frame_nlocals<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> Option<i64> {
-    if ctx.fbw_mode.inline_subwalk {
+    if ctx.callee_shadow.is_some() {
         return active_frame_code(ctx)
             .map(|code| crate::state::callee_layout_for_call_assembler(code).0 as i64);
     }
+    // No callee shadow: the walk names the outer portal frame, and the sym is
+    // the authority for it even where its jitcode carries no code object (a
+    // fixture install), which the code-derived count could not answer.
     let sym = ctx.fbw_mode.snapshot_sym;
     if sym.is_null() {
         return None;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -631,13 +631,61 @@ fn folded_store_is_observable_local<Sym: WalkSym>(
     if !shadow.frame_materialized {
         return false;
     }
+    let Some(nlocals) = active_frame_nlocals(ctx) else {
+        return false;
+    };
+    slot >= 0 && slot < nlocals
+}
+
+/// `CodeObject` of the frame a vable op names — the callee's inside an inline
+/// sub-walk, the outer portal frame's otherwise.
+fn active_frame_code<'a, Sym: WalkSym>(
+    ctx: &'a WalkContext<'_, '_, Sym>,
+) -> Option<&'a pyre_interpreter::CodeObject> {
+    let code_ptr = if ctx.fbw_mode.inline_subwalk {
+        ctx.callee_shadow.as_ref()?.code_ptr
+    } else {
+        let sym = ctx.fbw_mode.snapshot_sym;
+        if sym.is_null() {
+            return None;
+        }
+        // SAFETY: sym and its jitcode are live for the full-body walk; read-only.
+        unsafe {
+            let jitcode = (*sym).jitcode();
+            if jitcode.is_null() {
+                return None;
+            }
+            let jitcode = &*jitcode;
+            jitcode.payload.code_ptr
+        }
+    };
+    // SAFETY: the code object outlives the walk that resolved it; read-only.
+    unsafe { code_ptr.as_ref() }
+}
+
+/// Local-region size of the frame a `getarrayitem_vable_*` /
+/// `setarrayitem_vable_*` slot indexes.
+///
+/// The op names its own frame, so the split between the
+/// `locals_cells_stack_w` prefix and the operand-stack region is that frame's
+/// own count.  `fbw_mode.snapshot_sym` describes the outermost portal frame;
+/// reading the count off it inside a sub-walk misreads every callee slot at or
+/// above the CALLER's count as operand stack.  For `_find_ti(self, dt, i)`
+/// (6 slots) inlined into `utcoffset(self, dt)` (2), that folded away the
+/// `STORE_FAST` of every local from slot 2 up, and a guard resuming inside the
+/// callee then read them back as NULL from the reconstructed frame — the next
+/// call in the callee arrived one positional argument short.
+fn active_frame_nlocals<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> Option<i64> {
+    if ctx.fbw_mode.inline_subwalk {
+        return active_frame_code(ctx)
+            .map(|code| crate::state::callee_layout_for_call_assembler(code).0 as i64);
+    }
     let sym = ctx.fbw_mode.snapshot_sym;
     if sym.is_null() {
-        return false;
+        return None;
     }
     // SAFETY: pointer live for the full-body walk; read-only.
-    let nlocals = unsafe { (*sym).nlocals() } as i64;
-    slot >= 0 && slot < nlocals
+    Some(unsafe { (*sym).nlocals() } as i64)
 }
 
 /// RPython parity: `pyjitpl.py _opimpl_setarrayitem_vable`.
@@ -732,19 +780,16 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     // (`GuardSnapshotVableUntyped`).  Gate on a live mirror + a Ref store into
     // the local region so a genuine null / non-mirrored slot keeps the legacy
     // read.
-    if value.is_none() && value_bank == 'r' && ctx.vstack_valid {
-        let full_body_sym = ctx.fbw_mode.snapshot_sym;
-        if !full_body_sym.is_null() {
-            // SAFETY: pointer live for the full-body walk; read-only.
-            let nlocals = unsafe { (*full_body_sym).nlocals() as i64 };
-            if index_value >= 0 && index_value < nlocals {
-                if let Some(&tos) = ctx.vstack_boxes.last() {
-                    if !tos.is_none() {
-                        value = tos;
-                    }
-                }
-            }
-        }
+    if value.is_none()
+        && value_bank == 'r'
+        && ctx.vstack_valid
+        && let Some(nlocals) = active_frame_nlocals(ctx)
+        && index_value >= 0
+        && index_value < nlocals
+        && let Some(&tos) = ctx.vstack_boxes.last()
+        && !tos.is_none()
+    {
+        value = tos;
     }
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
     let concrete =
@@ -791,43 +836,28 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     // general boundary model remains authoritative for other push/pop shapes.
     // Local/cell stores remain excluded by the `index >= nlocals` gate.
     if value_bank == 'r' && ctx.vstack_valid {
-        let full_body_sym = ctx.fbw_mode.snapshot_sym;
-        if !full_body_sym.is_null() {
-            // SAFETY: pointer live for the full-body walk; read-only.
-            let nlocals = unsafe { (*full_body_sym).nlocals() } as i64;
-            if index_value >= nlocals {
-                let method_load = unsafe {
-                    let jitcode = (*full_body_sym).jitcode();
-                    if jitcode.is_null() {
-                        false
-                    } else {
-                        let jitcode = &*jitcode;
-                        if jitcode.payload.code_ptr.is_null() {
-                            false
-                        } else {
-                            pyre_interpreter::decode_instruction_at(
-                                &*jitcode.payload.code_ptr,
-                                ctx.vstack_cur_pypc as usize,
-                            )
-                            .is_some_and(|(instr, op_arg)| match instr
-                            {
-                                pyre_interpreter::Instruction::LoadAttr { namei } => {
-                                    namei.get(op_arg).is_method()
-                                }
-                                _ => false,
-                            })
+        if let Some(nlocals) = active_frame_nlocals(ctx)
+            && index_value >= nlocals
+        {
+            // `vstack_cur_pypc` is a pc in the frame the op names, so it must
+            // be decoded against that frame's own bytecode.
+            let method_load = active_frame_code(ctx).is_some_and(|code| {
+                pyre_interpreter::decode_instruction_at(code, ctx.vstack_cur_pypc as usize)
+                    .is_some_and(|(instr, op_arg)| match instr {
+                        pyre_interpreter::Instruction::LoadAttr { namei } => {
+                            namei.get(op_arg).is_method()
                         }
-                    }
-                };
-                if method_load {
-                    let stack_slot = (index_value - nlocals) as usize;
-                    if ctx.vstack_boxes.len() <= stack_slot {
-                        ctx.vstack_boxes.resize(stack_slot + 1, OpRef::NONE);
-                    }
-                    ctx.vstack_boxes[stack_slot] = value;
+                        _ => false,
+                    })
+            });
+            if method_load {
+                let stack_slot = (index_value - nlocals) as usize;
+                if ctx.vstack_boxes.len() <= stack_slot {
+                    ctx.vstack_boxes.resize(stack_slot + 1, OpRef::NONE);
                 }
-                ctx.vstack_last_ref = value;
+                ctx.vstack_boxes[stack_slot] = value;
             }
+            ctx.vstack_last_ref = value;
         }
     }
     Ok((DispatchOutcome::Continue, op.next_pc))


### PR DESCRIPTION
Five commits on top of `origin/main`. Four of them are one story: **a
coordinate is only meaningful in the frame, and at the operand offset, that
produced it.** The fifth is the gate that surfaced all of them.

## The gate

`check.py` grows a `cpython-suite` stage that runs `pyre/cpython_tests/run.py`
against `baseline.json` (103 modules, ~300s, dynasm). The suite already
existed; nothing gated it, so a module going `PASS -> FAIL` was invisible
outside a manual run. Every defect below was found by turning it on.

## Three wrong-frame reads

A full-body walk that descends into an inlined callee carries two sets of
metadata: the outer portal frame's, and the callee's. Interpreting a
**callee-scoped** quantity — a vable slot index, a JitCode offset, a Python pc —
with **outer-frame** metadata reads a real value from the wrong frame, which is
why these are miscompiles rather than aborts.

1. **`getarrayitem_vable_*` / `setarrayitem_vable_*` slot split**
   (`vable_ops.rs`). The locals/stack split used the outer sym's `nlocals`,
   so a callee's `STORE_FAST` was classified as a stack push and never
   recorded; the blackhole then read NULL for that local.
   `test.test_datetime` showed it as `_find_ti`'s
   `bisect_right(self.lt[dt.fold], ts)` raising `missing 1 required positional
   argument`.

2. **In-flight `FOR_ITER` identity** (`diag.rs`). The stash paired the
   callee's `op_pc` with the **outer** JitCode's index, so
   `inflight_foriter_body_pc` resolved a callee offset through the caller's pc
   tables and answered with a Python pc belonging to neither loop. A callee
   loop's item was stashed under an identity no resume could match, and a
   caller loop resolving to the same pc had its own entry replaced.

3. **Nested-inline `last_instr`** (`inline_call.rs`). In `f -> g -> h`, the
   coordinate published onto the outer frame while a residual runs came from
   mapping the **intermediate** callee's `op.pc` through the portal's tables.
   Observable as `sys._getframe(2).f_lineno` reporting the driver's `def`-body
   line as well as the real call line — pinned by
   `parity_tests/nested_inline_caller_lineno.py`.

`fbw_mode.inline_subwalk` is **not** the discriminant for "am I in a callee
frame": it is also set for a canonical-helper descent and a recursive root
closure, neither of which resolves a callee. Frame layout keys off
`ctx.callee_shadow`; JitCode identity keys off
`ctx.inline_callee_consts.jitcode_index` — the same resolution
`build_multi_frame_miframe` already applies to its innermost frame.

## The wrong operand offset

`reconstructed_all_ref_call_stack` read the residual op's Ref var-list at
operand offset **1**. That holds for the Ref-only shape `iRd>r`, but the
method-form `CALL` helpers lower through `iIRd>r`, whose leading Int list is
variable-width — `dispatch_residual_call_iIRd_kind` reads its own Ref list at
`1 + i_width`. At offset 1 the read landed on the **Int** list's length byte
and resolved its register indices through the **Ref** bank.

The composed stack passed validation anyway, because the composition
self-corrects its height:

```rust
prefix_len = vstack_boxes.len() - fresh.len()   // absorbs any fresh.len()
stack      = vstack_boxes[..prefix_len] ++ fresh
```

`stack.len() == vstack_boxes.len()` for *any* `fresh`, so the flush's
`depth_at_py_pc` check could not fail. For `p[0]` inside a `for p in ...` body
the committed stack was `[iterator, p, iterator]`, and the interpreter
re-executed the subscript with the loop's iterator as the index:

```python
re.compile("|".join("%d" % x for x in range(2000)))
# TypeError: list indices must be integers or slices, not list_iterator
#   _compiler.py:504 _get_charset_prefix -> op, av = p[0]
```

which failed `test.test_re`. The offset now comes from the op's argcodes,
walking the widths of `blackhole.py:112-157` — the same walk `decode_op_at`
performs. An op declaring no Ref list declines to the legacy replay.

Audited: the other 22 hard-coded offset-1 reads are reached only from
`dispatch_residual_call_iRd_kind`, where 1 is correct.
`reconstructed_all_ref_call_stack` was the single site reachable from both
dispatchers, because it hangs off `try_walker_inline_resolved_user_call`.

## The iterator `__setstate__` cursor

Parity coverage for the `ssize_t` boundary of the cursor, continuing #1074.

## Testing

- `pyre/extra_tests/parity_tests/run.py` — all pass, including the two new
  fixtures (`nested_inline_caller_lineno.py`,
  `foriter_body_call_abort_operand_stack.py`) on cpython, dynasm and cranelift.
- `cargo test -p pyre-jit-trace` — 357 passed, 0 failed. Two new unit tests
  pin the FOR_ITER identity and the argcode-derived offset; both were checked
  green -> red -> green by negating their halves in place.
- `check.py` — `cpython-suite dynasm PASS, 103 modules`. `test.test_re` and
  `test.test_datetime` both pass.

Known base red, not from this branch: `synth/pypy_type_surface` regresses
`bridges_compiled 5 -> 102` on all three backends at this merge-base. It is
the `Cls.__name__` fold guarding a raw null `w_class` on `getset_descriptor`,
fixed by #1106, which is not in this base. Not re-recorded.

## Branch note

This force-update drops `843de7569dc` ("send `pair[i]` on the arity-2 tuple
specialisations back to the residual") from the branch. That commit removed the
subscript fold because it miscompiled `test.test_datetime`; the first commit
here fixes that miscompile at its root, and `test.test_datetime` passes with
the fold in place, so the workaround is no longer needed. The narrower
`SpecialisedPairKind::Object` decline that is already on `main` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional CPython suite validation on Darwin ARM64, including baseline comparisons and timeout reporting.
  * Added `--no-cpython-suite` to skip CPython suite validation when needed.

* **Bug Fixes**
  * Improved JIT behavior for nested inlining, local-variable handling, iterator operations, caller line reporting, and attribute access.
  * Improved coordinate tracking across inlined calls to prevent incorrect runtime results.

* **Tests**
  * Added coverage for nested inlining, iterator state restoration, guard failures, and iterator dispatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->