### PR TITLE
error, baseobjspace, function: four more surrogate-bearing surfaces, and the parity coverage for them

### DIFF
--- a/pyre/extra_tests/parity_tests/mapdict_devolved_raising_eq.py
+++ b/pyre/extra_tests/parity_tests/mapdict_devolved_raising_eq.py
@@ -68,6 +68,8 @@ except ValueError:
     pass
 except KeyError:
     raise AssertionError("raising __eq__ reported as a missing key")
+else:
+    raise AssertionError("raising __eq__ swallowed on the dict subscript")
 
 # A colliding key that compares unequal without raising is an ordinary miss, so
 # the class attribute answers.
@@ -133,5 +135,7 @@ except ValueError:
     pass
 except AttributeError:
     raise AssertionError("raising __eq__ reported as a missing attribute")
+else:
+    raise AssertionError("raising __eq__ swallowed on a surrogate name")
 
 print("OK")

--- a/pyre/extra_tests/parity_tests/os_utime_pathconf_truncate.py
+++ b/pyre/extra_tests/parity_tests/os_utime_pathconf_truncate.py
@@ -117,9 +117,12 @@ check(os.stat(p).st_mtime_ns == storable(2**62), os.stat(p).st_mtime_ns)
 # construction that cannot be every one: an APFS timestamp IS an int64 of
 # nanoseconds, so 2262 is its ceiling too, and ext4 stores a 34-bit second and
 # stops in 2446. Both clamp what they are handed (some hosts refuse it), where
-# NTFS counts 100ns ticks to the year 30828. So the identity — the seconds in
-# nanoseconds, whatever second was stored — is what every platform is held to,
-# and the exact value only where the second survived the round trip.
+# NTFS counts 100ns ticks to the year 30828. A clamp stops at the last instant
+# the store can name, and that need not fall on a whole second: APFS stops at
+# `2**63 - 1` nanoseconds, whose remainder is 854775807ns. So what every
+# platform is held to is that the count neither wrapped nor names a later
+# instant than the one asked for, and that the two fields read back the same
+# time; the exact value only where the second survived the round trip.
 FAR = 8.8e11
 try:
     os.utime(p, (FAR, FAR))
@@ -127,7 +130,9 @@ except OSError:
     pass
 else:
     st = os.stat(p)
-    check(st.st_mtime_ns == int(st.st_mtime) * 1_000_000_000, st.st_mtime_ns)
+    check(0 < st.st_mtime_ns <= int(FAR) * 1_000_000_000, st.st_mtime_ns)
+    second, nanosecond = divmod(st.st_mtime_ns, 1_000_000_000)
+    check(st.st_mtime == second + 1e-9 * nanosecond, (st.st_mtime, st.st_mtime_ns))
     if st.st_mtime == FAR:
         check(st.st_mtime_ns == 880_000_000_000_000_000_000, st.st_mtime_ns)
 

--- a/pyre/extra_tests/parity_tests/surrogate_name_messages.py
+++ b/pyre/extra_tests/parity_tests/surrogate_name_messages.py
@@ -88,6 +88,47 @@ def check_function_qualname():
         raise AssertionError("no TypeError")
 
 
+def check_bound_method_repr():
+    class C:
+        def m(self, a):
+            return a
+
+    C.m.__qualname__ = S
+    o = C()
+    assert repr(o.m).startswith("<bound method %s of " % S), ascii(repr(o.m))
+    assert FFFD not in repr(o.m), ascii(repr(o.m))
+
+    try:
+        o.m()
+    except TypeError as e:
+        assert str(e) == S + "() missing 1 required positional argument: 'a'", ascii(str(e))
+    else:
+        raise AssertionError("no TypeError")
+
+
+def check_unhashable_key_wrapper():
+    # The wrapped hash error becomes this exception's own args[0], so the
+    # surrogate is the value it carries -- escaping belongs to the display.
+    class BadHash:
+        def __hash__(self):
+            raise TypeError(S)
+
+    # Only the wrapped hash message is pinned here.  The type is spelled by
+    # __name__ rather than __qualname__, which is a separate divergence from
+    # the one this checks.
+    for build, kind in ((lambda: {}[BadHash()], "dict key"), (lambda: {BadHash()}, "set element")):
+        try:
+            build()
+        except TypeError as e:
+            tail = " as a %s (%s)" % (kind, S)
+            assert str(e).startswith("cannot use '"), ascii(str(e))
+            assert str(e).endswith(tail), ascii(str(e))
+            assert e.args[0] == str(e), ascii(e.args[0])
+            assert FFFD not in str(e), ascii(str(e))
+        else:
+            raise AssertionError("no TypeError")
+
+
 def check_generator_qualname():
     def g():
         yield 1
@@ -114,12 +155,14 @@ def check_contextvars():
         raise AssertionError("no RuntimeError")
 
     # A variable with no default names itself by repr in the LookupError, so
-    # the message carries whatever its own repr does.
-    unset = contextvars.ContextVar(Repr.__name__)
+    # the message carries whatever its own repr does.  The name holds the
+    # surrogate, so a lossy conversion anywhere on that path shows up here.
+    unset = contextvars.ContextVar(S)
     try:
         unset.get()
     except LookupError as e:
         assert str(e) == repr(unset), ascii(str(e))
+        assert FFFD not in str(e), ascii(str(e))
     else:
         raise AssertionError("no LookupError")
 
@@ -145,6 +188,8 @@ def check_base_exception_str():
 
 
 check_function_qualname()
+check_bound_method_repr()
+check_unhashable_key_wrapper()
 check_generator_qualname()
 check_contextvars()
 check_excepthook()

--- a/pyre/extra_tests/parity_tests/surrogate_traceback_render.py
+++ b/pyre/extra_tests/parity_tests/surrogate_traceback_render.py
@@ -83,8 +83,24 @@ def check_value_keeps_the_code_point():
         raise AssertionError("no AttributeError")
 
 
+def check_syntaxerror_text_render():
+    # A constructor-supplied `text` is any str, unlike a compiled source line,
+    # so it can hold a lone surrogate.  The offending line is escaped and kept,
+    # with the caret still under the reported column -- not replaced wholesale
+    # by a placeholder.
+    script = 'raise SyntaxError("bad", ("x.py", 1, 1, "\\udcff\\n", 1, 2))'
+    proc = subprocess.run([sys.executable, "-c", script], capture_output=True)
+    assert proc.returncode == 1, proc.returncode
+    lines = proc.stderr.splitlines()
+    assert rb'    \udcff' in lines, proc.stderr
+    assert b"    ^" in lines, proc.stderr
+    assert b"<unprintable>" not in proc.stderr, proc.stderr
+    assert lines[-1] == b"SyntaxError: bad", lines[-1]
+
+
 check_uncaught_render()
 check_group_render()
 check_group_str_keeps_the_code_point()
 check_value_keeps_the_code_point()
+check_syntaxerror_text_render()
 print("OK")

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -154,10 +154,15 @@ pub fn wrap_dict_key_hash_error(key: PyObjectRef, err: PyError) -> PyError {
             return err;
         }
     }
-    PyError::type_error(format!(
-        "cannot use '{}' as a dict key ({})",
-        object_functionstr_type_name(key),
-        err.message_text(),
+    // The wrapped message becomes this exception's own `args[0]`, so it is
+    // carried as the value it is; escaping belongs to whatever displays it.
+    PyError::type_error(crate::display::wtf8_format!(
+        format!(
+            "cannot use '{}' as a dict key (",
+            object_functionstr_type_name(key)
+        ),
+        err.message_wtf8(),
+        ")",
     ))
 }
 
@@ -173,10 +178,13 @@ pub fn wrap_set_element_hash_error(item: PyObjectRef, err: PyError) -> PyError {
             return err;
         }
     }
-    PyError::type_error(format!(
-        "cannot use '{}' as a set element ({})",
-        object_functionstr_type_name(item),
-        err.message_text(),
+    PyError::type_error(crate::display::wtf8_format!(
+        format!(
+            "cannot use '{}' as a set element (",
+            object_functionstr_type_name(item)
+        ),
+        err.message_wtf8(),
+        ")",
     ))
 }
 

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1490,12 +1490,13 @@ impl PyError {
             Ok(w) if !w.is_null() && !unsafe { pyre_object::is_none(w) } => w,
             _ => return false,
         };
-        // The buffer is assembled from text the printer already escaped, so
-        // it is well-formed; a decode failure would mean a byte no writer put
-        // there, and the lossy read is the last resort for it.
+        // Every writer into the buffer emits WTF-8, filenames included.  A
+        // decode failure would mean a byte none of them put there; read it the
+        // way a filesystem name is read so it keeps its escape instead of
+        // folding to U+FFFD, and so this sink and the fd sink agree.
         let w_text = match rustpython_wtf8::Wtf8::from_bytes(buf) {
             Some(text) => pyre_object::w_str_from_wtf8(text.to_wtf8_buf()),
-            None => pyre_object::w_str_new(&String::from_utf8_lossy(buf)),
+            None => pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_filename_wtf8(buf)),
         };
         let result = crate::baseobjspace::call_method(stderr, "write", &[w_text]);
         if result.is_null() {
@@ -1898,14 +1899,10 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
         (!w.is_null() && unsafe { pyre_object::is_str(w) })
             .then(|| unsafe { pyre_object::w_str_get_wtf8(w) }.to_owned())
     };
-    // `text` is a line of source, which the compiler only accepted as UTF-8, so
-    // the caret arithmetic below can work on a `str`.
-    let str_of = |w: PyObjectRef| -> Option<String> {
-        wtf8_of(w).map(|wtf8| match wtf8.as_str() {
-            Ok(s) => s.to_owned(),
-            Err(_) => "<unprintable>".to_string(),
-        })
-    };
+    // Code points in a WTF-8 byte run: every byte that is not a continuation
+    // byte starts one, and a lone surrogate is a single three-byte run, so it
+    // counts as the one column the caret arithmetic treats it as.
+    let code_point_len = |bytes: &[u8]| bytes.iter().filter(|b| (*b & 0xC0) != 0x80).count();
     let int_of = |w: PyObjectRef| -> Option<i64> {
         (!w.is_null() && unsafe { pyre_object::is_int(w) })
             .then(|| unsafe { pyre_object::intobject::w_int_get_value(w) })
@@ -1917,18 +1914,31 @@ fn write_syntax_error_object<W: Write>(writer: &mut W, exc: PyObjectRef) -> std:
         writer.write_all(fname.as_bytes())?;
         writeln!(writer, "\", line {lineno}")?;
     }
-    if let Some(text) = str_of(attr("text")) {
-        let raw = text.trim_end_matches(['\n', '\r']);
-        let shown = raw.trim_start();
-        let lead_bytes = raw.len() - shown.len();
-        let lead = raw[..lead_bytes].chars().count();
-        writeln!(writer, "    {shown}")?;
+    if let Some(text) = wtf8_of(attr("text")) {
+        // A constructor-supplied `text` is any str, so it may hold a lone
+        // surrogate even though a compiled line cannot.  It goes out as the
+        // report's own WTF-8 like the filename above; the trims below cut only
+        // ASCII, which leaves the run well-formed.
+        let bytes = text.as_bytes();
+        let end = bytes.len()
+            - bytes
+                .iter()
+                .rev()
+                .take_while(|b| **b == b'\n' || **b == b'\r')
+                .count();
+        let raw = &bytes[..end];
+        let lead_bytes = raw.iter().take_while(|b| b.is_ascii_whitespace()).count();
+        let shown = &raw[lead_bytes..];
+        let lead = code_point_len(&raw[..lead_bytes]);
+        writer.write_all(b"    ")?;
+        writer.write_all(shown)?;
+        writer.write_all(b"\n")?;
         if let Some(offset) = int_of(attr("offset")).filter(|&offset| offset > 0) {
             // Traceback formatting treats the stored columns as display
             // columns and clamps malformed constructor-supplied offsets to
             // the displayed line.  Offsets at or below zero suppress the
             // marker entirely.
-            let displayed_len = raw.chars().count();
+            let displayed_len = code_point_len(raw);
             let display_col = |offset: i64| ((offset as usize) - 1).min(displayed_len);
             let start_col = display_col(offset);
             let end_col = int_of(attr("end_offset"))
@@ -2863,11 +2873,15 @@ fn write_traceback_chain_from_tb<W: Write>(
             continue;
         }
         let (filename, lineno, funcname) = key;
-        // The filesystem bytes, not their WTF-8 decoding: a lone surrogate has
-        // no UTF-8 spelling either way, and the byte form is the one that
-        // still names the file to whatever reads the stream.
+        // The name is *reported* as the text it decodes to, with the same error
+        // handler that read it off the filesystem, so a byte with no UTF-8
+        // spelling reaches the stream as its escape.  Writing the raw bytes
+        // instead would leave the report a mix of those bytes and the WTF-8
+        // around them, which no sink can encode as a whole.  Opening the source
+        // still wants the bytes, which `filename` keeps.
+        let shown_filename = crate::gateway::fsdecode_filename_wtf8(&filename);
         writer.write_all(b"  File \"")?;
-        writer.write_all(&filename)?;
+        writer.write_all(shown_filename.as_bytes())?;
         writeln!(writer, "\", line {lineno}, in {funcname}")?;
         // `FrameSummary._set_lines` collects every line the failing
         // instruction spans, so a statement written across several lines (a
@@ -3142,14 +3156,15 @@ pub(crate) fn emit_report_to_host_stderr(buf: &[u8]) {
             let text = crate::display::wtf8_display_string(report.to_wtf8_buf(), "<unprintable>");
             crate::host_seam::emit_stderr(text.as_bytes());
         }
-        // A frame's `co_filename` goes out as the filesystem bytes it was read
-        // as, so a path byte with no UTF-8 spelling leaves the report a mix of
-        // those bytes and the WTF-8 around them, which is not a WTF-8 buffer
-        // and has no encode to spend. Pass it through: the byte form is what
-        // still names the file to whatever reads the stream, and re-reading it
-        // as UTF-8 would substitute U+FFFD for the one byte that carries the
-        // name.
-        None => crate::host_seam::emit_stderr(buf),
+        // Every writer into the buffer emits WTF-8, so this is a byte none of
+        // them put there.  Read it the way a filesystem name is read, then
+        // spend the same encode the arm above does: the byte survives as its
+        // escape, and this sink and the `sys.stderr` sink agree on the report.
+        None => {
+            let decoded = crate::gateway::fsdecode_filename_wtf8(buf);
+            let text = crate::display::wtf8_display_string(decoded, "<unprintable>");
+            crate::host_seam::emit_stderr(text.as_bytes());
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2813,13 +2813,18 @@ pub unsafe fn descr_method_repr(obj: PyObjectRef) -> Result<PyObjectRef, crate::
         }
         Err(err) => return Err(err),
     };
+    // The name is spliced in as itself, so a lone surrogate in a `__qualname__`
+    // reaches the repr rather than collapsing the whole name to the placeholder.
+    // The `is_str` filter is what makes the unchecked WTF-8 read sound.
     let name = w_name
         .filter(|&value| unsafe { pyre_object::is_str(value) })
-        .and_then(|value| unsafe { pyre_object::w_str_get_value_opt(value) })
-        .unwrap_or("?");
+        .map(|value| unsafe { pyre_object::w_str_get_wtf8(value) }.to_wtf8_buf())
+        .unwrap_or_else(|| Wtf8Buf::from_string("?".to_owned()));
     let instance_repr = unsafe { crate::display::py_repr_wtf8(instance)? };
     Ok(pyre_object::w_str_from_wtf8(crate::display::wtf8_format!(
-        format!("<bound method {name} of "),
+        "<bound method ",
+        name,
+        " of ",
         instance_repr,
         ">"
     )))


### PR DESCRIPTION
Follow-up to #1089, addressing its review findings. The PR merged before the
review was worked through, so the fixes land separately.

## Four more surrogate-bearing surfaces (`4ac2cc9`)

`wrap_dict_key_hash_error` and `wrap_set_element_hash_error` built the outer
message from `message_text()`, whose display-side escape put the six characters
spelling `\udcff` into the new exception's own `args[0]`. They take
`message_wtf8()` instead, so the wrapped value is carried as the value it is and
escaping stays with whatever displays it.

`method_repr` read the bound function's name with `w_str_get_value_opt`, so a
`__qualname__` holding a lone surrogate collapsed the whole name to `?`. It now
reads the name as WTF-8 under an `is_str` filter, which is what makes the
unchecked read sound.

`write_syntax_error_object` replaced a constructor-supplied `text` that is not
valid UTF-8 with `<unprintable>`. The line is kept as WTF-8 and the caret
columns are counted in code points, so the caret still lands under the reported
column.

`write_traceback_chain` wrote a frame's `co_filename` as the filesystem bytes,
which left the report a mix of those bytes and the WTF-8 around it. The name is
decoded for display with the same handler that read it off the filesystem, and
the raw bytes are retained separately for opening the source, so the buffer is
WTF-8 throughout and both stderr sinks spend the same `backslashreplace` encode
on it.

python3.14 renders all four cases with the escape, byte-identically.

## Parity coverage (`d360a18`)

`surrogate_name_messages` gains the bound-method repr and the dict-key /
set-element hash wrappers. Its `ContextVar` LookupError case named the variable
with `Repr.__name__`, which held no surrogate and so could not have failed; it
now uses the surrogate-bearing string.

`surrogate_traceback_render` gains the constructor-supplied `SyntaxError` text.

Two `try` blocks in `mapdict_devolved_raising_eq` asserted that a raising
`__eq__` propagates but had no `else` arm, so a read that returned a value was
reported as a pass.

## Review findings not fixed here

Two were checked against python3.14 and the current behaviour is correct, so
nothing changed: the property `__qualname__` spelling and the `ImportError`
case.

Three are filed as follow-up tasks rather than widened into this diff:

- the borrowed-`&str` probe in `dictmultiobject` wants a reentrancy audit under
  `IndexMap::get`
- dict-key / set-element hash errors name the type by `__name__` rather than
  `__qualname__` — verified byte-identical on `main`, so it predates this work
  and is a separate divergence from the one fixed above
- `pyrex` should keep the script path an `OsString` through `parse_args`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unusual filenames and lone surrogate characters in tracebacks, syntax errors, exception messages, and bound method representations.
  * Improved caret positioning and diagnostic output for source code containing invalid characters.
  * Dictionary and set errors now display affected keys accurately without lossy character replacement.
  * Exceptions raised during key or attribute comparisons now propagate correctly instead of appearing as missing entries.
  * Improved handling of far-future file timestamps while respecting filesystem limits.

* **Tests**
  * Added coverage for invalid-character error messages, comparison exceptions, and timestamp behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->