### PR TITLE
jit: seed the cut-trace escape closure from post-cut guard snapshots

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -442,6 +442,15 @@ jobs:
       env:
         PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
       run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/parity_tests/run.py
+    - name: Run the vendored root extra_tests
+      # PyPy's own `extra_tests/` tree, run in place through a driver that
+      # supplies the pytest names those files use. Only `run.py`'s ENABLED list
+      # runs; the rest of the tree needs pytest surface, third-party packages,
+      # or PyPy modules that are not here. Windows selects nothing today and
+      # the runner exits 0 saying so.
+      env:
+        PYRE_CHECK_PYTHON3: ${{ steps.cpython.outputs.python-path }}
+      run: ${{ steps.cpython.outputs.python-path }} pyre/extra_tests/upstream/run.py
     - name: JIT structural stats vs committed baseline (Linux, informational)
       # Diff each benchmark's [jit-stats] counters against the committed
       # pyre/bench/<name>.<backend>.jitstats baselines. The counters are decided

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -767,12 +767,94 @@ impl TreeLoop {
 
         // Seed with refs used by post-cut ops (args only, not fail_args).
         // RPython CutTrace parity: pre-cut refs in fail_args map to
-        // OpRef::NONE (resume data handles materialization). Only regular
-        // op args seed escaped refs for prefix re-emission.
+        // OpRef::NONE (resume data handles materialization) — fail_args are
+        // attached after optimization by `store_final_boxes_in_guard`, so the
+        // cut namespace owes them nothing. Only regular op args seed escaped
+        // refs for prefix re-emission.
         for op in cut_ops {
             for arg in op.getarglist().iter() {
                 if is_pre_cut_ref(&arg.to_opref()) && escaped_set.insert(arg.to_opref()) {
                     queue.push_back(arg.to_opref());
+                }
+            }
+        }
+
+        // A snapshot is NOT fail_args: it is captured during tracing and is the
+        // only description a guard has of the frame state it resumes into. Some
+        // pre-cut boxes reach the cut region through a snapshot slot alone —
+        // a pure loop-invariant value (`nested + 1` computed once before the
+        // cut) stays live on the Python operand stack across the merge point
+        // while every post-cut operand reads the cached pre-cut box, so no
+        // post-cut ARGUMENT names it and the loop above never sees it.
+        //
+        // Upstream never has to re-emit any of this: `CutTrace`
+        // (`opencoder.py`) is a view over the same trace, and the cut is a
+        // jitdriver merge point where the whole live set is already
+        // `inputargs` — a snapshot referencing a position before `start` would
+        // trip `TraceIterator._get`'s assert. Pyre cuts at a position whose
+        // live set is wider than `original_boxes`, so a snapshot-only
+        // reference has to seed the same prefix re-emission the operand path
+        // uses. Left unseeded, the remap below rewrote the slot to
+        // `OpRef::NONE`, `_number_boxes` emitted `NULLREF`, and the resumed
+        // frame's operand slot was written NULL — the argument of a live call
+        // arriving unbound.
+        //
+        // Prefix re-emission RE-EXECUTES the definition at the cut point, so it
+        // reconstructs faithfully only where nothing it drags along carries a
+        // side effect. The BFS below pulls in the whole transitive definition
+        // cone, so the condition is on the CONE, not the root: an allocation
+        // whose field feeds from a residual call would re-issue that call. Walk
+        // the pre-cut dependencies and admit only an entirely side-effect-free
+        // cone; anything else keeps the `OpRef::NONE` mapping it has today.
+        // A `CallMayForceR` in a snapshot slot is therefore still lost — an
+        // extra observable call is worse than the NULL slot it would repair.
+        // Allocation (`NewWithVtable`) IS re-emitted: resume already hands a
+        // virtual a fresh object, and the boxed operands this recovers are
+        // compared by value. A pre-cut ORIGINAL inputarg has no definition to
+        // re-execute — phase 4 maps it to its pool constant — so it is a leaf.
+        let snapshot_cone_is_reemittable = |root: &OpRef| -> bool {
+            let mut seen: IndexSet<OpRef> = IndexSet::new();
+            let mut stack: Vec<OpRef> = vec![*root];
+            while let Some(r) = stack.pop() {
+                if r.raw() < num_original_inputargs || !seen.insert(r) {
+                    continue;
+                }
+                let Some(op) = self.ops.get((r.raw() - num_original_inputargs) as usize) else {
+                    return false;
+                };
+                if !op.opcode.has_no_side_effect() {
+                    return false;
+                }
+                for arg in op.getarglist().iter() {
+                    let a = arg.to_opref();
+                    if is_pre_cut_ref(&a) {
+                        stack.push(a);
+                    }
+                }
+            }
+            true
+        };
+        for op in cut_ops {
+            let snapshot_id = op.rd_resume_position.get();
+            if snapshot_id < 0 {
+                continue;
+            }
+            let Some(snap) = self.snapshots.get(snapshot_id as usize) else {
+                continue;
+            };
+            let tagged = snap
+                .vable_boxes
+                .iter()
+                .chain(snap.vref_boxes.iter())
+                .chain(snap.frames.iter().flat_map(|f| f.boxes.iter()));
+            for t in tagged {
+                if let crate::recorder::SnapshotTagged::Box(r, _) = t {
+                    if is_pre_cut_ref(r)
+                        && snapshot_cone_is_reemittable(r)
+                        && escaped_set.insert(*r)
+                    {
+                        queue.push_back(*r);
+                    }
                 }
             }
         }
@@ -1888,6 +1970,105 @@ mod tests {
         assert_eq!(cut.ops[3].opcode, OpCode::Jump);
         // Verify remapping chain: v2's arg should reference re-emitted v1
         assert_eq!(cut.ops[1].arg(0).to_opref(), iop(1)); // v1 → prefix idx 0 → BoxInt at position 1
+    }
+
+    /// Build a one-frame snapshot whose virtualizable array is `vable`.
+    fn snapshot_with_vable(
+        vable: Vec<crate::recorder::SnapshotTagged>,
+    ) -> crate::recorder::Snapshot {
+        crate::recorder::Snapshot {
+            frames: vec![crate::recorder::SnapshotFrame {
+                jitcode_index: 0,
+                pc: 0,
+                py_pc: 0,
+                boxes: Vec::new(),
+            }],
+            vable_boxes: vable,
+            vref_boxes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_cut_trace_from_reemits_ref_held_only_by_a_snapshot() {
+        // A pre-cut op that NO post-cut argument names, but that a post-cut
+        // guard's snapshot still holds: the operand-stack slot of a loop-
+        // invariant value. Seeded only from op args, the cut mapped it to
+        // `OpRef::NONE`, `_number_boxes` emitted NULLREF, and the resumed
+        // frame read that operand as NULL.
+        let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
+        let mut ops = Vec::new();
+        // v2 = int_add(v0, v1) — before the cut; consumed by nothing after it.
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
+        op0.pos.set(iop(2));
+        ops.push(op0);
+        // guard_true(v0) — after the cut, resuming through snapshot 0.
+        let mut op1 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        op1.pos.set(vop(3));
+        op1.rd_resume_position.set(0);
+        ops.push(op1);
+        let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+        op2.pos.set(vop(4));
+        ops.push(op2);
+        let snapshots = vec![snapshot_with_vable(vec![
+            crate::recorder::SnapshotTagged::Box(iop(2), Type::Int),
+        ])];
+        let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
+
+        let start = TreeLoopCutPosition::new(1); // cut after op0
+        let original_boxes = vec![
+            crate::trace_ctx::GreenBox::new(iarg(0), Type::Int),
+            crate::trace_ctx::GreenBox::new(iarg(1), Type::Int),
+        ];
+        let cut = trace.cut_trace_from(start, &original_boxes);
+
+        // The add is re-emitted as a prefix op, and the snapshot slot names it.
+        assert_eq!(cut.ops[0].opcode, OpCode::IntAdd);
+        let slot = cut.snapshots[0].vable_boxes[0];
+        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
+            panic!("snapshot slot lost its box: {slot:?}");
+        };
+        assert!(!r.is_none(), "snapshot slot mapped to NONE: {slot:?}");
+        assert_eq!(r, cut.ops[0].pos.get());
+    }
+
+    #[test]
+    fn test_cut_trace_from_leaves_side_effecting_snapshot_ref_unmapped() {
+        // Re-emission re-EXECUTES the definition, so a side-effecting pre-cut
+        // op is not admitted: an extra observable call is worse than the NULL
+        // slot it would repair. It keeps the `OpRef::NONE` mapping.
+        let inputargs = vec![InputArg::new_int(0)];
+        let mut ops = Vec::new();
+        let mut op0 = Op::new(OpCode::CallMayForceR, &[iarg_box(0)]);
+        op0.pos.set(OpRef::ref_op(1));
+        ops.push(op0);
+        let mut op1 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        op1.pos.set(vop(2));
+        op1.rd_resume_position.set(0);
+        ops.push(op1);
+        let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+        op2.pos.set(vop(3));
+        ops.push(op2);
+        let snapshots = vec![snapshot_with_vable(vec![
+            crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
+        ])];
+        let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
+
+        let start = TreeLoopCutPosition::new(1);
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
+        let cut = trace.cut_trace_from(start, &original_boxes);
+
+        assert!(
+            cut.ops.iter().all(|o| o.opcode != OpCode::CallMayForceR),
+            "a side-effecting op was re-emitted into the cut prefix"
+        );
+        let slot = cut.snapshots[0].vable_boxes[0];
+        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
+            panic!("unexpected snapshot slot shape: {slot:?}");
+        };
+        assert!(
+            r.is_none(),
+            "expected the unmapped NONE fallback, got {r:?}"
+        );
     }
 
     // ══════════════════════════════════════════════════════════════════

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -859,13 +859,31 @@ impl TreeLoop {
         // undeliverable — so test the same predicate phase 4 branches on and
         // decline when the constant is absent: `test.test_collections` and
         // `test.test_urlparse` crashed on that assert with `18 != 19`.
-        let snapshot_cone_is_reemittable = |root: &OpRef| -> bool {
+        //
+        // One impure ROOT stays admissible: an allocation, replayed TOGETHER
+        // with the stores that filled it. Replaying `New*` alone is what makes
+        // it inadmissible — the contents come from separate `SetfieldGc`s that
+        // no argument cone reaches, so the object arrives blank — but those
+        // stores write into an object that does not exist yet in the cut
+        // namespace, so replaying them observes nothing. That holds only while
+        // every pre-cut op naming the allocation is either a guard, which reads
+        // it and retains nothing, or a store whose FIRST argument is the
+        // allocation itself. A store that puts it into something else, or a
+        // call that receives it, publishes the object: a replay then mints a
+        // second identity that the original holder can tell apart, so refuse.
+        // Each stored value has to be reconstructible in its own right, so it
+        // is walked like any other operand.
+        //
+        // Returns the extra pre-cut ops the caller must seed alongside the
+        // root; `None` is the decline.
+        let snapshot_cone_is_reemittable = |root: &OpRef| -> Option<Vec<OpRef>> {
             let mut seen: IndexSet<OpRef> = IndexSet::new();
-            let mut stack: Vec<OpRef> = vec![*root];
-            while let Some(r) = stack.pop() {
+            let mut extra: Vec<OpRef> = Vec::new();
+            let mut stack: Vec<(OpRef, bool)> = vec![(*root, true)];
+            while let Some((r, is_root)) = stack.pop() {
                 if r.raw() < num_original_inputargs {
                     if inputarg_consts.get(r.raw() as usize).is_none() {
-                        return false;
+                        return None;
                     }
                     continue;
                 }
@@ -873,19 +891,46 @@ impl TreeLoop {
                     continue;
                 }
                 let Some(op) = self.ops.get((r.raw() - num_original_inputargs) as usize) else {
-                    return false;
+                    return None;
                 };
                 if !op.opcode.is_always_pure() {
-                    return false;
+                    if !is_root || !op.opcode.is_malloc() {
+                        return None;
+                    }
+                    for other in self.ops[..start.op_index].iter() {
+                        if !other.getarglist().iter().any(|a| a.to_opref() == r) {
+                            continue;
+                        }
+                        if other.opcode.is_guard() {
+                            continue;
+                        }
+                        let fills_the_allocation = (other.opcode.is_setfield()
+                            || other.opcode.is_setarrayitem()
+                            || other.opcode.is_setinteriorfield())
+                            && other.arg(0).to_opref() == r;
+                        if !fills_the_allocation {
+                            return None;
+                        }
+                        for i in 1..other.num_args() {
+                            let a = other.arg(i).to_opref();
+                            if a == r {
+                                return None;
+                            }
+                            if is_pre_cut_ref(&a) {
+                                stack.push((a, false));
+                            }
+                        }
+                        extra.push(other.pos.get());
+                    }
                 }
                 for arg in op.getarglist().iter() {
                     let a = arg.to_opref();
                     if is_pre_cut_ref(&a) {
-                        stack.push(a);
+                        stack.push((a, false));
                     }
                 }
             }
-            true
+            Some(extra)
         };
         for op in cut_ops {
             let snapshot_id = op.rd_resume_position.get();
@@ -905,7 +950,7 @@ impl TreeLoop {
                     if !is_pre_cut_ref(r) {
                         continue;
                     }
-                    if !snapshot_cone_is_reemittable(r) {
+                    let Some(extra) = snapshot_cone_is_reemittable(r) else {
                         if crate::majit_log_enabled() {
                             let root = r
                                 .raw()
@@ -919,9 +964,16 @@ impl TreeLoop {
                             );
                         }
                         return None;
-                    }
+                    };
                     if escaped_set.insert(*r) {
                         queue.push_back(*r);
+                    }
+                    // The allocation's filling stores ride along; `op_escaped`
+                    // is ordered by position, so they re-emit after it.
+                    for e in extra {
+                        if escaped_set.insert(e) {
+                            queue.push_back(e);
+                        }
                     }
                 }
             }
@@ -2203,6 +2255,105 @@ mod tests {
         );
     }
 
+    /// Ref-typed sibling of [`iop_box`], for allocation results.
+    fn rop_box(pos: u32) -> Operand {
+        rooted_resop_operand(Type::Ref, pos)
+    }
+
+    #[test]
+    fn test_cut_trace_from_replays_an_allocation_with_the_stores_that_filled_it() {
+        // `New*` alone reconstructs a BLANK object, because its contents come
+        // from separate stores no argument cone reaches. Replaying those stores
+        // alongside it restores the contents, and they observe nothing: they
+        // write into an object that does not exist yet in the cut namespace.
+        // The `GuardClass` reads the allocation and retains nothing, so it does
+        // not block the admission and is not replayed.
+        let inputargs = vec![InputArg::new_int(0)];
+        let mut op0 = Op::new(OpCode::NewWithVtable, &[]);
+        op0.pos.set(OpRef::ref_op(1));
+        let mut op1 = Op::new(OpCode::SetfieldGc, &[rop_box(1), iarg_box(0)]);
+        op1.pos.set(vop(2));
+        let mut op2 = Op::new(OpCode::GuardClass, &[rop_box(1)]);
+        op2.pos.set(vop(3));
+        let mut op3 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        op3.pos.set(vop(4));
+        op3.rd_resume_position.set(0);
+        let mut op4 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+        op4.pos.set(vop(5));
+        let snapshots = vec![snapshot_with_frame_boxes(vec![
+            crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
+        ])];
+        let trace = TreeLoop::with_snapshots(inputargs, vec![op0, op1, op2, op3, op4], snapshots);
+
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
+        let cut = trace
+            .cut_trace_from(TreeLoopCutPosition::new(3), &original_boxes)
+            .expect("an unpublished allocation and its stores are replayable");
+
+        assert_eq!(cut.ops[0].opcode, OpCode::NewWithVtable);
+        assert_eq!(
+            cut.ops[1].opcode,
+            OpCode::SetfieldGc,
+            "the store that filled the allocation was not replayed with it"
+        );
+        assert_eq!(
+            cut.ops[1].arg(0).to_opref(),
+            cut.ops[0].pos.get(),
+            "the replayed store does not write into the replayed allocation"
+        );
+        let slot = cut.snapshots[0].frames[0].boxes[0];
+        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
+            panic!("snapshot slot lost its box: {slot:?}");
+        };
+        assert_eq!(r, cut.ops[0].pos.get());
+    }
+
+    #[test]
+    fn test_cut_trace_from_declines_on_an_allocation_that_escaped() {
+        // Publishing the allocation gives a second holder that can tell the
+        // replayed identity apart from the original. Both shapes publish it:
+        // storing it INTO another object, and handing it to a call — the call
+        // is the one the store-shape checks cannot see, since it is neither a
+        // guard nor a store at all.
+        for publish_with_a_call in [false, true] {
+            let inputargs = vec![InputArg::new_int(0)];
+            let mut op0 = Op::new(OpCode::NewWithVtable, &[]);
+            op0.pos.set(OpRef::ref_op(1));
+            let mut op1 = Op::new(OpCode::NewWithVtable, &[]);
+            op1.pos.set(OpRef::ref_op(2));
+            let mut publish = if publish_with_a_call {
+                Op::new(OpCode::CallMayForceR, &[rop_box(1)])
+            } else {
+                Op::new(OpCode::SetfieldGc, &[rop_box(2), rop_box(1)])
+            };
+            publish.pos.set(if publish_with_a_call {
+                OpRef::ref_op(3)
+            } else {
+                vop(3)
+            });
+            let mut op3 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+            op3.pos.set(vop(4));
+            op3.rd_resume_position.set(0);
+            let mut op4 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+            op4.pos.set(vop(5));
+            let snapshots = vec![snapshot_with_frame_boxes(vec![
+                crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
+            ])];
+            let trace =
+                TreeLoop::with_snapshots(inputargs, vec![op0, op1, publish, op3, op4], snapshots);
+
+            let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
+            let cut = trace.cut_trace_from(TreeLoopCutPosition::new(3), &original_boxes);
+
+            assert!(
+                cut.is_none(),
+                "an allocation published by a {} was replayed; snapshot slot is {:?}",
+                if publish_with_a_call { "call" } else { "store" },
+                cut.map(|c| c.snapshots[0].frames[0].boxes[0]),
+            );
+        }
+    }
+
     #[test]
     fn test_cut_trace_from_declines_on_an_effect_observing_snapshot_ref() {
         // The boundary that matters is `is_always_pure`, not
@@ -2211,7 +2362,13 @@ mod tests {
         // so it never joins the cone; re-emitting the load at cut entry would
         // read the value written AFTER the snapshot named it. Pin the gap
         // between the two predicates so widening it back is a test failure.
-        for opcode in [OpCode::GetfieldGcR, OpCode::GcLoadR, OpCode::NewWithVtable] {
+        //
+        // The loads carry that subject on their own. `New*` also sits in the
+        // gap but has a rule of its own — it is replayed together with the
+        // stores that fill it, see
+        // `test_cut_trace_from_replays_an_allocation_with_the_stores_that_filled_it`
+        // and `test_cut_trace_from_declines_on_an_allocation_that_escaped`.
+        for opcode in [OpCode::GetfieldGcR, OpCode::GcLoadR] {
             assert!(
                 opcode.has_no_side_effect() && !opcode.is_always_pure(),
                 "{opcode:?} no longer sits between the two predicates, so this \

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -810,13 +810,30 @@ impl TreeLoop {
         // extra observable call is worse than the NULL slot it would repair.
         // Allocation (`NewWithVtable`) IS re-emitted: resume already hands a
         // virtual a fresh object, and the boxed operands this recovers are
-        // compared by value. A pre-cut ORIGINAL inputarg has no definition to
-        // re-execute — phase 4 maps it to its pool constant — so it is a leaf.
+        // compared by value.
+        //
+        // A pre-cut ORIGINAL inputarg has no definition to re-execute, so it is
+        // a leaf — but only phase 4's pool-constant arm can actually deliver
+        // one. Its other arm appends the inputarg to the new entry contract, and
+        // `patch_new_loop_to_load_virtualizable_fields` requires that list to be
+        // exactly the red args followed by the virtualizable's static fields and
+        // array items, asserting it (`compile.py:458`). A snapshot's frame boxes
+        // ARE the frame's locals, so seeding from snapshots reaches original
+        // inputargs constantly where operand seeding reached them rarely. Test
+        // the same predicate phase 4 branches on, and refuse the root when the
+        // constant is absent: a widened entry contract crashes the compile,
+        // which is worse than the NULL slot it would repair.
         let snapshot_cone_is_reemittable = |root: &OpRef| -> bool {
             let mut seen: IndexSet<OpRef> = IndexSet::new();
             let mut stack: Vec<OpRef> = vec![*root];
             while let Some(r) = stack.pop() {
-                if r.raw() < num_original_inputargs || !seen.insert(r) {
+                if r.raw() < num_original_inputargs {
+                    if inputarg_consts.get(r.raw() as usize).is_none() {
+                        return false;
+                    }
+                    continue;
+                }
+                if !seen.insert(r) {
                     continue;
                 }
                 let Some(op) = self.ops.get((r.raw() - num_original_inputargs) as usize) else {
@@ -2069,6 +2086,57 @@ mod tests {
             r.is_none(),
             "expected the unmapped NONE fallback, got {r:?}"
         );
+    }
+
+    #[test]
+    fn test_cut_trace_from_snapshot_seed_does_not_widen_the_entry_contract() {
+        // A snapshot's frame boxes are the frame's locals, so a snapshot root's
+        // cone reaches original inputargs that no post-cut argument names. Phase
+        // 4 can only deliver such an inputarg from a pool constant; without one
+        // it appends an extra inputarg, and
+        // `patch_new_loop_to_load_virtualizable_fields` asserts the list is
+        // exactly the red args plus the virtualizable's fields
+        // (`compile.py:458`) — `test.test_collections` and `test.test_urlparse`
+        // crashed there with `assert i == len(inputargs) failed (18 != 19)`.
+        // Refuse the root instead; the slot keeps the NONE it has today.
+        let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
+        let mut ops = Vec::new();
+        // v2 = int_add(v0, v1) — pre-cut, named by nothing after the cut.
+        let mut op0 = Op::new(OpCode::IntAdd, &[iarg_box(0), iarg_box(1)]);
+        op0.pos.set(iop(2));
+        ops.push(op0);
+        let mut op1 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+        op1.pos.set(vop(3));
+        op1.rd_resume_position.set(0);
+        ops.push(op1);
+        let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+        op2.pos.set(vop(4));
+        ops.push(op2);
+        let snapshots = vec![snapshot_with_vable(vec![
+            crate::recorder::SnapshotTagged::Box(iop(2), Type::Int),
+        ])];
+        let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
+
+        // v1 is deliberately NOT an original box, and `cut_trace_from` passes an
+        // empty constant pool, so phase 4 would have to invent an inputarg.
+        let start = TreeLoopCutPosition::new(1);
+        let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
+        let cut = trace.cut_trace_from(start, &original_boxes);
+
+        assert_eq!(
+            cut.inputargs.len(),
+            original_boxes.len(),
+            "the cut invented an inputarg the virtualizable expansion cannot account for"
+        );
+        assert!(
+            cut.ops.iter().all(|o| o.opcode != OpCode::IntAdd),
+            "a root whose cone needs an undeliverable inputarg was re-emitted"
+        );
+        let slot = cut.snapshots[0].vable_boxes[0];
+        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
+            panic!("unexpected snapshot slot shape: {slot:?}");
+        };
+        assert!(r.is_none(), "expected the unmapped NONE fallback, got {r:?}");
     }
 
     // ══════════════════════════════════════════════════════════════════

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2136,7 +2136,10 @@ mod tests {
         let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
             panic!("unexpected snapshot slot shape: {slot:?}");
         };
-        assert!(r.is_none(), "expected the unmapped NONE fallback, got {r:?}");
+        assert!(
+            r.is_none(),
+            "expected the unmapped NONE fallback, got {r:?}"
+        );
     }
 
     // ══════════════════════════════════════════════════════════════════

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -708,11 +708,13 @@ impl TreeLoop {
     /// become the new inputargs; any OpRef referenced after the cut but
     /// defined before it (and not in `original_boxes`) is re-emitted as a
     /// prefix operation (transitive closure of dependencies).
+    /// `None` when the cut cannot be taken without losing a live value; see
+    /// [`Self::cut_trace_from_with_consts`].  The caller keeps the uncut trace.
     pub fn cut_trace_from(
         &self,
         start: TreeLoopCutPosition,
         original_boxes: &[crate::trace_ctx::GreenBox],
-    ) -> TreeLoop {
+    ) -> Option<TreeLoop> {
         self.cut_trace_from_with_consts(start, original_boxes, &[])
     }
 
@@ -720,12 +722,26 @@ impl TreeLoop {
     /// original inputarg.  Escaped original inputargs are remapped to these
     /// pool-managed constants (already GC-rooted), preventing both stale
     /// pointers and entry-contract mismatches at compiled-code entry.
+    ///
+    /// Returns `None` when a pre-cut box reaches the cut region through a
+    /// guard snapshot alone and its definition cone cannot be re-emitted.
+    /// The value has no representation in the cut namespace, and the only
+    /// alternatives are a wrong one (mapping the slot to `OpRef::NONE`, which
+    /// the encoder turns into a NULL in the resumed frame) or re-executing a
+    /// side effect.
+    ///
+    /// The caller must CANCEL the compilation, not fall back to the uncut
+    /// trace: once a merge point is live, the loop token, entry contract and
+    /// optimizer seed downstream are all built for the cut namespace, and
+    /// handing them the uncut trace fails `test_re` outright (measured 3/3 vs
+    /// 0/3 on a same-binary toggle).  Cancelling runs the loop in the
+    /// interpreter, which is correct.
     pub fn cut_trace_from_with_consts(
         &self,
         start: TreeLoopCutPosition,
         original_boxes: &[crate::trace_ctx::GreenBox],
         inputarg_consts: &[OpRef],
-    ) -> TreeLoop {
+    ) -> Option<TreeLoop> {
         use indexmap::IndexSet;
         use std::collections::VecDeque;
 
@@ -805,12 +821,19 @@ impl TreeLoop {
         // cone, so the condition is on the CONE, not the root: an allocation
         // whose field feeds from a residual call would re-issue that call. Walk
         // the pre-cut dependencies and admit only an entirely side-effect-free
-        // cone; anything else keeps the `OpRef::NONE` mapping it has today.
-        // A `CallMayForceR` in a snapshot slot is therefore still lost — an
-        // extra observable call is worse than the NULL slot it would repair.
-        // Allocation (`NewWithVtable`) IS re-emitted: resume already hands a
-        // virtual a fresh object, and the boxed operands this recovers are
+        // cone. Allocation (`NewWithVtable`) IS re-emitted: resume already hands
+        // a virtual a fresh object, and the boxed operands this recovers are
         // compared by value.
+        //
+        // A cone that is NOT re-emittable (a `CallMayForceR` feeding a snapshot
+        // slot) leaves the value with no representation in the cut namespace at
+        // all: the operand stack it lives on is in the virtualizable, not in
+        // `original_boxes`, so it is neither an inputarg nor re-derivable. Both
+        // remaining options are worse than not cutting — mapping the slot to
+        // `OpRef::NONE` writes a NULL into the resumed frame (a live call
+        // argument arriving unbound), and re-emitting issues an extra observable
+        // call. Decline; the caller cancels the compilation and the loop runs in
+        // the interpreter.
         //
         // A pre-cut ORIGINAL inputarg has no definition to re-execute, so it is
         // a leaf — but only phase 4's pool-constant arm can actually deliver
@@ -820,9 +843,9 @@ impl TreeLoop {
         // array items, asserting it (`compile.py:458`). A snapshot's frame boxes
         // ARE the frame's locals, so seeding from snapshots reaches original
         // inputargs constantly where operand seeding reached them rarely. Test
-        // the same predicate phase 4 branches on, and refuse the root when the
-        // constant is absent: a widened entry contract crashes the compile,
-        // which is worse than the NULL slot it would repair.
+        // the same predicate phase 4 branches on, and decline when the constant
+        // is absent: a widened entry contract crashes the compile, which is
+        // worse still than the NULL slot it would repair.
         let snapshot_cone_is_reemittable = |root: &OpRef| -> bool {
             let mut seen: IndexSet<OpRef> = IndexSet::new();
             let mut stack: Vec<OpRef> = vec![*root];
@@ -866,10 +889,19 @@ impl TreeLoop {
                 .chain(snap.frames.iter().flat_map(|f| f.boxes.iter()));
             for t in tagged {
                 if let crate::recorder::SnapshotTagged::Box(r, _) = t {
-                    if is_pre_cut_ref(r)
-                        && snapshot_cone_is_reemittable(r)
-                        && escaped_set.insert(*r)
-                    {
+                    if !is_pre_cut_ref(r) {
+                        continue;
+                    }
+                    if !snapshot_cone_is_reemittable(r) {
+                        if crate::majit_log_enabled() {
+                            eprintln!(
+                                "[jit][cut-decline] snapshot-only ref {r:?} has a \
+                                 side-effecting definition cone; keeping the uncut trace",
+                            );
+                        }
+                        return None;
+                    }
+                    if escaped_set.insert(*r) {
                         queue.push_back(*r);
                     }
                 }
@@ -1122,7 +1154,11 @@ impl TreeLoop {
                 }
             })
             .collect();
-        TreeLoop::from_oprc(new_inputargs, new_ops, remapped_snapshots)
+        Some(TreeLoop::from_oprc(
+            new_inputargs,
+            new_ops,
+            remapped_snapshots,
+        ))
     }
 }
 
@@ -1880,7 +1916,9 @@ mod tests {
             crate::trace_ctx::GreenBox::new(iarg(1), Type::Int),
         ];
 
-        let cut = trace.cut_trace_from(start, &original_boxes);
+        let cut = trace
+            .cut_trace_from(start, &original_boxes)
+            .expect("cut declined unexpectedly");
         assert_eq!(cut.inputargs.len(), 2);
         assert_eq!(cut.ops.len(), 2); // IntMul + Jump
         assert_eq!(cut.ops[0].opcode, OpCode::IntMul);
@@ -1913,7 +1951,9 @@ mod tests {
         // original_boxes only has v0 — v2 is escaped
         let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes);
+        let cut = trace
+            .cut_trace_from(start, &original_boxes)
+            .expect("cut declined unexpectedly");
         // v1 = OpRef::input_arg_int(1) is an original trace inputarg NOT in original_boxes.
         // It's referenced by the escaped int_add op → added as extra inputarg.
         // Result: inputargs = [v0, v1], prefix = [int_add], post-cut = [int_mul, jump]
@@ -1946,7 +1986,9 @@ mod tests {
         let start = TreeLoopCutPosition::new(1);
         let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes);
+        let cut = trace
+            .cut_trace_from(start, &original_boxes)
+            .expect("cut declined unexpectedly");
         assert_eq!(cut.ops.len(), 2);
         // Constant ref should be preserved as-is
         assert_eq!(cut.ops[0].arg(1).to_opref(), const_ref);
@@ -1977,7 +2019,9 @@ mod tests {
         let start = TreeLoopCutPosition::new(2); // cut after op0 and op1
         let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
 
-        let cut = trace.cut_trace_from(start, &original_boxes);
+        let cut = trace
+            .cut_trace_from(start, &original_boxes)
+            .expect("cut declined unexpectedly");
         // 1 inputarg, 2 prefix ops (v1=int_add, v2=int_mul), 2 post-cut ops
         assert_eq!(cut.inputargs.len(), 1);
         assert_eq!(cut.ops.len(), 4);
@@ -2036,7 +2080,9 @@ mod tests {
             crate::trace_ctx::GreenBox::new(iarg(0), Type::Int),
             crate::trace_ctx::GreenBox::new(iarg(1), Type::Int),
         ];
-        let cut = trace.cut_trace_from(start, &original_boxes);
+        let cut = trace
+            .cut_trace_from(start, &original_boxes)
+            .expect("cut declined unexpectedly");
 
         // The add is re-emitted as a prefix op, and the snapshot slot names it.
         assert_eq!(cut.ops[0].opcode, OpCode::IntAdd);
@@ -2049,10 +2095,12 @@ mod tests {
     }
 
     #[test]
-    fn test_cut_trace_from_leaves_side_effecting_snapshot_ref_unmapped() {
+    fn test_cut_trace_from_declines_on_a_side_effecting_snapshot_ref() {
         // Re-emission re-EXECUTES the definition, so a side-effecting pre-cut
-        // op is not admitted: an extra observable call is worse than the NULL
-        // slot it would repair. It keeps the `OpRef::NONE` mapping.
+        // op is not admitted. The value then has no representation in the cut
+        // namespace at all, and mapping the slot to `OpRef::NONE` would write a
+        // NULL into the resumed frame — so the cut is declined outright and the
+        // caller keeps the uncut trace, which still holds the definition.
         let inputargs = vec![InputArg::new_int(0)];
         let mut ops = Vec::new();
         let mut op0 = Op::new(OpCode::CallMayForceR, &[iarg_box(0)]);
@@ -2075,16 +2123,9 @@ mod tests {
         let cut = trace.cut_trace_from(start, &original_boxes);
 
         assert!(
-            cut.ops.iter().all(|o| o.opcode != OpCode::CallMayForceR),
-            "a side-effecting op was re-emitted into the cut prefix"
-        );
-        let slot = cut.snapshots[0].vable_boxes[0];
-        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
-            panic!("unexpected snapshot slot shape: {slot:?}");
-        };
-        assert!(
-            r.is_none(),
-            "expected the unmapped NONE fallback, got {r:?}"
+            cut.is_none(),
+            "expected the cut to be declined, got a trace whose snapshot slot is {:?}",
+            cut.map(|c| c.snapshots[0].vable_boxes[0]),
         );
     }
 
@@ -2098,7 +2139,9 @@ mod tests {
         // exactly the red args plus the virtualizable's fields
         // (`compile.py:458`) — `test.test_collections` and `test.test_urlparse`
         // crashed there with `assert i == len(inputargs) failed (18 != 19)`.
-        // Refuse the root instead; the slot keeps the NONE it has today.
+        // `is_always_pure()` does not cover this: the root here is an `IntAdd`,
+        // so the cone is replay-safe and it is the ENTRY CONTRACT, not the
+        // replay, that cannot represent the value. Decline the cut.
         let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
         let mut ops = Vec::new();
         // v2 = int_add(v0, v1) — pre-cut, named by nothing after the cut.
@@ -2123,22 +2166,11 @@ mod tests {
         let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
         let cut = trace.cut_trace_from(start, &original_boxes);
 
-        assert_eq!(
-            cut.inputargs.len(),
+        assert!(
+            cut.is_none(),
+            "expected the cut to be declined, got one with {:?} inputargs for {} original boxes",
+            cut.map(|c| c.inputargs.len()),
             original_boxes.len(),
-            "the cut invented an inputarg the virtualizable expansion cannot account for"
-        );
-        assert!(
-            cut.ops.iter().all(|o| o.opcode != OpCode::IntAdd),
-            "a root whose cone needs an undeliverable inputarg was re-emitted"
-        );
-        let slot = cut.snapshots[0].vable_boxes[0];
-        let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
-            panic!("unexpected snapshot slot shape: {slot:?}");
-        };
-        assert!(
-            r.is_none(),
-            "expected the unmapped NONE fallback, got {r:?}"
         );
     }
 

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2052,18 +2052,28 @@ mod tests {
         assert_eq!(cut.ops[1].arg(0).to_opref(), iop(1)); // v1 → prefix idx 0 → BoxInt at position 1
     }
 
-    /// Build a one-frame snapshot whose virtualizable array is `vable`.
-    fn snapshot_with_vable(
-        vable: Vec<crate::recorder::SnapshotTagged>,
+    /// Build a one-frame snapshot whose frame-live array is `boxes`.
+    ///
+    /// These are the frame's locals and operand stack — `_list_of_boxes`
+    /// (`opencoder.py:712-716`), consumed by `_prepare_next_section` — and the
+    /// array the dropped call operand actually lived in. `vable_boxes` and
+    /// `vref_boxes` are left empty on purpose: they are not interchangeable
+    /// with frame-live slots. `consume_virtualizable_boxes` reads slot zero as
+    /// the virtualizable ITSELF and sizes the rest against it
+    /// (`resume.py:1088-1091`), and `consume_virtualref_boxes` hands its pairs
+    /// to `continue_tracing`, so putting an operand-stack value there would
+    /// exercise a shape the recorder cannot produce.
+    fn snapshot_with_frame_boxes(
+        boxes: Vec<crate::recorder::SnapshotTagged>,
     ) -> crate::recorder::Snapshot {
         crate::recorder::Snapshot {
             frames: vec![crate::recorder::SnapshotFrame {
                 jitcode_index: 0,
                 pc: 0,
                 py_pc: 0,
-                boxes: Vec::new(),
+                boxes,
             }],
-            vable_boxes: vable,
+            vable_boxes: Vec::new(),
             vref_boxes: Vec::new(),
         }
     }
@@ -2089,7 +2099,7 @@ mod tests {
         let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
         op2.pos.set(vop(4));
         ops.push(op2);
-        let snapshots = vec![snapshot_with_vable(vec![
+        let snapshots = vec![snapshot_with_frame_boxes(vec![
             crate::recorder::SnapshotTagged::Box(iop(2), Type::Int),
         ])];
         let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
@@ -2105,7 +2115,7 @@ mod tests {
 
         // The add is re-emitted as a prefix op, and the snapshot slot names it.
         assert_eq!(cut.ops[0].opcode, OpCode::IntAdd);
-        let slot = cut.snapshots[0].vable_boxes[0];
+        let slot = cut.snapshots[0].frames[0].boxes[0];
         let crate::recorder::SnapshotTagged::Box(r, _) = slot else {
             panic!("snapshot slot lost its box: {slot:?}");
         };
@@ -2132,7 +2142,7 @@ mod tests {
         let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
         op2.pos.set(vop(3));
         ops.push(op2);
-        let snapshots = vec![snapshot_with_vable(vec![
+        let snapshots = vec![snapshot_with_frame_boxes(vec![
             crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
         ])];
         let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
@@ -2144,7 +2154,7 @@ mod tests {
         assert!(
             cut.is_none(),
             "expected the cut to be declined, got a trace whose snapshot slot is {:?}",
-            cut.map(|c| c.snapshots[0].vable_boxes[0]),
+            cut.map(|c| c.snapshots[0].frames[0].boxes[0]),
         );
     }
 
@@ -2174,7 +2184,7 @@ mod tests {
         let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
         op2.pos.set(vop(4));
         ops.push(op2);
-        let snapshots = vec![snapshot_with_vable(vec![
+        let snapshots = vec![snapshot_with_frame_boxes(vec![
             crate::recorder::SnapshotTagged::Box(iop(2), Type::Int),
         ])];
         let trace = TreeLoop::with_snapshots(inputargs, ops, snapshots);
@@ -2216,7 +2226,7 @@ mod tests {
             op1.rd_resume_position.set(0);
             let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
             op2.pos.set(vop(3));
-            let snapshots = vec![snapshot_with_vable(vec![
+            let snapshots = vec![snapshot_with_frame_boxes(vec![
                 crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
             ])];
             let trace = TreeLoop::with_snapshots(inputargs, vec![op0, op1, op2], snapshots);
@@ -2227,7 +2237,7 @@ mod tests {
             assert!(
                 cut.is_none(),
                 "{opcode:?} was admitted for re-emission; snapshot slot is {:?}",
-                cut.map(|c| c.snapshots[0].vable_boxes[0]),
+                cut.map(|c| c.snapshots[0].frames[0].boxes[0]),
             );
         }
     }

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -708,8 +708,9 @@ impl TreeLoop {
     /// become the new inputargs; any OpRef referenced after the cut but
     /// defined before it (and not in `original_boxes`) is re-emitted as a
     /// prefix operation (transitive closure of dependencies).
-    /// `None` when the cut cannot be taken without losing a live value; see
-    /// [`Self::cut_trace_from_with_consts`].  The caller keeps the uncut trace.
+    /// `None` when the cut cannot be taken without losing a live value; the
+    /// caller must cancel the compilation — see
+    /// [`Self::cut_trace_from_with_consts`].
     pub fn cut_trace_from(
         &self,
         start: TreeLoopCutPosition,
@@ -815,25 +816,36 @@ impl TreeLoop {
         // frame's operand slot was written NULL — the argument of a live call
         // arriving unbound.
         //
-        // Prefix re-emission RE-EXECUTES the definition at the cut point, so it
-        // reconstructs faithfully only where nothing it drags along carries a
-        // side effect. The BFS below pulls in the whole transitive definition
-        // cone, so the condition is on the CONE, not the root: an allocation
-        // whose field feeds from a residual call would re-issue that call. Walk
-        // the pre-cut dependencies and admit only an entirely side-effect-free
-        // cone. Allocation (`NewWithVtable`) IS re-emitted: resume already hands
-        // a virtual a fresh object, and the boxed operands this recovers are
-        // compared by value.
+        // Prefix re-emission RE-EXECUTES the definition at the cut point, so a
+        // definition is admissible only if re-running it there yields the value
+        // the snapshot recorded. That is `is_always_pure`: a function of its own
+        // arguments alone. `has_no_side_effect` is a strictly weaker property
+        // and does NOT imply it — an op can be free of effects while still
+        // OBSERVING them:
         //
-        // A cone that is NOT re-emittable (a `CallMayForceR` feeding a snapshot
-        // slot) leaves the value with no representation in the cut namespace at
-        // all: the operand stack it lives on is in the virtualizable, not in
-        // `original_boxes`, so it is neither an inputarg nor re-derivable. Both
-        // remaining options are worse than not cutting — mapping the slot to
-        // `OpRef::NONE` writes a NULL into the resumed frame (a live call
-        // argument arriving unbound), and re-emitting issues an extra observable
-        // call. Decline; the caller cancels the compilation and the loop runs in
-        // the interpreter.
+        //   - the loads between `ALWAYS_PURE_LAST` and `NOSIDEEFFECT_LAST`
+        //     (`GcLoad*`, `Getfield*`, `Getarrayitem*`, `RawLoad*`,
+        //     `ThreadlocalrefGet`, ...) read memory. A pre-cut store between the
+        //     load and the cut is itself side-effecting, so it is never in the
+        //     cone; replaying the load at cut entry then returns the NEW value,
+        //     not the one the snapshot named.
+        //   - allocations (`New*`) get their contents from separate `SetfieldGc`
+        //     stores, which are likewise side-effecting and outside the argument
+        //     cone. Re-emitting the allocation alone yields a BLANK object.
+        //   - `ForceToken` / `VirtualRef*` mint identity; a replay mints a
+        //     different one.
+        //
+        // The condition is on the CONE, not the root, since the BFS below pulls
+        // in the whole transitive definition set.
+        //
+        // A cone that is NOT re-emittable leaves the value with no
+        // representation in the cut namespace at all. Promoting it to an extra
+        // inputarg is not available either: inputargs are re-bound from
+        // `original_boxes` on every entry, and an op-defined value has no box
+        // there. That leaves only mapping the slot to `OpRef::NONE`, which
+        // writes a NULL into the resumed frame (a live call argument arriving
+        // unbound), or re-emitting anyway and recovering the wrong value. Both
+        // are worse than not compiling: decline, and the caller cancels.
         //
         // A pre-cut ORIGINAL inputarg has no definition to re-execute, so it is
         // a leaf — but only phase 4's pool-constant arm can actually deliver
@@ -842,10 +854,11 @@ impl TreeLoop {
         // exactly the red args followed by the virtualizable's static fields and
         // array items, asserting it (`compile.py:458`). A snapshot's frame boxes
         // ARE the frame's locals, so seeding from snapshots reaches original
-        // inputargs constantly where operand seeding reached them rarely. Test
-        // the same predicate phase 4 branches on, and decline when the constant
-        // is absent: a widened entry contract crashes the compile, which is
-        // worse still than the NULL slot it would repair.
+        // inputargs constantly where operand seeding reached them rarely. Purity
+        // does not cover this — an `IntAdd` cone is replay-safe and still
+        // undeliverable — so test the same predicate phase 4 branches on and
+        // decline when the constant is absent: `test.test_collections` and
+        // `test.test_urlparse` crashed on that assert with `18 != 19`.
         let snapshot_cone_is_reemittable = |root: &OpRef| -> bool {
             let mut seen: IndexSet<OpRef> = IndexSet::new();
             let mut stack: Vec<OpRef> = vec![*root];
@@ -862,7 +875,7 @@ impl TreeLoop {
                 let Some(op) = self.ops.get((r.raw() - num_original_inputargs) as usize) else {
                     return false;
                 };
-                if !op.opcode.has_no_side_effect() {
+                if !op.opcode.is_always_pure() {
                     return false;
                 }
                 for arg in op.getarglist().iter() {
@@ -894,9 +907,15 @@ impl TreeLoop {
                     }
                     if !snapshot_cone_is_reemittable(r) {
                         if crate::majit_log_enabled() {
+                            let root = r
+                                .raw()
+                                .checked_sub(num_original_inputargs)
+                                .and_then(|i| self.ops.get(i as usize))
+                                .map(|op| op.opcode);
                             eprintln!(
-                                "[jit][cut-decline] snapshot-only ref {r:?} has a \
-                                 side-effecting definition cone; keeping the uncut trace",
+                                "[jit][cut-decline] snapshot-only ref {r:?} (root {root:?}) \
+                                 has a definition cone that is not replay-safe; \
+                                 cancelling this compilation",
                             );
                         }
                         return None;
@@ -2100,7 +2119,7 @@ mod tests {
         // op is not admitted. The value then has no representation in the cut
         // namespace at all, and mapping the slot to `OpRef::NONE` would write a
         // NULL into the resumed frame — so the cut is declined outright and the
-        // caller keeps the uncut trace, which still holds the definition.
+        // caller cancels the compilation.
         let inputargs = vec![InputArg::new_int(0)];
         let mut ops = Vec::new();
         let mut op0 = Op::new(OpCode::CallMayForceR, &[iarg_box(0)]);
@@ -2172,6 +2191,45 @@ mod tests {
             cut.map(|c| c.inputargs.len()),
             original_boxes.len(),
         );
+    }
+
+    #[test]
+    fn test_cut_trace_from_declines_on_an_effect_observing_snapshot_ref() {
+        // The boundary that matters is `is_always_pure`, not
+        // `has_no_side_effect`: a load causes no effect but OBSERVES one. A
+        // pre-cut store between the load and the cut is itself side-effecting,
+        // so it never joins the cone; re-emitting the load at cut entry would
+        // read the value written AFTER the snapshot named it. Pin the gap
+        // between the two predicates so widening it back is a test failure.
+        for opcode in [OpCode::GetfieldGcR, OpCode::GcLoadR, OpCode::NewWithVtable] {
+            assert!(
+                opcode.has_no_side_effect() && !opcode.is_always_pure(),
+                "{opcode:?} no longer sits between the two predicates, so this \
+                 test cannot tell them apart",
+            );
+
+            let inputargs = vec![InputArg::new_int(0)];
+            let mut op0 = Op::new(opcode, &[iarg_box(0)]);
+            op0.pos.set(OpRef::ref_op(1));
+            let mut op1 = Op::new(OpCode::GuardTrue, &[iarg_box(0)]);
+            op1.pos.set(vop(2));
+            op1.rd_resume_position.set(0);
+            let mut op2 = Op::new(OpCode::Jump, &[iarg_box(0)]);
+            op2.pos.set(vop(3));
+            let snapshots = vec![snapshot_with_vable(vec![
+                crate::recorder::SnapshotTagged::Box(OpRef::ref_op(1), Type::Ref),
+            ])];
+            let trace = TreeLoop::with_snapshots(inputargs, vec![op0, op1, op2], snapshots);
+
+            let original_boxes = vec![crate::trace_ctx::GreenBox::new(iarg(0), Type::Int)];
+            let cut = trace.cut_trace_from(TreeLoopCutPosition::new(1), &original_boxes);
+
+            assert!(
+                cut.is_none(),
+                "{opcode:?} was admitted for re-emission; snapshot slot is {:?}",
+                cut.map(|c| c.snapshots[0].vable_boxes[0]),
+            );
+        }
     }
 
     // ══════════════════════════════════════════════════════════════════

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5914,6 +5914,12 @@ impl<M: Clone> MetaInterp<M> {
             // fallback here: everything downstream of a live merge point is
             // built for the cut namespace and entry contract, so cancel this
             // compilation and let the interpreter run the loop instead.
+            //
+            // `compile.py:269` cannot reach this: `trace.cut_trace_from` builds
+            // a lazy view and is total.  The cancellation is not a new exit
+            // though — it lands on the outcome the `except InvalidLoop` arm
+            // just below it already defines, "this trace produced no loop",
+            // reached one step earlier because pyre's cut is materialized.
             let Some(cut) = trace.cut_trace_from_with_consts(
                 start,
                 original_boxes,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5909,8 +5909,19 @@ impl<M: Clone> MetaInterp<M> {
             }
             // cut_trace_from_with_consts remaps escaped original inputargs to
             // their trace-entry Const via a transient build-time map keyed by
-            // `OpRef.raw()`.
-            trace.cut_trace_from_with_consts(start, original_boxes, &ctx.initial_inputarg_consts)
+            // `OpRef.raw()`.  It declines (`None`) when the cut would drop a
+            // value held only by a guard snapshot.  The uncut trace is NOT a
+            // fallback here: everything downstream of a live merge point is
+            // built for the cut namespace and entry contract, so cancel this
+            // compilation and let the interpreter run the loop instead.
+            let Some(cut) = trace.cut_trace_from_with_consts(
+                start,
+                original_boxes,
+                &ctx.initial_inputarg_consts,
+            ) else {
+                return CompileOutcome::Cancelled;
+            };
+            cut
         } else {
             trace
         };
@@ -7508,7 +7519,17 @@ impl<M: Clone> MetaInterp<M> {
                         header_pc,
                     );
                 }
-                trace.cut_trace_from_with_consts(start, original_boxes, &initial_inputarg_consts)
+                // As in `compile_loop_body`: a declined cut cannot fall back to
+                // the uncut trace, because the retrace is installed against the
+                // merge point's entry contract.  Cancel the retrace instead.
+                let Some(cut) = trace.cut_trace_from_with_consts(
+                    start,
+                    original_boxes,
+                    &initial_inputarg_consts,
+                ) else {
+                    return false;
+                };
+                cut
             } else {
                 trace
             };

--- a/pyre/extra_tests/README.md
+++ b/pyre/extra_tests/README.md
@@ -28,9 +28,38 @@ works.  `testutils.py` is the helper module shipped with the snippets
   invariants line-by-line.  Each script cites the upstream
   file:line it guards; passing requires `exit 0` AND the final
   stdout line being `OK`.  Runner: `pyre/extra_tests/parity_tests/run.py`.
+- `upstream/` — no tests of its own: a runner plus a driver for the
+  vendored PyPy tree at the repository **root** `extra_tests/`.  Those
+  files stay where upstream put them and run in place, so anything they
+  already cover does not get rewritten under `parity_tests/`.
+  Runner: `pyre/extra_tests/upstream/run.py`.
 
-Both runners share the same backend discovery (cpython +
+All three runners share the same backend discovery (cpython +
 pyre-dynasm + pyre-cranelift) and exit code semantics.
+
+## The vendored root `extra_tests/`
+
+Those files are pytest modules: module-level `test_*` functions,
+`pytest.raises`, `pytest.skip`.  The `pytest.py` / `_pytest/` copy
+vendored beside them predates 3.12 and imports `imp`, so it loads under
+neither interpreter, and no pytest is installed.  `upstream/driver.py`
+registers a `pytest` module in `sys.modules` carrying `raises`, `skip`
+and `fail`, then executes one file's tests in place:
+
+```sh
+python3 pyre/extra_tests/upstream/run.py              # the enabled set
+python3 pyre/extra_tests/upstream/run.py --all -v     # survey the whole tree
+./target/release/pyre-dynasm \
+    pyre/extra_tests/upstream/driver.py extra_tests/test_os.py
+```
+
+`run.py`'s `ENABLED` list is what the gate runs; `--all` is a survey
+switch.  Surveyed 2026-08-09 with `--all --cpython-only`: **11 of 59**
+files run under CPython at all.  The other 48 need pytest surface the
+shim does not carry (`mark`, `fixture`, `importorskip`), a third-party
+package (`hypothesis`, `cffi`, `greenlet`), or a module that is PyPy's
+(`_structseq`, `_immutables_map`).  Widening `ENABLED` means checking a
+file against CPython and every pyre backend first.
 
 ## Source
 

--- a/pyre/extra_tests/parity_tests/os_spawn_family.py
+++ b/pyre/extra_tests/parity_tests/os_spawn_family.py
@@ -35,10 +35,8 @@ check(os.P_NOWAIT == os.P_NOWAITO, "P_NOWAIT and P_NOWAITO disagree")
 exe = sys.executable
 check(bool(exe), "no sys.executable to spawn")
 
-# P_WAIT hands back what the child exited with.
-code = os.spawnv(os.P_WAIT, exe, [exe, "-c", "raise SystemExit(7)"])
-check(code == 7, f"spawnv(P_WAIT) returned {code!r}, not the child's exit code")
-
+# P_WAIT hands back what the child exited with. `extra_tests/test_os.py`
+# pins the non-zero code; this is the zero one.
 code = os.spawnv(os.P_WAIT, exe, [exe, "-c", ""])
 check(code == 0, f"spawnv(P_WAIT) on a clean exit returned {code!r}")
 
@@ -50,14 +48,7 @@ waited, status = os.waitpid(pid, 0)
 check(waited == pid, f"waitpid returned {waited!r} for {pid!r}")
 check(os.waitstatus_to_exitcode(status) == 3, f"child status {status!r}")
 
-# spawnve carries an environment of its own.
-code = os.spawnve(
-    os.P_WAIT,
-    exe,
-    [exe, "-c", "import os,sys; sys.exit(int(os.environ['PARITY_MARK']))"],
-    {**os.environ, "PARITY_MARK": "5"},
-)
-check(code == 5, f"spawnve did not pass the environment: {code!r}")
+# `spawnve` and the environment it carries are `extra_tests/test_os.py`'s.
 
 # spawnvp looks the name up along $PATH, so a bare name resolves.
 if hasattr(os, "spawnvp"):

--- a/pyre/extra_tests/upstream/driver.py
+++ b/pyre/extra_tests/upstream/driver.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""In-process driver for one file of the vendored `extra_tests/` tree.
+
+    <interpreter> pyre/extra_tests/upstream/driver.py <path/to/test_x.py>
+
+The vendored tree at the repository root is PyPy's own suite and is written
+against pytest: module-level `test_*` functions, `pytest.raises` as a context
+manager, `pytest.skip` to opt out at runtime.  The `pytest.py` / `_pytest/`
+copy that ships beside it predates Python 3.12 and imports `imp`, so it cannot
+load under either interpreter here, and no pytest is installed.
+
+Rather than copy the test bodies somewhere runnable, this driver supplies the
+part of the pytest API those files actually use and executes them in place.
+The shim is registered in `sys.modules` instead of being written as a
+`pytest.py` file so that nothing else on `sys.path` is shadowed.
+
+Output is one `PASS` / `SKIP` / `FAIL` line per test plus a summary line; the
+exit code is 0 iff no test failed.  A file whose tests are all skipped still
+exits 0 — the upstream files guard on `os.fork`, `/tmp`, `/bin/sh` and so on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import traceback
+import types
+from pathlib import Path
+
+
+class Skipped(Exception):
+    """Raised by the shim's `skip()`; reported as SKIP, not as a failure."""
+
+
+def _skip(reason: str = "") -> None:
+    raise Skipped(reason)
+
+
+class _RaisesContext:
+    def __init__(self, expected):
+        self.expected = expected
+        self.value = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, tb):
+        if exc_type is None:
+            raise AssertionError(f"DID NOT RAISE {self.expected!r}")
+        if issubclass(exc_type, self.expected):
+            self.value = exc_value
+            return True
+        return False
+
+
+def _raises(expected, *args, **kwargs):
+    """`raises(Exc)` as a context manager, `raises(Exc, func, *a, **kw)` direct."""
+    if not args:
+        return _RaisesContext(expected)
+    func, rest = args[0], args[1:]
+    try:
+        func(*rest, **kwargs)
+    except expected as exc:
+        return exc
+    raise AssertionError(f"DID NOT RAISE {expected!r}")
+
+
+def _install_pytest_shim() -> None:
+    shim = types.ModuleType("pytest")
+    shim.raises = _raises
+    shim.skip = _skip
+    shim.fail = lambda msg="": (_ for _ in ()).throw(AssertionError(msg))
+    shim.Skipped = Skipped
+    sys.modules["pytest"] = shim
+
+
+def _load(path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(f"usage: {argv[0]} <test file>", file=sys.stderr)
+        return 2
+    path = Path(argv[1]).resolve()
+
+    _install_pytest_shim()
+    module = _load(path)
+
+    # `vars()` preserves definition order, which is the order pytest collects in.
+    tests = [
+        (name, obj)
+        for name, obj in vars(module).items()
+        if name.startswith("test") and callable(obj)
+    ]
+    if not tests:
+        print(f"{path.name}: no tests collected", file=sys.stderr)
+        return 1
+
+    passed = skipped = failed = 0
+    for name, func in tests:
+        try:
+            func()
+        except Skipped as exc:
+            skipped += 1
+            print(f"SKIP {name} ({exc})")
+        except BaseException:  # noqa: BLE001 - report, don't abort the file
+            failed += 1
+            print(f"FAIL {name}")
+            traceback.print_exc()
+        else:
+            passed += 1
+            print(f"PASS {name}")
+
+    print(f"{path.name}: {passed} passed, {skipped} skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/pyre/extra_tests/upstream/run.py
+++ b/pyre/extra_tests/upstream/run.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Runner for the vendored PyPy `extra_tests/` tree at the repository root.
+
+Those files are upstream's, not ours: they are left where they are and run in
+place through `driver.py`, which supplies the small slice of the pytest API
+they use.  Nothing is copied into `pyre/extra_tests/`.
+
+Only the files named in `ENABLED` run.  The tree carries 60+ files covering
+surface pyre has not reached yet, and a runner that reddens on all of them
+would report nothing; a file joins the list once it passes under CPython and
+under the pyre backends.
+
+Usage:
+    python3 pyre/extra_tests/upstream/run.py [--dynasm-only|--cranelift-only]
+                                             [--cpython-only]
+                                             [--filter SUBSTRING]
+                                             [--timeout SECONDS]
+                                             [--all] [--list] [-v]
+
+Exit code is 0 iff every (file, backend) pair passed.  `--all` ignores
+`ENABLED` and runs the whole vendored tree; it is a survey switch, not a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parent.parent.parent
+UPSTREAM = ROOT / "extra_tests"
+DRIVER = HERE / "driver.py"
+TARGET_RELEASE = ROOT / "target" / "release"
+
+EXE = ".exe" if sys.platform == "win32" else ""
+
+# Vendored upstream files that pass here, each with the `os.name` it needs
+# (None runs everywhere).  Add a file after checking it passes under CPython
+# and every pyre backend; `--all` shows what the rest do.
+ENABLED: list[tuple[str, str | None]] = [
+    # `spawnv`/`spawnve` are noop stubs under `nt` (interp_posix.rs:1292 — the
+    # module owns those names on Windows and there is no implementation behind
+    # them), so `test_spawnv`'s `ret == 42` is not a Windows expectation.
+    ("test_os.py", "posix"),
+]
+
+
+def _files(args: argparse.Namespace) -> tuple[list[Path], int]:
+    """Selected files, and how many `ENABLED` entries this platform skipped."""
+    if args.all:
+        candidates = [(p.name, None) for p in sorted(UPSTREAM.glob("test_*.py"))]
+    else:
+        candidates = ENABLED
+    out: list[Path] = []
+    off_platform = 0
+    for name, os_name in candidates:
+        if os_name is not None and os.name != os_name:
+            off_platform += 1
+            continue
+        p = UPSTREAM / name
+        if not p.exists():
+            print(f"missing vendored test file: {p}", file=sys.stderr)
+            continue
+        if args.filter and args.filter not in p.name:
+            continue
+        out.append(p)
+    return out, off_platform
+
+
+def _run(cmd: list[str], path: Path, timeout: int) -> tuple[bool, str]:
+    try:
+        proc = subprocess.run(
+            cmd + [str(DRIVER), str(path)],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return False, "timeout"
+    if proc.returncode == 0:
+        tail = [line for line in proc.stdout.splitlines() if line.strip()]
+        return True, tail[-1] if tail else ""
+    err = proc.stderr.strip().splitlines()
+    out = proc.stdout.strip().splitlines()
+    detail = out[-1] if out else (err[-1] if err else "")
+    return False, f"rc={proc.returncode} {detail}"
+
+
+def _runners(args: argparse.Namespace) -> list[tuple[str, list[str]]]:
+    runners: list[tuple[str, list[str]]] = []
+    cpython = os.environ.get("PYRE_CHECK_PYTHON3") or "python3"
+    if not args.dynasm_only and not args.cranelift_only:
+        runners.append(("cpython", [cpython]))
+    if args.cpython_only:
+        return runners
+    dynasm = TARGET_RELEASE / f"pyre-dynasm{EXE}"
+    cranelift = TARGET_RELEASE / f"pyre-cranelift{EXE}"
+    if not args.cranelift_only and dynasm.exists():
+        runners.append(("dynasm", [str(dynasm)]))
+    if not args.dynasm_only and cranelift.exists():
+        runners.append(("cranelift", [str(cranelift)]))
+    return runners
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dynasm-only", action="store_true")
+    parser.add_argument("--cranelift-only", action="store_true")
+    parser.add_argument("--cpython-only", action="store_true")
+    parser.add_argument("--all", action="store_true",
+                        help="run the whole vendored tree, not just ENABLED")
+    parser.add_argument("--filter", default=None,
+                        help="run only files whose name contains this substring")
+    parser.add_argument("--timeout", type=int, default=120,
+                        help="per-file timeout in seconds (default 120)")
+    parser.add_argument("--list", action="store_true",
+                        help="list files that would run, then exit")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="print pass/fail for every (file, backend)")
+    args = parser.parse_args()
+
+    files, off_platform = _files(args)
+    if args.list:
+        for p in files:
+            print(p.name)
+        return 0
+
+    runners = _runners(args)
+    if not files:
+        if off_platform:
+            print(f"nothing to run on {os.name}: "
+                  f"{off_platform} enabled file(s) are other-platform")
+            return 0
+        print("no vendored extra_tests files selected", file=sys.stderr)
+        return 1
+    if not runners:
+        print("no runners enabled", file=sys.stderr)
+        return 1
+
+    print(f"runners: {[name for name, _ in runners]}")
+    print(f"files:   {len(files)}"
+          + (f" ({off_platform} skipped on {os.name})" if off_platform else ""))
+    print()
+
+    fails: list[tuple[str, str, str]] = []
+    passes: dict[str, int] = {name: 0 for name, _ in runners}
+
+    for path in files:
+        row = [f"  {path.name:<34s}"]
+        row_failed = False
+        for backend, cmd in runners:
+            ok, detail = _run(cmd, path, args.timeout)
+            row.append(f"{backend}={'OK' if ok else 'FAIL'}")
+            if ok:
+                passes[backend] += 1
+            else:
+                row_failed = True
+                fails.append((path.name, backend, detail))
+        if args.verbose or row_failed:
+            print(" ".join(row))
+
+    print()
+    print("Summary:")
+    for backend, _ in runners:
+        print(f"  {backend:<10s}  {passes[backend]:>3d}/{len(files)} passed")
+    for name, backend, detail in fails:
+        print(f"  FAIL {name} [{backend}] {detail}")
+
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -802,6 +802,7 @@ pub(crate) fn compute_bridge_root_parent_frame<Sym: WalkSym>(
         "bridge_root_parent",
         None,
         &[],
+        None,
     );
     // The concrete image this paused root resumes from when a descendant
     // sub-walk aborts and the drain converts the chain instead of rewinding to

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2262,6 +2262,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
             "builtin_wrapper_call_site",
             None,
             &[],
+            None,
         )
     };
 
@@ -4176,6 +4177,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
                     "call_site_capture",
                     None,
                     &[],
+                    None,
                 );
                 (
                     boxes,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2310,6 +2310,16 @@ pub enum DispatchError {
     /// interpreter fallback (correct, untraced) instead of compiling a trace
     /// whose guard-failure path corrupts the frame.
     BranchGuardKeptStackUnsupported { pc: usize },
+    /// A branch guard's snapshot has a live Ref color whose operand-stack slot
+    /// has no per-slot source: the walk mirror holds `OpRef::NONE` there and
+    /// the decoded edge-move recovery carries no entry for that color.
+    /// The remaining fallback reads
+    /// the resume merge color out of the guard-pc register file, where it is
+    /// unwritten at the guard point or reused by the regalloc — the #424
+    /// merge-color staleness the per-slot mirror replaced.  The gate that lets
+    /// a valid mirror through justified itself by that recovery, so where the
+    /// recovery does not in fact cover the slot the capture declines instead.
+    BranchGuardKeptSlotUnsourced { pc: usize },
     /// A kept-stack branch guard's not-taken (resume) arm READS a regular
     /// Ref register (`< num_regs_r`) that is neither snapshot-live nor
     /// produced inside the arm, so the blackhole resumes it as NULL and
@@ -2425,6 +2435,7 @@ impl DispatchError {
             Self::LoopHeaderJdIndexUnresolved { .. } => "LoopHeaderJdIndexUnresolved",
             Self::SubWalkClosedLoop { .. } => "SubWalkClosedLoop",
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
+            Self::BranchGuardKeptSlotUnsourced { .. } => "BranchGuardKeptSlotUnsourced",
             Self::ForceQuasiImmutable { .. } => "ForceQuasiImmutable",
             Self::LoopBearingCalleeInlineUnsupported { .. } => "LoopBearingCalleeInlineUnsupported",
             Self::FieldDescrMissingParentDescr { .. } => "FieldDescrMissingParentDescr",
@@ -2492,6 +2503,7 @@ impl DispatchError {
             | Self::LoopHeaderJdIndexUnresolved { pc, .. }
             | Self::SubWalkClosedLoop { pc, .. }
             | Self::BranchGuardKeptStackUnsupported { pc, .. }
+            | Self::BranchGuardKeptSlotUnsourced { pc, .. }
             | Self::ForceQuasiImmutable { pc, .. }
             | Self::LoopBearingCalleeInlineUnsupported { pc, .. }
             | Self::FieldDescrMissingParentDescr { pc, .. }
@@ -4923,6 +4935,11 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
     entry_caller: &'static str,
     vstack: Option<&[OpRef]>,
     kept_recovered: &[(u16, OpRef)],
+    // Set to the first live Ref color whose operand-stack slot has NO per-slot
+    // source (mirror hole + no edge-move recovery), so the branch-guard caller
+    // can decline instead of encoding the stale merge-color read.  `None` for
+    // the callers that are not reconstructing a branch guard.
+    mut unrecovered_kept: Option<&mut Option<u32>>,
 ) -> Vec<OpRef> {
     // `#124` Approach B: resolve the base live-box set through the carried
     // JitCode coordinate so the encoder's color set matches the decoder's
@@ -5142,10 +5159,42 @@ fn collect_outer_active_boxes<Sym: WalkSym>(
                 color,
             ) {
                 if sem >= nlocals {
-                    if let Some(&m) = mirror.get(sem - nlocals) {
-                        if m != OpRef::NONE && !opref_is_null_const_ptr(m) {
-                            active.push(m);
-                            continue;
+                    let m = mirror.get(sem - nlocals).copied().unwrap_or(OpRef::NONE);
+                    if m != OpRef::NONE && !opref_is_null_const_ptr(m) {
+                        active.push(m);
+                        continue;
+                    }
+                    // The mirror did not supply this operand-stack slot, so the
+                    // decoded edge-move recovery below is the only other
+                    // per-slot source.  Without an entry for this color the
+                    // fallback reads the resume merge color out of the guard-pc
+                    // register file, where it is unwritten at the guard point or
+                    // reused by the regalloc — the #424 staleness the per-slot
+                    // mirror was introduced to replace.  The kept-stack gate
+                    // admits a valid mirror on the stated grounds that this
+                    // recovery covers such a slot; report the case where that is
+                    // false so the caller declines rather than encode the stale
+                    // read.
+                    //
+                    // Restricted to a NONE hole, where there is demonstrably no
+                    // source at all.  A NULL const-ptr is NOT declined, and that
+                    // is a measured decision rather than an oversight: a census
+                    // over `test_re`, `test_strftime` and all 393 synth programs
+                    // found 3 mirror-missed slots, every one a NULL const-ptr
+                    // with `recovered=false` — so the gate's justification is
+                    // indeed false there — but all 3 are in one PASSING program
+                    // (`synth/list_append_write_barrier_gc`), and declining them
+                    // regressed it (loops 12→11, bridges 5→3, aborts 1→4) with
+                    // no demonstration that the value encoded today is wrong.
+                    // Whether that NULL is the slot's real value (a `PUSH_NULL`
+                    // sentinel) cannot be settled here: the mirror has several
+                    // writers and only `reseed_vstack_from_shadow` gates a NULL
+                    // behind the live-NULL marker, while the per-op reconcile
+                    // and the vable write-through store one directly.  Settling
+                    // that is what closes the remaining case.
+                    if m == OpRef::NONE && !kept_recovered.contains_key(&idx) {
+                        if let Some(first) = unrecovered_kept.as_deref_mut() {
+                            first.get_or_insert(idx);
                         }
                     }
                 }
@@ -9024,7 +9073,12 @@ fn guarded_branch_core<Sym: WalkSym>(
         // for an unrestorable-Ref arm (Hazard 1) or an INVALID mirror
         // (undermodeled walk); a VALID mirror with a NONE hole (an
         // edge-materialized merge temp) compiles, its slot sourced from
-        // the decoded trampoline recovery (`resolved_recovered`).
+        // the decoded trampoline recovery (`resolved_recovered`).  That
+        // last claim is not assumed: an uncovered slot with no recovery
+        // entry has no per-slot source at all, and
+        // `collect_outer_active_boxes` reports it so the snapshot capture
+        // declines (`BranchGuardKeptSlotUnsourced`) rather than falling
+        // through to the stale merge-color read.
         let mirror_covers_kept = ctx.vstack_valid
             && resume_depth.is_some_and(|d| {
                 (0..d).all(|s| {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1080,6 +1080,11 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                     ),
                 }
             };
+            // A branch guard whose kept operand-stack slot has neither a mirror
+            // box nor an edge-move entry has no per-slot source; the gate that
+            // admitted this guard assumed the recovery covered it, so decline
+            // rather than encode the stale merge-color read.
+            let mut unsourced_kept: Option<u32> = None;
             let active = collect_outer_active_boxes(
                 sym,
                 ctx.trace_ctx,
@@ -1094,7 +1099,18 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 entry_caller,
                 ctx.vstack_valid.then_some(ctx.vstack_boxes.as_slice()),
                 scope.branch_guard_kept_recovered,
+                has_branch_guard.then_some(&mut unsourced_kept),
             );
+            if let Some(color) = unsourced_kept {
+                if crate::jitcode_dispatch::fbw_debug_abort_enabled() {
+                    eprintln!(
+                        "[decline-why] KEPT-SLOT-UNSOURCED pc={op_pc} color={color} \
+                         vstack_valid={}",
+                        ctx.vstack_valid,
+                    );
+                }
+                return Err(DispatchError::BranchGuardKeptSlotUnsourced { pc: op_pc });
+            }
             let pc_word = resolved_offset as u32;
             let forward_py_pc = forward_snapshot_py_pc(jitcode_index, pc_word)?;
             ctx.trace_ctx
@@ -1768,6 +1784,7 @@ pub(crate) fn compute_inline_caller_frame<Sym: WalkSym>(
         "inline_caller",
         None,
         &[],
+        None,
     );
     if let (Some(result_color), Some(saved)) = (
         result_color.filter(|&color| color < ctx.registers_r.len()),

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1084,6 +1084,13 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             // box nor an edge-move entry has no per-slot source; the gate that
             // admitted this guard assumed the recovery covered it, so decline
             // rather than encode the stale merge-color read.
+            //
+            // `get_list_of_active_boxes` (`pyjitpl.py:225`) has no such case:
+            // it reads `self.registers_r[index]`, and the register bank IS the
+            // source, so every live index resolves by construction.  Pyre's
+            // operand stack lives in the virtualizable and is rebuilt from a
+            // mirror plus the branch trampoline's ref moves, so a slot can
+            // genuinely resolve to nothing.
             let mut unsourced_kept: Option<u32> = None;
             let active = collect_outer_active_boxes(
                 sym,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9799,6 +9799,7 @@ pub(crate) fn orthodox_list_pop_commit<Sym: WalkSym>(
         "w_list_pop_end_call_site",
         None,
         &[],
+        None,
     );
 
     let saved_entry = ctx.entry_py_pc;

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9497,6 +9497,7 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
         "w_list_append_call_site",
         None,
         &[],
+        None,
     );
 
     // Swap in the call-site resume context + the callee's GLOBAL descr pool

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -5699,6 +5699,12 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 DE::GuardSnapshotVableUntyped { .. }
                 | DE::MayForceNullRefArgUnsupported { .. }
                 | DE::BranchGuardKeptStackUnsupported { .. }
+                // Listed with its sibling kept-stack decline rather than left
+                // to the catch-all: the mirror shape and recovery set behind it
+                // are per-walk, not a static property of the coordinate, so
+                // retiring the location would be too strong.  The abort ceiling
+                // reaches the same terminal state if it does recur.
+                | DE::BranchGuardKeptSlotUnsourced { .. }
                 | DE::LoopBearingCalleeInlineUnsupported { .. }
                 | DE::UnfoldableListAppendResidualUnsupported { .. }
                 // Plain, retryable: `ABORT_FORCE_QUASIIMMUT` abandons THIS


### PR DESCRIPTION
`main`'s CPython gate has been red on exactly one module since 2026-08-07:

```
── REGRESSIONS (1) ──
  - test.test_re: PASS -> FAIL  rc=1
```

```
File "lib-python/3/re/_parser.py", line 460, in _parse_sub
  itemsappend(_parse(source, state, verbose, nested + 1, not nested and not items))
TypeError: _parse() missing 1 required positional argument: 'nested'
```

The message says arity; the defect is a **value**. `PYRE_BH_NULL_ARG=1` names it in
one run — `[bh-null-arg] arg[3]/5 NULL … at <frame _parser.py, line 460, code
_parse_sub>`. `args[3]` is `nested + 1`; a NULL in the argument vector is dropped
by `bh_call_fn_impl`'s `reload_args`, so five arguments arrive as four and the
binder reports the *name* as missing.

## Cause

`TreeLoop::cut_trace_from_with_consts` seeds its escaped-ref closure from
**post-cut operation arguments only**. A snapshot is not `fail_args` — `fail_args`
are attached after optimization by `store_final_boxes_in_guard`, so the cut
namespace owes them nothing, but a snapshot is captured during tracing and is the
only description a guard has of the frame it resumes into.

`nested + 1` is computed once before the cut and stays live on the Python operand
stack across the merge point, while every post-cut operand reads the cached
pre-cut box. So no post-cut *argument* names it, the seeding loop never sees it,
the snapshot remap's `else` arm rewrites it to `OpRef::NONE`, `_number_boxes`
emits `NULLREF`, and `store_live_frame_array_slot` writes NULL into the resumed
frame's operand slot.

Measured at the drop site, **every** dropped ref was snapshot-only
(`used_by_postcut_op=false`, 632 vable / 221 frame / 58 vref).

Upstream cannot hit this: `CutTrace` (`opencoder.py`) is a view over the same
trace and cuts at a jitdriver merge point where the whole live set is already
`inputargs` — a snapshot naming a position before `start` would trip
`TraceIterator._get`'s assert. Pyre cuts at a position whose live set is wider
than `original_boxes` (a Python operand stack lives in the virtualizable), so it
needs the prefix re-emission it already had, for op args only.

## Fix

Seed the closure from the vable, vref and frame sections of every post-cut
guard's snapshot as well.

Prefix re-emission **re-executes** the definition and the BFS pulls the whole
transitive cone, so a root is admitted only when its entire pre-cut dependency
cone is `has_no_side_effect()` — the condition is on the cone, not the root: an
allocation whose field feeds from a residual call would re-issue that call.
Measured seeds across a whole `test_re` run are exactly two: `NewWithVtable`
(admitted — resume already hands a virtual a fresh object, and the boxed operands
this recovers are compared by value) and `CallMayForceR` (**refused** — an extra
observable call is worse than the NULL slot it would repair).

## That refusal is a documented gap, and it was measured before being left open

A temporary probe at the refusal site plus the pre-existing `PYRE_BH_NULL_ARG`,
over **all 109 gated modules** (108 ran to completion; `test_runpy` truncated at
the gate's own 300 s, both counters 0 up to the cut):

| | |
|---|---|
| `bh_null` (**harm**) | **0 in every module** |
| `cut_refused` (**occurrence**) | `test.test_re` only, 3–4 per run, all `CallMayForceR` |
| that module | green with this patch |

Occurrence without observable harm, so this patch adds no machinery for it. The
shape that would close it without re-execution already exists in the same
function — phase 4 carries an `orig_inputarg_escaped` ref as an **extra inputarg**
instead of re-emitting it — and is worth extending when harm is actually observed.

## Verification

* `test.test_re` — **303 errors → 0**, `OK (skipped=13)`, rc=0. `PYRE_NO_JIT=1` was
  already `OK`, i.e. JIT-only.
* `pyre/check.py --backend dynasm` — 410/410 at `59dfaf3dbe3`. At the current base
  it is 409/410, and the one red is **not this patch**: `synth/pypy_type_surface`
  reports `bridges_compiled 102 -> 5, guard_failures 20497 -> 1011`. #1086
  (`e5eff816849`) rewrote 1063 `.jitstats` files and recorded **the storming state**
  for this fixture over a `main` where the type-name fold is fixed — the observed
  5 / 1011 (loops 11) is the correct post-fix reading. Attributed by a same-tree
  patch-on/off A/B: the base build without this commit fails with the byte-identical
  message. Not re-recorded here — re-recording a regression as a baseline is what
  produced this red.
* `cargo test -p majit-metainterp cut_trace_from` — 7 passed. The two new tests
  guard one half each: `test_cut_trace_from_reemits_ref_held_only_by_a_snapshot`
  goes red when the seed is disabled, and
  `test_cut_trace_from_leaves_side_effecting_snapshot_ref_unmapped` goes red when
  the cone filter is removed.
* `test_strftime`, an intermittent `_parse_sub` `IndexError` recorded at 4/25 —
  **0/25** here (and 0/25 independently on an earlier base). Strong, not proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trace cutting to correctly handle references captured in guard snapshots.
  * Preserved safe snapshot references while preventing side-effecting references from being reused.
  * Fixed handling of guard failure arguments to avoid exposing invalid references.
* **Tests**
  * Added coverage for snapshot-only reference restoration and side-effecting call safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->