### PR TITLE
jit: fold list.pop() by descending w_list_pop_end_inner, and residualise the int box's collector-heap arm

### DIFF
--- a/pyre/bench/synth/list_pop_append.py
+++ b/pyre/bench/synth/list_pop_append.py
@@ -1,9 +1,19 @@
-# pyre-check: max-pypy-ratio=172
+# pyre-check: max-pypy-ratio=22
+# Both `append` and `pop` now fold, so this reads 3.2x on dynasm and 4.3x on
+# cranelift where it read 73.5x here before the pop fold -- and the loop that
+# reached 188.0x on windows-latest is the same one. The ceiling is twice the
+# slowest local reading carried across this fixture's own measured host span
+# (188.0/73.5 = 2.6x, taken while it still residualized). That span is the one
+# projected quantity here; refit from the runners' own readings once CI has
+# reported them rather than widening this again.
 # Benchmark: integer list pop/append loop (per-strategy ops)
-# Exercises W_ListObject.pop_end() / append() on Integer strategy.
-# PYPYLOG confirms: guard_class(IntegerListStrategy) + ArrayS 8 ops only.
-# On main, first pop() called items_to_vec() → Object strategy;
-# on this branch, stays Integer throughout (no boxing overhead).
+# Exercises `w_list_append_inner` / `w_list_pop_end_inner` on Integer storage,
+# both reached by an orthodox descent, so the compiled loop carries the array
+# ops themselves rather than a call to them: the pop's `CallMayForceR` +
+# `GuardNotForced` + the 48-byte bound-method allocation are gone, and what is
+# left is a length read, a guard, an `int_sub` and a length store.
+# The oracle agrees on the shape -- pypy traces the pair to raw
+# `setarrayitem_gc` + `setfield_gc` with no boxing.
 
 N = 30000000
 

--- a/pyre/bench/synth/pypy_type_surface.cranelift.jitstats
+++ b/pyre/bench/synth/pypy_type_surface.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=102
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20497
+guard_failures=1011
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=11
+retraces_compiled=0

--- a/pyre/bench/synth/pypy_type_surface.dynasm.jitstats
+++ b/pyre/bench/synth/pypy_type_surface.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=102
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20497
+guard_failures=1011
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=11
+retraces_compiled=0

--- a/pyre/bench/synth/pypy_type_surface.wasm.jitstats
+++ b/pyre/bench/synth/pypy_type_surface.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=102
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20497
+guard_failures=1011
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=11
+retraces_compiled=0

--- a/pyre/extra_tests/parity_tests/list_pop_fold.py
+++ b/pyre/extra_tests/parity_tests/list_pop_fold.py
@@ -1,0 +1,148 @@
+# Integer-strategy `list.pop()`, run hot enough to be traced.
+#
+# The pop fold descends the real `w_list_pop_end_inner` body, which is the
+# `index == -1` half of `descr_pop` (`listobject.py`): a length read, an
+# unboxed item read, a length store, and the wrap.  It fires only for the
+# no-argument form on an Integer-strategy list; every other shape below has to
+# decline cleanly and still answer correctly, which is what the checksums pin.
+#
+# The fold applies the pop eagerly while tracing and journals it, so a guard
+# failure has to rewind both the length and the item.  The loops therefore
+# alternate two receivers and re-read what they popped: a rewind that restores
+# the length but not the value, or that restores them in the wrong order,
+# corrupts a checksum here.
+
+N = 400
+
+
+def check(got, want, label):
+    assert got == want, "%s: %r != %r" % (label, got, want)
+
+
+# ── the folded shape: append then pop, hot, with a live result ──
+def append_pop_live(n):
+    xs = [0, 1, 2, 3, 4]
+    total = 0
+    i = 0
+    while i < n:
+        xs.append(i)
+        total = total + xs.pop()
+        i = i + 1
+    return total * 100 + len(xs)
+
+
+def expected_append_pop_live(n):
+    return sum(range(n)) * 100 + 5
+
+
+# ── the same shape with the result discarded, so the box is dead ──
+def append_pop_dead(n):
+    xs = [7, 8, 9]
+    i = 0
+    while i < n:
+        xs.append(i)
+        xs.pop()
+        i = i + 1
+    return len(xs) * 1000 + xs[0] * 100 + xs[2]
+
+
+# ── two receivers alternating: a wrong rewind routes a value to the other list
+def two_receivers(n):
+    xs = [0]
+    ys = [0]
+    a = 0
+    b = 0
+    i = 0
+    while i < n:
+        xs.append(i)
+        ys.append(-i)
+        a = a + xs.pop()
+        b = b + ys.pop()
+        i = i + 1
+    return a + b + len(xs) + len(ys)
+
+
+# ── draining to empty, then one pop too many ──
+def drain_then_overpop(n):
+    xs = []
+    i = 0
+    while i < n:
+        xs.append(i)
+        i = i + 1
+    total = 0
+    while xs:
+        total = total + xs.pop()
+    try:
+        xs.pop()
+    except IndexError as e:
+        return total * 10 + len(str(e).split()[0])
+    return -1
+
+
+# ── declines: the indexed form, and the non-Integer strategies ──
+def pop_indexed(n):
+    xs = list(range(n))
+    total = 0
+    i = 0
+    while i < n // 2:
+        total = total + xs.pop(0)
+        i = i + 1
+    return total * 100 + len(xs)
+
+
+def pop_float(n):
+    xs = [0.5]
+    total = 0.0
+    i = 0
+    while i < n:
+        xs.append(i + 0.5)
+        total = total + xs.pop()
+        i = i + 1
+    return int(total * 2) * 10 + len(xs)
+
+
+def pop_object(n):
+    xs = ["seed"]
+    total = 0
+    i = 0
+    while i < n:
+        xs.append("e%d" % (i % 7))
+        total = total + int(xs.pop()[1:])
+        i = i + 1
+    return total * 10 + len(xs)
+
+
+# ── despecialisation mid-loop: an Integer list that becomes an Object one ──
+def strategy_flip(n):
+    xs = [0, 1, 2]
+    total = 0
+    i = 0
+    while i < n:
+        if i == n // 2:
+            xs.append("x")
+            total = total + len(xs.pop())
+        else:
+            xs.append(i)
+            total = total + xs.pop()
+        i = i + 1
+    return total * 10 + len(xs)
+
+
+def run():
+    check(append_pop_live(N), expected_append_pop_live(N), "append_pop_live")
+    check(append_pop_dead(N), 3 * 1000 + 7 * 100 + 9, "append_pop_dead")
+    check(two_receivers(N), 2, "two_receivers")
+    check(drain_then_overpop(N), sum(range(N)) * 10 + 3, "drain_then_overpop")
+    check(pop_indexed(N), sum(range(N // 2)) * 100 + N - N // 2, "pop_indexed")
+    check(pop_float(N), (sum(range(N)) * 2 + N) * 10 + 1, "pop_float")
+    check(pop_object(N), sum(i % 7 for i in range(N)) * 10 + 1, "pop_object")
+    check(strategy_flip(N), (sum(range(N)) - N // 2 + 1) * 10 + 3, "strategy_flip")
+
+
+run()
+
+# A second pass on already-warm code: every loop above has been traced by now,
+# so this run executes the compiled form rather than building it.
+run()
+
+print("OK")

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1797,6 +1797,22 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::w_list_append",
         w_list_append as *const (),
     );
+    let w_list_pop_end_inner: unsafe fn(pyre_object::PyObjectRef) -> pyre_object::PyObjectRef =
+        pyre_object::listobject::w_list_pop_end_inner;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::listobject::w_list_pop_end_inner",
+        "pyre_object::w_list_pop_end_inner",
+        w_list_pop_end_inner as *const (),
+    );
+    let w_list_pop_end: unsafe fn(pyre_object::PyObjectRef) -> Option<pyre_object::PyObjectRef> =
+        pyre_object::listobject::w_list_pop_end;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::listobject::w_list_pop_end",
+        "pyre_object::w_list_pop_end",
+        w_list_pop_end as *const (),
+    );
     let w_list_len: unsafe fn(pyre_object::PyObjectRef) -> usize =
         pyre_object::listobject::w_list_len;
     push_alias_pair(

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -961,6 +961,20 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_alloc_stable_raw",
         pyre_object::gc_hook::try_gc_alloc_stable_raw as *const (),
     );
+    // `w_int_gc_alloc` is the collector-heap arm of `w_int_new`, reached from
+    // inside a descended body whenever a fold boxes an int. Bind the
+    // macro-emitted trampoline rather than the raw fn, for the reason
+    // `prepare_list_ref_store` documents: the raw `(i64) -> *mut PyObject` is
+    // `(i64) -> i32` on wasm32, while the wasm backend types the residual's
+    // `call_indirect` `(i64) -> i64` from the descr alone.
+    let w_int_gc_alloc: extern "C" fn(i64) -> i64 =
+        pyre_object::intobject::__majit_call_target_w_int_gc_alloc;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::intobject::w_int_gc_alloc",
+        "pyre_object::w_int_gc_alloc",
+        w_int_gc_alloc as *const (),
+    );
     // `w_type_set_abstract` stores the runtime-mutable `flag_abstract` atomic — a
     // side effect on per-type state, not a build-time constant, so it carries
     // `#[dont_look_inside]` and binds its `()`-returning `fn` directly by
@@ -1047,11 +1061,19 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // a `jit_static_pytype_addrs` / `jit_static_ref_addrs` row: those carry
     // the address of a value fixed at build time, and folding a
     // runtime-stamped id that way would bake `TypeIdCell::UNASSIGNED`.
+    //
+    // `enabled` binds the trampoline instead: it gates the GC allocation route
+    // of every boxing constructor, so a descended body reaches it, and a raw
+    // `-> bool` is `() -> i32` on wasm32 against the descr-derived
+    // `() -> i64`.  The two type-id readers keep the direct binding — no
+    // descended body reaches them yet — but they are the same latent shape.
+    let gc_interp_enabled: extern "C" fn() -> i64 =
+        pyre_object::gc_interp::__majit_call_target_enabled;
     push_alias_pair(
         &mut entries,
         "pyre_object::gc_interp::enabled",
         "pyre_object::enabled",
-        pyre_object::gc_interp::enabled as *const (),
+        gc_interp_enabled as *const (),
     );
     push_alias_pair(
         &mut entries,

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -670,6 +670,17 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             "pop from empty list",
         ));
     }
+    // listobject.py:766-767 — clearly distinguish list.pop() from the
+    // general list.pop(index) path.
+    if index == -1 {
+        return match unsafe { pyre_object::listobject::w_list_pop_end(args[0]) } {
+            Some(v) => Ok(v),
+            None => Err(crate::PyError::new(
+                crate::PyErrorKind::IndexError,
+                "pop index out of range",
+            )),
+        };
+    }
     match unsafe { pyre_object::listobject::w_list_pop(args[0], index) } {
         Some(v) => Ok(v),
         None => Err(crate::PyError::new(

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4755,6 +4755,27 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 // ── List TypeDef ─────────────────────────────────────────────────────
 // PyPy: pypy/objspace/std/listobject.py TypeDef("list", ...)
 
+/// `listobject.py:758 W_ListObject.descr_pop`, exposed through
+/// `interp2app` (`listobject.py:2455`).
+///
+/// This must be a named gateway wrapper, not a direct `init_list_type`
+/// registration: RPython's `BuiltinCode.func` is a PBC containing the
+/// generated interp2app function graphs. Publishing the wrapper descriptor
+/// below gives pyre's source translator the same candidate graph and lets a
+/// traced `list.pop()` call descend to `w_list_pop_end_inner`.
+pub fn __pyre_wrap_list_descr_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::type_methods::list_method_pop(args)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __majit_builtin_wrapper_target_list_descr_pop: crate::gateway::BuiltinWrapperDescriptor =
+    crate::gateway::BuiltinWrapperDescriptor {
+        path: concat!(module_path!(), "::", stringify!(__pyre_wrap_list_descr_pop)),
+        func: __pyre_wrap_list_descr_pop,
+    };
+
 /// Name of `obj`'s type, for operand-type error messages.
 fn arg_type_name(obj: PyObjectRef) -> String {
     unsafe {
@@ -4855,7 +4876,7 @@ fn init_list_type(ns: PyObjectRef) {
         pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
             ns,
             "pop",
-            make_builtin_function("pop", crate::type_methods::list_method_pop),
+            make_builtin_function("pop", __pyre_wrap_list_descr_pop),
         )
     };
     unsafe {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -382,7 +382,7 @@ pub(crate) fn fbw_built_exc_take(op: OpRef) -> bool {
 /// begins (mirrors [`bool_box_truth_reset`]).
 pub(crate) fn fbw_store_journal_reset() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
-    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_SYS_EXC_JOURNAL.with(|j| j.borrow_mut().clear());
@@ -460,9 +460,32 @@ pub(crate) fn fbw_store_journal_push(
 /// append's gate), so the rewind is allocation-free.
 // Consumed by the #171 `list.append` orthodox descent
 // (`try_walker_orthodox_list_append`).
-pub(crate) fn fbw_append_journal_push(list: pyre_object::PyObjectRef, length_before: usize) {
-    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().push((list, length_before)));
+pub(crate) fn fbw_list_journal_push_append(list: pyre_object::PyObjectRef, length_before: usize) {
+    FBW_LIST_EFFECT_JOURNAL.with(|j| {
+        j.borrow_mut().push(FbwListEffect::Append {
+            list,
+            length_before,
+        })
+    });
     // gh#467: see `fbw_store_journal_push`.
+    fbw_bump_executed_effect();
+}
+
+/// Record an eagerly executed Integer-strategy end-pop and its boxed displaced
+/// item so a non-commit walk can restore both the length and element even if
+/// the list changes strategy before rollback.
+pub(crate) fn fbw_list_journal_push_pop_end(
+    list: pyre_object::PyObjectRef,
+    length_before: usize,
+    w_item: pyre_object::PyObjectRef,
+) {
+    FBW_LIST_EFFECT_JOURNAL.with(|j| {
+        j.borrow_mut().push(FbwListEffect::PopEnd {
+            list,
+            length_before,
+            w_item,
+        })
+    });
     fbw_bump_executed_effect();
 }
 
@@ -548,7 +571,7 @@ pub(crate) fn fbw_traceback_journal_push_if_attached(
 /// the undo logs.
 pub(crate) fn fbw_store_journal_commit() {
     FBW_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
-    FBW_APPEND_JOURNAL.with(|j| j.borrow_mut().clear());
+    FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_APPEND_PROMOTE_JOURNAL.with(|j| j.borrow_mut().clear());
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().clear());
     // A committed walk keeps its eager `sys_exc_value` store (the compiled
@@ -732,7 +755,7 @@ pub fn fbw_foriter_inflight_take_for_resume(
         if stack[at].body_effect_since_consume
             || stack[at].body_completed
             || fbw_store_journal_len() != 0
-            || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
+            || FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len()) != 0
             || fbw_has_unjournaled_effect()
         {
             return None;
@@ -767,7 +790,7 @@ pub fn fbw_foriter_inflight_completed_at_resume(frame: usize, resume_py_pc: usiz
         stack[at].body_completed
             && !stack[at].body_effect_since_consume
             && fbw_store_journal_len() == 0
-            && FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) == 0
+            && FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len()) == 0
             && !fbw_has_unjournaled_effect()
     })
 }
@@ -806,7 +829,7 @@ pub(crate) fn fbw_foriter_inflight_top_body_pc() -> Option<usize> {
 pub fn fbw_foriter_any_body_effect_signal() -> bool {
     fbw_foriter_body_effect_since_consume()
         || fbw_store_journal_len() != 0
-        || FBW_APPEND_JOURNAL.with(|j| j.borrow().len()) != 0
+        || FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len()) != 0
         || FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len()) != 0
 }
 
@@ -826,7 +849,7 @@ pub fn fbw_foriter_any_body_effect_signal() -> bool {
 ///   mutation already stands on the live heap, so a body re-run would double
 ///   it (Finding #1).
 /// * either journal non-empty (`FBW_STORE_JOURNAL` list setitem /
-///   `FBW_APPEND_JOURNAL` list append).  On the production abort path
+///   `FBW_LIST_EFFECT_JOURNAL` list append/pop). On the production abort path
 ///   `fbw_store_journal_rollback` empties these BEFORE this take, so this is
 ///   normally false here; the check is a belt-and-suspenders refusal in case
 ///   a future caller takes before the rollback.
@@ -855,7 +878,7 @@ pub fn fbw_foriter_inflight_take() -> Option<(pyre_object::PyObjectRef, usize)> 
         return None;
     };
     let store_len = fbw_store_journal_len();
-    let append_len = FBW_APPEND_JOURNAL.with(|j| j.borrow().len());
+    let append_len = FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len());
     let cell_store_len = FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len());
     let unjournaled = fbw_has_unjournaled_effect();
     if body_effect || store_len != 0 || append_len != 0 || cell_store_len != 0 {
@@ -941,16 +964,67 @@ pub(crate) fn fbw_store_journal_rollback() {
             }
         }
     });
-    // Rewind each eager append's length in reverse push order
-    // (allocation-free length set; the journal records only spare-capacity
-    // appends, so there is no realloc to undo and the strategy at rollback
-    // equals the strategy at push). Dispatch the rewind to the strategy's
-    // length field: Object rewinds the `W_ListObject.length` header,
-    // Integer/Float the `int_items`/`float_items` length.
-    FBW_APPEND_JOURNAL.with(|j| {
+    // Undo eager list effects in reverse push order. Append entries record
+    // only spare-capacity growth, so no allocation needs undoing; a later
+    // strategy switch preserves their logical length. Dispatch every entry
+    // against the strategy that is live at rollback time.
+    FBW_LIST_EFFECT_JOURNAL.with(|j| {
         let mut entries = j.borrow_mut();
-        while let Some((list, length_before)) = entries.pop() {
+        while let Some(entry) = entries.pop() {
             unsafe {
+                let (list, length_before) = match entry {
+                    FbwListEffect::Append {
+                        list,
+                        length_before,
+                    } => (list, length_before),
+                    FbwListEffect::PopEnd {
+                        list,
+                        length_before,
+                        w_item,
+                    } => {
+                        let list_ref = &mut *(list as *mut pyre_object::listobject::W_ListObject);
+                        match list_ref.strategy {
+                            pyre_object::listobject::ListStrategy::Integer => {
+                                pyre_object::listobject::ll_list_int_set_len(
+                                    list_ref,
+                                    length_before,
+                                );
+                                pyre_object::listobject::ll_list_int_setitem_fast(
+                                    list_ref,
+                                    length_before - 1,
+                                    pyre_object::w_int_get_value(w_item),
+                                );
+                            }
+                            pyre_object::listobject::ListStrategy::Object => {
+                                // A later ordinary append of a non-int can switch
+                                // the popped Integer list to Object storage, seeded
+                                // only from the post-pop prefix. Restore into that
+                                // live block rather than the discarded int block.
+                                pyre_object::listobject::ll_list_obj_set_len(
+                                    list_ref,
+                                    length_before,
+                                );
+                                pyre_object::listobject::ll_list_obj_setitem_fast(
+                                    list_ref,
+                                    length_before - 1,
+                                    w_item,
+                                );
+                            }
+                            pyre_object::listobject::ListStrategy::Float
+                            | pyre_object::listobject::ListStrategy::Empty => {
+                                crate::trace::fbw_diag::bump(
+                                    crate::trace::fbw_diag::STORE_JOURNAL_ROLLBACK_FAILED,
+                                );
+                                if fbw_debug_abort_enabled() {
+                                    eprintln!(
+                                        "[fbw-list-effect-journal] PopEnd rollback failed (invalid strategy)"
+                                    );
+                                }
+                            }
+                        }
+                        continue;
+                    }
+                };
                 let list_ref = &mut *(list as *mut pyre_object::listobject::W_ListObject);
                 match list_ref.strategy {
                     pyre_object::listobject::ListStrategy::Object => {
@@ -1077,7 +1151,7 @@ pub(crate) fn fbw_store_journal_len() -> usize {
 pub(crate) fn fbw_journaled_effect_lens() -> (usize, usize, usize) {
     (
         fbw_store_journal_len(),
-        FBW_APPEND_JOURNAL.with(|j| j.borrow().len()),
+        FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len()),
         FBW_CELL_STORE_JOURNAL.with(|j| j.borrow().len()),
     )
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2084,7 +2084,7 @@ pub enum DispatchError {
     /// strategy/value is unsupported — `orthodox_list_append_recognize`
     /// returned `None`) or the fold is disabled.  Unlike the fold's
     /// `orthodox_list_append_commit`, the generic residual dispatcher
-    /// concrete-executes `jit_list_append` WITHOUT `fbw_append_journal_push`,
+    /// concrete-executes `jit_list_append` WITHOUT `fbw_list_journal_push_append`,
     /// so `fbw_store_journal_rollback` cannot rewind it; a later trace abort +
     /// interpreter replay would then apply the SAME append twice. Decline the
     /// trace to interpretation instead of falling through, mirroring the
@@ -5670,22 +5670,20 @@ thread_local! {
     static FBW_STORE_JOURNAL: std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
-    /// Undo log for the walked region's eagerly executed list APPENDS:
-    /// `(list, length_before_append)` pairs pushed by the `list.append`
-    /// specialization before it grows the list.  Same rationale as
-    /// [`FBW_STORE_JOURNAL`] — the append is admitted only when
-    /// `w_list_can_append_without_realloc` holds, so the undo is a pure
-    /// length rewind (`w_list_int_set_len`, no reallocation, no boxing) and
-    /// the backing array still has the slot.  A committing walk drops the
-    /// log; a non-commit walk rewinds each list's length in reverse push
-    /// order so the legacy replay re-appends against the pre-walk heap.
-    /// Entries' list refs are GC roots via [`fbw_store_journal_root_walker`].
-    static FBW_APPEND_JOURNAL: std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>> =
+    /// Ordered undo log for eagerly executed list effects. Same transitional
+    /// rationale as [`FBW_STORE_JOURNAL`]: a committing walk drops the log;
+    /// a non-commit walk replays it in reverse push order so interleaved
+    /// appends and end-pops restore the exact pre-walk list state. Dies with
+    /// the legacy replay paths. Entries' list refs are GC roots via
+    /// [`fbw_store_journal_root_walker`]. `PopEnd::w_item` is boxed so a
+    /// strategy change can restore it into Object storage, and is visited
+    /// because the journal holds it live across safepoints.
+    static FBW_LIST_EFFECT_JOURNAL: std::cell::RefCell<Vec<FbwListEffect>> =
         const { std::cell::RefCell::new(Vec::new()) };
 
     /// Undo log for Empty-list first-append promotion during pyre's
     /// speculative full-body walk.  Entries ride the same commit/rollback
-    /// lifecycle as [`FBW_APPEND_JOURNAL`]: a committed walk keeps the typed
+    /// lifecycle as [`FBW_LIST_EFFECT_JOURNAL`]: a committed walk keeps the typed
     /// strategy, while a replayed walk restores the list to Empty so replay
     /// can execute the append from the original shape.  This exists only for
     /// pyre's speculative-replay walk and can be removed when
@@ -5900,6 +5898,18 @@ thread_local! {
     static FBW_EXC_PENDING_PUSH_SET: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
 }
 
+enum FbwListEffect {
+    Append {
+        list: pyre_object::PyObjectRef,
+        length_before: usize,
+    },
+    PopEnd {
+        list: pyre_object::PyObjectRef,
+        length_before: usize,
+        w_item: pyre_object::PyObjectRef,
+    },
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum InlineAbortCarrier {
     Entry {
@@ -5963,7 +5973,7 @@ pub(crate) struct EntryFallback {
 
 struct FbwStoreJournalRootArea {
     stores: *const std::cell::RefCell<Vec<[pyre_object::PyObjectRef; 3]>>,
-    appends: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, usize)>>,
+    list_effects: *const std::cell::RefCell<Vec<FbwListEffect>>,
     append_promote: *const std::cell::RefCell<Vec<pyre_object::PyObjectRef>>,
     abort_overrides: *const std::cell::RefCell<Vec<(usize, pyre_object::PyObjectRef)>>,
     cell_stores: *const std::cell::RefCell<Vec<(pyre_object::PyObjectRef, i64)>>,
@@ -5982,7 +5992,7 @@ struct FbwStoreJournalRootArea {
 thread_local! {
     static FBW_STORE_JOURNAL_ROOT_AREA: FbwStoreJournalRootArea = FbwStoreJournalRootArea {
         stores: FBW_STORE_JOURNAL.with(|value| value as *const _),
-        appends: FBW_APPEND_JOURNAL.with(|value| value as *const _),
+        list_effects: FBW_LIST_EFFECT_JOURNAL.with(|value| value as *const _),
         append_promote: FBW_APPEND_PROMOTE_JOURNAL.with(|value| value as *const _),
         abort_overrides: FBW_ABORT_OUTER_STACK_OVERRIDES.with(|value| value as *const _),
         cell_stores: FBW_CELL_STORE_JOURNAL.with(|value| value as *const _),
@@ -6235,9 +6245,17 @@ pub unsafe fn fbw_store_journal_root_walker_area(
             visitor(unsafe { &mut *(slot as *mut pyre_object::PyObjectRef).cast() });
         }
     }
-    let appends = unsafe { &mut *(*area.appends).as_ptr() };
-    for (list, _len) in appends.iter_mut() {
-        visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+    let list_effects = unsafe { &mut *(*area.list_effects).as_ptr() };
+    for effect in list_effects.iter_mut() {
+        match effect {
+            FbwListEffect::Append { list, .. } => {
+                visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+            }
+            FbwListEffect::PopEnd { list, w_item, .. } => {
+                visitor(unsafe { &mut *(list as *mut pyre_object::PyObjectRef).cast() });
+                visitor(unsafe { &mut *(w_item as *mut pyre_object::PyObjectRef).cast() });
+            }
+        }
     }
     // SAFETY: promoted-list refs can be nursery-resident across the rest of
     // the walk; a minor collection may move them before rollback restores

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -75,7 +75,7 @@ thread_local! {
     ///
     /// Reset at walk start.  Residuals are the only executor that can put
     /// something irreversible between two points of ONE opcode: the eager
-    /// journaled folds (`fbw_store_journal_push` / `fbw_append_journal_push` /
+    /// journaled folds (`fbw_store_journal_push` / `fbw_list_journal_push_append` /
     /// `fbw_cell_store_journal_push`) each terminate their own opcode
     /// (STORE_SUBSCR, the `append` CALL, STORE_NAME/STORE_GLOBAL), so no
     /// residual of the same opcode instance can follow one.
@@ -2625,7 +2625,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
     // un-lowered allocating helper).  Executing it here mutates `list` in place
     // (resize + store); journal the pre-append length so an aborting walk's
     // rollback rewinds the one append and the deliver re-applies it exactly once
-    // (the same `fbw_append_journal_push` contract the fold's own commit uses),
+    // (the same `fbw_list_journal_push_append` contract the fold's own commit uses),
     // making the fall-through abort-safe instead of a silent double.
     let list_append_journal: Option<(pyre_object::PyObjectRef, usize)> =
         if call_descr.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ListAppendValue {
@@ -3477,7 +3477,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // self) rather than a fresh-object op that merely shared the slot.
             if let Some((lhs, len_before)) = inplace_list_journal {
                 if result_i64 as usize == lhs as usize {
-                    fbw_append_journal_push(lhs, len_before);
+                    fbw_list_journal_push_append(lhs, len_before);
                 }
             }
             // A folded-decline `jit_list_append` fall-through (realloc-boundary
@@ -3486,7 +3486,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
             // once.  The append always mutates its receiver (void `0` result),
             // so no in-place `result == lhs` re-check is needed.
             if let Some((list, len_before)) = list_append_journal {
-                fbw_append_journal_push(list, len_before);
+                fbw_list_journal_push_append(list, len_before);
             }
             // pyjitpl.py `result_box.value = result` analogue — stamp
             // the recorded OpRef with the executed concrete so downstream
@@ -3571,7 +3571,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                         result_i64 as usize,
                         ctx.entry_py_pc(),
                         fbw_store_journal_len(),
-                        FBW_APPEND_JOURNAL.with(|j| j.borrow().len()),
+                        FBW_LIST_EFFECT_JOURNAL.with(|j| j.borrow().len()),
                         fbw_has_unjournaled_effect(),
                     );
                 }
@@ -4630,6 +4630,21 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // linear `catch_exception/L`.
     clear_walk_exception(ctx);
 
+    // Offer the specific pop fold before generic builtin inlining. Now that
+    // `list.pop` has a `__pyre_wrap_*` gateway, the generic path finds its
+    // jitcode and otherwise descends into the wrapper until `w_list_len`'s
+    // lock seam. Restrict this to the root walk: guards emitted in an inline
+    // subwalk resume at the caller CALL boundary and could repeat an earlier
+    // caller side effect.
+    if ctx.is_authoritative_executor
+        && !ctx.fbw_mode.inline_subwalk
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_orthodox_list_pop(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // BuiltinCode.func is an indirect PBC target exactly like RPython's
     // gateway wrappers.  Enter its generated JitCode before considering the
     // user-function-only full-body walk below.
@@ -5085,7 +5100,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // call arrives as `CallFn` with `dst_bank == 'r'` (the None result is a
     // Ref, not void) and `r_args = [bound-method, PY_NULL, value]`.  Falls
     // through to the residual for any non-matching shape (SAFE).  The eager append rides
-    // `FBW_APPEND_JOURNAL`, whose commit/rollback epilogues run on FBW walk
+    // `FBW_LIST_EFFECT_JOURNAL`, whose commit/rollback epilogues run on FBW walk
     // ends (same lifecycle as the STORE_SUBSCR store journal).
     //
     // Restrict to the top full-body frame: inside an inlined callee sub-walk
@@ -5138,7 +5153,7 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // Fold to native array stores when the receiver has spare capacity, or
         // fall through to the generic `jit_list_append` residual below.  The
         // fold's `orthodox_list_append_commit` journals the append
-        // (`fbw_append_journal_push`) so `fbw_store_journal_rollback` rewinds it
+        // (`fbw_list_journal_push_append`) so `fbw_store_journal_rollback` rewinds it
         // on abort; the generic executor is now equally abort-safe — its
         // `list_append_journal` records the same pre-append length before
         // running `jit_list_append`, so a later abort + interpreter replay

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9581,9 +9581,276 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     // iterations, a traceback name list with its last frame doubled).
     // Re-read the length instead of assuming which side ran: it is the
     // receiver's own state, so it answers for both.
-    fbw_append_journal_push(inner_self, len_before);
+    fbw_list_journal_push_append(inner_self, len_before);
     if unsafe { pyre_object::w_list_len(inner_self) } == len_before {
         unsafe { pyre_object::w_list_append(inner_self, value) };
+    }
+    Ok(())
+}
+
+/// Descend the guard-free Integer-strategy `w_list_pop_end_inner` body for a
+/// bound `list.pop()` call, recording its length/item array operations instead
+/// of an opaque residual call.
+pub(crate) fn try_walker_orthodox_list_pop<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    code: &[u8],
+    op: &DecodedOp,
+    r_args: &[OpRef],
+    dst: usize,
+) -> Result<Option<()>, DispatchError> {
+    if r_args.len() != 2 {
+        return Ok(None);
+    }
+    let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
+    let (ConcreteValue::Ref(callable), ConcreteValue::Ref(null_or_self)) =
+        (arg_concretes[0], arg_concretes[1])
+    else {
+        return Ok(None);
+    };
+    if callable.is_null() || !null_or_self.is_null() {
+        return Ok(None);
+    }
+
+    let (inner_func, inner_self, len_before, raw_item) = unsafe {
+        if !pyre_object::function::is_method(callable) {
+            return Ok(None);
+        }
+        let inner_func = pyre_object::function::w_method_get_func(callable);
+        let inner_self = pyre_object::function::w_method_get_self(callable);
+        if inner_func.is_null() || inner_self.is_null() {
+            return Ok(None);
+        }
+        let list_type = pyre_interpreter::typedef::gettypeobject(&pyre_object::pyobject::LIST_TYPE);
+        if pyre_interpreter::lookup_in_type(list_type, "pop") != Some(inner_func) {
+            return Ok(None);
+        }
+        let Some((len_before, raw_item)) = orthodox_list_pop_recognize(inner_self) else {
+            return Ok(None);
+        };
+        (inner_func, inner_self, len_before, raw_item)
+    };
+
+    // Resolve every possible decline before recording a guard.
+    let Some((sub_body, sym_ptr)) = orthodox_list_pop_body_and_sym(ctx) else {
+        return Ok(None);
+    };
+    let sym = unsafe { &*sym_ptr };
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    let callable_op = r_args[0];
+
+    let method_type_addr = &pyre_object::function::METHOD_TYPE as *const _ as i64;
+    if !callable_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(callable_op) {
+        let type_const = ctx.trace_ctx.const_int(method_type_addr);
+        ctx.trace_ctx
+            .record_guard(OpCode::GuardClass, &[callable_op, type_const], 0);
+        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    }
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .class_now_known(callable_op, method_type_addr);
+    let func_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_function_descr(),
+    );
+    let func_const = ctx.trace_ctx.const_ref(inner_func as i64);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[func_ref, func_const], 0);
+    walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(func_ref, func_const);
+    let self_ref = crate::state::opimpl_getfield_gc_r(
+        ctx.trace_ctx,
+        callable_op,
+        crate::descr::method_w_self_descr(),
+    );
+
+    match orthodox_list_pop_commit(
+        ctx, op, sym, &sub_body, self_ref, inner_self, len_before, raw_item, dst,
+    ) {
+        Ok(()) => Ok(Some(())),
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+            ctx.trace_ctx.cut_trace(pre_fold_pos);
+            ctx.trace_ctx.heap_cache_mut().reset();
+            bool_box_truth_reset();
+            Ok(None)
+        }
+        Err(error) => Err(error),
+    }
+}
+
+/// Recognize a non-empty Integer-strategy list and sample its final unboxed
+/// item before the descended executor can mutate the live list.
+unsafe fn orthodox_list_pop_recognize(
+    inner_self: pyre_object::PyObjectRef,
+) -> Option<(usize, i64)> {
+    if !pyre_object::pyobject::is_list(inner_self)
+        || !pyre_object::w_list_uses_int_storage(inner_self)
+    {
+        return None;
+    }
+    let len_before = pyre_object::w_list_len(inner_self);
+    if len_before == 0 {
+        return None;
+    }
+    let list = &*(inner_self as *const pyre_object::listobject::W_ListObject);
+    let raw_item = pyre_object::listobject::ll_list_int_getitem_fast(list, len_before - 1);
+    Some((len_before, raw_item))
+}
+
+/// Resolve the pop body and enclosing full-body snapshot before IR emission.
+pub(crate) fn orthodox_list_pop_body_and_sym<Sym: WalkSym>(
+    ctx: &WalkContext<'_, '_, Sym>,
+) -> Option<(SubJitCodeBody, *const Sym)> {
+    let jc_arc = crate::jitcode_runtime::list_pop_end_jitcode()?;
+    let sub_body = sub_jitcode_body_by_index(jc_arc.index())?;
+    let sym_ptr = ctx.fbw_mode.snapshot_sym;
+    if sym_ptr.is_null() || unsafe { (&*sym_ptr).jitcode().is_null() } {
+        return None;
+    }
+    Some((sub_body, sym_ptr))
+}
+
+/// Publish the pop call-site resume coordinate, descend the real helper body,
+/// write its Ref result, and journal/apply the concrete shrink exactly once.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn orthodox_list_pop_commit<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    sym: &Sym,
+    sub_body: &SubJitCodeBody,
+    self_ref: OpRef,
+    inner_self: pyre_object::PyObjectRef,
+    len_before: usize,
+    raw_item: i64,
+    dst: usize,
+) -> Result<(), DispatchError> {
+    ctx.trace_ctx
+        .set_opref_concrete(self_ref, Value::Ref(majit_ir::GcRef(inner_self as usize)));
+
+    let (call_site_py_pc, vsd_value, outer_jitcode_index, call_site_marker) = unsafe {
+        let jc = &*sym.jitcode();
+        let jc_index = jc.index as u32;
+        let marker = jc.payload.resume_marker_for_jitcode_pc(op.pc);
+        let mut py = jc
+            .payload
+            .forward_py_pc_for_jitcode_pc(op.pc)
+            .unwrap_or_else(|| {
+                crate::py_coord::note_empty_twin_fallback(
+                    "list_pop_commit",
+                    jc.index,
+                    op.pc as i32,
+                );
+                crate::py_coord::containing_py_pc_for_jitcode_pc(&jc.payload.metadata, op.pc)
+            });
+        if jc.payload.code_ptr.is_null() {
+            (py, sym.valuestackdepth() as i64, jc_index, marker)
+        } else {
+            let codeobj = &*jc.payload.code_ptr;
+            py = skip_python_trivia_forward(codeobj, py as usize) as u32;
+            let depth = if jc.payload.depth_trivia_populated() {
+                jc.payload.depth_trivia_for_jitcode_pc(op.pc)
+            } else {
+                crate::liveness::liveness_for(jc.payload.code_ptr)
+                    .depth_at_py_pc()
+                    .get(py as usize)
+                    .copied()
+            };
+            let vsd = match depth {
+                Some(d) => (sym.nlocals() + d as usize) as i64,
+                None => sym.valuestackdepth() as i64,
+            };
+            (py, vsd, jc_index, marker)
+        }
+    };
+    if sym.owns_virtualizable_shadow() {
+        let li = call_site_py_pc as i64 - 1;
+        let li_op = ctx.trace_ctx.const_int(li);
+        crate::trace_opcode::mirror_vable_static_to_boxes(
+            ctx.trace_ctx,
+            "last_instr",
+            li_op,
+            Value::Int(li),
+        );
+        let vsd_op = ctx.trace_ctx.const_int(vsd_value);
+        crate::trace_opcode::mirror_vable_static_to_boxes(
+            ctx.trace_ctx,
+            "valuestackdepth",
+            vsd_op,
+            Value::Int(vsd_value),
+        );
+    }
+    let call_site_word = call_site_marker
+        .map(|marker| marker as i32)
+        .unwrap_or(majit_ir::resumedata::NO_JITCODE_PC);
+    let active = collect_outer_active_boxes(
+        sym,
+        ctx.trace_ctx,
+        ctx.registers_i,
+        ctx.registers_r,
+        ctx.registers_f,
+        outer_jitcode_index,
+        false,
+        call_site_word,
+        op.pc as i32,
+        OuterActiveBoxesEntryTwin::Plain,
+        "w_list_pop_end_call_site",
+        None,
+        &[],
+    );
+
+    let saved_entry = ctx.entry_py_pc;
+    let saved_marker = ctx.outer_resume_marker_jit_pc;
+    let saved_oji = ctx.outer_jitcode_index;
+    let saved_active = std::mem::take(&mut ctx.outer_active_boxes);
+    let saved_descr_refs = ctx.descr_refs;
+    let saved_raw_descrs = ctx.raw_descrs;
+    let saved_lookup = ctx.sub_jitcode_lookup;
+    ctx.entry_py_pc = EntryPyPc::Jit(op.pc);
+    ctx.outer_resume_marker_jit_pc = call_site_marker;
+    ctx.outer_jitcode_index = outer_jitcode_index;
+    ctx.outer_active_boxes = active;
+    ctx.descr_refs = crate::jitcode_runtime::all_descr_refs();
+    ctx.raw_descrs = RawDescrPool::Global;
+    ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
+
+    let saved_fbw_mode = ctx.fbw_mode;
+    ctx.fbw_mode.inline_subwalk = true;
+    let walk_result = run_sub_jitcode_walk(
+        ctx,
+        op.pc,
+        sub_body,
+        &[],
+        &[],
+        &[self_ref],
+        &[ConcreteValue::Ref(inner_self)],
+        &[],
+    );
+    ctx.fbw_mode = saved_fbw_mode;
+    ctx.entry_py_pc = saved_entry;
+    ctx.outer_resume_marker_jit_pc = saved_marker;
+    ctx.outer_jitcode_index = saved_oji;
+    ctx.outer_active_boxes = saved_active;
+    ctx.descr_refs = saved_descr_refs;
+    ctx.raw_descrs = saved_raw_descrs;
+    ctx.sub_jitcode_lookup = saved_lookup;
+
+    let result = match walk_result? {
+        DispatchOutcome::SubReturn {
+            result: Some(result),
+        } => result,
+        DispatchOutcome::SubReturn { result: None } => {
+            return Err(DispatchError::UnexpectedVoidSubReturn { pc: op.pc });
+        }
+        _ => return Err(DispatchError::UnexpectedVoidSubReturn { pc: op.pc }),
+    };
+    write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
+
+    let w_item = pyre_object::w_int_new(raw_item);
+    fbw_list_journal_push_pop_end(inner_self, len_before, w_item);
+    if unsafe { pyre_object::w_list_len(inner_self) } == len_before {
+        unsafe { pyre_object::w_list_pop_end(inner_self) };
     }
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -2292,7 +2292,7 @@ fn append_journal_rollback_rewinds_length() {
     // Rollback path: journal push + eager append (production order, see
     // try_walker_orthodox_list_append), then a non-commit exit rewinds
     // the length.
-    super::fbw_append_journal_push(list, len_before);
+    super::fbw_list_journal_push_append(list, len_before);
     unsafe { w_list_append(list, w_int_new(50)) };
     assert_eq!(unsafe { w_list_len(list) }, 5);
     super::fbw_store_journal_rollback();
@@ -2303,7 +2303,7 @@ fn append_journal_rollback_rewinds_length() {
     );
 
     // Commit path: the eager append stands; the log is dropped.
-    super::fbw_append_journal_push(list, len_before);
+    super::fbw_list_journal_push_append(list, len_before);
     unsafe { w_list_append(list, w_int_new(60)) };
     super::fbw_store_journal_commit();
     assert_eq!(
@@ -2318,9 +2318,94 @@ fn append_journal_rollback_rewinds_length() {
 }
 
 #[test]
+fn pop_end_journal_rollback_restores_item_and_length() {
+    use pyre_object::listobject::{W_ListObject, ll_list_int_getitem_fast, w_list_len, w_list_new};
+    use pyre_object::{w_int_new, w_list_pop_end};
+
+    super::fbw_store_journal_reset();
+    let list = w_list_new(vec![w_int_new(10), w_int_new(20), w_int_new(30)]);
+    let len_before = unsafe { w_list_len(list) };
+    let raw_item =
+        unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), len_before - 1) };
+    unsafe { w_list_pop_end(list) };
+    super::fbw_list_journal_push_pop_end(list, len_before, w_int_new(raw_item));
+    assert_eq!(unsafe { w_list_len(list) }, len_before - 1);
+
+    super::fbw_store_journal_rollback();
+    assert_eq!(unsafe { w_list_len(list) }, len_before);
+    assert_eq!(
+        unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), len_before - 1) },
+        raw_item
+    );
+}
+
+#[test]
+fn pop_end_journal_rollback_after_strategy_switch() {
+    use pyre_object::listobject::{
+        W_ListObject, ll_list_int_getitem_fast, w_list_len, w_list_new, w_list_uses_object_storage,
+    };
+    use pyre_object::{w_int_get_value, w_int_new, w_list_append, w_list_getitem, w_list_pop_end};
+
+    super::fbw_store_journal_reset();
+    let list = w_list_new(vec![w_int_new(10), w_int_new(20), w_int_new(30)]);
+    let len_before = unsafe { w_list_len(list) };
+    let raw_item =
+        unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), len_before - 1) };
+    unsafe { w_list_pop_end(list) };
+    super::fbw_list_journal_push_pop_end(list, len_before, w_int_new(raw_item));
+
+    unsafe { w_list_append(list, pyre_object::w_str_new("strategy switch")) };
+    assert!(unsafe { w_list_uses_object_storage(list) });
+
+    super::fbw_store_journal_rollback();
+    assert_eq!(unsafe { w_list_len(list) }, len_before);
+    let restored = unsafe { w_list_getitem(list, (len_before - 1) as i64).unwrap() };
+    assert_eq!(unsafe { w_int_get_value(restored) }, raw_item);
+}
+
+#[test]
+fn interleaved_append_pop_journal_rollback_restores_original() {
+    use pyre_object::listobject::{W_ListObject, ll_list_int_getitem_fast, w_list_len, w_list_new};
+    use pyre_object::{w_int_new, w_list_append, w_list_pop_end};
+
+    super::fbw_store_journal_reset();
+    let original = [10, 20, 30];
+    let list = w_list_new(original.into_iter().map(w_int_new).collect());
+
+    let len_before_append = unsafe { w_list_len(list) };
+    super::fbw_list_journal_push_append(list, len_before_append);
+    unsafe { w_list_append(list, w_int_new(40)) };
+
+    let len_before_pop = unsafe { w_list_len(list) };
+    let raw_item =
+        unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), len_before_pop - 1) };
+    unsafe { w_list_pop_end(list) };
+    super::fbw_list_journal_push_pop_end(list, len_before_pop, w_int_new(raw_item));
+
+    let len_before_append = unsafe { w_list_len(list) };
+    super::fbw_list_journal_push_append(list, len_before_append);
+    unsafe { w_list_append(list, w_int_new(50)) };
+
+    let len_before_pop = unsafe { w_list_len(list) };
+    let raw_item =
+        unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), len_before_pop - 1) };
+    unsafe { w_list_pop_end(list) };
+    super::fbw_list_journal_push_pop_end(list, len_before_pop, w_int_new(raw_item));
+
+    super::fbw_store_journal_rollback();
+    assert_eq!(unsafe { w_list_len(list) }, original.len());
+    for (index, expected) in original.into_iter().enumerate() {
+        assert_eq!(
+            unsafe { ll_list_int_getitem_fast(&*(list as *const W_ListObject), index) },
+            expected
+        );
+    }
+}
+
+#[test]
 fn append_journal_rollback_rewinds_object_length() {
     // #171 object-append: the orthodox fold journals object-strategy
-    // appends through the SAME `FBW_APPEND_JOURNAL` as the int spec, so a
+    // appends through the SAME `FBW_LIST_EFFECT_JOURNAL` as the int spec, so a
     // non-commit rollback must rewind the strategy-correct length — the
     // `W_ListObject.length` header (`ll_list_obj_set_len`), not
     // `int_items.len`.  Rewinding via the int leaf would leave the object
@@ -2344,7 +2429,7 @@ fn append_journal_rollback_rewinds_object_length() {
         "post-grow object list must have spare capacity for the in-place append"
     );
 
-    super::fbw_append_journal_push(list, len_before);
+    super::fbw_list_journal_push_append(list, len_before);
     unsafe { w_list_append(list, w_none()) };
     assert_eq!(unsafe { w_list_len(list) }, 5);
     super::fbw_store_journal_rollback();

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -318,6 +318,9 @@ thread_local! {
     /// Cached `ALL_JITCODES` index of `w_list_append` for the current
     /// thread. `thread_local!` because the names index is also thread-local.
     static LIST_APPEND_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
+    /// Cached `ALL_JITCODES` index of `w_list_pop_end_inner` for the current
+    /// thread. Resolved by name because jitcode indices are build-dependent.
+    static LIST_POP_END_JITCODE_INDEX: OnceCell<Option<usize>> = const { OnceCell::new() };
 }
 
 /// Scan the build-time names index for the unique entry equal to `name`.
@@ -359,6 +362,14 @@ pub(crate) fn named_jitcode(name: &str) -> Option<Arc<JitCode>> {
 pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
     let idx = LIST_APPEND_JITCODE_INDEX
         .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_append_inner")))?;
+    get_jitcode_by_index(idx)
+}
+
+/// The guard-free charon `w_list_pop_end_inner` body in `ALL_JITCODES`,
+/// resolved by name and cached per thread.
+pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
+    let idx = LIST_POP_END_JITCODE_INDEX
+        .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_pop_end_inner")))?;
     get_jitcode_by_index(idx)
 }
 
@@ -1797,6 +1808,17 @@ mod tests {
         assert!(
             !jc.code.is_empty(),
             "w_list_append_inner jitcode should have non-empty bytecode (assembled body)"
+        );
+    }
+
+    #[test]
+    fn list_pop_end_jitcode_resolves_charon_body() {
+        let jc = list_pop_end_jitcode()
+            .expect("build-time pipeline must contain the charon `w_list_pop_end_inner` jitcode");
+        assert_eq!(jc.name, "w_list_pop_end_inner");
+        assert!(
+            !jc.code.is_empty(),
+            "w_list_pop_end_inner jitcode should have non-empty bytecode (assembled body)"
         );
     }
 

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1244,13 +1244,15 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
     /// `celldict.py:207-216 copy` — produce a fresh W_DictObject that
     /// owns unwrapped cell values keyed by str objects.
     ///
-    /// PyPy's destination strategy is `UnicodeDictStrategy`; pyre
-    /// still allocates the destination through `w_dict_new()` (which
-    /// installs `OBJECT_DICT_STRATEGY`) — line-by-line parity for the
-    /// destination strategy lands when typed strategy storage is in
-    /// place.
+    /// The destination is born on `UnicodeDictStrategy` over that
+    /// strategy's own empty storage, matching `:208-209`'s
+    /// `fromcache(UnicodeDictStrategy)` / `get_empty_storage()` pair rather
+    /// than starting the copy on the object strategy.  Every key below is a
+    /// str, so the fill stays on the strategy it was born with.
     unsafe fn copy(&self, w_dict: PyObjectRef) -> PyObjectRef {
-        let new_dict = crate::dictmultiobject::w_dict_new();
+        let strategy = &crate::dictmultiobject::UNICODE_DICT_STRATEGY_REF;
+        let new_dict =
+            crate::dictmultiobject::w_dict_new_with(strategy, strategy.get_empty_storage());
         if let Some(entries) = crate::dictmultiobject::w_module_dict_object_storage(w_dict) {
             for (k, &v) in entries.iter() {
                 crate::dictmultiobject::w_dict_store(new_dict, k.obj, v);

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -103,23 +103,53 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
         let idx = (value - PREBUILTINTFROM) as usize;
         return (&SMALL_INTS[idx] as *const W_IntObject).cast_mut() as PyObjectRef;
     }
-    let obj = W_IntObject {
+    if crate::gc_interp::enabled() {
+        let boxed = w_int_gc_alloc(value);
+        if !boxed.is_null() {
+            return boxed;
+        }
+    }
+    crate::lltype::malloc_typed(W_IntObject {
         ob_header: PyObject {
             ob_type: &INT_TYPE as *const PyType,
             w_class: get_instantiate(&INT_TYPE),
         },
         intval: value,
-    };
-    if crate::gc_interp::enabled() {
-        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
-        if !raw.is_null() {
-            unsafe {
-                std::ptr::write(raw as *mut W_IntObject, obj);
-                return raw as PyObjectRef;
-            }
-        }
+    }) as PyObjectRef
+}
+
+/// The collector-heap arm of [`w_int_new`]: the `gct_fv_gc_malloc` bracket
+/// (`rpython/memory/gctransform/framework.py`) in its alloc-then-init form —
+/// take the block, then write the header and payload into it, rather than
+/// copying a stack-built struct over it. Returns null when no collector owns
+/// the heap, which is the caller's signal to take the `malloc_typed` arm.
+///
+/// Residualised (`rlib/jit.py:139 @dont_look_inside`) rather than traced. A
+/// stack-built struct would lower to a `SyntheticTransparentCtor` for the
+/// `PyObject` header whose funcptr constant degrades to a `symbolic_fnaddr`
+/// hash, which a descending sub-jitcode walk cannot record and declines on;
+/// writing the fields individually instead lands the header's own `ob_type`
+/// slot at offset 0, which the wasm backend does not lower faithfully. The
+/// boundary keeps both shapes out of the trace, and costs the arm nothing
+/// where it is unreachable: `gc_interp::enabled()` is false on the native
+/// backends, whose `malloc_typed` arm is fused into a `NewWithVtable` by the
+/// boxing-constructor pass exactly as before.
+/// Spelled `*mut PyObject` rather than `PyObjectRef` so the attribute emits
+/// its `extern "C"` call trampoline: the macro recognises raw pointers
+/// syntactically and declines to emit one for an aliased return type.
+#[majit_macros::dont_look_inside]
+pub fn w_int_gc_alloc(value: i64) -> *mut PyObject {
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
+    if raw.is_null() {
+        return crate::PY_NULL;
     }
-    crate::lltype::malloc_typed(obj) as PyObjectRef
+    unsafe {
+        let p = raw as *mut W_IntObject;
+        (*p).ob_header.ob_type = &INT_TYPE as *const PyType;
+        (*p).ob_header.w_class = get_instantiate(&INT_TYPE);
+        (*p).intval = value;
+    }
+    raw as PyObjectRef
 }
 
 /// Create a W_IntObject bypassing the small-int cache.

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1593,7 +1593,22 @@ pub unsafe fn w_list_pop(obj: PyObjectRef, index: i64) -> Option<PyObjectRef> {
     }
 }
 
-/// Remove and return last item. Returns `None` if empty.
+/// Remove and return the last item. Returns `None` if empty.
+///
+/// Splits into a guard-taking wrapper and a lock-free
+/// [`w_list_pop_end_inner`], matching [`w_list_append`] /
+/// [`w_list_append_inner`], because the pop fold descends this body:
+///
+/// * the wrapper must stay look-inside — the codewriter only reaches graphs
+///   through look-inside calls from a jitdriver portal
+///   (`grab_initial_jitcodes` / `enum_pending_graphs`), so a
+///   `dont_look_inside` wrapper hides the inner body from the pipeline as
+///   well;
+/// * the descended body must hold no guard — a `w_list_lock` acquire/release
+///   pair inside it declines the fold's sub-walk.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ListObject`.
 pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
     let _roots = crate::gc_roots::push_roots();
     let root_base = crate::gc_roots::shadow_stack_len();
@@ -1601,28 +1616,40 @@ pub unsafe fn w_list_pop_end(obj: PyObjectRef) -> Option<PyObjectRef> {
     let obj = crate::gc_roots::shadow_stack_get(root_base);
     let _list_guard = w_list_lock(obj);
     let obj = crate::gc_roots::shadow_stack_get(root_base);
+    let list = &*(obj as *const W_ListObject);
+    let length = match list.strategy {
+        ListStrategy::Empty => 0,
+        ListStrategy::Integer => ll_list_int_length(list),
+        ListStrategy::Float => list.float_items.len(),
+        ListStrategy::Object => list.length,
+    };
+    if length == 0 {
+        None
+    } else {
+        Some(w_list_pop_end_inner(obj))
+    }
+}
+
+/// [`w_list_pop_end`]'s body, run with the list's guard already held.
+///
+/// # Safety
+/// `obj` must point to a valid non-empty `W_ListObject`, the caller must hold
+/// `w_list_lock(obj)`, and the list's length must be greater than zero.
+pub unsafe fn w_list_pop_end_inner(obj: PyObjectRef) -> PyObjectRef {
     let list = &mut *(obj as *mut W_ListObject);
     match list.strategy {
-        // listobject.py:1180 EmptyListStrategy.pop raises IndexError.
-        ListStrategy::Empty => None,
+        // EmptyListStrategy.pop is unreachable after descr_pop's length check
+        // (pypy/objspace/std/listobject.py).
+        ListStrategy::Empty => PY_NULL,
         ListStrategy::Integer => {
-            if list.int_items.len() == 0 {
-                return None;
-            }
-            Some(w_int_new(list.int_items.pop()))
+            let length = ll_list_int_length(list);
+            let index = length - 1;
+            let item = ll_list_int_getitem_fast(list, index);
+            ll_list_int_set_len(list, index);
+            w_int_new(item)
         }
-        ListStrategy::Float => {
-            if list.float_items.len() == 0 {
-                return None;
-            }
-            Some(w_float_new(list.float_items.pop()))
-        }
-        ListStrategy::Object => {
-            if list.length == 0 {
-                return None;
-            }
-            Some(list.object_pop())
-        }
+        ListStrategy::Float => w_float_new(list.float_items.pop()),
+        ListStrategy::Object => list.object_pop(),
     }
 }
 
@@ -2250,6 +2277,30 @@ mod tests {
             assert!(w_list_pop(list, 5).is_none());
             assert!(w_list_pop(list, -5).is_none());
             assert_eq!(w_list_len(list), 1);
+        }
+    }
+
+    #[test]
+    fn test_w_list_pop_end_returns_none_for_empty_every_strategy() {
+        let empty = w_list_new(Vec::new());
+        let integer = w_list_new(vec![w_int_new(1)]);
+        let float = w_list_new(vec![crate::floatobject::w_float_new(1.0)]);
+        let object = w_list_new_object(vec![w_int_new(1)]);
+
+        unsafe {
+            assert!(w_list_pop_end(integer).is_some());
+            assert!(w_list_pop_end(float).is_some());
+            assert!(w_list_pop_end(object).is_some());
+
+            assert!(w_list_uses_empty_storage(empty));
+            assert!(w_list_uses_int_storage(integer));
+            assert!(w_list_uses_float_storage(float));
+            assert!(w_list_uses_object_storage(object));
+
+            assert!(w_list_pop_end(empty).is_none());
+            assert!(w_list_pop_end(integer).is_none());
+            assert!(w_list_pop_end(float).is_none());
+            assert!(w_list_pop_end(object).is_none());
         }
     }
 


### PR DESCRIPTION
## `list.pop()` fold

`descr_pop` had lost its `index == -1` arm (`listobject.py:766-767`), so every
`lst.pop()` went through the general `pop(index)` path. `w_list_pop_end` is
split at the `w_list_lock` acquire the way `w_list_append` already is, and the
guard-free `w_list_pop_end_inner` is descended by an orthodox sub-jitcode walk,
so the compiled loop carries the array ops themselves rather than a call to
them: the `CallMayForceR` + `GuardNotForced` + the 48-byte bound-method
allocation are gone, leaving a length read, a guard, an `int_sub` and a length
store. `pop(i)` still declines — `ll_pop_nonneg` / `ll_pop_zero` carry a
`list.pop(...)` oopspec upstream, `ll_pop_default` does not.

`list.pop` gets a `__pyre_wrap_*` gateway so `find_all_graphs_bfs` admits it
(jitcode index 2176 -> 2374 names). The append journal becomes one ordered
`FbwListEffect` log replayed in reverse push order, since a pop must restore a
value and not just a length; rollback restores length first, then item, and
dispatches on the list's *current* strategy — a later ordinary append can flip
a popped Integer list to Object storage, and restoring into the discarded int
block trips `IntArray::set_len`.

## Int box on the collector heap

`w_int_new` built the `W_IntObject` on the stack and copied it into the block
`try_gc_alloc_stable_raw` returned. The boxing-constructor pass fuses only the
`lltype::malloc_typed(%agg)` route into a `NewWithVtable`, so on the collector
route `%agg` stayed live as the whole-struct store's operand and the `PyObject`
header's `SyntheticTransparentCtor` survived into the emitted body as a call to
a `symbolic_fnaddr` hash, which the descending walk cannot record. That is why
the fold fired natively and declined on wasm: `gc_interp::enabled()` is false on
the native backends, so the same descent takes different branches.

The collector route moves into `w_int_gc_alloc`, `dont_look_inside` and bound in
`jit_fnaddr`. Writing the header fields into the raw block from the traced body
instead is *not* equivalent — the wasm backend does not lower the `ob_type`
store at offset 0 faithfully, and `list.pop()` then returns a box whose
`w_class` is wrong. `list_ops`, `list_insert_pop_index` and
`list_bound_method_mutation` catch that; `list_pop_append` does not, since it
discards the popped value.

`gc_interp::enabled` and `w_int_gc_alloc` bind their `extern "C"` call
trampolines rather than the raw fns: the wasm backend types a residual's
`call_indirect` from the descr alone, so a raw `-> bool` / `-> *mut PyObject`
traps `indirect call type mismatch`. The trampoline is only emitted for a
syntactically raw pointer return, not for the `PyObjectRef` alias.

## celldict copy

`CellDictStrategy::copy` allocated the destination through `w_dict_new()`
(`OBJECT_DICT_STRATEGY`); `celldict.py:208-209` takes the destination storage
from `UnicodeDictStrategy` and wraps the result with that strategy. The unicode
strategy's empty storage is the same `IndexMap<ObjectKey, PyObjectRef>` box the
object strategy uses, so the str-keyed fill is unchanged.

## Measurements

`synth/list_pop_append`, N=30M:

| | before | after |
|---|---|---|
| dynasm | 0.22s (73.5x) | **0.16s (3.2x)** |
| cranelift | 0.26s | **0.20s (4.2x)** |
| wasm | 5.19s (103.9x) | **0.84s (20.3x)** |

`max-pypy-ratio` refits 172 -> 22. `pypy_type_surface`'s counters are re-recorded
to what this branch produces (the gateway changes the discovered graph set);
main's own CI reports the old values as red at this base.

## Gate

```
ALL PASSED: dynasm 410/410
ALL PASSED: cranelift 410/410
wasm 403 passed, 3 failed
```

The three wasm failures are pre-existing on `main` — its own CI reports the
identical numbers at this branch's base
(`ca_bridge_multiframe_resume_double_call` 2581->2592,
`recursion_memo_branch` 4724->4704, `wasm_ca_trampoline_decline` 404->601).
They are not re-recorded here.

New coverage: `extra_tests/parity_tests/list_pop_fold.py` (8 cases including a
mid-loop Integer->Object despecialisation, run on all three backends) and a
`pop_end_journal_rollback_after_strategy_switch` unit test that fails on the
un-journaled build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved support for optimizing `list.pop()` during execution, including indexed, typed, and mixed-content lists.
  - Added reliable handling for empty-list and over-pop scenarios, including `IndexError`.

- **Bug Fixes**
  - Improved rollback and state restoration for sequences that combine `append()`, `pop()`, and list type changes.
  - Corrected dictionary copying to preserve the appropriate storage behavior.

- **Performance**
  - Reduced JIT bridge compilation and guard failures in benchmark measurements.
  - Lowered overhead for common list append/pop patterns and integer allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->