### PR TITLE
jit: map live values onto the front target LABEL's own argument order

### DIFF
--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2322,34 +2322,32 @@ impl<S: JitState> JitDriver<S> {
             }
             None => None,
         };
+        // Only the compact values are already in the LABEL's argument order. The
+        // walk's full live values are in state-field order, so they get mapped
+        // here; `back_edge_internal` takes whatever it is handed as final.
         let direct_live_values = match compact_label_values {
             Some(values) => Some(values),
             None => match full_live_values {
                 Some(values) => {
-                    if let Some(expected) = self
-                        .meta
-                        .front_target_inputarg_types(key)
-                        .map(|types| types.len())
-                    {
-                        if values.len() != expected {
-                            if crate::callee_rca_enabled() {
-                                eprintln!(
-                                    "[callee-rca][direct-entry-pack] key={key} \
-                                     dispatch_key={dispatch_key} full_len={} \
-                                     label_len={expected} -> pack-in-back-edge",
-                                    values.len()
-                                );
-                            }
+                    let packed = self.meta.pack_front_target_live_values(key, &values);
+                    if crate::callee_rca_enabled() {
+                        match packed.as_ref() {
+                            Some(packed) => eprintln!(
+                                "[callee-rca][direct-entry-pack] key={key} \
+                                 dispatch_key={dispatch_key} \
+                                 source=full-live-packed full_len={} compact_len={}",
+                                values.len(),
+                                packed.len()
+                            ),
+                            None => eprintln!(
+                                "[callee-rca][direct-entry-pack] key={key} \
+                                 dispatch_key={dispatch_key} full_len={} \
+                                 source=full-live-packed -> decline",
+                                values.len()
+                            ),
                         }
                     }
-                    if crate::callee_rca_enabled() {
-                        eprintln!(
-                            "[callee-rca][direct-entry-pack] key={key} dispatch_key={dispatch_key} \
-                             source=full-compatible len={}",
-                            values.len()
-                        );
-                    }
-                    Some(values)
+                    packed
                 }
                 None => None,
             },
@@ -4186,6 +4184,10 @@ impl<S: JitState> JitDriver<S> {
             if !self.sync_before(state, &compiled_meta, descriptor.as_deref()) {
                 return None;
             }
+            // `direct_live_values` arrive already in the target LABEL's argument
+            // order; state-extracted ones are in state-field order and have to be
+            // mapped before a dispatch-key entry can use them.
+            let values_are_label_ordered = direct_live_values.is_some();
             let mut live_values = if let Some(values) = direct_live_values {
                 values
             } else {
@@ -4208,40 +4210,56 @@ impl<S: JitState> JitDriver<S> {
                 };
                 live_values
             };
-            if dispatch_key.is_some() {
-                let Some(expected) = self
+            if dispatch_key.is_some() && !values_are_label_ordered {
+                let full_len = live_values.len();
+                let Some(packed) = self
                     .meta
-                    .front_target_inputarg_types(green_key)
-                    .map(|types| types.len())
+                    .pack_front_target_live_values(green_key, &live_values)
                 else {
-                    return None;
-                };
-                if live_values.len() != expected {
-                    let full_len = live_values.len();
-                    let Some(packed) = self
-                        .meta
-                        .pack_front_target_live_values(green_key, &live_values)
-                    else {
-                        if crate::callee_rca_enabled() {
-                            eprintln!(
-                                "[callee-rca][direct-entry-pack] key={green_key} \
-                                 dispatch_key={:?} full_len={full_len} label_len={expected} \
-                                 source=front-target-source-positions -> decline",
-                                dispatch_key,
-                            );
-                        }
-                        return None;
-                    };
                     if crate::callee_rca_enabled() {
                         eprintln!(
-                            "[callee-rca][direct-entry-pack] key={green_key} dispatch_key={:?} \
-                             source=front-target-source-positions full_len={full_len} \
-                             compact_len={}",
+                            "[callee-rca][direct-entry-pack] key={green_key} \
+                             dispatch_key={:?} full_len={full_len} \
+                             source=front-target-source-positions -> decline",
                             dispatch_key,
-                            packed.len()
                         );
                     }
-                    live_values = packed;
+                    return None;
+                };
+                if crate::callee_rca_enabled() {
+                    eprintln!(
+                        "[callee-rca][direct-entry-pack] key={green_key} dispatch_key={:?} \
+                         source=front-target-source-positions full_len={full_len} \
+                         compact_len={}",
+                        dispatch_key,
+                        packed.len()
+                    );
+                }
+                live_values = packed;
+            }
+            if dispatch_key.is_some() && values_are_label_ordered {
+                // The compact values are LABEL-ordered by construction, but the
+                // same unchecked Ref dereference is downstream of them, so the
+                // types are confirmed here as well.
+                let Some(types) = self.meta.front_target_inputarg_types(green_key) else {
+                    return None;
+                };
+                if types.len() != live_values.len()
+                    || types
+                        .iter()
+                        .zip(live_values.iter())
+                        .any(|(want, value)| value.get_type() != *want)
+                {
+                    if crate::callee_rca_enabled() {
+                        eprintln!(
+                            "[callee-rca][direct-entry-pack] key={green_key} \
+                             dispatch_key={:?} source=compact-label label_types={types:?} \
+                             value_types={:?} -> decline",
+                            dispatch_key,
+                            live_values.iter().map(|v| v.get_type()).collect::<Vec<_>>(),
+                        );
+                    }
+                    return None;
                 }
             }
 
@@ -5464,29 +5482,19 @@ impl<S: JitState> JitDriver<S> {
             };
         };
         let mut live_values = live_values;
+        // `live_values` is in state-field order; a dispatch-key entry lands on a
+        // LABEL whose arguments are its own, so the mapping runs unconditionally.
         if dispatch_key.is_some() {
-            let Some(expected) = self
+            let Some(packed) = self
                 .meta
-                .front_target_inputarg_types(green_key)
-                .map(|types| types.len())
+                .pack_front_target_live_values(green_key, &live_values)
             else {
                 return DetailedDriverRunOutcome::Abort {
                     restored: false,
                     via_blackhole: false,
                 };
             };
-            if live_values.len() != expected {
-                let Some(packed) = self
-                    .meta
-                    .pack_front_target_live_values(green_key, &live_values)
-                else {
-                    return DetailedDriverRunOutcome::Abort {
-                        restored: false,
-                        via_blackhole: false,
-                    };
-                };
-                live_values = packed;
-            }
+            live_values = packed;
         }
         pre_run();
         let result = if let Some(dispatch_key) = dispatch_key {
@@ -6715,13 +6723,12 @@ impl<S: JitState> JitDriver<S> {
         )?;
         let mut live_values = live_values;
         let mut dispatch_key = single_pass_dispatch_key;
+        // `live_values` is in state-field order; a dispatch-key entry lands on a
+        // LABEL whose arguments are its own, so the mapping runs unconditionally.
         if dispatch_key.is_some() {
-            let expected = self.meta.front_target_inputarg_types(key_hash)?.len();
-            if live_values.len() != expected {
-                live_values = self
-                    .meta
-                    .pack_front_target_live_values(key_hash, &live_values)?;
-            }
+            live_values = self
+                .meta
+                .pack_front_target_live_values(key_hash, &live_values)?;
         }
         pre_run();
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9374,7 +9374,8 @@ impl<M: Clone> MetaInterp<M> {
                 return None;
             }
         };
-        let expected = self.front_target_inputarg_types(green_key)?.len();
+        let types = self.front_target_inputarg_types(green_key)?;
+        let expected = types.len();
         if source_positions.len() != expected {
             if crate::callee_rca_enabled() {
                 eprintln!(
@@ -9387,7 +9388,7 @@ impl<M: Clone> MetaInterp<M> {
             return None;
         }
         let mut packed = Vec::with_capacity(source_positions.len());
-        for &source in source_positions {
+        for (slot, &source) in source_positions.iter().enumerate() {
             let Some(value) = full_live_values.get(source).copied() else {
                 if crate::callee_rca_enabled() {
                     eprintln!(
@@ -9399,6 +9400,23 @@ impl<M: Clone> MetaInterp<M> {
                 }
                 return None;
             };
+            // The LABEL declares each argument's type, and compiled code reads a
+            // Ref slot as a pointer without checking it. A mapping that lands an
+            // Int in a Ref slot dereferences the integer, so a type disagreement
+            // is refused here rather than executed.
+            if value.get_type() != types[slot] {
+                if crate::callee_rca_enabled() {
+                    eprintln!(
+                        "[callee-rca][direct-entry-pack-detail] key={green_key} \
+                         slot={slot} source={source} value_type={:?} label_type={:?} \
+                         sources={:?}",
+                        value.get_type(),
+                        types[slot],
+                        source_positions,
+                    );
+                }
+                return None;
+            }
             packed.push(value);
         }
         Some(packed)
@@ -21369,6 +21387,120 @@ mod tests {
             meta.front_target_inputarg_types(green_key),
             Some(vec![Type::Ref, Type::Ref, Type::Ref, Type::Int])
         );
+    }
+
+    /// A `MetaInterp` holding one compiled loop whose front target LABEL takes
+    /// `(Int, Ref, Ref, Ref)`, with `source_positions` as given.
+    fn meta_with_front_label_int_ref_ref_ref(
+        green_key: u64,
+        source_positions: Option<Vec<usize>>,
+    ) -> (MetaInterp<()>, std::sync::Arc<JitCellToken>) {
+        let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let trace_id = 11;
+        let token = std::sync::Arc::new(JitCellToken::new(3));
+        let start_token = crate::history::TargetToken::new_preamble(0);
+        let start_descr = start_token.as_jump_target_descr();
+        let inputargs = vec![InputArg::new_ref(0), InputArg::new_ref(1)];
+        let ops = vec![
+            mk_op(OpCode::SameAsR, &[OpRef::input_arg_ref(0)], 2),
+            mk_op(OpCode::IntAdd, &[OpRef::int_op(100), OpRef::int_op(101)], 3),
+            mk_op_with_descr(
+                OpCode::Label,
+                &[
+                    OpRef::int_op(3),
+                    OpRef::input_arg_ref(0),
+                    OpRef::input_arg_ref(1),
+                    OpRef::ref_op(2),
+                ],
+                OpRef::NONE.raw(),
+                start_descr,
+            ),
+        ];
+        let mut constants: majit_ir::ConstMap<majit_ir::Const> = majit_ir::ConstMap::new();
+        constants.insert(100, majit_ir::Const::Int(1));
+        constants.insert(101, majit_ir::Const::Int(2));
+        let mut traces = indexmap::IndexMap::new();
+        traces.insert(
+            trace_id,
+            CompiledTrace {
+                inputargs: inputargs.iter().map(InputArg::fresh_value_copy).collect(),
+                ops: ops.into_iter().map(std::rc::Rc::new).collect(),
+                constants,
+                exit_layouts: indexmap::IndexMap::new(),
+                terminal_exit_layouts: indexmap::IndexMap::new(),
+            },
+        );
+        meta.warm_state_mut()
+            .attach_procedure_to_interp(green_key, std::sync::Arc::clone(&token));
+        meta.compiled_loops.insert(
+            green_key,
+            CompiledEntry {
+                token: std::sync::Arc::downgrade(&token),
+                meta: (),
+                front_target_tokens: vec![start_token],
+                front_entry_index: Some(0),
+                front_target_source_positions: source_positions,
+                root_trace_id: trace_id,
+                traces,
+                previous_tokens: Vec::new(),
+                next_global_opref: 0,
+            },
+        );
+        (meta, token)
+    }
+
+    /// The LABEL's argument order is its own, not the frontend's state-field
+    /// order, and the two can agree in length while disagreeing in position.
+    /// `aheui`'s `pi/pi.jinseo` under the cranelift backend hit exactly that:
+    /// four state values `(Int, Int, Ref, Ref)` entered a four-argument
+    /// `(Int, Ref, Ref, Ref)` LABEL, and compiled code dereferenced the second
+    /// `Int` as a pointer.
+    #[test]
+    fn test_pack_front_target_live_values_reorders_and_refuses_mismatches() {
+        let state_order = vec![
+            Value::Int(23),
+            Value::Int(2),
+            Value::Ref(majit_ir::GcRef(0x1000)),
+            Value::Ref(majit_ir::GcRef(0x2000)),
+        ];
+
+        // Sound mapping: LABEL slot i takes state value `sources[i]`. The
+        // permutation is not the identity, so a pack that silently passed its
+        // input through would fail this assert.
+        let (meta, _token) = meta_with_front_label_int_ref_ref_ref(7, Some(vec![1, 2, 3, 2]));
+        assert_eq!(
+            meta.front_target_inputarg_types(7),
+            Some(vec![Type::Int, Type::Ref, Type::Ref, Type::Ref])
+        );
+        let packed = meta
+            .pack_front_target_live_values(7, &state_order)
+            .expect("a complete, type-agreeing mapping packs");
+        assert_eq!(
+            packed,
+            vec![
+                Value::Int(2),
+                Value::Ref(majit_ir::GcRef(0x1000)),
+                Value::Ref(majit_ir::GcRef(0x2000)),
+                Value::Ref(majit_ir::GcRef(0x1000)),
+            ]
+        );
+        assert_ne!(packed, state_order, "the pack must not be a pass-through");
+
+        // Incomplete mapping: three sources for a four-argument LABEL. This is
+        // the `pi.jinseo` shape — the fourth LABEL argument is a trace-internal
+        // value with no state field behind it, so there is nothing to enter with.
+        let (meta, _token) = meta_with_front_label_int_ref_ref_ref(8, Some(vec![1, 2, 3]));
+        assert_eq!(meta.pack_front_target_live_values(8, &state_order), None);
+
+        // Right arity, wrong types: the identity mapping puts `Int(2)` in the
+        // LABEL's second slot, which is `Ref`.
+        let (meta, _token) = meta_with_front_label_int_ref_ref_ref(9, Some(vec![0, 1, 2, 3]));
+        assert_eq!(meta.pack_front_target_live_values(9, &state_order), None);
+
+        // No mapping recorded at all.
+        let (meta, _token) = meta_with_front_label_int_ref_ref_ref(10, None);
+        assert_eq!(meta.pack_front_target_live_values(10, &state_order), None);
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -218,6 +218,12 @@ impl W_Unpickler {
         }
         // The memo persists across `load` calls (a multi-object stream may
         // back-reference an object memoized by an earlier load).
+        let stack = pyre_object::listobject::w_list_new(Vec::new());
+        pyre_object::gc_roots::pin_root(stack);
+        let stack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let metastack = pyre_object::listobject::w_list_new(Vec::new());
+        pyre_object::gc_roots::pin_root(metastack);
+        let metastack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let memo = pyre_object::listobject::w_list_new(Vec::new());
         pyre_object::gc_roots::pin_root(memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -234,8 +240,8 @@ impl W_Unpickler {
         current.fix_imports = fix_imports;
         current.w_file_read = pyre_object::gc_roots::shadow_stack_get(read_slot);
         current.w_file_readline = pyre_object::gc_roots::shadow_stack_get(readline_slot);
-        current.w_stack = pyre_object::w_none();
-        current.w_metastack = pyre_object::w_none();
+        current.w_stack = pyre_object::gc_roots::shadow_stack_get(stack_slot);
+        current.w_metastack = pyre_object::gc_roots::shadow_stack_get(metastack_slot);
         current.w_memo = pyre_object::gc_roots::shadow_stack_get(memo_slot);
         current.memo_index = 0;
         current.w_frame = pyre_object::w_none();
@@ -291,17 +297,27 @@ impl W_Unpickler {
             );
         }
 
-        // Fresh stack each load; the memo persists across `load` calls so a
-        // later object can back-reference one memoized by an earlier load
-        // (lazily created when the unpickler was built only via `__new__`).
-        let w_stack = pyre_object::listobject::w_list_new(Vec::new());
-        let me = cur(slot);
-        me.w_stack = w_stack;
-        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
-        let me = cur(slot);
-        me.w_metastack = w_metastack;
-        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        // Reset the constructor-owned stacks in place. An object built only
+        // via `__new__` still initializes them lazily on its first `load`.
+        if unsafe { pyre_object::is_none(cur(slot).w_stack) } {
+            let w_stack = pyre_object::listobject::w_list_new(Vec::new());
+            let me = cur(slot);
+            me.w_stack = w_stack;
+            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        }
+        if unsafe { pyre_object::is_none(cur(slot).w_metastack) } {
+            let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
+            let me = cur(slot);
+            me.w_metastack = w_metastack;
+            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        }
+        unsafe {
+            pyre_object::listobject::w_list_clear(cur(slot).w_stack);
+            pyre_object::listobject::w_list_clear(cur(slot).w_metastack);
+        }
+        // The memo persists across `load` calls so a later object can
+        // back-reference one memoized by an earlier load. It is created lazily
+        // only when the unpickler was built via `__new__` without `__init__`.
         if unsafe { pyre_object::is_none(cur(slot).w_memo) } {
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             let me = cur(slot);

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -218,12 +218,6 @@ impl W_Unpickler {
         }
         // The memo persists across `load` calls (a multi-object stream may
         // back-reference an object memoized by an earlier load).
-        let stack = pyre_object::listobject::w_list_new(Vec::new());
-        pyre_object::gc_roots::pin_root(stack);
-        let stack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        let metastack = pyre_object::listobject::w_list_new(Vec::new());
-        pyre_object::gc_roots::pin_root(metastack);
-        let metastack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let memo = pyre_object::listobject::w_list_new(Vec::new());
         pyre_object::gc_roots::pin_root(memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -240,8 +234,8 @@ impl W_Unpickler {
         current.fix_imports = fix_imports;
         current.w_file_read = pyre_object::gc_roots::shadow_stack_get(read_slot);
         current.w_file_readline = pyre_object::gc_roots::shadow_stack_get(readline_slot);
-        current.w_stack = pyre_object::gc_roots::shadow_stack_get(stack_slot);
-        current.w_metastack = pyre_object::gc_roots::shadow_stack_get(metastack_slot);
+        current.w_stack = pyre_object::w_none();
+        current.w_metastack = pyre_object::w_none();
         current.w_memo = pyre_object::gc_roots::shadow_stack_get(memo_slot);
         current.memo_index = 0;
         current.w_frame = pyre_object::w_none();
@@ -297,27 +291,17 @@ impl W_Unpickler {
             );
         }
 
-        // Reset the constructor-owned stacks in place. An object built only
-        // via `__new__` still initializes them lazily on its first `load`.
-        if unsafe { pyre_object::is_none(cur(slot).w_stack) } {
-            let w_stack = pyre_object::listobject::w_list_new(Vec::new());
-            let me = cur(slot);
-            me.w_stack = w_stack;
-            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        }
-        if unsafe { pyre_object::is_none(cur(slot).w_metastack) } {
-            let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
-            let me = cur(slot);
-            me.w_metastack = w_metastack;
-            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        }
-        unsafe {
-            pyre_object::listobject::w_list_clear(cur(slot).w_stack);
-            pyre_object::listobject::w_list_clear(cur(slot).w_metastack);
-        }
-        // The memo persists across `load` calls so a later object can
-        // back-reference one memoized by an earlier load. It is created lazily
-        // only when the unpickler was built via `__new__` without `__init__`.
+        // Fresh stack each load; the memo persists across `load` calls so a
+        // later object can back-reference one memoized by an earlier load
+        // (lazily created when the unpickler was built only via `__new__`).
+        let w_stack = pyre_object::listobject::w_list_new(Vec::new());
+        let me = cur(slot);
+        me.w_stack = w_stack;
+        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
+        let me = cur(slot);
+        me.w_metastack = w_metastack;
+        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
         if unsafe { pyre_object::is_none(cur(slot).w_memo) } {
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             let me = cur(slot);


### PR DESCRIPTION
## What

A dispatch-key entry lands on a compiled **LABEL**, whose arguments are its own — not the frontend's state-field layout. Three sites in `jitdriver.rs` re-mapped the values only when the two disagreed in *length*:

```rust
if live_values.len() != expected { pack_front_target_live_values(...) }
```

Equal arity was taken as equal order.

## The failure

`aheui`'s `pi/pi.jinseo` under the cranelift backend:

| | |
|---|---|
| frontend state order | `[selected: Int(23), stacksize: Int(2), selected_ref: Ref, storage_ref: Ref]` |
| LABEL args | `Label(v23: Int, v2: Ref, v3: Ref, v202: Ref)` |

`4 == 4`, so the mapping was skipped and `Int(2)` entered slot 1. Compiled code loads a Ref slot as a pointer without checking it — `EXC_BAD_ACCESS address=0x1c` at `ldr x5,[x3]`.

Only cranelift reaches this: every other backend takes `Backend::supports_dispatch_key_entry()`'s `false` default, so its dispatch key is always 0 and the peeled preamble runs. `dynasm` on the same program at the same thresholds logged 293 compiled entries, all `dispatch_key=0`.

For this trace the recorded mapping is `sources=[1, 2, 3]` against a four-argument LABEL — the fourth argument is `SameAsR(pools[21])`, a trace-internal value with no state field behind it, so no state-derived entry is possible at all. The sound answer is to decline.

## Changes

- All three `jitdriver.rs` sites run the mapping unconditionally under a dispatch key and decline the entry when it is unavailable. The fallback is the key-0 entry every other backend takes.
- `try_resume_into_compiled_loop`'s full-live fallback is mapped where it is produced, so `direct_live_values` is LABEL-ordered at every caller (only `single_pass_compact_label_values` was, before).
- `pack_front_target_live_values` confirms each packed value's type against the LABEL's declared inputarg type; `back_edge_internal` confirms the same for the compact values it does not re-map.
- Regression test `test_pack_front_target_live_values_reorders_and_refuses_mismatches` asserts the pack is not a pass-through first, then refuses the incomplete-mapping, wrong-type and no-mapping cases. With the type check disabled it fails with exactly the defective value: `Some([Int(23), Int(2), Ref, Ref])`.

## Gates

The defect was **not** visible at every threshold — `pi.jinseo` crashed at 1000/5000/20000/100000 and ran clean at 100–990, 1001–2000 and 1e9, deterministically. Non-monotone in threshold means the variable is which loop header becomes hot, so a single-threshold suite can be green with the defect live. The gate sweeps it.

| `MAJIT_THRESHOLD` | cranelift | dynasm |
|---|---|---|
| 100 | 62/62 | 62/62 |
| 1000 | 62/62 | 62/62 |
| 5000 | 62/62 | 62/62 |
| 20000 | 62/62 | 62/62 |
| 100000 | 62/62 | 62/62 |

Zero crash/abort/alarm lines at every step; cranelift was 61/62 before.

- aheui official suite, JIT never fires (`MAJIT_THRESHOLD=1e9`): 62/62
- `jitstats.py check`: 0 failed, no baseline re-recorded
- aheui workspace tests, `majit-metainterp` release tests, `cargo fmt -p majit-metainterp -- --check`: all clean
- pyre-side frontends with `--features cranelift`: `tl` 28 passed, `tinyframe` 10, `braininterp` 7, `cel` compiles (it has no tests)
- HEAD identical before and after the gate run

`pyre/check.py` was not run. The changed branches are dead under `dynasm`, where `dispatch_key` is always `None` — that is an argument from reading the callers, not a measurement.

The two `_pickle` commits under this one were already on the branch and are not part of this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)