### PR TITLE
check.py: give the non-Windows perf ceiling its denominator term

### DIFF
--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1977,9 +1977,25 @@ class Check:
         # ``pyre <= baseline * limit`` needs 2q on the left and 2q*limit on the
         # right.  Adding one tick to every raw sample cannot model this: those
         # additions cancel during startup subtraction.
+        #
+        # The right-hand ``baseline * limit`` amplifies the baseline's own
+        # measurement error by `limit`, and off Windows that term was missing:
+        # the buffer carried only the left-hand `BENCH_COMPARE_BUFFER_S` and no
+        # allowance for a noisy denominator.  A baseline near EXEC_TIME_FLOOR_S
+        # is a difference of two medians each granular to about one floor, so its
+        # residual run-to-run error is ~EXEC_TIME_FLOOR_S, and the budget it sets
+        # swings by `limit * EXEC_TIME_FLOOR_S`.  This makes the effective
+        # ceiling `limit * (1 + EXEC_TIME_FLOOR_S / baseline)`: the grace is
+        # `floor / baseline`, real only when the baseline is close to the floor
+        # -- exactly where the denominator cannot be trusted -- and vanishing
+        # for a baseline that is real work.  `exception_traceback_loop_forms`
+        # read 35.6x on one runner and 37.1x on another against an unchanged
+        # ~2.3s exec, a 0.06s baseline wobbling +-0.004s across the 36x line.
         compare_buffer = BENCH_COMPARE_BUFFER_S
         if sys.platform == "win32":
             compare_buffer += 2 * WIN_TIMER_QUANTUM_S * (1 + limit)
+        else:
+            compare_buffer += limit * EXEC_TIME_FLOOR_S
 
         def failed_bound(measured, baseline_value):
             exec_measured = self._exec_time(backend, measured)


### PR DESCRIPTION
## Summary

One commit: the non-Windows perf ceiling was missing the denominator term its
Windows counterpart already carries.

Fixes `pyre/check.py (ubuntu-24.04)` —
`cranelift synth/exception_traceback_loop_forms 36.3x > gate 36x`.

## `check.py: buffer the non-Windows perf ceiling against denominator noise`

The ceiling test is `pyre_exec > baseline_exec * limit + compare_buffer`. The
right-hand side amplifies the **baseline's** measurement error by `limit`, and
only the Windows path carried a term for it (`2q * (1 + limit)`); off Windows the
buffer was just the left-hand `BENCH_COMPARE_BUFFER_S`, a numerator term. A
baseline near `EXEC_TIME_FLOOR_S` is a difference of two medians each granular to
about one floor, so the budget it sets swings by `limit * EXEC_TIME_FLOOR_S`.

That term is added off Windows now. The effective ceiling becomes
`limit * (1 + EXEC_TIME_FLOOR_S / baseline)`: the grace is `floor / baseline`,
real only where the denominator cannot be trusted and vanishing for a baseline
that is real work (≤1% at a 1s baseline). No per-fixture ceiling is changed and
no baseline is re-recorded.

Not a regression in pyre: `exception_traceback_loop_forms` read 35.6x on one
runner and 36.3–37.6x on others against an **unchanged ~2.2–2.4s exec** — a 0.06s
pypy denominator wobbling ±0.004s across the line. A retry-by-median run failed
too, so it does not clear itself.

Complementary to #1086, which refits per-fixture ceilings to twice the slowest
observed ratio and reasons about the effective bound as
`limit + compare_buffer/exec_baseline`; #1086 did not refit this fixture.

## Verification

- Gate arithmetic on the runners' own numbers: the 36.3x/37.1x readings pass with
  the added term, `main`'s 35.6x verdict is unchanged, and a synthetic 2x
  regression still fails.
- CI on this branch: `pyre/check.py` **passes on ubuntu-24.04 and
  windows-latest**. The macOS `check.py` job and `CPython suite (gate)` fail, and
  both are **inherited from `main`** — same two rows, verbatim, in `main`'s own run
  at `0c3c4777ba9`: `test.test_pickletools PASS -> FAIL (errors=1)` and
  `test.test_re PASS -> FAIL (errors=303)`. Neither is a perf row; the perf suite
  itself is 410/410 on dynasm and 410/410 on cranelift in that same job. `test_re`
  is the defect #1122 fixes.
  ⚠ Note this run is not a *demonstration* of the fix: `main`'s ubuntu `check.py`
  is green in the control too, so the intermittent ceiling failure simply did not
  recur. The argument rests on the arithmetic and the recorded failing readings.

## Measured scope, and the one thing this loosens

Counted from the comparison table of the macOS `check.py` job on this branch
(377 fixtures timed against pypy):

| | |
|---|---|
| ceilings armed (dynasm) | **273** |
| printed `~`, gate not applied (baseline clamped to the floor) | **104** |
| armed **and** `exec_baseline ≥ FLOOR_GATE_MIN_BASELINE_S` (0.05s) | **67** |
| armed with a baseline below that | **~206** |
| armed with pypy raw ≤ 0.020s, i.e. exec within one floor of the clamp | **69** |

The clamp boundary sits exactly at pypy raw `0.020s` (max among `~` rows = min
among armed rows), which puts pypy startup at about `0.015s`.

The added grace is `floor / exec_baseline`, so it is ≤10% only for the 67
fixtures whose baseline clears `FLOOR_GATE_MIN_BASELINE_S`, and it approaches
**100%** — an effective ceiling of roughly `2 × limit` — for the ~69 sitting just
above the clamp. `FLOOR_GATE_MIN_BASELINE_S` currently guards **only the floor**
(`check.py:2038`); the ceiling path has no such requirement, so this widening
lands on fixtures whose ratio the same constant already declares unmeasurable.

I am not changing that here: the motivating fixture is in the trustworthy group
(`exception_traceback_loop_forms`, pypy raw `0.09s` ⇒ exec ≈ `0.075s` ⇒ grace
≈ 6.7%), and disarming or re-scoping ceilings on ~206 fixtures is a coverage
decision, not a bug fix. The coherent follow-up is to make the ceiling decline to
arm below `FLOOR_GATE_MIN_BASELINE_S` exactly as the floor does — flagged here so
the choice is explicit rather than implied by this patch.

## Withdrawn from this PR: the two cut-trace commits

This PR originally also carried
`jit: seed the cut-trace escape closure from post-cut guard snapshots` and
`jit: decline a snapshot root whose cone needs an extra inputarg`. Both are
**dropped** — #1122 fixes the same defect with a sounder design, and the two
should not race each other into the same function:

| | this PR (dropped) | #1122 |
|---|---|---|
| cone predicate | `has_no_side_effect()` | **`is_always_pure()`** |
| on a refused root | keep the `NONE` mapping and compile | **cancel the compilation** |

`has_no_side_effect()` is the wrong boundary: the band runs to
`_NOSIDEEFFECT_LAST` and so admits every mutable load (`GETFIELD_GC`,
`GETARRAYITEM_GC`, `GC_LOAD`, `RAW_LOAD`) and every allocation (`NEW*`). Prefix
re-emission re-executes the definition at the cut, so a replayed load returns
memory as it is at the cut rather than the value the snapshot named, and a
replayed allocation mints a blank second object. `is_always_pure()` is the
correct predicate. Credit to the Codex parity review on this PR for naming it.

One thing does **not** carry over to #1122, and is left here for whoever picks it
up: #1122 still treats a pre-cut original inputarg as an unconditional leaf,
with the comment that phase 4 maps it to its pool constant. Phase 4 has a second
arm — it appends the value as an **extra inputarg** — and
`patch_new_loop_to_load_virtualizable_fields` requires the run after the red args
to be exactly the virtualizable's expansion, asserting `i == len(inputargs)`
(`compile.py:458`). Detail and a reproduction are in a comment on #1122.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
