### PR TITLE
jit: guard the raw namespace dict reads, and flush the virtualizable after mirroring a static field

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -6300,7 +6300,7 @@ mod register_keyed_size_authority_tests {
         // Parent lists f16, f24, f32 — so `f24` is at index 1.
         gc._cache_size
             .insert(key.clone(), size_descr_at(7, 0, &[16, 24, 32]));
-        let mut lookup = |gc: &mut GcCache| {
+        let lookup = |gc: &mut GcCache| {
             gc.get_field_descr(
                 key.clone(),
                 "f24",

--- a/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
+++ b/majit/majit-metainterp/tests/jit_interp_float_state_field.rs
@@ -254,7 +254,7 @@ mod scalar_f32 {
     fn f32_scalar_minimal(program: &Bytecode, threshold: u32) -> i64 {
         let mut driver: JitDriver<F32State> = JitDriver::new(threshold);
         let mut pc: usize = 0;
-        let mut state = F32State { a: 0, f: 0.0 };
+        let state = F32State { a: 0, f: 0.0 };
         {
             use majit_metainterp::JitState as _;
             state

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2046,6 +2046,7 @@ pub fn lower_fun_decl_with_static_addrs(
 
 /// The `struct_field_attrs` projection of [`derive_program_metadata`] —
 /// the map the whole-program loop lowers this LLBC's decls with.
+#[cfg(test)]
 pub(crate) fn struct_field_attrs_of(
     llbc: &Llbc,
 ) -> std::collections::HashMap<String, Vec<(String, ValueType)>> {

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -69,6 +69,7 @@ pub(crate) mod bool_then;
 pub(crate) mod checked_arith;
 pub(crate) mod checked_arith_uint;
 pub(crate) mod from_size_align;
+#[cfg(test)]
 pub(crate) mod graph_body;
 pub(crate) mod iter_next;
 pub mod llbc_hints;

--- a/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=0
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20
+guard_failures=400
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=20
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3
+retraces_compiled=0

--- a/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=0
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20
+guard_failures=400
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=20
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3
+retraces_compiled=0

--- a/pyre/bench/synth/class_body_exec_hot_loop.py
+++ b/pyre/bench/synth/class_body_exec_hot_loop.py
@@ -1,4 +1,4 @@
-# pyre-check: max-pypy-ratio=20
+# pyre-check: max-pypy-ratio=40
 # A class body and an `exec(code, ns)` body are the two frames that receive
 # their namespace through `setdictscope`, and both route a hot loop through the
 # JIT portal.
@@ -20,13 +20,18 @@
 # correct without it, so that half is not observable here.  It needs a debug
 # build to show, and nothing in this suite runs one.
 #
-# The loop has to run far enough in one entry to warm the portal.
+# N has to run far enough in one entry to warm the portal.
 # `exec_fresh_globals_delete_name` already runs an exec-body loop and stayed
 # green throughout: at 400 iterations it never reached the divergence.
+#
+# REPEAT sizes the whole workload rather than the trace.  At 5 the pypy
+# baseline lands under its startup, `_baseline_exec_time_clamped` marks the
+# ratio `~`, and no ratio gate is applied at all; 100 puts pypy's execution
+# around 0.14s, well clear of `FLOOR_GATE_MIN_BASELINE_S`.
 import collections
 
 N = 3000
-REPEAT = 5
+REPEAT = 100
 
 
 def class_body_while():

--- a/pyre/bench/synth/class_body_exec_hot_loop.py
+++ b/pyre/bench/synth/class_body_exec_hot_loop.py
@@ -18,7 +18,9 @@
 # without flushing it back left the live frame behind and tripped that check on
 # `last_instr` -- but the check is `debug_assertions`-gated and the values stay
 # correct without it, so that half is not observable here.  It needs a debug
-# build to show, and nothing in this suite runs one.
+# build, which this suite does not run; the gate for it is
+# `class_body_and_exec_loops_keep_the_vable_shadow_synchronized` in
+# pyre-jit's `gc_stress` test binary.
 #
 # N has to run far enough in one entry to warm the portal.
 # `exec_fresh_globals_delete_name` already runs an exec-body loop and stayed

--- a/pyre/bench/synth/class_body_exec_hot_loop.py
+++ b/pyre/bench/synth/class_body_exec_hot_loop.py
@@ -1,0 +1,79 @@
+# pyre-check: max-pypy-ratio=20
+# A class body and an `exec(code, ns)` body are the two frames that receive
+# their namespace through `setdictscope`, and both route a hot loop through the
+# JIT portal.
+#
+# What this file gates in a release build is the namespace read: `exec` accepts
+# any namespace that passes `PyDict_Check`, so the dict subclass and the
+# OrderedDict below are both legal, and neither carries the raw `W_DictObject`
+# layout that the tracer read namespace lengths and callee globals through.
+# Reading them that way faulted, and this workload segfaults without the
+# guards.  A fresh namespace per repeat also has the recorded trace looked up
+# again against a length that cannot be read.
+#
+# These frames also read a Ref static virtualizable field for LOAD_NAME /
+# STORE_NAME, which is what makes them the shapes that reach
+# `check_synchronized_virtualizable`; a function-frame loop reads no Ref vable
+# field and never looks.  Mirroring a static vable field into the shadow
+# without flushing it back left the live frame behind and tripped that check on
+# `last_instr` -- but the check is `debug_assertions`-gated and the values stay
+# correct without it, so that half is not observable here.  It needs a debug
+# build to show, and nothing in this suite runs one.
+#
+# The loop has to run far enough in one entry to warm the portal.
+# `exec_fresh_globals_delete_name` already runs an exec-body loop and stayed
+# green throughout: at 400 iterations it never reached the divergence.
+import collections
+
+N = 3000
+REPEAT = 5
+
+
+def class_body_while():
+    class C:
+        i = 0
+        total = 0
+        while i < N:
+            total += i
+            i += 1
+
+    return C.total
+
+
+def class_body_for():
+    class C:
+        total = 0
+        for i in range(N):
+            total += i
+
+    return C.total
+
+
+CODE = compile(
+    "total = 0\ni = 0\nwhile i < N:\n    total += i\n    i += 1\n",
+    "<exec-ns>",
+    "exec",
+)
+
+
+class NS(dict):
+    pass
+
+
+def exec_into(ns):
+    ns["N"] = N
+    exec(CODE, ns)
+    return ns["total"]
+
+
+def main():
+    checksum = 0
+    for _ in range(REPEAT):
+        checksum += class_body_while()
+        checksum += class_body_for()
+        checksum += exec_into(NS())
+        checksum += exec_into(collections.OrderedDict())
+    print(checksum)
+
+
+main()

--- a/pyre/bench/synth/class_body_exec_hot_loop.wasm.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=0
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=20
+guard_failures=400
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=3

--- a/pyre/bench/synth/class_body_exec_hot_loop.wasm.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=20
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=3
+retraces_compiled=0

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -7331,7 +7331,7 @@ pub(crate) unsafe fn is_native_exception_dunder(method: PyObjectRef) -> bool {
         exception_repr_method as crate::gateway::BuiltinCodeFn,
     ]
     .iter()
-    .any(|&target| std::ptr::fn_addr_eq(f, target))
+    .any(|&target| crate::gateway::builtin_code_fn_eq(f, target))
 }
 
 /// `interp_exceptions.py:993-998 W_SystemExit.descr_init` — a lone argument

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -12149,6 +12149,13 @@ pub(crate) fn try_walker_load_global_cell_fold<Sym: WalkSym>(
     if w_globals.is_null() {
         return Ok(false);
     }
+    // Raw dict access in the inlined-callee builtins leg below is valid only
+    // for an exact plain dict or module dict.  Dict subclasses are legal exec
+    // namespaces but use a different object layout, so leave them to the live
+    // residual lookup.
+    if !unsafe { pyre_object::is_dict(w_globals) } {
+        return Ok(false);
+    }
     // `namei` is the raw `LOAD_GLOBAL` oparg; bit 0 is the push-NULL flag,
     // so the `co_names` index is `namei >> 1` (mirror `bh_load_global_fn`).
     let name_idx = (namei as usize) >> 1;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -18,7 +18,7 @@ use pyre_interpreter::pyframe::PyFrame;
 use pyre_object::PyObjectRef;
 use pyre_object::boolobject::w_bool_get_value;
 use pyre_object::pyobject::{
-    FLOAT_TYPE, INT_TYPE, get_instantiate, is_bool, is_float, is_int, py_type_check,
+    FLOAT_TYPE, INT_TYPE, get_instantiate, is_bool, is_dict, is_float, is_int, py_type_check,
 };
 use pyre_object::{PY_NULL, w_float_get_value, w_int_get_value, w_int_new};
 
@@ -6791,23 +6791,33 @@ impl PyreJitState {
         self.frame_array_mut(PYFRAME_LOCALS_CELLS_STACK_OFFSET)
     }
 
-    fn namespace_len(&self) -> usize {
+    /// Return the namespace length for module dictionaries and exact plain
+    /// dictionaries. Other mappings use a different object layout, so their
+    /// length is unknown rather than zero: namespace-dependent traces must not
+    /// treat two unsafe-to-inspect mappings as compatible.
+    fn namespace_len(&self) -> Option<usize> {
         let Some(frame_ptr) = self.frame_ptr() else {
-            return 0;
+            return None;
         };
         let w_globals = unsafe {
             *(frame_ptr.add(PYFRAME_W_GLOBALS_OFFSET) as *const pyre_object::PyObjectRef)
         };
         if w_globals.is_null() {
-            return 0;
+            return None;
         }
         // `dictmultiobject.py:107-109 W_DictMultiObject.length`. The common
         // module-dict case reads `ModuleDictStorage` directly (O(1)) — this guard is on the
-        // per-portal-entry path. Plain dict globals (exec/eval) fall back to
-        // the polymorphic strategy length.
-        unsafe {
-            pyre_object::dictmultiobject::module_dict_storage_len(w_globals)
-                .unwrap_or_else(|| pyre_object::dictmultiobject::w_dict_len(w_globals))
+        // per-portal-entry path. Exact plain dict globals (exec/eval) fall back
+        // to the polymorphic strategy length; dict subclasses and other
+        // mappings do not carry that layout and remain unknown.
+        if let Some(len) =
+            unsafe { pyre_object::dictmultiobject::module_dict_storage_len(w_globals) }
+        {
+            Some(len)
+        } else if unsafe { is_dict(w_globals) } {
+            Some(unsafe { pyre_object::dictmultiobject::w_dict_len(w_globals) })
+        } else {
+            None
         }
     }
 
@@ -9292,7 +9302,7 @@ impl JitState for PyreJitState {
         let capacity = self.array_capacity();
         PyreMeta {
             num_locals,
-            ns_len: self.namespace_len(),
+            ns_len: self.namespace_len().unwrap_or(0),
             // Provisional seed only.  build_meta runs at trace START, before the
             // walk records any LOAD_GLOBAL/LOAD_NAME, so the true value does not
             // exist yet.  finish_trace_namespace_dependency overwrites this from
@@ -9554,7 +9564,8 @@ impl JitState for PyreJitState {
         // module-global reads still need this conservative gate because
         // same-key value rebinds are not value-guarded yet.
         self.local_count() == meta.num_locals
-            && (!meta.namespace_dependent || self.namespace_len() == meta.ns_len)
+            && (!meta.namespace_dependent
+                || self.namespace_len().is_some_and(|len| len == meta.ns_len))
     }
 
     fn setup_bridge_sym(
@@ -12152,7 +12163,7 @@ mod tests {
         let mut meta = empty_meta();
         meta.num_locals = state.local_count();
         meta.namespace_dependent = false;
-        meta.ns_len = state.namespace_len() + 5;
+        meta.ns_len = state.namespace_len().unwrap_or(0) + 5;
         assert!(<PyreJitState as JitState>::is_compatible(&state, &meta));
     }
 
@@ -12165,7 +12176,7 @@ mod tests {
         let mut meta = empty_meta();
         meta.num_locals = state.local_count();
         meta.namespace_dependent = true;
-        meta.ns_len = state.namespace_len() + 5;
+        meta.ns_len = state.namespace_len().unwrap_or(0) + 5;
         assert!(!<PyreJitState as JitState>::is_compatible(&state, &meta));
     }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -5275,6 +5275,14 @@ fn loop_inlines_abort_permanent_callee(
         if root_globals.is_null() {
             return None;
         }
+        if !pyre_object::is_dict(root_globals) {
+            // A dict subclass is a legal exec namespace but does not carry the
+            // raw W_DictObject layout.  Stop the pre-emptive scan: `None` here
+            // means "could not enumerate", not "proved there is no aborting
+            // callee".  The ordinary walk remains responsible for meeting an
+            // `abort_permanent` marker.
+            return None;
+        }
         let raw_code = pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
             as *const CodeObject;
         if raw_code.is_null() {
@@ -5341,6 +5349,13 @@ fn loop_inlines_abort_permanent_callee(
         }
 
         while let Some((code_ptr, globals)) = queue.pop_front() {
+            if !pyre_object::is_dict(globals) {
+                // Callee globals can likewise be an unreadable dict subclass.
+                // Abandon this conservative preflight rather than treating the
+                // skipped namespace as proof that no aborting callee exists;
+                // the ordinary walk will encounter any marker it reaches.
+                return None;
+            }
             let raw = pyre_interpreter::w_code_get_ptr(code_ptr as pyre_object::PyObjectRef)
                 as *const CodeObject;
             if raw.is_null() {

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -574,7 +574,10 @@ use crate::frame_layout::{PYFRAME_DEBUGDATA_OFFSET, PYFRAME_PYCODE_OFFSET};
 /// No-op when the virtualizable shadow is not seeded (non-virtualizable
 /// trace, or before `init_virtualizable_boxes`) and when only its OpRef
 /// half is live — a bridge-entry rebuild seeds no concrete values, and
-/// there is no concrete slot to mirror into.
+/// there is no concrete slot to mirror into. When a concrete slot is
+/// mirrored, pair the shadow write with `synchronize_virtualizable()`, just
+/// like `TraceCtx::vable_setfield` / RPython `_opimpl_setfield_vable`, so the
+/// live virtualizable cannot lag behind `virtualizable_boxes`.
 pub(crate) fn mirror_vable_static_to_boxes(
     ctx: &mut TraceCtx,
     static_field_name: &str,
@@ -589,6 +592,7 @@ pub(crate) fn mirror_vable_static_to_boxes(
         .and_then(|info| info.static_field_index_by_name(static_field_name));
     if let Some(idx) = idx {
         ctx.set_virtualizable_entry_at(idx, opref, concrete);
+        ctx.synchronize_virtualizable();
     }
 }
 

--- a/pyre/pyre-jit/tests/gc_stress.rs
+++ b/pyre/pyre-jit/tests/gc_stress.rs
@@ -23,6 +23,11 @@
 //! must be live, proving the program's objects routed through the real managed
 //! heap rather than the leaking `lltype::malloc` Box fallback (which would make
 //! the survival checks meaningless).
+//!
+//! This binary is also the crate's only end-to-end Python path that runs with
+//! `debug_assertions` on. One regression test uses it for the non-GC invariant
+//! that the virtualizable shadow and heap agree when
+//! `check_synchronized_virtualizable` runs.
 
 use std::rc::Rc;
 
@@ -127,6 +132,73 @@ fn run_on_worker(
         .join()
         .expect("worker thread panicked")
         .expect(fail_msg);
+}
+
+/// Class and `exec(code, ns)` bodies use dict-scope frames, whose LOAD_NAME /
+/// STORE_NAME traffic reads Ref static virtualizable fields. In debug builds,
+/// that path checks that the virtualizable shadow and heap copy stay
+/// synchronized after tracing mirrors static fields into boxes.
+#[test]
+fn class_body_and_exec_loops_keep_the_vable_shadow_synchronized() {
+    const PROGRAM: &str = r#"
+class Namespace(dict):
+    pass
+
+CODE = """
+i = 0
+total = 0
+while i < 3000:
+    total = total + i
+    i = i + 1
+"""
+
+def class_bodies():
+    acc = 0
+    repeat = 0
+    while repeat < 3:
+        class Probe:
+            i = 0
+            total = 0
+            while i < 3000:
+                total = total + i
+                i = i + 1
+        assert Probe.total == 4498500, Probe.total
+        assert Probe.i == 3000, Probe.i
+        acc = acc + Probe.total + Probe.i
+        repeat = repeat + 1
+    return acc
+
+def exec_bodies():
+    acc = 0
+    repeat = 0
+    while repeat < 3:
+        plain = {}
+        exec(CODE, plain)
+        assert plain["total"] == 4498500, plain["total"]
+        assert plain["i"] == 3000, plain["i"]
+        acc = acc + plain["total"] + plain["i"]
+
+        subclass = Namespace()
+        exec(CODE, subclass)
+        assert subclass["total"] == 4498500, subclass["total"]
+        assert subclass["i"] == 3000, subclass["i"]
+        acc = acc + subclass["total"] + subclass["i"]
+
+        repeat = repeat + 1
+    return acc
+
+class_result = class_bodies()
+exec_result = exec_bodies()
+assert class_result == 13504500, class_result
+assert exec_result == 27009000, exec_result
+assert class_result + exec_result == 40513500
+"#;
+    run_on_worker(
+        PROGRAM,
+        "<vable_shadow_debug_gate>",
+        "virtualizable shadow synchronization checks",
+        "virtualizable shadow debug gate program failed",
+    );
 }
 
 /// `W_ObjectObject` is GC-managed: an instance's movable attribute values


### PR DESCRIPTION
A hot loop in a class body or in an `exec(code, ns)` body killed the tracer two
different ways. Both are fixed here, with the coverage each one actually admits.

The discriminator is the frame kind, not the opcode. These two shapes are the
frames handed a namespace through `PyFrame::setdictscope`. A function-frame
loop, a module top-level loop, and `exec(src)` with no namespace argument are
all fine.

## 1. Raw namespace dict reads — release-visible, SIGSEGV

`w_dict_len` / `w_dict_getitem_str` dereference the `W_DictObject` layout and
are only valid for an exact dict or a module dict. `exec` checks its namespace
with `isinstance_w(w_obj, w_dict_type)`, so a **dict subclass** or an
`OrderedDict` is a legal namespace that carries no such layout. Three sites read
a frame's globals that way with no guard:

- `PyreJitState::namespace_len`
- `loop_inlines_abort_permanent_callee`
- `try_walker_load_global_cell_fold`

`namespace_len` now returns `Option<usize>`, and `is_compatible` refuses to
reuse a recorded trace when the length is unknown. Returning `0` for an
unreadable mapping would have been the quiet wrong answer: two mappings nobody
can inspect would compare equal and the gate would pass forever.

It is a family rather than a single site — after `namespace_len` was fixed the
fault simply moved to `w_dict_getitem_str`, which is how the other two were
found.

## 2. The virtualizable shadow was never flushed — debug-only

`mirror_vable_static_to_boxes` wrote `virtualizable_boxes` through
`set_virtualizable_entry_at` and stopped there. `TraceCtx::vable_setfield` pairs
that write with `synchronize_virtualizable()`, which is what
`_opimpl_setfield_vable` does on its last line. `setdictscope` frames read a Ref
static vable field for LOAD_NAME / STORE_NAME, so they are the shapes that reach
`check_synchronized_virtualizable`, and it tripped on `last_instr`.

Refuted on the way: `synchronize_virtualizable`'s silent early-returns. Probed —
24 write-backs, zero bails.

## Coverage, and what each piece does and does not gate

`pyre/bench/synth/class_body_exec_hot_loop.py` plus its three jitstats
baselines. Two control arms decide what it is worth:

| control | result |
|---|---|
| whole fix reverted, release | fixture dies `rc=139`, 3/3, empty stdout |
| only the vable flush reverted, release | fixture **passes** 3/3 with the correct value |

So the synth fixture gates part 1 only. `check_synchronized_virtualizable`
begins `if !cfg!(debug_assertions) { return; }`, and check.py, the synth suite
and `extra_tests` all run release binaries, so part 2 needed a debug gate:
`class_body_and_exec_loops_keep_the_vable_shadow_synchronized` in pyre-jit's
`gc_stress` test binary. Its own control arm, measured: with
`synchronize_virtualizable()` removed it fails on

```
virtualizable static field 0 ("last_instr") diverged from the shadow:
a vable write did not update virtualizable_boxes
```

and passes with it restored. Worth checking rather than assuming — the whole
program runs in 1.21 s, and a debug workload that never gets hot would pass
while reaching nothing.

It went into the existing `gc_stress` binary on purpose. That module's doc
records that six former binaries were consolidated to avoid six heavy relinks of
the pyre-jit + interpreter + object stack; an added `#[test]` costs no relink, a
new binary does.

## Sizing the fixture so its ratio gate arms

The fixture first ran `REPEAT = 5` and printed `~23.9x` against a
`max-pypy-ratio` of 20 — and passed. The `~` is check.py saying
`_baseline_exec_time_clamped`: pypy's execution had been clamped to
`EXEC_TIME_FLOOR_S`, so **no ratio gate was applied at all**. Execution time is
total minus measured startup, and at that size pypy's total sat at its own
startup.

`REPEAT = 100` puts pypy's execution around 0.14 s, well past
`FLOOR_GATE_MIN_BASELINE_S`, and the ratio then prints unmarked and is actually
compared. The ceiling moved 20 → 40 to follow the documented convention (twice
the slowest runner; wasm measured 20.1x). Recorded: dynasm 9.5x, cranelift
11.8x, wasm 20.1x.

## Also here

`fix build warnings` — an unnecessary `mut` in `descr.rs` and in a
majit-metainterp test, `#[cfg(test)]` on two majit-translate front items, and
`builtins.rs` routing a function-pointer comparison through
`gateway::builtin_code_fn_eq` instead of `std::ptr::fn_addr_eq`.

## Verification status

The debug gate and its control arm were measured on base `0c3c4777ba9`.

The full `pyre/check.py` runs (dynasm and cranelift, 410 passed / 1 failed, the
one failure being the then-inherited `synth/pypy_type_surface`) were measured on
base `a7eb493079f`, which is **two rebases old**. `#1104` has since restored
that baseline, and the base is now `1b31a5b3060`. The suite has not been re-run
at the current base, so treat those numbers as describing the SHA they were
taken on rather than this head.

— *written by Claude*
