### PR TITLE
builtins: keep the default print target alive across the Python it runs (print, displayhook)

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -874,7 +874,7 @@
       "dynasm": "TIMEOUT"
     },
     "test.test_print": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_profile": {
       "dynasm": "IMPORTERROR"

--- a/pyre/extra_tests/parity_tests/_oracle_stdlib/test/__init__.py
+++ b/pyre/extra_tests/parity_tests/_oracle_stdlib/test/__init__.py
@@ -1,0 +1,13 @@
+# Dummy file to make this directory a package.
+#
+# It stands in for CPython's own `test` package, which several parity scripts
+# import for `test.support` helpers and which the standalone CPython builds
+# this repo is commonly run against do not ship.  `__path__` points at the
+# vendored copy, so the helper code is CPython's own.
+#
+# Only `test` is served this way.  Putting `lib-python/3` itself on the oracle's
+# `PYTHONPATH` would shadow its entire stdlib with the vendored one, and an
+# oracle running the tree under test answers nothing.
+from pathlib import Path
+
+__path__ = [str(Path(__file__).resolve().parents[5] / "lib-python" / "3" / "test")]

--- a/pyre/extra_tests/parity_tests/displayhook_sink_outlives_write.py
+++ b/pyre/extra_tests/parity_tests/displayhook_sink_outlives_write.py
@@ -1,0 +1,75 @@
+# `sys.displayhook` writes twice, and either write may unbind the sink.
+#
+# The hook renders `repr(obj)` and then writes the repr and a newline.  Both
+# the repr and the write re-enter the eval loop, so either can rebind
+# `sys.stdout` and drop the last reference to the object the hook is writing
+# through — after which reusing that object reads reclaimed memory.
+# `pypy/module/sys/app.py:252-253` fetches `sys_stdout()` once per write.
+#
+# Which sink receives the newline is deliberately not asserted: CPython keeps
+# the sink it resolved first and writes the newline to that one (gh-130163),
+# while PyPy re-fetches and writes to whatever `sys.stdout` names by then.
+# What both guarantee is that the two writes happen and that neither goes
+# through a reclaimed object, so that is what this checks.
+import gc
+import io
+import sys
+
+
+def check_repr_rebinds_stdout():
+    """`test_sys.TestSys.test_gh130163` — the repr drops the sink."""
+
+    class X:
+        def __repr__(self):
+            sys.stdout = io.StringIO()
+            gc.collect()
+            return "foo"
+
+    saved = sys.stdout
+    try:
+        sys.stdout = io.StringIO()  # the only reference
+        sys.displayhook(X())
+    finally:
+        sys.stdout = saved
+
+
+def check_write_rebinds_stdout():
+    """The repr write drops the sink, so the newline write cannot reuse it."""
+    log = []
+
+    def make_sink(tag):
+        def write(s):
+            log.append((tag, s))
+            if tag == "first":
+                sys.stdout = make_sink("second")  # `first` loses its only reference
+                gc.collect()
+            return len(s)
+
+        class Sink:
+            pass
+
+        sink = Sink()
+        # A plain function in the instance dict: the call passes no `self`, so
+        # while `write` runs, nothing but `sys.stdout` keeps the sink alive.  A
+        # bound method would root it as the callee's argument and the hazard
+        # would never arise.
+        sink.write = write
+        sink.flush = lambda: None
+        return sink
+
+    saved = sys.stdout
+    try:
+        sys.stdout = make_sink("first")  # the only reference
+        sys.displayhook(42)
+    finally:
+        sys.stdout = saved
+    # Non-vacuous: both writes really ran, and the repr went to the sink that
+    # was current when the hook started.
+    assert [s for _tag, s in log] == ["42", "\n"], log
+    assert log[0][0] == "first", log
+
+
+check_repr_rebinds_stdout()
+check_write_rebinds_stdout()
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/print_sink_outlives_str.py
+++ b/pyre/extra_tests/parity_tests/print_sink_outlives_str.py
@@ -1,0 +1,76 @@
+# `print()` keeps using the sink it resolved, after running Python that can
+# unbind it.
+#
+# With no `file=`, `print` resolves `sys.stdout` once and then calls `str()` on
+# each argument and `write` on the sink.  Both re-enter the eval loop, so a
+# `__str__` that rebinds `sys.stdout` drops the last reference to the object
+# `print` is holding, and the collection that follows reclaims it — the write
+# after it goes through a freed object.  The sink therefore has to be held for
+# the whole call, not read once into a local.
+#
+# `check_str_rebinds_stdout` is CPython's `test_print.test_gh130163`.  The other
+# two move the rebinding into the sink's own `write`: `write` is a plain
+# function in the instance dict, so the call does not pass the sink as `self`
+# and nothing but `print` itself keeps it alive while it runs.  That covers the
+# separator and terminator writes, which take a different path from the
+# argument write.
+import gc
+import sys
+from io import StringIO
+
+
+def check_str_rebinds_stdout():
+    class X:
+        def __str__(self):
+            sys.stdout = StringIO()
+            gc.collect()
+            return "foo"
+
+    saved = sys.stdout
+    try:
+        sys.stdout = StringIO()  # the only reference
+        print(X())
+    finally:
+        sys.stdout = saved
+
+
+def check_write_rebinds_stdout(*args, **kwargs):
+    """`print(*args, **kwargs)` where the first write unbinds the sink."""
+    written = []
+
+    def writer(s):
+        written.append(s)
+        sys.stdout = StringIO()  # the running sink loses its only reference
+        gc.collect()
+        return len(s)
+
+    def make_sink():
+        class Sink:
+            pass
+
+        sink = Sink()
+        sink.write = writer  # plain function: the call passes no `self`
+        sink.flush = lambda: None
+        return sink
+
+    saved = sys.stdout
+    try:
+        sys.stdout = make_sink()  # the only reference
+        print(*args, **kwargs)
+    finally:
+        sys.stdout = saved
+    # Non-vacuous: the sink really was written through more than once, so the
+    # writes after the rebinding are the ones the fix has to survive.
+    assert len(written) > 1, written
+
+
+check_str_rebinds_stdout()
+# Two arguments so the separator write runs between them, and the default
+# terminator write runs after.
+check_write_rebinds_stdout("a", "b")
+# The explicit `sep=` / `end=` objects take the argument path instead.
+check_write_rebinds_stdout("a", "b", sep="-", end="!\n")
+# `flush=True` calls the sink once more, after every write.
+check_write_rebinds_stdout("a", "b", flush=True)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/run.py
+++ b/pyre/extra_tests/parity_tests/run.py
@@ -274,11 +274,31 @@ def _annotate(failures: list[Failure]) -> None:
         print(f"::error file={path},title=parity::{escaped}")
 
 
+def _cpython_env() -> dict[str, str]:
+    """Lend the oracle the vendored `test` package.
+
+    Scripts that import `test.support` cannot run on an oracle whose build
+    omits the `test` package, as the standalone CPython distributions do —
+    the import fails before the script asserts anything.  `_oracle_stdlib`
+    holds a `test` package whose `__path__` is `lib-python/3/test`, so the
+    helpers are CPython's own source at the version the rest of the vendored
+    stdlib is pinned to, on every host alike.
+
+    A `PYTHONPATH` entry precedes the stdlib, so this wins even where the
+    oracle does ship `test`; that is the point of pinning it.  Only `test` is
+    exposed — `lib-python/3` itself on the path would shadow the oracle's whole
+    stdlib with the tree under test.
+    """
+    entry = str(HERE / "_oracle_stdlib")
+    existing = os.environ.get("PYTHONPATH")
+    return {"PYTHONPATH": f"{entry}{os.pathsep}{existing}" if existing else entry}
+
+
 def _runners(
     only_dynasm: bool, only_cranelift: bool, gc_poison: bool
 ) -> list[tuple[str, list[str], dict[str, str] | None]]:
     runners: list[tuple[str, list[str], dict[str, str] | None]] = []
-    runners.append(("cpython", [_cpython()], None))
+    runners.append(("cpython", [_cpython()], _cpython_env()))
     pyre_env = {"MAJIT_GC_NURSERY_POISON": "1"} if gc_poison else None
     dynasm = TARGET_RELEASE / f"pyre-dynasm{EXE}"
     cranelift = TARGET_RELEASE / f"pyre-cranelift{EXE}"

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3950,6 +3950,44 @@ fn set_builtins_underscore(value: PyObjectRef) {
     }
 }
 
+/// One `print_item_to(x, sys_stdout())` / `print_newline_to(sys_stdout())`
+/// step: resolve the live sink, then write one string through it.
+///
+/// The resolution belongs to the step, not to the call. `app.py:252-253`
+/// evaluates `sys_stdout()` once per write, so the sink is never carried from
+/// one write to the next — and it must not be here either, because a write
+/// runs Python that may rebind `sys.stdout`. A sink reachable only through
+/// that binding is reclaimed at the following safepoint, and reusing the
+/// pointer then reads freed memory.
+///
+/// `Ok(false)` reports `sys.stdout is None`, which writes nothing.
+fn displayhook_write(part: PyObjectRef) -> Result<bool, crate::PyError> {
+    // Pin the string for the whole step. It is reachable only through this
+    // Rust local, and both resolving the sink (a module `__getattr__`) and
+    // looking up its `write` can re-enter the eval loop, where the
+    // `PYRE_GC_INTERP` safepoint sweeps an unrooted old-gen object and moves a
+    // surviving one — so read it back from the rooted slot at the point of use.
+    let roots = pyre_object::gc_roots::push_roots();
+    let part_slot = roots.base();
+    roots.pin_root(part);
+    match resolve_default_print_target()? {
+        DefaultPrintTarget::Native => {
+            let s = unsafe { print_render(roots.get(part_slot))? };
+            crate::print_output(&s);
+        }
+        DefaultPrintTarget::Rebound(fp) => {
+            let r = crate::baseobjspace::call_method(fp, "write", &[roots.get(part_slot)]);
+            if r.is_null() {
+                return Err(crate::call::take_call_error().unwrap_or_else(|| {
+                    crate::PyError::runtime_error("displayhook: file.write() failed")
+                }));
+            }
+        }
+        DefaultPrintTarget::Silent => return Ok(false),
+    }
+    Ok(true)
+}
+
 /// `sys.displayhook(value)` — print `repr(value)` followed by a newline to
 /// the live `sys.stdout` and bind `builtins._` to the value. A `None` value
 /// prints nothing and leaves `_` unchanged (`sys_displayhook` in sysmodule.c).
@@ -3962,24 +4000,17 @@ pub(crate) fn sys_displayhook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate
     // stale binding, then set to the value once the write succeeds.
     set_builtins_underscore(w_none());
     let repr = pyre_object::w_str_from_wtf8(unsafe { crate::display::py_repr_wtf8(value)? });
-    let newline = w_str_new("\n");
-    match resolve_default_print_target()? {
-        DefaultPrintTarget::Native => {
-            let s = unsafe { print_render(repr)? };
-            crate::print_output(&s);
-            crate::print_output("\n");
-        }
-        DefaultPrintTarget::Rebound(fp) => {
-            for part in [repr, newline] {
-                let r = crate::baseobjspace::call_method(fp, "write", &[part]);
-                if r.is_null() {
-                    return Err(crate::call::take_call_error().unwrap_or_else(|| {
-                        crate::PyError::runtime_error("displayhook: file.write() failed")
-                    }));
-                }
-            }
-        }
-        DefaultPrintTarget::Silent => return Ok(w_none()),
+    // `pypy/module/sys/app.py:252-253` —
+    //     print_item_to(repr(obj), sys_stdout())
+    //     print_newline_to(sys_stdout())
+    // two writes, each against a freshly fetched `sys.stdout`. The newline
+    // string is built here rather than alongside `repr` for the same reason:
+    // nothing outlives the write it belongs to.
+    if !displayhook_write(repr)? {
+        return Ok(w_none());
+    }
+    if !displayhook_write(w_str_new("\n"))? {
+        return Ok(w_none());
     }
     set_builtins_underscore(value);
     Ok(w_none())

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3836,6 +3836,20 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         },
     };
 
+    // The sink has to outlive the Python this call runs.  `str(arg)` and every
+    // `file.write` attribute lookup re-enter the eval loop, so a `sys.stdout`
+    // rebinding there can drop the last reference to the object resolved just
+    // above and the next safepoint reclaims it — the write that follows would
+    // then go through a dangling pointer.  Root it once for the rest of the
+    // call and read the rooted slot at each use, so a collection that moves it
+    // is followed and one that would have freed it cannot happen.
+    let file_roots = pyre_object::gc_roots::push_roots();
+    let file_slot = file.map(|fp| {
+        let base = file_roots.base();
+        file_roots.pin_root(fp);
+        base
+    });
+
     // `bltinmodule.c print_impl` writes incrementally: `str(arg)`, then the
     // separator before each following arg, then `end`.  Each source is rendered
     // at emit time so a raising `__str__` leaves the bytes already emitted on
@@ -3845,7 +3859,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // stdout path renders through the strict utf-8 error handler in
     // `print_render`.
     let emit = |source: PyObjectRef| -> Result<(), crate::PyError> {
-        let Some(fp) = file else {
+        let Some(file_slot) = file_slot else {
             let s = unsafe { print_render(source)? };
             crate::print_output(&s);
             return Ok(());
@@ -3859,6 +3873,10 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::gc_roots::pin_root(s_obj);
         let s_obj =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
+        // Read the sink only here: `py_str_wtf8` above ran `__str__`, and the
+        // rooted slot — not the pointer resolved before it — is what a move
+        // under that call updated.
+        let fp = file_roots.get(file_slot);
         let r = crate::baseobjspace::call_method(fp, "write", &[s_obj]);
         if r.is_null() {
             return Err(crate::call::take_call_error()
@@ -3871,7 +3889,7 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // throwaway str object per gap/line.  The `file=` path still hands a str
     // to `file.write`.
     let emit_literal = |lit: &str| -> Result<(), crate::PyError> {
-        let Some(fp) = file else {
+        let Some(file_slot) = file_slot else {
             crate::print_output(lit);
             return Ok(());
         };
@@ -3882,6 +3900,9 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         pyre_object::gc_roots::pin_root(s);
         let s =
             pyre_object::gc_roots::shadow_stack_get(pyre_object::gc_roots::shadow_stack_len() - 1);
+        // Same as `emit`: the preceding write's own lookup may have moved the
+        // sink, so take it from the rooted slot.
+        let fp = file_roots.get(file_slot);
         let r = crate::baseobjspace::call_method(fp, "write", &[s]);
         if r.is_null() {
             return Err(crate::call::take_call_error()
@@ -3903,11 +3924,12 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         None => emit_literal("\n")?,
     }
     if flush {
-        match file {
+        match file_slot {
             None => {
                 crate::host_seam::flush_stdout();
             }
-            Some(fp) => {
+            Some(file_slot) => {
+                let fp = file_roots.get(file_slot);
                 let r = crate::baseobjspace::call_method(fp, "flush", &[]);
                 if r.is_null() {
                     return Err(crate::call::take_call_error().unwrap_or_else(|| {


### PR DESCRIPTION
Two dangling-sink defects in the default print target, plus the parity-oracle change that made the second one's regression test runnable.

## `print()` — SIGSEGV

`builtin_print` resolved `sys.stdout` once into a Rust local and then reused that pointer across `str(arg)` and every `file.write` lookup, all of which re-enter the eval loop. A `__str__` that rebinds `sys.stdout` drops the sink's last reference and the next safepoint reclaims it, so the following write went through freed memory.

`pypy/module/__builtin__/app_io.py:76-96` binds `fp = sys.stdout` **once** and reuses it — an app-level local is a GC root, a Rust local is not. So the faithful port is to root it and read the rooted slot at each use, which is what this does.

| | before | after |
|---|---|---|
| `test.test_print` | SIGSEGV 6/6, both backends, JIT on and off | `Ran 9 tests, OK` |

`test.test_print` moves `CRASH -> PASS` in `baseline.json` (hand-edited, single entry — not `--update-baseline`), so the gate now runs it: `109 to run`.

## `sys.displayhook` — hang

The sibling defect, and it was **the same defect** despite the different symptom. `sys_displayhook` resolved `sys.stdout` once and used it for both the repr write and the newline write. `sample` on the hung process put **100% of samples** in one chain:

```
sys_displayhook -> getattr_str_impl -> lookup_where -> indexmap::get_index_of
```

— an attribute lookup on a reclaimed sink whose freed memory still probed as a table instead of faulting. Freed-but-mapped memory spins; unmapped memory faults. A control that changes only the sink's reachability, keeping the same writes and the same `gc.collect()`, terminates.

`pypy/module/sys/app.py:252-253` fetches `sys_stdout()` separately for each write:

```python
print_item_to(repr(obj), sys_stdout())
print_newline_to(sys_stdout())
```

`displayhook_write` is that step. The two fixes differ in shape because upstream differs: `print_` holds one sink, `displayhook` re-fetches.

### ⚠️ Reviewer note — a real observable divergence

With a sink that rebinds `sys.stdout` inside its own first `write`, measured on all three:

| | repr write | newline write |
|---|---|---|
| CPython 3.14.6 | `first` | **`first`** — keeps a strong reference to what it resolved (gh-130163) |
| PyPy 7.3.22 | `first` | **`second`** — re-fetches |
| this PR | `first` | `second` |

There is no blend available. This follows PyPy. Switching to CPython's semantics instead would mean rooting the sink exactly as `print` now does, and is a one-function change if that is preferred.

Also unchanged and still divergent: `sys.stdout = None` returns silently here, where `sysmodule.c` raises `RuntimeError("lost sys.stdout")`. `DefaultPrintTarget::Silent` carries `print`'s semantics (where a silent return is correct) into `displayhook` (where it is not). Left out so this diff moves one variable; happy to fix separately.

## Parity oracle gets the vendored `test` package

`builtin_module_loader_spec.py` imports `test.support.import_helper`, and the standalone CPython distributions this repo is commonly run against do not ship the `test` package — so the import failed before the script asserted anything. `_oracle_stdlib/test/__init__.py` is a package whose `__path__` is `lib-python/3/test`, and the cpython runner gets a `PYTHONPATH` naming it.

Only `test` is exposed. Putting `lib-python/3` itself on the path would shadow the oracle's whole stdlib with the tree under test, and an oracle running the tree under test answers nothing. Verified: with the entry set, `test.support` resolves to `lib-python/3/test/support/__init__.py` while `os` and `importlib` still resolve inside the oracle's own stdlib.

## Verification

- **Non-vacuity of the displayhook test**: built the parent commit's binary and ran `displayhook_sink_outlives_write.py` on it — `rc=142` (hang) under both JIT modes, while `print_sink_outlives_str.py` passes on that same binary. The test isolates this defect, not the print one.
- The test asserts the two written strings and **not** which sink received them, since the oracle and pyre disagree there by design.
- Parity: `all parity tests pass`; diffing the per-script table against the previous full run, the only changes are the rows this PR adds.
- Ordinary displayhook semantics (native path, `_` binding, `None`, raising `write`, raising `repr`) match CPython 3.14.6 exactly.

### `check.py` is red, and all three reds are pre-existing — verified by A/B, not by argument

Built a binary from the parent commit and ran exactly the failing subjects:

| red | base binary | this branch | owner |
|---|---|---|---|
| `test.test_re` | `errors=303` | `errors=303` | #1117 |
| `test.test_pickletools` | `errors=1` | `errors=1` | known, bisected to #1087 |
| `synth/list_pop_append` | over the 22x gate | over the 22x gate | fixture modified by #1119 |

`sys.displayhook` is invoked **0 times** in all three subjects, so the changed function never executes there. `list_pop_append` first looked ~20% slower on this branch; an interleaved A/B with a same-binary determinism control put that difference inside the noise band (the same binary against itself spans 2.46-3.82s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
