### PR TITLE
majit: carry a struct field's declared width and signedness into its descr

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -36,6 +36,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.residual_writes,
         &config.pool_arrays,
         &config.ref_fields,
+        &config.int_fields,
         &config.call_returns,
         &config.headerless_structs,
         &config.native_int_binops,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -350,6 +350,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     calls: &[crate::jit_interp::CallEntry],
     ref_params: &[(Ident, syn::Path)],
     ref_fields: &[crate::jit_interp::RefFieldEntry],
+    int_fields: &[crate::jit_interp::IntFieldEntry],
     native_int_binops: &[(Path, Ident)],
     native_tag_small: &[Path],
     headerless_structs: &[Path],
@@ -387,6 +388,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         .collect();
     let inline_config = if ref_param_structs.is_empty()
         && ref_fields.is_empty()
+        && int_fields.is_empty()
         && native_int_binops.is_empty()
         && native_tag_small.is_empty()
         && headerless_structs.is_empty()
@@ -395,6 +397,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     } else {
         Some(LowererConfig::inline_helper(
             ref_fields,
+            int_fields,
             native_int_binops,
             native_tag_small,
             headerless_structs,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -37,12 +37,23 @@ impl<'c> Lowerer<'c> {
                 .unwrap_or_default();
             let key = format!("{}::{}", struct_last, field);
             let is_ref = config.ref_fields.contains_key(&key);
+            // Same declared width the getfield/setfield lowering registers, so
+            // this write-EI rebuild mints the field descr the reads resolve to
+            // rather than a machine-word twin of it.
+            let member = syn::Member::Named(field.clone());
+            let (__fsize, __fsigned, __fcheck) =
+                super::lower_vable::field_scalar_tokens(config, &key, path, &member);
             fields.push(quote! {
-                (
-                    ::core::mem::offset_of!(#path, #field),
-                    #is_ref,
-                    stringify!(#field),
-                )
+                {
+                    #__fcheck
+                    (
+                        ::core::mem::offset_of!(#path, #field),
+                        #is_ref,
+                        stringify!(#field),
+                        #__fsize,
+                        #__fsigned,
+                    )
+                }
             });
         }
         let layouts: Vec<_> = layouts

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1,6 +1,36 @@
 use super::lower_value::struct_type_id_tokens;
 use super::*;
 
+/// The `(field_size, is_signed)` a struct-layout registration reports for one
+/// field, plus a compile-time check that the declaration matches the Rust
+/// struct.  `descr.py:218-239 get_field_descr` derives both from `FIELDTYPE`,
+/// but the macro sees only the field's name at the access site, so a sub-word
+/// integer field has to be named in `int_fields` to be registered as one.
+/// Anything undeclared keeps the machine-word default.
+pub(super) fn field_scalar_tokens(
+    config: &LowererConfig,
+    key: &str,
+    struct_path: &syn::Path,
+    member: &syn::Member,
+) -> (TokenStream, TokenStream, TokenStream) {
+    match config.int_fields.get(key) {
+        Some((ty, signed)) => (
+            quote! { ::core::mem::size_of::<#ty>() },
+            quote! { #signed },
+            // Fails to compile unless the field really has the declared type,
+            // so the declaration cannot drift from the struct it describes.
+            quote! {
+                const _: fn(&#struct_path) -> #ty = |__s| __s.#member;
+            },
+        ),
+        None => (
+            quote! { ::core::mem::size_of::<usize>() },
+            quote! { true },
+            quote! {},
+        ),
+    }
+}
+
 impl<'c> Lowerer<'c> {
     /// Read an immediate operand byte from the green bytecode array:
     /// `program[<index>]`.  Mirrors the dispatch-top opcode fetch
@@ -738,6 +768,8 @@ impl<'c> Lowerer<'c> {
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
+        let (__fsize, __fsigned, __fcheck) =
+            field_scalar_tokens(config, &ref_field_key, &struct_path, &member);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, a
@@ -761,6 +793,7 @@ impl<'c> Lowerer<'c> {
                     vec![Register::ref_(result_reg)],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -770,6 +803,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -796,6 +831,7 @@ impl<'c> Lowerer<'c> {
                     vec![Register::int(result_reg)],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -805,6 +841,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -853,6 +891,8 @@ impl<'c> Lowerer<'c> {
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
+        let (__fsize, __fsigned, __fcheck) =
+            field_scalar_tokens(config, &ref_field_key, &struct_path, &member);
         let ref_field_entry = config.ref_fields.get(&ref_field_key);
         let is_ref_field = ref_field_entry.is_some();
         let tid = struct_type_id_tokens(&struct_path, false);
@@ -866,6 +906,7 @@ impl<'c> Lowerer<'c> {
                     vec![Register::ref_(result_reg)],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -875,6 +916,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.getfield_gc_r(
@@ -900,6 +943,7 @@ impl<'c> Lowerer<'c> {
                     vec![Register::int(result_reg)],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -909,6 +953,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.getfield_gc_i(
@@ -1040,6 +1086,8 @@ impl<'c> Lowerer<'c> {
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
+        let (__fsize, __fsigned, __fcheck) =
+            field_scalar_tokens(config, &ref_field_key, &struct_path, &member);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
         // Raw (headerless) ref-scalar pointee → `is_gc_managed = false`, the
         // same id the matching getfield uses so this setfield invalidates it.
@@ -1063,6 +1111,7 @@ impl<'c> Lowerer<'c> {
                     vec![],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -1072,6 +1121,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1096,6 +1147,7 @@ impl<'c> Lowerer<'c> {
                     vec![],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -1105,6 +1157,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.setfield_gc_i(
@@ -1149,6 +1203,8 @@ impl<'c> Lowerer<'c> {
             .map(|s| s.ident.to_string())
             .unwrap_or_default();
         let ref_field_key = format!("{}::{}", struct_last, member_name);
+        let (__fsize, __fsigned, __fcheck) =
+            field_scalar_tokens(config, &ref_field_key, &struct_path, &member);
         let is_ref_field = config.ref_fields.contains_key(&ref_field_key);
         let tid = struct_type_id_tokens(&struct_path, false);
         let base_reg = binding.reg;
@@ -1165,6 +1221,7 @@ impl<'c> Lowerer<'c> {
                     vec![],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -1174,6 +1231,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             true,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.setfield_gc_r(
@@ -1197,6 +1256,7 @@ impl<'c> Lowerer<'c> {
                     vec![],
                 ),
                 quote! {
+                    #__fcheck
                     __builder.register_struct_layout(
                         ::core::mem::size_of::<#struct_path>(),
                         #tid,
@@ -1206,6 +1266,8 @@ impl<'c> Lowerer<'c> {
                             ::core::mem::offset_of!(#struct_path, #member),
                             false,
                             stringify!(#member),
+                            #__fsize,
+                            #__fsigned,
                         )],
                     );
                     __builder.setfield_gc_i(

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -23,8 +23,11 @@ pub(super) fn field_scalar_tokens(
                 const _: fn(&#struct_path) -> #ty = |__s| __s.#member;
             },
         ),
+        // `scalar_size`'s own default for a non-`Ref` field: the `i64` storage,
+        // which is 8 on every target and NOT the machine word (a `usize` here
+        // would report 4 on wasm32).
         None => (
-            quote! { ::core::mem::size_of::<usize>() },
+            quote! { ::core::mem::size_of::<i64>() },
             quote! { true },
             quote! {},
         ),

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -553,11 +553,16 @@ impl<'c> Lowerer<'c> {
             .iter()
             .map(|(member, value)| {
                 let is_ref = matches!(value.kind, BindingKind::Ref);
+                // A struct literal names no sub-word integer field: the
+                // allocation's own field stores go through the int/ref banks,
+                // so the layout registers the machine-word default here.
                 quote! {
                     (
                         ::core::mem::offset_of!(#struct_path, #member),
                         #is_ref,
                         stringify!(#member),
+                        ::core::mem::size_of::<usize>(),
+                        true,
                     )
                 }
             })

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -555,13 +555,14 @@ impl<'c> Lowerer<'c> {
                 let is_ref = matches!(value.kind, BindingKind::Ref);
                 // A struct literal names no sub-word integer field: the
                 // allocation's own field stores go through the int/ref banks,
-                // so the layout registers the machine-word default here.
+                // so the layout registers `scalar_size`'s default here. A ref
+                // field's width comes from `Type::Ref` and ignores this.
                 quote! {
                     (
                         ::core::mem::offset_of!(#struct_path, #member),
                         #is_ref,
                         stringify!(#member),
-                        ::core::mem::size_of::<usize>(),
+                        ::core::mem::size_of::<i64>(),
                         true,
                     )
                 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -194,6 +194,12 @@ pub struct LowererConfig {
     /// encounters a field access and the `(struct, field)` pair matches, it
     /// emits `getfield_gc_r` / `setfield_gc_r` (ref-kind) instead of `_gc_i`.
     pub(super) ref_fields: HashMap<String, (syn::Path, Ident, syn::Path)>,
+    /// Sub-word integer struct field declarations.  Key = `"StructType::field"`,
+    /// value = `(rust_int_type, is_signed)`.  Source:
+    /// `JitInterpConfig.int_fields`.  A field listed here registers its real
+    /// width and signedness with the struct layout instead of the machine-word
+    /// default, which is what makes `descr.is_integer_bounded()` true for it.
+    pub(super) int_fields: HashMap<String, (Ident, bool)>,
     /// Return struct type for ref-returning calls.  Key = canonical func
     /// path segments, value = struct type path.  When a `residual_ref` call
     /// result is bound, the lowerer sets `Binding.struct_type` from this map
@@ -851,9 +857,33 @@ pub(super) fn inferred_record_known_result_policy_check(result_kind: BindingKind
     }
 }
 
+/// Build the `int_fields` lookup: key = `"StructLastSegment::field"`.
+fn int_fields_map(
+    int_fields: &[crate::jit_interp::IntFieldEntry],
+) -> HashMap<String, (Ident, bool)> {
+    int_fields
+        .iter()
+        .map(|entry| {
+            let struct_name = entry
+                .struct_type
+                .segments
+                .last()
+                .map(|s| s.ident.to_string())
+                .unwrap_or_default();
+            let key = format!("{}::{}", struct_name, entry.field);
+            // Validated at parse time.
+            (
+                key,
+                (entry.int_type.clone(), entry.is_signed().unwrap_or(true)),
+            )
+        })
+        .collect()
+}
+
 impl LowererConfig {
     pub fn inline_helper(
         ref_fields: &[crate::jit_interp::RefFieldEntry],
+        int_fields: &[crate::jit_interp::IntFieldEntry],
         native_int_binops: &[(syn::Path, syn::Ident)],
         native_tag_small: &[syn::Path],
         headerless_structs: &[syn::Path],
@@ -899,6 +929,7 @@ impl LowererConfig {
             residual_writes: Vec::new(),
             pool_arrays: Vec::new(),
             ref_fields: ref_fields_map,
+            int_fields: int_fields_map(int_fields),
             call_returns: HashMap::new(),
             headerless_structs: headerless_structs
                 .iter()
@@ -931,6 +962,7 @@ impl LowererConfig {
         residual_writes: &[crate::jit_interp::ResidualWriteEntry],
         pool_arrays: &[crate::jit_interp::PoolArrayEntry],
         ref_fields: &[crate::jit_interp::RefFieldEntry],
+        int_fields: &[crate::jit_interp::IntFieldEntry],
         call_returns: &[(Path, Path)],
         headerless_structs: &[Path],
         native_int_binops: &[(Path, Ident)],
@@ -1137,6 +1169,7 @@ impl LowererConfig {
             env_type_name: env_type.to_string(),
             residual_writes,
             ref_fields: ref_fields_map,
+            int_fields: int_fields_map(int_fields),
             call_returns: call_returns
                 .iter()
                 .map(|(func, ret_type)| (canonical_path_segments(func), ret_type.clone()))

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -2569,6 +2569,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2593,6 +2594,7 @@ mod tests {
             &[],
             &[],
             &[],
+            &[],
         )
         .expect("jit_inline lowering should succeed")
         .expect("helper should lower");
@@ -2612,6 +2614,7 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            &[],
             &[],
             &[],
             &[],

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -137,6 +137,17 @@ pub struct JitInterpConfig {
     /// The `PointeeType` is recorded so subsequent field access on the
     /// returned ref can resolve its struct layout.
     pub ref_fields: Vec<RefFieldEntry>,
+    /// Sub-word integer field declarations, `int_fields = { Struct::field =>
+    /// u32, ... }`.  A field access lowers to `getfield_gc_i` /
+    /// `setfield_gc_i` either way; what this adds is the field's real width
+    /// and signedness, which the descr otherwise reports as a full signed
+    /// machine word.  `descr.py:218-239 get_field_descr` takes both from
+    /// `FIELDTYPE`, and `intbounds.py` narrows a load's range only when
+    /// `descr.is_integer_bounded()` — true exactly for a sub-word integer
+    /// field.  Undeclared fields keep the machine-word default, so this is
+    /// opt-in per field; a declaration that disagrees with the Rust struct
+    /// fails to compile (see the generated `const _` check).
+    pub int_fields: Vec<IntFieldEntry>,
     /// Struct type annotations for ref-returning call results.
     /// `call_returns = { func_path => StructType, ... }`.  When a
     /// `residual_ref` (or similar ref-returning) call result is bound,
@@ -383,6 +394,32 @@ pub struct RefFieldEntry {
     pub pointee_type: Path,
 }
 
+/// One entry in `int_fields = { Struct::field => u32, ... }`.
+#[derive(Clone)]
+pub struct IntFieldEntry {
+    /// The struct that owns the field (e.g. `Stack`).
+    pub struct_type: Path,
+    /// The field name within the struct (e.g. `size`).
+    pub field: Ident,
+    /// The field's Rust integer type, which supplies its width and sign.
+    pub int_type: Ident,
+}
+
+impl IntFieldEntry {
+    /// `descr.py:240-254 get_type_flag(FIELDTYPE)` — the signed/unsigned half,
+    /// read off the declared Rust type.
+    pub(crate) fn is_signed(&self) -> syn::Result<bool> {
+        match self.int_type.to_string().as_str() {
+            "i8" | "i16" | "i32" | "i64" | "isize" => Ok(true),
+            "u8" | "u16" | "u32" | "u64" | "usize" | "bool" => Ok(false),
+            other => Err(syn::Error::new_spanned(
+                &self.int_type,
+                format!("int_fields: `{other}` is not an integer type"),
+            )),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) enum CallPolicyKind {
     ResidualVoid,
@@ -559,6 +596,7 @@ impl Parse for JitInterpConfig {
         let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
         let mut pool_arrays: Vec<PoolArrayEntry> = Vec::new();
         let mut ref_fields: Vec<RefFieldEntry> = Vec::new();
+        let mut int_fields: Vec<IntFieldEntry> = Vec::new();
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
         let mut headerless_structs: Vec<Path> = Vec::new();
@@ -620,6 +658,9 @@ impl Parse for JitInterpConfig {
                 }
                 "ref_fields" => {
                     ref_fields = parse_ref_fields_map(input)?;
+                }
+                "int_fields" => {
+                    int_fields = parse_int_fields_map(input)?;
                 }
                 "call_returns" => {
                     call_returns = parse_call_returns_map(input)?;
@@ -688,6 +729,7 @@ impl Parse for JitInterpConfig {
             residual_writes,
             pool_arrays,
             ref_fields,
+            int_fields,
             call_returns,
             struct_allocs,
             headerless_structs,
@@ -832,6 +874,28 @@ fn split_struct_field_path(full_path: Path) -> syn::Result<(Path, Ident)> {
         segments: segments.into_iter().collect(),
     };
     Ok((struct_type, field))
+}
+
+/// Parse `int_fields = { Struct::field => u32, ... }`.  Split like
+/// `ref_fields`: the last segment of `Struct::field` is the field name.
+pub(crate) fn parse_int_fields_map(input: ParseStream) -> syn::Result<Vec<IntFieldEntry>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let (struct_type, field) = split_struct_field_path(content.parse::<Path>()?)?;
+        content.parse::<Token![=>]>()?;
+        let int_type: Ident = content.parse()?;
+        let entry = IntFieldEntry {
+            struct_type,
+            field,
+            int_type,
+        };
+        entry.is_signed()?;
+        entries.push(entry);
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
 }
 
 pub(crate) fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFieldEntry>> {

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -34,6 +34,7 @@ struct JitInlineArgs {
     calls: Vec<jit_interp::CallEntry>,
     ref_params: Vec<(Ident, Path)>,
     ref_fields: Vec<jit_interp::RefFieldEntry>,
+    int_fields: Vec<jit_interp::IntFieldEntry>,
     native_int_binops: Vec<(Path, Ident)>,
     native_tag_small: Vec<Path>,
     struct_allocs: Vec<(Path, Path)>,
@@ -45,6 +46,7 @@ impl Parse for JitInlineArgs {
         let mut calls: Vec<jit_interp::CallEntry> = Vec::new();
         let mut ref_params: Vec<(Ident, Path)> = Vec::new();
         let mut ref_fields: Vec<jit_interp::RefFieldEntry> = Vec::new();
+        let mut int_fields: Vec<jit_interp::IntFieldEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
@@ -91,6 +93,9 @@ impl Parse for JitInlineArgs {
                 "ref_fields" => {
                     ref_fields = jit_interp::parse_ref_fields_map(input)?;
                 }
+                "int_fields" => {
+                    int_fields = jit_interp::parse_int_fields_map(input)?;
+                }
                 "helpers" => {
                     let content;
                     syn::bracketed!(content in input);
@@ -126,6 +131,7 @@ impl Parse for JitInlineArgs {
             calls,
             ref_params,
             ref_fields,
+            int_fields,
             native_int_binops,
             native_tag_small,
             struct_allocs,
@@ -2365,6 +2371,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.calls,
         &args.ref_params,
         &args.ref_fields,
+        &args.int_fields,
         &args.native_int_binops,
         &args.native_tag_small,
         &args.headerless_structs,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -564,7 +564,7 @@ impl JitCodeBuilder {
         size: usize,
         type_id: u64,
         headerless: bool,
-        fields: &[(usize, bool, &str)],
+        fields: &[(usize, bool, &str, usize, bool)],
     ) {
         self.touch_ref_reg(dest);
         // descr.py:108-120 get_size_descr + init_size_descr: cache the
@@ -622,7 +622,7 @@ impl JitCodeBuilder {
         type_id: u64,
         is_gc_managed: bool,
         headerless: bool,
-        fields: &[(usize, bool, &str)],
+        fields: &[(usize, bool, &str, usize, bool)],
     ) {
         // Every emit site re-registers the layout it accesses, so the same few
         // type_ids arrive hundreds of times.  When the spec already lists an
@@ -636,7 +636,7 @@ impl JitCodeBuilder {
             .struct_size_specs
             .get(&type_id)
             .is_some_and(|existing| {
-                fields.iter().all(|&(offset, _, _)| {
+                fields.iter().all(|&(offset, _, _, _, _)| {
                     existing
                         .all_fielddescrs
                         .iter()
@@ -701,25 +701,32 @@ impl JitCodeBuilder {
     /// literal of the same struct an identical, deterministic
     /// `all_fielddescrs` order so the `type_id`-keyed cache is not polluted
     /// and the optimizer's `FieldDescr.n()` indexing stays consistent.
-    fn field_specs_from_layout(fields: &[(usize, bool, &str)]) -> Vec<BhFieldSpec> {
-        let mut ordered: Vec<(usize, bool, &str)> = fields.to_vec();
-        ordered.sort_by_key(|&(offset, _, _)| offset);
+    fn field_specs_from_layout(fields: &[(usize, bool, &str, usize, bool)]) -> Vec<BhFieldSpec> {
+        let mut ordered: Vec<(usize, bool, &str, usize, bool)> = fields.to_vec();
+        ordered.sort_by_key(|&(offset, _, _, _, _)| offset);
         ordered
             .iter()
             .enumerate()
-            .map(|(idx, &(offset, is_ref, name))| {
-                let (field_type, field_flag, is_field_signed) = if is_ref {
+            .map(|(idx, &(offset, is_ref, name, decl_size, decl_signed))| {
+                // descr.py:240-254 `get_type_flag(FIELDTYPE)`: a pointer field
+                // is FLAG_POINTER; an integer field is FLAG_SIGNED or
+                // FLAG_UNSIGNED by its own type and carries its own width.
+                // The emit site supplies both for an integer field; a ref field
+                // is a pointer word by construction.
+                let (field_type, field_size, field_flag, is_field_signed) = if is_ref {
                     (
                         majit_ir::value::Type::Ref,
+                        scalar_size(majit_ir::value::Type::Ref),
                         majit_ir::descr::ArrayFlag::Pointer,
                         false,
                     )
                 } else {
-                    (
-                        majit_ir::value::Type::Int,
-                        majit_ir::descr::ArrayFlag::Signed,
-                        true,
-                    )
+                    let flag = if decl_signed {
+                        majit_ir::descr::ArrayFlag::Signed
+                    } else {
+                        majit_ir::descr::ArrayFlag::Unsigned
+                    };
+                    (majit_ir::value::Type::Int, decl_size, flag, decl_signed)
                 };
                 BhFieldSpec {
                     // descr.py:656 SimpleFieldDescr id is unset until the
@@ -729,7 +736,7 @@ impl JitCodeBuilder {
                     field_key: name.to_string(),
                     name: name.to_string(),
                     offset,
-                    field_size: scalar_size(field_type),
+                    field_size,
                     field_type,
                     field_flag,
                     is_field_signed,
@@ -810,10 +817,21 @@ impl JitCodeBuilder {
         // rather than the first of them.  A guessed NAME is the damaging half:
         // it becomes the descr's `_cache_field` key downstream, so naming the
         // aggregate hands the leaf's access the aggregate's descr.
-        let (index_in_parent, name) =
-            field_slot_in(&parent_spec.all_fielddescrs, field_name, offset)
-                .map(|idx| (idx, parent_spec.all_fielddescrs[idx].name.clone()))
-                .unwrap_or((0, String::new()));
+        let slot = field_slot_in(&parent_spec.all_fielddescrs, field_name, offset);
+        let (index_in_parent, name) = slot
+            .map(|idx| (idx, parent_spec.all_fielddescrs[idx].name.clone()))
+            .unwrap_or((0, String::new()));
+        // The registered layout is the record of what `descr.py:218-239
+        // get_field_descr` derives from FIELDTYPE, so a field it names supplies
+        // its own width and signedness.  The IR bank the access lands in
+        // cannot: every integer read arrives here as `Type::Int` whether the
+        // field is a byte or a word.
+        let (field_size, field_flag, is_field_signed) = slot
+            .map(|idx| {
+                let f = &parent_spec.all_fielddescrs[idx];
+                (f.field_size, f.field_flag, f.is_field_signed)
+            })
+            .unwrap_or((scalar_size(field_type), field_flag, is_field_signed));
         // Carry the scalars only.  `patch_field_descr_parents`, called
         // unconditionally from `try_finish` after the decline early-return,
         // replaces this snapshot with `struct_size_specs`' final merged spec
@@ -832,7 +850,7 @@ impl JitCodeBuilder {
         });
         self.add_bh_descr(CanonicalBhDescr::Field {
             offset,
-            field_size: scalar_size(field_type),
+            field_size,
             field_type,
             field_flag,
             is_field_signed,
@@ -1861,8 +1879,8 @@ impl JitCodeBuilder {
             true,
             false,
             &[
-                (length_offset, false, "length"),
-                (items_offset, true, "items"),
+                (length_offset, false, "length", scalar_size(majit_ir::value::Type::Int), true),
+                (items_offset, true, "items", scalar_size(majit_ir::value::Type::Ref), false),
             ],
         );
         let all_fielddescrs = self
@@ -6101,10 +6119,10 @@ mod tests {
         const TID: u64 = 0x5747_5F49_4458;
         let mut builder = JitCodeBuilder::new();
         // Site 1 registers only the HIGH offset, so the mint ranks it 0.
-        builder.register_struct_layout(24, TID, false, false, &[(16, false, "hi")]);
+        builder.register_struct_layout(24, TID, false, false, &[(16, false, "hi", 8, true)]);
         builder.getfield_gc_i(0, 1, 16, TID, "hi");
         // Site 2 registers the LOW offset; the merge re-indexes to {8→0, 16→1}.
-        builder.register_struct_layout(24, TID, false, false, &[(8, false, "lo")]);
+        builder.register_struct_layout(24, TID, false, false, &[(8, false, "lo", 8, true)]);
         builder.getfield_gc_i(2, 1, 8, TID, "lo");
         let jitcode = builder.finish();
 

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1879,8 +1879,20 @@ impl JitCodeBuilder {
             true,
             false,
             &[
-                (length_offset, false, "length", scalar_size(majit_ir::value::Type::Int), true),
-                (items_offset, true, "items", scalar_size(majit_ir::value::Type::Ref), false),
+                (
+                    length_offset,
+                    false,
+                    "length",
+                    scalar_size(majit_ir::value::Type::Int),
+                    true,
+                ),
+                (
+                    items_offset,
+                    true,
+                    "items",
+                    scalar_size(majit_ir::value::Type::Ref),
+                    false,
+                ),
             ],
         );
         let all_fielddescrs = self
@@ -6193,7 +6205,7 @@ mod tests {
                 TID,
                 false,
                 false,
-                &[(8, false, "agg"), (8, true, "leaf")],
+                &[(8, false, "agg", 8, true), (8, true, "leaf", 8, false)],
             );
             builder.getfield_gc_i(0, 1, 8, TID, name);
             // `finish` runs the postcondition under `cfg!(debug_assertions)`; a
@@ -6243,7 +6255,11 @@ mod tests {
     #[test]
     fn a_named_field_resolves_by_name_through_an_ambiguous_offset() {
         const TID: u64 = 0x4E41_4D45_4B59;
-        let fields = [(0, false, "head"), (8, false, "agg"), (8, true, "leaf")];
+        let fields = [
+            (0, false, "head", 8, false),
+            (8, false, "agg", 8, true),
+            (8, true, "leaf", 8, false),
+        ];
         assert_eq!(
             super::field_slot_in(&JitCodeBuilder::field_specs_from_layout(&fields), "leaf", 8,),
             Some(2),

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -475,29 +475,32 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
 /// before `finish_setup_descrs` (jitcode assembly does), matching the
 /// non-trivial-raw-set construction-timing `call_descr` asserts.
 pub fn struct_fields_write_effect_info(
-    layouts: &[(usize, u64, bool, &[(usize, bool, &str)])],
+    layouts: &[(usize, u64, bool, &[(usize, bool, &str, usize, bool)])],
     can_raise: bool,
 ) -> majit_ir::EffectInfo {
     // Mirror `JitCodeBuilder::field_specs_from_layout`: sort by offset so
     // `index_in_parent` is the stable by-offset rank, scalar = one machine word.
     let mut fds = Vec::new();
     for &(struct_size, type_id, is_gc_managed, fields) in layouts {
-        let mut ordered: Vec<(usize, bool, &str)> = fields.to_vec();
-        ordered.sort_by_key(|&(offset, _, _)| offset);
+        let mut ordered: Vec<(usize, bool, &str, usize, bool)> = fields.to_vec();
+        ordered.sort_by_key(|&(offset, _, _, _, _)| offset);
         let specs: Vec<majit_ir::descr::SimpleFieldDescrSpec> = ordered
             .iter()
             .enumerate()
-            .map(|(idx, &(offset, is_ref, name))| {
-                let (field_type, flag) = if is_ref {
+            .map(|(idx, &(offset, is_ref, name, decl_size, decl_signed))| {
+                let (field_type, field_size, flag) = if is_ref {
                     (
                         majit_ir::value::Type::Ref,
+                        jitcode::scalar_size(majit_ir::value::Type::Ref),
                         majit_ir::descr::ArrayFlag::Pointer,
                     )
                 } else {
-                    (
-                        majit_ir::value::Type::Int,
-                        majit_ir::descr::ArrayFlag::Signed,
-                    )
+                    let flag = if decl_signed {
+                        majit_ir::descr::ArrayFlag::Signed
+                    } else {
+                        majit_ir::descr::ArrayFlag::Unsigned
+                    };
+                    (majit_ir::value::Type::Int, decl_size, flag)
                 };
                 majit_ir::descr::SimpleFieldDescrSpec {
                     index: u32::MAX,
@@ -506,8 +509,9 @@ pub fn struct_fields_write_effect_info(
                     offset,
                     // Same width rule as the `field_specs_from_layout` twin
                     // this mirrors: a `Ref` field is one target word (4 on
-                    // wasm32), an `Int` field is its `i64` storage.
-                    field_size: jitcode::scalar_size(field_type),
+                    // wasm32); an `Int` field is its declared storage, which is
+                    // a machine word unless the emit site named it narrower.
+                    field_size,
                     field_type,
                     is_immutable: false,
                     is_quasi_immutable: false,
@@ -527,7 +531,7 @@ pub fn struct_fields_write_effect_info(
             &specs,
         );
         let struct_key = majit_ir::descr::LLType::Struct(type_id);
-        fds.extend(fields.iter().map(|(_, _, write_field)| {
+        fds.extend(fields.iter().map(|(_, _, write_field, _, _)| {
             majit_ir::descr::gc_cache()
                 .lock()
                 .unwrap()

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -10804,7 +10804,7 @@ mod tests {
             16,
             0xCD,
             false,
-            &[(0, false, "value"), (8, true, "next")],
+            &[(0, false, "value", 8, true), (8, true, "next", 8, false)],
         ); // ref reg 0 = Node*
         builder.load_const_i_value(0, 99); // int reg 0 = 99
         builder.setfield_gc_i(0, 0, 0, 0xCD, "value"); // Node.value = 99
@@ -10876,7 +10876,7 @@ mod tests {
             16,
             0xCE,
             false,
-            &[(0, false, "value"), (8, true, "next")],
+            &[(0, false, "value", 8, true), (8, true, "next", 8, false)],
         );
         builder.setfield_gc_i_c(0, -7, 0, 0xCE, "value"); // Node.value = -7 (inline const)
         let jitcode = builder.finish();

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -218,6 +218,12 @@ impl W_Unpickler {
         }
         // The memo persists across `load` calls (a multi-object stream may
         // back-reference an object memoized by an earlier load).
+        let stack = pyre_object::listobject::w_list_new(Vec::new());
+        pyre_object::gc_roots::pin_root(stack);
+        let stack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let metastack = pyre_object::listobject::w_list_new(Vec::new());
+        pyre_object::gc_roots::pin_root(metastack);
+        let metastack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let memo = pyre_object::listobject::w_list_new(Vec::new());
         pyre_object::gc_roots::pin_root(memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -234,8 +240,8 @@ impl W_Unpickler {
         current.fix_imports = fix_imports;
         current.w_file_read = pyre_object::gc_roots::shadow_stack_get(read_slot);
         current.w_file_readline = pyre_object::gc_roots::shadow_stack_get(readline_slot);
-        current.w_stack = pyre_object::w_none();
-        current.w_metastack = pyre_object::w_none();
+        current.w_stack = pyre_object::gc_roots::shadow_stack_get(stack_slot);
+        current.w_metastack = pyre_object::gc_roots::shadow_stack_get(metastack_slot);
         current.w_memo = pyre_object::gc_roots::shadow_stack_get(memo_slot);
         current.memo_index = 0;
         current.w_frame = pyre_object::w_none();
@@ -291,17 +297,27 @@ impl W_Unpickler {
             );
         }
 
-        // Fresh stack each load; the memo persists across `load` calls so a
-        // later object can back-reference one memoized by an earlier load
-        // (lazily created when the unpickler was built only via `__new__`).
-        let w_stack = pyre_object::listobject::w_list_new(Vec::new());
-        let me = cur(slot);
-        me.w_stack = w_stack;
-        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
-        let me = cur(slot);
-        me.w_metastack = w_metastack;
-        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        // Reset the constructor-owned stacks in place. An object built only
+        // via `__new__` still initializes them lazily on its first `load`.
+        if unsafe { pyre_object::is_none(cur(slot).w_stack) } {
+            let w_stack = pyre_object::listobject::w_list_new(Vec::new());
+            let me = cur(slot);
+            me.w_stack = w_stack;
+            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        }
+        if unsafe { pyre_object::is_none(cur(slot).w_metastack) } {
+            let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
+            let me = cur(slot);
+            me.w_metastack = w_metastack;
+            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        }
+        unsafe {
+            pyre_object::listobject::w_list_clear(cur(slot).w_stack);
+            pyre_object::listobject::w_list_clear(cur(slot).w_metastack);
+        }
+        // The memo persists across `load` calls so a later object can
+        // back-reference one memoized by an earlier load. It is created lazily
+        // only when the unpickler was built via `__new__` without `__init__`.
         if unsafe { pyre_object::is_none(cur(slot).w_memo) } {
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             let me = cur(slot);

--- a/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/unpickler.rs
@@ -218,12 +218,6 @@ impl W_Unpickler {
         }
         // The memo persists across `load` calls (a multi-object stream may
         // back-reference an object memoized by an earlier load).
-        let stack = pyre_object::listobject::w_list_new(Vec::new());
-        pyre_object::gc_roots::pin_root(stack);
-        let stack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-        let metastack = pyre_object::listobject::w_list_new(Vec::new());
-        pyre_object::gc_roots::pin_root(metastack);
-        let metastack_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let memo = pyre_object::listobject::w_list_new(Vec::new());
         pyre_object::gc_roots::pin_root(memo);
         let memo_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
@@ -240,8 +234,8 @@ impl W_Unpickler {
         current.fix_imports = fix_imports;
         current.w_file_read = pyre_object::gc_roots::shadow_stack_get(read_slot);
         current.w_file_readline = pyre_object::gc_roots::shadow_stack_get(readline_slot);
-        current.w_stack = pyre_object::gc_roots::shadow_stack_get(stack_slot);
-        current.w_metastack = pyre_object::gc_roots::shadow_stack_get(metastack_slot);
+        current.w_stack = pyre_object::w_none();
+        current.w_metastack = pyre_object::w_none();
         current.w_memo = pyre_object::gc_roots::shadow_stack_get(memo_slot);
         current.memo_index = 0;
         current.w_frame = pyre_object::w_none();
@@ -297,27 +291,17 @@ impl W_Unpickler {
             );
         }
 
-        // Reset the constructor-owned stacks in place. An object built only
-        // via `__new__` still initializes them lazily on its first `load`.
-        if unsafe { pyre_object::is_none(cur(slot).w_stack) } {
-            let w_stack = pyre_object::listobject::w_list_new(Vec::new());
-            let me = cur(slot);
-            me.w_stack = w_stack;
-            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        }
-        if unsafe { pyre_object::is_none(cur(slot).w_metastack) } {
-            let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
-            let me = cur(slot);
-            me.w_metastack = w_metastack;
-            unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
-        }
-        unsafe {
-            pyre_object::listobject::w_list_clear(cur(slot).w_stack);
-            pyre_object::listobject::w_list_clear(cur(slot).w_metastack);
-        }
-        // The memo persists across `load` calls so a later object can
-        // back-reference one memoized by an earlier load. It is created lazily
-        // only when the unpickler was built via `__new__` without `__init__`.
+        // Fresh stack each load; the memo persists across `load` calls so a
+        // later object can back-reference one memoized by an earlier load
+        // (lazily created when the unpickler was built only via `__new__`).
+        let w_stack = pyre_object::listobject::w_list_new(Vec::new());
+        let me = cur(slot);
+        me.w_stack = w_stack;
+        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
+        let w_metastack = pyre_object::listobject::w_list_new(Vec::new());
+        let me = cur(slot);
+        me.w_metastack = w_metastack;
+        unpickler_write_barrier(me as *mut W_Unpickler as PyObjectRef);
         if unsafe { pyre_object::is_none(cur(slot).w_memo) } {
             let w_memo = pyre_object::listobject::w_list_new(Vec::new());
             let me = cur(slot);


### PR DESCRIPTION
## Summary

`jit_inline`/`jit_interp` derived every non-`Ref` struct field's descr from the IR
type alone, so an integer field was always **one signed machine word** regardless of
the Rust field's declared type. RPython does not do that: `descr.py:218
get_field_descr` sizes the field from `FIELDTYPE`, and `descr.py:241 get_type_flag`
takes the flag from that same type.

The width is load-bearing for the optimizer. `intbounds` narrows a `GETFIELD_GC_I`
result only when the descr is sub-word — `is_integer_bounded()` is true exactly for
`0 < field_size < 8` — so a field declared `u32` in Rust came back as a full-range
`i64` and could not be bounded.

### What changed

- `jit_inline`/`jit_interp` gain an `int_fields = { Struct::field => u32 }` clause. A
  field named there registers `size_of::<ty>()` and the type's signedness with the
  struct layout; an undeclared field keeps the previous signed 8-byte default.
- The declaration cannot drift from the struct it describes: the macro emits
  `const _: fn(&Struct) -> ty = |s| s.field;`, so a wrong type is a compile error at
  the declaration site.
- `field_specs_from_layout`, `add_struct_field_descr` and the
  `struct_fields_write_effect_info` twin now all read the width and flag from the
  registered layout instead of each re-deriving one signed machine word.
  `GcCache::_cache_field` is first-write-wins, so the descr's width previously
  depended on which of them minted the field descr first; now they agree by
  construction.
- The registered layout tuple grows from `(offset, is_ref, name)` to
  `(offset, is_ref, name, field_size, is_signed)`.

The second commit fixes a latent bug in the first plus its fallout: the
undeclared-field default was spelled `size_of::<usize>()`, which is 4 on wasm32,
while `scalar_size` reports `size_of::<i64>()` for every non-`Ref` field. It also
updates six `#[cfg(test)]` call sites left at the old arity — `cargo check` does not
compile those, so only `cargo test` sees them — and reformats one layout literal that
`cargo fmt --check` rejected.

### Effect

No in-tree behaviour change: nothing in this repo declares `int_fields`, and the
default width/flag are the same 8-byte signed values the previous code derived, so
every existing field descr is unchanged.

The mechanism is exercised by an out-of-tree consumer (the aheui JIT), where
narrowing a stack-depth counter to `u32` lets `intbounds` bound the depth load and
collapse the re-guard chain that a rangeless `depth + 1` forces:

| `logo.aheui`   | before | after |
| -------------- | -----: | ----: |
| emitted ops    |   8925 |  3830 |
| guards         |   2514 |   610 |
| `GuardTrue`    |   2209 |   305 |

with byte-identical program output (996310 bytes, exit 42). The compiled trace's
`GcLoadI` width immediates become 585×signed-8 + 305×unsigned-4, a direct readout of
the descr.

### Note on the commit list

The two `_pickle:` commits are older branch content and cancel out — this PR's net
diff against `main` is the two `majit:` commits only.

## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring integer field types and signedness in JIT configurations.
  * Improved handling of sub-word integer fields in generated code and inline helpers.
  * Struct layouts now preserve field widths and signed/unsigned metadata.

* **Bug Fixes**
  * Corrected field read, write, and residual-effect metadata to reflect declared integer types.
  * Added validation for configured integer field types and compile-time field-type checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->