### PR TITLE
jit-trace: stop indexing the Python-keyed depth table with a JitCode offset

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -925,7 +925,8 @@ pub(crate) fn recipe_parent_frame_from_recipe(
         recipe.jitcode_pc,
     );
     let stack_only = recipe.valuestackdepth.saturating_sub(recipe.nlocals);
-    let maps = crate::state::bridge_semantic_maps_from_pc(recipe.jitcode_index, recipe.jitcode_pc);
+    let maps =
+        crate::state::bridge_semantic_maps_from_jitcode_pc(recipe.jitcode_index, recipe.jitcode_pc);
     let null_ref = ctx.const_ref(pyre_object::PY_NULL as i64);
     let mut boxes = Vec::with_capacity(banks.total_len());
     // Per-color `(color, box)` pairs for the blackhole capture below, collected

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2171,7 +2171,8 @@ fn carrier_stack_box_for_ref_arg<Sym: WalkSym>(
         return None;
     }
     let nlocals = unsafe { (&(*raw_code).varnames).len() };
-    let maps = crate::state::bridge_semantic_maps_from_pc(consts.jitcode_index, op_pc as i32);
+    let maps =
+        crate::state::bridge_semantic_maps_from_jitcode_pc(consts.jitcode_index, op_pc as i32);
     let semantic = crate::state::semantic_ref_slot_for_reg_color(
         nlocals,
         maps.stack_depth_at_pc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -2041,7 +2041,7 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
     // here (before the nested callee's body walk) — not at capture — places the
     // stores ahead of every in-callee guard, so `_number_virtuals` reads the
     // populated array when it numbers those guards' resume data.
-    if let Some(marker) = resume_marker_jit_pc {
+    if resume_marker_jit_pc.is_some() {
         if caller_liveness_word != majit_ir::resumedata::NO_JITCODE_PC && depth > 1 {
             let (frame_reg, _) = crate::state::portal_red_regs_at(jitcode_index as i32);
             let frame_red = (frame_reg != u16::MAX)
@@ -2058,9 +2058,10 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
                 // `depth` is the operand-stack depth at the CALL return point,
                 // top slot = the pending nested-call result.
                 let pending_top_slot = nlocals + depth - 1;
-                // No Python coordinate here: `marker` is
-                // `inline_call_return_marker`'s `decode_op_at(..).next_pc`, a
-                // JitCode byte offset.
+                // No Python coordinate here. This slot used to carry
+                // `resume_marker_jit_pc`, which `inline_call_return_marker`
+                // mints as `decode_op_at(..).next_pc` — a JitCode byte offset,
+                // not a Python PC. It gates the block above and nothing else.
                 let maps = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
                     jitcode_index as i32,
                     None,
@@ -2529,10 +2530,8 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     let mut recovered_regs_r = ctx.registers_r.to_vec();
     let code = unsafe { &*callee_pjc.code_ptr };
     let (stack_base, _) = crate::state::callee_layout_for_call_assembler(code);
-    let maps = crate::state::bridge_semantic_maps_from_jitcode_pc(
-        callee_jitcode_index,
-        callee_jitcode_pc,
-    );
+    let maps =
+        crate::state::bridge_semantic_maps_from_jitcode_pc(callee_jitcode_index, callee_jitcode_pc);
     // The kept-stack guard gate is certified by this callee frame's
     // operand-stack mirror.  Publish the same boxes into the carried
     // coordinate's Ref colors before collecting the frame snapshot, so the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -1004,7 +1004,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             if after_residual_call && sym.owns_virtualizable_shadow() {
                 let maps = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
                     jitcode_index as i32,
-                    liveness_py_pc as i32,
+                    Some(liveness_py_pc as i32),
                     guard_jitcode_pc,
                 );
                 let banks = crate::state::frame_liveness_reg_indices_by_bank_at_with_jitcode_pc(
@@ -2058,9 +2058,12 @@ pub(crate) fn compute_nested_inline_caller_frame<Sym: WalkSym>(
                 // `depth` is the operand-stack depth at the CALL return point,
                 // top slot = the pending nested-call result.
                 let pending_top_slot = nlocals + depth - 1;
+                // No Python coordinate here: `marker` is
+                // `inline_call_return_marker`'s `decode_op_at(..).next_pc`, a
+                // JitCode byte offset.
                 let maps = crate::state::bridge_semantic_maps_at_with_jitcode_pc(
                     jitcode_index as i32,
-                    marker as i32,
+                    None,
                     caller_liveness_word,
                 );
                 let array_descr = crate::state::pyobject_gcarray_descr();
@@ -2526,7 +2529,10 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     let mut recovered_regs_r = ctx.registers_r.to_vec();
     let code = unsafe { &*callee_pjc.code_ptr };
     let (stack_base, _) = crate::state::callee_layout_for_call_assembler(code);
-    let maps = crate::state::bridge_semantic_maps_from_pc(callee_jitcode_index, callee_jitcode_pc);
+    let maps = crate::state::bridge_semantic_maps_from_jitcode_pc(
+        callee_jitcode_index,
+        callee_jitcode_pc,
+    );
     // The kept-stack guard gate is certified by this callee frame's
     // operand-stack mirror.  Publish the same boxes into the carried
     // coordinate's Ref colors before collecting the frame snapshot, so the

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1791,34 +1791,30 @@ pub(crate) struct BridgeSemanticMaps {
     pub pcdep_entries: Vec<(u8, u16, u16)>,
 }
 
-/// Measurement gate for the `via_py_pc` fallback of
-/// [`bridge_semantic_maps_at_with_jitcode_pc`].  The fallback indexes the
-/// Python-PC-keyed `LiveVars::depth_at_py_pc` with that function's `pc`
-/// parameter, but `bridge_semantic_maps_from_pc` supplies ONE word for both
-/// the `pc` and `jitcode_pc` slots, and five of its callers pass a JitCode
-/// byte offset (`RebuiltFrame::pc` is documented as the byte offset, with the
-/// Python coordinate in the separate `py_pc` field).
+/// Per-call-site counters for the `via_py_pc` fallback of
+/// [`bridge_semantic_maps_at_with_jitcode_pc`], which indexes the
+/// Python-PC-keyed `LiveVars::depth_at_py_pc`.
 ///
-/// The partition that decides whether that mis-keying is observable:
-/// an offset past the end of the table reads `None` and the fallback already
-/// answers 0, but an offset that lands inside the table returns a real depth
-/// belonging to a different coordinate.  `in_range` with a non-zero depth is
-/// the only case that reaches `setup_bridge_sym`'s `semantic_prefix_len`.
+/// The partition that decides whether a Python coordinate is being read at a
+/// point the caller did not mean: an offset past the end of the table reads
+/// `None` and the fallback answers 0, but one that lands inside returns a real
+/// depth belonging to a different instruction. `in_range_nonzero` is the only
+/// bucket that reaches `setup_bridge_sym`'s `semantic_prefix_len`, so it is the
+/// standing check on the one caller that still supplies a `Some` coordinate
+/// (`resume_snapshot.rs` `walker_capture_snapshot_for_last_guard_impl`,
+/// `liveness_py_pc`); a fire there means that argument is not a Python PC after
+/// all.
+///
+/// The counters are per site, not per process: with one shared counter only the
+/// site that fires first is ever named, so a run in which one leg never
+/// executed is indistinguishable from one in which it executed second.
 ///
 /// Pure telemetry — with the variable unset every counter path is skipped and
 /// the fallback's value is unchanged.
-fn empty_twin_census_enabled() -> bool {
-    static E: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *E.get_or_init(|| std::env::var_os("PYRE_M73_EMPTYTWIN_CENSUS").is_some())
-}
-
-/// One counter set per call site. The heartbeat has to be per site, not per
-/// process: with a single shared counter only the site that fires first is
-/// ever named, so a run in which one leg never executed is indistinguishable
-/// from one in which it executed second.
 struct EmptyTwinSite {
     name: &'static str,
     hits: std::sync::atomic::AtomicU64,
+    no_py_pc: std::sync::atomic::AtomicU64,
     null_code: std::sync::atomic::AtomicU64,
     out_of_range: std::sync::atomic::AtomicU64,
     in_range_zero: std::sync::atomic::AtomicU64,
@@ -1833,6 +1829,7 @@ impl EmptyTwinSite {
         Self {
             name,
             hits: zero(),
+            no_py_pc: zero(),
             null_code: zero(),
             out_of_range: zero(),
             in_range_zero: zero(),
@@ -1846,8 +1843,16 @@ static EMPTY_TWIN_MISS: EmptyTwinSite = EmptyTwinSite::new("twin_miss");
 /// No jitcode coordinate was carried at all.
 static EMPTY_TWIN_NON_DECODABLE: EmptyTwinSite = EmptyTwinSite::new("non_decodable");
 
-fn empty_twin_census(site: &EmptyTwinSite, rp: usize, table_len: Option<usize>, depth: u16) {
-    if !empty_twin_census_enabled() {
+fn empty_twin_census(
+    site: &EmptyTwinSite,
+    rp: Option<usize>,
+    table_len: Option<usize>,
+    depth: u16,
+) {
+    // Shares `PYRE_M73_EMPTYTWIN_CENSUS` with `py_coord::note_empty_twin_fallback`,
+    // so one run reports both. That one prints `[m73-emptytwin]`; this one prints
+    // `[m73-bridge-maps]`, distinct under a case-insensitive filter too.
+    if !crate::py_coord::emptytwin_census_enabled() {
         return;
     }
     use std::sync::atomic::Ordering;
@@ -1855,12 +1860,13 @@ fn empty_twin_census(site: &EmptyTwinSite, rp: usize, table_len: Option<usize>, 
     let hits = site.hits.fetch_add(1, Ordering::Relaxed) + 1;
     // `in_range_nonzero` is the only bucket that can reach `setup_bridge_sym`'s
     // `semantic_prefix_len`: a real depth read at a coordinate the caller never
-    // meant as a Python PC.
-    let (bucket, counter, live) = match table_len {
-        None => ("null_code", &site.null_code, false),
-        Some(len) if rp >= len => ("out_of_range", &site.out_of_range, false),
-        Some(_) if depth == 0 => ("in_range_zero", &site.in_range_zero, false),
-        Some(_) => ("in_range_nonzero", &site.in_range_nonzero, true),
+    // meant as a Python PC. `no_py_pc` is the leg that used to read one.
+    let (bucket, counter, live) = match (rp, table_len) {
+        (None, _) => ("no_py_pc", &site.no_py_pc, false),
+        (Some(_), None) => ("null_code", &site.null_code, false),
+        (Some(rp), Some(len)) if rp >= len => ("out_of_range", &site.out_of_range, false),
+        (Some(_), Some(_)) if depth == 0 => ("in_range_zero", &site.in_range_zero, false),
+        (Some(_), Some(_)) => ("in_range_nonzero", &site.in_range_nonzero, true),
     };
     let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
     // Every bucket announces its first witness, so the buckets that do fire are
@@ -1868,12 +1874,13 @@ fn empty_twin_census(site: &EmptyTwinSite, rp: usize, table_len: Option<usize>, 
     // on a stream carrying other buckets' lines is empty, not unprinted.
     if n == 1 || (live && n <= 20) {
         eprintln!(
-            "[M73-EMPTYTWIN] site={name} bucket={bucket} n={n} rp={rp} len={table_len:?} depth={depth}"
+            "[m73-bridge-maps] site={name} bucket={bucket} n={n} rp={rp:?} len={table_len:?} depth={depth}"
         );
     }
     if hits % 100_000 == 0 {
         eprintln!(
-            "[M73-EMPTYTWIN] totals site={name} hits={hits} null_code={} out_of_range={} in_range_zero={} in_range_nonzero={}",
+            "[m73-bridge-maps] totals site={name} hits={hits} no_py_pc={} null_code={} out_of_range={} in_range_zero={} in_range_nonzero={}",
+            site.no_py_pc.load(Ordering::Relaxed),
             site.null_code.load(Ordering::Relaxed),
             site.out_of_range.load(Ordering::Relaxed),
             site.in_range_zero.load(Ordering::Relaxed),
@@ -1891,9 +1898,16 @@ fn empty_twin_census(site: &EmptyTwinSite, rp: usize, table_len: Option<usize>, 
 /// through the carried `jitcode_pc`. Without this the decode-side
 /// color→slot inversion reads the merge-target PC's pcdep (where the
 /// computed kept temp is dead), leaving the temp as `OpRef::NONE`.
+/// `py_pc` is the caller's OWN Python coordinate, or `None` when it holds
+/// only a JitCode coordinate. It is not interchangeable with `jitcode_pc`:
+/// it indexes the Python-PC-keyed static liveness, and `py_coord.rs`'s
+/// module invariant is that "runtime consumers never project a JitCode PC
+/// through a Python-keyed map". `None` is what makes that statable —
+/// passing the JitCode word here reads a foreign instruction's depth
+/// whenever the offset happens to fall inside the table.
 pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
     jitcode_index: i32,
-    pc: i32,
+    py_pc: Option<i32>,
     jitcode_pc: i32,
 ) -> BridgeSemanticMaps {
     ensure_finish_setup();
@@ -1921,14 +1935,25 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // `liveness_py_pc = guard_py_pc` keying. The guard PC is where the
         // computed kept operand-stack temps are live; at the merge-target PC
         // they've been consumed and carry no pcdep entry.
-        let via_py_pc = |rp: usize, site: &'static EmptyTwinSite| -> usize {
+        //
+        // A caller holding no Python coordinate answers 0: the static
+        // liveness table cannot be queried without a Python PC, and the
+        // JitCode offset is not one. `codewriter.rs:14808` records that this
+        // table is deliberately NOT the walk-visited `depth_at_pc` the
+        // jitcode-keyed twins carry, so there is no jitcode-keyed spelling of
+        // this read to fall back to either.
+        let via_py_pc = |rp: Option<i32>, site: &'static EmptyTwinSite| -> usize {
+            let Some(rp) = rp.and_then(|p| usize::try_from(p).ok()) else {
+                empty_twin_census(site, None, None, 0);
+                return 0;
+            };
             if payload.code_ptr.is_null() {
-                empty_twin_census(site, rp, None, 0);
+                empty_twin_census(site, Some(rp), None, 0);
                 return 0;
             }
             let table = crate::liveness::liveness_for(payload.code_ptr).depth_at_py_pc();
             let depth = table.get(rp).copied().unwrap_or(0);
-            empty_twin_census(site, rp, Some(table.len()), depth);
+            empty_twin_census(site, Some(rp), Some(table.len()), depth);
             depth as usize
         };
         let (stack_depth_at_pc, pcdep_entries) = if jitcode_pc >= 0
@@ -1941,22 +1966,20 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
             // `jitcode_pc` via the predecessor-keyed twins. Every real carried
             // coordinate is an op-start or block-head offset of a colored
             // jitcode, for which the codewriter seeds these twins; a twin miss
-            // degrades to the merge-target PC (the same fallback the
-            // non-decodable path uses below), keeping liveness and pcdep on one
-            // coordinate. A portal bridge is uncolored, so `via_py_pc` returns
-            // `(0, empty)` for any resolved py; the merge-target fallback is
-            // identical to the containing JitCode-PC coordinate lookup.
+            // degrades to the caller's own merge-target Python PC, keeping
+            // liveness and pcdep on one coordinate, and to 0 when the caller
+            // has none.
             match (
                 payload.depth_for_jitcode_pc_pred(jp),
                 payload.pcdep_for_jitcode_pc(jp),
             ) {
                 (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                _ => (via_py_pc(pc as usize, &EMPTY_TWIN_MISS), Vec::new()),
+                _ => (via_py_pc(py_pc, &EMPTY_TWIN_MISS), Vec::new()),
             }
         } else {
             // A non-decodable carried coordinate falls back to the merge-target
             // PC so liveness and pcdep key the same point.
-            (via_py_pc(pc as usize, &EMPTY_TWIN_NON_DECODABLE), Vec::new())
+            (via_py_pc(py_pc, &EMPTY_TWIN_NON_DECODABLE), Vec::new())
         };
         BridgeSemanticMaps {
             // #73: the codewriter colored this jitcode iff `pcdep_color_slots`
@@ -1969,8 +1992,13 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
     })
 }
 
-pub(crate) fn bridge_semantic_maps_from_pc(jitcode_index: i32, pc: i32) -> BridgeSemanticMaps {
-    bridge_semantic_maps_at_with_jitcode_pc(jitcode_index, pc, pc)
+/// For a caller that holds only a JitCode coordinate. Named for that
+/// coordinate so the word cannot be re-routed into the Python-PC slot.
+pub(crate) fn bridge_semantic_maps_from_jitcode_pc(
+    jitcode_index: i32,
+    jitcode_pc: i32,
+) -> BridgeSemanticMaps {
+    bridge_semantic_maps_at_with_jitcode_pc(jitcode_index, None, jitcode_pc)
 }
 
 /// Operand-stack Ref constants (`(semantic_slot, raw_ref)`) at the resume PC of
@@ -7715,7 +7743,7 @@ fn reconstruct_inline_recipe(
     let (pframe_reg, pec_reg) = portal_red_regs_at(frame.jitcode_index);
     let (pframe_reg, pec_reg) = (pframe_reg as u32, pec_reg as u32);
     let has_frame = reg_indices.ref_.contains(&pframe_reg);
-    let maps = bridge_semantic_maps_from_pc(frame.jitcode_index, frame.pc);
+    let maps = bridge_semantic_maps_from_jitcode_pc(frame.jitcode_index, frame.pc);
     // resume.py:1042-1057 `rebuild_from_resumedata` / `consume_boxes` rebuilds
     // every paused frame and fills EVERY live register from the resume stream
     // with no shape classifier. Pyre recovers a portal callee's locals from the
@@ -9999,7 +10027,8 @@ impl JitState for PyreJitState {
         // `[0,nlocals)` prefix to identity colors (now retired). Invert each
         // live color to its slot via `semantic_ref_slot_for_reg_color` so the
         // mirror is correct under freely-colored locals.
-        let maps = crate::state::bridge_semantic_maps_from_pc(frame0.jitcode_index, frame0.pc);
+        let maps =
+            crate::state::bridge_semantic_maps_from_jitcode_pc(frame0.jitcode_index, frame0.pc);
         // For a kept-stack branch guard, the vable's runtime
         // `valuestackdepth` reflects the merge-target depth (post
         // consumption) rather than the guard's deeper live depth. The

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1791,23 +1791,35 @@ pub(crate) struct BridgeSemanticMaps {
     pub pcdep_entries: Vec<(u8, u16, u16)>,
 }
 
-/// Per-call-site counters for the `via_py_pc` fallback of
+/// Counters for the `via_py_pc` fallback of
 /// [`bridge_semantic_maps_at_with_jitcode_pc`], which indexes the
-/// Python-PC-keyed `LiveVars::depth_at_py_pc`.
+/// Python-PC-keyed `LiveVars::depth_at_py_pc`. One instance per *leg* that
+/// reaches the fallback — the `site=` field of the printed line names the leg,
+/// not the caller.
 ///
 /// The partition that decides whether a Python coordinate is being read at a
 /// point the caller did not mean: an offset past the end of the table reads
 /// `None` and the fallback answers 0, but one that lands inside returns a real
-/// depth belonging to a different instruction. `in_range_nonzero` is the only
-/// bucket that reaches `setup_bridge_sym`'s `semantic_prefix_len`, so it is the
-/// standing check on the one caller that still supplies a `Some` coordinate
-/// (`resume_snapshot.rs` `walker_capture_snapshot_for_last_guard_impl`,
-/// `liveness_py_pc`); a fire there means that argument is not a Python PC after
-/// all.
+/// depth belonging to a different instruction.
 ///
-/// The counters are per site, not per process: with one shared counter only the
-/// site that fires first is ever named, so a run in which one leg never
-/// executed is indistinguishable from one in which it executed second.
+/// Which bucket a caller can produce is fixed by the argument it passes, so the
+/// two ends must not be welded together:
+/// * `setup_bridge_sym` is the one consumer that reads `stack_depth_at_pc`
+///   unconditionally (`stack_only.max(..)` → `semantic_prefix_len`), and it
+///   passes `None` — so `no_py_pc` is the only bucket reachable from there and
+///   `in_range_*` is structurally unreachable.
+/// * `in_range_nonzero` can only come from the one caller that supplies a
+///   `Some` coordinate, `resume_snapshot.rs`
+///   `walker_capture_snapshot_for_last_guard_impl`'s `liveness_py_pc`, whose
+///   depth feeds that function's own `semantic_limit`.
+///
+/// That caller's coordinate is a Python PC by construction, so a nonzero depth
+/// there is the designed result of the leg, not an anomaly — the bucket records
+/// which leg ran, and does not by itself witness a coordinate mixup.
+///
+/// The counters are per leg, not per process: with one shared counter only the
+/// leg that fires first is ever named, so a run in which one leg never executed
+/// is indistinguishable from one in which it executed second.
 ///
 /// Pure telemetry — with the variable unset every counter path is skipped and
 /// the fallback's value is unchanged.
@@ -1840,14 +1852,28 @@ impl EmptyTwinSite {
 
 /// The carried jitcode coordinate decoded, but the twin tables had no entry.
 static EMPTY_TWIN_MISS: EmptyTwinSite = EmptyTwinSite::new("twin_miss");
-/// No jitcode coordinate was carried at all.
+/// No usable jitcode coordinate: either none was carried (`NO_JITCODE_PC`) or
+/// the carried offset does not decode as a `-live-` anchored startpoint.
 static EMPTY_TWIN_NON_DECODABLE: EmptyTwinSite = EmptyTwinSite::new("non_decodable");
 
+/// `jit_pc` / `twin` report the coordinate this leg declined on and what the
+/// jitcode-keyed containing-depth twin would have answered there — the
+/// measurement the "route the fallback through the twins instead of answering
+/// 0" question needs. On the 399-file synth corpus all 20 executions answer
+/// `jit_pc >= 0` with `twin = Some(3..=5)`, so that change is not inert.
+///
+/// What this does NOT resolve: the counters are per leg, not per call site, so
+/// a fire cannot be attributed to one of the callers. That matters, because
+/// `setup_bridge_sym` is the only one whose `stack_depth_at_pc` read is
+/// unconditional; at the others an empty `pcdep_entries` makes the depth inert
+/// regardless of its value.
 fn empty_twin_census(
     site: &EmptyTwinSite,
     rp: Option<usize>,
     table_len: Option<usize>,
     depth: u16,
+    jit_pc: i32,
+    twin: Option<u16>,
 ) {
     // Shares `PYRE_M73_EMPTYTWIN_CENSUS` with `py_coord::note_empty_twin_fallback`,
     // so one run reports both. That one prints `[m73-emptytwin]`; this one prints
@@ -1858,9 +1884,9 @@ fn empty_twin_census(
     use std::sync::atomic::Ordering;
     let name = site.name;
     let hits = site.hits.fetch_add(1, Ordering::Relaxed) + 1;
-    // `in_range_nonzero` is the only bucket that can reach `setup_bridge_sym`'s
-    // `semantic_prefix_len`: a real depth read at a coordinate the caller never
-    // meant as a Python PC. `no_py_pc` is the leg that used to read one.
+    // `rp >= len` must be tested before the `depth == 0` arm: `table.get(rp)`
+    // already collapses an out-of-range read to 0, so the zero arm would
+    // otherwise swallow it and the two would be indistinguishable.
     let (bucket, counter, live) = match (rp, table_len) {
         (None, _) => ("no_py_pc", &site.no_py_pc, false),
         (Some(_), None) => ("null_code", &site.null_code, false),
@@ -1872,9 +1898,12 @@ fn empty_twin_census(
     // Every bucket announces its first witness, so the buckets that do fire are
     // the positive control for the ones that do not: a bucket that stays silent
     // on a stream carrying other buckets' lines is empty, not unprinted.
+    // `in_range_nonzero` gets 20 rather than one because it is the only bucket
+    // whose value varies — the rest answer 0 by construction, so one witness
+    // says everything about them.
     if n == 1 || (live && n <= 20) {
         eprintln!(
-            "[m73-bridge-maps] site={name} bucket={bucket} n={n} rp={rp:?} len={table_len:?} depth={depth}"
+            "[m73-bridge-maps] site={name} bucket={bucket} n={n} rp={rp:?} len={table_len:?} depth={depth} jit_pc={jit_pc} twin={twin:?}"
         );
     }
     if hits % 100_000 == 0 {
@@ -1926,8 +1955,8 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // usize would otherwise be a huge OOB index. No-op for offsets /
         // NO_JITCODE_PC (flip-off), so byte-identical when off.
         let jitcode_pc = crate::jitcode_dispatch::expand_branch_carried(payload, jitcode_pc);
-        // The rd_numb pc word is already the published resume coordinate. Use
-        // it directly for the py_pc-keyed liveness/depth table fallback.
+        // A `Some` py_pc is already the published resume coordinate, so the
+        // py_pc-keyed liveness/depth table fallback reads it directly.
         //
         // When the carried `jitcode_pc` is set (kept-stack branch
         // guard), resolve the guard's Python PC from the jitcode coordinate
@@ -1936,24 +1965,43 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // computed kept operand-stack temps are live; at the merge-target PC
         // they've been consumed and carry no pcdep entry.
         //
-        // A caller holding no Python coordinate answers 0: the static
-        // liveness table cannot be queried without a Python PC, and the
-        // JitCode offset is not one. `codewriter.rs:14808` records that this
-        // table is deliberately NOT the walk-visited `depth_at_pc` the
-        // jitcode-keyed twins carry, so there is no jitcode-keyed spelling of
-        // this read to fall back to either.
+        // A caller holding no Python coordinate answers 0. That is a decline,
+        // and a lossy one — not the best available answer.
+        //
+        // Jitcode-keyed spellings of this same static table exist:
+        // `depth_containing_for_jitcode_pc` is built (`finalize_jitcode`, the
+        // `depth_containing_by_jit_pc` block) to reproduce
+        // `depth_at_py_pc[containing_py]` for every offset, and
+        // `depth_trivia_for_jitcode_pc` reads it at the trivia-skipped py.
+        // `collect_outer_active_boxes`, the encode half this mirrors, already
+        // sources its own `stack_depth_at_pc` from those twins with no Python
+        // PC in hand. The census below measured what they would answer here:
+        // over the 399-file synth corpus every one of the 20 executions of this
+        // leg carried a non-negative offset at which the containing twin
+        // answers 3, 4 or 5 — so routing through it is a real change in the
+        // reconstructed frame's width, not a no-op, and it is left to its own
+        // measurement rather than folded into a coordinate repair.
+        //
+        // What this leg must not do, and did before the `Option`, is index the
+        // Python-keyed table with the JitCode word.
         let via_py_pc = |rp: Option<i32>, site: &'static EmptyTwinSite| -> usize {
+            // Census-only: what the jitcode-keyed twin would answer at the
+            // coordinate this leg is declining on. Behind the census gate, so a
+            // production run does no extra work for it.
+            let twin = (crate::py_coord::emptytwin_census_enabled() && jitcode_pc >= 0)
+                .then(|| payload.depth_containing_for_jitcode_pc(jitcode_pc as usize))
+                .flatten();
             let Some(rp) = rp.and_then(|p| usize::try_from(p).ok()) else {
-                empty_twin_census(site, None, None, 0);
+                empty_twin_census(site, None, None, 0, jitcode_pc, twin);
                 return 0;
             };
             if payload.code_ptr.is_null() {
-                empty_twin_census(site, Some(rp), None, 0);
+                empty_twin_census(site, Some(rp), None, 0, jitcode_pc, twin);
                 return 0;
             }
             let table = crate::liveness::liveness_for(payload.code_ptr).depth_at_py_pc();
             let depth = table.get(rp).copied().unwrap_or(0);
-            empty_twin_census(site, Some(rp), Some(table.len()), depth);
+            empty_twin_census(site, Some(rp), Some(table.len()), depth, jitcode_pc, twin);
             depth as usize
         };
         let (stack_depth_at_pc, pcdep_entries) = if jitcode_pc >= 0
@@ -1992,8 +2040,19 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
     })
 }
 
-/// For a caller that holds only a JitCode coordinate. Named for that
-/// coordinate so the word cannot be re-routed into the Python-PC slot.
+/// For a caller that passes a JitCode coordinate and no Python one. Named for
+/// that coordinate so the word cannot be re-routed into the Python-PC slot.
+///
+/// Three callers genuinely hold nothing else (`bridge_subwalk.rs`
+/// `recipe.jitcode_pc`, `residual_call.rs` `op_pc`, `resume_snapshot.rs`
+/// `callee_jitcode_pc`). The two `RebuiltFrame` callers (`state.rs`
+/// `reconstruct_inline_recipe` and `setup_bridge_sym`) do hold one — the
+/// forward-carried `RebuiltFrame::py_pc`, which `py_coord.rs` names as a
+/// sanctioned Python-coordinate source — and decline it anyway: they carried
+/// `.pc` here before, and supplying `.py_pc` instead would widen
+/// `semantic_prefix_len` off a coordinate the old code never read. Declining is
+/// what keeps this a coordinate repair; what the declined leg leaves on the
+/// table is recorded at `via_py_pc`.
 pub(crate) fn bridge_semantic_maps_from_jitcode_pc(
     jitcode_index: i32,
     jitcode_pc: i32,
@@ -9872,7 +9931,7 @@ impl JitState for PyreJitState {
         // For a kept-stack branch guard, the vable's
         // `valuestackdepth` may reflect the merge-target depth (consumed
         // stack) rather than the guard's deeper live depth. The guard PC's
-        // pcdep `stack_depth_at_pc` (from `depth_at_py_pc`, resolved through
+        // pcdep `stack_depth_at_pc` (the `depth_pred_by_jit_pc` twin, keyed by
         // the carried `jitcode_pc`) IS the guard-time depth. Use the larger
         // of the two so the color→slot inversion covers the kept temps.
         // This is deferred until after `maps` is read (below) via a

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -1791,6 +1791,97 @@ pub(crate) struct BridgeSemanticMaps {
     pub pcdep_entries: Vec<(u8, u16, u16)>,
 }
 
+/// Measurement gate for the `via_py_pc` fallback of
+/// [`bridge_semantic_maps_at_with_jitcode_pc`].  The fallback indexes the
+/// Python-PC-keyed `LiveVars::depth_at_py_pc` with that function's `pc`
+/// parameter, but `bridge_semantic_maps_from_pc` supplies ONE word for both
+/// the `pc` and `jitcode_pc` slots, and five of its callers pass a JitCode
+/// byte offset (`RebuiltFrame::pc` is documented as the byte offset, with the
+/// Python coordinate in the separate `py_pc` field).
+///
+/// The partition that decides whether that mis-keying is observable:
+/// an offset past the end of the table reads `None` and the fallback already
+/// answers 0, but an offset that lands inside the table returns a real depth
+/// belonging to a different coordinate.  `in_range` with a non-zero depth is
+/// the only case that reaches `setup_bridge_sym`'s `semantic_prefix_len`.
+///
+/// Pure telemetry — with the variable unset every counter path is skipped and
+/// the fallback's value is unchanged.
+fn empty_twin_census_enabled() -> bool {
+    static E: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *E.get_or_init(|| std::env::var_os("PYRE_M73_EMPTYTWIN_CENSUS").is_some())
+}
+
+/// One counter set per call site. The heartbeat has to be per site, not per
+/// process: with a single shared counter only the site that fires first is
+/// ever named, so a run in which one leg never executed is indistinguishable
+/// from one in which it executed second.
+struct EmptyTwinSite {
+    name: &'static str,
+    hits: std::sync::atomic::AtomicU64,
+    null_code: std::sync::atomic::AtomicU64,
+    out_of_range: std::sync::atomic::AtomicU64,
+    in_range_zero: std::sync::atomic::AtomicU64,
+    in_range_nonzero: std::sync::atomic::AtomicU64,
+}
+
+impl EmptyTwinSite {
+    const fn new(name: &'static str) -> Self {
+        const fn zero() -> std::sync::atomic::AtomicU64 {
+            std::sync::atomic::AtomicU64::new(0)
+        }
+        Self {
+            name,
+            hits: zero(),
+            null_code: zero(),
+            out_of_range: zero(),
+            in_range_zero: zero(),
+            in_range_nonzero: zero(),
+        }
+    }
+}
+
+/// The carried jitcode coordinate decoded, but the twin tables had no entry.
+static EMPTY_TWIN_MISS: EmptyTwinSite = EmptyTwinSite::new("twin_miss");
+/// No jitcode coordinate was carried at all.
+static EMPTY_TWIN_NON_DECODABLE: EmptyTwinSite = EmptyTwinSite::new("non_decodable");
+
+fn empty_twin_census(site: &EmptyTwinSite, rp: usize, table_len: Option<usize>, depth: u16) {
+    if !empty_twin_census_enabled() {
+        return;
+    }
+    use std::sync::atomic::Ordering;
+    let name = site.name;
+    let hits = site.hits.fetch_add(1, Ordering::Relaxed) + 1;
+    // `in_range_nonzero` is the only bucket that can reach `setup_bridge_sym`'s
+    // `semantic_prefix_len`: a real depth read at a coordinate the caller never
+    // meant as a Python PC.
+    let (bucket, counter, live) = match table_len {
+        None => ("null_code", &site.null_code, false),
+        Some(len) if rp >= len => ("out_of_range", &site.out_of_range, false),
+        Some(_) if depth == 0 => ("in_range_zero", &site.in_range_zero, false),
+        Some(_) => ("in_range_nonzero", &site.in_range_nonzero, true),
+    };
+    let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+    // Every bucket announces its first witness, so the buckets that do fire are
+    // the positive control for the ones that do not: a bucket that stays silent
+    // on a stream carrying other buckets' lines is empty, not unprinted.
+    if n == 1 || (live && n <= 20) {
+        eprintln!(
+            "[M73-EMPTYTWIN] site={name} bucket={bucket} n={n} rp={rp} len={table_len:?} depth={depth}"
+        );
+    }
+    if hits % 100_000 == 0 {
+        eprintln!(
+            "[M73-EMPTYTWIN] totals site={name} hits={hits} null_code={} out_of_range={} in_range_zero={} in_range_nonzero={}",
+            site.null_code.load(Ordering::Relaxed),
+            site.out_of_range.load(Ordering::Relaxed),
+            site.in_range_zero.load(Ordering::Relaxed),
+            site.in_range_nonzero.load(Ordering::Relaxed),
+        );
+    }
+}
+
 /// When a kept-stack branch guard carries the guard's own jitcode
 /// coordinate (`jitcode_pc != NO_JITCODE_PC`), the pcdep/depth tables
 /// must be keyed at the GUARD's Python PC — the encode side
@@ -1830,15 +1921,15 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
         // `liveness_py_pc = guard_py_pc` keying. The guard PC is where the
         // computed kept operand-stack temps are live; at the merge-target PC
         // they've been consumed and carry no pcdep entry.
-        let via_py_pc = |rp: usize| -> usize {
+        let via_py_pc = |rp: usize, site: &'static EmptyTwinSite| -> usize {
             if payload.code_ptr.is_null() {
+                empty_twin_census(site, rp, None, 0);
                 return 0;
             }
-            crate::liveness::liveness_for(payload.code_ptr)
-                .depth_at_py_pc()
-                .get(rp)
-                .copied()
-                .unwrap_or(0) as usize
+            let table = crate::liveness::liveness_for(payload.code_ptr).depth_at_py_pc();
+            let depth = table.get(rp).copied().unwrap_or(0);
+            empty_twin_census(site, rp, Some(table.len()), depth);
+            depth as usize
         };
         let (stack_depth_at_pc, pcdep_entries) = if jitcode_pc >= 0
             && payload
@@ -1860,12 +1951,12 @@ pub(crate) fn bridge_semantic_maps_at_with_jitcode_pc(
                 payload.pcdep_for_jitcode_pc(jp),
             ) {
                 (Some(depth), Some(pcdep)) => (depth as usize, pcdep),
-                _ => (via_py_pc(pc as usize), Vec::new()),
+                _ => (via_py_pc(pc as usize, &EMPTY_TWIN_MISS), Vec::new()),
             }
         } else {
             // A non-decodable carried coordinate falls back to the merge-target
             // PC so liveness and pcdep key the same point.
-            (via_py_pc(pc as usize), Vec::new())
+            (via_py_pc(pc as usize, &EMPTY_TWIN_NON_DECODABLE), Vec::new())
         };
         BridgeSemanticMaps {
             // #73: the codewriter colored this jitcode iff `pcdep_color_slots`


### PR DESCRIPTION
## Summary

`bridge_semantic_maps_at_with_jitcode_pc` indexes the Python-PC-keyed
`LiveVars::depth_at_py_pc` with its second parameter. **Six of its seven call
sites reach it holding a JitCode byte offset** — the thing `py_coord.rs`'s module
invariant forbids:

> the forward-carried `SnapshotFrame.py_pc` resume channel [and the codewriter
> twins] are the only Python-coordinate sources; runtime consumers never project
> a JitCode PC through a Python-keyed map.

Five arrived through `bridge_semantic_maps_from_pc(idx, pc)`, which fed one word
into both the Python slot and the JitCode slot. The sixth passed
`inline_call_return_marker`'s `decode_op_at(..).next_pc`.

The parameter becomes `Option<i32>`, and the fallback answers `0` without
touching the table when it is `None`. `bridge_semantic_maps_from_pc` becomes
`bridge_semantic_maps_from_jitcode_pc`, named for the coordinate it carries so
the word cannot be re-routed into the Python slot. Only
`walker_capture_snapshot_for_last_guard_impl`'s `liveness_py_pc` stays `Some`.
The sibling `try_frame_liveness_reg_indices_by_bank_at_with_jitcode_pc` already
declines on an absent coordinate rather than reconstructing one; this matches it.

Each of the seven coordinates was classified independently from its *producer*
(not from the comments under test), and all seven agreed: six JitCode byte
offsets, one genuine Python PC.

### Measurement

399-file synth corpus, census before and after: the same 20 files reach the leg,
moving `bucket=out_of_range` (rp 231..1214 against table lengths 28..257) →
`bucket=no_py_pc`. Both answer 0, so this is **inert on the corpus**. The defect
it removes is the unmeasured case — a short function whose JitCode offset lands
*inside* the table and returns a foreign instruction's depth.

### What this deliberately does not do, and the number that says it matters

Answering `0` is a decline, not the best available answer. This PR measures how
lossy the decline is, rather than asserting it away:

| | |
|---|---|
| executions of the leg | 20 / 399 files |
| carrying a usable `jit_pc >= 0` | 20 |
| what `depth_containing_for_jitcode_pc` would answer there | `Some(3)` ×14, `Some(4)` ×4, `Some(5)` ×2 |
| would answer `None` or `Some(0)` | **0** |

`depth_containing_for_jitcode_pc` is built to reproduce
`depth_at_py_pc[containing_py]` for *every* offset, and
`collect_outer_active_boxes` — the encode half this function mirrors — already
sources its own `stack_depth_at_pc` from those twins with no Python PC in hand.
So routing this leg through them is invariant-conforming and **not** a no-op: it
would widen `setup_bridge_sym`'s `semantic_prefix_len` by 3–5 slots wherever the
leg runs. That is a change in reconstructed frame width, not a coordinate repair,
so it is out of scope here and left as follow-up.

**Stated as open:** the census counters are per *leg*, not per *call site*, so
those 20 non-zero counterfactuals are not yet attributed to `setup_bridge_sym` —
the only caller whose `stack_depth_at_pc` read is unconditional
(`stack_only.max(..)`). At the other five an empty `pcdep_entries` makes
`semantic_ref_slot_for_reg_color` return `None` regardless of the depth, so the
value is inert there. Per-call-site attribution is step 1 of that follow-up.

### Retractions

The third commit retracts two claims from the second commit's message: the
`codewriter.rs:14808` citation (it is the closing brace of an unrelated
`[pcmap-residual]` block — the passage meant is `finalize_jitcode`'s
`static_depth` construction, which records the *converse*), and
"`in_range_nonzero` — the only bucket reaching `setup_bridge_sym`'s
`semantic_prefix_len`", which that same commit made unreachable from there. The
first commit's `415/415 and 414/414` was measured on a base that has since moved
and does not describe this tree.

### Verification

- LLBC: all five artefacts re-extracted and verified FRESH before the gate.
  (`pyre-jit`'s fingerprint covers its dependency closure, so a comment-only edit
  in `pyre-jit-trace` staled it — and a plain `cargo build` returned 0 without
  re-running the check.)
- `LC_ALL=C python3 pyre/check.py --backend dynasm,cranelift`: **ALL PASSED —
  dynasm 417/417, cranelift 416/416**, exit 0.
- ⚠️ Run it **without** `LC_ALL=C` and dynasm reports `test.test_format PASS ->
  FAIL` at `test_locale`. That is environmental, not this patch: it reproduces
  under `PYRE_NO_JIT=1`, reproduces on cranelift too (which simply has no
  `test.test_format` entry in `pyre/cpython_tests/baseline.json` — only
  `{"dynasm": "PASS"}` is recorded), and the assertion is
  `assertIn(',', '123456789')` — `format(n, 'n')` does not apply the locale's
  `thousands_sep`. The recorded PASS was taken where `sep` was empty, so
  `assertIn('', text)` was vacuously true. No workflow in `.github/workflows/`
  pins a locale, so which way this gate reads depends on the runner's `LANG`.
  Flagging it; not fixing it here.
- HEAD sentinel identical at the start and end of the gate run.

## Self-review

Reviewed in a separate session from the one that generated the code, two ways:
the repo's Codex parity prompt (`.github/codex-review-prompt.md`), and a
seven-way independent classification of the call-site coordinates plus four
adversarial refutation passes over value-safety, census completeness,
instrumentation, and comment accuracy.

Those reviews found real defects **in this patch**, all of them in what the patch
asserted rather than what it computed, and all are fixed in the third commit: a
line citation that a rebase had turned into a closing brace; a negative existence
claim ("no jitcode-keyed spelling of this read exists") refuted by three live
ones; a causal claim about the census that this patch's own change inverted; a
`from_jitcode_pc` doc premise false at two of five callers; and a binding left
unused by the change.

- [x] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [x] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.

Section 2 carried one finding: that the `(0, empty pcdep)` fallback "silently
fabricates an empty stack map" and these paths "should decline/abort
reconstruction when their required JitCode metadata is absent". It is not
resolved here, deliberately, and it is not introduced by this patch — the same
leg produced `(0, empty)` before, by an accident of the offset falling out of
range rather than by decision. Turning it into a genuine decline changes
reconstruction outcomes on the 20 benches above and needs its own before/after
measurement and gate. What this patch does instead is make the decline
*representable* and *measured*, which is the precondition for that work. The
counterfactual table above is the evidence for the follow-up.

- [ ] I did not use AI to write the code of this patch.
  - Commits carry `Assisted-by: Claude`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of JIT-compiled code during tracing and execution resumption.
  - Corrected stack and frame reconstruction for residual calls and nested inline frames.
  - Prevented mismatches between compiled-code positions and Python source positions.
  - Improved semantic mapping and liveness tracking to support more reliable debugging and runtime behavior.
  - Added fallback telemetry to help identify mapping issues in affected execution paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->