### PR TITLE
rlib: move rbigint's storage and GC vocabulary out of the algorithm port

### DIFF
--- a/majit/majit-rlib/src/lltypesystem/rlist.rs
+++ b/majit/majit-rlib/src/lltypesystem/rlist.rs
@@ -184,6 +184,93 @@ pub unsafe fn typed_items_block_clear(block: *mut TypedItemsBlock) {
     }
 }
 
+/// The `[Digit]` list body `rbigint._digits` is lowered to — a
+/// `Ptr(GcArray(Signed))`.
+///
+/// This is a namespace, not a wrapper: the field stays a raw
+/// `*mut TypedItemsBlock` so the annotator keeps seeing the source-level
+/// `GcArray(Signed)` shape and `RBigInt::digit` keeps projecting `_digits`
+/// directly.
+///
+/// What it owns is the *vocabulary*. Upstream draws this line already:
+/// `rbigint.py` writes `[NULLDIGIT] * size` and `rbigint(digits, sign, size)`
+/// and never names a malloc, an allocation tier, or an array type id — the
+/// rtyper supplies those, `ll_newlist` (rlist.py:324-329) and
+/// `ll_alloc_and_set` (rtyper/rlist.py:494-503). A consumer of this type
+/// spells the list operation; the array's GC type id and the tier it is
+/// allocated in stay here.
+pub struct Digits;
+
+impl Digits {
+    /// `ll_newlist(LIST, length)` (rlist.py:324-329) — allocate the items
+    /// array without initializing it. `malloc_zero_filled` is false for
+    /// incminimark (incminimark.py:211), so the items keep whatever the
+    /// nursery held.
+    ///
+    /// # Safety
+    /// Every item the caller reads must be one it has written. Use
+    /// [`Digits::alloc_and_set_zero`] for the `[NULLDIGIT] * n` shape.
+    #[inline]
+    pub unsafe fn new(length: usize) -> *mut TypedItemsBlock {
+        unsafe { alloc_typed_items_block_nursery(length, GC_INT_ARRAY_GC_TYPE_ID) }
+    }
+
+    /// Fallible [`Digits::new`], for the upstream paths whose translated
+    /// allocation carries an explicit `MemoryError` edge.
+    ///
+    /// # Safety
+    /// Same obligation as [`Digits::new`].
+    #[inline]
+    pub unsafe fn try_new(length: usize) -> Option<*mut TypedItemsBlock> {
+        unsafe { try_alloc_typed_items_block_nursery(length, GC_INT_ARRAY_GC_TYPE_ID) }
+    }
+
+    /// `ll_alloc_and_set(LIST, count, 0)` (rtyper/rlist.py:494-503) —
+    /// `ll_newlist` followed by `rgc.ll_arrayclear`. This is what
+    /// `[NULLDIGIT] * count` lowers to.
+    ///
+    /// # Safety
+    /// The result is a fresh block outside any traced owner; the caller must
+    /// store it into one before anything can collect.
+    #[inline]
+    pub unsafe fn alloc_and_set_zero(count: usize) -> *mut TypedItemsBlock {
+        unsafe {
+            let block = Self::new(count);
+            typed_items_block_clear(block);
+            block
+        }
+    }
+
+    /// Fallible [`Digits::alloc_and_set_zero`].
+    ///
+    /// # Safety
+    /// Same obligation as [`Digits::alloc_and_set_zero`].
+    #[inline]
+    pub unsafe fn try_alloc_and_set_zero(count: usize) -> Option<*mut TypedItemsBlock> {
+        unsafe {
+            let block = Self::try_new(count)?;
+            typed_items_block_clear(block);
+            Some(block)
+        }
+    }
+
+    /// The one-element body of a prebuilt list, at process lifetime.
+    ///
+    /// Upstream's prebuilt `rbigint` digit lists are translated constants with
+    /// the same lifetime; see [`alloc_typed_items_block_immortal`].
+    ///
+    /// # Safety
+    /// Only for a prebuilt whose owner is itself immortal.
+    #[inline]
+    pub unsafe fn prebuilt(item: i64) -> *mut TypedItemsBlock {
+        unsafe {
+            let block = alloc_typed_items_block_immortal(1);
+            *(typed_items_block_items_base(block) as *mut i64) = item;
+            block
+        }
+    }
+}
+
 /// Allocate a headerless, process-lifetime `GcArray(Signed/Float)` body.
 ///
 /// This is only for translated prebuilt objects whose module-global owner is

--- a/majit/majit-rlib/src/rbigint.rs
+++ b/majit/majit-rlib/src/rbigint.rs
@@ -15,13 +15,18 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 
+/// The GC boundary this port needs and `rbigint.py` does not have, because
+/// upstream's translator generates it. Kept out of this file so what remains
+/// here is the port of the upstream one.
+mod gc;
+
+use gc::PendingPartsCacheDigitRoot;
+pub use gc::*;
+
 use crate::lltypesystem::rlist::{
-    GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
-    alloc_typed_items_block_immortal, alloc_typed_items_block_nursery,
-    try_alloc_typed_items_block_nursery, typed_items_block_capacity, typed_items_block_clear,
+    Digits, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock, typed_items_block_capacity,
     typed_items_block_items_base,
 };
-use majit_gc::GcAllocOutcome;
 
 pub const SUPPORT_INT128: bool = true;
 pub const BYTEORDER: &str = if cfg!(target_endian = "little") {
@@ -247,55 +252,6 @@ pub const fn intsign(i: i64) -> i64 {
 pub struct RBigInt {
     _digits: *mut TypedItemsBlock,
     _size: i64,
-}
-
-/// Address-stable GC root for a host-side, by-value `RBigInt`.
-///
-/// RPython's GC transform puts an `rbigint` local's `_digits` edge in the
-/// shadow stack whenever that local is live across a call that can collect.
-/// Rust locals have no generated stack map, so interpreter-level consumers
-/// that retain an unboxed `RBigInt` across a Python callback use this exact
-/// analogue.  The `Box` is required: moving this guard must not move the slot
-/// registered with MiniMark.
-pub struct RBigIntGcRoot {
-    value: Box<RBigInt>,
-    slot: *mut majit_ir::GcRef,
-    registered: bool,
-}
-
-impl RBigIntGcRoot {
-    pub fn new(value: RBigInt) -> Self {
-        let mut value = Box::new(value);
-        let slot = (&mut value._digits as *mut *mut TypedItemsBlock).cast::<majit_ir::GcRef>();
-        let registered = unsafe { majit_gc::gc_add_root(slot) };
-        Self {
-            value,
-            slot,
-            registered,
-        }
-    }
-}
-
-impl std::ops::Deref for RBigIntGcRoot {
-    type Target = RBigInt;
-
-    fn deref(&self) -> &Self::Target {
-        &self.value
-    }
-}
-
-impl std::ops::DerefMut for RBigIntGcRoot {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.value
-    }
-}
-
-impl Drop for RBigIntGcRoot {
-    fn drop(&mut self) {
-        if self.registered {
-            majit_gc::gc_remove_root(self.slot);
-        }
-    }
 }
 
 /// `rpython.rlib.rstring.NumberStringParser`.
@@ -528,203 +484,6 @@ const fn ascii_digit(c: u8) -> Option<i64> {
 unsafe impl Send for RBigInt {}
 unsafe impl Sync for RBigInt {}
 
-/// Offset used when registering the raw RBigInt payload with MiniMark.
-pub const RBIGINT_DIGITS_OFFSET: usize = std::mem::offset_of!(RBigInt, _digits);
-pub const RBIGINT_PAYLOAD_SIZE: usize = std::mem::size_of::<RBigInt>();
-
-/// Runtime GC id for the plain `rbigint` object.  The payload has one GC edge,
-/// `_digits`, to its `GcArray(Signed)` and no destructor or external storage.
-static RBIGINT_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-
-pub fn set_rbigint_gc_type_id(id: u32) {
-    RBIGINT_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
-}
-
-#[majit_macros::dont_look_inside]
-pub fn rbigint_gc_type_id() -> u32 {
-    RBIGINT_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Return the translated prebuilt object's immortal payload address when
-/// `value` already aliases one of its digit arrays. Identity of the digit
-/// slot, not numeric equality, is intentional: upstream has a few internal
-/// zero results that must remain fresh because their digits are filled later.
-fn prebuilt_payload_pointer(value: &RBigInt) -> Option<*mut RBigInt> {
-    // All four are single-digit objects: `zero()` carries `_size == 0` and the
-    // other three `|_size| == 1` (rbigint.py:1652-1656). Their digit arrays are
-    // one element long, so a value holding two or more digits cannot alias any
-    // of them — and `_normalize` (rbigint.py:1601-1603) is the only route by
-    // which a computed result reaches the zero form, where it assigns
-    // `self._digits = NULLDIGITS` itself. Deciding that from the size leaves
-    // the table for the values that can actually match.
-    if !(-1..=1).contains(&value._size) {
-        return None;
-    }
-    let digits = value._digits as usize;
-    for index in 0..PREBUILT_DIGITS.len() {
-        // An unpublished slot reads 0, which no live digit array can equal.
-        if PREBUILT_DIGITS[index].load(std::sync::atomic::Ordering::Relaxed) != digits {
-            continue;
-        }
-        let Some(&raw) = prebuilt_slots()[index].get() else {
-            continue;
-        };
-        let prebuilt = unsafe { &*(raw as *const RBigInt) };
-        if value._size == prebuilt._size {
-            return Some(raw as *mut RBigInt);
-        }
-    }
-    None
-}
-
-#[inline]
-pub(crate) fn alloc_rbigint_nursery_impl(
-    value: RBigInt,
-    canonicalize_prebuilt: bool,
-) -> *mut RBigInt {
-    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
-        return prebuilt;
-    }
-    let tid = rbigint_gc_type_id();
-    let mut needs_write_barrier = true;
-    // A `Some(null)` here means the GC owns the heap and could not satisfy the
-    // request; `malloc_raw` below would then leave `_digits` — this payload's
-    // one traced edge — unreachable to the collector.
-    if tid != 0
-        && let Some(raw) = GcAllocOutcome::classify(unsafe {
-            majit_gc::alloc_fast_nursery_typed_with_placement(
-                tid,
-                RBIGINT_PAYLOAD_SIZE,
-                &mut needs_write_barrier,
-            )
-        })
-        .allocated_or_abort(RBIGINT_PAYLOAD_SIZE)
-    {
-        unsafe {
-            std::ptr::write(raw as *mut RBigInt, value);
-        }
-        // framework.py:28-61 `propagate_no_write_barrier_needed` removes
-        // GC-pointer field barriers while initializing a fresh fixed-size
-        // nursery allocation. The no-collect allocator reports the exceptional
-        // old-gen spill, where `_digits` can still be young.
-        if needs_write_barrier {
-            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
-        }
-        return raw as *mut RBigInt;
-    }
-    crate::malloc_raw(value)
-}
-
-#[inline]
-pub fn alloc_rbigint_nursery(value: RBigInt) -> *mut RBigInt {
-    alloc_rbigint_nursery_impl(value, true)
-}
-
-/// No-collect twin of [`alloc_rbigint_clone_nursery_collecting`]: allocate a
-/// fresh handle for a shallow copy whose digit array happens to be a prebuilt
-/// value's, without canonicalizing it back onto that prebuilt payload.
-#[inline]
-pub fn alloc_rbigint_clone_nursery(value: RBigInt) -> *mut RBigInt {
-    alloc_rbigint_nursery_impl(value, false)
-}
-
-#[inline]
-fn alloc_rbigint_nursery_collecting_impl(
-    mut value: RBigInt,
-    canonicalize_prebuilt: bool,
-) -> *mut RBigInt {
-    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
-        return prebuilt;
-    }
-    let tid = rbigint_gc_type_id();
-    if tid != 0 {
-        // RPython's stack map exposes this freshly-computed rbigint's sole GC
-        // edge only when malloc reaches collect_and_reserve. The rooted
-        // collecting hook preserves that shape: the common nursery bump does
-        // no dynamic root-set mutation, while the nursery-full slow path
-        // temporarily registers and forwards this exact digit slot.
-        //
-        // The rbigint payload registers no destructor and is not a WEAKREF —
-        // its one traced edge is `_digits` — so this malloc site is one of the
-        // `malloc_fast` sites `gct_fv_gc_malloc` (`framework.py:820-838`)
-        // selects.
-        let digit_slot =
-            (&mut value._digits as *mut *mut TypedItemsBlock).cast::<majit_ir::GcRef>();
-        let mut needs_write_barrier = true;
-        // `NoRoute` falls through to the no-collect path below, which has its
-        // own hook to try. A failure does not: this allocation already ran a
-        // minor collection, so retrying the no-collect path would only reach
-        // its `malloc_raw` fallback and hide the failure behind an untraced
-        // payload.
-        let raw = GcAllocOutcome::classify(unsafe {
-            majit_gc::alloc_fast_nursery_collecting_typed_rooted(
-                tid,
-                RBIGINT_PAYLOAD_SIZE,
-                digit_slot,
-                &mut needs_write_barrier,
-            )
-        })
-        .allocated_or_abort(RBIGINT_PAYLOAD_SIZE);
-        if let Some(raw) = raw {
-            unsafe {
-                std::ptr::write(raw as *mut RBigInt, value);
-            }
-            // framework.py:28-61 `propagate_no_write_barrier_needed` removes
-            // GC-pointer field barriers while initializing a fresh fixed-size
-            // nursery allocation. Retain it only for collectors that satisfy
-            // the request in old-gen.
-            if needs_write_barrier {
-                majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
-            }
-            return raw as *mut RBigInt;
-        }
-    }
-    alloc_rbigint_nursery_impl(value, canonicalize_prebuilt)
-}
-
-#[inline]
-pub fn alloc_rbigint_nursery_collecting(value: RBigInt) -> *mut RBigInt {
-    alloc_rbigint_nursery_collecting_impl(value, true)
-}
-
-/// Allocate the fresh translated GC handle required by `RBigInt::clone`.
-///
-/// RPython's `rbigint.neg`/`abs` shallow-copy the immutable digit list and
-/// then update the new rbigint object's sign. Rust represents that intermediate
-/// object as a by-value handle, so the clone residual must preserve the shared
-/// digit array while bypassing the ordinary prebuilt-payload canonicalization.
-#[inline]
-pub fn alloc_rbigint_clone_nursery_collecting(value: RBigInt) -> *mut RBigInt {
-    alloc_rbigint_nursery_collecting_impl(value, false)
-}
-
-#[inline]
-pub fn alloc_rbigint_stable(value: RBigInt) -> *mut RBigInt {
-    if let Some(prebuilt) = prebuilt_payload_pointer(&value) {
-        return prebuilt;
-    }
-    let tid = rbigint_gc_type_id();
-    if tid != 0 {
-        // `NoRoute` leaves `raw` null and falls through to `malloc_raw`; a
-        // `Failed` aborts inside `allocated_or_abort`.
-        let raw = GcAllocOutcome::classify(majit_gc::alloc_oldgen_typed(tid, RBIGINT_PAYLOAD_SIZE))
-            .allocated_or_abort(RBIGINT_PAYLOAD_SIZE)
-            .unwrap_or(std::ptr::null_mut());
-        if !raw.is_null() {
-            unsafe {
-                std::ptr::write(raw as *mut RBigInt, value);
-            }
-            // `raw` is old-gen while `value._digits` is the RPython-style
-            // nursery GcArray(Signed).  Without this creation barrier a minor
-            // collection never visits the payload and reclaims/moves the live
-            // digit array behind W_LongObject.
-            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
-            return raw as *mut RBigInt;
-        }
-    }
-    crate::malloc_raw(value)
-}
-
 /// RPython's `tuple2` of two `rbigint`s — the return type of `rbigint.divmod`
 /// and `rbigint.int_divmod` (rbigint.py:1002 / 1050, both `@jit.elidable`).
 ///
@@ -741,124 +500,6 @@ pub struct RBigIntPair {
 pub const RBIGINT_PAIR_SIZE: usize = std::mem::size_of::<RBigIntPair>();
 pub const RBIGINT_PAIR_ITEM0_OFFSET: usize = std::mem::offset_of!(RBigIntPair, item0);
 pub const RBIGINT_PAIR_ITEM1_OFFSET: usize = std::mem::offset_of!(RBigIntPair, item1);
-
-/// Runtime GC id for the `tuple2` struct. Both fields are traced edges; a pair
-/// allocated before the id is published (bare tests, pre-init bootstrap) falls
-/// back to a leaked raw allocation, like the payload helpers above.
-static RBIGINT_PAIR_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
-
-pub fn set_rbigint_pair_gc_type_id(id: u32) {
-    RBIGINT_PAIR_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
-}
-
-#[majit_macros::dont_look_inside]
-pub fn rbigint_pair_gc_type_id() -> u32 {
-    RBIGINT_PAIR_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
-}
-
-/// Explicit root for an already-allocated GC pointer held in a host local.
-///
-/// RPython's stack map covers `div` and `mod` from the moment each is allocated
-/// until the `tuple2` malloc stores them. A Rust local has no generated map, so
-/// each payload pointer registers its own slot; the collector forwards through
-/// it exactly as it would through a shadow-stack entry.
-struct PendingPairItemRoot {
-    slot: *mut majit_ir::GcRef,
-    registered: bool,
-}
-
-impl PendingPairItemRoot {
-    /// `slot` must outlive the guard and must not move while it is registered.
-    unsafe fn new(slot: *mut *mut RBigInt) -> Self {
-        let slot = slot.cast::<majit_ir::GcRef>();
-        let registered = unsafe { majit_gc::gc_add_root(slot) };
-        Self { slot, registered }
-    }
-}
-
-impl Drop for PendingPairItemRoot {
-    fn drop(&mut self) {
-        if self.registered {
-            majit_gc::gc_remove_root(self.slot);
-        }
-    }
-}
-
-/// Allocate both halves and the `tuple2` that owns them.
-///
-/// The order is upstream's: `div` and `mod` become GC objects first, the pair
-/// last, so no store outlives the allocation that could move its target. Each
-/// step keeps everything already allocated reachable — the by-value handles via
-/// their `_digits` roots inside the payload allocator, the payload pointers via
-/// the guards here.
-pub fn alloc_rbigint_pair_nursery_collecting(item0: RBigInt, item1: RBigInt) -> *mut RBigIntPair {
-    // Until a half has its own payload it is only a by-value handle, and the
-    // payload allocator roots the digits of the handle it was given — not the
-    // other one. Root both up front, as `_int_divmod`'s caller does around its
-    // two `newlong` calls.
-    let item0 = RBigIntGcRoot::new(item0);
-    let item1 = RBigIntGcRoot::new(item1);
-
-    let mut item0 = alloc_rbigint_nursery_collecting(item0.translated_alias());
-    let _item0_root = unsafe { PendingPairItemRoot::new(&mut item0) };
-    let mut item1 = alloc_rbigint_nursery_collecting(item1.translated_alias());
-    let _item1_root = unsafe { PendingPairItemRoot::new(&mut item1) };
-
-    let tid = rbigint_pair_gc_type_id();
-    if tid != 0 {
-        // The collecting hook is the one the JIT residual wants; backends
-        // without it fall through to the no-collect allocator, and only a
-        // pre-init heap reaches `malloc_raw`. An untraced pair would be an
-        // invisible edge to two GC-managed payloads, so this chain must not end
-        // in `malloc_raw` while the payloads themselves are GC-managed.
-        let raw = GcAllocOutcome::classify(majit_gc::alloc_nursery_collecting_typed(
-            tid,
-            RBIGINT_PAIR_SIZE,
-        ))
-        .allocated_or_abort(RBIGINT_PAIR_SIZE)
-        .or_else(|| {
-            GcAllocOutcome::classify(majit_gc::alloc_nursery_typed(tid, RBIGINT_PAIR_SIZE))
-                .allocated_or_abort(RBIGINT_PAIR_SIZE)
-        });
-        if let Some(raw) = raw {
-            unsafe {
-                // Any collection the allocation above ran forwarded both roots,
-                // so these reads take the post-collection addresses.
-                std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
-            }
-            // A nursery-full allocation can satisfy the pair from old-gen while
-            // both payloads stay young, so this is not the fresh fixed-size
-            // initialization whose field barriers framework.py:28-61
-            // `propagate_no_write_barrier_needed` removes.
-            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
-            return raw as *mut RBigIntPair;
-        }
-    }
-    crate::malloc_raw(RBigIntPair { item0, item1 })
-}
-
-/// Build the `tuple2` over two payloads that are already reachable.
-///
-/// The walker needs a concrete pair to attach to the `CallR` it records, but it
-/// runs on the host stack with no gcmap over its live set — which is the one
-/// thing [`alloc_rbigint_pair_nursery_collecting`] requires of its caller. This
-/// allocation therefore cannot collect, so the caller's live payloads keep the
-/// addresses it read them at.
-pub fn alloc_rbigint_pair_no_collect(item0: *mut RBigInt, item1: *mut RBigInt) -> *mut RBigIntPair {
-    let tid = rbigint_pair_gc_type_id();
-    if tid != 0
-        && let Some(raw) =
-            GcAllocOutcome::classify(majit_gc::alloc_nursery_typed(tid, RBIGINT_PAIR_SIZE))
-                .allocated_or_abort(RBIGINT_PAIR_SIZE)
-    {
-        unsafe {
-            std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
-        }
-        majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
-        return raw as *mut RBigIntPair;
-    }
-    crate::malloc_raw(RBigIntPair { item0, item1 })
-}
 
 impl Clone for RBigInt {
     fn clone(&self) -> Self {
@@ -923,10 +564,7 @@ impl RBigInt {
     #[inline]
     fn prebuilt(index: usize, digit: Digit, sign: i64) -> Self {
         let raw = *prebuilt_slots()[index].get_or_init(|| {
-            let block = unsafe { alloc_typed_items_block_immortal(1) };
-            unsafe {
-                *(typed_items_block_items_base(block) as *mut Digit) = digit;
-            }
+            let block = unsafe { Digits::prebuilt(digit) };
             let value = Self {
                 _digits: block,
                 _size: sign,
@@ -962,9 +600,7 @@ impl RBigInt {
         // into the flow graph.
         debug_assert!(size >= 0);
         let logical_len = if size == 0 { digits.len() as i64 } else { size };
-        let block = unsafe {
-            alloc_typed_items_block_nursery(digits.len().max(1), GC_INT_ARRAY_GC_TYPE_ID)
-        };
+        let block = unsafe { Digits::new(digits.len().max(1)) };
         unsafe {
             let base = typed_items_block_items_base(block) as *mut Digit;
             if digits.is_empty() {
@@ -993,10 +629,7 @@ impl RBigInt {
             size
         };
         let allocation_size = digits.len().max(1);
-        let block = unsafe {
-            try_alloc_typed_items_block_nursery(allocation_size, GC_INT_ARRAY_GC_TYPE_ID)
-        }
-        .ok_or(RBigIntError::Memory)?;
+        let block = unsafe { Digits::try_new(allocation_size) }.ok_or(RBigIntError::Memory)?;
         unsafe {
             let base = typed_items_block_items_base(block) as *mut Digit;
             if digits.is_empty() {
@@ -1021,9 +654,7 @@ impl RBigInt {
     #[inline]
     fn with_size(size: i64, sign: i64) -> Self {
         debug_assert!(size >= 0);
-        let block =
-            unsafe { alloc_typed_items_block_nursery(size as usize, GC_INT_ARRAY_GC_TYPE_ID) };
-        unsafe { typed_items_block_clear(block) };
+        let block = unsafe { Digits::alloc_and_set_zero(size as usize) };
         Self {
             _digits: block,
             _size: size * sign,
@@ -1036,11 +667,8 @@ impl RBigInt {
     #[inline]
     fn try_with_size(size: i64, sign: i64) -> Result<Self, RBigIntError> {
         let allocation_size = usize::try_from(size).map_err(|_| RBigIntError::Memory)?;
-        let block = unsafe {
-            try_alloc_typed_items_block_nursery(allocation_size, GC_INT_ARRAY_GC_TYPE_ID)
-        }
-        .ok_or(RBigIntError::Memory)?;
-        unsafe { typed_items_block_clear(block) };
+        let block = unsafe { Digits::try_alloc_and_set_zero(allocation_size) }
+            .ok_or(RBigIntError::Memory)?;
         Ok(Self {
             _digits: block,
             _size: size * sign,
@@ -4705,38 +4333,6 @@ struct PartsCacheBase {
     parts_cache: std::sync::Mutex<std::sync::Arc<Vec<std::sync::Arc<RBigInt>>>>,
 }
 
-/// Explicit root for a cached rbigint that has been computed but is not yet
-/// reachable from the translated module-global `_parts_cache` graph.
-///
-/// RPython's GC transform roots this local automatically across publication.
-/// In pyre another mutator may collect while this thread is allocating the
-/// host-side snapshot vector, so the cached value's movable GcArray(Signed)
-/// slot must be registered until either the shared list owns it or it is
-/// discarded after losing a concurrent append race.
-struct PendingPartsCacheDigitRoot {
-    slot: *mut majit_ir::GcRef,
-    registered: bool,
-}
-
-impl PendingPartsCacheDigitRoot {
-    /// `value`'s Arc allocation keeps the slot address stable for this
-    /// guard's lifetime.
-    unsafe fn new(value: &std::sync::Arc<RBigInt>) -> Self {
-        let value = std::sync::Arc::as_ptr(value) as *mut RBigInt;
-        let slot = unsafe { std::ptr::addr_of_mut!((*value)._digits).cast::<majit_ir::GcRef>() };
-        let registered = unsafe { majit_gc::gc_add_root(slot) };
-        Self { slot, registered }
-    }
-}
-
-impl Drop for PendingPartsCacheDigitRoot {
-    fn drop(&mut self) {
-        if self.registered {
-            majit_gc::gc_remove_root(self.slot);
-        }
-    }
-}
-
 impl PartsCacheBase {
     fn base_parameters(base: i64) -> (i64, i64) {
         let mut mindigits = 1;
@@ -4773,10 +4369,7 @@ impl PartsCacheBase {
     /// collector's first root walk.
     fn new_prebuilt_decimal() -> Self {
         let (mindigits, curr) = Self::base_parameters(10);
-        let block = unsafe { alloc_typed_items_block_immortal(1) };
-        unsafe {
-            *(typed_items_block_items_base(block) as *mut Digit) = curr;
-        }
+        let block = unsafe { Digits::prebuilt(curr) };
         let part = RBigInt {
             _digits: block,
             _size: 1,
@@ -4847,45 +4440,6 @@ static PARTS_CACHE: std::sync::LazyLock<std::sync::Mutex<Vec<Option<PartsCacheRe
 /// `_parts_cache_10` during runtime initialization.
 pub fn initialize_rbigint_parts_cache() {
     std::sync::LazyLock::force(&PARTS_CACHE);
-}
-
-/// Visit the `_digits` GC slots held by the process-global formatter cache.
-/// PyPy's module-global `_parts_cache` is part of the translated prebuilt root
-/// graph; pyre's embedder adapts these raw slots to its `GcRef` root visitor.
-pub fn walk_rbigint_cache_digit_slots(mut visitor: impl FnMut(&mut *mut u8)) {
-    // rbigint.py's NULLRBIGINT / ONERBIGINT / ONENEGATIVERBIGINT /
-    // FIVERBIGINT are translated prebuilt roots.  Do not initialize a
-    // previously-unused constant from inside the collector; visit only slots
-    // already published by ordinary execution.
-    for slot in prebuilt_slots() {
-        if let Some(&raw) = slot.get() {
-            let value = unsafe { &mut *(raw as *mut RBigInt) };
-            visitor(unsafe {
-                &mut *(&mut value._digits as *mut *mut TypedItemsBlock as *mut *mut u8)
-            });
-        }
-    }
-
-    let all = PARTS_CACHE
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
-    for cache in all.iter().flatten() {
-        let parts = cache
-            .parts_cache
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        for value in parts.iter() {
-            // Every published snapshot is a monotonic extension and shares
-            // these exact Arc<RBigInt> objects with older reader snapshots.
-            // The collector runs this callback at STW, so forwarding the
-            // shared object's `_digits` slot updates every reader without an
-            // aliasing data race.
-            let value = unsafe { &mut *(std::sync::Arc::as_ptr(value) as *mut RBigInt) };
-            visitor(unsafe {
-                &mut *(&mut value._digits as *mut *mut TypedItemsBlock as *mut *mut u8)
-            });
-        }
-    }
 }
 
 /// rbigint.py:3054 `_PartsCache.get_cached_parts`.
@@ -6181,7 +5735,7 @@ mod tests {
         ];
 
         for value in prebuilts {
-            let prebuilt = prebuilt_payload_pointer(&value).expect("prebuilt payload");
+            let prebuilt = gc::prebuilt_payload_pointer(&value).expect("prebuilt payload");
             let original_sign = unsafe { (*prebuilt).get_sign() };
             let original_digits = unsafe { (*prebuilt)._digits };
             let cloned = alloc_rbigint_clone_nursery_collecting(value.clone());

--- a/majit/majit-rlib/src/rbigint/gc.rs
+++ b/majit/majit-rlib/src/rbigint/gc.rs
@@ -1,0 +1,458 @@
+//! The GC boundary of `rbigint` — everything `rpython/rlib/rbigint.py` does
+//! not contain because RPython's translator supplies it.
+//!
+//! Upstream's rbigint names no malloc, no root, and no write barrier: the GC
+//! transform inserts shadow-stack pushes and barriers into the final graphs
+//! (`rpython/memory/gctransform/framework.py`), two pipeline stages after the
+//! codewriter (`rpython/translator/driver.py:348` vs `:408`). pyre's binary is
+//! produced by rustc, which has no such stage, so this code is written by hand
+//! — but it is written *here*, in the layer that corresponds to the one that
+//! generates it, and not in the port of the algorithm file.
+//!
+//! What belongs here: root guards for handles a Rust local holds across a
+//! collecting call, the payload/`tuple2` allocators and the tier they select,
+//! creation write barriers, and the runtime GC type ids. What does not:
+//! anything with a line in `rbigint.py`.
+
+use super::*;
+use majit_gc::GcAllocOutcome;
+
+// ---- RBigIntGcRoot ----
+/// Address-stable GC root for a host-side, by-value `RBigInt`.
+///
+/// RPython's GC transform puts an `rbigint` local's `_digits` edge in the
+/// shadow stack whenever that local is live across a call that can collect.
+/// Rust locals have no generated stack map, so interpreter-level consumers
+/// that retain an unboxed `RBigInt` across a Python callback use this exact
+/// analogue.  The `Box` is required: moving this guard must not move the slot
+/// registered with MiniMark.
+pub struct RBigIntGcRoot {
+    value: Box<RBigInt>,
+    slot: *mut majit_ir::GcRef,
+    registered: bool,
+}
+
+impl RBigIntGcRoot {
+    pub fn new(value: RBigInt) -> Self {
+        let mut value = Box::new(value);
+        let slot = (&mut value._digits as *mut *mut TypedItemsBlock).cast::<majit_ir::GcRef>();
+        let registered = unsafe { majit_gc::gc_add_root(slot) };
+        Self {
+            value,
+            slot,
+            registered,
+        }
+    }
+}
+
+impl std::ops::Deref for RBigIntGcRoot {
+    type Target = RBigInt;
+
+    fn deref(&self) -> &Self::Target {
+        &self.value
+    }
+}
+
+impl std::ops::DerefMut for RBigIntGcRoot {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.value
+    }
+}
+
+impl Drop for RBigIntGcRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            majit_gc::gc_remove_root(self.slot);
+        }
+    }
+}
+
+// ---- payload offsets, type id, prebuilt identity, payload allocators ----
+/// Offset used when registering the raw RBigInt payload with MiniMark.
+pub const RBIGINT_DIGITS_OFFSET: usize = std::mem::offset_of!(RBigInt, _digits);
+pub const RBIGINT_PAYLOAD_SIZE: usize = std::mem::size_of::<RBigInt>();
+
+/// Runtime GC id for the plain `rbigint` object.  The payload has one GC edge,
+/// `_digits`, to its `GcArray(Signed)` and no destructor or external storage.
+static RBIGINT_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+pub fn set_rbigint_gc_type_id(id: u32) {
+    RBIGINT_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[majit_macros::dont_look_inside]
+pub fn rbigint_gc_type_id() -> u32 {
+    RBIGINT_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Return the translated prebuilt object's immortal payload address when
+/// `value` already aliases one of its digit arrays. Identity of the digit
+/// slot, not numeric equality, is intentional: upstream has a few internal
+/// zero results that must remain fresh because their digits are filled later.
+pub(super) fn prebuilt_payload_pointer(value: &RBigInt) -> Option<*mut RBigInt> {
+    // All four are single-digit objects: `zero()` carries `_size == 0` and the
+    // other three `|_size| == 1` (rbigint.py:1652-1656). Their digit arrays are
+    // one element long, so a value holding two or more digits cannot alias any
+    // of them — and `_normalize` (rbigint.py:1601-1603) is the only route by
+    // which a computed result reaches the zero form, where it assigns
+    // `self._digits = NULLDIGITS` itself. Deciding that from the size leaves
+    // the table for the values that can actually match.
+    if !(-1..=1).contains(&value._size) {
+        return None;
+    }
+    let digits = value._digits as usize;
+    for index in 0..PREBUILT_DIGITS.len() {
+        // An unpublished slot reads 0, which no live digit array can equal.
+        if PREBUILT_DIGITS[index].load(std::sync::atomic::Ordering::Relaxed) != digits {
+            continue;
+        }
+        let Some(&raw) = prebuilt_slots()[index].get() else {
+            continue;
+        };
+        let prebuilt = unsafe { &*(raw as *const RBigInt) };
+        if value._size == prebuilt._size {
+            return Some(raw as *mut RBigInt);
+        }
+    }
+    None
+}
+
+#[inline]
+pub(crate) fn alloc_rbigint_nursery_impl(
+    value: RBigInt,
+    canonicalize_prebuilt: bool,
+) -> *mut RBigInt {
+    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
+        return prebuilt;
+    }
+    let tid = rbigint_gc_type_id();
+    let mut needs_write_barrier = true;
+    // A `Some(null)` here means the GC owns the heap and could not satisfy the
+    // request; `malloc_raw` below would then leave `_digits` — this payload's
+    // one traced edge — unreachable to the collector.
+    if tid != 0
+        && let Some(raw) = GcAllocOutcome::classify(unsafe {
+            majit_gc::alloc_fast_nursery_typed_with_placement(
+                tid,
+                RBIGINT_PAYLOAD_SIZE,
+                &mut needs_write_barrier,
+            )
+        })
+        .allocated_or_abort(RBIGINT_PAYLOAD_SIZE)
+    {
+        unsafe {
+            std::ptr::write(raw as *mut RBigInt, value);
+        }
+        // framework.py:28-61 `propagate_no_write_barrier_needed` removes
+        // GC-pointer field barriers while initializing a fresh fixed-size
+        // nursery allocation. The no-collect allocator reports the exceptional
+        // old-gen spill, where `_digits` can still be young.
+        if needs_write_barrier {
+            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
+        }
+        return raw as *mut RBigInt;
+    }
+    crate::malloc_raw(value)
+}
+
+#[inline]
+pub fn alloc_rbigint_nursery(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_impl(value, true)
+}
+
+/// No-collect twin of [`alloc_rbigint_clone_nursery_collecting`]: allocate a
+/// fresh handle for a shallow copy whose digit array happens to be a prebuilt
+/// value's, without canonicalizing it back onto that prebuilt payload.
+#[inline]
+pub fn alloc_rbigint_clone_nursery(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_impl(value, false)
+}
+
+#[inline]
+fn alloc_rbigint_nursery_collecting_impl(
+    mut value: RBigInt,
+    canonicalize_prebuilt: bool,
+) -> *mut RBigInt {
+    if canonicalize_prebuilt && let Some(prebuilt) = prebuilt_payload_pointer(&value) {
+        return prebuilt;
+    }
+    let tid = rbigint_gc_type_id();
+    if tid != 0 {
+        // RPython's stack map exposes this freshly-computed rbigint's sole GC
+        // edge only when malloc reaches collect_and_reserve. The rooted
+        // collecting hook preserves that shape: the common nursery bump does
+        // no dynamic root-set mutation, while the nursery-full slow path
+        // temporarily registers and forwards this exact digit slot.
+        //
+        // The rbigint payload registers no destructor and is not a WEAKREF —
+        // its one traced edge is `_digits` — so this malloc site is one of the
+        // `malloc_fast` sites `gct_fv_gc_malloc` (`framework.py:820-838`)
+        // selects.
+        let digit_slot =
+            (&mut value._digits as *mut *mut TypedItemsBlock).cast::<majit_ir::GcRef>();
+        let mut needs_write_barrier = true;
+        // `NoRoute` falls through to the no-collect path below, which has its
+        // own hook to try. A failure does not: this allocation already ran a
+        // minor collection, so retrying the no-collect path would only reach
+        // its `malloc_raw` fallback and hide the failure behind an untraced
+        // payload.
+        let raw = GcAllocOutcome::classify(unsafe {
+            majit_gc::alloc_fast_nursery_collecting_typed_rooted(
+                tid,
+                RBIGINT_PAYLOAD_SIZE,
+                digit_slot,
+                &mut needs_write_barrier,
+            )
+        })
+        .allocated_or_abort(RBIGINT_PAYLOAD_SIZE);
+        if let Some(raw) = raw {
+            unsafe {
+                std::ptr::write(raw as *mut RBigInt, value);
+            }
+            // framework.py:28-61 `propagate_no_write_barrier_needed` removes
+            // GC-pointer field barriers while initializing a fresh fixed-size
+            // nursery allocation. Retain it only for collectors that satisfy
+            // the request in old-gen.
+            if needs_write_barrier {
+                majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
+            }
+            return raw as *mut RBigInt;
+        }
+    }
+    alloc_rbigint_nursery_impl(value, canonicalize_prebuilt)
+}
+
+#[inline]
+pub fn alloc_rbigint_nursery_collecting(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_collecting_impl(value, true)
+}
+
+/// Allocate the fresh translated GC handle required by `RBigInt::clone`.
+///
+/// RPython's `rbigint.neg`/`abs` shallow-copy the immutable digit list and
+/// then update the new rbigint object's sign. Rust represents that intermediate
+/// object as a by-value handle, so the clone residual must preserve the shared
+/// digit array while bypassing the ordinary prebuilt-payload canonicalization.
+#[inline]
+pub fn alloc_rbigint_clone_nursery_collecting(value: RBigInt) -> *mut RBigInt {
+    alloc_rbigint_nursery_collecting_impl(value, false)
+}
+
+#[inline]
+pub fn alloc_rbigint_stable(value: RBigInt) -> *mut RBigInt {
+    if let Some(prebuilt) = prebuilt_payload_pointer(&value) {
+        return prebuilt;
+    }
+    let tid = rbigint_gc_type_id();
+    if tid != 0 {
+        // `NoRoute` leaves `raw` null and falls through to `malloc_raw`; a
+        // `Failed` aborts inside `allocated_or_abort`.
+        let raw = GcAllocOutcome::classify(majit_gc::alloc_oldgen_typed(tid, RBIGINT_PAYLOAD_SIZE))
+            .allocated_or_abort(RBIGINT_PAYLOAD_SIZE)
+            .unwrap_or(std::ptr::null_mut());
+        if !raw.is_null() {
+            unsafe {
+                std::ptr::write(raw as *mut RBigInt, value);
+            }
+            // `raw` is old-gen while `value._digits` is the RPython-style
+            // nursery GcArray(Signed).  Without this creation barrier a minor
+            // collection never visits the payload and reclaims/moves the live
+            // digit array behind W_LongObject.
+            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
+            return raw as *mut RBigInt;
+        }
+    }
+    crate::malloc_raw(value)
+}
+
+// ---- pair type id and pair allocators ----
+/// Runtime GC id for the `tuple2` struct. Both fields are traced edges; a pair
+/// allocated before the id is published (bare tests, pre-init bootstrap) falls
+/// back to a leaked raw allocation, like the payload helpers above.
+static RBIGINT_PAIR_GC_TYPE_ID: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+
+pub fn set_rbigint_pair_gc_type_id(id: u32) {
+    RBIGINT_PAIR_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+#[majit_macros::dont_look_inside]
+pub fn rbigint_pair_gc_type_id() -> u32 {
+    RBIGINT_PAIR_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Explicit root for an already-allocated GC pointer held in a host local.
+///
+/// RPython's stack map covers `div` and `mod` from the moment each is allocated
+/// until the `tuple2` malloc stores them. A Rust local has no generated map, so
+/// each payload pointer registers its own slot; the collector forwards through
+/// it exactly as it would through a shadow-stack entry.
+struct PendingPairItemRoot {
+    slot: *mut majit_ir::GcRef,
+    registered: bool,
+}
+
+impl PendingPairItemRoot {
+    /// `slot` must outlive the guard and must not move while it is registered.
+    unsafe fn new(slot: *mut *mut RBigInt) -> Self {
+        let slot = slot.cast::<majit_ir::GcRef>();
+        let registered = unsafe { majit_gc::gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for PendingPairItemRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            majit_gc::gc_remove_root(self.slot);
+        }
+    }
+}
+
+/// Allocate both halves and the `tuple2` that owns them.
+///
+/// The order is upstream's: `div` and `mod` become GC objects first, the pair
+/// last, so no store outlives the allocation that could move its target. Each
+/// step keeps everything already allocated reachable — the by-value handles via
+/// their `_digits` roots inside the payload allocator, the payload pointers via
+/// the guards here.
+pub fn alloc_rbigint_pair_nursery_collecting(item0: RBigInt, item1: RBigInt) -> *mut RBigIntPair {
+    // Until a half has its own payload it is only a by-value handle, and the
+    // payload allocator roots the digits of the handle it was given — not the
+    // other one. Root both up front, as `_int_divmod`'s caller does around its
+    // two `newlong` calls.
+    let item0 = RBigIntGcRoot::new(item0);
+    let item1 = RBigIntGcRoot::new(item1);
+
+    let mut item0 = alloc_rbigint_nursery_collecting(item0.translated_alias());
+    let _item0_root = unsafe { PendingPairItemRoot::new(&mut item0) };
+    let mut item1 = alloc_rbigint_nursery_collecting(item1.translated_alias());
+    let _item1_root = unsafe { PendingPairItemRoot::new(&mut item1) };
+
+    let tid = rbigint_pair_gc_type_id();
+    if tid != 0 {
+        // The collecting hook is the one the JIT residual wants; backends
+        // without it fall through to the no-collect allocator, and only a
+        // pre-init heap reaches `malloc_raw`. An untraced pair would be an
+        // invisible edge to two GC-managed payloads, so this chain must not end
+        // in `malloc_raw` while the payloads themselves are GC-managed.
+        let raw = GcAllocOutcome::classify(majit_gc::alloc_nursery_collecting_typed(
+            tid,
+            RBIGINT_PAIR_SIZE,
+        ))
+        .allocated_or_abort(RBIGINT_PAIR_SIZE)
+        .or_else(|| {
+            GcAllocOutcome::classify(majit_gc::alloc_nursery_typed(tid, RBIGINT_PAIR_SIZE))
+                .allocated_or_abort(RBIGINT_PAIR_SIZE)
+        });
+        if let Some(raw) = raw {
+            unsafe {
+                // Any collection the allocation above ran forwarded both roots,
+                // so these reads take the post-collection addresses.
+                std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
+            }
+            // A nursery-full allocation can satisfy the pair from old-gen while
+            // both payloads stay young, so this is not the fresh fixed-size
+            // initialization whose field barriers framework.py:28-61
+            // `propagate_no_write_barrier_needed` removes.
+            majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
+            return raw as *mut RBigIntPair;
+        }
+    }
+    crate::malloc_raw(RBigIntPair { item0, item1 })
+}
+
+/// Build the `tuple2` over two payloads that are already reachable.
+///
+/// The walker needs a concrete pair to attach to the `CallR` it records, but it
+/// runs on the host stack with no gcmap over its live set — which is the one
+/// thing [`alloc_rbigint_pair_nursery_collecting`] requires of its caller. This
+/// allocation therefore cannot collect, so the caller's live payloads keep the
+/// addresses it read them at.
+pub fn alloc_rbigint_pair_no_collect(item0: *mut RBigInt, item1: *mut RBigInt) -> *mut RBigIntPair {
+    let tid = rbigint_pair_gc_type_id();
+    if tid != 0
+        && let Some(raw) =
+            GcAllocOutcome::classify(majit_gc::alloc_nursery_typed(tid, RBIGINT_PAIR_SIZE))
+                .allocated_or_abort(RBIGINT_PAIR_SIZE)
+    {
+        unsafe {
+            std::ptr::write(raw as *mut RBigIntPair, RBigIntPair { item0, item1 });
+        }
+        majit_gc::gc_write_barrier(majit_ir::GcRef(raw as usize));
+        return raw as *mut RBigIntPair;
+    }
+    crate::malloc_raw(RBigIntPair { item0, item1 })
+}
+
+// ---- PendingPartsCacheDigitRoot ----
+/// Explicit root for a cached rbigint that has been computed but is not yet
+/// reachable from the translated module-global `_parts_cache` graph.
+///
+/// RPython's GC transform roots this local automatically across publication.
+/// In pyre another mutator may collect while this thread is allocating the
+/// host-side snapshot vector, so the cached value's movable GcArray(Signed)
+/// slot must be registered until either the shared list owns it or it is
+/// discarded after losing a concurrent append race.
+pub(super) struct PendingPartsCacheDigitRoot {
+    slot: *mut majit_ir::GcRef,
+    registered: bool,
+}
+
+impl PendingPartsCacheDigitRoot {
+    /// `value`'s Arc allocation keeps the slot address stable for this
+    /// guard's lifetime.
+    pub(super) unsafe fn new(value: &std::sync::Arc<RBigInt>) -> Self {
+        let value = std::sync::Arc::as_ptr(value) as *mut RBigInt;
+        let slot = unsafe { std::ptr::addr_of_mut!((*value)._digits).cast::<majit_ir::GcRef>() };
+        let registered = unsafe { majit_gc::gc_add_root(slot) };
+        Self { slot, registered }
+    }
+}
+
+impl Drop for PendingPartsCacheDigitRoot {
+    fn drop(&mut self) {
+        if self.registered {
+            majit_gc::gc_remove_root(self.slot);
+        }
+    }
+}
+
+// ---- walk_rbigint_cache_digit_slots ----
+/// Visit the `_digits` GC slots held by the process-global formatter cache.
+/// PyPy's module-global `_parts_cache` is part of the translated prebuilt root
+/// graph; pyre's embedder adapts these raw slots to its `GcRef` root visitor.
+pub fn walk_rbigint_cache_digit_slots(mut visitor: impl FnMut(&mut *mut u8)) {
+    // rbigint.py's NULLRBIGINT / ONERBIGINT / ONENEGATIVERBIGINT /
+    // FIVERBIGINT are translated prebuilt roots.  Do not initialize a
+    // previously-unused constant from inside the collector; visit only slots
+    // already published by ordinary execution.
+    for slot in prebuilt_slots() {
+        if let Some(&raw) = slot.get() {
+            let value = unsafe { &mut *(raw as *mut RBigInt) };
+            visitor(unsafe {
+                &mut *(&mut value._digits as *mut *mut TypedItemsBlock as *mut *mut u8)
+            });
+        }
+    }
+
+    let all = PARTS_CACHE
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    for cache in all.iter().flatten() {
+        let parts = cache
+            .parts_cache
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        for value in parts.iter() {
+            // Every published snapshot is a monotonic extension and shares
+            // these exact Arc<RBigInt> objects with older reader snapshots.
+            // The collector runs this callback at STW, so forwarding the
+            // shared object's `_digits` slot updates every reader without an
+            // aliasing data race.
+            let value = unsafe { &mut *(std::sync::Arc::as_ptr(value) as *mut RBigInt) };
+            visitor(unsafe {
+                &mut *(&mut value._digits as *mut *mut TypedItemsBlock as *mut *mut u8)
+            });
+        }
+    }
+}


### PR DESCRIPTION
`rpython/rlib/rbigint.py` contains no malloc, root, or write barrier — the GC
transform inserts them into the final graphs
(`rpython/memory/gctransform/framework.py`), two pipeline stages after the
codewriter builds jitcodes (`rpython/translator/driver.py:348` vs `:408`).
pyre's port carried 42 such mentions in the algorithm file.

pyre's binary is produced by rustc, which has no gctransform stage, so this
code stays hand-written. What this PR changes is *where* it is written: the
storage vocabulary moves down to the rlist layer that owns it, and the GC
boundary moves out of the algorithm port into a sibling module.

## What changed

**`rlist: give the digit array's allocation an rlist-level spelling`**

`rbigint.rs` named `GC_INT_ARRAY_GC_TYPE_ID`,
`alloc_typed_items_block_nursery`, `try_alloc_typed_items_block_nursery`,
`alloc_typed_items_block_immortal` and `typed_items_block_clear` at six
construction sites. Upstream names none of these: it writes `[NULLDIGIT] * size`
and the malloc lives in `ll_newlist` (rtyper/lltypesystem/rlist.py:324-329), the
clear in `ll_alloc_and_set` (rtyper/rlist.py:494-503).

Adds `Digits` to `lltypesystem/rlist.rs` — `new`/`try_new`,
`alloc_and_set_zero`/`try_alloc_and_set_zero`, `prebuilt` — and calls those from
the six sites.

**`rlib: move rbigint's GC boundary into a child module`**

Moves 430 lines to `rbigint/gc.rs`: `RBigIntGcRoot`, `RBIGINT_DIGITS_OFFSET`,
`RBIGINT_PAYLOAD_SIZE`, the payload and `tuple2` GC type ids and setters,
`prebuilt_payload_pointer`, the seven `alloc_rbigint_*` allocators,
`PendingPairItemRoot` and the two pair allocators,
`PendingPartsCacheDigitRoot`, `walk_rbigint_cache_digit_slots`.
`pub use gc::*` keeps all 29 external `majit_rlib::rbigint::*` path spellings.

## Result

| | before | after | upstream |
|---|---|---|---|
| GC vocabulary in the algorithm file (production code) | 42 | **0** | 0 |
| lines | 7814 | 7369 | 3846 |

The 0 is over `majit_gc`, `GcAllocOutcome`, `gc_add_root`, `gc_remove_root`,
`gc_write_barrier`, `alloc_rbigint_*`, `majit_ir::GcRef`, `*_GC_TYPE_ID`,
`nursery`, `oldgen`, `immortal`, `malloc_raw`, counted over code lines with
comments and `#[cfg(test)]` excluded, with `Digits::` (6) as the positive
control that the census discriminates. Four mentions remain inside
`#[cfg(test)]`, in the allocator tests.

## Deliberately not moved

- **The `RBigIntPair` struct and its offset constants.** It is upstream's
  `tuple2`, not GC vocabulary, and `pyre-jit-trace/src/descr.rs:1823` keys its
  descr group on the def-path string `"rbigint::RBigIntPair"` with no test
  pinning it — moving the struct would repath that silently. Only its
  allocators moved.
- **`RBigInt._digits`'s field type.** `front/mir.rs:1405` overrides that field
  to `[i64]` for the annotator and `test_rbigint_mir.rs:704` pins
  `RBigInt::digit` to a direct `_digits` projection, so a newtype's `.0` would
  insert an op between them. `Digits` is therefore a namespace, not a wrapper.
- **The read path.** `typed_items_block_items_base` /
  `typed_items_block_capacity` stay as-is because
  `graph_is_items_block_base_accessor` (`front/mir.rs:17258`) matches that
  accessor by path, and the `.add(ITEMS_OFFSET)` fold depends on it.

## What this does not do

It does not make the plumbing *generated*. Deleting caller-side rooting —
`RBigIntGcRoot` at the interpreter boundary, and the wider `push_roots` class —
needs stack maps rustc does not emit. That remains hand-written; this PR only
puts it in the layer that corresponds to the one generating it upstream.

## Verification

- `cargo build --release -p pyrex --features dynasm` — clean
- `test_rbigint_mir` 5/5, on LLBC re-extracted after the final edit
- `rbigint_digits_still_folds_capacity_length_view` — passes, items-base fold intact
- `cargo test -p majit-rlib` — 53 passed
- `cargo test --all`
- CPython suite under `LC_ALL=C` — 200 PASS / 0 FAIL, no regressions
- synth: dynasm 416, cranelift 416/416, wasm 412/412

### One pre-existing failure this surfaced, not fixed here

`pyre/check.py` on a host with a grouping locale reports
`test.test_format: PASS -> FAIL` at `test_locale`, because
`format(123456789, "n")` returns `'123456789'` where CPython/PyPy return
`'123,456,789'`.

It is not from this branch and not a JIT issue:

- reproduces under `PYRE_NO_JIT=1` and on the cranelift binary
- `LC_ALL=C` makes the whole suite pass (empty `grouping` skips the assertion),
  which is what the recorded baseline encodes
- structurally, `format()`'s implementation cannot produce it:
  `pyre-interpreter/src/type_methods.rs` has zero `localeconv` /
  `thousands_sep` mentions (pyre has 18 elsewhere, under `_locale`), spells
  `'n' => (10, 3, false, "")` with an empty separator, and `p.ty != 'n'`
  disables the explicit `,`/`_` grouping as well

The baseline is deliberately left as recorded rather than re-recorded to
absorb it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved garbage-collection integration for arbitrary-precision integer operations.
  - Added safer allocation paths for digit storage, including fallible and zero-initialized options.
  - Added support for stable, nursery, cloning, and prebuilt integer allocations.
  - Improved handling of integer caches and temporary values during garbage collection.
  - Removed obsolete allocation and rooting interfaces in favor of the updated implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->