### PR TITLE
Fix unittest and multiprocessing compatibility

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -16064,15 +16064,26 @@ impl<M: Clone> MetaInterp<M> {
             if let Some(ctx) = self.tracing.as_mut() {
                 ctx.heapcache_invalidate_caches_varargs(opnum1, Some(effectinfo), &opref_args);
             }
-            // pyjitpl.py:2074-2077: handle resbox void / make_result_of_lastop
-            // — make_result_of_lastop's target_index plumbing is not
-            // wired here yet; documented above on miframe_execute_varargs.
+            // pyjitpl.py:2074-2077: handle resbox void / make_result_of_lastop.
+            // The result must be installed before vable_after_residual_call
+            // and GUARD_NOT_FORCED capture their resume snapshot.  Otherwise
+            // a reused destination register still contains its pre-call
+            // value, and blackhole resume returns that stale value after an
+            // asynchronous force.
             let resbox_pair = match resbox {
                 Some(opref) if descr_view.result_type() != majit_ir::Type::Void => {
                     Some((opref, c_result))
                 }
                 _ => None,
             };
+            if let (Some((opref, concrete)), Some((kind, target_index))) = (resbox_pair, dst) {
+                self.framestack.current_mut().make_result_of_lastop(
+                    kind,
+                    target_index,
+                    opref,
+                    concrete,
+                );
+            }
             // pyjitpl.py:2078: vable_after_residual_call(funcbox)
             // SwitchToBlackhole(ABORT_ESCAPE, raising_exception=True)
             // surfaces here when the virtualizable escaped during the
@@ -19032,6 +19043,10 @@ mod metainterp_static_data_tests {
         a + b * 1000
     }
 
+    extern "C" fn execute_varargs_ref_helper() -> i64 {
+        0xcafe
+    }
+
     extern "C" fn execute_varargs_void_helper() {}
 
     extern "C" fn execute_varargs_float_concrete_helper(a: i64) -> i64 {
@@ -19768,6 +19783,67 @@ mod metainterp_static_data_tests {
                 .any(|op| op.opcode == OpCode::GuardNotForced),
             "GUARD_NOT_FORCED must follow CALL_MAY_FORCE",
         );
+    }
+
+    #[test]
+    fn force_virtual_residual_call_installs_result_before_guard_snapshot() {
+        // pyjitpl.py:2074-2079 — make_result_of_lastop(resbox) precedes
+        // vable_after_residual_call and GUARD_NOT_FORCED.  The dispatch
+        // walker captures the guard's resume snapshot after this helper
+        // returns, so the destination register must already name the call
+        // result rather than its stale pre-call value.
+        use crate::BackEdgeAction;
+        use crate::jitcode::{JitArgKind, JitCodeBuilder};
+
+        let mut meta = MetaInterp::<()>::new(0);
+        meta.finish_setup_descrs_for_jitdrivers();
+        let action =
+            meta.force_start_tracing(0, (0, 0), None, &[Value::Ref(majit_ir::GcRef(0xdead))]);
+        assert!(matches!(action, BackEdgeAction::StartedTracing));
+
+        // Give make_result_of_lastop a real ref-typed destination at the
+        // frame's current post-call pc, matching the dispatcher's state on
+        // entry to do_residual_call_full.
+        let mut builder = JitCodeBuilder::new();
+        builder.load_const_r_value(0, 0);
+        builder.inline_call_irf_r(0, &[], &[], &[], Some(0));
+        let post_call_pc = builder.current_pos();
+        let mut frame =
+            crate::pyjitpl::MIFrame::new(std::sync::Arc::new(builder.finish()), post_call_pc);
+        frame.ref_regs[0] = Some(OpRef::input_arg_ref(0));
+        frame.ref_values[0] = Some(0xdead);
+        meta.framestack.push(frame);
+
+        let mut effect = majit_ir::EffectInfo::default();
+        effect.extraeffect = majit_ir::effectinfo::ExtraEffect::ForcesVirtualOrVirtualizable;
+        let descr_view = StubCallDescr {
+            arg_types: vec![],
+            result_type: majit_ir::Type::Ref,
+            effect: effect.clone(),
+        };
+        let descr_ref = majit_ir::descr::make_call_descr(vec![], majit_ir::Type::Ref, effect);
+        let fnaddr = execute_varargs_ref_helper as *const () as i64;
+        let funcbox_ref = meta.trace_ctx().expect("active trace").const_ref(fnaddr);
+        let funcbox = (JitArgKind::Ref, funcbox_ref, fnaddr);
+
+        let (result_op, result_value) = meta
+            .do_residual_call_full(
+                funcbox,
+                &[],
+                descr_ref,
+                &descr_view,
+                post_call_pc,
+                false,
+                None,
+                Some((JitArgKind::Ref, 0)),
+            )
+            .expect("residual call must not abort")
+            .expect("ref call must produce a result");
+
+        assert_eq!(result_value, 0xcafe);
+        let frame = meta.framestack.current_mut();
+        assert_eq!(frame.ref_regs[0], Some(result_op));
+        assert_eq!(frame.ref_values[0], Some(0xcafe));
     }
 
     #[test]

--- a/pyre/cpython_tests/README.md
+++ b/pyre/cpython_tests/README.md
@@ -51,10 +51,12 @@ Key flags: `--backend dynasm|cranelift`, `--no-jit` (`PYRE_NO_JIT=1`),
 - `script` (default): `pyre <path>/test_xxx.py` — runs the file directly as
   `__main__`, firing its `unittest.main()`. The most robust mode today; it
   bypasses `runpy` / `importlib.util.find_spec`.
-- `module`: `pyre -m test.<module>` — same entry via `runpy`. Blocked until
-  `importlib.util.find_spec` is wired to pyre's importer (see backlog).
+- `module`: `pyre -m test.<module>` — the same module entry via `runpy`,
+  without libregrtest's process setup and result protocol.
 - `regrtest`: `pyre -m test -v <module>` — CPython's libregrtest, the
-  PyPy/RustPython form, for once libregrtest imports cleanly.
+  PyPy/RustPython form. Libregrtest imports cleanly and `test_regrtest` passes;
+  use this mode when the runner-owned setup and canonical module identity are
+  part of the behavior under test.
 
 ## Result classes
 
@@ -77,10 +79,11 @@ not even be imported/run — an interpreter or stdlib-compat gap) · `CRASH`
 
 ## Current state and backlog (Phase 0)
 
-The baseline currently records **32 `PASS`**, 381 `IMPORTERROR`, 20 `SKIP`,
-1 `CRASH` (434 modules, stdlib 3.14.6). The `PASS` set grows as the gaps
-below are closed; the rest still hit an interpreter or stdlib-compat gap
-before their tests can run. (It was 0 `PASS` / 414 `IMPORTERROR` before the
+The baseline currently records **205 `PASS`**, 165 `IMPORTERROR`, 22 `FAIL`,
+22 `SKIP`, 14 `CRASH`, and 6 `TIMEOUT` (434 modules, stdlib 3.14.6). The
+`PASS` set grows as the gaps below are closed; non-passing modules include both
+import/stdlib gaps and tests that reach semantic failures, crashes, or timeouts.
+(It was 0 `PASS` / 414 `IMPORTERROR` before the
 `-m`/`STORE_SLICE`/submodule-binding/`_ast`/PEP-709-hidden-locals fixes
 below.)
 
@@ -118,14 +121,11 @@ first:
    fails when `support` isn't already an attribute; IMPORT_FROM must fall back
    to importing the submodule. Also `from unittest import mock`
    (`unittest.mock` submodule).
-2. **`importlib.util.find_spec` returns `None`.** pyre's native importer is
-   not wired into importlib's `meta_path`, so `runpy` (`-m`) can't locate
-   modules. Blocks `--mode module`/`regrtest`.
-3. **Compiler gap (external `rustpython-codegen`): `class_decorator` symbol
+2. **Compiler gap (external `rustpython-codegen`): `class_decorator` symbol
    missing from the symbol table** — `compile error: the symbol
    'class_decorator' must be present in the symbol table` (hit by
    `test_grammar`). Lives in the git-pinned compiler dependency, not pyre's
    tree.
-4. **Assorted stdlib-compat gaps** surfaced per module (e.g. `datetime.date`,
+3. **Assorted stdlib-compat gaps** surfaced per module (e.g. `datetime.date`,
    `genericpath._splitext`, `typing`'s `_idfunc`, complex `re` patterns). Run
    `--full --report` to enumerate the current set.

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -463,7 +463,7 @@
       "dynasm": "PASS"
     },
     "test.test_fork1": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_format": {
       "dynasm": "PASS"
@@ -740,16 +740,16 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_multiprocessing_fork": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "SKIP"
     },
     "test.test_multiprocessing_forkserver": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "TIMEOUT"
     },
     "test.test_multiprocessing_main_handling": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "FAIL"
     },
     "test.test_multiprocessing_spawn": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "TIMEOUT"
     },
     "test.test_named_expressions": {
       "dynasm": "FAIL"
@@ -935,7 +935,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_regrtest": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_remote_pdb": {
       "dynasm": "IMPORTERROR"
@@ -1151,7 +1151,7 @@
       "dynasm": "PASS"
     },
     "test.test_threadsignals": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_time": {
       "dynasm": "PASS"
@@ -1253,7 +1253,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_unittest": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_univnewlines": {
       "dynasm": "PASS"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -11,16 +11,14 @@ Each module is launched one of three ways, selectable with `--mode`:
 
   * script (default): `pyre <path>/test_xxx.py` — runs the test file directly
     as `__main__` so its `if __name__ == "__main__": unittest.main()` block
-    fires. Needs only `unittest` plus the module's own imports; bypasses
-    `runpy` / `importlib.util.find_spec` (which pyre's native importer does
-    not yet feed), so it is the most robust mode today. Runner metadata gives
+    fires. Needs only `unittest` plus the module's own imports, so it remains
+    the most robust mode today. Runner metadata gives
     resource-heavy or dotted-identity-sensitive modules the corresponding
     libregrtest bootstrap without changing this default.
   * module: `pyre -m test.<module>` — same unittest entry but via `runpy`
-    (currently blocked until `importlib.util.find_spec` is wired to pyre's
-    importer).
+    and the canonical dotted module identity.
   * regrtest: `pyre -m test -v <module>` — CPython's own libregrtest, the
-    PyPy/RustPython form (used once libregrtest imports cleanly).
+    PyPy/RustPython form. Libregrtest and `test_regrtest` run cleanly.
 
 A (module, backend) result is classified as:
 
@@ -109,6 +107,11 @@ KNOWN_SKIPS = {
 # so do not inject it into those modules or any subprocesses they spawn.
 STATS_STDERR_INCOMPATIBLE = {
     "test.test_inspect",
+    # test_regrtest exercises both line-oriented `--list-*` output and the
+    # worker JSON protocol through several generations of child interpreters.
+    # Its subprocess helpers intentionally sanitize their environments, so the
+    # root-only ancestry marker cannot keep MAJIT_STATS out of every child.
+    "test.test_regrtest",
 }
 
 # ── classification ───────────────────────────────────────────────────
@@ -296,10 +299,10 @@ _RESOURCE_DRIVER = (
 
 # test_descr and test_enum assert fully qualified class/enum names. Running
 # their files as __main__ changes those names even on CPython, so preserve the
-# dotted identity that libregrtest gives them.  The thread suites repeatedly
-# spawn child interpreters and import their canonical `test.test_*` modules;
-# running the parent as a second `__main__` module would test a different
-# module identity from both libregrtest and those children.
+# dotted identity that libregrtest gives them.  test_regrtest and the thread
+# suites repeatedly spawn child interpreters and import/filter their canonical
+# `test.test_*` modules; running the parent as a second `__main__` module would
+# test a different module identity from both libregrtest and those children.
 #
 # test_runpy's file as __main__ does not run test_runpy at all — it starts
 # libregrtest over the whole suite (measured: 491 modules on CPython 3.14,
@@ -307,6 +310,7 @@ _RESOURCE_DRIVER = (
 DOTTED_IDENTITY_MODULES = {
     "test.test_descr",
     "test.test_enum",
+    "test.test_regrtest",
     "test.test_runpy",
     "test.test_thread",
     "test.test_threading",
@@ -359,6 +363,15 @@ def run_module(binary: Path, module: str, mode: str, timeout: int,
         if module in STATS_STDERR_INCOMPATIBLE:
             module_env = env.copy()
             module_env.pop("MAJIT_STATS", None)
+        if mode == "script" and module == "test.test_regrtest":
+            # libregrtest/setup.py:88-96 `setup_process` keeps a non-ASCII
+            # environment value present for every test process.  Script mode
+            # deliberately bypasses that setup, but test_regrtest verifies the
+            # runner-owned invariant itself, so reproduce the same environment
+            # rather than grading the runner test outside its contract.
+            if module_env is env:
+                module_env = env.copy()
+            module_env.setdefault("PYTHONREGRTEST_UNICODE_GUARD", "æ")
         try:
             proc = subprocess.run(
                 cmd, cwd=cwd, env=module_env, capture_output=True, text=True,

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -14459,7 +14459,7 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
                         not_iterable_type_name(obj)
                     )));
                 }
-                let w_iter = crate::call::call_function_impl_result(method, &[obj])?;
+                let w_iter = get_and_call_function(method, obj, w_type, &[])?;
                 return iter_check_is_iterator(w_iter);
             }
             // descroperation.py:333-334 — `__getitem__` fallback only when
@@ -16564,7 +16564,7 @@ pub fn next(obj: PyObjectRef) -> PyResult {
         if is_instance(obj) {
             let w_type = w_instance_get_type(obj);
             if let Some(method) = lookup_in_type_where(w_type, "__next__") {
-                return crate::call::call_function_impl_result(method, &[obj]);
+                return get_and_call_function(method, obj, w_type, &[]);
             }
         }
         // PyPy `space.next(w_obj)` performs a type-MRO `__next__` lookup for
@@ -18372,7 +18372,7 @@ pub(crate) fn contains_slot(haystack: PyObjectRef, needle: PyObjectRef) -> Resul
                 if is_none(method) {
                     return Err(not_container_error(haystack));
                 }
-                let result = crate::builtins::call_and_check(method, &[haystack, needle])?;
+                let result = get_and_call_function(method, haystack, w_type, &[needle])?;
                 return is_true(result);
             }
         }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -9807,7 +9807,9 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         if let Some(method) =
             unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__float__") }
         {
-            let result = crate::call::call_function_impl_result(method, &[obj])?;
+            let result = unsafe {
+                crate::baseobjspace::get_and_call_function(method, obj, tp.as_ptr(), &[])?
+            };
             unsafe {
                 if is_float(result) {
                     // floatobject.py:228-238 — an exact float is returned as-is;
@@ -9836,7 +9838,9 @@ pub(crate) fn builtin_float(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
         if let Some(method) =
             unsafe { crate::baseobjspace::lookup_in_type(tp.as_ptr(), "__index__") }
         {
-            let r = crate::call::call_function_impl_result(method, &[obj])?;
+            let r = unsafe {
+                crate::baseobjspace::get_and_call_function(method, obj, tp.as_ptr(), &[])?
+            };
             // descroperation.py:609 `space.index` returns an arbitrary-size
             // Python int.  Accept both the machine-word and W_LongObject
             // layouts, then reuse the integer float conversion so an

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -269,6 +269,11 @@ pub struct ExecutionContext {
     pub w_profilefuncarg: PyObjectRef,
     pub thread_disappeared: bool,
     pub w_async_exception_type: PyObjectRef,
+    /// `threadlocals.py:9,95-97 ExecutionContext._signals_enabled` — only the
+    /// execution context owned by `OSThreadLocals._mainthreadident` may run
+    /// app-level signal handlers.  A fork from another thread promotes that
+    /// thread's EC in `thread::after_fork_child`.
+    pub signals_enabled: i32,
     /// Last process-wide all-threads hook generations applied by this EC.
     /// Only the owning OS thread writes these fields.
     pub trace_all_generation: usize,
@@ -391,6 +396,7 @@ impl ExecutionContext {
             w_profilefuncarg: pyre_object::PY_NULL,
             thread_disappeared: false,
             w_async_exception_type: pyre_object::PY_NULL,
+            signals_enabled: 0,
             trace_all_generation: 0,
             profile_all_generation: 0,
             thread_local_refs: Vec::new(),
@@ -424,6 +430,10 @@ impl ExecutionContext {
         ec.w_profilefuncarg = pyre_object::PY_NULL;
         ec.thread_disappeared = false;
         ec.w_async_exception_type = pyre_object::PY_NULL;
+        // threadlocals.py:9 — a fresh worker EC starts disabled.  `_set_ec`
+        // enables only the process main thread, and reinit_threads promotes
+        // the surviving EC after a fork.
+        ec.signals_enabled = 0;
         ec.trace_all_generation = 0;
         ec.profile_all_generation = 0;
         ec.thread_local_refs.clear();

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3688,15 +3688,19 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                             "sendmsg: ancillary level/type must be integers",
                         ));
                     }
-                    if !unsafe { pyre_object::bytesobject::is_bytes_like(data_o) } {
+                    // interp_socket.py:811-816 acquires a BUF_SIMPLE view,
+                    // just like the ordinary data items above.  This includes
+                    // array.array payloads used by multiprocessing's
+                    // SCM_RIGHTS fd transfer, not only bytes/bytearray.
+                    let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(data_o)? else {
                         return Err(crate::PyError::type_error(
                             "sendmsg: ancillary data must be bytes-like",
                         ));
-                    }
+                    };
                     let level = unsafe { pyre_object::w_int_get_value(level_o) } as libc::c_int;
                     let ty = unsafe { pyre_object::w_int_get_value(type_o) } as libc::c_int;
-                    let data =
-                        unsafe { pyre_object::bytesobject::bytes_like_data(data_o).to_vec() };
+                    let data = buffer.as_bytes().to_vec();
+                    buffer.release();
                     cmsgs.push((level, ty, data));
                 }
             }

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -321,12 +321,6 @@ impl ImportRLock {
     /// Registered upstream as the `child` fork hook
     /// (`pypy/module/imp/moduledef.py:45`, driven by
     /// `pypy/module/posix/interp_posix.py:1560`) and never exposed to Python.
-    /// pyre has no fork-hook dispatch, so nothing calls this yet.
-    /// CONVERGENCE: port `add_fork_hook`/`run_fork_hooks` into the posix
-    /// module and register the whole trio — `before`→`acquire_lock`,
-    /// `parent`→`release_lock`, `child`→`reinit_lock`.  Wiring the child hook
-    /// alone would make the depth test pick the wrong branch.
-    #[allow(dead_code)]
     fn reinit_lock(&self) {
         if self.lockcounter.load(Ordering::Relaxed) > 1 {
             // importing.py:216-224 — the old lock object is abandoned rather
@@ -384,9 +378,26 @@ fn release_lock() -> Result<(), crate::PyError> {
 /// `interp_imp.py:153 reinit_lock`.  Deliberately absent from the `_imp`
 /// namespace: `moduledef.py:26` exposes only `lock_held`, `acquire_lock` and
 /// `release_lock`.
-#[allow(dead_code)]
 fn reinit_lock() {
     getimportlock().reinit_lock();
+}
+
+/// `pypy/module/imp/moduledef.py:45-47` — the import module registers this
+/// exact before/parent/child trio with the process fork-hook lists.  Keep the
+/// gateways private to the interpreter: `_imp` exposes only the three public
+/// lock operations above.
+pub(crate) fn before_fork() {
+    acquire_lock();
+}
+
+pub(crate) fn after_fork_parent() -> Result<(), crate::PyError> {
+    // moduledef.py registers `interp_imp.release_lock`, whose gateway passes
+    // `silent_after_fork=False`; only native importhook cleanup uses `True`.
+    getimportlock().release_lock(false)
+}
+
+pub(crate) fn after_fork_child() {
+    reinit_lock();
 }
 
 fn frozen_module(name: &Wtf8) -> Option<&'static FrozenModule> {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -5913,6 +5913,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         .unwrap_or_else(|poison| poison.into_inner());
                     drop(blocked);
                     run_fork_callbacks("before");
+                    // pypy/module/imp/moduledef.py:45-47 registers the import
+                    // lock's acquire/release/reinit trio in the same ordered
+                    // interpreter-level hook lists that contain the app-level
+                    // callback dispatcher.  Holding it across the host fork
+                    // prevents a child from inheriting a partially initialized
+                    // sys.modules entry from another thread.
+                    crate::module::imp::interp_imp::before_fork();
                     // A free-threaded fork must snapshot native/Python lock
                     // state while every other mutator is parked.  Enter
                     // through the collector's full request path so no GC
@@ -5925,6 +5932,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         Ok(0) => {
                             crate::module::thread::after_fork_child();
                             run_fork_callbacks("child");
+                            crate::module::imp::interp_imp::after_fork_child();
                             // CPython's refcounting drops the replaced
                             // `_MainThread` before os.fork() returns, so its
                             // weakref has disappeared from `_dangling` when
@@ -5941,11 +5949,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         }
                         Ok(pid) => {
                             run_fork_callbacks("parent");
+                            crate::module::imp::interp_imp::after_fork_parent()?;
                             drop(fork_serial);
                             Ok(pyre_object::w_int_new(pid as i64))
                         }
                         Err(error) => {
                             run_fork_callbacks("parent");
+                            // interp_posix.py:1570-1575 keeps the original
+                            // fork OSError if a parent hook also fails.
+                            let _ = crate::module::imp::interp_imp::after_fork_parent();
                             drop(fork_serial);
                             Err(io_err(error, ""))
                         }

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -8,6 +8,7 @@ use crate::executioncontext::{
 };
 use crate::pyframe::PyFrame;
 use pyre_object::PyObjectRef;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 /// executioncontext.py:436-441 `space.getexecutioncontext().checksignals()`
 /// — deliver a signal that may have arrived during a syscall.  Resolves
@@ -77,29 +78,29 @@ fn errno_exception(class_name: &str, errno: i32) -> crate::PyError {
     err
 }
 
-thread_local! {
-    /// interp_signal.py:157-167 `Handlers.handlers_w` — signum → handler
-    /// (a callable, or the SIG_DFL/SIG_IGN ints).  A real Python dict so
-    /// the GC traces the handler callables; pinned for the process
-    /// lifetime.  Missing keys mean SIG_DFL (the pre-fill in PyPy's
-    /// `Handlers.__init__`).
-    static HANDLERS: std::cell::Cell<PyObjectRef> = const { std::cell::Cell::new(pyre_object::PY_NULL) };
-    /// moduledef.py:15 `default_int_handler` — cached so
-    /// `getsignal(SIGINT) is signal.default_int_handler` holds after the
-    /// startup install.
-    static DEFAULT_INT_HANDLER: std::cell::Cell<PyObjectRef> = const { std::cell::Cell::new(pyre_object::PY_NULL) };
-}
+/// interp_signal.py:157-167 `Handlers.handlers_w` — the single `Handlers`
+/// instance returned by `space.fromcache(Handlers)`.  Pyre has one interpreter
+/// per process, so this is process-global just like that object-space cache.
+/// It must not be TLS: a signal received by a worker is dispatched later by
+/// the main thread through this same table.
+static HANDLERS: AtomicUsize = AtomicUsize::new(0);
+
+/// moduledef.py:15 `default_int_handler`, likewise one object-space-owned
+/// callable.  The handler dict owns it after startup; this cell preserves the
+/// public identity used by both the module attribute and `getsignal(SIGINT)`.
+static DEFAULT_INT_HANDLER: AtomicUsize = AtomicUsize::new(0);
 
 fn handlers_dict() -> PyObjectRef {
-    HANDLERS.with(|cell| {
-        let mut d = cell.get();
-        if d.is_null() {
-            d = pyre_object::w_dict_new();
-            pyre_object::gc_roots::pin_root(d);
-            cell.set(d);
+    let mut d = HANDLERS.load(Ordering::Acquire) as PyObjectRef;
+    if d.is_null() {
+        d = pyre_object::w_dict_new();
+        pyre_object::gc_roots::pin_root(d);
+        match HANDLERS.compare_exchange(0, d as usize, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => {}
+            Err(installed) => d = installed as PyObjectRef,
         }
-        d
-    })
+    }
+    d
 }
 
 /// interp_signal.py:196-209 `handlers_w[n]` lookup.  Returns `PY_NULL`
@@ -125,30 +126,22 @@ pub fn set_handler(signum: i32, handler: PyObjectRef) {
 /// walked so handler callables reachable only through this dict survive
 /// collection.
 pub fn walk_signal_handler_roots(mut visitor: impl FnMut(&mut PyObjectRef)) {
-    HANDLERS.with(|cell| {
-        let mut d = cell.get();
-        if d.is_null() {
-            return;
-        }
-        // Visit the dict pointer itself as a root.  If the GC
-        // relocates the dict, `visitor` updates `d` in place;
-        // write the (possibly new) address back to the Cell.
-        let old = d;
-        visitor(&mut d);
-        if !std::ptr::eq(d, old) {
-            cell.set(d);
-        }
-        unsafe {
-            let strategy = pyre_object::dictmultiobject::w_dict_get_strategy(d);
-            strategy.walk_gc_refs(d, &mut |slot: *mut PyObjectRef| {
-                visitor(&mut *slot);
-            });
-        }
-    });
+    let mut d = HANDLERS.load(Ordering::Acquire) as PyObjectRef;
+    if d.is_null() {
+        return;
+    }
+    visitor(&mut d);
+    HANDLERS.store(d as usize, Ordering::Release);
+    unsafe {
+        let strategy = pyre_object::dictmultiobject::w_dict_get_strategy(d);
+        strategy.walk_gc_refs(d, &mut |slot: *mut PyObjectRef| {
+            visitor(&mut *slot);
+        });
+    }
 }
 
 pub fn capture_signal_handler_root_area() -> *const () {
-    HANDLERS.with(|handlers| handlers as *const _ as *const ())
+    &HANDLERS as *const AtomicUsize as *const ()
 }
 
 /// # Safety
@@ -158,13 +151,13 @@ pub unsafe fn walk_signal_handler_roots_area(
     data: *const (),
     mut visitor: impl FnMut(&mut PyObjectRef),
 ) {
-    let handlers = unsafe { &*(data as *const std::cell::Cell<PyObjectRef>) };
-    let mut dict = handlers.get();
+    let handlers = unsafe { &*(data as *const AtomicUsize) };
+    let mut dict = handlers.load(Ordering::Acquire) as PyObjectRef;
     if dict.is_null() {
         return;
     }
     visitor(&mut dict);
-    handlers.set(dict);
+    handlers.store(dict as usize, Ordering::Release);
     unsafe {
         let strategy = pyre_object::dictmultiobject::w_dict_get_strategy(dict);
         strategy.walk_gc_refs(dict, &mut |slot: *mut PyObjectRef| {
@@ -197,10 +190,19 @@ fn check_signum_in_range(signum: i64) -> Result<(), crate::PyError> {
 }
 
 /// interp_signal.py:291-326 `signal(signum, handler) -> previous`.
-fn signal_signal(w_signum: PyObjectRef, w_handler: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+fn signal_signal(
+    w_signum: PyObjectRef,
+    w_handler: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
     let signum = signum_arg(w_signum)?;
-    // interp_signal.py:307-310 — `signals_enabled()` is always true in
-    // single-threaded pyre, so the main-thread guard is omitted.
+    // interp_signal.py:307-310 — only the main/signal-enabled execution
+    // context may install process signal handlers.
+    let ec = crate::call::getexecutioncontext() as *const ExecutionContext;
+    if ec.is_null() || unsafe { (*ec).signals_enabled == 0 } {
+        return Err(crate::PyError::value_error(
+            "signal only works in main thread or with _signals_enabled",
+        ));
+    }
     check_signum_in_range(signum)?;
     // The range check bounds it to `1..NSIG`, so the narrowing is exact.
     let signum = signum as i32;
@@ -254,25 +256,31 @@ fn signal_getsignal(w_signum: PyObjectRef) -> Result<PyObjectRef, crate::PyError
 /// KeyboardInterrupt`.  Cached so the module attribute and the SIGINT
 /// handler-dict entry share one identity.
 pub fn default_int_handler_obj() -> PyObjectRef {
-    DEFAULT_INT_HANDLER.with(|cell| {
-        let mut h = cell.get();
-        if h.is_null() {
-            h = crate::make_builtin_function(
-                "default_int_handler",
-                // issue #2780: accept and ignore any non-keyword arguments.
-                |_| {
-                    let cls = crate::builtins::lookup_exc_class("KeyboardInterrupt")
-                        .expect("KeyboardInterrupt must be installed");
-                    let exc = crate::builtins::exc_exception_new(&[cls])
-                        .expect("exc_exception_new is infallible for empty args");
-                    Err(unsafe { crate::PyError::from_exc_object(exc) })
-                },
-            );
-            pyre_object::gc_roots::pin_root(h);
-            cell.set(h);
+    let mut h = DEFAULT_INT_HANDLER.load(Ordering::Acquire) as PyObjectRef;
+    if h.is_null() {
+        h = crate::make_builtin_function(
+            "default_int_handler",
+            // issue #2780: accept and ignore any non-keyword arguments.
+            |_| {
+                let cls = crate::builtins::lookup_exc_class("KeyboardInterrupt")
+                    .expect("KeyboardInterrupt must be installed");
+                let exc = crate::builtins::exc_exception_new(&[cls])
+                    .expect("exc_exception_new is infallible for empty args");
+                Err(unsafe { crate::PyError::from_exc_object(exc) })
+            },
+        );
+        pyre_object::gc_roots::pin_root(h);
+        match DEFAULT_INT_HANDLER.compare_exchange(
+            0,
+            h as usize,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {}
+            Err(installed) => h = installed as PyObjectRef,
         }
-        h
-    })
+    }
+    h
 }
 
 /// interp_signal.py:54-152 `CheckSignalAction` — a periodic action run
@@ -281,9 +289,12 @@ pub fn default_int_handler_obj() -> PyObjectRef {
 /// which for SIGINT (default) raises `KeyboardInterrupt`.
 pub struct CheckSignalAction {
     base: PeriodicAsyncAction,
-    /// interp_signal.py:65 — a signal seen but not yet reported (used by
-    /// the threaded fire-in-another-thread path; always -1 in pyre).
+    /// interp_signal.py:65 — a signal seen on a worker but not yet reported by
+    /// the signal-enabled main execution context.
     pending_signal: i32,
+    /// interp_signal.py:66/82-91 — a worker found a pending signal and left it
+    /// for the signal-enabled main execution context.
+    fire_in_another_thread: bool,
     /// interp_signal.py:66/103 — re-entrancy guard so a handler that
     /// itself triggers a checkpoint does not recurse into polling.
     in_poll: bool,
@@ -297,6 +308,7 @@ impl CheckSignalAction {
                 base: AsyncAction::new_periodic_base(space),
             },
             pending_signal: -1,
+            fire_in_another_thread: false,
             in_poll: false,
         })
     }
@@ -313,10 +325,8 @@ impl CheckSignalAction {
         result
     }
 
-    /// interp_signal.py:111-141 `_poll_for_signals_unlocked`.  pyre is
-    /// single-threaded, so `signals_enabled()` is always true and the
-    /// fire-in-another-thread branch is unreachable; the remote-debugger
-    /// arm is not surfaced.
+    /// interp_signal.py:111-141 `_poll_for_signals_unlocked`; the
+    /// remote-debugger arm is not surfaced.
     fn poll_for_signals_unlocked(
         &mut self,
         ec: &mut ExecutionContext,
@@ -332,11 +342,23 @@ impl CheckSignalAction {
             n = signalstate::signal_poll();
         }
         while n >= 0 {
-            self.pending_signal = -1;
-            report_signal(ec, n)?;
-            n = self.pending_signal;
-            if n < 0 {
-                n = signalstate::signal_poll();
+            if ec.signals_enabled != 0 {
+                // The main thread reports the signal and continues polling.
+                self.pending_signal = -1;
+                self.fire_in_another_thread = false;
+                report_signal(ec, n)?;
+                n = self.pending_signal;
+                if n < 0 {
+                    n = signalstate::signal_poll();
+                }
+            } else {
+                // interp_signal.py:135-140 — do not consume a process signal
+                // on a worker.  Keep it on the shared CheckSignalAction and
+                // arm the main EC's registered ticker for prompt delivery.
+                self.pending_signal = n;
+                self.fire_in_another_thread = true;
+                signalstate::rearm_ticker();
+                break;
             }
         }
         Ok(())

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -20,6 +20,10 @@ static THREAD_COUNT: AtomicI64 = AtomicI64::new(0);
 static STACK_SIZE: AtomicUsize = AtomicUsize::new(0);
 static FINALIZING: AtomicBool = AtomicBool::new(false);
 static FINALIZING_THREAD: AtomicI64 = AtomicI64::new(0);
+// `threadlocals.py:64 OSThreadLocals._mainthreadident`.  This belongs to the
+// process/interpreter-owned OSThreadLocals object, not TLS: workers consult the
+// same identity to decide whether their EC may dispatch app-level signals.
+static MAIN_THREAD_IDENT: AtomicI64 = AtomicI64::new(0);
 // Number of EC-owned `w_async_exception_type` slots which are non-null.
 // This keeps the process eval breaker armed until the targeted free-threaded
 // EC observes its own pending exception; another EC must not clear the shared
@@ -228,9 +232,20 @@ pub(crate) fn walk_thread_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
 }
 
 pub(crate) fn register_execution_context(ec: *const crate::PyExecutionContext) {
-    EXECUTION_CONTEXTS
-        .lock()
-        .insert(current_ident(), ec as usize);
+    let ident = current_ident();
+    let mut main_ident = MAIN_THREAD_IDENT.load(Ordering::Acquire);
+    if main_ident == 0 {
+        match MAIN_THREAD_IDENT.compare_exchange(0, ident, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => main_ident = ident,
+            Err(installed) => main_ident = installed,
+        }
+    }
+    if main_ident == ident {
+        // threadlocals.py:95-97 `_set_ec`: the first/native main thread is
+        // enabled for signals.  Each EC is written only by its owning thread.
+        unsafe { (*(ec as *mut crate::PyExecutionContext)).signals_enabled = 1 };
+    }
+    EXECUTION_CONTEXTS.lock().insert(ident, ec as usize);
 }
 
 pub(crate) fn unregister_execution_context() {
@@ -390,6 +405,16 @@ pub(crate) fn after_fork_child() {
     let ident = current_ident();
     {
         let mut contexts = EXECUTION_CONTEXTS.lock();
+        // threadlocals.py:161-171 `reinit_threads`: a fork can leave a worker
+        // as the sole surviving thread.  Preserve explicit enable/disable
+        // nesting while promoting that EC to the new main thread.
+        if let Some(&ec) = contexts.get(&ident) {
+            let ec = unsafe { &mut *(ec as *mut crate::PyExecutionContext) };
+            let old_main = MAIN_THREAD_IDENT.load(Ordering::Acquire);
+            let old_signals = ec.signals_enabled;
+            MAIN_THREAD_IDENT.store(ident, Ordering::Release);
+            ec.signals_enabled = old_signals + i32::from(ident != old_main);
+        }
         contexts.retain(|thread_ident, _| *thread_ident == ident);
         if let Some(&ec) = contexts.get(&ident) {
             for &wref in unsafe { &(*(ec as *const crate::PyExecutionContext)).thread_local_refs } {
@@ -2091,6 +2116,11 @@ crate::py_module! {
             unsafe { pyre_object::w_type_set_acceptable_as_base_class(ty, false) };
             ty
         },
+        // CPython 3.14 publishes the canonical type name as a module
+        // attribute as well as through the historical LockType alias.
+        // multiprocessing pickles synchronization factories containing this
+        // class by `_thread.lock`, so the canonical binding is load-bearing.
+        "lock"          => lock_class::type_object(),
         "RLock"         => rlock_class::type_object(),
         "_ThreadHandle" => handle_class::type_object(),
         "_local"        => local_type(),

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -2942,7 +2942,15 @@ unsafe fn try_instance_unaryop(
     if is_instance(a)
         && let Some(method) = lookup(a, dunder)
     {
-        return Ok(Some(crate::call::call_function_impl_result(method, &[a])?));
+        let Some(w_type) = crate::typedef::r#type(a) else {
+            return Ok(None);
+        };
+        return Ok(Some(crate::baseobjspace::get_and_call_function(
+            method,
+            a,
+            w_type.as_ptr(),
+            &[],
+        )?));
     }
     Ok(None)
 }
@@ -3940,13 +3948,23 @@ pub(crate) unsafe fn lookup_type_special(obj: PyObjectRef, dunder: &str) -> Opti
     crate::typedef::r#type(obj).and_then(|tp| lookup_in_type(tp.as_ptr(), dunder))
 }
 
-/// Call a special method and treat NotImplemented as "no result", per
-/// descroperation.py `_check_notimplemented`.
+/// Call a raw type-MRO special-method descriptor and treat NotImplemented as
+/// "no result", per descroperation.py `_invoke_binop` and
+/// `_check_notimplemented`.  `args[0]` is the receiver; custom descriptors
+/// must bind through `space.get_and_call_function` rather than receiving that
+/// object as an explicitly injected argument.
 pub(crate) fn try_call_special(
     method: PyObjectRef,
     args: &[PyObjectRef],
 ) -> Result<Option<PyObjectRef>, PyError> {
-    let result = crate::call::call_function_impl_result(method, args)?;
+    debug_assert!(!args.is_empty());
+    let receiver = args[0];
+    let Some(w_type) = crate::typedef::r#type(receiver) else {
+        return Ok(None);
+    };
+    let result = unsafe {
+        crate::baseobjspace::get_and_call_function(method, receiver, w_type.as_ptr(), &args[1..])?
+    };
     if unsafe { is_not_implemented(result) } {
         Ok(None)
     } else {
@@ -4771,6 +4789,26 @@ pub fn compare(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
     unsafe {
         if let Some(result) = try_compare_override(a, b, op)? {
             return Ok(result);
+        }
+        // PyPy `descroperation.py:_make_comparison_impl` swaps the operands
+        // whenever the right-hand type is a proper subtype, before invoking
+        // the inherited comparison implementation.  `try_compare_override`
+        // already performs that ordering for generic instances and genuine
+        // builtin overrides; this is the corresponding path for a builtin
+        // subclass which inherits (rather than overrides) its comparison
+        // slot, such as unittest.mock's `_CallList(list)`.
+        // Keep generic instances out of this slot-only path: PyPy preserves
+        // `w_orig_obj1` / `w_orig_obj2` when subtype-first methods all return
+        // NotImplemented, so the final ordering TypeError still names the
+        // original operator and operand order.
+        if !is_instance(a)
+            && !is_instance(b)
+            && let (Some(a_type), Some(b_type)) =
+                (crate::typedef::r#type(a), crate::typedef::r#type(b))
+        {
+            if a_type != b_type && issubtype_cached(b_type.as_ptr(), a_type.as_ptr()) {
+                return compare_slot(b, a, reverse_compare_op(op));
+            }
         }
     }
     compare_slot(a, b, op)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3586,7 +3586,12 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 // Propagate a raised `__bool__` instead of dropping its
                 // stashed error and falling through to `is_true`, which would
                 // dispatch a second time and leave the first copy pending.
-                let result = crate::builtins::call_and_check(method, &[w_obj])?;
+                let result = crate::baseobjspace::get_and_call_function(
+                    method,
+                    w_obj,
+                    w_type.as_ptr(),
+                    &[],
+                )?;
                 if !pyre_object::is_bool(result) {
                     // A tagged immediate is always an exact `int`; name it
                     // without derefing its (non-pointer) tagged bits as
@@ -3614,7 +3619,8 @@ fn bool_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 }
                 // __len__ returning negative → ValueError. Propagate a raised
                 // `__len__` rather than dropping its stashed error.
-                let len_result = crate::builtins::call_and_check(len_m, &[w_obj])?;
+                let len_result =
+                    crate::baseobjspace::get_and_call_function(len_m, w_obj, w_type.as_ptr(), &[])?;
                 if pyre_object::is_int(len_result) {
                     let v = pyre_object::w_int_get_value(len_result);
                     if v < 0 {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -2539,7 +2539,20 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // guard.  RPython reads these values directly from the active MIFrame's
     // register bank; the assignment below is pyre's slot-to-color lowering of
     // that one-red-frame state, not a lookup through the outer portal frame.
-    if ctx.vstack_valid && ctx.vstack_depth <= ctx.vstack_boxes.len() {
+    // Only a branch guard needs the kept-stack mirror overlay.  At every
+    // other guard, and especially at an after-residual guard, the active
+    // MIFrame register bank is authoritative (`pyjitpl.py
+    // get_list_of_active_boxes`).  The residual result was installed in that
+    // bank before `handle_possible_exception`; overlaying the still-pre-call
+    // vstack mirror here replaced the result color with the stale operand and
+    // made the innermost resume frame return the call's input.  Branch guards
+    // are the exceptional shape: their not-taken edge has not executed its
+    // color moves, so the certified per-frame vstack is the source for kept
+    // stack slots.
+    if scope.branch_guard_jitcode_pc.is_some()
+        && ctx.vstack_valid
+        && ctx.vstack_depth <= ctx.vstack_boxes.len()
+    {
         for &(bank, color, slot) in &maps.pcdep_entries {
             if bank != 1 {
                 continue;


### PR DESCRIPTION
## What changed

- bind special-method descriptors correctly for iteration, containment, numeric conversion, truth testing, and rich comparisons
- preserve subtype-first comparison ordering used by `unittest.mock._CallList`
- install residual-call results before may-force guard snapshots and keep inlined callee register state authoritative outside branch-guard kept-stack recovery
- make signal handlers and the default SIGINT handler process-global, restrict signal operations to the signal-enabled execution context, and preserve that ownership across fork
- run the import-lock before/parent/child fork hooks, accept generic buffers in `sendmsg()` ancillary data, and expose `_thread.lock`
- update the CPython runner metadata and baseline for the newly passing regrtest, fork, thread-signal, and unittest coverage

## Why

`test_unittest` exposed several descriptor-binding mismatches plus a JIT resume bug. A may-force call inside an inlined Python frame wrote its result correctly, but the multi-frame snapshot builder then replaced that live register with a stale pre-call operand-stack mirror. On guard failure, blackhole resume returned the stale object and changed `inspect.ismethod()` behavior.

The multiprocessing and signal failures came from interpreter-owned state being represented as TLS, missing PyPy fork-hook wiring, incomplete ancillary-buffer support, and missing canonical `_thread.lock` publication.

## Impact

`test_unittest` now runs all 1,090 tests successfully with three expected skips. Fork/regrtest/thread-signal baseline coverage also advances, while JIT frame identity and per-frame resume state remain intact.

## Validation

- `cargo check --features dynasm`
- `cargo test --features dynasm`
- focused may-force residual-call snapshot regression test
- fingerprint-enforced Charon LLBC re-extraction and release rebuild
- `python3 pyre/cpython_tests/run.py --backend dynasm --binary target/release/pyre-dynasm --mode regrtest --filter test_unittest --timeout 60`
- `python3 pyre/check.py --backend dynasm --no-synthetic --no-cpython-suite` — 17/17 passed
- `cargo fmt --check`
- `git diff --check`
