### PR TITLE
ctypes: expose frozen module tables

### DIFF
--- a/lib-python/3/test/test_ctypes/test_arrays.py
+++ b/lib-python/3/test/test_ctypes/test_arrays.py
@@ -5,7 +5,8 @@ from ctypes import (Structure, Array, ARRAY, sizeof, addressof,
                     create_string_buffer, create_unicode_buffer,
                     c_char, c_wchar, c_byte, c_ubyte, c_short, c_ushort, c_int, c_uint,
                     c_long, c_ulonglong, c_float, c_double, c_longdouble)
-from test.support import bigmemtest, _2G, threading_helper, Py_GIL_DISABLED
+from test.support import (bigmemtest, cpython_only, _2G, threading_helper,
+                          Py_GIL_DISABLED)
 from ._support import (_CData, PyCArrayType, Py_TPFLAGS_DISALLOW_INSTANTIATION,
                        Py_TPFLAGS_IMMUTABLETYPE)
 
@@ -23,6 +24,7 @@ class ArrayTestCase(unittest.TestCase):
         self.assertEqual(PyCArrayType.__name__, "PyCArrayType")
         self.assertEqual(type(PyCArrayType), type)
 
+    @cpython_only
     def test_type_flags(self):
         for cls in Array, PyCArrayType:
             with self.subTest(cls=cls):

--- a/lib-python/3/test/test_ctypes/test_simplesubclasses.py
+++ b/lib-python/3/test/test_ctypes/test_simplesubclasses.py
@@ -1,5 +1,6 @@
 import unittest
 from ctypes import Structure, CFUNCTYPE, c_int, _SimpleCData
+from test.support import cpython_only
 from ._support import (_CData, PyCSimpleType, Py_TPFLAGS_DISALLOW_INSTANTIATION,
                        Py_TPFLAGS_IMMUTABLETYPE)
 
@@ -20,6 +21,7 @@ class Test(unittest.TestCase):
 
         self.assertEqual(c_int.mro(), [c_int, _SimpleCData, _CData, object])
 
+    @cpython_only
     def test_type_flags(self):
         for cls in _SimpleCData, PyCSimpleType:
             with self.subTest(cls=cls):

--- a/lib-python/3/test/test_ctypes/test_struct_fields.py
+++ b/lib-python/3/test/test_ctypes/test_struct_fields.py
@@ -1,6 +1,7 @@
 import unittest
 import sys
 from ctypes import Structure, Union, sizeof, c_byte, c_char, c_int, CField
+from test.support import cpython_only
 from ._support import Py_TPFLAGS_IMMUTABLETYPE, StructCheckMixin
 
 
@@ -163,6 +164,7 @@ class FieldsTestBase(StructCheckMixin):
 class StructFieldsTestCase(unittest.TestCase, FieldsTestBase):
     cls = Structure
 
+    @cpython_only
     def test_cfield_type_flags(self):
         self.assertTrue(CField.__flags__ & Py_TPFLAGS_IMMUTABLETYPE)
 

--- a/lib-python/3/test/test_ctypes/test_structunion.py
+++ b/lib-python/3/test/test_ctypes/test_structunion.py
@@ -12,7 +12,7 @@ from ._support import (_CData, PyCStructType, UnionType,
                        Py_TPFLAGS_IMMUTABLETYPE)
 from struct import calcsize
 import contextlib
-from test.support import MS_WINDOWS
+from test.support import cpython_only, MS_WINDOWS
 
 
 class StructUnionTestBase:
@@ -77,6 +77,7 @@ class StructUnionTestBase:
         self.assertEqual(self.cls.mro(), [self.cls, _CData, object])
         self.assertEqual(type(self.metacls), type)
 
+    @cpython_only
     def test_type_flags(self):
         for cls in self.cls, self.metacls:
             with self.subTest(cls=cls):

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -286,7 +286,7 @@
       "dynasm": "PASS"
     },
     "test.test_ctypes": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_curses": {
       "dynasm": "IMPORTERROR"

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -104,17 +104,10 @@ pub(super) fn cdata_in_dll(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
             .unwrap_or_else(|| pyre_object::w_int_new(0));
         return crate::call::type_call_instantiate(cls, &[optimize]);
     }
-    if name.starts_with("_PyImport_Frozen") {
-        // Pyre has no frozen modules.  Export the ABI's terminating all-zero
-        // `_frozen` entry through a stable pointer variable.
-        let sentinel = Box::leak(Box::new([0usize; 3]));
-        let pointer = Box::leak(Box::new(sentinel.as_ptr() as usize));
-        return Ok(make_at_address(
-            cls,
-            pointer as *mut usize as usize,
-            size,
-            args[1],
-        ));
+    if let Some(pointer_variable) =
+        crate::module::imp::interp_imp::frozen_abi_pointer_variable(name)
+    {
+        return Ok(make_at_address(cls, pointer_variable, size, args[1]));
     }
     let address = super::interp_ctypes::lookup_symbol(handle, name.as_bytes())
         .map_err(|_| crate::PyError::value_error(format!("symbol '{name}' not found")))?;

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -4,7 +4,9 @@
 
 use crate::importing::BUILTIN_MODULES;
 use rustpython_wtf8::{Wtf8, Wtf8Buf};
+use std::ffi::CString;
 use std::sync::atomic::{AtomicI64, AtomicPtr, Ordering};
+use std::sync::OnceLock;
 
 struct FrozenModule {
     name: &'static str,
@@ -104,6 +106,75 @@ static FROZEN_MODULES: &[FrozenModule] = &[
         source: FrozenSource::Literal("initialized = True\n"),
     },
 ];
+
+/// The four-field prefix of CPython's public `struct _frozen` ABI consumed by
+/// `ctypes.POINTER(...).in_dll(pythonapi, "_PyImport_Frozen...")`.
+///
+/// Pyre's canonical frozen-module owner above stores source rather than
+/// marshalled CPython bytecode.  The ABI projection therefore exposes the
+/// source bytes as its non-empty payload while preserving the observable
+/// name/order/package table.  Import execution continues to go through
+/// `frozen_code`, so this compatibility view cannot become a second semantic
+/// owner of the modules.
+#[repr(C)]
+struct FrozenAbiEntry {
+    name: *const std::ffi::c_char,
+    code: *const u8,
+    size: i32,
+    is_package: i32,
+}
+
+fn build_frozen_abi_table(entries: &[FrozenModule]) -> usize {
+    let mut table = Vec::with_capacity(entries.len() + 1);
+    for entry in entries {
+        let name = CString::new(entry.name)
+            .expect("frozen module names contain no NUL bytes")
+            .into_raw();
+        let source = frozen_source(entry)
+            .map(|(source, _)| source.into_bytes())
+            .unwrap_or_else(|_| b"# frozen source unavailable\n".to_vec());
+        let source = Box::leak(source.into_boxed_slice());
+        let size = i32::try_from(source.len()).unwrap_or(i32::MAX);
+        table.push(FrozenAbiEntry {
+            name,
+            code: source.as_ptr(),
+            size,
+            is_package: i32::from(entry.is_package),
+        });
+    }
+    table.push(FrozenAbiEntry {
+        name: std::ptr::null(),
+        code: std::ptr::null(),
+        size: 0,
+        is_package: 0,
+    });
+
+    let table = Box::leak(table.into_boxed_slice());
+    Box::leak(Box::new(table.as_ptr() as usize)) as *mut usize as usize
+}
+
+/// Address of the stable pointer variable exported by CPython for each frozen
+/// table.  The split matches CPython's Bootstrap/Stdlib/Test ABI while the
+/// concatenated order remains exactly `FROZEN_MODULES`, the list returned by
+/// `_imp._frozen_module_names()`.
+pub(crate) fn frozen_abi_pointer_variable(name: &str) -> Option<usize> {
+    static BOOTSTRAP: OnceLock<usize> = OnceLock::new();
+    static STDLIB: OnceLock<usize> = OnceLock::new();
+    static TEST: OnceLock<usize> = OnceLock::new();
+
+    match name {
+        "_PyImport_FrozenBootstrap" => {
+            Some(*BOOTSTRAP.get_or_init(|| build_frozen_abi_table(&FROZEN_MODULES[..3])))
+        }
+        "_PyImport_FrozenStdlib" => {
+            Some(*STDLIB.get_or_init(|| build_frozen_abi_table(&FROZEN_MODULES[3..3])))
+        }
+        "_PyImport_FrozenTest" => {
+            Some(*TEST.get_or_init(|| build_frozen_abi_table(&FROZEN_MODULES[3..])))
+        }
+        _ => None,
+    }
+}
 
 static FROZEN_OVERRIDE: AtomicI64 = AtomicI64::new(0);
 


### PR DESCRIPTION
## What changed

- project pyre's canonical `_imp` frozen-module census through the three ctypes `_PyImport_Frozen*` ABI tables
- route ctypes `in_dll()` frozen-symbol lookup through those stable process-global tables
- classify CPython's ctypes `Py_TPFLAGS_IMMUTABLETYPE` assertions as CPython-only, preserving PyPy's public `type.__flags__` contract
- promote `test.test_ctypes` from `CRASH` to `PASS` in the CPython-suite baseline

## Why

Pyre already owns a real frozen-module census in `_imp`, but ctypes exposed an always-empty sentinel for every `_PyImport_Frozen*` symbol. The compatibility view now derives names, ordering, package flags, and payload storage from the existing owner rather than maintaining a second module census.

The vendored CPython 3.14 suite also asserts CPython-specific immutable-type bits for ctypes internals. PyPy intentionally reports its own public `__flags__` surface: static builtins do not gain that bit, and immutability remains enforced by the existing heap/static ownership path. Marking only those assertions `cpython_only` keeps the suite portable without changing runtime semantics.

## CI fix

The first version added `Py_TPFLAGS_IMMUTABLETYPE` to every non-heap pyre type. That made `synth/pypy_type_surface` fail on Linux, macOS, and Windows because the fixture locks PyPy's public flag values. This revision restores the line-for-line PyPy flag calculation and limits the compatibility adjustment to the CPython-only tests.

## Validation

- `PYPYLOG=jit-summary:- pypy3 pyre/bench/synth/pypy_type_surface.py`
- `python3 pyre/check.py --backend dynasm --synthetic-only --synthetic-pattern pypy_type_surface.py` (1/1 passed)
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `python3 pyre/cpython_tests/run.py --backend dynasm --filter test_ctypes --timeout 300`
- `python3 pyre/cpython_tests/run.py --backend dynasm --no-jit --filter test_ctypes --full --timeout 300`
- `python3 pyre/check.py --backend dynasm --no-synthetic --no-cpython-suite` (17/17 passed)
- refreshed LLBC for the default extraction set


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when accessing frozen-module data through `ctypes`.
  - Fixed frozen-module metadata handling to better match CPython behavior.
  - Resolved an issue that could cause dynamic assembly-related tests to crash.

- **Tests**
  - Updated platform-specific test coverage so CPython-only checks run in the appropriate environment.
  - Confirmed the affected `ctypes` test suite now passes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->