### PR TITLE
Trace w_int_new's allocation again, and cover fuse_boxing_alloc's cross-block walk

### DIFF
--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -7284,6 +7284,202 @@ mod tests {
     }
 
     #[test]
+    fn fuse_boxing_alloc_resolves_a_split_cluster_only_when_the_links_agree() {
+        // A boxing cluster's header stores sit before its `malloc_typed`, and
+        // each call ends a block, so `ob_type` / `w_class` reach the ctor as
+        // `Block.inputargs` while the `ConstRefAddr` producing them stays in a
+        // predecessor.  `resolve_addr` steps through the links to read it, and
+        // takes an answer only when every predecessor agrees: a phi merging two
+        // type pointers is not a constant, and stamping either one onto the
+        // allocation would name the wrong type.  Every other cluster here is
+        // built in one block, so neither half of that walk is otherwise reached.
+        type Var = crate::flowspace::model::Variable;
+        const FLOAT_TYPE_ADDR: i64 = 4357049520;
+        const OTHER_TYPE_ADDR: i64 = 4357049600;
+
+        fn call(graph: &mut FunctionGraph, blk: BlockId, path: &[&str], args: Vec<Var>) -> Var {
+            graph
+                .push_op_var(
+                    blk,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath {
+                            segments: path.iter().map(|s| (*s).to_string()).collect(),
+                        },
+                        args,
+                        result_ty: ValueType::Ref(Some("object".into())),
+                    },
+                    true,
+                )
+                .unwrap()
+        }
+        /// The `(ob_type, w_class)` pair a `w_float_new` header stores, both
+        /// read off a `&FLOAT_TYPE`-shaped constant at `addr`.
+        fn header_pair(graph: &mut FunctionGraph, blk: BlockId, addr: i64) -> Vec<Var> {
+            let cast = |graph: &mut FunctionGraph| {
+                let ty = graph
+                    .push_op_var(blk, OpKind::ConstRefAddr(addr), true)
+                    .unwrap();
+                call(graph, blk, &["__pyre_cast_instance", "PyType"], vec![ty])
+            };
+            let ob_type = cast(graph);
+            let w_class_cast = cast(graph);
+            let w_class = call(
+                graph,
+                blk,
+                &["pyre_object", "pyobject", "get_instantiate"],
+                vec![w_class_cast],
+            );
+            vec![ob_type, w_class]
+        }
+        /// The rest of the cluster, in `blk`: the nested `PyObject` header
+        /// taking the two values `blk` was handed, the `W_FloatObject` ctor and
+        /// its payload store, and the `malloc_typed` the fusion rewrites.
+        fn cluster_in(graph: &mut FunctionGraph, blk: BlockId, ob_type: &Var, w_class: &Var) {
+            let field = |base: &Var, name: &str, owner: &str, value: &Var| OpKind::FieldWrite {
+                base: base.clone(),
+                field: FieldDescriptor {
+                    name: name.into(),
+                    owner_root: Some(owner.into()),
+                    owner_id: None,
+                    base_is_deref: None,
+                    taken_by_address: false,
+                },
+                value: LinkArg::Value(value.clone()),
+                ty: ValueType::Ref(None),
+            };
+            let ctor = |graph: &mut FunctionGraph, name: &str| {
+                graph
+                    .push_op_var(
+                        blk,
+                        OpKind::Call {
+                            target: CallTarget::synthetic_transparent_ctor(name),
+                            args: vec![],
+                            result_ty: ValueType::Ref(Some(name.into())),
+                        },
+                        true,
+                    )
+                    .unwrap()
+            };
+            let payload = graph
+                .push_op_var(blk, OpKind::ConstFloat(0.0f64.to_bits()), true)
+                .unwrap();
+            let header = ctor(graph, "PyObject");
+            graph.push_op_var(blk, field(&header, "ob_type", "PyObject", ob_type), false);
+            graph.push_op_var(blk, field(&header, "w_class", "PyObject", w_class), false);
+            let agg = ctor(graph, "W_FloatObject");
+            graph.push_op_var(
+                blk,
+                field(&agg, "ob_header", "W_FloatObject", &header),
+                false,
+            );
+            graph.push_op_var(
+                blk,
+                field(&agg, "floatval", "W_FloatObject", &payload),
+                false,
+            );
+            let ret = call(
+                graph,
+                blk,
+                &["pyre_object", "lltype", "malloc_typed"],
+                vec![agg],
+            );
+            graph.set_return(blk, Some(ret));
+        }
+
+        /// One producer of the header pair, `crossings` blocks of pure relay,
+        /// then the cluster — the shape a run of calls before the allocation
+        /// leaves behind.
+        fn chain(crossings: usize) -> FunctionGraph {
+            let mut graph = FunctionGraph::new("test");
+            let entry = graph.startblock;
+            let mut carried = header_pair(&mut graph, entry, FLOAT_TYPE_ADDR);
+            let mut from = entry;
+            for _ in 0..crossings {
+                let (next, args) = graph.create_block_with_arg_vars(2);
+                graph.set_goto(from, next, carried);
+                carried = args;
+                from = next;
+            }
+            cluster_in(&mut graph, from, &carried[0], &carried[1]);
+            graph
+        }
+        /// Two predecessors of one merge block, each building its own header
+        /// pair off the address it is given, and the cluster in the merge.
+        fn merge(left_addr: i64, right_addr: i64) -> FunctionGraph {
+            let mut graph = FunctionGraph::new("test");
+            let entry = graph.startblock;
+            let cond = graph.push_op_var(entry, OpKind::ConstInt(0), true).unwrap();
+            let (join, carried) = graph.create_block_with_arg_vars(2);
+            let arms: Vec<Link> = [(true, left_addr), (false, right_addr)]
+                .into_iter()
+                .map(|(case, addr)| {
+                    let arm = graph.create_block();
+                    let pair = header_pair(&mut graph, arm, addr);
+                    graph.set_goto(arm, join, pair);
+                    Link::from_variables(&graph, vec![], arm, Some(ExitCase::Bool(case)))
+                })
+                .collect();
+            graph.block_mut(entry).exitswitch = Some(ExitSwitch::Value(cond));
+            graph.closeblock(entry, arms);
+            cluster_in(&mut graph, join, &carried[0], &carried[1]);
+            graph
+        }
+
+        let rows: [(&str, &dyn Fn() -> FunctionGraph, usize); 4] = [
+            ("one link crossing", &|| chain(1), 1),
+            ("two link crossings", &|| chain(2), 1),
+            (
+                "predecessors naming one type",
+                &|| merge(FLOAT_TYPE_ADDR, FLOAT_TYPE_ADDR),
+                1,
+            ),
+            (
+                "predecessors naming two types",
+                &|| merge(FLOAT_TYPE_ADDR, OTHER_TYPE_ADDR),
+                0,
+            ),
+        ];
+        for (shape, build, expected) in rows {
+            let mut graph = build();
+            assert_eq!(
+                fuse_boxing_alloc(&mut graph, &numeric_boxing_attrs()),
+                expected,
+                "{shape}: wrong number of fused clusters"
+            );
+            let vtables: Vec<i64> = graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .filter_map(|op| match &op.kind {
+                    OpKind::NewWithVtable { vtable, .. } => Some(*vtable),
+                    _ => None,
+                })
+                .collect();
+            // Naming the address rather than counting the op is what separates
+            // a walk that read the predecessor from one that read some other
+            // constant in the graph.
+            let expected_vtables = if expected == 0 {
+                Vec::new()
+            } else {
+                vec![FLOAT_TYPE_ADDR]
+            };
+            assert_eq!(vtables, expected_vtables, "{shape}: wrong vtable stamped");
+            let residual = graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call { target: CallTarget::FunctionPath { segments }, .. }
+                        if segments.last().map(String::as_str) == Some("malloc_typed")
+                )
+            });
+            assert_eq!(
+                residual,
+                expected == 0,
+                "{shape}: malloc_typed residual must survive exactly when the cluster declines"
+            );
+        }
+    }
+
+    #[test]
     fn fuse_boxing_alloc_sweeps_nested_header_chain() {
         // Faithful `w_float_new` shape: the boxing struct's header is a nested
         // `PyObject` ctor whose `ob_type` is a `__pyre_cast_instance` pointer

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -961,19 +961,19 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::try_gc_alloc_stable_raw",
         pyre_object::gc_hook::try_gc_alloc_stable_raw as *const (),
     );
-    // `w_int_box_slow` is the allocating tail of `w_int_new`, reached from
+    // `w_int_gc_alloc` is the collector-heap arm of `w_int_new`, reached from
     // inside a descended body whenever a fold boxes an int. Bind the
     // macro-emitted trampoline rather than the raw fn, for the reason
     // `prepare_list_ref_store` documents: the raw `(i64) -> *mut PyObject` is
     // `(i64) -> i32` on wasm32, while the wasm backend types the residual's
     // `call_indirect` `(i64) -> i64` from the descr alone.
-    let w_int_box_slow: extern "C" fn(i64) -> i64 =
-        pyre_object::intobject::__majit_call_target_w_int_box_slow;
+    let w_int_gc_alloc: extern "C" fn(i64) -> i64 =
+        pyre_object::intobject::__majit_call_target_w_int_gc_alloc;
     push_alias_pair(
         &mut entries,
-        "pyre_object::intobject::w_int_box_slow",
-        "pyre_object::w_int_box_slow",
-        w_int_box_slow as *const (),
+        "pyre_object::intobject::w_int_gc_alloc",
+        "pyre_object::w_int_gc_alloc",
+        w_int_gc_alloc as *const (),
     );
     // `w_type_set_abstract` stores the runtime-mutable `flag_abstract` atomic — a
     // side effect on per-type state, not a build-time constant, so it carries

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9699,7 +9699,10 @@ pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
     );
     match commit_result {
         Ok(()) => {}
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LIST-APPEND-SUBWALK pc={pc}");
+            }
             ctx.trace_ctx.cut_trace(pre_fold_pos);
             ctx.trace_ctx.heap_cache_mut().reset();
             bool_box_truth_reset();
@@ -10236,7 +10239,10 @@ pub(crate) fn try_walker_orthodox_list_pop<Sym: WalkSym>(
         ctx, op, sym, &sub_body, self_ref, inner_self, len_before, raw_item, dst,
     ) {
         Ok(()) => Ok(Some(())),
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LIST-POP-SUBWALK pc={pc}");
+            }
             ctx.trace_ctx.cut_trace(pre_fold_pos);
             ctx.trace_ctx.heap_cache_mut().reset();
             bool_box_truth_reset();
@@ -10486,7 +10492,10 @@ pub(crate) fn try_walker_orthodox_list_append_opcode<Sym: WalkSym>(
     );
     match commit_result {
         Ok(()) => {}
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+            if fbw_debug_abort_enabled() {
+                eprintln!("[decline-why] LIST-APPEND-SUBWALK pc={pc}");
+            }
             ctx.trace_ctx.cut_trace(pre_fold_pos);
             ctx.trace_ctx.heap_cache_mut().reset();
             bool_box_truth_reset();

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -101,13 +101,34 @@ static SMALL_INTS: LazyLock<PrebuiltInts> = LazyLock::new(|| {
     )
 });
 
-/// `pypy/objspace/std/intobject.py:883-897 wrapint` parity.
+/// `pypy/objspace/std/intobject.py:903-921 wrapint` parity.
 ///
 /// `withprebuiltint=False` (PyPy default) → always allocate fresh,
 /// matching upstream `return W_IntObject(x)`. With the flag enabled
 /// and `value` inside `[PREBUILTINTFROM, PREBUILTINTTO)` the cache
 /// returns the pre-allocated entry; outside the range we allocate
 /// (`instantiate(W_IntObject)` upstream).
+///
+/// Traced, not residualised, and `#[inline]` — `wrapint` carries no
+/// `@dont_look_inside` and its own comment reads "this whole function is
+/// getting inlined into every caller so keeping the branching to a minimum
+/// is a good idea" (intobject.py:908-910). The allocation upstream is
+/// `instantiate(W_IntObject)` followed by `w_res.intval = x`
+/// (intobject.py:913-920): alloc-then-init, which the rtyper lowers to the
+/// `new_with_vtable` + payload `setfield_gc` pair the optimizer can
+/// virtualize where the box does not escape. The stack-built
+/// `malloc_typed(W_IntObject { .. })` spelling below is the Rust form of the
+/// same thing: `fuse_boxing_alloc` (`majit-translate` `model.rs`) rewrites
+/// that cluster into exactly that pair, and it does fire here — its walk
+/// resolves the header pointers across the block boundary each call ends.
+///
+/// `bench/synth/list_pop_append` reads the same either way, and its negative
+/// control (boundary removed with the fusion reverted) failed to reproduce
+/// the regression that motivated the boundary, so that bench does not
+/// discriminate this mechanism in either direction. What decides it is the
+/// shape: a residual call can never be virtualized and `new_with_vtable`
+/// can, and the boundary's own stated blocker — the fusion not resolving a
+/// vtable here — is gone.
 ///
 /// The allocation path goes through [`crate::lltype::malloc_typed`]
 /// which carries `W_INT_GC_TYPE_ID` +
@@ -133,61 +154,10 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
         let idx = (value - PREBUILTINTFROM) as usize;
         return (&SMALL_INTS.0[idx] as *const W_IntObject).cast_mut() as PyObjectRef;
     }
-    w_int_box_slow(value)
-}
-
-/// The allocating tail of [`w_int_new`], behind a residualisation boundary
-/// (`rlib/jit.py:139 @dont_look_inside`). The collector arm is the
-/// `gct_fv_gc_malloc` bracket (`rpython/memory/gctransform/framework.py`) in
-/// its alloc-then-init form — take the block, then write the header and
-/// payload into it; it falls through to `malloc_typed` when no collector owns
-/// the heap.
-///
-/// Both arms have a shape no trace can carry, which is why the boundary sits
-/// around the pair rather than around either one. A stack-built `W_IntObject`
-/// lowers to a `SyntheticTransparentCtor` for its `PyObject` header, whose
-/// funcptr constant degrades to a `symbolic_fnaddr` hash; a descending
-/// sub-jitcode walk cannot record such a call, so it declines the entire
-/// descent — that is what takes `list.pop()`'s fold off the compiled loop.
-/// Writing the fields individually instead lands the header's own `ob_type`
-/// slot at offset 0, which the wasm backend does not lower faithfully.
-///
-/// The boundary is a deviation from `wrapint`
-/// (`objspace/std/intobject.py:908-910`), which keeps its allocation inline —
-/// its own comment there notes the function is inlined into every caller. The
-/// orthodox lowering is `new_with_vtable`, which stays in the trace and can be
-/// optimised away where the box does not escape. `fuse_boxing_alloc`
-/// (`majit-translate` `model.rs`) rewrites exactly this ctor-plus-`FieldWrite`
-/// shape into `NewWithVtable`, and it does now fire here: the static address
-/// table is populated in the build-script pipeline, and the pass reported
-/// every site unresolved only because its walk stopped at a block boundary —
-/// each call ends a block, so a header store sitting before one crosses as a
-/// link argument while its `ConstRefAddr` producer stays in the predecessor.
-///
-/// So the vtable now resolves here, but removing the boundary was measured to
-/// change nothing: `bench/synth/list_pop_append` reads the same on all three
-/// backends with the boundary present, with it removed, and with it removed
-/// while the fusion is reverted. That last arm is a negative control which was
-/// expected to reproduce the pre-boundary regression and did not, so the bench
-/// no longer discriminates this mechanism and its null says nothing either
-/// way. The boundary stays until an instrument that can tell the two apart
-/// says otherwise.
-///
-/// Spelled `*mut PyObject` rather than `PyObjectRef` so the attribute emits
-/// its `extern "C"` call trampoline: the macro recognises raw pointers
-/// syntactically and declines to emit one for an aliased return type.
-#[majit_macros::dont_look_inside]
-pub fn w_int_box_slow(value: i64) -> *mut PyObject {
     if crate::gc_interp::enabled() {
-        let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
-        if !raw.is_null() {
-            unsafe {
-                let p = raw as *mut W_IntObject;
-                (*p).ob_header.ob_type = &INT_TYPE as *const PyType;
-                (*p).ob_header.w_class = get_instantiate(&INT_TYPE);
-                (*p).intval = value;
-            }
-            return raw as PyObjectRef;
+        let boxed = w_int_gc_alloc(value);
+        if !boxed.is_null() {
+            return boxed;
         }
     }
     crate::lltype::malloc_typed(W_IntObject {
@@ -197,6 +167,45 @@ pub fn w_int_box_slow(value: i64) -> *mut PyObject {
         },
         intval: value,
     }) as PyObjectRef
+}
+
+/// The collector-heap arm of [`w_int_new`]: the `gct_fv_gc_malloc` bracket
+/// (`rpython/memory/gctransform/framework.py`) in its alloc-then-init form —
+/// take the block, then write the header and payload into it, rather than
+/// copying a stack-built struct over it. Returns null when no collector owns
+/// the heap, which is the caller's signal to take the `malloc_typed` arm.
+///
+/// Residualised (`rlib/jit.py:139 @dont_look_inside`) rather than traced,
+/// which [`w_int_new`] is not — a deviation this arm alone carries, because
+/// neither spelling of it reaches the trace intact. Writing the fields into
+/// the collector's block, as below, lands the header's own `ob_type` slot at
+/// offset 0, which the wasm backend does not lower faithfully. Building the
+/// struct on the stack and copying it in instead is not the
+/// `malloc_typed(%agg)` route `fuse_boxing_alloc` rewrites, so its
+/// `SyntheticTransparentCtor` for the `PyObject` header survives lowering as
+/// a call to a `symbolic_fnaddr` hash, which a descending sub-jitcode walk
+/// cannot record and declines on. The boundary keeps both shapes out of the
+/// trace, and costs nothing where the arm is unreachable:
+/// `gc_interp::enabled()` is false on the native backends, whose
+/// `malloc_typed` arm is fused into a `NewWithVtable`. Drop it once the wasm
+/// backend lowers an offset-0 field store faithfully.
+///
+/// Spelled `*mut PyObject` rather than `PyObjectRef` so the attribute emits
+/// its `extern "C"` call trampoline: the macro recognises raw pointers
+/// syntactically and declines to emit one for an aliased return type.
+#[majit_macros::dont_look_inside]
+pub fn w_int_gc_alloc(value: i64) -> *mut PyObject {
+    let raw = crate::gc_hook::try_gc_alloc_stable_raw(W_INT_GC_TYPE_ID, W_INT_OBJECT_SIZE);
+    if raw.is_null() {
+        return crate::PY_NULL;
+    }
+    unsafe {
+        let p = raw as *mut W_IntObject;
+        (*p).ob_header.ob_type = &INT_TYPE as *const PyType;
+        (*p).ob_header.w_class = get_instantiate(&INT_TYPE);
+        (*p).intval = value;
+    }
+    raw as PyObjectRef
 }
 
 /// Create a W_IntObject bypassing the small-int cache.


### PR DESCRIPTION
Three commits on top of `origin/main`.

### `jit: print the orthodox list sub-walk decline pc under PYRE_FBW_DEBUG_ABORT`

`OrthodoxSubWalkTraceUnsupported` carried a pc that never reached a log line, so
the two list sub-walk declines were indistinguishable from every other abort.
Two `[decline-why]` prints behind the existing `PYRE_FBW_DEBUG_ABORT` gate.

### `intobject: trace w_int_new's allocation again, as wrapint does`

`w_int_new` routed both its boxing arms through a `#[dont_look_inside]`
`w_int_box_slow`, which residualises the call and so makes the box
unvirtualizable by construction. The oracle, `intobject.py:903-921 wrapint`,
carries no `@dont_look_inside` — its comment at `:908-910` says the function
"is getting inlined into every caller" — and allocates then initialises
(`:913-920`), which is `new_with_vtable` + `setfield_gc`.

The boundary's own stated blocker was that the fusion could not resolve the
header pointers across the block boundary each call ends. #1141 fixed exactly
that, so the arm is traced again. The collector arm keeps its boundary as
`w_int_gc_alloc`, scoped to the one deviation that is still real (the wasm
backend's offset-0 field store).

Measured on this base: the compiled `lst.append(i); lst.pop()` loop emits
`NewWithVtable` (size 24, `type_id` 1) with `SetfieldGc … descr=W_IntObject.intval`
and **no residual `w_int_*` boxing call**. `synth/list_pop_append` 2.6x / 3.3x /
2.4x — the bench does not discriminate this mechanism in either direction, and
the commit message says so; the decision rests on the shape.

### `majit: test fuse_boxing_alloc across the links a split cluster crosses`

`resolve_addr` (added by #1141) steps through `Block.inputargs` and takes an
answer only when every predecessor agrees. Neither behaviour was reached by a
test: the case added with it, and all six that predate it, build their cluster
in a single block, so they resolve without entering the phi arm.

Four rows over one `W_FloatObject` cluster, differing only in where the header
values come from — one relay block, two relay blocks, two predecessors of a
merge naming one type, two naming different types. Each asserts the fused count,
the address stamped on the `NewWithVtable`, and whether the `malloc_typed`
survives as a residual. Asserting the address is what separates "walked to the
predecessor" from "read some other constant in the graph".

Non-vacuity measured by ablation on this tree:

| ablation | result |
| --- | --- |
| `resolve_addr` returns `None` for a phi | "one link crossing" fails, 6/6 pre-existing pass |
| the disagreement arm is dropped | "predecessors naming two types" fails, 6/6 pre-existing pass |

The diff is a 196-line addition inside `mod tests` with no deletions;
`resolve_addr` is unchanged.

### Verification

* `check.py`: dynasm 417/417, cranelift 416/416, wasm 412/412 (`HEAD` pinned
  identical before and after the run).
* `cargo test --workspace`: 106 suites, 7623 passed, 0 failed.

An earlier commit on this branch ported locale-aware `'n'` formatting; it was
dropped on rebase because #1147 landed a superset of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integer object allocation for collector-enabled execution, with a fallback path when allocation is unavailable.
  * Fixed boxing fusion across block boundaries, including cases with relayed and multiple matching predecessors.
  * Prevented fusion when predecessor type information conflicts.

* **Diagnostics**
  * Added debug logging for unsupported list operations during trace specialization, including the relevant program counter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->