### PR TITLE
llbc: fingerprint compiler inputs without tool-only invalidation

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -71,6 +71,13 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
+    - name: Check the LLBC fingerprint input walk
+      # Ahead of the Charon install so a regression reports in seconds. An
+      # `include*!` spelling the walk cannot resolve widens no digest and fails
+      # nothing downstream — the artefact just reads as fresh — so this is the
+      # only place that behaviour is observable. Needs no cargo and no git.
+      shell: bash
+      run: scripts/llbc_extract_selftest.py
     - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ rpaheui
 *.swp
 *.swo
 
+# macOS. The LLBC fingerprint enumerates untracked sources, so a Finder visit
+# to a crate's src/ would otherwise drop a .DS_Store into the digest.
+.DS_Store
+
 *.pyc
 *.pyo
 *~

--- a/pyre/scripts/extract-llbc.py
+++ b/pyre/scripts/extract-llbc.py
@@ -110,15 +110,18 @@ LAYOUT_TARGETS = ("wasm32-unknown-unknown",)
 # backend refuses to build for `wasm32-unknown-unknown`.
 LAYOUT_TARGET_RUSTFLAGS = '--cfg getrandom_backend="custom"'
 
-# Base fingerprint inputs shared by every pyre crate: workspace manifests plus
-# the extraction tooling itself, so an edit to the engine/driver busts caches.
+# Bump only when pyre's extraction behaviour changes in a way not already
+# represented by the effective cargo/Charon/layout flags hashed by the engine.
+# The explicit ABI keeps comments, diagnostics, tests, the forwarding shim and
+# the Charon installer from invalidating every multi-minute artefact.
+EXTRACTION_ABI = "1"
+
+# Workspace resolution is a compiler input. Extraction-tool implementation
+# files are deliberately absent; FINGERPRINT_SCHEMA and EXTRACTION_ABI carry
+# their output-affecting semantics without coupling cache keys to every edit.
 BASE_PATHSPECS = [
     "Cargo.lock",
     "Cargo.toml",
-    "scripts/llbc_extract.py",
-    "scripts/extract-llbc.py",
-    "pyre/scripts/extract-llbc.py",
-    "scripts/install-charon.py",
 ]
 
 
@@ -128,6 +131,7 @@ def main() -> None:
         DEFAULT_CRATES,
         root=ROOT,
         out_dir=ROOT / "build" / "llbc",
+        extraction_abi=EXTRACTION_ABI,
         base_pathspecs=BASE_PATHSPECS,
         metadata_feature_crates=("pyre-interpreter", "pyre-jit"),
         layout_targets=LAYOUT_TARGETS,

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -14,6 +14,7 @@ import hashlib
 import json
 import os
 import platform
+import re
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -252,6 +253,107 @@ def metadata(
     return result
 
 
+_INCLUDE_CALL = re.compile(r"\binclude(?:_str|_bytes)?!\s*\(\s*")
+# A plain, escape-free string literal is the only spelling this resolves. A raw
+# literal or one carrying a `\` escape falls through to the refusal below rather
+# than being decoded wrongly.
+_INCLUDE_PATH = re.compile(r"\"([^\"\\]*)\"")
+
+
+def include_closure(root: Path, files: set[Path]) -> set[Path]:
+    """The files `include*!` reads that no crate pathspec covers.
+
+    `include!` / `include_str!` / `include_bytes!` resolve their argument
+    against the directory of the file holding the macro, so an argument that
+    climbs out of the crate is still a compiler input while sitting outside
+    every pathspec the enumeration builds. `majit-metainterp`'s `REAL_RULES`
+    is the live instance: it includes PyPy's `real.rules` out of the vendored
+    `rpython/` tree, and editing that file changes what the crate compiles
+    without moving a digest that never hashed it.
+
+    Only a plain string literal is resolvable from the text, so an argument in
+    any other spelling stops extraction instead of being skipped: a skip is
+    indistinguishable from a fresh artefact, which is the failure this walk
+    exists to remove. The two spellings in the tree today are allowed by shape
+    and each is checked below; a third has to be audited the same way before it
+    can pass.
+
+    An argument matched inside a comment or a string names either nothing or a
+    file the crate does not read; both only widen the digest, which costs a
+    re-extraction and never a wrong offset.
+
+    `#[path]` is the other way a crate compiles a file outside its own tree and
+    is deliberately not walked: of the four in the workspace, the only pair
+    whose `mod` file any crate enumerates redirects into `pyre-jit-trace/src/`,
+    which that same crate's closure already covers. Walk it when a redirection
+    appears that a pathspec does not reach.
+
+    A refusal raised here reaches whoever runs extraction and whoever runs
+    `--fingerprint` from CI, but not `pyre-jit-trace`'s build script: that one
+    collapses every non-answer from this driver to silence on purpose
+    (`pyre/pyre-jit-trace/build.rs` `llbc_fingerprint_output`).
+    """
+    extra: set[Path] = set()
+    pending = [path for path in files if path.suffix == ".rs"]
+    queued = set(pending)
+    while pending:
+        rel_source = pending.pop()
+        source = root / rel_source
+        if not source.is_file():
+            continue
+        text = source.read_text(encoding="utf-8", errors="replace")
+        for call in _INCLUDE_CALL.finditer(text):
+            line = text.count("\n", 0, call.start()) + 1
+            where = f"{rel_source.as_posix()}:{line}"
+            literal = _INCLUDE_PATH.match(text, call.end())
+            if literal is None:
+                _reject_unresolvable_include(where, text[call.end() : call.end() + 80])
+                continue
+            target = (source.parent / literal.group(1)).resolve()
+            if not target.is_file():
+                continue
+            try:
+                rel = target.relative_to(root)
+            except ValueError:
+                raise SystemExit(
+                    f"extract-llbc.py: {where} includes {target}, which is "
+                    "outside the repository. The digest is keyed by "
+                    "repo-relative paths, so that file cannot be hashed and "
+                    "the artefact would read as fresh across edits to it."
+                ) from None
+            if rel in files or rel in extra:
+                continue
+            extra.add(rel)
+            if rel.suffix == ".rs" and rel not in queued:
+                queued.add(rel)
+                pending.append(rel)
+    return extra
+
+
+def _reject_unresolvable_include(where: str, tail: str) -> None:
+    """Let through the spellings whose inputs are covered; refuse the rest."""
+    # `include!()` with no argument only occurs in prose about the macro.
+    if tail.startswith(")"):
+        return
+    # `concat!(env!("OUT_DIR"), ...)` names a file the build script generates
+    # into the cargo out dir, from sources this enumeration already carries.
+    if tail.startswith("concat!") and 'env!("OUT_DIR")' in tail:
+        return
+    # A `macro_rules!` parameter, resolved at each call site. The one instance
+    # is the `appleveldefs:` arm of `pyre_module_init!`, whose call sites pass
+    # sibling `app_*.py` names that the crate's own `src/` pathspec enumerates.
+    if tail.startswith("$"):
+        return
+    raise SystemExit(
+        f"extract-llbc.py: {where} includes `{tail.splitlines()[0].strip()}`, "
+        "which this fingerprint cannot resolve to a path. Whatever it names "
+        "would be a compiler input the digest never hashes, so the artefact "
+        "would read as fresh across edits to it. Either give it a plain "
+        "string literal or add its shape to _reject_unresolvable_include with "
+        "the reason its inputs are already enumerated."
+    )
+
+
 def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> list[Path]:
     root = eng.root
     target_names: list[str] = []
@@ -346,8 +448,28 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
                         if "custom-build" not in kinds:
                             pathspecs.append(str(Path(rel_src).parent) + "/")
 
+    # git is the enumerator, but the index is not the input set: Charon and
+    # rustc read the working tree, so a source file that is on disk and not yet
+    # added belongs in the digest. `--cached` alone leaves it out, and a crate
+    # extracted while one of its files was untracked then fingerprints as fresh
+    # against sources the artefact was never built from — staging that same
+    # file later flips the identical bytes to STALE.
+    #
+    # `--exclude-standard` is what keeps the generated trees out. Everything it
+    # drops under these pathspecs today is produced by a build —
+    # `majit/charon-corpus/{target/,Cargo.lock}` and `pyre/check.snap/` — and
+    # nothing a crate compiles.
     result = subprocess.run(
-        ["git", "ls-files", "-z", "--", *pathspecs],
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            *pathspecs,
+        ],
         cwd=root,
         check=True,
         stdout=subprocess.PIPE,
@@ -357,6 +479,7 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
         for raw in result.stdout.split(b"\0")
         if raw
     }
+    files |= include_closure(root, files)
     return sorted(files, key=lambda path: path.as_posix())
 
 
@@ -369,9 +492,10 @@ def source_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> s
         if full_path.is_file():
             digest.update(full_path.read_bytes())
         else:
-            # `git ls-files` includes tracked paths deleted in the working
-            # tree. A deletion is part of the source state and must change the
-            # fingerprint instead of making extraction unusable until commit.
+            # The `--cached` half of the enumeration includes tracked paths
+            # deleted in the working tree. A deletion is part of the source
+            # state and must change the fingerprint instead of making
+            # extraction unusable until commit.
             digest.update(b"<deleted>")
         digest.update(b"\0")
     return digest.hexdigest()

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -21,6 +21,13 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 
+# Domain separator for the bytes hashed by `source_fingerprint`. Bump this
+# only when the fingerprint algorithm or the meaning of its input set changes.
+# Ordinary refactors, diagnostics and comments in this file do not change what
+# Charon compiles and must not invalidate every multi-minute LLBC artefact.
+FINGERPRINT_SCHEMA = "2"
+
+
 @dataclass
 class CrateSpec:
     """One extractable crate.
@@ -77,6 +84,7 @@ class Engine:
     base_pathspecs: list[str]
     charon_root: Path
     cargo_features: str
+    extraction_abi: str
     metadata_feature_crates: tuple[str, ...] = ()
     layout_targets: tuple[str, ...] = ()
     layout_target_rustflags: str = ""
@@ -190,13 +198,21 @@ def run_capture(args: list[str], *, cwd: Path) -> str:
     ).stdout
 
 
+_host_triple_cache: dict[Path, str] = {}
+
+
 def host_triple(root: Path) -> str:
     if value := os.environ.get("LLBC_TARGET_TRIPLE"):
+        return value
+    cache_key = root.resolve()
+    if value := _host_triple_cache.get(cache_key):
         return value
     rustc_info = run_capture(["rustc", "-vV"], cwd=root)
     for line in rustc_info.splitlines():
         if line.startswith("host: "):
-            return line.removeprefix("host: ")
+            value = line.removeprefix("host: ")
+            _host_triple_cache[cache_key] = value
+            return value
     raise SystemExit("extract-llbc.py: could not determine rustc host triple")
 
 
@@ -416,6 +432,15 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
                     continue
                 seen.add(package_id)
                 package = by_id[package_id]
+                # Apply the exclusion in the walk, not after it. This drops a
+                # package's exclusively-reached subtree as well as the named
+                # package. A node also reachable from a non-excluded parent is
+                # still pushed along that path and therefore remains present.
+                # The extracted artefact guard certifies the named package's
+                # absence; a subtree that has no path avoiding that package
+                # cannot occur without it.
+                if package["name"] in exclude:
+                    continue
                 closure.append(package)
 
                 for dep in resolve_nodes.get(package_id, {}).get("deps", []):
@@ -431,8 +456,6 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
                         stack.append(dep_package["id"])
 
             for package in closure:
-                if package["name"] in exclude:
-                    continue
                 package_dir = Path(package["manifest_path"]).resolve().parent
                 if package_dir.is_relative_to(root):
                     rel_dir = package_dir.relative_to(root).as_posix()
@@ -485,6 +508,41 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
 
 def source_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
     digest = hashlib.sha256()
+    # Keep the cache/staleness key tied to extraction semantics rather than to
+    # the implementation bytes of this driver. The driver-provided ABI covers
+    # repo-specific extraction behaviour; the remaining fields automatically
+    # cover the effective per-crate flags and target-layout configuration.
+    config_fields = [
+        ("fingerprint_schema", FINGERPRINT_SCHEMA),
+        ("extraction_abi", eng.extraction_abi),
+        ("cargo_features", cargo_features),
+        ("layout_target_rustflags", eng.layout_target_rustflags),
+    ]
+    for crate in sorted(crates):
+        spec = eng.spec(crate)
+        flags = crate_flags(spec, cargo_features)
+        config_fields.extend(
+            [
+                (f"{crate}.cargo_flags", "\x1f".join(flags)),
+                (
+                    f"{crate}.charon_flags",
+                    "\x1f".join(charon_crate_flags(spec, cargo_features)),
+                ),
+                (
+                    f"{crate}.layout_targets",
+                    "\x1f".join(crate_layout_targets(eng, spec)),
+                ),
+                (
+                    f"{crate}.layout_flags",
+                    "\x1f".join(crate_layout_flags(spec, cargo_features, flags)),
+                ),
+            ]
+        )
+    for key, value in config_fields:
+        digest.update(key.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(value.encode("utf-8"))
+        digest.update(b"\0")
     for path in fingerprint_inputs(eng, crates, cargo_features):
         digest.update(path.as_posix().encode("utf-8"))
         digest.update(b"\0")
@@ -587,6 +645,8 @@ def stamp_for(
             f"crate={crate}",
             f"platform={platform_key}",
             f"charon={charon_stamp}",
+            f"fingerprint_schema={FINGERPRINT_SCHEMA}",
+            f"extraction_abi={eng.extraction_abi}",
             f"features={cargo_features}",
             f"flags={' '.join(flags)}",
             f"charon_flags={' '.join(charon_flags)}",
@@ -607,6 +667,8 @@ def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
     the crate's own artefact.
     """
     extra = eng.layout_targets if spec.layout_targets is None else spec.layout_targets
+    if not extra:
+        return []
     host = host_triple(eng.root)
     return [t for t in extra if t != host]
 
@@ -885,6 +947,7 @@ def run_cli(
     *,
     root: Path,
     out_dir: Path,
+    extraction_abi: str,
     base_pathspecs: list[str] | None = None,
     charon_root: Path | None = None,
     metadata_feature_crates: tuple[str, ...] = (),
@@ -926,6 +989,7 @@ def run_cli(
         base_pathspecs=list(base_pathspecs) if base_pathspecs else ["Cargo.lock", "Cargo.toml"],
         charon_root=charon_root or root,
         cargo_features=cargo_features,
+        extraction_abi=extraction_abi,
         metadata_feature_crates=metadata_feature_crates,
         layout_targets=layout_targets,
         layout_target_rustflags=layout_target_rustflags,

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Check `include_closure` against every `include*!` argument spelling.
+
+`fingerprint_inputs` decides which bytes the LLBC staleness stamp — and the CI
+cache key built from it — covers. An argument spelling that walks off the end
+of that set does not fail anything: the artefact simply reads as fresh while
+the crate compiles something else. Nothing downstream can notice, so the check
+has to live here.
+
+Runs on a synthetic tree in a temp dir: no cargo, no git, well under a second.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import shutil
+import sys
+import tempfile
+
+ROOT = pathlib.Path(__file__).resolve().parent
+
+
+def load_engine():
+    """Import the engine by path; it is a library the drivers import, not a package."""
+    spec = importlib.util.spec_from_file_location(
+        "llbc_extract", ROOT / "llbc_extract.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    # `@dataclass` resolves annotations through `sys.modules[cls.__module__]`.
+    sys.modules["llbc_extract"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def run(engine) -> int:
+    root = pathlib.Path(tempfile.mkdtemp()).resolve()
+    outside = pathlib.Path(tempfile.mkdtemp()).resolve()
+    try:
+        (root / "src").mkdir()
+        (root / "data").mkdir()
+        (root / "data" / "rules.txt").write_text("rules")
+        (outside / "far.txt").write_text("far")
+
+        # FOLD: the file joins the digest. PASS: nothing to add, and nothing
+        # unresolved was passed over. REFUSE: extraction stops.
+        cases = [
+            ("literal outside the pathspecs", 'include_str!("../data/rules.txt");', "FOLD data/rules.txt"),
+            ("literal already enumerated", 'include_str!("lib.rs");', "PASS"),
+            ("nonexistent path", 'include_str!("../nope.txt");', "PASS"),
+            ("concat!(env!(OUT_DIR))", 'include!(concat!(env!("OUT_DIR"), "/g.rs"));', "PASS"),
+            ("macro_rules! parameter", "include_str!($appfile);", "PASS"),
+            ("prose about the macro", "// how include!() behaves", "PASS"),
+            ("raw literal", 'include_str!(r"../data/rules.txt");', "REFUSE"),
+            ("literal carrying an escape", 'include_str!("../data\\\\rules.txt");', "REFUSE"),
+            ("path through a constant", "include_str!(RULES_PATH);", "REFUSE"),
+        ]
+
+        # One `..` per component of `root/src` below the filesystem anchor.
+        chain = "../" * len(root.parts) + (outside / "far.txt").relative_to(
+            outside.anchor
+        ).as_posix()
+        cases.append(("`..` chain leaving the repo", f'include_str!("{chain}");', "REFUSE"))
+
+        try:
+            (root / "src" / "link.txt").symlink_to(outside / "far.txt")
+            cases.append(("symlink leaving the repo", 'include_str!("link.txt");', "REFUSE"))
+        except OSError as exc:
+            # Windows grants symlink creation only under Developer Mode.
+            print(f"skip: symlink case ({exc})")
+
+        failures = 0
+        for name, body, expected in cases:
+            (root / "src" / "lib.rs").write_text(body + "\n")
+            try:
+                extra = engine.include_closure(root, {pathlib.Path("src/lib.rs")})
+                sorted_extra = sorted(path.as_posix() for path in extra)
+                actual = "FOLD " + ",".join(sorted_extra) if extra else "PASS"
+            except SystemExit:
+                actual = "REFUSE"
+            if actual == expected:
+                print(f"ok   {name}: {actual}")
+            else:
+                failures += 1
+                print(f"FAIL {name}: expected {expected}, got {actual}")
+        return failures
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+        shutil.rmtree(outside, ignore_errors=True)
+
+
+def main() -> None:
+    failures = run(load_engine())
+    if failures:
+        raise SystemExit(f"llbc_extract_selftest: {failures} failed")
+    print("llbc_extract_selftest: all passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import importlib.util
 import pathlib
 import shutil
+import subprocess
 import sys
 import tempfile
 
@@ -89,8 +90,91 @@ def run(engine) -> int:
         shutil.rmtree(outside, ignore_errors=True)
 
 
+def run_fingerprint(engine) -> int:
+    """Exercise the complete source key against a synthetic Git working tree."""
+    root = pathlib.Path(tempfile.mkdtemp()).resolve()
+    try:
+        (root / "src").mkdir()
+        (root / "scripts").mkdir()
+        (root / "Cargo.toml").write_text("[package]\nname='probe'\nversion='0.0.0'\n")
+        (root / ".gitignore").write_text("src/ignored.rs\n")
+        (root / "src" / "lib.rs").write_text("pub fn answer() -> i64 { 42 }\n")
+        tool = root / "scripts" / "tool.py"
+        tool.write_text("# implementation detail\n")
+        subprocess.run(["git", "init", "-q"], cwd=root, check=True)
+        subprocess.run(
+            ["git", "add", ".gitignore", "Cargo.toml", "src/lib.rs", "scripts/tool.py"],
+            cwd=root,
+            check=True,
+        )
+
+        spec = engine.CrateSpec(
+            name="probe",
+            crate_dir=root,
+            output_name="probe.ullbc",
+            fingerprint_pathspecs=["src/"],
+            layout_targets=(),
+        )
+
+        def make_engine(*, extraction_abi="probe-1", rustflags=""):
+            return engine.Engine(
+                specs={"probe": spec},
+                default_crates=["probe"],
+                root=root,
+                out_dir=root / "out",
+                base_pathspecs=["Cargo.toml"],
+                charon_root=root,
+                cargo_features="",
+                extraction_abi=extraction_abi,
+                layout_target_rustflags=rustflags,
+            )
+
+        def fingerprint(eng):
+            return engine.source_fingerprint(eng, ["probe"], "")
+
+        failures = 0
+
+        def expect(name, condition):
+            nonlocal failures
+            if condition:
+                print(f"ok   {name}")
+            else:
+                failures += 1
+                print(f"FAIL {name}")
+
+        eng = make_engine()
+        base = fingerprint(eng)
+
+        tool.write_text("# diagnostics and comments changed\n")
+        expect("tool implementation is outside the source key", fingerprint(eng) == base)
+
+        untracked = root / "src" / "new.rs"
+        untracked.write_text("pub fn new_item() {}\n")
+        before_stage = fingerprint(eng)
+        expect("untracked source moves the source key", before_stage != base)
+        subprocess.run(["git", "add", "src/new.rs"], cwd=root, check=True)
+        expect("staging identical bytes preserves the source key", fingerprint(eng) == before_stage)
+
+        ignored = root / "src" / "ignored.rs"
+        ignored.write_text("build output\n")
+        expect("ignored file stays outside the source key", fingerprint(eng) == before_stage)
+
+        expect(
+            "extraction ABI moves the cache and staleness key",
+            fingerprint(make_engine(extraction_abi="probe-2")) != before_stage,
+        )
+        expect(
+            "effective layout configuration moves the key",
+            fingerprint(make_engine(rustflags="--cfg changed")) != before_stage,
+        )
+        return failures
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
 def main() -> None:
-    failures = run(load_engine())
+    engine = load_engine()
+    failures = run(engine) + run_fingerprint(engine)
     if failures:
         raise SystemExit(f"llbc_extract_selftest: {failures} failed")
     print("llbc_extract_selftest: all passed")


### PR DESCRIPTION
## Summary
- fingerprint untracked working-tree sources and files reached by `include!`/`include_str!`/`include_bytes!`
- reject unresolved or out-of-repository include inputs and exercise the walk in CI
- key LLBC freshness on an explicit fingerprint schema/extraction ABI plus effective Cargo, Charon, and layout configuration, instead of extraction-tool source bytes
- drop subtrees reached exclusively through excluded dependencies

## Why
The old key enumerated Git's index and crate pathspecs, so untracked sources and out-of-crate include inputs could leave stale LLBC looking fresh. At the same time, every edit to extraction diagnostics, tests, or wrappers invalidated all four expensive LLBC artifacts even when Charon output semantics were unchanged.

This patch makes missing compiler inputs fail closed while separating extraction semantics from tooling implementation details. A schema/ABI bump still forces the intentional one-time invalidation.

## Impact
- tool-only refactors no longer re-extract all LLBC artifacts
- current input counts fall from 53/111/419/703 to 49/107/411/699 for majit-rlib/pyre-object/pyre-interpreter/pyre-jit
- the new schema intentionally makes existing local stamps stale once

## Validation
- `python3 scripts/llbc_extract_selftest.py`
- `python3 -m py_compile scripts/llbc_extract.py scripts/llbc_extract_selftest.py pyre/scripts/extract-llbc.py`
- `git diff --check`
- `PYRE_LLBC_STRICT=0 cargo check --features dynasm`
- `PYRE_LLBC_STRICT=0 cargo test --features dynasm` (8 passed)

A strict `cargo check --features dynasm` reached the expected one-time schema transition and refused the four pre-existing local LLBC stamps as stale; no LLBC re-extraction was run locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved LLBC extraction fingerprinting to detect changes across tracked, untracked, and working-tree files.
  * Added support for resolving supported include paths while rejecting unsafe or invalid references.
  * Added cache invalidation for extraction behavior and layout changes.

* **Bug Fixes**
  * Improved handling of dependency exclusions, host detection, and empty cross-target layouts.
  * Added automated self-tests covering include resolution, symlinks, path traversal, and fingerprint behavior.

* **Chores**
  * Excluded macOS `.DS_Store` files from repository fingerprints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->