### PR TITLE
stdlib: complete json, struct, hashlib, and hmac

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -164,12 +176,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake2"
-version = "0.10.6"
+name = "blake2b_simd"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+checksum = "b79834656f71332577234b50bfc009996f7449e0c056884e6a02492ded0ca2f3"
 dependencies = [
- "digest",
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
+
+[[package]]
+name = "blake2s_simd"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee29928bad1e3f94c9d1528da29e07a1d3d04817ae8332de1e8b846c8439f4b3"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -274,6 +299,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,6 +356,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
@@ -764,7 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1046,6 +1087,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1261,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2008,6 +2067,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "petgraph"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2305,9 +2374,11 @@ dependencies = [
 name = "pyre-native"
 version = "0.0.2"
 dependencies = [
- "blake2",
+ "blake2b_simd",
+ "blake2s_simd",
  "flate2",
  "md-5",
+ "scrypt",
  "sha1",
  "sha2",
  "sha3",
@@ -2620,7 +2691,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2914,6 +2985,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "salsa20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,6 +3016,17 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "scrypt"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
+dependencies = [
+ "pbkdf2",
+ "salsa20",
+ "sha2",
+]
 
 [[package]]
 name = "semver"
@@ -3195,7 +3286,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4052,7 +4143,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,9 @@ md-5 = "0.10"
 sha1 = "0.10"
 sha2 = "0.10"
 sha3 = "0.10"
-blake2 = "0.10"
+blake2b_simd = { version = "1.0.4", default-features = false }
+blake2s_simd = { version = "1.0.4", default-features = false }
+scrypt = { version = "0.11", default-features = false }
 # zlib backend (pyre-native only): zlib-rs is a pure-Rust zlib port whose
 # DEFLATE output is byte-identical to the reference C zlib.
 flate2 = { version = "1.1.9", default-features = false }

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -562,13 +562,13 @@
       "dynasm": "PASS"
     },
     "test.test_hashlib": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_heapq": {
       "dynasm": "PASS"
     },
     "test.test_hmac": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_html": {
       "cranelift": "PASS",
@@ -644,7 +644,7 @@
       "dynasm": "PASS"
     },
     "test.test_json": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_keyword": {
       "cranelift": "PASS",
@@ -1069,7 +1069,7 @@
       "dynasm": "PASS"
     },
     "test.test_struct": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_structseq": {
       "dynasm": "PASS"

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -436,6 +436,12 @@ thread_local! {
 pub(crate) struct BuiltinModuleDef {
     init: fn(PyObjectRef),
     startup: Option<fn(PyObjectRef, *const PyExecutionContext) -> Result<(), crate::PyError>>,
+    /// The module follows ordinary `sys.modules` ownership and may be
+    /// collected after a fresh import is removed from that cache. Most of
+    /// pyre's legacy MixedModules still have JIT/native owners that require
+    /// their historical immortal holder; opt in only after that module's
+    /// state and cached references have been audited.
+    collectible: bool,
 }
 
 struct ImportRootArea {
@@ -469,6 +475,20 @@ pub fn register_builtin_module(name: &'static str, init: fn(PyObjectRef)) {
         BuiltinModuleDef {
             init,
             startup: None,
+            collectible: false,
+        },
+    );
+}
+
+/// Register a builtin module whose holder has no native/JIT owner beyond the
+/// ordinary Python object graph.
+pub fn register_collectible_builtin_module(name: &'static str, init: fn(PyObjectRef)) {
+    BUILTIN_MODULES.lock().unwrap().insert(
+        name,
+        BuiltinModuleDef {
+            init,
+            startup: None,
+            collectible: true,
         },
     );
 }
@@ -486,6 +506,7 @@ pub fn register_builtin_module_with_startup(
         BuiltinModuleDef {
             init,
             startup: Some(startup),
+            collectible: false,
         },
     );
 }
@@ -671,7 +692,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(_random);
     pyre_install_module!(_pypy_generic_alias);
     pyre_install_module!(_pickle);
-    pyre_install_module!("_struct"(r#struct));
+    register_collectible_builtin_module("_struct", crate::module::r#struct::init);
     pyre_install_module!(binascii);
     pyre_install_module!(marshal);
     pyre_install_module!(zlib);
@@ -1025,7 +1046,16 @@ pub(crate) fn load_builtin_module(name: &str) -> Option<PyObjectRef> {
             crate::gateway::with_module(static_name, value);
         }
     }
-    let module = pyre_object::w_module_new_aliasing_dict(name, w_dict);
+    // Before `sys.modules` exists the native bootstrap registry is the only
+    // owner and retains the legacy immortal module shape. Afterwards an
+    // audited collectible module follows the PyPy `space.sys.modules` object
+    // graph; legacy MixedModules retain the immortal holder until their
+    // native/JIT caches have been migrated to traced owners.
+    let module = if sys_modules_dict().is_null() || !module_def.collectible {
+        pyre_object::w_module_new_aliasing_dict(name, w_dict)
+    } else {
+        pyre_object::w_module_new_aliasing_dict_managed(name, w_dict)
+    };
     // function.py:797-815 BuiltinFunction.w_moduleobj — MixedModule binds
     // every interp-level function to the live defining module object.
     for key in &keys {
@@ -1607,10 +1637,16 @@ pub fn sys_modules_dict() -> PyObjectRef {
 }
 
 pub fn set_sys_module(name: &str, module: PyObjectRef) {
-    // A new module joins the `walk_module_dicts_gc` root set; its dict
-    // may hold young values — rescan on the next minor collection.
+    // Native-owned immortal modules need their managed dicts in
+    // `walk_module_dicts_gc`; managed modules are instead reached through the
+    // ordinary object graph rooted at `sys.modules`.  Test actual ownership,
+    // not whether that dict currently exists: the immortal bootstrap `sys`
+    // module installs `sys.modules` from inside its initializer, before this
+    // function receives the finished module.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
-    MODULE_DICT_ROOTS.lock().unwrap().insert(module as usize);
+    if !majit_gc::gc_owns_object(module as usize) {
+        MODULE_DICT_ROOTS.lock().unwrap().insert(module as usize);
+    }
     SYS_MODULES
         .lock()
         .unwrap()
@@ -1639,6 +1675,37 @@ pub fn remove_sys_module(name: &str) {
             pyre_object::w_dict_delitem_str(dict, name);
         }
     }
+}
+
+/// Drop the Python-visible import cache during process shutdown.
+///
+/// CPython's `finalize_modules()` clears `sys.modules` before module-global
+/// teardown; PyPy's object space likewise owns modules through
+/// `space.sys.modules`, rather than a permanent side table.  Keeping every
+/// imported module in the cache until `process::exit` prevents its managed
+/// module/dict cycles and their `__del__` objects from ever becoming
+/// unreachable.  Retain `sys` and `builtins` themselves because pyre's
+/// unraisable-error path still consults their live dictionaries while the
+/// released modules are finalized.
+pub fn release_sys_modules_for_shutdown() -> Vec<PyObjectRef> {
+    let dict = sys_modules_dict();
+    if dict.is_null() {
+        return Vec::new();
+    }
+    let entries = unsafe { pyre_object::w_dict_str_entries(dict) };
+    let mut modules = Vec::new();
+    for (name, module) in entries {
+        if matches!(name.as_str(), "sys" | "builtins") {
+            continue;
+        }
+        if !module.is_null() && unsafe { pyre_object::is_module(module) } {
+            modules.push(module);
+        }
+        unsafe {
+            pyre_object::w_dict_delitem_str(dict, &name);
+        }
+    }
+    modules
 }
 
 /// GC root walk over every bound module's dict storage.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1104,22 +1104,26 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // payload tail without renumbering an established class.
         subclass_range_alias(162, typed::<crate::module::_json::W_Scanner>()),
         subclass_range_alias(163, typed::<crate::module::_json::W_Encoder>()),
+        // `_hashlib`'s per-object digest/HMAC contexts follow their Python
+        // owners and have sweep-time native-state destructors in build_gc.
+        subclass_range_alias(164, typed::<crate::module::_hashlib::W_HashState>()),
+        subclass_range_alias(165, typed::<crate::module::_hashlib::W_Hmac>()),
         // `gc.GcRef` keeps its raw referent as a traced wrapper field.
         // referent field is traced on the wrapper itself, as in
         // `pypy/module/gc/referents.py`.
-        subclass_range_alias(164, typed::<crate::module::gc::gcref::W_GcRef>()),
+        subclass_range_alias(166, typed::<crate::module::gc::gcref::W_GcRef>()),
         // `gc.hooks` owns its three callback references directly, matching
         // W_AppLevelHooks in pypy/module/gc/hook.py.
-        subclass_range_alias(165, typed::<crate::module::gc::hook::W_AppLevelHooks>()),
+        subclass_range_alias(167, typed::<crate::module::gc::hook::W_AppLevelHooks>()),
         // `gc._get_stats()` returns referents.py's native W_GcStats owner.
-        subclass_range_alias(166, typed::<crate::module::gc::stats::W_GcStats>()),
+        subclass_range_alias(168, typed::<crate::module::gc::stats::W_GcStats>()),
         // `posix.DirEntry` — `allocate_stable` type registered last among the
         // native rclass registrations in `build_gc`, before the bare twister
         // id.
         // `posix` is compiled out on wasm32 (`module/mod.rs`), so this alias is
         // too; nothing unconditional follows it, so no id differs per target.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(167, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(169, typed::<crate::module::posix::W_DirEntry>()),
     ]
 }
 

--- a/pyre/pyre-interpreter/src/module/_blake2/_blake2_app.py
+++ b/pyre/pyre-interpreter/src/module/_blake2/_blake2_app.py
@@ -1,19 +1,177 @@
-"""App-level _blake2 constructors backed by the _hashlib HASH object.
+"""PyPy-shaped BLAKE2 objects with object-owned native digest state.
 
-Only the default digest sizes (blake2b-512 / blake2s-256) are computed;
-the keyed/salted/personalised parameters are accepted and ignored.
+The validation and object shape follow ``lib_pypy/_blake2/__init__.py``.
+Only the RFC 7693 state machine lives in ``_hashlib._blake2_new`` so copying,
+incremental updates, and GC ownership remain on the Python hash object rather
+than in a TLS cache or global side table.
 """
 
+import operator as _operator
 
-def blake2b(data=b"", *, digest_size=64, key=b"", salt=b"", person=b"",
-            fanout=1, depth=1, leaf_size=0, node_offset=0, node_depth=0,
-            inner_size=0, last_node=False, usedforsecurity=True):
-    from _hashlib import HASH
-    return HASH("blake2b", data)
+from _hashlib import _blake2_new as _new_state
 
 
-def blake2s(data=b"", *, digest_size=32, key=b"", salt=b"", person=b"",
-            fanout=1, depth=1, leaf_size=0, node_offset=0, node_depth=0,
-            inner_size=0, last_node=False, usedforsecurity=True):
-    from _hashlib import HASH
-    return HASH("blake2s", data)
+class _Immutable(type):
+    def __init__(cls, name, bases, namespace):
+        type.__setattr__(cls, "_immutable_names", frozenset(namespace))
+        type.__init__(cls, name, bases, namespace)
+
+    def __setattr__(cls, name, value):
+        qualname = ".".join((cls.__module__, cls.__name__))
+        raise TypeError(
+            "cannot set %r attribute of immutable type %r" % (name, qualname)
+        )
+
+
+_MISSING = object()
+
+
+def _make_blake_type(class_name, _salt_size, _person_size, _key_size,
+                     _digest_size, max_offset, _block_size):
+    class _Blake(metaclass=_Immutable):
+        SALT_SIZE = _salt_size
+        PERSON_SIZE = _person_size
+        MAX_KEY_SIZE = _key_size
+        MAX_DIGEST_SIZE = _digest_size
+
+        def __new__(cls, *args, **kwargs):
+            # Argument Clinic diagnoses a duplicate positional/keyword `data`
+            # before unknown keywords, then diagnoses unknown keywords before
+            # the data/string conflict. Python-function binding uses different
+            # wording, so preserve CPython's public ordering explicitly.
+            if len(args) > 1:
+                raise TypeError(
+                    "%s() takes at most 1 positional argument (%d given)" %
+                    (class_name, len(args))
+                )
+            if args and "data" in kwargs:
+                raise TypeError(
+                    "argument for %s() given by name ('data') and position (1)" %
+                    class_name
+                )
+            allowed = {
+                "data", "digest_size", "key", "salt", "person", "fanout",
+                "depth", "leaf_size", "node_offset", "node_depth",
+                "inner_size", "last_node", "usedforsecurity", "string",
+            }
+            for keyword in kwargs:
+                if keyword not in allowed:
+                    raise TypeError(
+                        "%s() got an unexpected keyword argument %r" %
+                        (class_name, keyword)
+                    )
+            data = args[0] if args else kwargs.get("data", _MISSING)
+            string = kwargs.get("string", _MISSING)
+            if data is not _MISSING and string is not _MISSING:
+                raise TypeError(
+                    "'data' and 'string' are mutually exclusive and support "
+                    "for 'string' keyword parameter is slated for removal in "
+                    "a future version."
+                )
+            if data is _MISSING:
+                data = b"" if string is _MISSING else string
+
+            digest_size = kwargs.get("digest_size", _digest_size)
+            key = kwargs.get("key", b"")
+            salt = kwargs.get("salt", b"")
+            person = kwargs.get("person", b"")
+            fanout = kwargs.get("fanout", 1)
+            depth = kwargs.get("depth", 1)
+            leaf_size = kwargs.get("leaf_size", 0)
+            node_offset = kwargs.get("node_offset", 0)
+            node_depth = kwargs.get("node_depth", 0)
+            inner_size = kwargs.get("inner_size", 0)
+            last_node = kwargs.get("last_node", False)
+            usedforsecurity = kwargs.get("usedforsecurity", True)
+
+            # PyPy sets every integer parameter into the native parameter
+            # block after range checking. operator.index matches the clinic
+            # integer converters while accepting integer subclasses.
+            digest_size = _operator.index(digest_size)
+            fanout = _operator.index(fanout)
+            depth = _operator.index(depth)
+            leaf_size = _operator.index(leaf_size)
+            node_offset = _operator.index(node_offset)
+            node_depth = _operator.index(node_depth)
+            inner_size = _operator.index(inner_size)
+            if not 1 <= digest_size <= cls.MAX_DIGEST_SIZE:
+                raise ValueError(
+                    "digest_size must be between 1 and %d bytes" %
+                    cls.MAX_DIGEST_SIZE
+                )
+            if len(key) > cls.MAX_KEY_SIZE:
+                raise ValueError("maximum key length is %d bytes" % cls.MAX_KEY_SIZE)
+            if len(salt) > cls.SALT_SIZE:
+                raise ValueError("maximum salt length is %d bytes" % cls.SALT_SIZE)
+            if len(person) > cls.PERSON_SIZE:
+                raise ValueError("maximum person length is %d bytes" % cls.PERSON_SIZE)
+            if not 0 <= fanout <= 255:
+                raise ValueError("fanout must be between 0 and 255")
+            if not 1 <= depth <= 255:
+                raise ValueError("depth must be between 1 and 255")
+            if leaf_size < 0:
+                raise ValueError("value must be positive")
+            if leaf_size > 0xFFFFFFFF:
+                raise OverflowError("leaf_size is too large")
+            if node_offset < 0:
+                raise ValueError("value must be positive")
+            if node_offset > max_offset:
+                raise OverflowError("node_offset is too large")
+            if not 0 <= node_depth <= 255:
+                raise ValueError("node_depth must be between 0 and 255")
+            if not 0 <= inner_size <= cls.MAX_DIGEST_SIZE:
+                raise ValueError(
+                    "inner_size must be between 0 and %d" %
+                    cls.MAX_DIGEST_SIZE
+                )
+
+            # Both clinic bool converters are observable through __bool__.
+            bool(usedforsecurity)
+            last_node = bool(last_node)
+            self = object.__new__(cls)
+            self._state = _new_state(
+                class_name, data, digest_size, key, salt, person, fanout,
+                depth, leaf_size, node_offset, node_depth, inner_size,
+                last_node,
+            )
+            return self
+
+        @property
+        def name(self):
+            return class_name
+
+        @property
+        def block_size(self):
+            return _block_size
+
+        @property
+        def digest_size(self):
+            return self._state.digest_size
+
+        def update(self, data):
+            self._state.update(data)
+
+        def digest(self):
+            return self._state.digest()
+
+        def hexdigest(self):
+            return self._state.hexdigest()
+
+        def copy(self):
+            other = object.__new__(type(self))
+            other._state = self._state.copy()
+            return other
+
+        def __repr__(self):
+            return "<%s.%s object at 0x%x>" % (
+                type(self).__module__, type(self).__name__, id(self)
+            )
+
+    type.__setattr__(_Blake, "__name__", class_name)
+    type.__setattr__(_Blake, "__qualname__", class_name)
+    type.__setattr__(_Blake, "__module__", "_blake2")
+    return _Blake
+
+
+blake2b = _make_blake_type("blake2b", 16, 16, 64, 64, (1 << 64) - 1, 128)
+blake2s = _make_blake_type("blake2s", 8, 8, 32, 32, (1 << 48) - 1, 64)

--- a/pyre/pyre-interpreter/src/module/_blake2/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_blake2/mod.rs
@@ -1,10 +1,12 @@
-//! _blake2 module — hashlib blocks OpenSSL's blake2 and uses this builtin
-//! instead.  The constructors defer to the `_hashlib` HASH object, which
-//! computes blake2b-512 / blake2s-256 through RustCrypto.
+//! `_blake2` module constants and PyPy-shaped app-level object types.
+//!
+//! The wrappers mirror `lib_pypy/_blake2/__init__.py`; their object-owned
+//! native RFC 7693 contexts are created by `_hashlib._blake2_new`.
 
 crate::py_module! {
     "_blake2",
     int_constants: {
+        "_GIL_MINSIZE" => 2048,
         "BLAKE2B_SALT_SIZE" => 16,
         "BLAKE2B_PERSON_SIZE" => 16,
         "BLAKE2B_MAX_KEY_SIZE" => 64,

--- a/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_hashlib/mod.rs
@@ -1,12 +1,11 @@
 //! _hashlib module — the OpenSSL-backed digest surface `hashlib.py` probes.
 //!
-//! The actual digests are computed by `pyre-native` through
-//! [`oneshot_digest`]; the `HASH` object lives in the app-level
-//! `_hashlib_app.py`, while the non-binding `openssl_<name>` and `new`
-//! constructors are interp-level here and build a `HASH`, which calls back
-//! into `_oneshot_digest` at digest time.  Accumulating the data and
-//! re-hashing on `digest()` keeps the object model trivial at the cost of
-//! recomputation.
+//! Digest state is object-owned, matching PyPy/CPython's per-HASH context.
+//! The algorithm implementations live in `pyre-native` (outside LLBC
+//! extraction); `_HashState` embeds their fixed-size opaque state buffer in
+//! the GC payload, so there is no TLS, global registry, or semantic side
+//! table. `HASH` and its `HASHXOF` subclass are native immutable types whose
+//! methods operate directly on that incremental state.
 
 use pyre_object::*;
 
@@ -58,31 +57,290 @@ fn lookup_digest_name(name: &[u8]) -> Option<&'static str> {
         .map(|(python_name, _)| *python_name)
 }
 
-/// `_oneshot_digest(name, data, length=0)` — bytes of the digest.
-fn oneshot_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let name_obj = args.first().copied().unwrap_or_else(w_none);
-    if !unsafe { is_str(name_obj) } {
-        return Err(crate::PyError::type_error("digest name must be a string"));
+const HASH_STATE_WORDS: usize = 64;
+
+#[repr(C)]
+struct HashStateStorage {
+    words: [usize; HASH_STATE_WORDS + 1],
+}
+
+impl HashStateStorage {
+    fn as_ptr(&self) -> *const usize {
+        let address = self.words.as_ptr() as usize;
+        ((address + 15) & !15) as *const usize
     }
-    let name = crate::baseobjspace::str_utf8_w(name_obj)?.to_string();
-    let data = match args.get(1).copied() {
-        Some(obj) if unsafe { bytesobject::is_bytes_like(obj) } => {
-            unsafe { bytesobject::bytes_like_data(obj) }.to_vec()
+
+    fn as_mut_ptr(&mut self) -> *mut usize {
+        self.as_ptr() as *mut usize
+    }
+}
+
+/// The fixed-size native digest context embedded directly in its Python
+/// owner. CPython stores an `EVP_MD_CTX *` on `EVPobject`; this inline opaque
+/// buffer is pyre-native's allocation-free equivalent.
+#[crate::pyre_class("_hashlib.HASH")]
+pub struct W_HashState {
+    name: PyObjectRef,
+    digest_size: i64,
+    storage: HashStateStorage,
+}
+
+impl W_HashState {
+    fn new(name: &'static str, data: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+        assert_eq!(
+            HASH_STATE_WORDS,
+            pyre_native::hash::HASH_STATE_STORAGE_WORDS
+        );
+        assert_eq!(16, pyre_native::hash::HASH_STATE_STORAGE_ALIGN);
+        let _roots = gc_roots::push_roots();
+        let name_slot = gc_roots::shadow_stack_len();
+        gc_roots::pin_root(w_str_new(name));
+        let state = W_HashState::allocate_stable(W_HashState {
+            ob: PyObject::default(),
+            name: gc_roots::shadow_stack_get(name_slot),
+            digest_size: pyre_native::hash::digest_output_size(name).unwrap_or(0) as i64,
+            storage: HashStateStorage {
+                words: [0; HASH_STATE_WORDS + 1],
+            },
+        });
+        let this = W_HashState::from_obj(state).expect("fresh _HashState");
+        assert!(unsafe {
+            pyre_native::hash::state_init(this.storage.as_mut_ptr(), HASH_STATE_WORDS, name)
+        });
+        if !data.is_empty() {
+            unsafe {
+                pyre_native::hash::state_update(this.storage.as_mut_ptr(), HASH_STATE_WORDS, data);
+            }
         }
-        Some(obj) if unsafe { is_none(obj) } => Vec::new(),
-        None => Vec::new(),
-        _ => return Err(crate::PyError::type_error("data must be bytes-like")),
-    };
-    let length = args
-        .get(2)
-        .map(|&o| unsafe { w_int_get_value(o) } as usize)
-        .unwrap_or(0);
-    match pyre_native::hash::compute_digest(&name, &data, length) {
-        Some(out) => Ok(w_bytes_from_bytes(&out)),
-        None => Err(crate::PyError::value_error(format!(
-            "unsupported hash type {name}"
-        ))),
+        if matches!(name, "shake_128" | "shake_256") {
+            unsafe { (*state).w_class = hash_xof_type() };
+        }
+        Ok(state)
     }
+
+    #[allow(clippy::too_many_arguments)]
+    fn new_blake2(
+        name: &'static str,
+        data: &[u8],
+        digest_size: usize,
+        key: &[u8],
+        salt: &[u8],
+        person: &[u8],
+        fanout: u8,
+        depth: u8,
+        leaf_size: u32,
+        node_offset: u64,
+        node_depth: u8,
+        inner_size: usize,
+        last_node: bool,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        let _roots = gc_roots::push_roots();
+        let name_slot = gc_roots::shadow_stack_len();
+        gc_roots::pin_root(w_str_new(name));
+        let state = W_HashState::allocate_stable(W_HashState {
+            ob: PyObject::default(),
+            name: gc_roots::shadow_stack_get(name_slot),
+            digest_size: digest_size as i64,
+            storage: HashStateStorage {
+                words: [0; HASH_STATE_WORDS + 1],
+            },
+        });
+        let this = W_HashState::from_obj(state).expect("fresh BLAKE2 state");
+        assert!(unsafe {
+            pyre_native::hash::state_init_blake2(
+                this.storage.as_mut_ptr(),
+                HASH_STATE_WORDS,
+                name,
+                digest_size,
+                key,
+                salt,
+                person,
+                fanout,
+                depth,
+                leaf_size,
+                node_offset,
+                node_depth,
+                inner_size,
+                last_node,
+            )
+        });
+        if !data.is_empty() {
+            unsafe {
+                pyre_native::hash::state_update(this.storage.as_mut_ptr(), HASH_STATE_WORDS, data);
+            }
+        }
+        Ok(state)
+    }
+
+    fn canonical_name(&self) -> &str {
+        unsafe { w_str_get_value(self.name) }
+    }
+
+    fn digest_bytes(&self, method: &str, args: &[PyObjectRef]) -> Result<Vec<u8>, crate::PyError> {
+        let name = self.canonical_name();
+        let length = if matches!(name, "shake_128" | "shake_256") {
+            if args.len() != 1 {
+                return Err(crate::PyError::type_error(format!(
+                    "{method}() missing required argument 'length' (pos 1)"
+                )));
+            }
+            let length = crate::baseobjspace::int_w(crate::baseobjspace::space_index(args[0])?)?;
+            usize::try_from(length)
+                .map_err(|_| crate::PyError::value_error("length must be non-negative"))?
+        } else {
+            if !args.is_empty() {
+                return Err(crate::PyError::type_error(format!(
+                    "{method}() takes no arguments ({} given)",
+                    args.len()
+                )));
+            }
+            0
+        };
+        Ok(unsafe {
+            pyre_native::hash::state_digest(self.storage.as_ptr(), HASH_STATE_WORDS, length)
+        })
+    }
+}
+
+/// Sweep-time cleanup for the placement-initialized native digest context.
+/// The Python name is a traced raw reference and has no Rust drop glue.
+pub unsafe fn w_hash_state_dealloc(obj: PyObjectRef) {
+    let this = unsafe { &mut *(obj as *mut W_HashState) };
+    unsafe {
+        pyre_native::hash::state_drop(this.storage.as_mut_ptr(), HASH_STATE_WORDS);
+    }
+}
+
+mod hash_state_class {
+    use super::*;
+
+    #[crate::pyre_methods]
+    impl W_HashState {
+        #[staticmethod]
+        fn __new__(
+            _cls: PyObjectRef,
+            _args: &[PyObjectRef],
+        ) -> Result<PyObjectRef, crate::PyError> {
+            Err(crate::PyError::type_error(
+                "cannot create '_hashlib.HASH' instances",
+            ))
+        }
+
+        #[getter]
+        fn name(&self) -> PyObjectRef {
+            self.name
+        }
+
+        #[getter]
+        fn digest_size(&self) -> i64 {
+            self.digest_size
+        }
+
+        #[getter]
+        fn block_size(&self) -> i64 {
+            match self.canonical_name() {
+                "md5" | "sha1" | "sha224" | "sha256" | "blake2s" => 64,
+                "sha384" | "sha512" | "blake2b" => 128,
+                "sha3_224" => 144,
+                "sha3_256" | "shake_256" => 136,
+                "sha3_384" => 104,
+                "sha3_512" => 72,
+                "shake_128" => 168,
+                _ => 0,
+            }
+        }
+
+        fn update(&mut self, data: PyObjectRef) -> Result<(), crate::PyError> {
+            let data = read_hash_buffer(data)?;
+            unsafe {
+                pyre_native::hash::state_update(self.storage.as_mut_ptr(), HASH_STATE_WORDS, &data);
+            }
+            Ok(())
+        }
+
+        fn digest(&self, args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+            Ok(w_bytes_from_bytes(
+                &self.digest_bytes("digest", &args[1..])?,
+            ))
+        }
+
+        fn hexdigest(&self, args: &[PyObjectRef]) -> Result<String, crate::PyError> {
+            let digest = self.digest_bytes("hexdigest", &args[1..])?;
+            let mut out = String::with_capacity(digest.len() * 2);
+            for byte in digest {
+                use std::fmt::Write;
+                let _ = write!(out, "{byte:02x}");
+            }
+            Ok(out)
+        }
+
+        fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
+            let _roots = gc_roots::push_roots();
+            let name_slot = gc_roots::shadow_stack_len();
+            gc_roots::pin_root(self.name);
+            let clone = W_HashState::allocate_stable(W_HashState {
+                ob: PyObject::default(),
+                name: gc_roots::shadow_stack_get(name_slot),
+                digest_size: self.digest_size,
+                storage: HashStateStorage {
+                    words: [0; HASH_STATE_WORDS + 1],
+                },
+            });
+            let clone = W_HashState::from_obj(clone).expect("fresh _HashState");
+            unsafe {
+                pyre_native::hash::state_copy(
+                    self.storage.as_ptr(),
+                    clone.storage.as_mut_ptr(),
+                    HASH_STATE_WORDS,
+                );
+                // PyPy `_hashlib.HASHXOF(HASH)` and CPython EVP_copy preserve
+                // the concrete HASH/HASHXOF class. Both share the same native
+                // payload layout, so carry the live instance's class tag.
+                clone.ob.w_class = self.ob.w_class;
+            }
+            Ok(clone as *mut W_HashState as PyObjectRef)
+        }
+
+        fn __repr__(&self) -> String {
+            let class_name = if matches!(self.canonical_name(), "shake_128" | "shake_256") {
+                "HASHXOF"
+            } else {
+                "HASH"
+            };
+            format!(
+                "<{} _hashlib.{class_name} object @ {:#x}>",
+                self.canonical_name(),
+                self as *const Self as usize
+            )
+        }
+    }
+}
+
+/// PyPy `lib_pypy/_hashlib/__init__.py`: `class HASHXOF(HASH): pass`.
+///
+/// The subclass introduces no fields, hence it deliberately reuses HASH's
+/// `W_HashState` layout instead of inventing a parallel payload or side table.
+#[majit_macros::dont_look_inside]
+fn hash_xof_type() -> PyObjectRef {
+    static TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+    *TYPE.get_or_init(|| {
+        crate::typedef::make_builtin_type_with_layout(
+            "_hashlib.HASHXOF",
+            |ns| unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                    ns,
+                    "__new__",
+                    crate::typedef::make_new_descr(|_| {
+                        Err(crate::PyError::type_error(
+                            "cannot create '_hashlib.HASHXOF' instances",
+                        ))
+                    }),
+                )
+            },
+            hash_state_class::type_object(),
+            <W_HashState as crate::PyreClassPyTypeOf>::PYTYPE,
+        ) as usize
+    }) as PyObjectRef
 }
 
 /// The `name: str` clinic conversion: `name` must be a str (or subclass, per
@@ -119,25 +377,9 @@ fn check_digest_name(name_obj: PyObjectRef) -> Result<(), crate::PyError> {
     Ok(())
 }
 
-/// `HASH(name)` name resolution — the Python name of the digest `name`
-/// selects.  OpenSSL resolves the digest when the context is created, so an
-/// unknown name is reported there rather than when the digest is finally
-/// taken.
-fn resolve_digest_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let name_obj = args.first().copied().unwrap_or_else(w_none);
-    check_digest_name(name_obj)?;
-    let name = unsafe { w_str_get_wtf8(name_obj) };
-    match lookup_digest_name(name.as_bytes()) {
-        Some(python_name) => Ok(w_str_new(python_name)),
-        None => Err(unsupported_digestmod(&format!(
-            "unsupported hash type {name}"
-        ))),
-    }
-}
-
 /// Build a `PyError` raising `_hashlib.UnsupportedDigestmodError` with `msg`.
-/// `hmac.py` catches this to fall back to its pure-Python HMAC, so the OpenSSL
-/// HMAC entry points always raise it: we have no streaming HMAC primitive.
+/// `hmac.py` catches this to fall back to its pure-Python HMAC when the
+/// requested digest is not one of the native streaming implementations.
 fn unsupported_digestmod(msg: &str) -> crate::PyError {
     let mut err = crate::PyError::value_error(msg.to_string());
     if let Some(cls) = crate::builtins::lookup_exc_class("_hashlib.UnsupportedDigestmodError") {
@@ -149,20 +391,494 @@ fn unsupported_digestmod(msg: &str) -> crate::PyError {
     err
 }
 
-/// `hmac_new(key, msg=b'', *, digestmod)` — always declines so `hmac.py`
-/// takes its pure-Python `_init_old` path.
-fn hmac_new(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Err(unsupported_digestmod("unsupported hash type"))
+const HMAC_STATE_WORDS: usize = 128;
+
+#[repr(C)]
+struct HmacStateStorage {
+    words: [usize; HMAC_STATE_WORDS + 1],
 }
 
-/// `hmac_digest(key, msg, digest)` — always declines so `hmac.digest()` takes
-/// its `_compute_digest_fallback` path.
-fn hmac_digest(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Err(unsupported_digestmod("unsupported hash type"))
+impl HmacStateStorage {
+    fn as_ptr(&self) -> *const usize {
+        let address = self.words.as_ptr() as usize;
+        ((address + 15) & !15) as *const usize
+    }
+
+    fn as_mut_ptr(&mut self) -> *mut usize {
+        self.as_ptr() as *mut usize
+    }
+}
+
+#[crate::pyre_class("_hashlib.HMAC")]
+pub struct W_Hmac {
+    name: PyObjectRef,
+    digest_size: i64,
+    block_size: i64,
+    storage: HmacStateStorage,
+}
+
+impl W_Hmac {
+    fn new(name: &'static str, key: &[u8], msg: &[u8]) -> Result<PyObjectRef, crate::PyError> {
+        assert_eq!(
+            HMAC_STATE_WORDS,
+            pyre_native::hash::HMAC_STATE_STORAGE_WORDS
+        );
+        assert_eq!(16, pyre_native::hash::HMAC_STATE_STORAGE_ALIGN);
+        let digest_size = pyre_native::hash::digest_output_size(name)
+            .ok_or_else(|| unsupported_digestmod("unsupported hash type"))?;
+        let block_size = pyre_native::hash::digest_block_size(name)
+            .ok_or_else(|| unsupported_digestmod("unsupported hash type"))?;
+        let _roots = gc_roots::push_roots();
+        let name_slot = gc_roots::shadow_stack_len();
+        gc_roots::pin_root(w_str_new(&format!("hmac-{name}")));
+        let obj = W_Hmac::allocate_stable(W_Hmac {
+            ob: PyObject::default(),
+            name: gc_roots::shadow_stack_get(name_slot),
+            digest_size: digest_size as i64,
+            block_size: block_size as i64,
+            storage: HmacStateStorage {
+                words: [0; HMAC_STATE_WORDS + 1],
+            },
+        });
+        let this = W_Hmac::from_obj(obj).expect("fresh HMAC");
+        assert!(unsafe {
+            pyre_native::hash::hmac_state_init(
+                this.storage.as_mut_ptr(),
+                HMAC_STATE_WORDS,
+                name,
+                key,
+            )
+        });
+        if !msg.is_empty() {
+            unsafe {
+                pyre_native::hash::hmac_state_update(
+                    this.storage.as_mut_ptr(),
+                    HMAC_STATE_WORDS,
+                    msg,
+                );
+            }
+        }
+        Ok(obj)
+    }
+}
+
+/// Sweep-time cleanup for the placement-initialized native HMAC context.
+pub unsafe fn w_hmac_dealloc(obj: PyObjectRef) {
+    let this = unsafe { &mut *(obj as *mut W_Hmac) };
+    unsafe {
+        pyre_native::hash::hmac_state_drop(this.storage.as_mut_ptr(), HMAC_STATE_WORDS);
+    }
+}
+
+mod hmac_class {
+    use super::*;
+
+    #[crate::pyre_methods]
+    impl W_Hmac {
+        #[staticmethod]
+        fn __new__(
+            _cls: PyObjectRef,
+            _args: &[PyObjectRef],
+        ) -> Result<PyObjectRef, crate::PyError> {
+            Err(crate::PyError::type_error(
+                "cannot create '_hashlib.HMAC' instances",
+            ))
+        }
+
+        #[getter]
+        fn name(&self) -> PyObjectRef {
+            self.name
+        }
+
+        #[getter]
+        fn digest_size(&self) -> i64 {
+            self.digest_size
+        }
+
+        #[getter]
+        fn block_size(&self) -> i64 {
+            self.block_size
+        }
+
+        fn update(&mut self, msg: PyObjectRef) -> Result<(), crate::PyError> {
+            let msg = read_hash_buffer(msg)?;
+            unsafe {
+                pyre_native::hash::hmac_state_update(
+                    self.storage.as_mut_ptr(),
+                    HMAC_STATE_WORDS,
+                    &msg,
+                );
+            }
+            Ok(())
+        }
+
+        fn digest(&self) -> PyObjectRef {
+            let digest = unsafe {
+                pyre_native::hash::hmac_state_digest(self.storage.as_ptr(), HMAC_STATE_WORDS)
+            };
+            w_bytes_from_bytes(&digest)
+        }
+
+        fn hexdigest(&self) -> String {
+            let digest = unsafe {
+                pyre_native::hash::hmac_state_digest(self.storage.as_ptr(), HMAC_STATE_WORDS)
+            };
+            let mut out = String::with_capacity(digest.len() * 2);
+            for byte in digest {
+                use std::fmt::Write;
+                let _ = write!(out, "{byte:02x}");
+            }
+            out
+        }
+
+        fn copy(&self) -> Result<PyObjectRef, crate::PyError> {
+            let _roots = gc_roots::push_roots();
+            let name_slot = gc_roots::shadow_stack_len();
+            gc_roots::pin_root(self.name);
+            let obj = W_Hmac::allocate_stable(W_Hmac {
+                ob: PyObject::default(),
+                name: gc_roots::shadow_stack_get(name_slot),
+                digest_size: self.digest_size,
+                block_size: self.block_size,
+                storage: HmacStateStorage {
+                    words: [0; HMAC_STATE_WORDS + 1],
+                },
+            });
+            let clone = W_Hmac::from_obj(obj).expect("fresh HMAC");
+            unsafe {
+                pyre_native::hash::hmac_state_copy(
+                    self.storage.as_ptr(),
+                    clone.storage.as_mut_ptr(),
+                    HMAC_STATE_WORDS,
+                );
+            }
+            Ok(obj)
+        }
+
+        fn __repr__(&self) -> String {
+            let name = unsafe { w_str_get_value(self.name) };
+            let name = name.strip_prefix("hmac-").unwrap_or(name);
+            format!("<{name} HMAC object @ {:#x}>", self as *const Self as usize)
+        }
+    }
+}
+
+fn resolve_hmac_digestmod(digestmod: PyObjectRef) -> Result<&'static str, crate::PyError> {
+    let name_obj = if unsafe { is_str(digestmod) } {
+        digestmod
+    } else if unsafe {
+        pyre_object::py_type_check(digestmod, &crate::function::BUILTIN_FUNCTION_TYPE)
+    } {
+        crate::baseobjspace::getattr_str(digestmod, "__name__")?
+    } else {
+        return Err(unsupported_digestmod("unsupported hash type"));
+    };
+    let name = unsafe { w_str_get_wtf8(name_obj) };
+    let bytes = name.as_bytes();
+    let bytes = bytes.strip_prefix(b"openssl_").unwrap_or(bytes);
+    lookup_digest_name(bytes).ok_or_else(|| unsupported_digestmod("unsupported hash type"))
+}
+
+fn hmac_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "hmac_new",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        1,
+        3,
+        0,
+    )?;
+    let key = crate::builtins::bind_pos_or_kw(positional, kwargs, 0, "key", "hmac_new", 1)?
+        .ok_or_else(|| crate::PyError::type_error("hmac_new() missing required argument 'key'"))?;
+    let msg = crate::builtins::bind_pos_or_kw(positional, kwargs, 1, "msg", "hmac_new", 2)?;
+    let digestmod =
+        crate::builtins::bind_pos_or_kw(positional, kwargs, 2, "digestmod", "hmac_new", 3)?
+            .ok_or_else(|| {
+                crate::PyError::type_error(
+                    "hmac_new() missing required argument 'digestmod' (pos 3)",
+                )
+            })?;
+    crate::builtins::kwarg_reject_unknown(kwargs, &["key", "msg", "digestmod"], "hmac_new")?;
+    let key = read_hash_buffer(key)?;
+    let msg = match msg {
+        Some(msg) if unsafe { !is_none(msg) } => read_hash_buffer(msg)?,
+        _ => Vec::new(),
+    };
+    W_Hmac::new(resolve_hmac_digestmod(digestmod)?, &key, &msg)
+}
+
+fn hmac_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "hmac_digest",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        3,
+        3,
+        0,
+    )?;
+    let key = crate::builtins::bind_pos_or_kw(positional, kwargs, 0, "key", "hmac_digest", 1)?
+        .ok_or_else(|| {
+            crate::PyError::type_error("hmac_digest() missing required argument 'key'")
+        })?;
+    let msg = crate::builtins::bind_pos_or_kw(positional, kwargs, 1, "msg", "hmac_digest", 2)?
+        .ok_or_else(|| {
+            crate::PyError::type_error("hmac_digest() missing required argument 'msg'")
+        })?;
+    let digestmod =
+        crate::builtins::bind_pos_or_kw(positional, kwargs, 2, "digest", "hmac_digest", 3)?
+            .ok_or_else(|| {
+                crate::PyError::type_error(
+                    "hmac_digest() missing required argument 'digest' (pos 3)",
+                )
+            })?;
+    crate::builtins::kwarg_reject_unknown(kwargs, &["key", "msg", "digest"], "hmac_digest")?;
+    let key = read_hash_buffer(key)?;
+    let msg = read_hash_buffer(msg)?;
+    let state = W_Hmac::new(resolve_hmac_digestmod(digestmod)?, &key, &msg)?;
+    let state = W_Hmac::from_obj(state).expect("fresh HMAC");
+    let digest =
+        unsafe { pyre_native::hash::hmac_state_digest(state.storage.as_ptr(), HMAC_STATE_WORDS) };
+    Ok(w_bytes_from_bytes(&digest))
+}
+
+fn pbkdf2_hmac(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    const KEYWORDS: &[&str] = &["hash_name", "password", "salt", "iterations", "dklen"];
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "pbkdf2_hmac",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        4,
+        5,
+        0,
+    )?;
+    let required = |index, name, position| {
+        crate::builtins::bind_pos_or_kw(positional, kwargs, index, name, "pbkdf2_hmac", position)?
+            .ok_or_else(|| {
+                crate::PyError::type_error(format!(
+                    "pbkdf2_hmac() missing required argument '{name}' (pos {position})"
+                ))
+            })
+    };
+    let hash_name = required(0, "hash_name", 1)?;
+    let password = required(1, "password", 2)?;
+    let salt = required(2, "salt", 3)?;
+    let iterations = required(3, "iterations", 4)?;
+    let dklen = crate::builtins::bind_pos_or_kw(positional, kwargs, 4, "dklen", "pbkdf2_hmac", 5)?;
+    crate::builtins::kwarg_reject_unknown(kwargs, KEYWORDS, "pbkdf2_hmac")?;
+
+    check_digest_name(hash_name)?;
+    let requested = unsafe { w_str_get_wtf8(hash_name) };
+    let name = lookup_digest_name(requested.as_bytes()).ok_or_else(|| {
+        crate::PyError::value_error(format!(
+            "[digital envelope routines] unsupported: {requested}"
+        ))
+    })?;
+    let password = read_hash_buffer(password)?;
+    let salt = read_hash_buffer(salt)?;
+    let iterations = crate::baseobjspace::int_w(crate::baseobjspace::space_index(iterations)?)?;
+    let iterations = usize::try_from(iterations)
+        .ok()
+        .filter(|&value| value > 0)
+        .ok_or_else(|| crate::PyError::value_error("iteration value must be greater than 0"))?;
+    let dklen = match dklen {
+        Some(obj) if unsafe { !is_none(obj) } => {
+            let value = crate::baseobjspace::int_w(crate::baseobjspace::space_index(obj)?)?;
+            usize::try_from(value)
+                .ok()
+                .filter(|&value| value > 0)
+                .ok_or_else(|| crate::PyError::value_error("key length must be greater than 0"))?
+        }
+        _ => pyre_native::hash::digest_output_size(name).unwrap_or(0),
+    };
+    let result = pyre_native::hash::compute_pbkdf2_hmac(name, &password, &salt, iterations, dklen)
+        .ok_or_else(|| crate::PyError::value_error("unsupported hash type"))?;
+    Ok(w_bytes_from_bytes(&result))
+}
+
+/// `scrypt(password, *, salt, n, r, p, maxmem=0, dklen=64)`.
+///
+/// CPython `_hashopenssl.c` takes only `password` positionally and sends the
+/// work to `EVP_PBE_scrypt`.  The pure-Rust backend implements the same RFC
+/// 7914 primitive; validation stays here so Python-visible errors and integer
+/// bounds do not depend on the backend crate's narrower parameter types.
+fn scrypt_kdf(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    const KEYWORDS: &[&str] = &["salt", "n", "r", "p", "maxmem", "dklen"];
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::clinic_arity(
+        "scrypt",
+        positional.len(),
+        crate::builtins::real_kwarg_count(kwargs),
+        1,
+        1,
+        6,
+    )?;
+    let password = positional.first().copied().ok_or_else(|| {
+        crate::PyError::type_error("scrypt() missing required argument 'password' (pos 1)")
+    })?;
+    crate::builtins::kwarg_reject_unknown(kwargs, KEYWORDS, "scrypt")?;
+    let required = |name: &str| {
+        crate::builtins::kwarg_get(kwargs, name).ok_or_else(|| {
+            crate::PyError::type_error(format!(
+                "scrypt() missing required keyword-only argument '{name}'"
+            ))
+        })
+    };
+    let salt = required("salt")?;
+    let n_obj = required("n")?;
+    let r_obj = required("r")?;
+    let p_obj = required("p")?;
+
+    let password = read_hash_buffer(password)?;
+    let salt = read_hash_buffer(salt)?;
+    let index = |obj| crate::baseobjspace::int_w(crate::baseobjspace::space_index(obj)?);
+    let n = index(n_obj)?;
+    let r = index(r_obj)?;
+    let p = index(p_obj)?;
+    let maxmem = match crate::builtins::kwarg_get(kwargs, "maxmem") {
+        Some(obj) => index(obj)?,
+        None => 0,
+    };
+    let dklen = match crate::builtins::kwarg_get(kwargs, "dklen") {
+        Some(obj) => index(obj)?,
+        None => 64,
+    };
+
+    let n = u64::try_from(n).unwrap_or(0);
+    if n < 2 || !n.is_power_of_two() {
+        return Err(crate::PyError::value_error(
+            "n must be a power of 2 greater than 1",
+        ));
+    }
+    let log_n = u8::try_from(n.trailing_zeros()).map_err(|_| {
+        crate::PyError::value_error("Invalid parameter combination for n, r, p, maxmem")
+    })?;
+    let r = u32::try_from(r)
+        .ok()
+        .filter(|&value| value > 0)
+        .ok_or_else(|| {
+            crate::PyError::value_error("Invalid parameter combination for n, r, p, maxmem")
+        })?;
+    let p = u32::try_from(p)
+        .ok()
+        .filter(|&value| value > 0)
+        .ok_or_else(|| {
+            crate::PyError::value_error("Invalid parameter combination for n, r, p, maxmem")
+        })?;
+    let maxmem = usize::try_from(maxmem).map_err(|_| {
+        crate::PyError::value_error("maxmem must be positive and smaller than 2147483647")
+    })?;
+    let dklen = usize::try_from(dklen)
+        .ok()
+        .filter(|&value| value > 0)
+        .ok_or_else(|| {
+            crate::PyError::value_error("dklen must be greater than 0 and smaller than 2147483647")
+        })?;
+    if maxmem > i32::MAX as usize {
+        return Err(crate::PyError::value_error(
+            "maxmem must be positive and smaller than 2147483647",
+        ));
+    }
+    if dklen > i32::MAX as usize {
+        return Err(crate::PyError::value_error(
+            "dklen must be greater than 0 and smaller than 2147483647",
+        ));
+    }
+
+    // RFC 7914's dominant allocation is V[N] with 128*r-byte entries. OpenSSL
+    // also needs B[p] and a working block. Honor an explicit caller limit;
+    // maxmem=0 retains OpenSSL's implementation-defined default behavior.
+    let memory = usize::try_from(n)
+        .ok()
+        .and_then(|n| n.checked_mul(r as usize))
+        .and_then(|v| v.checked_mul(128))
+        .and_then(|v| v.checked_add((p as usize).checked_mul(r as usize)?.checked_mul(128)?))
+        .and_then(|v| v.checked_add((r as usize).checked_mul(256)?))
+        .ok_or_else(|| {
+            crate::PyError::value_error("Invalid parameter combination for n, r, p, maxmem")
+        })?;
+    if maxmem != 0 && memory > maxmem {
+        return Err(crate::PyError::value_error(
+            "Invalid parameter combination for n, r, p, maxmem",
+        ));
+    }
+    let output = pyre_native::hash::compute_scrypt(&password, &salt, log_n, r, p, dklen)
+        .ok_or_else(|| {
+            crate::PyError::value_error("Invalid parameter combination for n, r, p, maxmem")
+        })?;
+    Ok(w_bytes_from_bytes(&output))
+}
+
+/// Private constructor used by PyPy-shaped `_blake2` app-level objects after
+/// they validate the public clinic contract. The returned HASH is the native,
+/// object-owned context held by the wrapper's `_state` attribute.
+fn blake2_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::builtins::clinic_arity("_blake2_new", args.len(), 0, 13, 13, 0)?;
+    let _roots = gc_roots::push_roots();
+    let base = gc_roots::shadow_stack_len();
+    for &arg in args {
+        gc_roots::pin_root(arg);
+    }
+    let arg = |index| gc_roots::shadow_stack_get(base + index);
+    let name_obj = arg(0);
+    check_digest_name(name_obj)?;
+    let requested = unsafe { w_str_get_wtf8(name_obj) };
+    let name = match requested.as_bytes() {
+        b"blake2b" => "blake2b",
+        b"blake2s" => "blake2s",
+        _ => return Err(crate::PyError::value_error("unsupported BLAKE2 type")),
+    };
+    let data = read_hash_buffer(arg(1))?;
+    let key = read_hash_buffer(arg(3))?;
+    let salt = read_hash_buffer(arg(4))?;
+    let person = read_hash_buffer(arg(5))?;
+    let index =
+        |position| crate::baseobjspace::int_w(crate::baseobjspace::space_index(arg(position))?);
+    let digest_size = usize::try_from(index(2)?)
+        .map_err(|_| crate::PyError::value_error("invalid digest size"))?;
+    let fanout =
+        u8::try_from(index(6)?).map_err(|_| crate::PyError::value_error("invalid fanout"))?;
+    let depth =
+        u8::try_from(index(7)?).map_err(|_| crate::PyError::value_error("invalid depth"))?;
+    let leaf_size =
+        u32::try_from(index(8)?).map_err(|_| crate::PyError::value_error("invalid leaf size"))?;
+    // BLAKE2b accepts the full unsigned 64-bit range; `int_w` would reject
+    // values above i64::MAX even though the app-level range check accepted
+    // them. operator.index has already normalized the public argument.
+    let node_offset = crate::baseobjspace::uint_w(arg(9))?;
+    let node_depth =
+        u8::try_from(index(10)?).map_err(|_| crate::PyError::value_error("invalid node depth"))?;
+    let inner_size = usize::try_from(index(11)?)
+        .map_err(|_| crate::PyError::value_error("invalid inner size"))?;
+    let last_node = crate::baseobjspace::is_true(arg(12))?;
+    W_HashState::new_blake2(
+        name,
+        &data,
+        digest_size,
+        &key,
+        &salt,
+        &person,
+        fanout,
+        depth,
+        leaf_size,
+        node_offset,
+        node_depth,
+        inner_size,
+        last_node,
+    )
 }
 
 /// Constant-time equality of two ASCII strings or two bytes-like objects.
 fn compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let a_obj = args.first().copied().unwrap_or_else(w_none);
+    let b_obj = args.get(1).copied().unwrap_or_else(w_none);
+    if unsafe { is_str(a_obj) } != unsafe { is_str(b_obj) } {
+        return Err(crate::PyError::type_error(
+            "unsupported operand types(s) or combination of types",
+        ));
+    }
     let read = |obj: PyObjectRef| -> Result<Vec<u8>, crate::PyError> {
         unsafe {
             if is_str(obj) {
@@ -185,8 +901,8 @@ fn compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             }
         }
     };
-    let a = read(args.first().copied().unwrap_or_else(w_none))?;
-    let b = read(args.get(1).copied().unwrap_or_else(w_none))?;
+    let a = read(a_obj)?;
+    let b = read(b_obj)?;
     let mut result = (a.len() ^ b.len()) as u8;
     for i in 0..a.len() {
         result |= a[i] ^ b.get(i).copied().unwrap_or(0);
@@ -266,18 +982,11 @@ fn make_hash(
         Some(slot) => read_hash_buffer(pyre_object::gc_roots::shadow_stack_get(slot))?,
         None => Vec::new(),
     };
-    let bytes_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(w_bytes_from_bytes(&data_bytes));
-    let module = crate::importing::check_sys_modules("_hashlib")
-        .ok_or_else(|| crate::PyError::runtime_error("_hashlib module not loaded"))?;
-    let hash_cls = crate::baseobjspace::getattr_str(module, "HASH")?;
-    crate::call::call_function_impl_result(
-        hash_cls,
-        &[
-            pyre_object::gc_roots::shadow_stack_get(name_slot),
-            pyre_object::gc_roots::shadow_stack_get(bytes_slot),
-        ],
-    )
+    let name_obj = pyre_object::gc_roots::shadow_stack_get(name_slot);
+    let name = unsafe { w_str_get_wtf8(name_obj) };
+    let name = lookup_digest_name(name.as_bytes())
+        .ok_or_else(|| unsupported_digestmod(&format!("unsupported hash type {name}")))?;
+    W_HashState::new(name, &data_bytes)
 }
 
 /// `new(name, data=b'', *, usedforsecurity=True, string=None)` — build a
@@ -329,6 +1038,10 @@ fn make_openssl_hash(digest: &str, args: &[PyObjectRef]) -> Result<PyObjectRef, 
 crate::py_module! {
     "_hashlib",
     interpleveldefs: {
+        "HASH" => hash_state_class::type_object(),
+        "HASHXOF" => hash_xof_type(),
+        "HMAC" => hmac_class::type_object(),
+        "_GIL_MINSIZE" => w_int_new(2048),
         "openssl_md_meth_names" => {
             let names: Vec<PyObjectRef> =
                 DIGEST_NAMES.iter().map(|(n, _)| w_str_new(n)).collect();
@@ -339,9 +1052,6 @@ crate::py_module! {
         // _hashopenssl.c — UnsupportedDigestmodError subclasses ValueError.
         "UnsupportedDigestmodError" => crate::builtins::lookup_exc_class("ValueError")
             .expect("ValueError installed"),
-    },
-    appleveldefs: {
-        "_hashlib_app.py" => ["HASH"],
     },
     functions: {
         "new" / * = new_hash,
@@ -357,11 +1067,49 @@ crate::py_module! {
         "openssl_sha3_512" / * = |args| make_openssl_hash("sha3_512", args),
         "openssl_shake_128" / * = |args| make_openssl_hash("shake_128", args),
         "openssl_shake_256" / * = |args| make_openssl_hash("shake_256", args),
-        "_oneshot_digest" / * = oneshot_digest,
-        "_resolve_digest_name" / 1 = resolve_digest_name,
         "compare_digest" / 2 = compare_digest,
         "hmac_new" / * = hmac_new,
         "hmac_digest" / * = hmac_digest,
-        "get_fips_mode" / * = |_| Ok(w_int_new(0)),
+        "pbkdf2_hmac" / * = pbkdf2_hmac,
+        "scrypt" / * = scrypt_kdf,
+        "_blake2_new" / * = blake2_new,
+        "get_fips_mode" / 0 = |_| Ok(w_int_new(0)),
+    },
+    extra_init: |ns| {
+        let _roots = gc_roots::push_roots();
+        let mapping_slot = gc_roots::shadow_stack_len();
+        gc_roots::pin_root(w_dict_new());
+        for (constructor, name) in [
+            ("openssl_md5", "md5"),
+            ("openssl_sha1", "sha1"),
+            ("openssl_sha224", "sha224"),
+            ("openssl_sha256", "sha256"),
+            ("openssl_sha384", "sha384"),
+            ("openssl_sha512", "sha512"),
+            ("openssl_sha3_224", "sha3_224"),
+            ("openssl_sha3_256", "sha3_256"),
+            ("openssl_sha3_384", "sha3_384"),
+            ("openssl_sha3_512", "sha3_512"),
+            ("openssl_shake_128", "shake_128"),
+            ("openssl_shake_256", "shake_256"),
+        ] {
+            let function = crate::module_ns_get(ns, constructor)
+                .expect("_hashlib constructor installed before extra_init");
+            let function_slot = gc_roots::shadow_stack_len();
+            gc_roots::pin_root(function);
+            let name_slot = gc_roots::shadow_stack_len();
+            gc_roots::pin_root(w_str_new(name));
+            crate::baseobjspace::setitem(
+                gc_roots::shadow_stack_get(mapping_slot),
+                gc_roots::shadow_stack_get(function_slot),
+                gc_roots::shadow_stack_get(name_slot),
+            )
+            .expect("populate _hashlib._constructors");
+        }
+        crate::module_ns_store(
+            ns,
+            "_constructors",
+            pyre_object::w_dict_proxy_new(gc_roots::shadow_stack_get(mapping_slot)),
+        );
     },
 }

--- a/pyre/pyre-interpreter/src/module/_json/machinery.rs
+++ b/pyre/pyre-interpreter/src/module/_json/machinery.rs
@@ -73,16 +73,16 @@ pub(super) fn scan_string(
     value: &Wtf8,
     char_offset: usize,
     strict: bool,
-) -> Result<(Wtf8Buf, usize), DecodeError> {
+) -> Result<(Wtf8Buf, usize, usize), DecodeError> {
     let unterminated = || DecodeError {
         msg: "Unterminated string starting at".to_owned(),
         pos: char_offset.saturating_sub(1),
     };
     let mut out = Wtf8Buf::new();
     let mut chars = value.code_point_indices().enumerate().peekable();
-    while let Some((char_i, (_, cp))) = chars.next() {
+    while let Some((char_i, (byte_i, cp))) = chars.next() {
         match cp.to_char_lossy() {
-            '"' => return Ok((out, char_offset + char_i + 1)),
+            '"' => return Ok((out, char_offset + char_i + 1, byte_i + 1)),
             '\\' => {
                 let (escape_i, (_, escaped)) = chars.next().ok_or_else(unterminated)?;
                 match escaped.to_char_lossy() {

--- a/pyre/pyre-interpreter/src/module/_json/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_json/mod.rs
@@ -115,7 +115,7 @@ fn scanstring_impl(doc: PyObjectRef, end: i64, strict_obj: PyObjectRef) -> PyRes
         json_decode_error("Unterminated string starting at".to_owned(), doc, start)
     })?;
     match machinery::scan_string(rest, start, strict) {
-        Ok((decoded, next)) => Ok(pyre_object::w_tuple_new(vec![
+        Ok((decoded, next, _)) => Ok(pyre_object::w_tuple_new(vec![
             pyre_object::w_str_from_wtf8(decoded),
             pyre_object::w_int_new(next as i64),
         ])),
@@ -132,142 +132,105 @@ fn stop_iteration(index: i64) -> PyError {
     }
 }
 
-fn scanner_call_inner(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyResult {
-    let value = require_string(doc)?;
-    if index < 0 {
-        return Err(stop_iteration(index));
+#[inline]
+fn skip_json_whitespace(
+    doc: PyObjectRef,
+    mut char_index: usize,
+    mut byte_index: usize,
+) -> (usize, usize) {
+    let bytes = unsafe { pyre_object::w_str_get_wtf8(doc) }.as_bytes();
+    while matches!(bytes.get(byte_index), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+        char_index += 1;
+        byte_index += 1;
     }
-    let index = index as usize;
-    let Some(first) = value.code_points().nth(index) else {
-        return Err(stop_iteration(index as i64));
+    (char_index, byte_index)
+}
+
+fn scanner_decode_error(msg: &str, doc: PyObjectRef, pos: usize) -> PyError {
+    json_decode_error(msg.to_owned(), doc, pos)
+}
+
+/// CPython `scan_once_unicode`: scanner state owns only the six callbacks and
+/// strict flag; the memo dict is born per public call and threaded through the
+/// recursive object/array descent.
+fn scanner_scan_once(
+    self_obj: PyObjectRef,
+    memo: PyObjectRef,
+    doc: PyObjectRef,
+    char_index: usize,
+    byte_index: usize,
+) -> Result<(PyObjectRef, usize, usize), PyError> {
+    let _roots = gc_roots::push_roots();
+    let slot = gc_roots::shadow_stack_len();
+    for value in [self_obj, memo, doc] {
+        gc_roots::pin_root(value);
+    }
+    let doc = gc_roots::shadow_stack_get(slot + 2);
+    let bytes = unsafe { pyre_object::w_str_get_wtf8(doc) }.as_bytes();
+    let Some(&first) = bytes.get(byte_index) else {
+        return Err(stop_iteration(char_index as i64));
     };
 
-    match first.to_char_lossy() {
-        '"' => {
-            let parse_string = crate::baseobjspace::getattr_str(self_obj, "parse_string")?;
-            let strict = crate::baseobjspace::getattr_str(self_obj, "strict")?;
-            let _roots = gc_roots::push_roots();
-            let slot = gc_roots::shadow_stack_len();
-            for value in [parse_string, strict, doc, self_obj] {
-                gc_roots::pin_root(value);
-            }
-            let end = pyre_object::w_int_new(index as i64 + 1);
-            gc_roots::pin_root(end);
-            crate::call::call_function_impl_result(
-                gc_roots::shadow_stack_get(slot),
-                &[
-                    gc_roots::shadow_stack_get(slot + 2),
-                    gc_roots::shadow_stack_get(slot + 4),
-                    gc_roots::shadow_stack_get(slot + 1),
-                ],
-            )
+    match first {
+        b'"' => {
+            let strict = W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
+                .expect("Scanner payload")
+                .strict;
+            let value = unsafe { pyre_object::w_str_get_wtf8(doc) };
+            let (decoded, next_char, bytes_used) =
+                machinery::scan_string(&value[byte_index + 1..], char_index + 1, strict)
+                    .map_err(|err| json_decode_error(err.msg, doc, err.pos))?;
+            Ok((
+                pyre_object::w_str_from_wtf8(decoded),
+                next_char,
+                byte_index + 1 + bytes_used,
+            ))
         }
-        '{' => {
-            let parse_object = crate::baseobjspace::getattr_str(self_obj, "parse_object")?;
-            let strict = crate::baseobjspace::getattr_str(self_obj, "strict")?;
-            let object_hook = crate::baseobjspace::getattr_str(self_obj, "object_hook")?;
-            let pairs_hook = crate::baseobjspace::getattr_str(self_obj, "object_pairs_hook")?;
-            let memo = crate::baseobjspace::getattr_str(self_obj, "memo")?;
-            let _roots = gc_roots::push_roots();
-            let slot = gc_roots::shadow_stack_len();
-            for value in [
-                parse_object,
-                strict,
-                self_obj,
-                object_hook,
-                pairs_hook,
-                memo,
+        b'{' => {
+            crate::stack_check::stack_check().map_err(|_| {
+                PyError::recursion_error(
+                    "maximum recursion depth exceeded while decoding a JSON object from a string",
+                )
+            })?;
+            scanner_parse_object(
+                gc_roots::shadow_stack_get(slot),
+                gc_roots::shadow_stack_get(slot + 1),
                 doc,
-            ] {
-                gc_roots::pin_root(value);
-            }
-            let end = pyre_object::w_int_new(index as i64 + 1);
-            gc_roots::pin_root(end);
-            let state = pyre_object::w_tuple_new(vec![
-                gc_roots::shadow_stack_get(slot + 6),
-                gc_roots::shadow_stack_get(slot + 7),
-            ]);
-            gc_roots::pin_root(state);
-            crate::call::call_function_impl_result(
-                gc_roots::shadow_stack_get(slot),
-                &[
-                    gc_roots::shadow_stack_get(slot + 8),
-                    gc_roots::shadow_stack_get(slot + 1),
-                    gc_roots::shadow_stack_get(slot + 2),
-                    gc_roots::shadow_stack_get(slot + 3),
-                    gc_roots::shadow_stack_get(slot + 4),
-                    gc_roots::shadow_stack_get(slot + 5),
-                ],
+                char_index + 1,
+                byte_index + 1,
             )
         }
-        '[' => {
-            let parse_array = crate::baseobjspace::getattr_str(self_obj, "parse_array")?;
-            let _roots = gc_roots::push_roots();
-            let slot = gc_roots::shadow_stack_len();
-            for value in [parse_array, self_obj, doc] {
-                gc_roots::pin_root(value);
-            }
-            let end = pyre_object::w_int_new(index as i64 + 1);
-            gc_roots::pin_root(end);
-            let state = pyre_object::w_tuple_new(vec![
-                gc_roots::shadow_stack_get(slot + 2),
-                gc_roots::shadow_stack_get(slot + 3),
-            ]);
-            gc_roots::pin_root(state);
-            crate::call::call_function_impl_result(
+        b'[' => {
+            crate::stack_check::stack_check().map_err(|_| {
+                PyError::recursion_error(
+                    "maximum recursion depth exceeded while decoding a JSON array from a string",
+                )
+            })?;
+            scanner_parse_array(
                 gc_roots::shadow_stack_get(slot),
-                &[
-                    gc_roots::shadow_stack_get(slot + 4),
-                    gc_roots::shadow_stack_get(slot + 1),
-                ],
+                gc_roots::shadow_stack_get(slot + 1),
+                doc,
+                char_index + 1,
+                byte_index + 1,
             )
         }
-        _ => scan_scalar(self_obj, doc, value, index),
+        _ => scan_scalar(
+            gc_roots::shadow_stack_get(slot),
+            doc,
+            char_index,
+            byte_index,
+        ),
     }
 }
 
-fn scanner_call_impl(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyResult {
-    // Recursive object/array callbacks invoke this same Scanner.  The memo is
-    // context-owned and is cleared only after the outermost token finishes.
-    let scanner = W_Scanner::from_obj(self_obj).expect("Scanner payload");
-    let depth = scanner.depth;
-    // `scan_once_unicode` brackets recursive container decoding with
-    // `Py_EnterRecursiveCall`.  The meta-tracing JIT can flatten this
-    // recursion, so the scanner-owned counter, not the native stack address,
-    // must remain the guard.
-    if depth >= crate::stack_check::get_recursion_limit() as i64 {
-        return Err(PyError::recursion_error(
-            "maximum recursion depth exceeded while decoding a JSON object",
-        ));
-    }
-    scanner.depth = depth + 1;
-    let result = scanner_call_inner(self_obj, doc, index);
-    W_Scanner::from_obj(self_obj)
-        .expect("Scanner payload")
-        .depth = depth;
-    if depth != 0 {
-        return result;
-    }
-    // `json.scanner.py:scan_once` clears the context-owned memo in a finally.
-    let _result_roots = gc_roots::push_roots();
-    let result_slots = pin_pyresult_payload(&result);
-    let memo = crate::baseobjspace::getattr_str(self_obj, "memo")?;
-    let clear_result = crate::call::call_function_impl_result(
-        crate::baseobjspace::getattr_str(memo, "clear")?,
-        &[],
-    );
-    let result = reload_pyresult_payload(result, result_slots);
-    match (result, clear_result) {
-        (Err(err), _) => Err(err),
-        (Ok(_), Err(err)) => Err(err),
-        (Ok(value), Ok(_)) => Ok(value),
-    }
-}
-
-fn scan_scalar(self_obj: PyObjectRef, doc: PyObjectRef, value: &Wtf8, index: usize) -> PyResult {
-    let byte_index = unsafe { pyre_object::w_str_index_to_byte(doc, index) };
-    let bytes = value.as_bytes();
-    let rest = &bytes[byte_index..];
+fn scan_scalar(
+    self_obj: PyObjectRef,
+    doc: PyObjectRef,
+    index: usize,
+    byte_index: usize,
+) -> Result<(PyObjectRef, usize, usize), PyError> {
+    let value = unsafe { pyre_object::w_str_get_wtf8(doc) };
+    let rest = &value.as_bytes()[byte_index..];
     let simple = if rest.starts_with(b"null") {
         Some((pyre_object::w_none(), 4))
     } else if rest.starts_with(b"true") {
@@ -278,10 +241,7 @@ fn scan_scalar(self_obj: PyObjectRef, doc: PyObjectRef, value: &Wtf8, index: usi
         None
     };
     if let Some((obj, len)) = simple {
-        return Ok(pyre_object::w_tuple_new(vec![
-            obj,
-            pyre_object::w_int_new((index + len) as i64),
-        ]));
+        return Ok((obj, index + len, byte_index + len));
     }
 
     let mut end = 0usize;
@@ -328,10 +288,7 @@ fn scan_scalar(self_obj: PyObjectRef, doc: PyObjectRef, value: &Wtf8, index: usi
         let number = unsafe { core::str::from_utf8_unchecked(&rest[..end]) };
         let parsed =
             crate::call::call_function_impl_result(parser, &[pyre_object::w_str_new(number)])?;
-        return Ok(pyre_object::w_tuple_new(vec![
-            parsed,
-            pyre_object::w_int_new((index + end) as i64),
-        ]));
+        return Ok((parsed, index + end, byte_index + end));
     }
 
     for (token, len) in [("NaN", 3usize), ("Infinity", 8), ("-Infinity", 9)] {
@@ -339,28 +296,348 @@ fn scan_scalar(self_obj: PyObjectRef, doc: PyObjectRef, value: &Wtf8, index: usi
             let parser = crate::baseobjspace::getattr_str(self_obj, "parse_constant")?;
             let parsed =
                 crate::call::call_function_impl_result(parser, &[pyre_object::w_str_new(token)])?;
-            return Ok(pyre_object::w_tuple_new(vec![
-                parsed,
-                pyre_object::w_int_new((index + len) as i64),
-            ]));
+            return Ok((parsed, index + len, byte_index + len));
         }
     }
     Err(stop_iteration(index as i64))
 }
 
+fn scanner_parse_object(
+    self_obj: PyObjectRef,
+    memo: PyObjectRef,
+    doc: PyObjectRef,
+    mut char_index: usize,
+    mut byte_index: usize,
+) -> Result<(PyObjectRef, usize, usize), PyError> {
+    let _roots = gc_roots::push_roots();
+    let slot = gc_roots::shadow_stack_len();
+    for value in [self_obj, memo, doc] {
+        gc_roots::pin_root(value);
+    }
+    let pairs_hook = W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
+        .expect("Scanner payload")
+        .object_pairs_hook;
+    let has_pairs_hook = !unsafe { pyre_object::is_none(pairs_hook) };
+    let result = if has_pairs_hook {
+        pyre_object::w_list_new_empty()
+    } else {
+        pyre_object::w_dict_new()
+    };
+    gc_roots::pin_root(result);
+
+    (char_index, byte_index) =
+        skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
+    let doc = gc_roots::shadow_stack_get(slot + 2);
+    if unsafe { pyre_object::w_str_get_wtf8(doc) }
+        .as_bytes()
+        .get(byte_index)
+        == Some(&b'}')
+    {
+        char_index += 1;
+        byte_index += 1;
+    } else {
+        loop {
+            let doc = gc_roots::shadow_stack_get(slot + 2);
+            if unsafe { pyre_object::w_str_get_wtf8(doc) }
+                .as_bytes()
+                .get(byte_index)
+                != Some(&b'"')
+            {
+                return Err(scanner_decode_error(
+                    "Expecting property name enclosed in double quotes",
+                    doc,
+                    char_index,
+                ));
+            }
+            let strict = W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
+                .expect("Scanner payload")
+                .strict;
+            let value = unsafe { pyre_object::w_str_get_wtf8(doc) };
+            let (decoded, next_char, bytes_used) =
+                machinery::scan_string(&value[byte_index + 1..], char_index + 1, strict)
+                    .map_err(|err| json_decode_error(err.msg, doc, err.pos))?;
+            char_index = next_char;
+            byte_index += 1 + bytes_used;
+
+            let iteration_roots = gc_roots::push_roots();
+            let item_slot = gc_roots::shadow_stack_len();
+            let candidate = pyre_object::w_str_from_wtf8(decoded);
+            gc_roots::pin_root(candidate);
+            let memo = gc_roots::shadow_stack_get(slot + 1);
+            let key =
+                match crate::baseobjspace::finditem(memo, gc_roots::shadow_stack_get(item_slot))? {
+                    Some(key) => key,
+                    None => {
+                        crate::baseobjspace::setitem(
+                            memo,
+                            gc_roots::shadow_stack_get(item_slot),
+                            gc_roots::shadow_stack_get(item_slot),
+                        )?;
+                        gc_roots::shadow_stack_get(item_slot)
+                    }
+                };
+            gc_roots::pin_root(key);
+
+            (char_index, byte_index) =
+                skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
+            let doc = gc_roots::shadow_stack_get(slot + 2);
+            if unsafe { pyre_object::w_str_get_wtf8(doc) }
+                .as_bytes()
+                .get(byte_index)
+                != Some(&b':')
+            {
+                return Err(scanner_decode_error(
+                    "Expecting ':' delimiter",
+                    doc,
+                    char_index,
+                ));
+            }
+            char_index += 1;
+            byte_index += 1;
+            (char_index, byte_index) = skip_json_whitespace(doc, char_index, byte_index);
+
+            let (value, next_char, next_byte) = scanner_scan_once(
+                gc_roots::shadow_stack_get(slot),
+                gc_roots::shadow_stack_get(slot + 1),
+                gc_roots::shadow_stack_get(slot + 2),
+                char_index,
+                byte_index,
+            )
+            .map_err(|err| {
+                if err.kind == crate::PyErrorKind::StopIteration {
+                    scanner_decode_error(
+                        "Expecting value",
+                        gc_roots::shadow_stack_get(slot + 2),
+                        char_index,
+                    )
+                } else {
+                    err
+                }
+            })?;
+            gc_roots::pin_root(value);
+            char_index = next_char;
+            byte_index = next_byte;
+
+            if has_pairs_hook {
+                let pair = pyre_object::w_tuple_new(vec![
+                    gc_roots::shadow_stack_get(item_slot + 1),
+                    gc_roots::shadow_stack_get(item_slot + 2),
+                ]);
+                gc_roots::pin_root(pair);
+                unsafe {
+                    pyre_object::w_list_append(
+                        gc_roots::shadow_stack_get(slot + 3),
+                        gc_roots::shadow_stack_get(item_slot + 3),
+                    );
+                }
+            } else {
+                crate::baseobjspace::setitem(
+                    gc_roots::shadow_stack_get(slot + 3),
+                    gc_roots::shadow_stack_get(item_slot + 1),
+                    gc_roots::shadow_stack_get(item_slot + 2),
+                )?;
+            }
+            drop(iteration_roots);
+
+            (char_index, byte_index) =
+                skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
+            let doc = gc_roots::shadow_stack_get(slot + 2);
+            match unsafe { pyre_object::w_str_get_wtf8(doc) }
+                .as_bytes()
+                .get(byte_index)
+            {
+                Some(b'}') => {
+                    char_index += 1;
+                    byte_index += 1;
+                    break;
+                }
+                Some(b',') => {
+                    let comma = char_index;
+                    char_index += 1;
+                    byte_index += 1;
+                    (char_index, byte_index) = skip_json_whitespace(doc, char_index, byte_index);
+                    if unsafe { pyre_object::w_str_get_wtf8(doc) }
+                        .as_bytes()
+                        .get(byte_index)
+                        == Some(&b'}')
+                    {
+                        return Err(scanner_decode_error(
+                            "Illegal trailing comma before end of object",
+                            doc,
+                            comma,
+                        ));
+                    }
+                }
+                _ => {
+                    return Err(scanner_decode_error(
+                        "Expecting ',' delimiter",
+                        doc,
+                        char_index,
+                    ));
+                }
+            }
+        }
+    }
+
+    let result = gc_roots::shadow_stack_get(slot + 3);
+    let hook = if has_pairs_hook {
+        W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
+            .expect("Scanner payload")
+            .object_pairs_hook
+    } else {
+        W_Scanner::from_obj(gc_roots::shadow_stack_get(slot))
+            .expect("Scanner payload")
+            .object_hook
+    };
+    if unsafe { pyre_object::is_none(hook) } {
+        Ok((result, char_index, byte_index))
+    } else {
+        let hooked = crate::call::call_function_impl_result(hook, &[result])?;
+        Ok((hooked, char_index, byte_index))
+    }
+}
+
+fn scanner_parse_array(
+    self_obj: PyObjectRef,
+    memo: PyObjectRef,
+    doc: PyObjectRef,
+    mut char_index: usize,
+    mut byte_index: usize,
+) -> Result<(PyObjectRef, usize, usize), PyError> {
+    let _roots = gc_roots::push_roots();
+    let slot = gc_roots::shadow_stack_len();
+    for value in [self_obj, memo, doc] {
+        gc_roots::pin_root(value);
+    }
+    let result = pyre_object::w_list_new_empty();
+    gc_roots::pin_root(result);
+    (char_index, byte_index) =
+        skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
+    let doc = gc_roots::shadow_stack_get(slot + 2);
+    if unsafe { pyre_object::w_str_get_wtf8(doc) }
+        .as_bytes()
+        .get(byte_index)
+        == Some(&b']')
+    {
+        return Ok((
+            gc_roots::shadow_stack_get(slot + 3),
+            char_index + 1,
+            byte_index + 1,
+        ));
+    }
+
+    loop {
+        let item_roots = gc_roots::push_roots();
+        let (value, next_char, next_byte) = scanner_scan_once(
+            gc_roots::shadow_stack_get(slot),
+            gc_roots::shadow_stack_get(slot + 1),
+            gc_roots::shadow_stack_get(slot + 2),
+            char_index,
+            byte_index,
+        )
+        .map_err(|err| {
+            if err.kind == crate::PyErrorKind::StopIteration {
+                scanner_decode_error(
+                    "Expecting value",
+                    gc_roots::shadow_stack_get(slot + 2),
+                    char_index,
+                )
+            } else {
+                err
+            }
+        })?;
+        gc_roots::pin_root(value);
+        unsafe {
+            pyre_object::w_list_append(
+                gc_roots::shadow_stack_get(slot + 3),
+                gc_roots::shadow_stack_get(gc_roots::shadow_stack_len() - 1),
+            );
+        }
+        drop(item_roots);
+        char_index = next_char;
+        byte_index = next_byte;
+        (char_index, byte_index) =
+            skip_json_whitespace(gc_roots::shadow_stack_get(slot + 2), char_index, byte_index);
+        let doc = gc_roots::shadow_stack_get(slot + 2);
+        match unsafe { pyre_object::w_str_get_wtf8(doc) }
+            .as_bytes()
+            .get(byte_index)
+        {
+            Some(b']') => {
+                char_index += 1;
+                byte_index += 1;
+                break;
+            }
+            Some(b',') => {
+                let comma = char_index;
+                char_index += 1;
+                byte_index += 1;
+                (char_index, byte_index) = skip_json_whitespace(doc, char_index, byte_index);
+                if unsafe { pyre_object::w_str_get_wtf8(doc) }
+                    .as_bytes()
+                    .get(byte_index)
+                    == Some(&b']')
+                {
+                    return Err(scanner_decode_error(
+                        "Illegal trailing comma before end of array",
+                        doc,
+                        comma,
+                    ));
+                }
+            }
+            _ => {
+                return Err(scanner_decode_error(
+                    "Expecting ',' delimiter",
+                    doc,
+                    char_index,
+                ));
+            }
+        }
+    }
+    Ok((gc_roots::shadow_stack_get(slot + 3), char_index, byte_index))
+}
+
+fn scanner_call_impl(self_obj: PyObjectRef, doc: PyObjectRef, index: i64) -> PyResult {
+    require_string(doc)?;
+    if index < 0 {
+        return Err(PyError::value_error("idx cannot be negative"));
+    }
+    let char_index = index as usize;
+    let byte_index = unsafe { pyre_object::w_str_index_to_byte(doc, char_index) };
+    if byte_index >= unsafe { pyre_object::w_str_get_wtf8(doc) }.len() {
+        return Err(stop_iteration(index));
+    }
+    let _roots = gc_roots::push_roots();
+    let slot = gc_roots::shadow_stack_len();
+    for value in [self_obj, doc] {
+        gc_roots::pin_root(value);
+    }
+    // CPython `scanner_call`: one exact dict per public invocation, shared by
+    // the whole recursive descent and discarded with the call.
+    let memo = pyre_object::w_dict_new();
+    gc_roots::pin_root(memo);
+    let (value, next, _) = scanner_scan_once(
+        gc_roots::shadow_stack_get(slot),
+        gc_roots::shadow_stack_get(slot + 2),
+        gc_roots::shadow_stack_get(slot + 1),
+        char_index,
+        byte_index,
+    )?;
+    gc_roots::pin_root(value);
+    Ok(pyre_object::w_tuple_new(vec![
+        gc_roots::shadow_stack_get(slot + 3),
+        pyre_object::w_int_new(next as i64),
+    ]))
+}
+
 #[crate::pyre_class("_json.Scanner")]
 pub struct W_Scanner {
-    parse_object: PyObjectRef,
-    parse_array: PyObjectRef,
-    parse_string: PyObjectRef,
-    strict: PyObjectRef,
+    strict: bool,
     parse_float: PyObjectRef,
     parse_int: PyObjectRef,
     parse_constant: PyObjectRef,
     object_hook: PyObjectRef,
     object_pairs_hook: PyObjectRef,
-    memo: PyObjectRef,
-    depth: i64,
 }
 
 mod scanner_class {
@@ -373,20 +650,8 @@ mod scanner_class {
         }
 
         #[getter]
-        fn parse_object(&self) -> PyObjectRef {
-            self.parse_object
-        }
-        #[getter]
-        fn parse_array(&self) -> PyObjectRef {
-            self.parse_array
-        }
-        #[getter]
-        fn parse_string(&self) -> PyObjectRef {
-            self.parse_string
-        }
-        #[getter]
         fn strict(&self) -> PyObjectRef {
-            self.strict
+            pyre_object::w_bool_from(self.strict)
         }
         #[getter]
         fn parse_float(&self) -> PyObjectRef {
@@ -407,10 +672,6 @@ mod scanner_class {
         #[getter]
         fn object_pairs_hook(&self) -> PyObjectRef {
             self.object_pairs_hook
-        }
-        #[getter]
-        fn memo(&self) -> PyObjectRef {
-            self.memo
         }
     }
 }
@@ -991,37 +1252,28 @@ fn make_scanner_impl(context: PyObjectRef) -> PyResult {
     let slot = gc_roots::shadow_stack_len();
     gc_roots::pin_root(context);
     for name in [
-        "parse_object",
-        "parse_array",
-        "parse_string",
         "strict",
         "parse_float",
         "parse_int",
         "parse_constant",
         "object_hook",
         "object_pairs_hook",
-        "memo",
     ] {
         let value = crate::baseobjspace::getattr_str(gc_roots::shadow_stack_get(slot), name)?;
         gc_roots::pin_root(value);
     }
     // Match the C accelerator: strict is converted during construction, so
     // an overriding `__bool__` raises before the first token is scanned.
-    let strict = crate::baseobjspace::is_true(gc_roots::shadow_stack_get(slot + 4))?;
+    let strict = crate::baseobjspace::is_true(gc_roots::shadow_stack_get(slot + 1))?;
     let _ = scanner_class::type_object();
     Ok(W_Scanner::allocate_stable(W_Scanner {
         ob: pyre_object::PyObject::default(),
-        parse_object: gc_roots::shadow_stack_get(slot + 1),
-        parse_array: gc_roots::shadow_stack_get(slot + 2),
-        parse_string: gc_roots::shadow_stack_get(slot + 3),
-        strict: pyre_object::w_bool_from(strict),
-        parse_float: gc_roots::shadow_stack_get(slot + 5),
-        parse_int: gc_roots::shadow_stack_get(slot + 6),
-        parse_constant: gc_roots::shadow_stack_get(slot + 7),
-        object_hook: gc_roots::shadow_stack_get(slot + 8),
-        object_pairs_hook: gc_roots::shadow_stack_get(slot + 9),
-        memo: gc_roots::shadow_stack_get(slot + 10),
-        depth: 0,
+        strict,
+        parse_float: gc_roots::shadow_stack_get(slot + 2),
+        parse_int: gc_roots::shadow_stack_get(slot + 3),
+        parse_constant: gc_roots::shadow_stack_get(slot + 4),
+        object_hook: gc_roots::shadow_stack_get(slot + 5),
+        object_pairs_hook: gc_roots::shadow_stack_get(slot + 6),
     }))
 }
 

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -47,6 +47,13 @@ fn op_length_hint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 /// `_compare_digest(a, b)` — constant-time equality of two ASCII strings or
 /// two bytes-like objects, used by `hmac` / `secrets`.
 fn op_compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let a_obj = args.first().copied().unwrap_or_else(w_none);
+    let b_obj = args.get(1).copied().unwrap_or_else(w_none);
+    if unsafe { is_str(a_obj) } != unsafe { is_str(b_obj) } {
+        return Err(crate::PyError::type_error(
+            "unsupported operand types(s) or combination of types",
+        ));
+    }
     let read = |obj: PyObjectRef| -> Result<Vec<u8>, crate::PyError> {
         unsafe {
             if is_str(obj) {
@@ -69,8 +76,8 @@ fn op_compare_digest(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             }
         }
     };
-    let a = read(args.first().copied().unwrap_or_else(w_none))?;
-    let b = read(args.get(1).copied().unwrap_or_else(w_none))?;
+    let a = read(a_obj)?;
+    let b = read(b_obj)?;
     let mut result = (a.len() ^ b.len()) as u8;
     for i in 0..a.len() {
         result |= a[i] ^ b.get(i).copied().unwrap_or(0);

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -1220,6 +1220,15 @@ impl W_Struct {
         let fmt = unsafe { w_str_get_value(self.format) };
         Ok(format!("Struct('{fmt}')"))
     }
+
+    /// CPython `Struct.__sizeof__` first applies
+    /// `ENSURE_STRUCT_IS_READY`; the exact allocator accounting is a
+    /// CPython-only assertion, while the half-initialized error is observable
+    /// cross-interpreter behavior.
+    fn __sizeof__(&self) -> Result<i64, crate::PyError> {
+        self.ensure_ready()?;
+        Ok(std::mem::size_of::<W_Struct>() as i64)
+    }
 }
 
 /// gateway `Signature` for a builtin whose named parameters are all

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3128,6 +3128,10 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     fn pick_str(args: &[PyObjectRef]) -> Option<PyObjectRef> {
         args.iter().find(|&&a| !a.is_null() && unsafe { is_str(a) }).copied()
     }
+    // POSIX EIO is 5 on every host ABI pyre targets. Keep the fallback value
+    // target-neutral: wasm's `libc` intentionally exposes no `EIO` symbol,
+    // while a real descriptor error still supplies its actual raw errno.
+    const EIO_FALLBACK: i32 = 5;
     // Encode through `encode_object` with the stream's error handler so a lone
     // surrogate is routed there (stdout `strict` → UnicodeEncodeError; stderr
     // `backslashreplace` → escaped) instead of panicking in `w_str_get_value`.
@@ -3146,7 +3150,12 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
                     #[cfg(not(feature = "sandbox"))]
                     {
                         use std::io::Write;
-                        let _ = std::io::stderr().write_all(&bytes);
+                        std::io::stderr().write_all(&bytes).map_err(|error| {
+                            crate::PyError::os_error_with_errno(
+                                error.raw_os_error().unwrap_or(EIO_FALLBACK),
+                                error.to_string(),
+                            )
+                        })?;
                     }
                     #[cfg(feature = "sandbox")]
                     crate::host_seam::ops::write(2, &bytes)
@@ -3168,7 +3177,12 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
                     #[cfg(not(feature = "sandbox"))]
                     {
                         use std::io::Write;
-                        let _ = std::io::stdout().write_all(&bytes);
+                        std::io::stdout().write_all(&bytes).map_err(|error| {
+                            crate::PyError::os_error_with_errno(
+                                error.raw_os_error().unwrap_or(EIO_FALLBACK),
+                                error.to_string(),
+                            )
+                        })?;
                     }
                     #[cfg(feature = "sandbox")]
                     crate::host_seam::ops::write(1, &bytes)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4779,6 +4779,22 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
 
+    // `len(x)` on an exact canonical list: inline the strategy-guarded
+    // length read (guard_value callable + guard_class + exact w_class +
+    // guard_value strategy + length getfield + wrapint) instead of the
+    // opaque `bh_call_fn(len_builtin, NULL, x)` residual — the shape the
+    // meta-tracer produces upstream (descroperation.py `_len` →
+    // `W_ListObject.length()`).  Read-only like the SUBSCR fold, so no
+    // sub-walk restriction; any non-matching shape falls through to the
+    // generic residual (SAFE).
+    if ctx.is_authoritative_executor
+        && dst_bank == 'r'
+        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
+        && try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)?.is_some()
+    {
+        return Ok((DispatchOutcome::Continue, op.next_pc));
+    }
+
     // BuiltinCode.func is an indirect PBC target exactly like RPython's
     // gateway wrappers.  Enter its generated JitCode before considering the
     // user-function-only full-body walk below.
@@ -5319,22 +5335,6 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
         && try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)?.is_some()
-    {
-        return Ok((DispatchOutcome::Continue, op.next_pc));
-    }
-
-    // `len(x)` on an exact canonical list: inline the strategy-guarded
-    // length read (guard_value callable + guard_class + exact w_class +
-    // guard_value strategy + length getfield + wrapint) instead of the
-    // opaque `bh_call_fn(len_builtin, NULL, x)` residual — the shape the
-    // meta-tracer produces upstream (descroperation.py `_len` →
-    // `W_ListObject.length()`).  Read-only like the SUBSCR fold, so no
-    // sub-walk restriction; any non-matching shape falls through to the
-    // generic residual (SAFE).
-    if ctx.is_authoritative_executor
-        && dst_bank == 'r'
-        && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)?.is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -676,6 +676,20 @@ unsafe fn tokenizer_iter_destructor(obj_addr: usize) {
     unsafe { pyre_interpreter::module::_tokenize::w_tokenizer_iter_dealloc(obj) };
 }
 
+unsafe fn hashlib_hash_state_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_hashlib::w_hash_state_dealloc(
+            obj_addr as pyre_object::PyObjectRef,
+        );
+    }
+}
+
+unsafe fn hashlib_hmac_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_hashlib::w_hmac_dealloc(obj_addr as pyre_object::PyObjectRef);
+    }
+}
+
 /// Custom trace for objects carrying the `MapdictStorageMixin` prefix
 /// (`W_ObjectObject` and native-layout Python subclasses such as
 /// `W_Random`; instance `map`+`storage`,
@@ -3481,6 +3495,25 @@ fn build_gc() -> Box<MiniMarkGC> {
         <pyre_interpreter::module::_json::W_Encoder
             as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // CPython's EVPobject and HMACobject own their native contexts.  Pyre's
+    // fixed-size opaque contexts live inline on the equivalent managed owner;
+    // attach drop glue so sweeping the owner releases the RustCrypto state.
+    let hashlib_hash_state_tid = register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_hashlib::W_HashState
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    gc.types
+        .set_destructor(hashlib_hash_state_tid, hashlib_hash_state_destructor);
+    let hashlib_hmac_tid = register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_hashlib::W_Hmac
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    gc.types
+        .set_destructor(hashlib_hmac_tid, hashlib_hmac_destructor);
     // `pypy/module/gc/referents.py:11-15 W_GcRef`: the wrapper's raw gcref
     // field is a normal traced edge so an internal object stays live and is
     // forwarded in place.  Register it before the target-gated DirEntry slot;

--- a/pyre/pyre-native/Cargo.toml
+++ b/pyre/pyre-native/Cargo.toml
@@ -11,5 +11,7 @@ md-5 = { workspace = true }
 sha1 = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
-blake2 = { workspace = true }
+blake2b_simd = { workspace = true }
+blake2s_simd = { workspace = true }
+scrypt = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }

--- a/pyre/pyre-native/src/hash.rs
+++ b/pyre/pyre-native/src/hash.rs
@@ -1,4 +1,3 @@
-use blake2::{Blake2b512, Blake2s256};
 use md5::Md5;
 use sha1::Sha1;
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512};
@@ -6,6 +5,417 @@ use sha3::{
     Sha3_224, Sha3_256, Sha3_384, Sha3_512, Shake128, Shake256,
     digest::{ExtendableOutput, Update, XofReader},
 };
+use std::sync::Mutex;
+
+#[derive(Clone)]
+enum HashState {
+    Md5(Md5),
+    Sha1(Sha1),
+    Sha224(Sha224),
+    Sha256(Sha256),
+    Sha384(Sha384),
+    Sha512(Sha512),
+    Sha3_224(Sha3_224),
+    Sha3_256(Sha3_256),
+    Sha3_384(Sha3_384),
+    Sha3_512(Sha3_512),
+    Shake128(Shake128),
+    Shake256(Shake256),
+    Blake2b(blake2b_simd::State),
+    Blake2s(blake2s_simd::State),
+}
+
+impl HashState {
+    fn new(name: &str) -> Option<Self> {
+        Some(match name {
+            "md5" => Self::Md5(Md5::default()),
+            "sha1" => Self::Sha1(Sha1::default()),
+            "sha224" => Self::Sha224(Sha224::default()),
+            "sha256" => Self::Sha256(Sha256::default()),
+            "sha384" => Self::Sha384(Sha384::default()),
+            "sha512" => Self::Sha512(Sha512::default()),
+            "sha3_224" => Self::Sha3_224(Sha3_224::default()),
+            "sha3_256" => Self::Sha3_256(Sha3_256::default()),
+            "sha3_384" => Self::Sha3_384(Sha3_384::default()),
+            "sha3_512" => Self::Sha3_512(Sha3_512::default()),
+            "shake_128" => Self::Shake128(Shake128::default()),
+            "shake_256" => Self::Shake256(Shake256::default()),
+            "blake2b" => Self::Blake2b(blake2b_simd::Params::new().to_state()),
+            "blake2s" => Self::Blake2s(blake2s_simd::Params::new().to_state()),
+            _ => return None,
+        })
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        macro_rules! update {
+            ($state:expr) => {
+                Update::update($state, data)
+            };
+        }
+        match self {
+            Self::Md5(state) => update!(state),
+            Self::Sha1(state) => update!(state),
+            Self::Sha224(state) => update!(state),
+            Self::Sha256(state) => update!(state),
+            Self::Sha384(state) => update!(state),
+            Self::Sha512(state) => update!(state),
+            Self::Sha3_224(state) => update!(state),
+            Self::Sha3_256(state) => update!(state),
+            Self::Sha3_384(state) => update!(state),
+            Self::Sha3_512(state) => update!(state),
+            Self::Shake128(state) => update!(state),
+            Self::Shake256(state) => update!(state),
+            Self::Blake2b(state) => {
+                state.update(data);
+            }
+            Self::Blake2s(state) => {
+                state.update(data);
+            }
+        }
+    }
+
+    fn digest(&self, length: usize) -> Vec<u8> {
+        macro_rules! fixed {
+            ($state:expr) => {
+                Digest::finalize($state.clone()).to_vec()
+            };
+        }
+        match self {
+            Self::Md5(state) => fixed!(state),
+            Self::Sha1(state) => fixed!(state),
+            Self::Sha224(state) => fixed!(state),
+            Self::Sha256(state) => fixed!(state),
+            Self::Sha384(state) => fixed!(state),
+            Self::Sha512(state) => fixed!(state),
+            Self::Sha3_224(state) => fixed!(state),
+            Self::Sha3_256(state) => fixed!(state),
+            Self::Sha3_384(state) => fixed!(state),
+            Self::Sha3_512(state) => fixed!(state),
+            Self::Blake2b(state) => state.finalize().as_bytes().to_vec(),
+            Self::Blake2s(state) => state.finalize().as_bytes().to_vec(),
+            Self::Shake128(state) => {
+                let mut out = vec![0; length];
+                state.clone().finalize_xof().read(&mut out);
+                out
+            }
+            Self::Shake256(state) => {
+                let mut out = vec![0; length];
+                state.clone().finalize_xof().read(&mut out);
+                out
+            }
+        }
+    }
+}
+
+type LockedHashState = Mutex<HashState>;
+
+/// Size/alignment contract for the opaque, object-owned storage embedded in
+/// pyre's `_HashState` payload.  The digest implementations are fixed-size
+/// state machines; none owns heap memory or needs drop glue.
+pub const HASH_STATE_STORAGE_WORDS: usize = 64;
+pub const HASH_STATE_STORAGE_ALIGN: usize = 16;
+
+fn check_storage(storage: *mut usize, words: usize) {
+    assert!(words >= HASH_STATE_STORAGE_WORDS);
+    assert!(std::mem::size_of::<LockedHashState>() <= words * std::mem::size_of::<usize>());
+    assert!(std::mem::align_of::<LockedHashState>() <= HASH_STATE_STORAGE_ALIGN);
+    assert!(!storage.is_null());
+    assert_eq!((storage as usize) % HASH_STATE_STORAGE_ALIGN, 0);
+}
+
+/// Initialize an object-owned opaque state buffer. Returns false for an
+/// unsupported canonical digest name.
+pub unsafe fn state_init(storage: *mut usize, words: usize, name: &str) -> bool {
+    check_storage(storage, words);
+    let Some(state) = HashState::new(name) else {
+        return false;
+    };
+    unsafe { storage.cast::<LockedHashState>().write(Mutex::new(state)) };
+    true
+}
+
+/// Initialize a BLAKE2 state with the complete RFC 7693 parameter block.
+/// The Python layer validates the exact PyPy/CPython ranges before calling;
+/// the backend APIs then encode the fields in the algorithm-defined little-
+/// endian parameter layout.
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn state_init_blake2(
+    storage: *mut usize,
+    words: usize,
+    name: &str,
+    digest_size: usize,
+    key: &[u8],
+    salt: &[u8],
+    person: &[u8],
+    fanout: u8,
+    depth: u8,
+    leaf_size: u32,
+    node_offset: u64,
+    node_depth: u8,
+    inner_size: usize,
+    last_node: bool,
+) -> bool {
+    check_storage(storage, words);
+    let state = match name {
+        "blake2b" => {
+            let mut params = blake2b_simd::Params::new();
+            params
+                .hash_length(digest_size)
+                .key(key)
+                .salt(salt)
+                .personal(person)
+                .fanout(fanout)
+                .max_depth(depth)
+                .max_leaf_length(leaf_size)
+                .node_offset(node_offset)
+                .node_depth(node_depth)
+                .inner_hash_length(inner_size)
+                .last_node(last_node);
+            HashState::Blake2b(params.to_state())
+        }
+        "blake2s" => {
+            let mut params = blake2s_simd::Params::new();
+            params
+                .hash_length(digest_size)
+                .key(key)
+                .salt(salt)
+                .personal(person)
+                .fanout(fanout)
+                .max_depth(depth)
+                .max_leaf_length(leaf_size)
+                .node_offset(node_offset)
+                .node_depth(node_depth)
+                .inner_hash_length(inner_size)
+                .last_node(last_node);
+            HashState::Blake2s(params.to_state())
+        }
+        _ => return false,
+    };
+    unsafe { storage.cast::<LockedHashState>().write(Mutex::new(state)) };
+    true
+}
+
+pub unsafe fn state_update(storage: *mut usize, words: usize, data: &[u8]) {
+    check_storage(storage, words);
+    let state = unsafe { &*storage.cast::<LockedHashState>() };
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .update(data);
+}
+
+pub unsafe fn state_digest(storage: *const usize, words: usize, length: usize) -> Vec<u8> {
+    check_storage(storage.cast_mut(), words);
+    let state = unsafe { &*storage.cast::<LockedHashState>() };
+    state
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .digest(length)
+}
+
+pub unsafe fn state_copy(src: *const usize, dst: *mut usize, words: usize) {
+    check_storage(src.cast_mut(), words);
+    check_storage(dst, words);
+    let source = unsafe { &*src.cast::<LockedHashState>() };
+    let cloned = source
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    unsafe { dst.cast::<LockedHashState>().write(Mutex::new(cloned)) };
+}
+
+pub unsafe fn state_drop(storage: *mut usize, words: usize) {
+    check_storage(storage, words);
+    unsafe { std::ptr::drop_in_place(storage.cast::<LockedHashState>()) };
+}
+
+#[derive(Clone)]
+struct HmacState {
+    inner: HashState,
+    outer: HashState,
+}
+
+impl HmacState {
+    fn new(name: &str, key: &[u8]) -> Option<Self> {
+        let block_size = digest_block_size(name)?;
+        let mut key = if key.len() > block_size {
+            HashState::new(name)?.tap_update(key).digest(0)
+        } else {
+            key.to_vec()
+        };
+        key.resize(block_size, 0);
+        let mut inner = HashState::new(name)?;
+        let mut outer = HashState::new(name)?;
+        let mut ipad = key.clone();
+        let mut opad = key;
+        for byte in &mut ipad {
+            *byte ^= 0x36;
+        }
+        for byte in &mut opad {
+            *byte ^= 0x5c;
+        }
+        inner.update(&ipad);
+        outer.update(&opad);
+        Some(Self { inner, outer })
+    }
+
+    fn update(&mut self, data: &[u8]) {
+        self.inner.update(data);
+    }
+
+    fn digest(&self) -> Vec<u8> {
+        let mut outer = self.outer.clone();
+        outer.update(&self.inner.digest(0));
+        outer.digest(0)
+    }
+}
+
+/// PBKDF2-HMAC (RFC 8018), used by `_hashlib.pbkdf2_hmac`.
+pub fn compute_pbkdf2_hmac(
+    name: &str,
+    password: &[u8],
+    salt: &[u8],
+    iterations: usize,
+    dklen: usize,
+) -> Option<Vec<u8>> {
+    if iterations == 0 || dklen == 0 {
+        return None;
+    }
+    let digest_size = digest_output_size(name)?;
+    let blocks = dklen.checked_add(digest_size - 1)? / digest_size;
+    if blocks > u32::MAX as usize {
+        return None;
+    }
+    let mut derived = Vec::with_capacity(blocks * digest_size);
+    let mut first_input = Vec::with_capacity(salt.len() + 4);
+    first_input.extend_from_slice(salt);
+    for block in 1..=blocks {
+        first_input.truncate(salt.len());
+        first_input.extend_from_slice(&(block as u32).to_be_bytes());
+        let mut hmac = HmacState::new(name, password)?;
+        hmac.update(&first_input);
+        let mut u = hmac.digest();
+        let mut accumulator = u.clone();
+        for _ in 1..iterations {
+            let mut hmac = HmacState::new(name, password)?;
+            hmac.update(&u);
+            u = hmac.digest();
+            for (out, byte) in accumulator.iter_mut().zip(&u) {
+                *out ^= *byte;
+            }
+        }
+        derived.extend_from_slice(&accumulator);
+    }
+    derived.truncate(dklen);
+    Some(derived)
+}
+
+/// RFC 7914 scrypt, used by `_hashlib.scrypt`.
+///
+/// `_hashlib` performs CPython's argument and memory-limit validation before
+/// entering this backend.  `Params::new` still enforces the algorithm's
+/// overflow constraints; its `len` field belongs to the optional password-
+/// hash facade and is not consulted by the raw `scrypt` KDF, so use a valid
+/// placeholder and size the caller-owned output independently.
+pub fn compute_scrypt(
+    password: &[u8],
+    salt: &[u8],
+    log_n: u8,
+    r: u32,
+    p: u32,
+    dklen: usize,
+) -> Option<Vec<u8>> {
+    let params = scrypt::Params::new(log_n, r, p, 32).ok()?;
+    let mut output = vec![0; dklen];
+    scrypt::scrypt(password, salt, &params, &mut output).ok()?;
+    Some(output)
+}
+
+impl HashState {
+    fn tap_update(mut self, data: &[u8]) -> Self {
+        self.update(data);
+        self
+    }
+}
+
+pub fn digest_block_size(name: &str) -> Option<usize> {
+    Some(match name {
+        "md5" | "sha1" | "sha224" | "sha256" | "blake2s" => 64,
+        "sha384" | "sha512" | "blake2b" => 128,
+        "sha3_224" => 144,
+        "sha3_256" => 136,
+        "sha3_384" => 104,
+        "sha3_512" => 72,
+        // RFC 2104 HMAC is not defined for XOF algorithms.
+        "shake_128" | "shake_256" => return None,
+        _ => return None,
+    })
+}
+
+pub fn digest_output_size(name: &str) -> Option<usize> {
+    Some(match name {
+        "md5" => 16,
+        "sha1" => 20,
+        "sha224" | "sha3_224" => 28,
+        "sha256" | "sha3_256" | "blake2s" => 32,
+        "sha384" | "sha3_384" => 48,
+        "sha512" | "sha3_512" | "blake2b" => 64,
+        "shake_128" | "shake_256" => return None,
+        _ => return None,
+    })
+}
+
+type LockedHmacState = Mutex<HmacState>;
+pub const HMAC_STATE_STORAGE_WORDS: usize = 128;
+pub const HMAC_STATE_STORAGE_ALIGN: usize = 16;
+
+fn check_hmac_storage(storage: *mut usize, words: usize) {
+    assert!(words >= HMAC_STATE_STORAGE_WORDS);
+    assert!(std::mem::size_of::<LockedHmacState>() <= words * std::mem::size_of::<usize>());
+    assert!(std::mem::align_of::<LockedHmacState>() <= HMAC_STATE_STORAGE_ALIGN);
+    assert!(!storage.is_null());
+    assert_eq!((storage as usize) % HMAC_STATE_STORAGE_ALIGN, 0);
+}
+
+pub unsafe fn hmac_state_init(storage: *mut usize, words: usize, name: &str, key: &[u8]) -> bool {
+    check_hmac_storage(storage, words);
+    let Some(state) = HmacState::new(name, key) else {
+        return false;
+    };
+    unsafe { storage.cast::<LockedHmacState>().write(Mutex::new(state)) };
+    true
+}
+
+pub unsafe fn hmac_state_update(storage: *mut usize, words: usize, data: &[u8]) {
+    check_hmac_storage(storage, words);
+    unsafe { &*storage.cast::<LockedHmacState>() }
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .update(data);
+}
+
+pub unsafe fn hmac_state_digest(storage: *const usize, words: usize) -> Vec<u8> {
+    check_hmac_storage(storage.cast_mut(), words);
+    unsafe { &*storage.cast::<LockedHmacState>() }
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .digest()
+}
+
+pub unsafe fn hmac_state_copy(src: *const usize, dst: *mut usize, words: usize) {
+    check_hmac_storage(src.cast_mut(), words);
+    check_hmac_storage(dst, words);
+    let cloned = unsafe { &*src.cast::<LockedHmacState>() }
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    unsafe { dst.cast::<LockedHmacState>().write(Mutex::new(cloned)) };
+}
+
+pub unsafe fn hmac_state_drop(storage: *mut usize, words: usize) {
+    check_hmac_storage(storage, words);
+    unsafe { std::ptr::drop_in_place(storage.cast::<LockedHmacState>()) };
+}
 
 #[inline(never)]
 pub fn compute_digest(name: &str, data: &[u8], length: usize) -> Option<Vec<u8>> {
@@ -20,8 +430,8 @@ pub fn compute_digest(name: &str, data: &[u8], length: usize) -> Option<Vec<u8>>
         "sha3_256" => Sha3_256::digest(data).to_vec(),
         "sha3_384" => Sha3_384::digest(data).to_vec(),
         "sha3_512" => Sha3_512::digest(data).to_vec(),
-        "blake2b" => Blake2b512::digest(data).to_vec(),
-        "blake2s" => Blake2s256::digest(data).to_vec(),
+        "blake2b" => blake2b_simd::blake2b(data).as_bytes().to_vec(),
+        "blake2s" => blake2s_simd::blake2s(data).as_bytes().to_vec(),
         "shake_128" => {
             let mut h = Shake128::default();
             h.update(data);
@@ -43,10 +453,27 @@ pub fn compute_digest(name: &str, data: &[u8], length: usize) -> Option<Vec<u8>>
 
 #[cfg(test)]
 mod tests {
-    use super::compute_digest;
+    use super::{
+        HASH_STATE_STORAGE_WORDS, HMAC_STATE_STORAGE_WORDS, compute_digest, compute_pbkdf2_hmac,
+        compute_scrypt, hmac_state_digest, hmac_state_drop, hmac_state_init, hmac_state_update,
+        state_copy, state_digest, state_drop, state_init, state_init_blake2, state_update,
+    };
 
     fn hex(bytes: &[u8]) -> String {
         bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+    }
+
+    struct HashStorage([usize; HASH_STATE_STORAGE_WORDS + 1]);
+
+    struct HmacStorage([usize; HMAC_STATE_STORAGE_WORDS + 1]);
+
+    fn aligned_ptr(words: &[usize]) -> *const usize {
+        let address = words.as_ptr() as usize;
+        ((address + 15) & !15) as *const usize
+    }
+
+    fn aligned_mut_ptr(words: &mut [usize]) -> *mut usize {
+        aligned_ptr(words) as *mut usize
     }
 
     #[test]
@@ -71,5 +498,134 @@ mod tests {
     #[test]
     fn rejects_unknown_algorithm() {
         assert!(compute_digest("not-a-hash", b"abc", 0).is_none());
+    }
+
+    #[test]
+    fn incremental_state_updates_and_copies_independently() {
+        let mut state = HashStorage([0usize; HASH_STATE_STORAGE_WORDS + 1]);
+        let mut clone = HashStorage([0usize; HASH_STATE_STORAGE_WORDS + 1]);
+        unsafe {
+            assert!(state_init(
+                aligned_mut_ptr(&mut state.0),
+                HASH_STATE_STORAGE_WORDS,
+                "sha256"
+            ));
+            state_update(
+                aligned_mut_ptr(&mut state.0),
+                HASH_STATE_STORAGE_WORDS,
+                b"ab",
+            );
+            state_copy(
+                aligned_ptr(&state.0),
+                aligned_mut_ptr(&mut clone.0),
+                HASH_STATE_STORAGE_WORDS,
+            );
+            state_update(
+                aligned_mut_ptr(&mut state.0),
+                HASH_STATE_STORAGE_WORDS,
+                b"c",
+            );
+            state_update(
+                aligned_mut_ptr(&mut clone.0),
+                HASH_STATE_STORAGE_WORDS,
+                b"d",
+            );
+            assert_eq!(
+                state_digest(aligned_ptr(&state.0), HASH_STATE_STORAGE_WORDS, 0),
+                compute_digest("sha256", b"abc", 0).unwrap()
+            );
+            assert_eq!(
+                state_digest(aligned_ptr(&clone.0), HASH_STATE_STORAGE_WORDS, 0),
+                compute_digest("sha256", b"abd", 0).unwrap()
+            );
+            state_drop(aligned_mut_ptr(&mut state.0), HASH_STATE_STORAGE_WORDS);
+            state_drop(aligned_mut_ptr(&mut clone.0), HASH_STATE_STORAGE_WORDS);
+        }
+    }
+
+    #[test]
+    fn incremental_hmac_matches_rfc_4231_sha256() {
+        let mut state = HmacStorage([0usize; HMAC_STATE_STORAGE_WORDS + 1]);
+        unsafe {
+            assert!(hmac_state_init(
+                aligned_mut_ptr(&mut state.0),
+                HMAC_STATE_STORAGE_WORDS,
+                "sha256",
+                &[0x0b; 20],
+            ));
+            hmac_state_update(
+                aligned_mut_ptr(&mut state.0),
+                HMAC_STATE_STORAGE_WORDS,
+                b"Hi There",
+            );
+            assert_eq!(
+                hex(&hmac_state_digest(
+                    aligned_ptr(&state.0),
+                    HMAC_STATE_STORAGE_WORDS,
+                )),
+                "b0344c61d8db38535ca8afceaf0bf12b881dc200c9833da726e9376c2e32cff7"
+            );
+            hmac_state_drop(aligned_mut_ptr(&mut state.0), HMAC_STATE_STORAGE_WORDS);
+        }
+    }
+
+    #[test]
+    fn pbkdf2_hmac_matches_rfc_6070_sha1() {
+        assert_eq!(
+            hex(&compute_pbkdf2_hmac("sha1", b"password", b"salt", 2, 20).unwrap()),
+            "ea6c014dc72d6f8ccd1ed92ace1d41f0d8de8957"
+        );
+    }
+
+    #[test]
+    fn scrypt_matches_rfc_7914() {
+        assert_eq!(
+            hex(&compute_scrypt(b"", b"", 4, 1, 1, 64).unwrap()),
+            "77d6576238657b203b19ca42c18a0497f16b4844e3074ae8dfdffa3fede21442\
+             fcd0069ded0948f8326a753a0fc81f17e8d3e0fb2e0d3628cf35e20c38d18906"
+                .replace(' ', "")
+        );
+    }
+
+    #[test]
+    fn blake2_parameter_block_matches_cpython_vectors() {
+        for (name, expected) in [
+            ("blake2b", "920568b0c5873b2f0ab67bedb6cf1b2b"),
+            ("blake2s", "bf2a8f7fe3c555012a6f8046e646bc75"),
+        ] {
+            let mut state = HashStorage([0usize; HASH_STATE_STORAGE_WORDS + 1]);
+            unsafe {
+                assert!(state_init_blake2(
+                    aligned_mut_ptr(&mut state.0),
+                    HASH_STATE_STORAGE_WORDS,
+                    name,
+                    16,
+                    b"bar",
+                    b"baz",
+                    b"bing",
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    true,
+                ));
+                state_update(
+                    aligned_mut_ptr(&mut state.0),
+                    HASH_STATE_STORAGE_WORDS,
+                    b"foo",
+                );
+                assert_eq!(
+                    hex(&state_digest(
+                        aligned_ptr(&state.0),
+                        HASH_STATE_STORAGE_WORDS,
+                        0,
+                    )),
+                    expected
+                );
+                state_drop(aligned_mut_ptr(&mut state.0), HASH_STATE_STORAGE_WORDS);
+            }
+        }
     }
 }

--- a/pyre/pyre-object/src/module.rs
+++ b/pyre/pyre-object/src/module.rs
@@ -146,6 +146,26 @@ pub fn w_module_new_managed(name: &str) -> PyObjectRef {
 /// discriminant to erase.
 #[majit_macros::dont_look_inside]
 pub fn w_module_new_aliasing_dict(name: &str, w_dict_object: PyObjectRef) -> PyObjectRef {
+    let value = module_aliasing_dict_value(name, w_dict_object);
+    crate::lltype::malloc_typed(value) as PyObjectRef
+}
+
+/// GC-managed counterpart of [`w_module_new_aliasing_dict`].
+///
+/// Once `sys.modules` exists it is the ordinary object-graph owner of imported
+/// modules, exactly as `space.sys.modules` is in PyPy.  A builtin module made
+/// after that point must therefore be collectible when its cache entry and
+/// every application reference disappear; in particular its
+/// module -> dict -> builtin function -> module cycle is not a process root.
+/// Stable allocation preserves the address assumptions of promoted module
+/// constants while still letting a major collection reclaim the cycle.
+#[majit_macros::dont_look_inside]
+pub fn w_module_new_aliasing_dict_managed(name: &str, w_dict_object: PyObjectRef) -> PyObjectRef {
+    let value = module_aliasing_dict_value(name, w_dict_object);
+    crate::lltype::malloc_typed_stable(value) as PyObjectRef
+}
+
+fn module_aliasing_dict_value(name: &str, w_dict_object: PyObjectRef) -> Module {
     if !name.is_empty() && !w_dict_object.is_null() && unsafe { crate::is_dict(w_dict_object) } {
         unsafe {
             crate::dictmultiobject::w_dict_setitem_str(
@@ -156,14 +176,14 @@ pub fn w_module_new_aliasing_dict(name: &str, w_dict_object: PyObjectRef) -> PyO
         }
     }
     let name = crate::lltype::malloc_raw(name.to_string());
-    crate::lltype::malloc_typed(Module {
+    Module {
         ob_header: PyObject {
             ob_type: &MODULE_TYPE as *const PyType,
             w_class: get_instantiate(&MODULE_TYPE),
         },
         name,
         w_dict: w_dict_object,
-    }) as PyObjectRef
+    }
 }
 
 /// Get the module name.

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -640,19 +640,22 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // `_json.Scanner` and `_json.Encoder` follow with typed managed payloads.
     (162, Some(0)),
     (163, Some(0)),
+    // `_hashlib`'s per-object digest and HMAC native-state owners.
+    (164, Some(0)),
+    (165, Some(0)),
     // `gc.GcRef` stores its raw referent as a traced wrapper edge.
     // gcref payload is a traced edge on the wrapper itself.
-    (164, Some(0)),
-    // `gc.hooks` keeps its three callback fields on W_AppLevelHooks.
-    (165, Some(0)),
-    // `gc._get_stats()` returns a native W_GcStats with scalar-only payload.
     (166, Some(0)),
+    // `gc.hooks` keeps its three callback fields on W_AppLevelHooks.
+    (167, Some(0)),
+    // `gc._get_stats()` returns a native W_GcStats with scalar-only payload.
+    (168, Some(0)),
     // W_GcStats is the final unconditional rclass registration.
     // `posix.DirEntry` follows it on native builds, last of the rclass
     // registrations and before the bare twister id. `posix` is compiled out
     // on wasm32, so its object-hierarchy slot is too.
     #[cfg(not(target_arch = "wasm32"))]
-    (167, Some(0)),
+    (169, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1128,6 +1128,53 @@ fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
     }
 }
 
+/// Release module globals whose objects carry a Python `__del__` after the
+/// modules have been detached from `sys.modules`.
+///
+/// Pyre still has native-owned immortal Module holders, so clearing the import
+/// cache alone cannot release a user finalizer stored in one of their dicts.
+/// CPython's full `finalize_modules` also coordinates weakref callbacks and a
+/// two-pass namespace clear; until that complete ordering is ported, erasing
+/// every helper module here would invalidate callback globals during the same
+/// shutdown. The finalizer queue already records precisely the observable
+/// user-deallocator case, so release those values newest-first and leave the
+/// supporting module namespaces alive for their callbacks.
+fn clear_shutdown_modules(
+    modules: Vec<pyre_object::PyObjectRef>,
+    ec_ptr: *const PyExecutionContext,
+) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let roots_start = pyre_object::gc_roots::shadow_stack_len();
+    for module in modules {
+        pyre_object::gc_roots::pin_root(module);
+    }
+    let roots_end = pyre_object::gc_roots::shadow_stack_len();
+    for slot in roots_start..roots_end {
+        let module = pyre_object::gc_roots::shadow_stack_get(slot);
+        if module.is_null() || !unsafe { pyre_object::is_module(module) } {
+            continue;
+        }
+        let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+        if dict.is_null() {
+            continue;
+        }
+        let mut entries = unsafe { pyre_object::w_dict_str_entries(dict) };
+        entries.reverse();
+        for (name, value) in entries {
+            let Some(value_type) = pyre_interpreter::typedef::r#type(value) else {
+                continue;
+            };
+            if !unsafe { pyre_object::w_type_get_hasuserdel(value_type.as_ptr()) } {
+                continue;
+            }
+            unsafe {
+                pyre_object::w_dict_setitem_str(dict, &name, pyre_object::w_none());
+            }
+            collect_and_run_finalizers(ec_ptr);
+        }
+    }
+}
+
 /// Whether releasing this binding can remove anything from the reachable set,
 /// and so whether the collection that follows it could find garbage an earlier
 /// one did not. Answering `false` skips a full mark-and-sweep of the whole
@@ -1212,6 +1259,11 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
     // itself holds, so without this a stream owned by any other module loses
     // its buffered writes.
     pyre_interpreter::module::_io::flush_all_streams();
+    // CPython `finalize_modules` releases the import cache before globals;
+    // otherwise module-owned cycles never become candidates for the
+    // collections below and their deallocators do not run at shutdown.
+    let shutdown_modules = pyre_interpreter::importing::release_sys_modules_for_shutdown();
+    clear_shutdown_modules(shutdown_modules, ec_ptr);
     collect_and_run_finalizers(ec_ptr);
     let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
     entries.reverse();


### PR DESCRIPTION
## Summary

- complete native `_json` scanner/encoder behavior and shutdown/error handling
- finish `_struct` compatibility and module lifecycle cleanup
- add object-owned incremental `_hashlib` and HMAC state, distinct `HASHXOF`, PBKDF2, and scrypt
- implement full BLAKE2 parameter blocks, keyed hashing, copying, and CPython clinic diagnostics
- keep builtin `len` specialization ahead of gateway inlining and promote the four CPython suites to PASS

## Validation

- `python3 scripts/extract-llbc.py`
- `PYRE_RTYPER_VERBOSE=1 cargo build --release -p pyre-jit-trace`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- release `test_hashlib`: 82 run, 18 skipped
- release `test_hmac`: 145 run, 58 skipped
- release `test_json`: 218 run, 3 skipped
- release `test_struct`: 43 run, 6 skipped
- focused CPython baseline runner: no regressions for all four suites