### PR TITLE
jit: trim recursive-call GC and frame overhead

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/arch.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/arch.rs
@@ -21,12 +21,8 @@ pub const FRAME_FIXED_SIZE: usize = 0;
 pub const PASS_ON_MY_FRAME: usize = 0;
 
 /// aarch64/arch.py:13 — `JITFRAME_FIXED_SIZE = NUM_MANAGED_REGS +
-/// NUM_VFP_REGS`, i.e. 18 GPR + 8 VFP = 26.
-///
-/// `NUM_MANAGED_REGS` must equal `len(all_regs)` (runner.py:84 asserts
-/// this); enabling callee-saved x21, x22 grows `all_regs` from 16 to 18,
-/// so the managed-register area of the jitframe grows to match.
-pub const JITFRAME_FIXED_SIZE: usize = 26;
+/// NUM_VFP_REGS`, i.e. 16 GPR + 8 VFP = 24.
+pub const JITFRAME_FIXED_SIZE: usize = 24;
 
 /// aarch64/arch.py: thread-local data is reached via the system TLS
 /// register, not via a fixed slot in the JIT frame.

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -31,7 +31,7 @@ use crate::regalloc::{RegAlloc, RegAllocOp};
 use crate::regloc::{Loc, RegLoc};
 use crate::runner::GuardGcTypeInfo;
 
-const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 18] = crate::aarch64::registers::ALL_REGS;
+const AARCH64_GEN_REGS: [crate::regloc::RegLoc; 16] = crate::aarch64::registers::ALL_REGS;
 
 const AARCH64_FLOAT_REGS: [crate::regloc::RegLoc; 8] = crate::aarch64::registers::ALL_VFP_REGS;
 
@@ -1384,9 +1384,9 @@ impl<'a> AssemblerARM64<'a> {
     /// x64: System V AMD64 ABI — first arg (jf_ptr) in RDI.
     /// aarch64: AAPCS64 — first arg (jf_ptr) in X0.
     ///
-    /// Save slots: 48 bytes total (fp/lr at [sp,#0], x19/x20 at
-    /// [sp,#16], x21/x22 at [sp,#32]).  Mirrors aarch64/assembler.py:1117-1122
-    /// which iterates `r.callee_saved_registers = [x19, x20, x21, x22]`.
+    /// Save slots: fp/lr at [sp,#0], x19/x20 at [sp,#16].  Mirrors
+    /// aarch64/assembler.py:1117-1122, which iterates
+    /// `r.callee_saved_registers = [x19, x20]`.
     ///
     /// aarch64/assembler.py:1092-1114 `_call_header_with_stack_check`:
     /// inline SP probe right after the frame pointer is captured,
@@ -1416,7 +1416,6 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64
             ; stp x29, x30, [sp, -(CALL_FRAME_SIZE as i32)]!
             ; stp x19, x20, [sp, #16]   // save callee-saved regs
-            ; stp x21, x22, [sp, #32]   // save callee-saved regs
             // assembler.py:1128-1129: spill the thread-local base the entry
             // received in x1, then take the jitframe out of x0.
             ; str x1, [sp, #SAVED_THREADLOCAL_OFS]
@@ -1468,7 +1467,6 @@ impl<'a> AssemblerARM64<'a> {
                     // Overflow fallthrough: return x29 as jf_ptr.
                     ; mov x0, x29
                     ; ldp x19, x20, [sp, #16]
-                    ; ldp x21, x22, [sp, #32]
                     ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
                     ; ret
                     ; =>continue_label
@@ -1491,7 +1489,6 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64
             ; mov x0, x29
             ; ldp x19, x20, [sp, #16]   // restore callee-saved regs
-            ; ldp x21, x22, [sp, #32]   // restore callee-saved regs
             ; ldp x29, x30, [sp], CALL_FRAME_SIZE as i32
             ; ret
         );
@@ -6611,7 +6608,7 @@ impl<'a> AssemblerARM64<'a> {
         // live Ref into its canonical jitframe slot. `gcmap` identifies
         // those slots by the same register-index table that
         // `get_gcmap` writes bits from (`core_reg_index`:
-        //   x0..x13 → slots 0..13, x19 → 14, x20 → 15, x21 → 16, x22 → 17).
+        //   x0..x13 → slots 0..13, x19 → 14, x20 → 15).
         //
         // Without this spill the GC walks `jf_frame` slots 0..15 (per
         // gcmap bits), finds garbage, and returns with live Refs in CPU
@@ -6628,7 +6625,7 @@ impl<'a> AssemblerARM64<'a> {
         // the malloc site (see `MALLOC_NURSERY_CLOBBER`).
         dynasm!(self.mc ; .arch aarch64 ; =>slow_path);
         let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
-        // Save x2..x13, x19..x22 to their slots (x0/x1 excluded per ignored_regs).
+        // Save x2..x13, x19/x20 to their slots (x0/x1 excluded per ignored_regs).
         dynasm!(self.mc ; .arch aarch64
             ; stp x2, x3, [x29, base_ofs + 2 * 8]
             ; stp x4, x5, [x29, base_ofs + 4 * 8]
@@ -6637,7 +6634,6 @@ impl<'a> AssemblerARM64<'a> {
             ; stp x10, x11, [x29, base_ofs + 10 * 8]
             ; stp x12, x13, [x29, base_ofs + 12 * 8]
             ; stp x19, x20, [x29, base_ofs + 14 * 8]
-            ; stp x21, x22, [x29, base_ofs + 16 * 8]
         );
         // assembler.py:649-650: store gcmap to jf_gcmap so the collector
         // can trace live Refs pinned to frame slots during the slow-path
@@ -6659,7 +6655,7 @@ impl<'a> AssemblerARM64<'a> {
         // pop_gcmap: clear jf_gcmap after collecting call
         let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS as u32;
         dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
-        // Restore x2..x13, x19..x22 from jitframe slots (GC may have
+        // Restore x2..x13, x19/x20 from jitframe slots (GC may have
         // updated the stored pointers). x0 keeps the allocated payload ptr.
         let base_ofs_r = crate::jitframe::FIRST_ITEM_OFFSET as i32;
         dynasm!(self.mc ; .arch aarch64
@@ -6670,7 +6666,6 @@ impl<'a> AssemblerARM64<'a> {
             ; ldp x10, x11, [x29, base_ofs_r + 10 * 8]
             ; ldp x12, x13, [x29, base_ofs_r + 12 * 8]
             ; ldp x19, x20, [x29, base_ofs_r + 14 * 8]
-            ; ldp x21, x22, [x29, base_ofs_r + 16 * 8]
         );
         // `dynasm_nursery_slowpath` returns x0 = 0 on real host OOM
         // (calloc failure preserved as NULL per runner.rs).  Route
@@ -6748,7 +6743,6 @@ impl<'a> AssemblerARM64<'a> {
             ; stp x10, x11, [x29, base_ofs + 10 * 8]
             ; stp x12, x13, [x29, base_ofs + 12 * 8]
             ; stp x19, x20, [x29, base_ofs + 14 * 8]
-            ; stp x21, x22, [x29, base_ofs + 16 * 8]
         );
         if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
             self.push_gcmap(gcmap as *mut usize);
@@ -6774,7 +6768,6 @@ impl<'a> AssemblerARM64<'a> {
             ; ldp x10, x11, [x29, base_ofs_r + 10 * 8]
             ; ldp x12, x13, [x29, base_ofs_r + 12 * 8]
             ; ldp x19, x20, [x29, base_ofs_r + 14 * 8]
-            ; ldp x21, x22, [x29, base_ofs_r + 16 * 8]
         );
         self.emit_propagate_memory_error_if_null(0);
 

--- a/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/regalloc.rs
@@ -32,7 +32,7 @@ fn check_imm_box(arg: OpRef) -> bool {
 }
 
 /// aarch64/registers.py:14
-///   `all_regs = registers[:14] + [x19, x20, x21, x22]`
+///   `all_regs = registers[:14] + [x19, x20]`
 pub fn all_core_regs() -> Vec<RegLoc> {
     registers::ALL_REGS.to_vec()
 }
@@ -74,14 +74,12 @@ pub fn call_result_fpr() -> RegLoc {
 /// `all_core_regs` list — used by gcmap and jitframe slot tables.
 ///
 /// aarch64 mapping (matches `all_core_regs`):
-///   x0..x13 → 0..13, x19 → 14, x20 → 15, x21 → 16, x22 → 17.
+///   x0..x13 → 0..13, x19 → 14, x20 → 15.
 pub fn core_reg_index(reg: RegLoc) -> Option<usize> {
     match reg.value {
         0..=13 => Some(reg.value as usize),
         19 => Some(14),
         20 => Some(15),
-        21 => Some(16),
-        22 => Some(17),
         _ => None,
     }
 }

--- a/majit/majit-backend-dynasm/src/aarch64/registers.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/registers.rs
@@ -94,14 +94,9 @@ pub const VFPREGISTERS: [RegLoc; 32] = [
 /// registers.py:13 `all_vfp_regs = vfpregisters[:8]`
 pub const ALL_VFP_REGS: [RegLoc; 8] = [D0, D1, D2, D3, D4, D5, D6, D7];
 
-/// registers.py:14 `all_regs = registers[:14] + [x19, x20, x21, x22]`
-///
-/// Upstream leaves x21, x22 commented out as the contemplated
-/// extension (`registers[:14] + [x19, x20] #, x21, x22]`); pyre enables
-/// exactly that pair so loop-carried values survive residual calls
-/// without spilling to the jitframe.
-pub const ALL_REGS: [RegLoc; 18] = [
-    X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X19, X20, X21, X22,
+/// registers.py:14 `all_regs = registers[:14] + [x19, x20]`.
+pub const ALL_REGS: [RegLoc; 16] = [
+    X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13, X19, X20,
 ];
 
 /// registers.py:16 `lr = x30`
@@ -122,9 +117,8 @@ pub const IP2: RegLoc = X15;
 /// registers.py:24 `ip3 = x14`
 pub const IP3: RegLoc = X14;
 
-/// registers.py:26 `callee_saved_registers = [x19, x20, x21, x22]`
-/// (upstream contemplates x21, x22 as a commented extension; enabled here).
-pub const CALLEE_SAVED_REGISTERS: [RegLoc; 4] = [X19, X20, X21, X22];
+/// registers.py:26 `callee_saved_registers = [x19, x20]`.
+pub const CALLEE_SAVED_REGISTERS: [RegLoc; 2] = [X19, X20];
 
 /// registers.py:27 `vfp_argument_regs = caller_vfp_resp = all_vfp_regs[:8]`
 pub const VFP_ARGUMENT_REGS: [RegLoc; 8] = ALL_VFP_REGS;
@@ -136,8 +130,8 @@ pub const VFP_IP: RegLoc = D15;
 /// registers.py:34 `argument_regs = [x0, x1, x2, x3, x4, x5, x6, x7]`
 pub const ARGUMENT_REGS: [RegLoc; 8] = [X0, X1, X2, X3, X4, X5, X6, X7];
 
-/// registers.py:35 `callee_resp = [x19, x20, x21, x22]`
-pub const CALLEE_RESP: [RegLoc; 4] = CALLEE_SAVED_REGISTERS;
+/// registers.py:35 `callee_resp = [x19, x20]`.
+pub const CALLEE_RESP: [RegLoc; 2] = CALLEE_SAVED_REGISTERS;
 
 /// registers.py:36 `caller_resp = argument_regs + [x8, x9, x10, x11, x12, x13]`
 pub const CALLER_RESP: [RegLoc; 14] = [X0, X1, X2, X3, X4, X5, X6, X7, X8, X9, X10, X11, X12, X13];

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -805,9 +805,14 @@ pub fn install_build_time_jitcode_at(index: usize, payload: std::sync::Arc<crate
 /// registry.
 ///
 /// PyCode wrappers use stable GC allocation, so the visitor marks each
-/// wrapper but never needs to rewrite `LIVE_CODE_WRAPPERS`.  Keeping this walk
-/// on the same per-mutator area as the jitcode constants preserves the owner:
-/// RPython reaches both through `MetaInterpStaticData.jitcodes`.
+/// wrapper but never needs to rewrite `LIVE_CODE_WRAPPERS`.  The registered
+/// pyre-jit area invokes this walk for major marking and, when tagged ints are
+/// disabled, skips it for minor collections: stable wrappers and constants
+/// cannot be nursery objects.  Tagged-int normalization can materialize a
+/// moving constant, so that configuration conservatively walks the combined
+/// area during minor collections too.  Keeping this walk on the same
+/// per-mutator area as the jitcode constants preserves the owner: RPython
+/// reaches both through `MetaInterpStaticData.jitcodes`.
 pub fn walk_jitcode_code_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     METAINTERP_SD.with(|state| {
         walk_jitcode_code_roots_in(&state.borrow(), visitor);
@@ -1058,12 +1063,15 @@ pub fn jitcode_pc_is_bare_reraise(jitcode_index: i32, offset: i32) -> bool {
 ///
 /// `blackhole_from_resumedata` seeds the blackhole register file directly
 /// from `jitcode.constants_r` (`init_register_files_from_runtime_jitcode`),
-/// so a constant boxed object reachable only from a jitcode and swept
-/// between trace executions leaves the next guard-failure resume reading a
-/// freed pointer.  The constant pool is immutable after build and its
-/// objects are non-moving — interpreter-routed int/float consts live in
-/// the non-moving old-gen, build-time consts are `malloc_typed`-immortal —
-/// so the slots are marked in place without forwarding.
+/// so a constant boxed object reachable only from a jitcode and swept by a
+/// major collection between trace executions leaves the next guard-failure
+/// resume reading a freed pointer.  The constant pool is immutable after
+/// build.  With tagged ints disabled, its objects are non-moving —
+/// interpreter-routed int/float consts live in the non-moving old-gen and
+/// build-time consts are `malloc_typed`-immortal — so the pyre-jit root-area
+/// wrapper skips this walk for minor collections and marks the slots in place
+/// during major marking.  The tagged-int configuration retains the minor walk
+/// because normalization can materialize a moving `W_IntObject`.
 pub fn walk_jitcode_constants_refs(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     METAINTERP_SD.with(|state| {
         walk_jitcode_constants_refs_in(&state.borrow(), visitor);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4813,6 +4813,28 @@ unsafe fn jitcode_constants_root_walker_area(
     data: *const (),
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
+    // incminimark.py:355 `prebuilt_root_objects` parity.  The two populations
+    // owned by this area cannot point into the nursery:
+    //
+    // * PyCode wrappers are allocated through `try_gc_alloc_stable_raw`;
+    // * with tagged ints disabled, JitCode `constants_r` entries are either
+    //   stable old-generation int/float objects or immortal build-time
+    //   constants.
+    //
+    // A minor collection cannot reclaim either population, and there is no
+    // old-to-young edge here for its remembered-set pass to discover.  Walking
+    // every JitCode on every recursive CALL_ASSEMBLER nursery refill therefore
+    // only repeated `drag_out_root`'s non-nursery fast return.  Major marking
+    // still has to keep both populations alive, exactly like RPython's
+    // unconditional `prebuilt_root_objects` major scan.
+    // If tagged ints are enabled, codewriter normalization can materialize a
+    // moving `W_IntObject`; retain the conservative minor scan in that mode.
+    if !pyre_object::tagged_int::CAN_BE_TAGGED
+        && majit_gc::shadow_stack::extra_root_walk_kind()
+            == majit_gc::shadow_stack::ExtraRootWalkKind::Minor
+    {
+        return;
+    }
     unsafe {
         pyre_jit_trace::state::walk_jitcode_code_roots_area(data, visitor);
         pyre_jit_trace::state::walk_jitcode_constants_refs_area(data, visitor);


### PR DESCRIPTION
## Summary

- skip the persistent JitCode/PyCode constant-root walk during minor collections when tagged ints are disabled, while retaining major marking and the conservative tagged-int path
- restore PyPy AArch64 register-set parity by removing the local x21/x22 extension
- shrink the managed JIT-frame register area from 26 slots to the upstream 24-slot shape

## Why

`fib_recursive` repeatedly crosses `CALL_ASSEMBLER` and refills the nursery. Profiling showed two avoidable costs on that path:

1. every minor collection walked all persistent JitCode roots even though the current non-tagged constant population is stable old-generation or immortal
2. the AArch64 backend saved, restored, and reserved JIT-frame slots for x21/x22 even though upstream PyPy leaves those registers out of `all_regs`

The root-walk change follows incminimark's prebuilt-root treatment, and the register change restores the upstream AArch64 storage shape.

## Impact

Paired local measurements showed about 2.4% improvement from the minor-root change and 8.1% from AArch64 register parity. The callee JIT-frame depth decreased from 30 to 28 and the bridge depth from 43 to 41.

The final benchmark gate measured `fib_recursive` at 0.63s versus CPython 0.64s and PyPy 0.22s. The remaining gap is primarily concrete PyFrame/locals/boxed-integer/JIT-frame materialization across recursive `CALL_ASSEMBLER`.

## Validation

- `cargo fmt --all -- --check`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test -p pyre-jit --features dynasm --test gc_stress` (34/34)
- `cargo test -p majit-backend-dynasm`
- `python3 pyre/check.py target/release/pyre-dynasm --backend dynasm --no-synthetic --no-cpython-suite` (17/17)
- `git diff --check`
