### PR TITLE
intobject: document why the prebuilt arm omits wrapint's payload store

### DIFF
--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -116,14 +116,12 @@ static SMALL_INTS: LazyLock<PrebuiltInts> = LazyLock::new(|| {
 /// there to pull the field into cache before the caller reads it. The
 /// prebuilt arm here returns without it, and cannot currently spell it: the
 /// pointer is derived from `&SMALL_INTS.0[idx]`, so writing through it is
-/// undefined rather than merely racy; the `unsafe impl Sync for PrebuiltInts`
-/// above rests on those entries staying immutable for process lifetime, which
-/// a store would break for concurrent callers; and `intval` is published to
-/// the JIT as an immutable field descr, which licenses the optimizer to drop
-/// the store in the traced arm anyway. Spelling it faithfully needs the
-/// payload behind an `UnsafeCell` and `intval` no longer described as
-/// immutable — until then the omission costs a cache hint and no semantics,
-/// and the arm is unreachable while `WITHPREBUILTINT` is false.
+/// undefined rather than merely racy, and the `unsafe impl Sync for
+/// PrebuiltInts` above rests on those entries staying immutable for process
+/// lifetime, which a store would break for concurrent callers. Spelling it
+/// faithfully needs the payload behind an `UnsafeCell` — until then the
+/// omission costs a cache hint and no semantics, and the arm is unreachable
+/// while `WITHPREBUILTINT` is false.
 ///
 /// Traced, not residualised, and `#[inline]` — `wrapint` carries no
 /// `@dont_look_inside` and its own comment reads "this whole function is

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -109,6 +109,22 @@ static SMALL_INTS: LazyLock<PrebuiltInts> = LazyLock::new(|| {
 /// returns the pre-allocated entry; outside the range we allocate
 /// (`instantiate(W_IntObject)` upstream).
 ///
+/// Upstream's two arms then join on a shared `w_res.intval = x`
+/// (`intobject.py:917-921`) which rewrites the payload of a *prebuilt* entry
+/// too. `PREBUILT[x - lower]` already holds `x`, so that store changes no
+/// value; its own comment calls it "an obscure hack to help the CPU cache",
+/// there to pull the field into cache before the caller reads it. The
+/// prebuilt arm here returns without it, and cannot currently spell it: the
+/// pointer is derived from `&SMALL_INTS.0[idx]`, so writing through it is
+/// undefined rather than merely racy; the `unsafe impl Sync for PrebuiltInts`
+/// above rests on those entries staying immutable for process lifetime, which
+/// a store would break for concurrent callers; and `intval` is published to
+/// the JIT as an immutable field descr, which licenses the optimizer to drop
+/// the store in the traced arm anyway. Spelling it faithfully needs the
+/// payload behind an `UnsafeCell` and `intval` no longer described as
+/// immutable — until then the omission costs a cache hint and no semantics,
+/// and the arm is unreachable while `WITHPREBUILTINT` is false.
+///
 /// Traced, not residualised, and `#[inline]` — `wrapint` carries no
 /// `@dont_look_inside` and its own comment reads "this whole function is
 /// getting inlined into every caller so keeping the branching to a minimum


### PR DESCRIPTION
Follow-up to #1159, acting on its Codex parity review. Doc comment only — no
code change.

The review's sections 1 and 2 were empty. Section 3 raised one finding, and it
is correct:

> `pyre/pyre-object/src/intobject.rs:153 ↔ pypy/objspace/std/intobject.py:911`:
> with prebuilt ints enabled, Pyre immediately returns the cached object; PyPy
> performs the additional `w_res.intval = x` write at `intobject.py:920`.

`wrapint`'s two arms join on a shared `w_res.intval = x`
(`intobject.py:917-921`) that rewrites a *prebuilt* entry's payload too, and
upstream annotates it: "an obscure hack to help the CPU cache: we store 'x'
even into a prebuilt integer's intval". `PREBUILT[x - lower]` already holds
`x`, so the store carries no value — it exists to pull the field into cache
before the caller reads it.

The disposition is won't-fix rather than a port, so what was missing was the
documentation. Two reasons, both checkable in the file:

* the returned pointer is derived from `&SMALL_INTS.0[idx]` (`intobject.rs:171`),
  so writing through it is undefined, not merely racy;
* `unsafe impl Sync for PrebuiltInts` (`intobject.rs:85`) rests on those entries
  staying immutable for process lifetime, which a store would break for
  concurrent callers.

Either alone blocks it. Converging needs the payload behind an `UnsafeCell`;
the comment says so, and notes the arm is unreachable while `WITHPREBUILTINT`
is false (the PyPy default this file mirrors).

The second commit removes a third reason I had written into the first — that
`intval` reaches the JIT as an immutable field descr. That was read off a trace
census on an older base, and field immutability is harvested from the LLBC
`_immutable_fields_` markers rather than declared in this file, so it is not
checkable from here and should not have been asserted.

Section 4's five structural adaptations were reviewed and need no change: the
`intobject.rs` pair is already documented on `w_int_gc_alloc` with its blocker
named and a drop condition stated, and the rest are the fnaddr registry, two
env-gated `[decline-why]` diagnostics, and a translator test fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
