### PR TITLE
llbc: harden extraction freshness and provenance

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6354,11 +6354,11 @@ impl OptContext {
         let mut memo = ResumeDataLoopMemo::new();
         // resume.py:403-405 passes `minimum_virtualizable_size` here, which
         // arms the `resume.py:236-239` length check inside `number()`. This
-        // call site used to hardcode `-1`, so the check — ported faithfully at
-        // `resume.rs:3951-3958` — was disabled for every guard ever numbered,
+        // call site used to hardcode `-1`, so the check — ported faithfully in
+        // `resume.rs::number` — was disabled for every guard ever numbered,
         // and a 0-length vable section reached the backend unremarked. It then
         // surfaced only if the guard was actually deopted, as
-        // `assert!(vable_size > 0)` at `resume.rs:7030`.
+        // `assert!(vable_size > 0)` in `resume.rs::consume_vable_info`.
         let Ok(numb_state) = memo.number(&snapshot, &env, self.minimum_virtualizable_size) else {
             return;
         };

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -5499,7 +5499,7 @@ impl Optimizer {
         // safe one (no false positives), but it does mean a trace whose
         // `virtualizable_boxes` is `None` while the driver's `vinfo` is `Some`
         // still slips past here and is caught only by the reader's
-        // `assert!(vable_size > 0)` at `resume.rs:7030`.
+        // `assert!(vable_size > 0)` in `resume.rs::consume_vable_info`.
         opt.minimum_virtualizable_size = config.static_field_offsets.len() as i64;
         opt.add_pass(Box::new(OptIntBounds::new()));
         opt.add_pass(Box::new(OptRewrite::new()));

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -366,10 +366,10 @@ struct UnwindTally {
     /// How many `on_unwind` targets' goto-chains execute *any*
     /// non-trivial statement before reaching UnwindResume/Abort.
     real_work: usize,
-    /// How many of those non-trivial chains carry a `Drop` terminator
-    /// somewhere in the chain (destructor cleanup, the most common
-    /// "looks like work" case).
-    real_work_drop_in_chain: usize,
+    /// How many of those non-trivial chains are destructor cleanup: the
+    /// source terminator is a `Drop` and the chain does not end at a
+    /// `Call` or a `Return`.
+    real_work_destructor_cleanup: usize,
     /// fn::bb examples of real-work unwind chains (capped).
     examples: Vec<String>,
     /// Goto-chain length histogram (0 = on_unwind target is itself the
@@ -412,6 +412,13 @@ fn classify_unwind_chain(
 ) -> (&'static str, bool, bool, usize) {
     let mut cur = start_bb;
     let mut did_real_work = false;
+    // NOTE: this flag is only observable on the arms that keep WALKING.
+    // The `Call`, `Return` and `Switch` arms return the instant they are
+    // reached, so they hand back whatever it held before the walk stopped
+    // — structurally `false` for a zero-hop chain, whatever the source
+    // terminator was. Do not use it as an exemption predicate; the caller
+    // keys the exemption on the source terminator and the eventual, both
+    // of which it already knows.
     let mut drop_in_chain = false;
     let mut hops = 0usize;
     // Bound the walk so a malformed/cyclic chain can't hang the test.
@@ -507,10 +514,19 @@ fn mir_on_unwind_target_taxonomy() {
                 classify_unwind_chain(blocks, on_unwind as usize);
             *tally.eventual.entry(eventual).or_default() += 1;
             *tally.chain_len_hist.entry(chain_len).or_default() += 1;
+            // A `Drop` terminator's unwind edge IS the destructor-cleanup
+            // continuation — precisely what this exemption exists for —
+            // while a chain ending in a `Call` or a `Return` may be a
+            // handler, which is the thing the assertion below exists to
+            // catch. So exempt on the SOURCE terminator plus the eventual,
+            // never on `drop_in_chain`: that flag is written only while
+            // walking and is unreachable at the arms that return at once.
+            let destructor_cleanup =
+                term_kind_label == "Drop" && !matches!(eventual, "Call" | "Return");
             if did_work {
                 tally.real_work += 1;
-                if drop_in_chain {
-                    tally.real_work_drop_in_chain += 1;
+                if destructor_cleanup {
+                    tally.real_work_destructor_cleanup += 1;
                 }
                 if tally.examples.len() < 40 {
                     tally.examples.push(format!(
@@ -549,12 +565,13 @@ fn mir_on_unwind_target_taxonomy() {
         tally.real_work
     );
     eprintln!(
-        "    of which carry a Drop (destructor) in the chain: {}",
-        tally.real_work_drop_in_chain
+        "    of which are destructor cleanup (Drop source, non-Call/Return \
+         eventual): {}",
+        tally.real_work_destructor_cleanup
     );
     eprintln!(
-        "    non-Drop real-work chains (genuine catch suspects): {}",
-        tally.real_work - tally.real_work_drop_in_chain
+        "    non-destructor real-work chains (genuine catch suspects): {}",
+        tally.real_work - tally.real_work_destructor_cleanup
     );
     if !tally.examples.is_empty() {
         eprintln!("\nreal-work examples (capped at 40):");
@@ -563,11 +580,10 @@ fn mir_on_unwind_target_taxonomy() {
         }
     }
 
-    // This test is observational: it never fails, it only prints the
-    // taxonomy. The decisive number to read is
-    // `non-Drop real-work chains` — if that is 0, every on_unwind path
-    // is a bare panic-propagation (UnwindResume/Abort) or pure
-    // destructor cleanup, and dropping it loses no try/except.
+    // The decisive number to read is `non-destructor real-work chains` —
+    // if that is 0, every on_unwind path is a bare panic-propagation
+    // (UnwindResume/Abort) or pure destructor cleanup, and dropping it
+    // loses no try/except.
     assert!(
         tally.total_call_terms > 0,
         "expected at least one Call/Assert/Drop terminator in the snapshot"
@@ -577,10 +593,10 @@ fn mir_on_unwind_target_taxonomy() {
     // other than pure destructor drop-glue. If this ever trips, the
     // corpus grew a Rust catch/cleanup that the front-graph driver would
     // silently drop, and the "drop on_unwind" adaptation must be revisited.
-    let non_drop_real_work = tally.real_work - tally.real_work_drop_in_chain;
+    let non_destructor_real_work = tally.real_work - tally.real_work_destructor_cleanup;
     assert_eq!(
-        non_drop_real_work, 0,
-        "found {non_drop_real_work} on_unwind chain(s) doing non-destructor \
+        non_destructor_real_work, 0,
+        "found {non_destructor_real_work} on_unwind chain(s) doing non-destructor \
          catch-like work; dropping on_unwind would lose semantics — see \
          examples above"
     );
@@ -707,20 +723,9 @@ fn dump_lowering_signatures() {
                 None => {}
             }
             for link in &blk.exits {
-                // The remaining Variable-carrying Link fields,
-                // `last_exception` / `last_exc_value`, are the only other
-                // operands a rebind could touch.  The flat MIR driver
-                // never populates them (rtyper-stage fields), so the
-                // signature omits them — assert that invariant so the
-                // omission is provably safe rather than an oversight.
-                // `exitcase` / `llexitcase` are deliberately omitted too,
-                // but carry no Variable (pure MIR-switch constants,
-                // RPO-invariant), so they need no guard.
-                assert!(
-                    link.last_exception.is_none() && link.last_exc_value.is_none(),
-                    "MIR-built Link carries last_exception/last_exc_value; \
-                     signature() must label them"
-                );
+                // `exitcase` / `llexitcase` are deliberately omitted: they
+                // carry no Variable (pure MIR-switch constants,
+                // RPO-invariant), so they need no label.
                 s.push_str(&format!("->{:?}(", link.target));
                 for a in &link.args {
                     match a {
@@ -729,6 +734,25 @@ fn dump_lowering_signatures() {
                     }
                 }
                 s.push(')');
+                // `last_exception` / `last_exc_value` are Variable-carrying
+                // Link fields a rebind can touch, so they are labelled like
+                // any other operand.  The flat MIR driver populates them:
+                // `lower_unstructured_with_static_addrs_and_attrs` runs
+                // `rewire_result_exc_call_sites`, `rewire_next_call_sites`
+                // and `rewire_checked_arith_call_sites`, and each assigns
+                // these fields on the exception exit it builds.  Omitting
+                // them would let a rebind of either move without moving
+                // the signature.
+                for (tag, arg) in [
+                    ("exc:", &link.last_exception),
+                    ("excv:", &link.last_exc_value),
+                ] {
+                    let Some(a) = arg else { continue };
+                    match a {
+                        LinkArg::Value(v) => s.push_str(&format!("{tag}{},", label(v.id()))),
+                        LinkArg::Const(_) => s.push_str(&format!("{tag}K,")),
+                    }
+                }
             }
             s.push(']');
         }

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -822,8 +822,21 @@ fn mir_on_unwind_target_taxonomy() {
             // catch. So exempt on the SOURCE terminator plus the eventual,
             // never on `drop_in_chain`: that flag is written only while
             // walking and is unreachable at the arms that return at once.
-            let destructor_cleanup =
-                term_kind_label == "Drop" && !matches!(eventual, "Call" | "Return");
+            //
+            // `Switch` is the third case and it splits. `classify_unwind_chain`
+            // calls it "cleanup that inspects state", and inside drop glue that
+            // is what it is: dropping an array branches over its elements, and
+            // this corpus holds exactly one such chain
+            // (`<array>::<Impl>::drop_in_place`, measured). Outside drop glue a
+            // branch on the unwind path is the catch-like control flow the
+            // assertion below exists to catch, so the exemption is withheld
+            // there. Keying on the drop-glue symbol is a proxy; it is the one
+            // the corpus actually distinguishes, and a `Switch` appearing under
+            // any other name is reported rather than absorbed.
+            let in_drop_glue = fd.item_meta.name_path().contains("drop_in_place");
+            let destructor_cleanup = term_kind_label == "Drop"
+                && !matches!(eventual, "Call" | "Return")
+                && (eventual != "Switch" || in_drop_glue);
             if did_work {
                 tally.real_work += 1;
                 if destructor_cleanup {
@@ -889,8 +902,8 @@ fn mir_on_unwind_target_taxonomy() {
         tally.total_call_terms > 0,
         "expected at least one Call/Assert/Drop terminator in the snapshot"
     );
-    // The decisive invariant — no on_unwind path does
-    // catch-like work (a Call/Switch/Return or a non-trivial statement)
+    // The decisive invariant — no on_unwind path does catch-like work (a
+    // Call/Return, a Switch outside drop glue, or a non-trivial statement)
     // other than pure destructor drop-glue. If this ever trips, the
     // corpus grew a Rust catch/cleanup that the front-graph driver would
     // silently drop, and the "drop on_unwind" adaptation must be revisited.

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -177,7 +177,7 @@ fn parse_read_bb_and_local(msg: &str) -> Option<(usize, u64)> {
 
 /// The census's finder predicate, and the one duplicated literal here.
 ///
-/// ⛔ This spelling is a COPY. `resolve_place` in `majit_translate`'s
+/// This spelling is a copy. `resolve_place` in `majit_translate`'s
 /// `front::mir` builds the failure message, and `is_known_lowering_gap`
 /// tests for this same substring to decide whether to re-lower the body in
 /// reverse-postorder. Neither is reachable from an integration test, so
@@ -400,7 +400,7 @@ fn arm_classifier(llbc: &Llbc) -> String {
     );
 
     // (2) The finder predicate, both directions, against the same pair.
-    // ⛔ See FINDER: this arms the predicate against a literal of the
+    // See FINDER: this arms the predicate against a literal of the
     // producer's shape, NOT against the producer.
     assert!(
         probe.contains(FINDER),
@@ -503,8 +503,8 @@ fn arm_classifier(llbc: &Llbc) -> String {
 /// only `Assign` to the local reaches the reading block exclusively via a
 /// back-edge (genuine loop-carried value, needs a phi / block-inputarg).
 ///
-/// ⛔ THE SUBJECT SET IS POST-RETRY, AND THAT CHANGES WHAT THE BUCKETS
-/// MEAN. `lower_fun_decl` lowers linearly, and on a `LowerError::Unsupported`
+/// The subject set is post-retry, which changes what the buckets mean.
+/// `lower_fun_decl` lowers linearly, and on a `LowerError::Unsupported`
 /// whose message satisfies `is_known_lowering_gap` — which is satisfied by
 /// exactly this census's [`FINDER`] substring — it re-lowers the whole body
 /// in `BlockOrder::ReversePostorder`. The retry's `?` propagates whatever

--- a/majit/majit-translate/tests/test_mir_stress.rs
+++ b/majit/majit-translate/tests/test_mir_stress.rs
@@ -175,146 +175,142 @@ fn parse_read_bb_and_local(msg: &str) -> Option<(usize, u64)> {
     Some((r, n))
 }
 
-/// Diagnostic: for each uninitialised-local
-/// lowering failure, classify whether processing blocks in
-/// reverse-postorder would bind the failing local before its read
-/// (forward-ref, fixable by traversal order alone, no phi) or whether the
-/// only `Assign` to the local reaches the reading block exclusively via a
-/// back-edge (genuine loop-carried value, needs a phi / block-inputarg).
-#[test]
-#[ignore = "diagnostic; set PYRE_MIR_STRESS_LLBC"]
-fn classify_uninitialised_local_rpo_vs_loop_carried() {
-    let Some(path) = stress_path() else {
-        eprintln!("skip: set PYRE_MIR_STRESS_LLBC");
-        return;
-    };
-    let llbc = Llbc::load(&path).expect("load stress llbc");
+/// The census's finder predicate, and the one duplicated literal here.
+///
+/// ⛔ This spelling is a COPY. `resolve_place` in `majit_translate`'s
+/// `front::mir` builds the failure message, and `is_known_lowering_gap`
+/// tests for this same substring to decide whether to re-lower the body in
+/// reverse-postorder. Neither is reachable from an integration test, so
+/// nothing in this file can arm the literal against its producer: if the
+/// driver's wording moves, this census reads 0 and that zero is a dead
+/// selector wearing the shape of a clean corpus. Stated rather than
+/// guarded — a guard here would only assert the copy against itself.
+const FINDER: &str = "uninitialised local";
 
-    let mut forward_ref = 0usize;
-    let mut loop_carried = 0usize;
-    let mut other = 0usize;
+/// Which bucket one uninitialised-local read falls into.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum UninitClass {
+    ForwardRef,
+    LoopCarried,
+    Unknown,
+}
 
-    for fd in llbc.iter_local_fns() {
-        if fd.is_global_initializer.is_some() {
-            continue;
+impl UninitClass {
+    fn label(self) -> &'static str {
+        match self {
+            UninitClass::ForwardRef => "forward-ref",
+            UninitClass::LoopCarried => "loop-carried",
+            UninitClass::Unknown => "unknown",
         }
-        let Some(body): Option<Unstructured> = fd.unstructured() else {
-            continue;
-        };
-        let Err(LowerError::Unsupported(msg)) = lower_fun_decl(&llbc, fd) else {
-            continue;
-        };
-        if !msg.contains("uninitialised local") {
-            continue;
-        }
-        let name = fd.item_meta.name_path();
-        let Some((read_bb, local_n)) = parse_read_bb_and_local(&msg) else {
-            eprintln!("PARSE-FAIL {name} | {msg}");
-            other += 1;
-            continue;
-        };
+    }
+}
 
-        let blocks = &body.body;
-
-        // (1) Every block that BINDS local N, i.e. seeds `local_var[N]`.
-        // The driver seeds the slot in two places:
-        //   * `lower_assign` on a *direct* `PlaceKind::Local(N)` Assign
-        //     statement (mir.rs:700), and
-        //   * the Call-terminator destination `CallPayload.dest` when it
-        //     is a direct `Local(N)` (mir.rs:1624).
-        // A *projection* write (`(*N).field = …`) presupposes N already
-        // bound and never seeds the slot — we record those separately for
-        // the detail string only.
-        let mut direct_assign_blocks: Vec<usize> = Vec::new();
-        let mut proj_assign_blocks: Vec<usize> = Vec::new();
-        for (bb_idx, blk) in blocks.iter().enumerate() {
-            let mut seeds = false;
-            let mut proj = false;
-            for st in &blk.statements {
-                if let Ok(StmtKind::Assign(place, _)) = st.stmt_kind() {
-                    match &place.kind {
-                        PlaceKind::Local(i) if *i == local_n => seeds = true,
-                        PlaceKind::Projection(..)
-                            if place_base_local(&place.kind) == Some(local_n) =>
-                        {
-                            proj = true
-                        }
-                        _ => {}
-                    }
-                }
-            }
-            // Call-terminator destination — the dominant binding site for
-            // these failures (the local is the result of a fn call).
-            if let Ok(TermKind::Call { call, .. }) = blk.term() {
-                match &call.dest.kind {
+/// Bucket one `(read_bb, local_n)` uninitialised-local read against a
+/// body's CFG, returning the class and the human detail line.
+///
+/// Extracted from the census loop so that the census and its positive
+/// control run the SAME classifier: a control that re-implements the
+/// classification grades a second copy and says nothing about the one that
+/// produced the tally.
+fn classify_uninit_read(
+    blocks: &[BasicBlock],
+    read_bb: usize,
+    local_n: u64,
+) -> (UninitClass, String) {
+    // (1) Every block that BINDS local N, i.e. seeds `local_var[N]`.
+    // The driver seeds the slot in two places:
+    //   * `lower_assign` on a *direct* `PlaceKind::Local(N)` Assign
+    //     statement, and
+    //   * the Call-terminator destination `CallPayload.dest` when it is a
+    //     direct `Local(N)`.
+    // A *projection* write (`(*N).field = …`) presupposes N already bound
+    // and never seeds the slot — we record those separately for the detail
+    // string only.
+    let mut direct_assign_blocks: Vec<usize> = Vec::new();
+    let mut proj_assign_blocks: Vec<usize> = Vec::new();
+    for (bb_idx, blk) in blocks.iter().enumerate() {
+        let mut seeds = false;
+        let mut proj = false;
+        for st in &blk.statements {
+            if let Ok(StmtKind::Assign(place, _)) = st.stmt_kind() {
+                match &place.kind {
                     PlaceKind::Local(i) if *i == local_n => seeds = true,
-                    PlaceKind::Projection(..)
-                        if place_base_local(&call.dest.kind) == Some(local_n) =>
-                    {
+                    PlaceKind::Projection(..) if place_base_local(&place.kind) == Some(local_n) => {
                         proj = true
                     }
                     _ => {}
                 }
             }
-            if seeds {
-                direct_assign_blocks.push(bb_idx);
-            }
-            if proj {
-                proj_assign_blocks.push(bb_idx);
+        }
+        // Call-terminator destination — the dominant binding site for
+        // these failures (the local is the result of a fn call).
+        if let Ok(TermKind::Call { call, .. }) = blk.term() {
+            match &call.dest.kind {
+                PlaceKind::Local(i) if *i == local_n => seeds = true,
+                PlaceKind::Projection(..) if place_base_local(&call.dest.kind) == Some(local_n) => {
+                    proj = true
+                }
+                _ => {}
             }
         }
-        direct_assign_blocks.dedup();
-        proj_assign_blocks.dedup();
-
-        // (2)+(3) CFG: reverse-postorder + back-edge set from block 0.
-        let (rpo_index, back_edges) = rpo_and_back_edges(blocks);
-
-        // Classify against the *binding* (direct) assign blocks.
-        let read_rpo = rpo_index.get(read_bb).copied().unwrap_or(usize::MAX);
-
-        // Forward-ref signal A: at least one direct-assign block precedes
-        // the read block in reverse-postorder.
-        let mut rpo_precedes = false;
-        // Forward-ref signal B (stronger): at least one direct-assign
-        // block reaches the read block over forward edges only (never
-        // crossing a back-edge), i.e. on a non-loop path.
-        let mut forward_reaches = false;
-        for &ab in &direct_assign_blocks {
-            let ab_rpo = rpo_index.get(ab).copied().unwrap_or(usize::MAX);
-            if ab_rpo != usize::MAX && read_rpo != usize::MAX && ab_rpo < read_rpo {
-                rpo_precedes = true;
-            }
-            if reaches_without_backedge(blocks, ab, read_bb, &back_edges) {
-                forward_reaches = true;
-            }
+        if seeds {
+            direct_assign_blocks.push(bb_idx);
         }
+        if proj {
+            proj_assign_blocks.push(bb_idx);
+        }
+    }
+    direct_assign_blocks.dedup();
+    proj_assign_blocks.dedup();
 
-        let category;
-        let detail;
-        if direct_assign_blocks.is_empty() {
-            // No direct binding site at all (only projection writes, or
-            // none). RPO ordering cannot help; this is not a plain
-            // forward-ref. Treat as loop-carried/other and explain.
-            if proj_assign_blocks.is_empty() {
-                category = "unknown";
-                detail = format!(
+    // (2)+(3) CFG: reverse-postorder + back-edge set from block 0.
+    let (rpo_index, back_edges) = rpo_and_back_edges(blocks);
+
+    // Classify against the *binding* (direct) assign blocks.
+    let read_rpo = rpo_index.get(read_bb).copied().unwrap_or(usize::MAX);
+
+    // Forward-ref signal A: at least one direct-assign block precedes the
+    // read block in reverse-postorder.
+    let mut rpo_precedes = false;
+    // Forward-ref signal B (stronger): at least one direct-assign block
+    // reaches the read block over forward edges only (never crossing a
+    // back-edge), i.e. on a non-loop path.
+    let mut forward_reaches = false;
+    for &ab in &direct_assign_blocks {
+        let ab_rpo = rpo_index.get(ab).copied().unwrap_or(usize::MAX);
+        if ab_rpo != usize::MAX && read_rpo != usize::MAX && ab_rpo < read_rpo {
+            rpo_precedes = true;
+        }
+        if reaches_without_backedge(blocks, ab, read_bb, &back_edges) {
+            forward_reaches = true;
+        }
+    }
+
+    if direct_assign_blocks.is_empty() {
+        // No direct binding site at all (only projection writes, or none).
+        // RPO ordering cannot help; this is not a plain forward-ref.
+        if proj_assign_blocks.is_empty() {
+            (
+                UninitClass::Unknown,
+                format!(
                     "local {local_n} read at bb{read_bb} has NO Assign anywhere \
                      (direct or projection); cannot classify"
-                );
-                other += 1;
-            } else {
-                category = "loop-carried";
-                detail = format!(
+                ),
+            )
+        } else {
+            (
+                UninitClass::LoopCarried,
+                format!(
                     "local {local_n} read at bb{read_bb} has only projection-base \
                      writes at {proj_assign_blocks:?} (no direct Local({local_n}) \
                      Assign to seed local_var); RPO ordering cannot bind it"
-                );
-                loop_carried += 1;
-            }
-        } else if rpo_precedes || forward_reaches {
-            category = "forward-ref";
-            forward_ref += 1;
-            detail = format!(
+                ),
+            )
+        }
+    } else if rpo_precedes || forward_reaches {
+        (
+            UninitClass::ForwardRef,
+            format!(
                 "direct Assign(Local({local_n})) at blocks {direct_assign_blocks:?}; \
                  read at bb{read_bb}; RPO read-rank={read_rpo}; \
                  rpo_precedes={rpo_precedes} forward_reaches={forward_reaches} \
@@ -325,11 +321,12 @@ fn classify_uninitialised_local_rpo_vs_loop_carried() {
                 } else {
                     format!("; proj-writes at {proj_assign_blocks:?}")
                 }
-            );
-        } else {
-            category = "loop-carried";
-            loop_carried += 1;
-            detail = format!(
+            ),
+        )
+    } else {
+        (
+            UninitClass::LoopCarried,
+            format!(
                 "direct Assign(Local({local_n})) at blocks {direct_assign_blocks:?}; \
                  read at bb{read_bb}; RPO read-rank={read_rpo}; back-edges={:?}; \
                  every assign-block reaches the read ONLY through a back-edge \
@@ -341,16 +338,320 @@ fn classify_uninitialised_local_rpo_vs_loop_carried() {
                 } else {
                     format!("; proj-writes at {proj_assign_blocks:?}")
                 }
-            );
-        }
+            ),
+        )
+    }
+}
 
-        eprintln!("CLASSIFY [{category}] {name} | {detail}");
+/// Collapse an `Unsupported` reason to a stable family key: every run of
+/// ASCII digits becomes `#`, and the result is bounded. `bb12: read of MIR
+/// local 7 …` and `bb3: read of MIR local 40 …` therefore share one row,
+/// so the reason table counts SHAPES rather than instances.
+fn reason_family(msg: &str) -> String {
+    let mut out = String::new();
+    let mut last_digit = false;
+    for c in msg.chars() {
+        if out.len() >= 72 {
+            out.push('…');
+            break;
+        }
+        if c.is_ascii_digit() {
+            if !last_digit {
+                out.push('#');
+            }
+            last_digit = true;
+        } else {
+            last_digit = false;
+            out.push(c);
+        }
+    }
+    out
+}
+
+/// Positive control for the census below: demonstrate that the classifier
+/// and its message parser CAN produce a non-zero bucket, on this corpus,
+/// through the same code the census runs.
+///
+/// A denominator alone does not make the tally readable — a walk that
+/// examines N functions and hands 0 to the classifier is still ambiguous
+/// unless something shows the classifier is capable of bucketing at all.
+/// This refuses (panics) rather than returning an uninterpretable zero:
+/// if no body in the corpus can arm it, the tally must not be reported.
+///
+/// It grades the INSTRUMENT, never the corpus: the subjects are synthesised
+/// `(read_bb, local)` pairs over a real body, so a green here says nothing
+/// about how many genuine uninitialised-local failures exist.
+fn arm_classifier(llbc: &Llbc) -> String {
+    // (1) The message parser, both directions, against literals.
+    let probe = "bb7: read of MIR local 42 before any Assign — \
+                 uninitialised local, not yet supported";
+    let unrelated = "bb7: a failure of some entirely different shape";
+    assert_eq!(
+        parse_read_bb_and_local(probe),
+        Some((7, 42)),
+        "control: the parser did not read (bb, local) out of a \
+         producer-shaped message — the census can classify nothing"
+    );
+    assert_eq!(
+        parse_read_bb_and_local(unrelated),
+        None,
+        "control: the parser accepted a message carrying no local read — \
+         its Some() would not be evidence"
+    );
+
+    // (2) The finder predicate, both directions, against the same pair.
+    // ⛔ See FINDER: this arms the predicate against a literal of the
+    // producer's shape, NOT against the producer.
+    assert!(
+        probe.contains(FINDER),
+        "control: FINDER misses a producer-shaped message"
+    );
+    assert!(
+        !unrelated.contains(FINDER),
+        "control: FINDER matches an unrelated message"
+    );
+
+    // (3)+(4) The classifier itself, on a REAL body from this corpus.
+    for fd in llbc.iter_local_fns() {
+        let Some(body): Option<Unstructured> = fd.unstructured() else {
+            continue;
+        };
+        let blocks = &body.body;
+        if blocks.len() < 2 {
+            continue;
+        }
+        let (rpo_index, _back_edges) = rpo_and_back_edges(blocks);
+
+        // Discovery only: find a block that directly binds SOME local, and
+        // a block that follows it in reverse-postorder. The bucket itself
+        // is decided by `classify_uninit_read`, not here.
+        let mut found: Option<(usize, usize, u64)> = None;
+        'outer: for (a, blk) in blocks.iter().enumerate() {
+            if rpo_index[a] == usize::MAX {
+                continue;
+            }
+            let mut bound: Option<u64> = None;
+            for st in &blk.statements {
+                if let Ok(StmtKind::Assign(place, _)) = st.stmt_kind() {
+                    if let PlaceKind::Local(i) = &place.kind {
+                        bound = Some(*i);
+                        break;
+                    }
+                }
+            }
+            if bound.is_none() {
+                if let Ok(TermKind::Call { call, .. }) = blk.term() {
+                    if let PlaceKind::Local(i) = &call.dest.kind {
+                        bound = Some(*i);
+                    }
+                }
+            }
+            let Some(n) = bound else { continue };
+            for r in 0..blocks.len() {
+                if rpo_index[r] != usize::MAX && rpo_index[r] > rpo_index[a] {
+                    found = Some((a, r, n));
+                    break 'outer;
+                }
+            }
+        }
+        let Some((assign_bb, read_bb, local_n)) = found else {
+            continue;
+        };
+        let name = fd.item_meta.name_path();
+
+        // POSITIVE arm: a read placed after its binding block in RPO must
+        // bucket as forward-ref.
+        let (cls, detail) = classify_uninit_read(blocks, read_bb, local_n);
+        assert_eq!(
+            cls,
+            UninitClass::ForwardRef,
+            "control: a read of local {local_n} at bb{read_bb}, bound at \
+             bb{assign_bb} which precedes it in RPO, did not bucket as \
+             forward-ref in {name} | {detail}"
+        );
+
+        // NEGATIVE arm: a local nothing binds must NOT bucket as either
+        // named class, or the positive arm above is not discriminating.
+        let (absent_cls, _) = classify_uninit_read(blocks, read_bb, u64::MAX);
+        assert_eq!(
+            absent_cls,
+            UninitClass::Unknown,
+            "control: a local with no Assign anywhere bucketed as \
+             {} in {name} — the classifier is not discriminating",
+            absent_cls.label()
+        );
+
+        return format!(
+            "control ARMED on {name}: local {local_n} bound at bb{assign_bb}, \
+             read at bb{read_bb} => forward-ref; the same read of an unbound \
+             local => unknown"
+        );
     }
 
+    panic!(
+        "control UNARMED: no body in this corpus offers a direct local \
+         binding with an RPO-later block, so nothing demonstrates the \
+         classifier can bucket a subject — refusing to report a tally \
+         nobody can read"
+    );
+}
+
+/// Diagnostic: for each uninitialised-local
+/// lowering failure, classify whether processing blocks in
+/// reverse-postorder would bind the failing local before its read
+/// (forward-ref, fixable by traversal order alone, no phi) or whether the
+/// only `Assign` to the local reaches the reading block exclusively via a
+/// back-edge (genuine loop-carried value, needs a phi / block-inputarg).
+///
+/// ⛔ THE SUBJECT SET IS POST-RETRY, AND THAT CHANGES WHAT THE BUCKETS
+/// MEAN. `lower_fun_decl` lowers linearly, and on a `LowerError::Unsupported`
+/// whose message satisfies `is_known_lowering_gap` — which is satisfied by
+/// exactly this census's [`FINDER`] substring — it re-lowers the whole body
+/// in `BlockOrder::ReversePostorder`. The retry's `?` propagates whatever
+/// that second attempt fails with, so a message reaching this census has
+/// already failed under BOTH block orders. Consequently a non-zero
+/// `forward_ref` is a DISAGREEMENT between this classifier and the driver
+/// (the classifier says RPO ordering binds the read; the driver ran RPO and
+/// it did not), never a subject waiting for an RPO fix.
+///
+/// The tally is therefore printed with its denominator: the filter ladder
+/// from local functions walked down to messages the finder matched, plus
+/// the family distribution of every `Unsupported` reason seen. Three zeros
+/// on a live `Err(Unsupported)` population and three zeros on an empty one
+/// are different readings, and the tally alone cannot tell them apart.
+#[test]
+#[ignore = "diagnostic; set PYRE_MIR_STRESS_LLBC"]
+fn classify_uninitialised_local_rpo_vs_loop_carried() {
+    let Some(path) = stress_path() else {
+        eprintln!("skip: set PYRE_MIR_STRESS_LLBC");
+        return;
+    };
+    let llbc = Llbc::load(&path).expect("load stress llbc");
+
+    // Arm the instrument BEFORE reporting anything it produces. This
+    // panics rather than returning if the classifier cannot be shown to
+    // bucket a subject on this corpus.
+    eprintln!("{}", arm_classifier(&llbc));
+
+    let mut forward_ref = 0usize;
+    let mut loop_carried = 0usize;
+    let mut other = 0usize;
+
+    // The filter ladder, so the three buckets sit on a stated population.
+    let mut walked = 0usize;
+    let mut skipped_global_init = 0usize;
+    let mut skipped_no_body = 0usize;
+    let mut lowered_ok = 0usize;
+    let mut err_not_found = 0usize;
+    let mut err_schema = 0usize;
+    let mut err_unsupported = 0usize;
+    let mut finder_matched = 0usize;
+    let mut reasons: BTreeMap<String, usize> = BTreeMap::new();
+
+    for fd in llbc.iter_local_fns() {
+        walked += 1;
+        if fd.is_global_initializer.is_some() {
+            skipped_global_init += 1;
+            continue;
+        }
+        let Some(body): Option<Unstructured> = fd.unstructured() else {
+            skipped_no_body += 1;
+            continue;
+        };
+        let msg = match lower_fun_decl(&llbc, fd) {
+            Ok(_) => {
+                lowered_ok += 1;
+                continue;
+            }
+            Err(LowerError::FunctionNotFound(_)) => {
+                err_not_found += 1;
+                continue;
+            }
+            Err(LowerError::Schema(_)) => {
+                err_schema += 1;
+                continue;
+            }
+            Err(LowerError::Unsupported(msg)) => {
+                err_unsupported += 1;
+                *reasons.entry(reason_family(&msg)).or_insert(0) += 1;
+                msg
+            }
+        };
+        if !msg.contains(FINDER) {
+            continue;
+        }
+        finder_matched += 1;
+        let name = fd.item_meta.name_path();
+        let Some((read_bb, local_n)) = parse_read_bb_and_local(&msg) else {
+            eprintln!("PARSE-FAIL {name} | {msg}");
+            other += 1;
+            continue;
+        };
+
+        let (class, detail) = classify_uninit_read(&body.body, read_bb, local_n);
+        match class {
+            UninitClass::ForwardRef => forward_ref += 1,
+            UninitClass::LoopCarried => loop_carried += 1,
+            UninitClass::Unknown => other += 1,
+        }
+        eprintln!("CLASSIFY [{}] {name} | {detail}", class.label());
+    }
+
+    let bucketed = forward_ref + loop_carried + other;
+
     eprintln!("\n=== uninitialised-local classification tally ===");
-    eprintln!("forward_ref  (RPO-fixable, no phi): {forward_ref}");
-    eprintln!("loop_carried (needs phi/inputarg):  {loop_carried}");
-    eprintln!("other/unknown:                       {other}");
+    eprintln!("forward_ref  (classifier says RPO order binds it): {forward_ref}");
+    eprintln!("loop_carried (classifier says needs phi/inputarg): {loop_carried}");
+    eprintln!("other/unknown:                                     {other}");
+    eprintln!("--- bucketed total:                                {bucketed}");
+
+    eprintln!("\n=== denominator: the ladder those buckets sit on ===");
+    eprintln!("local fns walked:                {walked}");
+    eprintln!("  skipped, global initializer:   {skipped_global_init}");
+    eprintln!("  skipped, no Unstructured body: {skipped_no_body}");
+    eprintln!("  lowered Ok:                    {lowered_ok}");
+    eprintln!("  Err(FunctionNotFound):         {err_not_found}");
+    eprintln!("  Err(Schema):                   {err_schema}");
+    eprintln!("  Err(Unsupported):              {err_unsupported}");
+    eprintln!("    of which matched {:?}: {finder_matched}", FINDER);
+
+    let mut families: Vec<(&String, &usize)> = reasons.iter().collect();
+    families.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
+    const TOP: usize = 20;
+    eprintln!(
+        "\n=== Err(Unsupported) reason families \
+         (probe-set total {err_unsupported} over {} distinct families) ===",
+        families.len()
+    );
+    for (family, n) in families.iter().take(TOP) {
+        eprintln!("  {n:>6}  {family}");
+    }
+    if families.len() > TOP {
+        let elided: usize = families.iter().skip(TOP).map(|(_, n)| **n).sum();
+        eprintln!(
+            "  ({} further families elided, {elided} occurrence(s))",
+            families.len() - TOP
+        );
+    }
+
+    // Partition identities. Neither says anything about the corpus — both
+    // hold by construction — but they make a future `continue` added
+    // without a counter, or a matched message that falls out of the
+    // classifier entirely, loud rather than a silently shrunk denominator.
+    assert_eq!(
+        bucketed, finder_matched,
+        "every message the finder matched must land in exactly one bucket"
+    );
+    assert_eq!(
+        walked,
+        skipped_global_init
+            + skipped_no_body
+            + lowered_ok
+            + err_not_found
+            + err_schema
+            + err_unsupported,
+        "every walked function must land on exactly one ladder rung"
+    );
 }
 
 /// Classification of where a Call/Assert/Drop `on_unwind` target leads,

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -535,8 +535,13 @@ def main() -> int:
             status, detail = fut.result()
             results[m] = (status, detail)
             done += 1
-            mark = {"PASS": "·", "FAIL": "F", "CRASH": "C",
-                    "TIMEOUT": "T", "IMPORTERROR": "i"}.get(status, "?")
+            # Every member of STATUSES needs a mark, SKIP included: a module
+            # that runs and bails with SkipTest is classified SKIP (:229),
+            # which is a different event from a module deselected before the
+            # run, and without its own mark it printed as "?" — the character
+            # reserved for a status this table does not know.
+            mark = {"PASS": "·", "FAIL": "F", "CRASH": "C", "TIMEOUT": "T",
+                    "IMPORTERROR": "i", "SKIP": "s"}.get(status, "?")
             sys.stdout.write(mark)
             sys.stdout.flush()
             if done % 80 == 0:
@@ -547,10 +552,23 @@ def main() -> int:
     counts = {s: 0 for s in STATUSES}
     for status, _ in results.values():
         counts[status] = counts.get(status, 0) + 1
-    counts["SKIP"] = len(skipped)
+    # `+=`, not `=`: SKIP arrives from two places — modules deselected before
+    # the run (`skipped`) and modules that ran and bailed with SkipTest
+    # (counted from `results` just above). Assigning dropped the second set,
+    # so the buckets did not sum to what was selected: a `--filter ctypes`
+    # run reported "2 to run" over "?F" and a summary totalling 1.
+    counts["SKIP"] += len(skipped)
     print("\n── summary ──")
     for s in STATUSES:
         print(f"  {s:12s} {counts[s]}")
+    # Reconcile rather than trust: the buckets partition the selection, so
+    # their sum is derivable and a disagreement means a status escaped the
+    # table. Computed, not read off the counters that produced it.
+    accounted = sum(counts[s] for s in STATUSES)
+    expected = len(to_run) + len(skipped)
+    if accounted != expected:
+        print(f"  {'UNACCOUNTED':12s} {expected - accounted}  "
+              f"(buckets sum to {accounted}, {expected} were selected)")
 
     # Regression / improvement analysis vs baseline.
     regressions: list[str] = []

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -569,6 +569,12 @@ def main() -> int:
     if accounted != expected:
         print(f"  {'UNACCOUNTED':12s} {expected - accounted}  "
               f"(buckets sum to {accounted}, {expected} were selected)")
+        # Nonzero, and before the analysis below. `check.py` reads this
+        # runner's exit code and never this line, so printing alone hands it a
+        # pass over a summary short by exactly this many modules. Returning
+        # here also stops `--report` and `--update-baseline` from recording a
+        # table that is missing a result.
+        return 1
 
     # Regression / improvement analysis vs baseline.
     regressions: list[str] = []

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -28,10 +28,12 @@ Return the size of object in bytes.";
 /// value is shared and lazily created; pyre's objects have the layout the
 /// question assumes, so the number is answerable and is answered.
 ///
-/// The divergence is confined to producing a number. Both terms of that number
-/// are read off the type rather than off the instance's storage, which is what
-/// keeps it from re-acquiring the inconsistency the upstream text warns about
-/// (see the pre-header comment below).
+/// The divergence is confined to producing a number, whose two terms come from
+/// different places. `size` is whatever the object's own `__sizeof__` returns,
+/// so it may read instance state — `list.__sizeof__` adds a word per allocated
+/// slot. The pre-header term is the one read off the type rather than off the
+/// instance's storage, which is what keeps that half from depending on the
+/// allocation that produced the object (see the pre-header comment below).
 fn get_sizeof(w_obj: PyObjectRef) -> crate::PyResult {
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = roots.base();

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -17,6 +17,21 @@ Return the size of object in bytes.";
 /// call the bound method, require a non-negative Py_ssize_t result, then add
 /// the pre-header used by a heap type.  Pyre has no physical CPython object
 /// pre-header, but exposes the 3.14 logical size required by `sys.getsizeof`.
+///
+/// Answering with a size is a deliberate divergence from this module's
+/// counterpart. `pypy/module/sys/vm.py:355-358` returns `w_default` unchanged
+/// and raises `TypeError` when no default was supplied, for the reason its own
+/// `getsizeof_missing` text gives: maps are shared across instances, equal
+/// strings may share their data, and some sequences materialise their items as
+/// you read them, so a per-object number would be inconsistent with reality
+/// there. That argument is about an object model where the storage backing a
+/// value is shared and lazily created; pyre's objects have the layout the
+/// question assumes, so the number is answerable and is answered.
+///
+/// The divergence is confined to producing a number. Both terms of that number
+/// are read off the type rather than off the instance's storage, which is what
+/// keeps it from re-acquiring the inconsistency the upstream text warns about
+/// (see the pre-header comment below).
 fn get_sizeof(w_obj: PyObjectRef) -> crate::PyResult {
     let roots = pyre_object::gc_roots::push_roots();
     let obj_slot = roots.base();

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -36,6 +36,83 @@ const CODEGEN_OUTPUTS: &[&str] = &[
 /// Lowering switches read by `majit-translate` while this build script runs.
 /// They affect generated graphs, so Cargo and the content cache must both see
 /// their values; otherwise an A/B can silently restore the opposite setting.
+
+/// Outputs whose bytes are this build-script process's own addresses, by
+/// construction: `fnaddr_bindings` is `(path, build_fnaddr)` and the two
+/// `*_bindings` tables are `(name, build_addr)`, captured so
+/// `runtime_fnaddr_patch` can re-pair them with the runtime's addresses (see
+/// the comments at their write sites). ASLR moves them on every process, so
+/// two processes always disagree and that disagreement is not a defect.
+///
+/// Excluded from the cross-process verdict only. Within one process the
+/// addresses are the same, so `DeterminismCheck::InProcess` still judges
+/// them — a difference there would be real.
+///
+/// Caching them is still sound: a restore serves this table and the
+/// `constants_i` baked against it from the *same* generation, so they stay
+/// consistent with each other.
+const HOST_ADDRESSED_OUTPUTS: &[&str] = &[
+    "fnaddr_bindings.bin",
+    "static_pytype_bindings.bin",
+    "static_ref_bindings.bin",
+];
+
+/// Opt-in self-check that the generated outputs are a function of the inputs
+/// [`codegen_cache_key`] hashes. Deliberately not part of that key: it changes
+/// nothing about what gets generated, it only compares two generations.
+const DETERMINISM_CHECK_ENV: &str = "PYRE_CODEGEN_DETERMINISM_CHECK";
+/// Subdirectory of `OUT_DIR` holding the second generation's outputs. Left in
+/// place after the comparison so a reported difference can be diffed by hand.
+const DETERMINISM_PROBE_SUBDIR: &str = "determinism-probe";
+/// Changing this value re-runs the build script and nothing else — see
+/// [`emit_rerun_directives`] for why the `cache` mode cannot be exercised
+/// without it.
+const DETERMINISM_NONCE_ENV: &str = "PYRE_CODEGEN_NONCE";
+
+/// Which pair of generations [`codegen_outputs_match`] compares.
+///
+/// Off by default because it doubles a multi-minute prepass.
+///
+/// * `1` / `in-process` — generate a second time into
+///   [`DETERMINISM_PROBE_SUBDIR`] and compare the two sets byte for byte.
+/// * `cache` — compare this run's outputs against the entry already stored
+///   under the same cache key, i.e. against a *different* process's bytes.
+///   Reports that it compared nothing when no entry exists yet; editing this
+///   file rekeys the cache, so that is the expected result of the first run
+///   after any change here.
+///
+/// Neither mode subsumes the other. `in-process` catches whatever is carried
+/// in mutable process state — a never-reset global registry, an allocation
+/// address used as an order — but it shares this process's hash seeds with
+/// the run it compares against, so a seed-derived order is invisible to it.
+/// `cache` sees the seed class as well, and only ever compares against a key
+/// that already has an entry.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DeterminismCheck {
+    Off,
+    InProcess,
+    AgainstCache,
+}
+
+impl DeterminismCheck {
+    /// Panics on an unrecognised value rather than reading it as `Off`: a
+    /// misspelled gate that silently checks nothing reports exactly like a
+    /// clean run.
+    fn from_env() -> Self {
+        match std::env::var(DETERMINISM_CHECK_ENV)
+            .unwrap_or_default()
+            .as_str()
+        {
+            "" | "0" => Self::Off,
+            "1" | "in-process" => Self::InProcess,
+            "cache" => Self::AgainstCache,
+            other => {
+                panic!("{DETERMINISM_CHECK_ENV}={other} is not one of: 0, 1, in-process, cache")
+            }
+        }
+    }
+}
+
 const LOWERING_GATE_ENV: [&str; 5] = [
     "PYRE_DYN_INDIRECT",
     "PYRE_FNPTR_INDIRECT",
@@ -70,12 +147,22 @@ fn main() {
     // visit order is keyed off the annotator/rtyper worklist maps
     // (`genpendingblocks`, `annotated`, `all_blocks`, …), which are
     // insertion-ordered `IndexMap`s, so the order in which the callee
-    // specialization chain is walked is deterministic and independent of the
-    // per-process SipHash seed.  A single in-process run suffices, matching
-    // RPython's single-shot translator.  The 1 GiB thread stack is needed
-    // for syn's recursive parse of ~150 files plus the rtyper chain
-    // (on Windows the main thread's 1 MiB default would
-    // STATUS_STACK_OVERFLOW).
+    // specialization chain is walked does not depend on the per-process
+    // SipHash seed.
+    //
+    // That covers the walk order and nothing downstream of it.  It does not
+    // establish that the emitted bytes are a function of the inputs: two
+    // generations of the same sources have been observed to produce different
+    // `jitcodes.bin` / `descrs.bin` / `ei_descr_mints.bin` while
+    // `jitcodes_index.bin` held still, from ordering and population decided
+    // after the walk (heap addresses used as a canonical order, a
+    // process-global mint registry).  `DeterminismCheck` is the opt-in check;
+    // an earlier reading of the paragraph above concluded "a single in-process
+    // run suffices", and that conclusion is why no check existed to catch it.
+    //
+    // The 1 GiB thread stack is needed for syn's recursive parse of ~150
+    // files plus the rtyper chain (on Windows the main thread's 1 MiB default
+    // would STATUS_STACK_OVERFLOW).
     run_worker();
 }
 
@@ -703,7 +790,14 @@ fn real_main() {
     // The callee census is emitted from the analysis itself. A cache restore
     // would print no rows, which is indistinguishable from an empty census.
     let callee_census = std::env::var_os("PYRE_CALLEE_CENSUS").is_some_and(|value| value == "1");
-    if !verbose_prepass && !callee_census && restore_codegen_cache(&cache_dir, &out_dir) {
+    // Restoring the outputs leaves the self-check nothing to compare, so it
+    // bypasses the cache for the same reason the verbose prepass does.
+    let determinism_check = DeterminismCheck::from_env();
+    if !verbose_prepass
+        && !callee_census
+        && determinism_check == DeterminismCheck::Off
+        && restore_codegen_cache(&cache_dir, &out_dir)
+    {
         eprintln!(
             "[pyre-jit-trace build.rs] restored generated JIT trace artifacts from cache {}",
             cache_key
@@ -713,177 +807,257 @@ fn real_main() {
         return;
     }
 
-    let pipeline = majit_translate::analyze_multiple_pipeline_with_modules(
-        &module_path_refs,
-        &analyze_config,
-        None,
-        vinfo_factory,
-        &fnaddr_bindings,
-        static_addrs,
-    );
-
-    // Generate tracing code from the canonical graph-first analysis result.
-    let code = majit_translate::generate_trace_code_from_pipeline(&pipeline);
-
-    std::fs::write(format!("{out_dir}/jit_trace_gen.rs"), &code).unwrap();
-
-    // JSON metadata for debugging
-    let json = serde_json::to_string_pretty(&pipeline).unwrap();
-    std::fs::write(format!("{out_dir}/jit_metadata.json"), &json).unwrap();
-
-    // Persist `pipeline.jitcodes` (RPython `all_jitcodes` from
-    // codewriter.py:89) as individually encoded entries plus a name/offset
-    // index. Runtime materializes entries lazily into the shared
-    // MetaInterpStaticData jitcodes store — same single-store model as
-    // RPython `warmspot.py:281-282` `self.metainterp_sd.jitcodes =
-    // codewriter.make_jitcodes()`.
-    let mut jitcodes_bin = Vec::new();
-    let mut jitcode_names = Vec::with_capacity(pipeline.jitcodes.len());
-    let mut jitcode_offsets = Vec::with_capacity(pipeline.jitcodes.len() + 1);
-    jitcode_offsets.push(0_u32);
-    for jitcode in &pipeline.jitcodes {
-        jitcode_names.push(jitcode.name.clone());
-        jitcodes_bin.extend(bincode::serialize(jitcode).unwrap());
-        jitcode_offsets.push(
-            u32::try_from(jitcodes_bin.len())
-                .expect("serialized jitcodes.bin exceeds the u32 offset range"),
+    // One whole generation, writing every [`CODEGEN_OUTPUTS`] entry into the
+    // directory it is handed. That directory is `OUT_DIR` for the build's own
+    // outputs and the probe subdirectory for the second generation
+    // `DeterminismCheck::InProcess` compares against; the parameter shadows
+    // the outer `out_dir` so both calls read as "write into out_dir".
+    let generate_into = |out_dir: &str| {
+        let pipeline = majit_translate::analyze_multiple_pipeline_with_modules(
+            &module_path_refs,
+            &analyze_config,
+            None,
+            vinfo_factory,
+            &fnaddr_bindings,
+            static_addrs,
         );
+
+        // Generate tracing code from the canonical graph-first analysis result.
+        let code = majit_translate::generate_trace_code_from_pipeline(&pipeline);
+
+        std::fs::write(format!("{out_dir}/jit_trace_gen.rs"), &code).unwrap();
+
+        // JSON metadata for debugging
+        let json = serde_json::to_string_pretty(&pipeline).unwrap();
+        std::fs::write(format!("{out_dir}/jit_metadata.json"), &json).unwrap();
+
+        // Persist `pipeline.jitcodes` (RPython `all_jitcodes` from
+        // codewriter.py:89) as individually encoded entries plus a name/offset
+        // index. Runtime materializes entries lazily into the shared
+        // MetaInterpStaticData jitcodes store — same single-store model as
+        // RPython `warmspot.py:281-282` `self.metainterp_sd.jitcodes =
+        // codewriter.make_jitcodes()`.
+        let mut jitcodes_bin = Vec::new();
+        let mut jitcode_names = Vec::with_capacity(pipeline.jitcodes.len());
+        let mut jitcode_offsets = Vec::with_capacity(pipeline.jitcodes.len() + 1);
+        jitcode_offsets.push(0_u32);
+        for jitcode in &pipeline.jitcodes {
+            jitcode_names.push(jitcode.name.clone());
+            jitcodes_bin.extend(bincode::serialize(jitcode).unwrap());
+            jitcode_offsets.push(
+                u32::try_from(jitcodes_bin.len())
+                    .expect("serialized jitcodes.bin exceeds the u32 offset range"),
+            );
+        }
+        let jitcodes_index_bin = bincode::serialize(&(jitcode_names, jitcode_offsets)).unwrap();
+        std::fs::write(format!("{out_dir}/jitcodes.bin"), &jitcodes_bin).unwrap();
+        std::fs::write(format!("{out_dir}/jitcodes_index.bin"), &jitcodes_index_bin).unwrap();
+        let indirectcalltargets_bin =
+            bincode::serialize(&pipeline.indirectcalltarget_indices).unwrap();
+        std::fs::write(
+            format!("{out_dir}/indirectcalltargets.bin"),
+            &indirectcalltargets_bin,
+        )
+        .unwrap();
+
+        // Persist the explicit portal → main-JitCode mapping. Runtime consumes
+        // this directly instead of rediscovering the portal through name or flag
+        // scans.
+        let jit_drivers_bin = bincode::serialize(&pipeline.jit_drivers).unwrap();
+        std::fs::write(format!("{out_dir}/jit_drivers.bin"), &jit_drivers_bin).unwrap();
+
+        // Persist the runtime opname → u8 table so
+        // `JitCode.code` (assembler-local mapping) decodes back to the
+        // canonical `(opname, argcodes)` shape at runtime (shadow dispatch,
+        // IR diffing).  RPython equivalent: the table handed to
+        // `BlackholeInterpBuilder::setup_insns` at metainterp startup
+        // (`pyjitpl.py:2227-2243`).
+        //
+        // RPython parity (`assembler.py:220 self.insns.setdefault(key,
+        // len(self.insns))`): the table is the assembler's emission-driven
+        // dict, populated by `write_insn` calls during graph flattening.
+        // Pyre's analog is `pipeline.insns`, snapshotted from
+        // `codewriter.assembler.insns()` after `make_jitcodes` finishes
+        // (`majit-translate/src/lib.rs:910`).  Each distinct key gets a
+        // fresh byte; the forward map is injective.  `blackhole.py:913`
+        // aliases the bhimpl handler under two Python attribute names
+        // (`bhimpl_goto_if_not_int_is_true = bhimpl_goto_if_not`) but
+        // does NOT register a second opname in `Assembler.insns`; the
+        // alias is at the dispatch-function-name level only.  Pyre
+        // therefore registers exactly one opname per byte; the runtime
+        // inverse (`byte → opname`) is 1:1 and panics on duplicate-byte
+        // collisions (`jitcode_runtime.rs:INSNS_BYTE_TO_OPNAME`).
+        //
+        // Serialize through a `BTreeMap` view so the byte output is stable
+        // across processes (Rust's `HashMap` SipHash makes raw iteration
+        // non-deterministic; RPython's Python dict is insertion-ordered).
+        let insns_sorted: std::collections::BTreeMap<&String, &u8> =
+            pipeline.insns.iter().collect();
+        let insns_bin = bincode::serialize(&insns_sorted).unwrap();
+        std::fs::write(format!("{out_dir}/insns.bin"), &insns_bin).unwrap();
+
+        // RPython `blackhole.py:59 self.setup_descrs(asm.descrs)` + `:102-103
+        // def setup_descrs(self, descrs): self.descrs = descrs`. Persists the
+        // build-time assembler's shared descr pool so that 'd'/'j' argcodes
+        // in `JitCode.code` resolve at runtime via
+        // `BlackholeInterpBuilder::setup_descrs(...)` — the single-store
+        // model (same list consumed by every `BlackholeInterpreter` produced
+        // by `acquire_interp`).
+        let descrs_bin = bincode::serialize(&pipeline.descrs).unwrap();
+        std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
+
+        // The table above is RPython's `opcode_descrs` (`pyjitpl.py:2261
+        // setup_descrs(asm.descrs)`), not its `all_descrs` (`pyjitpl.py:2289
+        // self.cpu.setup_descrs()` = the full gccache walk at `descr.py:25-47`).
+        // Upstream never has to distinguish them here because one gccache serves
+        // one process, so `compute_bitstrings` unions descrs that are already
+        // present. Pyre mints in this process and resolves in another, so the
+        // raw-set members no opcode names would have no slot on the far side;
+        // persist their mint arguments and let the runtime cache take the same
+        // `descr.py:224-238` miss branch this one did.
+        let ei_descr_mints_bin = bincode::serialize(&pipeline.ei_descr_mints).unwrap();
+        std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), &ei_descr_mints_bin).unwrap();
+
+        // RPython `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`.
+        // Persist the build-time assembler's shared `all_liveness` byte stream so a
+        // runtime consumer re-tracing a build-time jitcode (whose `BC_LIVE` ops
+        // carry offsets baked against this table) can install it into
+        // `metainterp_sd.liveness_info` and resolve those offsets.
+        let liveness_bin = bincode::serialize(&pipeline.all_liveness).unwrap();
+        std::fs::write(format!("{out_dir}/liveness.bin"), &liveness_bin).unwrap();
+
+        // RPython's translator AOT-compiles every helper into a single binary, so
+        // `JitCode.fnaddr` / `constants_i` funcptrs are linker-resolved and stable
+        // at runtime.  Pyre's `majit-translate` runs in `build.rs` — a separate
+        // process from `pyre-dynasm` — so every fnaddr captured here is the
+        // build-script process's address, which ASLR (and the divergent executable
+        // layouts) invalidates at runtime.  Persist the `(path, build_fnaddr)`
+        // table the codewriter consumed so the runtime patcher
+        // (`runtime_fnaddr_patch::patch_constants_i_fnaddrs`) can pair each build
+        // address with the matching runtime address from
+        // `pyre_interpreter::jit_trace_fnaddrs()` and overwrite stale constants
+        // before the walker invokes them.
+        let fnaddr_bindings_owned: Vec<(String, i64)> = fnaddr_bindings
+            .iter()
+            .map(|(p, a)| ((*p).to_string(), *a))
+            .collect();
+        let fnaddr_bindings_bin = bincode::serialize(&fnaddr_bindings_owned).unwrap();
+        std::fs::write(
+            format!("{out_dir}/fnaddr_bindings.bin"),
+            &fnaddr_bindings_bin,
+        )
+        .unwrap();
+
+        // Same ASLR hazard for the static-data addresses the codewriter baked
+        // into `constants_i` (host `PyType` singletons and prebuilt refs supplied
+        // via `HostStaticAddrs`): the build-script process's `&pyre_object::X`
+        // address does not survive into the runtime executable.  Persist the
+        // `(name, build_addr)` tables so `runtime_fnaddr_patch::
+        // patch_constants_i_static_addrs` can re-pair them with the runtime
+        // addresses from `jit_static_pytype_addrs` / `jit_static_ref_addrs`.
+        let pytype_bindings_owned: Vec<(String, i64)> = static_pytype_addrs
+            .iter()
+            .map(|(n, a)| ((*n).to_string(), *a))
+            .collect();
+        std::fs::write(
+            format!("{out_dir}/static_pytype_bindings.bin"),
+            bincode::serialize(&pytype_bindings_owned).unwrap(),
+        )
+        .unwrap();
+        let ref_bindings_owned: Vec<(String, i64)> = static_ref_addrs
+            .iter()
+            .map(|(n, a)| ((*n).to_string(), *a))
+            .collect();
+        std::fs::write(
+            format!("{out_dir}/static_ref_bindings.bin"),
+            bincode::serialize(&ref_bindings_owned).unwrap(),
+        )
+        .unwrap();
+
+        // Report
+        eprintln!(
+            "[pyre-jit-trace build.rs] canonical analysis: {} JIT drivers, {} functions, {} blocks, {} flat ops, {} all_jitcodes ({} bytes bodies + {} bytes index), generated {} bytes",
+            pipeline.jit_drivers.len(),
+            pipeline.functions.len(),
+            pipeline.total_blocks,
+            pipeline.total_ops,
+            pipeline.jitcodes.len(),
+            jitcodes_bin.len(),
+            jitcodes_index_bin.len(),
+            code.len(),
+        );
+    };
+
+    generate_into(&out_dir);
+
+    let reproducible = match determinism_check {
+        DeterminismCheck::Off => true,
+        DeterminismCheck::InProcess => {
+            let probe_dir = std::path::Path::new(&out_dir).join(DETERMINISM_PROBE_SUBDIR);
+            let _ = std::fs::remove_dir_all(&probe_dir);
+            std::fs::create_dir_all(&probe_dir).expect("create the determinism probe directory");
+            eprintln!(
+                "[pyre-jit-trace build.rs] codegen determinism: generating a second time into {}",
+                probe_dir.display()
+            );
+            // The second generation runs against whatever process-global
+            // state the first one left behind. If that state makes it panic,
+            // the outputs are not a function of the inputs either, so report
+            // it rather than take down a build whose own outputs — the first
+            // generation's, already written — are intact.
+            let completed = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                generate_into(&probe_dir.to_string_lossy())
+            }))
+            .is_ok();
+            if completed {
+                codegen_outputs_match(
+                    "a second in-process generation",
+                    std::path::Path::new(&out_dir),
+                    &probe_dir,
+                    false,
+                )
+            } else {
+                println!(
+                    "cargo::warning=codegen determinism: the second in-process generation \
+                     panicked (see the panic above), so nothing was compared; the codegen does \
+                     not survive running twice in one process. Compare across processes with \
+                     {DETERMINISM_CHECK_ENV}=cache instead"
+                );
+                false
+            }
+        }
+        DeterminismCheck::AgainstCache => {
+            if CODEGEN_OUTPUTS
+                .iter()
+                .all(|name| cache_dir.join(name).is_file())
+            {
+                codegen_outputs_match(
+                    &format!("the stored cache entry {cache_key}"),
+                    &cache_dir,
+                    std::path::Path::new(&out_dir),
+                    true,
+                )
+            } else {
+                // Compared nothing, which is neither a pass nor a failure —
+                // say so rather than let an empty comparison read as clean.
+                // Storing below is what gives the next run something to
+                // compare against.
+                println!(
+                    "cargo::warning=codegen determinism: cache key {cache_key} has no stored \
+                     entry, so nothing was compared; re-run this build to compare against the \
+                     entry it is about to store"
+                );
+                true
+            }
+        }
+    };
+    if !reproducible {
+        println!(
+            "cargo::warning=codegen determinism: the outputs at cache key {cache_key} are not \
+             reproducible; refusing to store them"
+        );
+        return;
     }
-    let jitcodes_index_bin = bincode::serialize(&(jitcode_names, jitcode_offsets)).unwrap();
-    std::fs::write(format!("{out_dir}/jitcodes.bin"), &jitcodes_bin).unwrap();
-    std::fs::write(format!("{out_dir}/jitcodes_index.bin"), &jitcodes_index_bin).unwrap();
-    let indirectcalltargets_bin = bincode::serialize(&pipeline.indirectcalltarget_indices).unwrap();
-    std::fs::write(
-        format!("{out_dir}/indirectcalltargets.bin"),
-        &indirectcalltargets_bin,
-    )
-    .unwrap();
-
-    // Persist the explicit portal → main-JitCode mapping. Runtime consumes
-    // this directly instead of rediscovering the portal through name or flag
-    // scans.
-    let jit_drivers_bin = bincode::serialize(&pipeline.jit_drivers).unwrap();
-    std::fs::write(format!("{out_dir}/jit_drivers.bin"), &jit_drivers_bin).unwrap();
-
-    // Persist the runtime opname → u8 table so
-    // `JitCode.code` (assembler-local mapping) decodes back to the
-    // canonical `(opname, argcodes)` shape at runtime (shadow dispatch,
-    // IR diffing).  RPython equivalent: the table handed to
-    // `BlackholeInterpBuilder::setup_insns` at metainterp startup
-    // (`pyjitpl.py:2227-2243`).
-    //
-    // RPython parity (`assembler.py:220 self.insns.setdefault(key,
-    // len(self.insns))`): the table is the assembler's emission-driven
-    // dict, populated by `write_insn` calls during graph flattening.
-    // Pyre's analog is `pipeline.insns`, snapshotted from
-    // `codewriter.assembler.insns()` after `make_jitcodes` finishes
-    // (`majit-translate/src/lib.rs:910`).  Each distinct key gets a
-    // fresh byte; the forward map is injective.  `blackhole.py:913`
-    // aliases the bhimpl handler under two Python attribute names
-    // (`bhimpl_goto_if_not_int_is_true = bhimpl_goto_if_not`) but
-    // does NOT register a second opname in `Assembler.insns`; the
-    // alias is at the dispatch-function-name level only.  Pyre
-    // therefore registers exactly one opname per byte; the runtime
-    // inverse (`byte → opname`) is 1:1 and panics on duplicate-byte
-    // collisions (`jitcode_runtime.rs:INSNS_BYTE_TO_OPNAME`).
-    //
-    // Serialize through a `BTreeMap` view so the byte output is stable
-    // across processes (Rust's `HashMap` SipHash makes raw iteration
-    // non-deterministic; RPython's Python dict is insertion-ordered).
-    let insns_sorted: std::collections::BTreeMap<&String, &u8> = pipeline.insns.iter().collect();
-    let insns_bin = bincode::serialize(&insns_sorted).unwrap();
-    std::fs::write(format!("{out_dir}/insns.bin"), &insns_bin).unwrap();
-
-    // RPython `blackhole.py:59 self.setup_descrs(asm.descrs)` + `:102-103
-    // def setup_descrs(self, descrs): self.descrs = descrs`. Persists the
-    // build-time assembler's shared descr pool so that 'd'/'j' argcodes
-    // in `JitCode.code` resolve at runtime via
-    // `BlackholeInterpBuilder::setup_descrs(...)` — the single-store
-    // model (same list consumed by every `BlackholeInterpreter` produced
-    // by `acquire_interp`).
-    let descrs_bin = bincode::serialize(&pipeline.descrs).unwrap();
-    std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
-
-    // The table above is RPython's `opcode_descrs` (`pyjitpl.py:2261
-    // setup_descrs(asm.descrs)`), not its `all_descrs` (`pyjitpl.py:2289
-    // self.cpu.setup_descrs()` = the full gccache walk at `descr.py:25-47`).
-    // Upstream never has to distinguish them here because one gccache serves
-    // one process, so `compute_bitstrings` unions descrs that are already
-    // present. Pyre mints in this process and resolves in another, so the
-    // raw-set members no opcode names would have no slot on the far side;
-    // persist their mint arguments and let the runtime cache take the same
-    // `descr.py:224-238` miss branch this one did.
-    let ei_descr_mints_bin = bincode::serialize(&pipeline.ei_descr_mints).unwrap();
-    std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), &ei_descr_mints_bin).unwrap();
-
-    // RPython `pyjitpl.py:2264 self.liveness_info = "".join(asm.all_liveness)`.
-    // Persist the build-time assembler's shared `all_liveness` byte stream so a
-    // runtime consumer re-tracing a build-time jitcode (whose `BC_LIVE` ops
-    // carry offsets baked against this table) can install it into
-    // `metainterp_sd.liveness_info` and resolve those offsets.
-    let liveness_bin = bincode::serialize(&pipeline.all_liveness).unwrap();
-    std::fs::write(format!("{out_dir}/liveness.bin"), &liveness_bin).unwrap();
-
-    // RPython's translator AOT-compiles every helper into a single binary, so
-    // `JitCode.fnaddr` / `constants_i` funcptrs are linker-resolved and stable
-    // at runtime.  Pyre's `majit-translate` runs in `build.rs` — a separate
-    // process from `pyre-dynasm` — so every fnaddr captured here is the
-    // build-script process's address, which ASLR (and the divergent executable
-    // layouts) invalidates at runtime.  Persist the `(path, build_fnaddr)`
-    // table the codewriter consumed so the runtime patcher
-    // (`runtime_fnaddr_patch::patch_constants_i_fnaddrs`) can pair each build
-    // address with the matching runtime address from
-    // `pyre_interpreter::jit_trace_fnaddrs()` and overwrite stale constants
-    // before the walker invokes them.
-    let fnaddr_bindings_owned: Vec<(String, i64)> = fnaddr_bindings
-        .iter()
-        .map(|(p, a)| ((*p).to_string(), *a))
-        .collect();
-    let fnaddr_bindings_bin = bincode::serialize(&fnaddr_bindings_owned).unwrap();
-    std::fs::write(
-        format!("{out_dir}/fnaddr_bindings.bin"),
-        &fnaddr_bindings_bin,
-    )
-    .unwrap();
-
-    // Same ASLR hazard for the static-data addresses the codewriter baked
-    // into `constants_i` (host `PyType` singletons and prebuilt refs supplied
-    // via `HostStaticAddrs`): the build-script process's `&pyre_object::X`
-    // address does not survive into the runtime executable.  Persist the
-    // `(name, build_addr)` tables so `runtime_fnaddr_patch::
-    // patch_constants_i_static_addrs` can re-pair them with the runtime
-    // addresses from `jit_static_pytype_addrs` / `jit_static_ref_addrs`.
-    let pytype_bindings_owned: Vec<(String, i64)> = static_pytype_addrs
-        .iter()
-        .map(|(n, a)| ((*n).to_string(), *a))
-        .collect();
-    std::fs::write(
-        format!("{out_dir}/static_pytype_bindings.bin"),
-        bincode::serialize(&pytype_bindings_owned).unwrap(),
-    )
-    .unwrap();
-    let ref_bindings_owned: Vec<(String, i64)> = static_ref_addrs
-        .iter()
-        .map(|(n, a)| ((*n).to_string(), *a))
-        .collect();
-    std::fs::write(
-        format!("{out_dir}/static_ref_bindings.bin"),
-        bincode::serialize(&ref_bindings_owned).unwrap(),
-    )
-    .unwrap();
-
-    // Report
-    eprintln!(
-        "[pyre-jit-trace build.rs] canonical analysis: {} JIT drivers, {} functions, {} blocks, {} flat ops, {} all_jitcodes ({} bytes bodies + {} bytes index), generated {} bytes",
-        pipeline.jit_drivers.len(),
-        pipeline.functions.len(),
-        pipeline.total_blocks,
-        pipeline.total_ops,
-        pipeline.jitcodes.len(),
-        jitcodes_bin.len(),
-        jitcodes_index_bin.len(),
-        code.len(),
-    );
 
     if let Err(e) = store_codegen_cache(&cache_dir, &out_dir) {
         eprintln!(
@@ -959,6 +1133,14 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
     println!("cargo::rerun-if-env-changed=PYRE_RTYPER_VERBOSE");
     println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS");
     println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS_ROWS");
+    println!("cargo::rerun-if-env-changed={DETERMINISM_CHECK_ENV}");
+    // Re-runs this script without changing anything it hashes. That is the
+    // only way to exercise `DeterminismCheck::AgainstCache`, which needs two
+    // runs at the *same* cache key: with the gate value held constant Cargo
+    // considers the script fresh and skips the second run, and any input edit
+    // that would force one also rekeys the cache and leaves nothing to
+    // compare against. Deliberately absent from `codegen_cache_key`.
+    println!("cargo::rerun-if-env-changed={DETERMINISM_NONCE_ENV}");
     for key in LOWERING_GATE_ENV {
         println!("cargo::rerun-if-env-changed={key}");
     }
@@ -1073,6 +1255,105 @@ fn prune_codegen_cache(repo_root: &str, keep: &std::path::Path) {
     for (_, path) in by_last_use.into_iter().skip(retained) {
         let _ = std::fs::remove_dir_all(path);
     }
+}
+
+/// Compare two generated output sets file by file. True only when every
+/// [`CODEGEN_OUTPUTS`] entry was read on both sides and is byte-identical: an
+/// output that cannot be read on one side is an inconclusive comparison, and
+/// an inconclusive comparison must not report as a clean one.
+///
+/// Reports through `cargo::warning`, which cargo surfaces for a workspace
+/// crate's build script. A bare `println!` / `eprintln!` needs `-vv`, which is
+/// how a build-script line documenting the cache restore went unread long
+/// enough to be mistaken for the restore not happening.
+///
+/// Names the identical outputs as well as the differing ones. Which files hold
+/// still localises the cause faster than which files move: `jitcodes.bin`
+/// moving while `jitcodes_index.bin` holds says the entries changed while
+/// their names and boundaries did not, which rules out the walk order and
+/// points at what is written into each entry. A size change and an
+/// equal-size change are different findings too — one moved a count, the
+/// other only an order — so both lengths are reported, not just that they
+/// differ.
+///
+/// `cross_process` excuses [`HOST_ADDRESSED_OUTPUTS`] from the verdict. They
+/// are still reported, on their own line: a check that files a by-design
+/// difference as a defect is one people learn to ignore, and then it reports
+/// nothing at all.
+fn codegen_outputs_match(
+    label: &str,
+    baseline: &std::path::Path,
+    probe: &std::path::Path,
+    cross_process: bool,
+) -> bool {
+    let mut identical: Vec<&str> = Vec::new();
+    let mut differing: Vec<String> = Vec::new();
+    let mut host_addressed: Vec<&str> = Vec::new();
+    let mut unreadable: Vec<String> = Vec::new();
+    for name in CODEGEN_OUTPUTS {
+        match (
+            std::fs::read(baseline.join(name)),
+            std::fs::read(probe.join(name)),
+        ) {
+            (Ok(a), Ok(b)) if a == b => identical.push(name),
+            (Ok(_), Ok(_)) if cross_process && HOST_ADDRESSED_OUTPUTS.contains(name) => {
+                host_addressed.push(name);
+            }
+            (Ok(a), Ok(b)) => {
+                let offset = a
+                    .iter()
+                    .zip(b.iter())
+                    .position(|(x, y)| x != y)
+                    .unwrap_or_else(|| a.len().min(b.len()));
+                differing.push(format!(
+                    "{name} ({} vs {} bytes, first difference at offset {offset})",
+                    a.len(),
+                    b.len()
+                ));
+            }
+            (a, b) => unreadable.push(format!(
+                "{name} (baseline {}, probe {})",
+                if a.is_ok() { "read" } else { "unreadable" },
+                if b.is_ok() { "read" } else { "unreadable" }
+            )),
+        }
+    }
+    if !host_addressed.is_empty() {
+        eprintln!(
+            "[pyre-jit-trace build.rs] codegen determinism: {} host-address table(s) differ from \
+             {label} as expected, excluded from the verdict: {}",
+            host_addressed.len(),
+            host_addressed.join(" ")
+        );
+    }
+    if differing.is_empty() && unreadable.is_empty() {
+        eprintln!(
+            "[pyre-jit-trace build.rs] codegen determinism: all {} reproducible outputs are \
+             identical to {label}",
+            identical.len()
+        );
+        return true;
+    }
+    for entry in &differing {
+        println!("cargo::warning=codegen determinism: DIFFERS from {label}: {entry}");
+    }
+    for entry in &unreadable {
+        println!("cargo::warning=codegen determinism: NOT COMPARED against {label}: {entry}");
+    }
+    println!(
+        "cargo::warning=codegen determinism: {} of {} outputs unchanged from {label}: {}",
+        identical.len(),
+        CODEGEN_OUTPUTS.len(),
+        identical.join(" ")
+    );
+    if !host_addressed.is_empty() {
+        println!(
+            "cargo::warning=codegen determinism: excluded as host addresses (expected to differ \
+             across processes): {}",
+            host_addressed.join(" ")
+        );
+    }
+    false
 }
 
 fn restore_codegen_cache(cache_dir: &std::path::Path, out_dir: &str) -> bool {

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -411,19 +411,29 @@ use llbc_fingerprint::{
 /// Wait for the fingerprint oracle with a deadline.
 ///
 /// A build script that blocks forever is strictly worse than a missing
-/// warning, and `std` has no `wait_timeout`, so the wait runs on a helper
-/// thread and a timeout abandons the child.  Every non-answer — spawn failure,
-/// non-zero exit, unparseable stdout — collapses to `None`, i.e. silence: an
-/// unavailable oracle must not break offline, hermetic or vendored builds.
-fn llbc_fingerprint_output(child: std::process::Child) -> Option<FingerprintFields> {
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait_with_output());
-    });
-    let output = rx
-        .recv_timeout(std::time::Duration::from_secs(120))
-        .ok()?
-        .ok()?;
+/// warning, and `std` has no `wait_timeout`, so the child is polled until the
+/// deadline. A timed-out or otherwise unobservable child is killed and reaped;
+/// it must not retain Cargo locks after the build proceeds. Every non-answer —
+/// spawn failure, non-zero exit, unparseable stdout — collapses to `None`. The
+/// caller reports freshness as unknown without breaking offline, hermetic or
+/// vendored builds.
+fn llbc_fingerprint_output(mut child: std::process::Child) -> Option<FingerprintFields> {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(120);
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if std::time::Instant::now() < deadline => {
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return None;
+            }
+        }
+    }
+
+    let output = child.wait_with_output().ok()?;
     if !output.status.success() {
         return None;
     }

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -386,6 +386,14 @@ fn llbc_source_fingerprint(
 /// reads it.  `PYRE_LLBC_STRICT=0` demotes it back to a warning for a
 /// deliberately-stale working build, and `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`
 /// skips the comparison entirely.
+///
+/// Three outcomes per crate, on two channels: **fresh** is silent, **stale**
+/// errors (or warns with strict mode disabled), and **unknown** — unreadable stamp, or an
+/// oracle that did not answer — warns without ever being promoted.  Keeping
+/// unknown off the silent channel is the point: otherwise "no warning" means
+/// both *checked and current* and *nobody checked*, and a reader cannot tell
+/// which build they got.  Cf. the same conflation in `llbc_extract.py`'s
+/// direct-invocation no-op.
 fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     println!("cargo::rerun-if-env-changed=PYRE_LLBC_STRICT");
     println!("cargo::rerun-if-env-changed=PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
@@ -398,12 +406,26 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     }
     let llbc_dir = repo_root.join("build").join("llbc");
     let mut stale: Vec<(&str, String, String)> = Vec::new();
+    // Freshness has THREE outcomes, and the third used to be spelled the same
+    // way as "fresh": silence.  A crate whose stamp is unreadable, or whose
+    // oracle does not answer, is *unknown* — and "nobody checked" is not a
+    // licence to read its field offsets, it is the absence of the check that
+    // would grant one.
+    let mut unknown: Vec<(&str, &'static str)> = Vec::new();
     for &crate_name in LLBC_CRATES {
+        // An absent artefact is the bootstrap case, already reported by the
+        // prepass; only an artefact that EXISTS can be silently trusted, so
+        // only that case is worth calling unknown.
+        let artefact_exists = llbc_dir.join(format!("{crate_name}.ullbc")).is_file();
         let stamp_path = llbc_dir.join(format!("{crate_name}.ullbc.fingerprint"));
         let Ok(stamp) = std::fs::read_to_string(&stamp_path) else {
+            if artefact_exists {
+                unknown.push((crate_name, "no .fingerprint stamp beside the artefact"));
+            }
             continue;
         };
         let Some(recorded) = stamp_field(&stamp, "source=") else {
+            unknown.push((crate_name, "stamp carries no source= line"));
             continue;
         };
         let features = stamp_field(&stamp, "features=").unwrap_or_default();
@@ -411,11 +433,23 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
         let current =
             llbc_source_fingerprint(repo_root, &driver, crate_name, &features, &layout_targets);
         let Some(current) = current else {
+            unknown.push((crate_name, "the fingerprint oracle did not answer"));
             continue;
         };
         if current != recorded {
             stale.push((crate_name, recorded, current));
         }
+    }
+    // Reported as a warning and never promoted by `PYRE_LLBC_STRICT`: the
+    // documented contract is that an unavailable oracle must not break offline,
+    // hermetic or vendored builds, and failing here would break exactly the
+    // builds the fallback exists for.  Saying so costs one line and removes the
+    // ambiguity.  `PYRE_LLBC_SKIP_FINGERPRINT_CHECK` acknowledges and silences.
+    for (crate_name, reason) in &unknown {
+        println!(
+            "cargo::warning=LLBC FRESHNESS UNKNOWN: {crate_name}.ullbc was not checked \
+             ({reason}); it may or may not match the current sources"
+        );
     }
     if stale.is_empty() {
         return;

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -1,5 +1,7 @@
 #[path = "src/call_spec.rs"]
 mod call_spec;
+#[path = "src/llbc_fingerprint.rs"]
+mod llbc_fingerprint;
 #[path = "src/virtualizable_spec.rs"]
 mod virtualizable_spec;
 
@@ -374,16 +376,11 @@ fn preflight_llbc_or_fail() {
     std::process::exit(1);
 }
 
-/// Read one `key=value` line out of a `.fingerprint` stamp.
-///
-/// `scripts/llbc_extract.py:449-476` (`stamp_for`) writes the stamp as one
-/// `key=value` per line, so a prefix match is the whole parse.  `key` includes
-/// the `=`.
-fn stamp_field(stamp: &str, key: &str) -> Option<String> {
-    stamp
-        .lines()
-        .find_map(|line| line.strip_prefix(key).map(str::to_string))
-}
+// The stamp and the `--fingerprint` stdout are the same `key=value` format
+// written by the same producer, so both are parsed by `llbc_fingerprint`
+// rather than once per reader here.  `tests/llbc_fingerprint_format_test.rs`
+// pins that module against the driver's real output.
+use llbc_fingerprint::{freshness_policy, parse_fingerprint_stdout, stamp_field, FreshnessMode};
 
 /// Wait for the fingerprint oracle with a deadline.
 ///
@@ -404,19 +401,19 @@ fn llbc_fingerprint_output(child: std::process::Child) -> Option<String> {
     if !output.status.success() {
         return None;
     }
-    let value = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    // A bare lowercase sha256 and nothing else; anything else means the driver
-    // printed something this code does not model.
-    let is_hash = value.len() == 64 && value.bytes().all(|b| b.is_ascii_hexdigit());
-    is_hash.then_some(value)
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    parse_fingerprint_stdout(&stdout)
 }
 
 /// Ask the extraction driver what the current sources hash to.
 ///
-/// `scripts/llbc_extract.py:815-817` prints exactly the value the stamp's
-/// `source=` line holds — same `source_fingerprint()` call, same single-crate
-/// list as `stamp_for` at `:474` — so there is one implementation of the
-/// digest and it is not this one.
+/// `scripts/llbc_extract.py` prints the same `key=value` lines it writes into
+/// the stamp, and its `source=` field is the same `source_fingerprint()` call
+/// `stamp_for` records — so there is one implementation of the digest and it
+/// is not this one.  Parsed by `llbc_fingerprint::parse_fingerprint_stdout`,
+/// which reads the field by name; the driver adds fields (`external=` did,
+/// in `2f0e44cde70`) and a reader that models the output as one bare value
+/// stops answering the moment it does.
 ///
 /// `CARGO_FEATURES` and `LLBC_LAYOUT_TARGETS` are replayed out of the stamp:
 /// `fingerprint_inputs` (`scripts/llbc_extract.py:255-360`) walks the
@@ -474,6 +471,12 @@ fn llbc_source_fingerprint(
 /// deliberately-stale working build, and `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`
 /// skips the comparison entirely.
 ///
+/// `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=1` opts out entirely — announcing that it
+/// did, so opting out and passing stay distinguishable.  Both take exactly
+/// `1`, any other value is reported rather than ignored, and setting both is
+/// refused; see `llbc_fingerprint::freshness_policy` for why that is a
+/// contradiction and not a precedence question.
+///
 /// Three outcomes per crate, on two channels: **fresh** is silent, **stale**
 /// errors (or warns with strict mode disabled), and **unknown** — unreadable stamp, or an
 /// oracle that did not answer — warns without ever being promoted.  Keeping
@@ -484,8 +487,24 @@ fn llbc_source_fingerprint(
 fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     println!("cargo::rerun-if-env-changed=PYRE_LLBC_STRICT");
     println!("cargo::rerun-if-env-changed=PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
-    if std::env::var_os("PYRE_LLBC_SKIP_FINGERPRINT_CHECK").is_some() {
-        return;
+    // A non-UTF8 value is not `1`, so lossy conversion lands it in the
+    // unrecognised arm and it is reported rather than read as unset.
+    let env_switch = |name: &str| std::env::var_os(name).map(|v| v.to_string_lossy().into_owned());
+    let strict_var = env_switch("PYRE_LLBC_STRICT");
+    let skip_var = env_switch("PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
+    let policy = freshness_policy(strict_var.as_deref(), skip_var.as_deref());
+    let policy_directive = match policy.mode {
+        FreshnessMode::Refuse => "cargo::error",
+        _ => "cargo::warning",
+    };
+    for line in &policy.diagnostics {
+        println!("{policy_directive}={line}");
+    }
+    match policy.mode {
+        // Both switches set. Refuse rather than pick one: see `freshness_policy`.
+        FreshnessMode::Refuse => std::process::exit(1),
+        FreshnessMode::Skip => return,
+        FreshnessMode::Warn | FreshnessMode::Strict => {}
     }
     let driver = repo_root.join("scripts").join("extract-llbc.py");
     if !driver.is_file() {
@@ -544,7 +563,7 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     // The directive string is the only difference between the two modes, so it
     // is chosen once and the same lines go through it.  `cargo::warning=` and
     // `cargo::error=` each carry a single line with no embedded newline.
-    let strict = std::env::var_os("PYRE_LLBC_STRICT").as_deref() != Some(std::ffi::OsStr::new("0"));
+    let strict = policy.mode == FreshnessMode::Strict;
     let directive = if strict {
         "cargo::error"
     } else {

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -380,7 +380,7 @@ fn preflight_llbc_or_fail() {
 // written by the same producer, so both are parsed by `llbc_fingerprint`
 // rather than once per reader here.  `tests/llbc_fingerprint_format_test.rs`
 // pins that module against the driver's real output.
-use llbc_fingerprint::{freshness_policy, parse_fingerprint_stdout, stamp_field, FreshnessMode};
+use llbc_fingerprint::{FreshnessMode, freshness_policy, parse_fingerprint_stdout, stamp_field};
 
 /// Wait for the fingerprint oracle with a deadline.
 ///
@@ -411,9 +411,9 @@ fn llbc_fingerprint_output(child: std::process::Child) -> Option<String> {
 /// the stamp, and its `source=` field is the same `source_fingerprint()` call
 /// `stamp_for` records — so there is one implementation of the digest and it
 /// is not this one.  Parsed by `llbc_fingerprint::parse_fingerprint_stdout`,
-/// which reads the field by name; the driver adds fields (`external=` did,
-/// in `2f0e44cde70`) and a reader that models the output as one bare value
-/// stops answering the moment it does.
+/// which reads the field by name. The driver may add fields, as it did for
+/// `external=`; a reader that models the output as one bare value stops
+/// answering as soon as that happens.
 ///
 /// `CARGO_FEATURES` and `LLBC_LAYOUT_TARGETS` are replayed out of the stamp:
 /// `fingerprint_inputs` (`scripts/llbc_extract.py:255-360`) walks the
@@ -489,9 +489,10 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     println!("cargo::rerun-if-env-changed=PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
     // A non-UTF8 value is not `1`, so lossy conversion lands it in the
     // unrecognised arm and it is reported rather than read as unset.
-    let env_switch = |name: &str| std::env::var_os(name).map(|v| v.to_string_lossy().into_owned());
-    let strict_var = env_switch("PYRE_LLBC_STRICT");
-    let skip_var = env_switch("PYRE_LLBC_SKIP_FINGERPRINT_CHECK");
+    let strict_var =
+        std::env::var_os("PYRE_LLBC_STRICT").map(|value| value.to_string_lossy().into_owned());
+    let skip_var = std::env::var_os("PYRE_LLBC_SKIP_FINGERPRINT_CHECK")
+        .map(|value| value.to_string_lossy().into_owned());
     let policy = freshness_policy(strict_var.as_deref(), skip_var.as_deref());
     let policy_directive = match policy.mode {
         FreshnessMode::Refuse => "cargo::error",

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -39,21 +39,45 @@ const CODEGEN_OUTPUTS: &[&str] = &[
 /// They affect generated graphs, so Cargo and the content cache must both see
 /// their values; otherwise an A/B can silently restore the opposite setting.
 
-/// Outputs whose bytes are this build-script process's own addresses, by
-/// construction: `fnaddr_bindings` is `(path, build_fnaddr)` and the two
-/// `*_bindings` tables are `(name, build_addr)`, captured so
-/// `runtime_fnaddr_patch` can re-pair them with the runtime's addresses (see
-/// the comments at their write sites). ASLR moves them on every process, so
-/// two processes always disagree and that disagreement is not a defect.
+/// Outputs carrying this build-script process's own addresses, by
+/// construction. ASLR moves them on every process, so two processes always
+/// disagree and that disagreement is not a defect.
+///
+/// The three `*_bindings` tables are nothing but addresses: `fnaddr_bindings`
+/// is `(path, build_fnaddr)` and the other two are `(name, build_addr)`,
+/// captured so `runtime_fnaddr_patch` can re-pair them with the runtime's
+/// addresses (see the comments at their write sites).
+///
+/// The other three carry the values those tables exist to repair — the
+/// codewriter bakes `pyre_interpreter::jit_trace_fnaddrs()` addresses into
+/// `JitCode.fnaddr` and funcptr/static-data entries of `JitCode.constants_i`,
+/// which `runtime_fnaddr_patch::patch_constants_i_fnaddrs` and
+/// `patch_static_addr_constants` overwrite after deserialization. They reach
+/// `jitcodes.bin` directly, `descrs.bin` through `BhDescr::JitCode.fnaddr`
+/// (`codewriter/assembler.rs`, `fnaddr: jitcode.fnaddr`), and
+/// `jit_metadata.json` through the same pipeline serialized as JSON.
 ///
 /// Excluded from the cross-process verdict only. Within one process the
-/// addresses are the same, so `DeterminismCheck::InProcess` still judges
-/// them — a difference there would be real.
+/// addresses are the same, so `DeterminismCheck::InProcess` still judges every
+/// one of them — a difference there is real, and `jitcodes.bin` / `descrs.bin`
+/// moving between two in-process generations is the defect that mode was
+/// written for.
 ///
-/// Caching them is still sound: a restore serves this table and the
-/// `constants_i` baked against it from the *same* generation, so they stay
+/// What decides the cross-process verdict after these exclusions:
+/// `jit_trace_gen.rs`, `jitcodes_index.bin`, `indirectcalltargets.bin`,
+/// `jit_drivers.bin`, `insns.bin`, `ei_descr_mints.bin`, `liveness.bin`.
+/// `jitcodes_index.bin` is the load-bearing one — it holds each jitcode's name
+/// and its byte boundaries in `jitcodes.bin`, and an address is a fixed-width
+/// `i64` there, so a change in jitcode population, order or body length still
+/// moves it while an address change alone does not.
+///
+/// Caching them is still sound: a restore serves these tables and the
+/// `constants_i` baked against them from the *same* generation, so they stay
 /// consistent with each other.
 const HOST_ADDRESSED_OUTPUTS: &[&str] = &[
+    "jit_metadata.json",
+    "jitcodes.bin",
+    "descrs.bin",
     "fnaddr_bindings.bin",
     "static_pytype_bindings.bin",
     "static_ref_bindings.bin",
@@ -380,7 +404,9 @@ fn preflight_llbc_or_fail() {
 // written by the same producer, so both are parsed by `llbc_fingerprint`
 // rather than once per reader here.  `tests/llbc_fingerprint_format_test.rs`
 // pins that module against the driver's real output.
-use llbc_fingerprint::{FreshnessMode, freshness_policy, parse_fingerprint_stdout, stamp_field};
+use llbc_fingerprint::{
+    FingerprintFields, FreshnessMode, freshness_policy, parse_fingerprint_fields, stamp_field,
+};
 
 /// Wait for the fingerprint oracle with a deadline.
 ///
@@ -389,7 +415,7 @@ use llbc_fingerprint::{FreshnessMode, freshness_policy, parse_fingerprint_stdout
 /// thread and a timeout abandons the child.  Every non-answer — spawn failure,
 /// non-zero exit, unparseable stdout — collapses to `None`, i.e. silence: an
 /// unavailable oracle must not break offline, hermetic or vendored builds.
-fn llbc_fingerprint_output(child: std::process::Child) -> Option<String> {
+fn llbc_fingerprint_output(child: std::process::Child) -> Option<FingerprintFields> {
     let (tx, rx) = std::sync::mpsc::channel();
     std::thread::spawn(move || {
         let _ = tx.send(child.wait_with_output());
@@ -402,31 +428,37 @@ fn llbc_fingerprint_output(child: std::process::Child) -> Option<String> {
         return None;
     }
     let stdout = String::from_utf8(output.stdout).ok()?;
-    parse_fingerprint_stdout(&stdout)
+    parse_fingerprint_fields(&stdout)
 }
 
-/// Ask the extraction driver what the current sources hash to.
+/// Ask the extraction driver what the current inputs hash to.
 ///
 /// `scripts/llbc_extract.py` prints the same `key=value` lines it writes into
-/// the stamp, and its `source=` field is the same `source_fingerprint()` call
-/// `stamp_for` records — so there is one implementation of the digest and it
-/// is not this one.  Parsed by `llbc_fingerprint::parse_fingerprint_stdout`,
-/// which reads the field by name. The driver may add fields, as it did for
-/// `external=`; a reader that models the output as one bare value stops
-/// answering as soon as that happens.
+/// the stamp, and its `source=` / `external=` fields are the same
+/// `source_fingerprint()` / `external_fingerprint()` calls `stamp_for` records
+/// — so there is one implementation of each digest and it is not this one.
+/// Parsed by `llbc_fingerprint::parse_fingerprint_fields`, which reads the
+/// fields by name. The driver may add more, as it did for `external=`; a
+/// reader that models the output as one bare value stops answering as soon as
+/// that happens.
+///
+/// Both fields, because they cover disjoint input sets and only their
+/// conjunction says "current": `source=` stops at the repository boundary, so
+/// a package patched to a sibling checkout — or a proc macro built from one —
+/// moves `external=` alone.
 ///
 /// `CARGO_FEATURES` and `LLBC_LAYOUT_TARGETS` are replayed out of the stamp:
 /// `fingerprint_inputs` (`scripts/llbc_extract.py:255-360`) walks the
 /// dependency closure under the feature set and the cross-target layout set in
 /// force at extraction time, so recomputing under this build's defaults would
 /// report a difference the sources do not have.
-fn llbc_source_fingerprint(
+fn llbc_current_fingerprint(
     repo_root: &std::path::Path,
     driver: &std::path::Path,
     crate_name: &str,
     features: &str,
     layout_targets: &str,
-) -> Option<String> {
+) -> Option<FingerprintFields> {
     for python in ["python3", "python"] {
         let spawned = std::process::Command::new(python)
             .arg(driver)
@@ -460,6 +492,14 @@ fn llbc_source_fingerprint(
 /// The oracle is the extractor's own stamp.  `scripts/llbc_extract.py:643-652`
 /// already skips a crate whose stamp still matches, so this is the comparison
 /// the producer trusts, evaluated by the consumer.
+///
+/// Both of the stamp's fingerprint fields are compared, not just `source=`.
+/// The two cover disjoint input sets: `source=` hashes what `git ls-files`
+/// reaches and stops at the repository boundary, `external=` hashes what the
+/// closure reaches outside it.  A package patched to a sibling checkout moves
+/// only the second, and comparing one field would consume a frozen artefact as
+/// current for exactly that edit — feeding stale bodies and layouts into
+/// codegen.  The standalone `--check` compares both; so does this.
 ///
 /// A stale artefact fails the build.  It was warning-only, on the argument
 /// that the build still works for everything whose layout did not move; the
@@ -509,10 +549,26 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     }
     let driver = repo_root.join("scripts").join("extract-llbc.py");
     if !driver.is_file() {
+        // An oracle that cannot be found cannot answer, which is the unknown
+        // case — not the fresh one — and returning quietly here would spell
+        // "nobody checked" exactly like "checked and current" for every crate
+        // at once.  The checkouts this fires in (a vendored tree, a source
+        // archive, a partial clone) did not set
+        // `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, so they get an acknowledgement
+        // rather than silence.  One line, and the exit status is untouched:
+        // failing here would break the builds the fallback exists for.
+        println!(
+            "cargo::warning=LLBC FRESHNESS UNKNOWN: no crate was checked \
+             (scripts/extract-llbc.py is not present); the artefacts in build/llbc may or may \
+             not match the current sources"
+        );
         return;
     }
     let llbc_dir = repo_root.join("build").join("llbc");
-    let mut stale: Vec<(&str, String, String)> = Vec::new();
+    // `(crate, field, recorded, current)`. One crate can be stale on both
+    // fields, and which one moved is the difference between "your own sources
+    // changed" and "a dependency in another checkout changed".
+    let mut stale: Vec<(&str, &'static str, String, String)> = Vec::new();
     // Freshness has THREE outcomes, and the third used to be spelled the same
     // way as "fresh": silence.  A crate whose stamp is unreadable, or whose
     // oracle does not answer, is *unknown* — and "nobody checked" is not a
@@ -531,20 +587,32 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
             }
             continue;
         };
-        let Some(recorded) = stamp_field(&stamp, "source=") else {
+        let Some(recorded_source) = stamp_field(&stamp, "source=") else {
             unknown.push((crate_name, "stamp carries no source= line"));
+            continue;
+        };
+        // Required, not defaulted: an empty `external=` is a positive claim
+        // that nothing outside the repository was folded in, and a stamp too
+        // old to carry the field never made it.
+        let Some(recorded_external) = stamp_field(&stamp, "external=") else {
+            unknown.push((crate_name, "stamp carries no external= line"));
             continue;
         };
         let features = stamp_field(&stamp, "features=").unwrap_or_default();
         let layout_targets = stamp_field(&stamp, "layout_targets=").unwrap_or_default();
         let current =
-            llbc_source_fingerprint(repo_root, &driver, crate_name, &features, &layout_targets);
+            llbc_current_fingerprint(repo_root, &driver, crate_name, &features, &layout_targets);
         let Some(current) = current else {
             unknown.push((crate_name, "the fingerprint oracle did not answer"));
             continue;
         };
-        if current != recorded {
-            stale.push((crate_name, recorded, current));
+        for (field, recorded, current) in [
+            ("source", recorded_source, current.source),
+            ("external", recorded_external, current.external),
+        ] {
+            if recorded != current {
+                stale.push((crate_name, field, recorded, current));
+            }
         }
     }
     // Reported as a warning and never promoted by `PYRE_LLBC_STRICT`: the
@@ -570,17 +638,21 @@ fn fail_if_llbc_stale(repo_root: &std::path::Path) {
     } else {
         "cargo::warning"
     };
-    for (crate_name, recorded, current) in &stale {
+    for (crate_name, field, recorded, current) in &stale {
         println!(
-            "{directive}=LLBC STALE: {crate_name}.ullbc was extracted at source={recorded}, \
-             sources now hash to {current}"
+            "{directive}=LLBC STALE: {crate_name}.ullbc was extracted at {field}={recorded}, \
+             the tree now has {field}={current}"
         );
     }
-    let crates = stale
-        .iter()
-        .map(|(crate_name, _, _)| *crate_name)
-        .collect::<Vec<_>>()
-        .join(" ");
+    // Deduplicated: a crate stale on both fields contributed two lines above,
+    // and the re-extraction takes it once.
+    let mut stale_crates: Vec<&str> = Vec::new();
+    for &(crate_name, ..) in &stale {
+        if !stale_crates.contains(&crate_name) {
+            stale_crates.push(crate_name);
+        }
+    }
+    let crates = stale_crates.join(" ");
     println!(
         "{directive}=Field offsets read out of these artefacts may name the wrong bytes; \
          re-extract with: python3 scripts/extract-llbc.py {crates}"
@@ -1072,9 +1144,25 @@ fn real_main() {
         }
     };
     if !reproducible {
+        // What the refusal actually costs differs by mode, so only the
+        // consequence is chosen and the report is written once. `AgainstCache`
+        // reaches a `false` verdict only when an entry already exists — that
+        // entry is what it compared against — and `store_codegen_cache`
+        // returns early when it does, so there was never a store to refuse.
+        // Saying "refusing to store them" there would tell a reader the bad
+        // outputs were kept out of the cache while the unverified entry sits
+        // in it, ready for the next ordinary build to restore.
+        let consequence = match determinism_check {
+            DeterminismCheck::AgainstCache => format!(
+                "nothing was stored — the entry it disagreed with was already there and stays, \
+                 so the next ordinary build restores it; remove {} to stop that",
+                cache_dir.display()
+            ),
+            _ => "refusing to store them".to_string(),
+        };
         println!(
             "cargo::warning=codegen determinism: the outputs at cache key {cache_key} are not \
-             reproducible; refusing to store them"
+             reproducible; {consequence}"
         );
         return;
     }
@@ -1150,6 +1238,7 @@ fn emit_rerun_directives(repo_root: &str, source_paths: &[String]) {
     emit_rerun_if_changed_recursive(&format!("{repo_root}/majit/majit-translate/src"));
     println!("cargo::rerun-if-changed=src/virtualizable_spec.rs");
     println!("cargo::rerun-if-changed=src/call_spec.rs");
+    println!("cargo::rerun-if-changed=src/llbc_fingerprint.rs");
     println!("cargo::rerun-if-env-changed=PYRE_RTYPER_VERBOSE");
     println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS");
     println!("cargo::rerun-if-env-changed=PYRE_CALLEE_CENSUS_ROWS");
@@ -1340,8 +1429,8 @@ fn codegen_outputs_match(
     }
     if !host_addressed.is_empty() {
         eprintln!(
-            "[pyre-jit-trace build.rs] codegen determinism: {} host-address table(s) differ from \
-             {label} as expected, excluded from the verdict: {}",
+            "[pyre-jit-trace build.rs] codegen determinism: {} host-addressed output(s) differ \
+             from {label} as expected, excluded from the verdict: {}",
             host_addressed.len(),
             host_addressed.join(" ")
         );

--- a/pyre/pyre-jit-trace/src/lib.rs
+++ b/pyre/pyre-jit-trace/src/lib.rs
@@ -80,6 +80,7 @@ pub mod helpers;
 pub mod jitcode_dispatch;
 pub mod jitcode_runtime;
 pub mod liveness;
+pub mod llbc_fingerprint;
 pub mod py_coord;
 pub mod pyjitcode;
 pub mod pyjitpl;

--- a/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
+++ b/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
@@ -141,10 +141,49 @@ pub fn freshness_policy(strict: Option<&str>, skip: Option<&str>) -> FreshnessPo
 ///
 /// Deliberately no bare-digest fallback.  Accepting the pre-`external=` shape
 /// would let this keep silently honouring a format the driver no longer emits,
-/// which is the mechanism that produced that defect; the two version together
-/// in one repository, so refusing an unmodelled shape is the safe direction.
+/// which is the mechanism that produced that defect; the two versions travel
+/// together in one repository, so refusing an unmodelled shape is the safe
+/// direction.
+///
+/// One half of the answer.  A consumer deciding whether an artefact is current
+/// wants [`parse_fingerprint_fields`], which reads the other half too.
 pub fn parse_fingerprint_stdout(stdout: &str) -> Option<String> {
     let source = stamp_field(stdout, "source=")?;
     let is_hash = source.len() == 64 && source.bytes().all(|b| b.is_ascii_hexdigit());
     is_hash.then_some(source)
+}
+
+/// Both fingerprint fields, as one answer.
+///
+/// They are separate fields because they answer different questions whose
+/// remedies differ: `source=` hashes this repository's tracked inputs,
+/// `external=` everything the dependency closure reaches outside it — a
+/// `[patch]`ed package in a sibling checkout, a proc macro built from another
+/// tree.  Editing one of those moves `external=` and leaves `source=` exactly
+/// where it was, so a reader of one field accepts a frozen artefact whose
+/// bodies and layouts came from source that has since changed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FingerprintFields {
+    /// `source=`, validated as a bare sha256.
+    pub source: String,
+    /// `external=` verbatim: one `<root label>=<digest>` per out-of-repo
+    /// group, space-separated, and empty when the whole closure lives in this
+    /// repository — the common case.  Kept opaque; this side does not model
+    /// the encoding, only whether the value moved.
+    pub external: String,
+}
+
+/// Parse both fields out of `--fingerprint`'s stdout.
+///
+/// `external=` is required rather than defaulted to empty.  The driver prints
+/// it on every invocation, so an output without it is a shape this reader does
+/// not model, and defaulting would read "nothing outside the repo" off an
+/// answer that never made that claim.  Its absence collapses to `None` — the
+/// oracle did not answer — which is the same disposition an unparseable digest
+/// gets, and which a caller reports rather than passes over in silence.
+pub fn parse_fingerprint_fields(stdout: &str) -> Option<FingerprintFields> {
+    Some(FingerprintFields {
+        source: parse_fingerprint_stdout(stdout)?,
+        external: stamp_field(stdout, "external=")?,
+    })
 }

--- a/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
+++ b/pyre/pyre-jit-trace/src/llbc_fingerprint.rs
@@ -1,0 +1,150 @@
+//! The `key=value` line format shared by the LLBC fingerprint stamp and the
+//! extraction driver's `--fingerprint` output.
+//!
+//! One format, two producers, two readers.  `scripts/llbc_extract.py` writes
+//! the stamp beside each `.ullbc` and prints the same fields on stdout for
+//! `--fingerprint`; `build.rs` reads both.  Keeping the parse here — rather
+//! than open-coding it per reader — is deliberate: the fields are extended
+//! from the Python side, and a reader that models the format loosely goes
+//! quiet instead of failing when a field is added.
+
+/// Read one `key=value` line out of a `key=value`-per-line block.
+///
+/// `key` includes the `=`.  A prefix match is the whole parse.
+pub fn stamp_field(text: &str, key: &str) -> Option<String> {
+    text.lines()
+        .find_map(|line| line.strip_prefix(key).map(str::to_string))
+}
+
+/// What the freshness check should do, given its two switches.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FreshnessMode {
+    /// Do not check at all.
+    Skip,
+    /// Check; report a stale artefact as a warning.
+    Warn,
+    /// Check; report a stale artefact as an error and fail the build.
+    Strict,
+    /// The switches contradict each other; fail without checking.
+    Refuse,
+}
+
+/// The outcome of reading both switches: what to do, and what to say.
+#[derive(Debug, Clone)]
+pub struct FreshnessPolicy {
+    pub mode: FreshnessMode,
+    /// Lines the caller must emit. Never silently empty when a switch was set
+    /// to something unrecognised.
+    pub diagnostics: Vec<String>,
+}
+
+/// One switch's raw value, classified. An unrecognised value must not be
+/// silently treated as either enabled or disabled.
+enum Switch {
+    Unset,
+    On,
+    Off,
+    Unrecognised,
+}
+
+fn classify_skip(value: Option<&str>) -> Switch {
+    match value {
+        None => Switch::Unset,
+        Some("1") => Switch::On,
+        Some(_) => Switch::Unrecognised,
+    }
+}
+
+fn classify_strict(value: Option<&str>) -> Switch {
+    match value {
+        None => Switch::Unset,
+        Some("1") => Switch::On,
+        Some("0") => Switch::Off,
+        Some(_) => Switch::Unrecognised,
+    }
+}
+
+/// Decide the mode from the raw values of `PYRE_LLBC_STRICT` and
+/// `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`.
+///
+/// Strict checking is the default; `PYRE_LLBC_STRICT=0` deliberately demotes
+/// stale artefacts to warnings. The skip switch takes exactly `1`. Unknown
+/// values are diagnosed and retain the safe strict default.
+///
+/// Setting both is refused rather than resolved by precedence.  Honouring the
+/// opt-out silently would tell a caller who asked for a hard gate that their
+/// build passed; honouring strict would override an opt-out that exists so
+/// offline, hermetic and vendored builds keep working.  Neither is a defensible
+/// reading of "strict, and also do not check".
+pub fn freshness_policy(strict: Option<&str>, skip: Option<&str>) -> FreshnessPolicy {
+    const STRICT: &str = "PYRE_LLBC_STRICT";
+    const SKIP: &str = "PYRE_LLBC_SKIP_FINGERPRINT_CHECK";
+
+    let mut diagnostics = Vec::new();
+    let mut note_unrecognised = |name: &str, value: Option<&str>, valid: &str| {
+        if let Some(raw) = value {
+            diagnostics.push(format!(
+                "{name}={raw:?} is not a value this build understands, so it is \
+                 being ignored; {valid}"
+            ));
+        }
+    };
+
+    let strict_switch = classify_strict(strict);
+    if matches!(strict_switch, Switch::Unrecognised) {
+        note_unrecognised(
+            STRICT,
+            strict,
+            "use `0` to demote stale artefacts to warnings or `1` for strict mode",
+        );
+    }
+    let skip_switch = classify_skip(skip);
+    if matches!(skip_switch, Switch::Unrecognised) {
+        note_unrecognised(SKIP, skip, "the only value that skips the check is `1`");
+    }
+
+    let mode = match (strict_switch, skip_switch) {
+        (Switch::On, Switch::On) => FreshnessMode::Refuse,
+        (_, Switch::On) => FreshnessMode::Skip,
+        (Switch::Off, _) => FreshnessMode::Warn,
+        (Switch::Unset | Switch::On | Switch::Unrecognised, _) => FreshnessMode::Strict,
+    };
+
+    match mode {
+        FreshnessMode::Refuse => diagnostics.push(format!(
+            "{STRICT}=1 and {SKIP}=1 are contradictory: the first asks for a \
+             hard failure on a stale artefact, the second asks for no check at \
+             all. Refusing rather than silently honouring one of them — unset \
+             whichever you did not mean."
+        )),
+        // Announced, not silent: an opt-out that says nothing makes "did not
+        // check" and "checked and fresh" the same absence of output, which is
+        // the conflation the FRESHNESS UNKNOWN channel exists to prevent.
+        FreshnessMode::Skip => diagnostics.push(format!(
+            "{SKIP}=1 — the LLBC freshness check was skipped; field offsets \
+             read out of build/llbc may not match the current sources"
+        )),
+        FreshnessMode::Warn | FreshnessMode::Strict => {}
+    }
+
+    FreshnessPolicy { mode, diagnostics }
+}
+
+/// Parse the source digest out of `--fingerprint`'s stdout.
+///
+/// The driver prints the same `key=value` lines it writes into the stamp, so
+/// the field is parsed by name and the hex test is an assertion on the parsed
+/// value — not the parser.  Reading the whole of stdout as the digest is what
+/// broke when `external=` was added: a second line made the bare-sha256 test
+/// fail, every crate collapsed to "the oracle did not answer", and the build
+/// went quiet.
+///
+/// Deliberately no bare-digest fallback.  Accepting the pre-`external=` shape
+/// would let this keep silently honouring a format the driver no longer emits,
+/// which is the mechanism that produced that defect; the two version together
+/// in one repository, so refusing an unmodelled shape is the safe direction.
+pub fn parse_fingerprint_stdout(stdout: &str) -> Option<String> {
+    let source = stamp_field(stdout, "source=")?;
+    let is_hash = source.len() == 64 && source.bytes().all(|b| b.is_ascii_hexdigit());
+    is_hash.then_some(source)
+}

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -6199,8 +6199,8 @@ pub(crate) fn fail_arg_types_for_virtualizable_state(len: usize) -> Vec<Type> {
 ///        preserved.
 ///      - **Resume-data numbering** (port of `resume.py:148-181
 ///        ResumeDataLoopMemo.large_ints / .refs`):
-///        `resume.rs:3460-3490 ResumeDataLoopMemo.large_ints /
-///        .refs` memo separately dedups constants when assigning
+///        `resume.rs::ResumeDataLoopMemo`'s `large_ints` / `refs`
+///        memo separately dedups constants when assigning
 ///        resume numbering tags.
 fn copy_constants<F>(registers: &mut Vec<OpRef>, constants: &[i64], targetindex: usize, mut mint: F)
 where
@@ -6284,7 +6284,7 @@ impl PyreSym {
     /// `ConstClass(constants[i])`'s fresh-Box allocation
     /// (`history.py:220/261/307`). Per-value dedup, where it exists
     /// upstream, lives in the resume memo
-    /// (`resume.rs:3460-3490 ResumeDataLoopMemo.large_ints / .refs`
+    /// (`resume.rs::ResumeDataLoopMemo`'s `large_ints` / `refs` fields,
     /// per `resume.py:148-181`), not in the constant pool. Re-entering
     /// this helper therefore overwrites the trailing slots with freshly
     /// minted OpRefs across all three banks, matching `copy_constants`

--- a/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
@@ -1,0 +1,131 @@
+//! The LLBC `--fingerprint` format contract, tested against the real producer.
+//!
+//! `build.rs` asks `scripts/extract-llbc.py --fingerprint <crate>` what the
+//! sources currently hash to and compares the answer with the stamp beside the
+//! artefact.  Producer and consumer live in different languages and are joined
+//! only by this format, so the interesting failure is not a wrong answer — it
+//! is the consumer quietly failing to parse a format the producer legitimately
+//! extended, after which every crate reports "not checked" and the build looks
+//! exactly like success.
+//!
+//! That is what happened: `2f0e44cde70` added an `external=` field, turning one
+//! bare digest into two `key=value` lines, and the consumer's bare-sha256 test
+//! stopped matching.  The unit cases below would all have passed on that broken
+//! code had they been written beforehand — they encode whatever shape their
+//! author believed in.  **Only `real_driver_output_parses` could have caught it**,
+//! because it asks the producer instead of assuming.
+
+use pyre_jit_trace::llbc_fingerprint::{parse_fingerprint_stdout, stamp_field};
+
+const HASH: &str = "d9b2992606c82b29c531f4f4d6a42e43808564620ab63d781eba135f9307c584";
+
+/// Walk up from this crate until the extraction driver is found.
+fn repo_root() -> Option<std::path::PathBuf> {
+    let mut dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("scripts").join("extract-llbc.py").is_file() {
+            return Some(dir.to_path_buf());
+        }
+        dir = dir.parent()?;
+    }
+}
+
+/// The pair test: the real driver's real output, parsed by the real consumer.
+///
+/// Ignored by default because it shells out to `python3` and the driver is not
+/// present in every checkout; CI runs the ignored set, where an absent driver
+/// is a hard failure rather than a silent skip. A test that quietly passes when
+/// it could not run is the same defect this file exists to prevent.
+#[test]
+#[ignore = "shells out to python3 + scripts/extract-llbc.py; run in CI via --ignored"]
+fn real_driver_output_parses() {
+    let root = repo_root().expect(
+        "scripts/extract-llbc.py not found above CARGO_MANIFEST_DIR — \
+         this test was asked to run, so an absent driver is a failure, not a skip",
+    );
+    let out = std::process::Command::new("python3")
+        .arg(root.join("scripts").join("extract-llbc.py"))
+        .arg("--fingerprint")
+        .arg("pyre-object")
+        .current_dir(&root)
+        .output()
+        .expect("failed to spawn python3");
+
+    assert!(
+        out.status.success(),
+        "driver exited {:?}; stderr:\n{}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("driver stdout is not UTF-8");
+    let parsed = parse_fingerprint_stdout(&stdout);
+
+    assert!(
+        parsed.is_some(),
+        "the consumer could not parse the producer's actual output.\n\
+         This is the producer/consumer drift this test exists to catch: the \
+         driver's format moved and `parse_fingerprint_stdout` was not taught.\n\
+         raw stdout ({} bytes): {:?}",
+        stdout.len(),
+        stdout,
+    );
+    let digest = parsed.unwrap();
+    assert_eq!(digest.len(), 64, "digest is not a sha256: {digest:?}");
+    assert!(
+        digest.bytes().all(|b| b.is_ascii_hexdigit()),
+        "digest is not hex: {digest:?}",
+    );
+}
+
+#[test]
+fn parses_the_current_two_field_output() {
+    let stdout = format!("source={HASH}\nexternal=\n");
+    assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
+}
+
+#[test]
+fn field_order_does_not_matter() {
+    let stdout = format!("external=\nsource={HASH}\n");
+    assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
+}
+
+#[test]
+fn an_unknown_trailing_field_is_ignored() {
+    let stdout = format!("source={HASH}\nexternal=\nsomething_new=42\n");
+    assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
+}
+
+/// No bare-hash fallback. Accepting the pre-`2f0e44cde70` shape would let the
+/// consumer keep silently honouring a format the producer no longer emits —
+/// the exact mechanism that produced the defect. Driver and consumer version
+/// together in one repository, so strict is the safe direction.
+#[test]
+fn a_bare_hash_is_rejected() {
+    assert_eq!(parse_fingerprint_stdout(HASH), None);
+}
+
+#[test]
+fn a_short_digest_is_rejected() {
+    let stdout = format!("source={}\nexternal=\n", &HASH[..63]);
+    assert_eq!(parse_fingerprint_stdout(&stdout), None);
+}
+
+#[test]
+fn a_non_hex_digest_is_rejected() {
+    let stdout = format!("source={}zz\nexternal=\n", &HASH[..62]);
+    assert_eq!(parse_fingerprint_stdout(&stdout), None);
+}
+
+#[test]
+fn empty_output_is_rejected() {
+    assert_eq!(parse_fingerprint_stdout(""), None);
+}
+
+#[test]
+fn stamp_field_reads_one_key() {
+    let stamp = format!("crate=pyre-object\nsource={HASH}\nexternal=\n");
+    assert_eq!(stamp_field(&stamp, "source=").as_deref(), Some(HASH));
+    assert_eq!(stamp_field(&stamp, "external=").as_deref(), Some(""));
+    assert_eq!(stamp_field(&stamp, "absent="), None);
+}

--- a/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_fingerprint_format_test.rs
@@ -8,8 +8,8 @@
 //! extended, after which every crate reports "not checked" and the build looks
 //! exactly like success.
 //!
-//! That is what happened: `2f0e44cde70` added an `external=` field, turning one
-//! bare digest into two `key=value` lines, and the consumer's bare-sha256 test
+//! Adding the `external=` field turned one bare digest into two `key=value`
+//! lines, and the consumer's bare-sha256 test
 //! stopped matching.  The unit cases below would all have passed on that broken
 //! code had they been written beforehand — they encode whatever shape their
 //! author believed in.  **Only `real_driver_output_parses` could have caught it**,
@@ -96,7 +96,7 @@ fn an_unknown_trailing_field_is_ignored() {
     assert_eq!(parse_fingerprint_stdout(&stdout).as_deref(), Some(HASH));
 }
 
-/// No bare-hash fallback. Accepting the pre-`2f0e44cde70` shape would let the
+/// No bare-hash fallback. Accepting the old single-value shape would let the
 /// consumer keep silently honouring a format the producer no longer emits —
 /// the exact mechanism that produced the defect. Driver and consumer version
 /// together in one repository, so strict is the safe direction.

--- a/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
@@ -1,0 +1,94 @@
+//! `PYRE_LLBC_STRICT` / `PYRE_LLBC_SKIP_FINGERPRINT_CHECK` interaction.
+//!
+//! Two switches on one guard, and before this was fixed they had two
+//! independent ways of silently disarming it:
+//!
+//! * the opt-out was read first and returned, so `SKIP` defeated `STRICT` with
+//!   no diagnostic that the escalation had been overridden; and
+//! * the predicates disagreed — `SKIP` was a presence test (`…=0` still
+//!   skipped) while `STRICT` demanded exactly `"1"` (`…=true` did nothing).
+//!   The permissive parse was on the dangerous door and the exact one on the
+//!   safe door.
+//!
+//! The rule these tests encode: **an unrecognised value is never silently the
+//! same as unset**, and **asking for strict while also asking to skip is a
+//! contradiction, not a precedence question.**
+
+use pyre_jit_trace::llbc_fingerprint::{freshness_policy, FreshnessMode};
+
+#[test]
+fn both_unset_is_strict_and_says_nothing() {
+    let p = freshness_policy(None, None);
+    assert_eq!(p.mode, FreshnessMode::Strict);
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+}
+
+#[test]
+fn strict_one_promotes_to_error() {
+    let p = freshness_policy(Some("1"), None);
+    assert_eq!(p.mode, FreshnessMode::Strict);
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+}
+
+/// The opt-out is honoured, but it announces itself. Returning silently would
+/// make "opted out" and "checked and fresh" the same absence of output — the
+/// conflation the UNKNOWN channel exists to prevent.
+#[test]
+fn skip_one_opts_out_but_says_so() {
+    let p = freshness_policy(None, Some("1"));
+    assert_eq!(p.mode, FreshnessMode::Skip);
+    assert_eq!(p.diagnostics.len(), 1, "{:?}", p.diagnostics);
+    assert!(p.diagnostics[0].contains("PYRE_LLBC_SKIP_FINGERPRINT_CHECK"));
+}
+
+/// The headline regression: asking for both is refused, not resolved by
+/// precedence. Honouring SKIP lies to the caller; honouring STRICT overrides
+/// an opt-out that exists for offline and vendored builds.
+#[test]
+fn strict_and_skip_together_is_refused() {
+    let p = freshness_policy(Some("1"), Some("1"));
+    assert_eq!(p.mode, FreshnessMode::Refuse);
+    let joined = p.diagnostics.join("\n");
+    assert!(joined.contains("PYRE_LLBC_STRICT"), "{joined}");
+    assert!(
+        joined.contains("PYRE_LLBC_SKIP_FINGERPRINT_CHECK"),
+        "{joined}"
+    );
+}
+
+/// An unrecognised strict spelling is reported while retaining the safe
+/// strict-by-default policy.
+#[test]
+fn an_unrecognised_strict_value_is_not_silently_unset() {
+    let p = freshness_policy(Some("true"), None);
+    assert_eq!(p.mode, FreshnessMode::Strict);
+    assert_eq!(p.diagnostics.len(), 1, "{:?}", p.diagnostics);
+    assert!(p.diagnostics[0].contains("PYRE_LLBC_STRICT"));
+    assert!(p.diagnostics[0].contains("true"));
+}
+
+/// `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=0` used to skip — the presence test read
+/// a value that plainly says "off" as "on".
+#[test]
+fn skip_zero_does_not_skip() {
+    let p = freshness_policy(None, Some("0"));
+    assert_eq!(p.mode, FreshnessMode::Strict);
+    assert_eq!(p.diagnostics.len(), 1, "{:?}", p.diagnostics);
+    assert!(p.diagnostics[0].contains("PYRE_LLBC_SKIP_FINGERPRINT_CHECK"));
+}
+
+/// And the two defects compounding: a junk opt-out value must not disarm a
+/// correctly spelled escalation.
+#[test]
+fn a_junk_skip_value_does_not_defeat_strict() {
+    let p = freshness_policy(Some("1"), Some("0"));
+    assert_eq!(p.mode, FreshnessMode::Strict);
+    assert_eq!(p.diagnostics.len(), 1, "{:?}", p.diagnostics);
+    assert!(p.diagnostics[0].contains("PYRE_LLBC_SKIP_FINGERPRINT_CHECK"));
+}
+
+#[test]
+fn an_empty_value_is_unrecognised_not_set() {
+    assert_eq!(freshness_policy(None, Some("")).mode, FreshnessMode::Strict);
+    assert_eq!(freshness_policy(Some(""), None).mode, FreshnessMode::Strict);
+}

--- a/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
@@ -30,6 +30,17 @@ fn strict_one_promotes_to_error() {
     assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
 }
 
+/// `PYRE_LLBC_STRICT=0` is the only value that lets a stale artefact through
+/// without failing the build — `build.rs` picks `cargo::warning` over
+/// `cargo::error` from exactly this mode — so a regression folding the off
+/// switch back into `Strict` would pass every other case in this file.
+#[test]
+fn strict_zero_demotes_to_a_warning() {
+    let p = freshness_policy(Some("0"), None);
+    assert_eq!(p.mode, FreshnessMode::Warn);
+    assert!(p.diagnostics.is_empty(), "{:?}", p.diagnostics);
+}
+
 /// The opt-out is honoured, but it announces itself. Returning silently would
 /// make "opted out" and "checked and fresh" the same absence of output — the
 /// conflation the UNKNOWN channel exists to prevent.

--- a/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
+++ b/pyre/pyre-jit-trace/tests/llbc_freshness_policy_test.rs
@@ -14,7 +14,7 @@
 //! same as unset**, and **asking for strict while also asking to skip is a
 //! contradiction, not a precedence question.**
 
-use pyre_jit_trace::llbc_fingerprint::{freshness_policy, FreshnessMode};
+use pyre_jit_trace::llbc_fingerprint::{FreshnessMode, freshness_policy};
 
 #[test]
 fn both_unset_is_strict_and_says_nothing() {

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -2030,7 +2030,7 @@ fn jit_blackhole_resume_from_guard(
 /// (`result.values`).  The collector is moving, so a minor collection
 /// triggered while `blackhole_from_resumedata` lazily materializes virtuals
 /// (`getvirtual_ptr` → allocator) relocates the boxed objects and leaves the
-/// copy holding from-space pointers; `decode_ref` (resume.rs:1575) then reads
+/// copy holding from-space pointers; `resume.rs::decode_ref` then reads
 /// a stale pointer for a box-sourced slot and the blackhole dereferences
 /// freed memory.  Resume *constants* are already forwarded by
 /// `rd_consts_root_walker_area`, but the box-sourced slots here are not.

--- a/pyre/pyre-object/src/tagged_int.rs
+++ b/pyre/pyre-object/src/tagged_int.rs
@@ -9,11 +9,13 @@
 //! real pointer; `None`/`True`/`False` are even-aligned statics and are
 //! never tagged.
 //!
-//! The tag path is live behind [`CAN_BE_TAGGED`] (#22 enablement): the
+//! The tag path is gated behind [`CAN_BE_TAGGED`], which is `false` and
+//! has never been turned on (#22 tracks enablement). Once it is: the
 //! maker (`intobject::w_int_new`) returns small ints as immediates, the
 //! readers/dispatch chokepoints `& 1`-precheck before any `ob_type`
 //! deref, and the GC collector skips tagged immediates
-//! (`taggedpointers`, wired through `pyre-jit`'s `build_gc`).
+//! (`taggedpointers`, wired through `pyre-jit`'s `build_gc`). While it
+//! is `false` none of that is reachable.
 //!
 //! The bit layout mirrors the already-ported rtyper helper
 //! `majit/majit-translate/src/translator/rtyper/lltypesystem/rtagged.rs`
@@ -23,13 +25,22 @@
 use crate::pyobject::PyObjectRef;
 
 /// `rpython/rtyper/lltypesystem/rtagged.py:64-96` static `can_be_tagged`
-/// gate, collapsed to the single runtime `int` class. Enabled (#22),
-/// mirroring `rpython/config/translationoption.py:185 taggedpointers`
-/// turned on, so every consumer chokepoint takes the `& 1` tag precheck
-/// and the maker emits small ints as immediates. `rerased.py:1-3`: the
-/// point is to avoid putting `& 1` tag checks on every object — they are
-/// gated on this static, which is kept in lockstep with the GC
-/// `taggedpointers` config (`pyre-jit` `build_gc`).
+/// gate, collapsed to the single runtime `int` class. Off, mirroring
+/// `rpython/config/translationoption.py:185 taggedpointers` left off;
+/// #22 tracks turning it on, at which point every consumer chokepoint
+/// takes the `& 1` tag precheck and the maker emits small ints as
+/// immediates. `rerased.py:1-3`: the point is to avoid putting `& 1` tag
+/// checks on every object — they are gated on this static, which is kept
+/// in lockstep with the GC `taggedpointers` config (`pyre-jit`
+/// `build_gc`).
+///
+/// While this is `false` no tagged value can exist at runtime. The sole
+/// production caller of [`tag_int`] is `intobject::w_int_new`, behind
+/// this same gate, so the maker arm is compile-time dead and every
+/// consumer's `& 1` precheck is inert. So do not read an odd, small bit
+/// pattern found in a live `PyObjectRef` as a tagged immediate: nothing
+/// can mint one, and such a value is corruption that happens to match
+/// the encoding.
 pub const CAN_BE_TAGGED: bool = false;
 
 /// `value` fits the tagged immediate range, i.e. the payload survives

--- a/pyre/pyre-object/src/tagged_int.rs
+++ b/pyre/pyre-object/src/tagged_int.rs
@@ -9,8 +9,8 @@
 //! real pointer; `None`/`True`/`False` are even-aligned statics and are
 //! never tagged.
 //!
-//! The tag path is gated behind [`CAN_BE_TAGGED`], which is `false` and
-//! has never been turned on (#22 tracks enablement). Once it is: the
+//! The tag path is gated behind [`CAN_BE_TAGGED`], which is currently `false`.
+//! If it is enabled: the
 //! maker (`intobject::w_int_new`) returns small ints as immediates, the
 //! readers/dispatch chokepoints `& 1`-precheck before any `ob_type`
 //! deref, and the GC collector skips tagged immediates
@@ -26,8 +26,8 @@ use crate::pyobject::PyObjectRef;
 
 /// `rpython/rtyper/lltypesystem/rtagged.py:64-96` static `can_be_tagged`
 /// gate, collapsed to the single runtime `int` class. Off, mirroring
-/// `rpython/config/translationoption.py:185 taggedpointers` left off;
-/// #22 tracks turning it on, at which point every consumer chokepoint
+/// `rpython/config/translationoption.py:185 taggedpointers` left off. If it is
+/// enabled, every consumer chokepoint
 /// takes the `& 1` tag precheck and the maker emits small ints as
 /// immediates. `rerased.py:1-3`: the point is to avoid putting `& 1` tag
 /// checks on every object — they are gated on this static, which is kept

--- a/pyre/scripts/extract-llbc.py
+++ b/pyre/scripts/extract-llbc.py
@@ -19,11 +19,10 @@ from llbc_extract import CrateSpec, run_cli  # noqa: E402
 
 # `pyre-object` / `pyre-interpreter` exclude `majit-translate` from their
 # fingerprint: their `.ullbc` holds zero references to it, so a pure edit there
-# reuses the cached artefact. The exclusion also drops the subtree reachable
-# ONLY through it — on this tree that is `majit-charon-reader`, whose sole
-# dependent-of-record is `majit-translate`, worth 4 files to `pyre-interpreter`.
+# reuses the cached artefact. The exclusion also drops dependencies reachable
+# only through `majit-translate`.
 #
-# ⚠ Only `pyre-interpreter` is actually affected: `pyre-object` does not
+# Only `pyre-interpreter` is affected: `pyre-object` does not
 # depend on `majit-translate` at all, so its entry here is an inert
 # declaration and its input list is byte-identical with and without it. Do not
 # read that row as a second confirmation of anything.

--- a/pyre/scripts/extract-llbc.py
+++ b/pyre/scripts/extract-llbc.py
@@ -19,7 +19,16 @@ from llbc_extract import CrateSpec, run_cli  # noqa: E402
 
 # `pyre-object` / `pyre-interpreter` exclude `majit-translate` from their
 # fingerprint: their `.ullbc` holds zero references to it, so a pure edit there
-# reuses the cached artefact. `pyre-jit` is deliberately ABSENT — its `.ullbc`
+# reuses the cached artefact. The exclusion also drops the subtree reachable
+# ONLY through it — on this tree that is `majit-charon-reader`, whose sole
+# dependent-of-record is `majit-translate`, worth 4 files to `pyre-interpreter`.
+#
+# ⚠ Only `pyre-interpreter` is actually affected: `pyre-object` does not
+# depend on `majit-translate` at all, so its entry here is an inert
+# declaration and its input list is byte-identical with and without it. Do not
+# read that row as a second confirmation of anything.
+#
+# `pyre-jit` is deliberately ABSENT — its `.ullbc`
 # embeds majit-translate *type* layouts (translator::rtyper::lltypesystem,
 # model, flowspace::model, codewriter, tool::algo, …), so a type change there
 # must re-extract it.

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -16,6 +16,7 @@ import json
 import os
 import platform
 import re
+import shlex
 import subprocess
 import sys
 from dataclasses import dataclass, field
@@ -89,11 +90,20 @@ class Engine:
     metadata_feature_crates: tuple[str, ...] = ()
     layout_targets: tuple[str, ...] = ()
     layout_target_rustflags: str = ""
-    # Files/directories outside `root` that a driver declares by hand, for
-    # inputs the dependency walk cannot find: the engine module itself, and
-    # any build-determining file `git ls-files` refuses to list (an ignored
-    # `.cargo/config.toml`, a lockfile a repo does not commit). Patched path
-    # deps need no declaration — `_collect_inputs` discovers those.
+    # Files/directories a driver declares by hand because the git channel
+    # cannot carry them. Two kinds, and BOTH are hashed by content:
+    #
+    #   * outside `root` — the engine module itself, a sibling checkout. `git
+    #     ls-files` refuses a pathspec that leaves the repository.
+    #   * inside `root` but IGNORED — an uncommitted `.cargo/config.toml`, a
+    #     lockfile a repo gitignores. `_collect_inputs` resolves pathspecs
+    #     through `ls-files ∪ ls-files --others --exclude-standard`, and an
+    #     ignored file is in neither, so declaring it as a pathspec is inert.
+    #     `refuse_inert_pathspecs` names this field as the remedy, so keep it
+    #     accepting in-root paths: labels come from `os.path.relpath`, which
+    #     spells an in-root path without any `..`.
+    #
+    # Patched path deps need no declaration — `_collect_inputs` discovers those.
     external_inputs: tuple[Path, ...] = ()
 
     def spec(self, crate: str) -> CrateSpec:
@@ -377,6 +387,103 @@ def _reject_unresolvable_include(where: str, tail: str) -> None:
     )
 
 
+def refuse_inert_pathspecs(eng: Engine) -> None:
+    """Refuse a declared fingerprint input that cannot contribute anything.
+
+    A pathspec is an input only if git will list a file under it, because
+    `_collect_inputs` resolves the in-root channel through `git ls-files` and
+    nothing else. A pathspec matching zero files is therefore a silent no-op —
+    and a no-op that READS as coverage everywhere a human looks: in the
+    driver's list, in the comments that cite it, and in the design decisions
+    that rest on it. A driver carried `Cargo.lock` in exactly that state while
+    a comment eight lines above called it a declared input and used it to
+    justify skipping the more expensive `cargo metadata` walk, so the cheaper
+    option was resting on coverage that did not exist.
+
+    This lives in the ENGINE rather than in one driver because every consumer
+    of the engine has the same hole: the check was first written against one
+    driver's `BASE_PATHSPECS`, and each other driver kept the defect until it
+    grew its own copy. Refusing here catches the whole class at the one place
+    that resolves pathspecs, and it would have fired the day either known
+    offender was added.
+
+    Scope is the DECLARED pathspecs — `base_pathspecs`, and each spec's
+    `fingerprint_pathspecs`. The ones `_collect_inputs` discovers from `cargo
+    metadata` are facts about the build rather than a human's claim of
+    coverage, and refusing on those would fail a driver over a dependency's
+    layout it does not control. Every spec is checked, not only the crates
+    requested on this run: a pathspec that rots in a spec nobody asked for
+    today is then found on the next run, rather than the next time that one
+    crate happens to be extracted.
+
+    ⛔ The DECISION is git's, and only git's. `Path.exists()` below feeds the
+    MESSAGE and nothing else — do not "simplify" this to an existence test. An
+    ignored file EXISTS on disk and is invisible to `git ls-files`, which is
+    the entire defect. Filesystem-reachable and git-reachable are different
+    predicates, and a check that conflates them answers a question nobody
+    asked. (The defect is not `exists()`; it is using `exists()` to answer a
+    question about git. An `is_file()` test on a module about to be imported is
+    a genuine filesystem question and stays correct.)
+
+    `ls-files ∪ ls-files --others --exclude-standard` is the definition of
+    git-reachable used here, matching `_collect_inputs` exactly. `ls-files
+    --error-unmatch` alone is TRACKED-only, and would call a brand-new unadded
+    file inert when the engine does hash it.
+
+    The two failure modes need different remedies, so they are reported apart:
+    a path that EXISTS but is ignored is a coverage hole, a path that does not
+    exist is a typo or a file that moved.
+    """
+
+    def git_lists(*args: str) -> bool:
+        result = subprocess.run(
+            ["git", "-C", str(eng.root), *args],
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        return bool(result.stdout.strip())
+
+    declared: list[tuple[str, list[str]]] = [("base_pathspecs", eng.base_pathspecs)]
+    for name, spec in eng.specs.items():
+        if spec.fingerprint_pathspecs is not None:
+            declared.append(
+                (f"specs[{name!r}].fingerprint_pathspecs", spec.fingerprint_pathspecs)
+            )
+
+    inert: list[tuple[str, str, bool]] = []
+    for label, pathspecs in declared:
+        for pathspec in pathspecs:
+            # `--others` only when the tracked query came back empty: the live
+            # case is one subprocess per pathspec instead of two, and this runs
+            # on every invocation including the `--check` a build script makes.
+            if git_lists("ls-files", "--", pathspec):
+                continue
+            if git_lists("ls-files", "--others", "--exclude-standard", "--", pathspec):
+                continue
+            inert.append((label, pathspec, (eng.root / pathspec).exists()))
+    if not inert:
+        return
+
+    lines = ["extract-llbc.py: declared fingerprint pathspecs that match no file:"]
+    for label, pathspec, on_disk in inert:
+        if on_disk:
+            lines.append(
+                f"  {label}: {pathspec!r} — EXISTS on disk but git will not list"
+                f" it (ignored?), so it contributes nothing to the fingerprint."
+                f" Either stop declaring it or cover it another way — an"
+                f" out-of-root or ignored file goes in `external_inputs=`,"
+                f" which is hashed by content; do not leave it here reading as"
+                f" coverage."
+            )
+        else:
+            lines.append(
+                f"  {label}: {pathspec!r} — does not exist. Renamed, moved, or a"
+                f" typo: whatever it was meant to fingerprint is now"
+                f" unfingerprinted."
+            )
+    raise SystemExit("\n".join(lines))
+
+
 def _collect_inputs(
     eng: Engine, crates: list[str], cargo_features: str
 ) -> tuple[list[str], list[Path]]:
@@ -387,9 +494,11 @@ def _collect_inputs(
     * `pathspecs` — repo-relative, resolved through `git ls-files` below, so
       the working tree (including untracked-not-ignored files) is what gets
       hashed.
-    * `external` — absolute paths OUTSIDE `eng.root`, which `git ls-files`
-      cannot name at all: it refuses a pathspec that leaves the repository.
-      These are hashed by content instead, by `external_fingerprint`.
+    * `external` — absolute paths the git channel cannot carry: anything
+      outside `eng.root`, which `git ls-files` refuses to name at all, plus
+      whatever a driver declares in `external_inputs` (which is also how an
+      in-root but IGNORED file gets covered). Hashed by content instead, by
+      `external_fingerprint`.
 
     The second list used to be dropped on the floor. The dependency walk below
     admits path deps by `source is None`, which is how cargo spells BOTH an
@@ -554,69 +663,166 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
     return _collect_inputs(eng, crates, cargo_features)[0]
 
 
-def external_input_entries(
+def external_input_groups(
     eng: Engine, crates: list[str], cargo_features: str
-) -> list[tuple[str, Path]]:
-    """Out-of-root inputs hashed into `external=`, as `(label, absolute path)`.
+) -> list[tuple[str, list[tuple[str, Path]]]]:
+    """Out-of-root inputs GROUPED by the root that declared or discovered them.
+
+    `[(root label, [(file label, absolute path), …]), …]`, sorted by root label
+    and, within a root, by file label.
 
     Deliberately NOT named `external_inputs`: that is the driver-facing keyword
     of `run_cli`, and a parameter of that name shadows the module-level
     function for the whole body.
 
+    ⭐ The GROUP, not the file and not the whole set, is the unit `external=`
+    records a digest for, and that choice is the only reason `check` can name a
+    mover. One digest over every out-of-root file fires identically whether a
+    doc comment moved in a crate the artefact barely references or
+    `majit-macros` did — a proc macro whose expansion IS the extracted crate's
+    item bodies, so its movement voids every measurement already read out of
+    the artefact. Same remedy (`--force`), very different consequence, and a
+    single digest cannot tell them apart. Per FILE is the other extreme and no
+    better: cel's declared closure is hundreds of files, and a report naming
+    hundreds of movers carries the same zero bits spelled longer.
+
+    Roots are deduped by label — the metadata walk runs once per layout
+    platform and rediscovers the same packages — but files are NOT deduped
+    across roots. `<crate>/src/lib.rs` and `<crate>/src/` are both roots the
+    walk emits, so an edit to `lib.rs` moves both, and that pair of movers is
+    the narrowing a reader wants rather than noise.
+
     The label — not the absolute path — is what enters the digest, so two
-    checkouts of the same layout in different directories agree. Directories
-    are expanded here rather than at collection time so the walk sees the
-    working tree at hashing time, matching `source=`'s
+    checkouts of the same layout in different directories agree. Labels are
+    relative to the artefact root, so a stamp survives relocating the whole
+    cohabitation (`<super>/{pyre,cel-jit,majit}`) as a unit; it does not
+    survive rearranging those repos RELATIVE to each other, which is the
+    correct sensitivity, because that changes which sources are compiled.
+
+    Directories are expanded here rather than at collection time so the walk
+    sees the working tree at hashing time, matching `source=`'s
     save-not-commit behaviour for the in-root half.
     """
     _, roots = _collect_inputs(eng, crates, cargo_features)
 
     def label_for(path: Path) -> str:
-        # Relative to the artefact root, so the stamp survives relocating the
-        # whole cohabitation (`<super>/{pyre,cel-jit,majit}`) as a unit. It
-        # does not survive rearranging the repos RELATIVE to each other, which
-        # is the correct sensitivity: that changes which sources are compiled.
         return Path(os.path.relpath(path, eng.root)).as_posix()
 
-    found: dict[str, Path] = {}
+    groups: dict[str, list[tuple[str, Path]]] = {}
     for entry in roots:
-        if entry.is_file():
-            found[label_for(entry)] = entry
+        root_label = label_for(entry)
+        if root_label in groups:
             continue
-        if not entry.is_dir():
-            # A declared input that does not exist still has to move the
-            # digest, exactly as a deleted tracked file does in `source=`.
-            found.setdefault(label_for(entry), entry)
-            continue
-        for sub in entry.rglob("*"):
-            # `target/` is build output and dot-dirs are VCS/tooling state;
-            # neither is a compiler input, and `target/` alone is tens of GB.
-            parts = set(sub.relative_to(entry).parts[:-1])
-            if "target" in parts or any(p.startswith(".") for p in parts):
-                continue
-            if sub.is_file():
-                found[label_for(sub)] = sub
-    return sorted(found.items())
+        if entry.is_dir():
+            found: dict[str, Path] = {}
+            for sub in entry.rglob("*"):
+                # `target/` is build output and dot-dirs are VCS/tooling state;
+                # neither is a compiler input, and `target/` alone is tens of GB.
+                parts = set(sub.relative_to(entry).parts[:-1])
+                if "target" in parts or any(p.startswith(".") for p in parts):
+                    continue
+                if sub.is_file():
+                    found[label_for(sub)] = sub
+            groups[root_label] = sorted(found.items())
+        else:
+            # A file, or a declared root that does not exist. The absent case
+            # still gets a group, so it moves the digest when it appears —
+            # exactly as a deleted tracked file does in `source=`.
+            groups[root_label] = [(root_label, entry)]
+    return sorted(groups.items())
 
 
-def external_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
-    """Digest of the out-of-root inputs, or `""` when there are none.
+def external_group_digest(root_label: str, files: list[tuple[str, Path]]) -> str:
+    """Digest of one out-of-root group.
 
-    Empty is the common case (a consumer whose whole dependency closure lives
-    inside its own repo, which is every pyre crate today) and it is spelled as
-    an empty value rather than a digest-of-nothing so the stamp says plainly
-    that nothing outside the repo was folded in.
+    The root label is folded in first so an EMPTY group (a declared directory
+    holding no file the filter admits) still gets a digest of its own rather
+    than colliding with every other empty group.
     """
-    entries = external_input_entries(eng, crates, cargo_features)
-    if not entries:
-        return ""
     digest = hashlib.sha256()
-    for label, path in entries:
+    digest.update(root_label.encode("utf-8"))
+    digest.update(b"\0")
+    for label, path in files:
         digest.update(label.encode("utf-8"))
         digest.update(b"\0")
         digest.update(path.read_bytes() if path.is_file() else b"<absent>")
         digest.update(b"\0")
     return digest.hexdigest()
+
+
+def external_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
+    """`external=`'s stamp value: one `<root label>=<digest>` per group.
+
+    Empty is the common case (a consumer whose whole dependency closure lives
+    inside its own repo, which is every pyre crate today) and it is spelled as
+    an empty value rather than a digest-of-nothing, so the stamp says plainly
+    that nothing outside the repo was folded in.
+
+    `shlex.quote` per entry, space-separated: a root label is a filesystem path
+    and may hold a space or a quote, and the value has to survive as ONE line
+    of a line-oriented stamp. `parse_external` is the inverse.
+
+    One stamp KEY, not one key per root. `STAMP_KEYS` is a fixed schema and
+    `check` refuses a stamp missing any member of it; deriving the key set from
+    the very declaration whose movement is under test would mean a dropped
+    input takes its own coverage assertion with it, and "the field is gone"
+    would read the same as "there was never such a field".
+    """
+    groups = external_input_groups(eng, crates, cargo_features)
+    return " ".join(
+        shlex.quote(f"{root_label}={external_group_digest(root_label, files)}")
+        for root_label, files in groups
+    )
+
+
+def parse_external(value: str) -> dict[str, str]:
+    """Split an `external=` stamp value into `{root label: digest}`.
+
+    Inverse of `external_fingerprint`'s encoding. `rpartition`, not `partition`:
+    a label may contain `=`, and the hex digest that follows never does.
+    """
+    entries: dict[str, str] = {}
+    for token in shlex.split(value):
+        label, sep, digest = token.rpartition("=")
+        if sep:
+            entries[label] = digest
+    return entries
+
+
+def external_diff(crate: str, recorded: str, expected: str) -> list[str]:
+    """Name WHICH out-of-root input moved, rather than printing two digests.
+
+    `external=` carries one digest per root precisely so this can be written.
+    With a single digest there is nothing to say here beyond "something outside
+    the repo changed" — a guard that fires without informing, which is the
+    shape this field is structured to avoid.
+    """
+    was = parse_external(recorded)
+    now = parse_external(expected)
+    lines: list[str] = []
+    for label in sorted(set(was) | set(now)):
+        if label not in now:
+            lines.append(
+                f"{crate}: external: {label!r} is no longer a declared input, "
+                f"but the artefact was built with it folded in"
+            )
+        elif label not in was:
+            lines.append(
+                f"{crate}: external: {label!r} is an input the artefact never "
+                f"covered"
+            )
+        elif was[label] != now[label]:
+            lines.append(f"{crate}: external: {label!r} changed")
+    if not lines:
+        # The packed values differ while every root agrees: an encoding this
+        # engine did not write, or a reordering. Reporting nothing here would
+        # turn a mismatch into a silent pass.
+        lines.append(
+            f"{crate}: external: {recorded!r} does not match {expected!r} "
+            f"although every root agrees — the value was not written by this "
+            f"engine"
+        )
+    return lines
 
 
 def source_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
@@ -1125,8 +1331,11 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         configuration; comparing it against this process's `CARGO_FEATURES`
         would refuse a byte-correct artefact whenever the caller left the
         default in place. Replaying keeps `flags=`, `charon_flags=`,
-        `layout_flags=` and `source=` real comparisons — all four are
-        recomputed from the replayed value.
+        `layout_flags=`, `source=` and `external=` real comparisons — all
+        five are recomputed from the replayed value. (`external=` belongs on
+        that list because the dependency walk it feeds off is itself run
+        per feature set, so a feature that pulls in a patched path dep
+        changes which out-of-root inputs exist.)
       * artefact and stamp mtimes are printed, never gated. `extract` writes
         both in one pass, and the source digest already answers the question a
         timestamp only approximates.
@@ -1250,6 +1459,13 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             )
             continue
         for key in differing:
+            if key == "external":
+                # Two packed per-root lists, not two hashes: printing them as
+                # opaque values would hand the reader kilobytes and no answer.
+                stale.extend(
+                    external_diff(crate, recorded[key], want.get(key, ""))
+                )
+                continue
             stale.append(
                 f"{crate}: {key}: artefact says {recorded[key]!r}, "
                 f"tree says {want.get(key)!r}"
@@ -1415,6 +1631,11 @@ def run_cli(
         layout_target_rustflags=layout_target_rustflags,
         external_inputs=tuple(external_inputs),
     )
+    # Before ANY subcommand, including the read-only instruments: an inert
+    # pathspec makes `--list-inputs` and `--fingerprint` report a coverage the
+    # stamp does not have, and those are the two outputs a reader trusts when
+    # deciding whether the guard is working.
+    refuse_inert_pathspecs(eng)
 
     crates = args.crates or default_crates
     if args.list_inputs:
@@ -1422,9 +1643,16 @@ def run_cli(
             print(path.as_posix())
         # Marked, because the two channels are hashed into different stamp
         # fields and an unmarked union would read as one list of repo-relative
-        # paths — which is what made the out-of-root inputs easy to miss.
-        for label, _ in external_input_entries(eng, crates, cargo_features):
-            print(f"external:{label}")
+        # paths — which is what made the out-of-root inputs easy to miss. The
+        # root is named on every line because it, not the file, is the unit
+        # `external=` records a digest for and `check` reports a move against.
+        for root_label, files in external_input_groups(eng, crates, cargo_features):
+            if not files:
+                # A declared root the filter emptied. It still holds a digest,
+                # so listing nothing for it would under-report the coverage.
+                print(f"external[{root_label}]: (no files)")
+            for label, _ in files:
+                print(f"external[{root_label}]:{label}")
         return
     if args.fingerprint:
         # BOTH fields. Printing only `source=` here previously cost a session:

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1646,8 +1646,8 @@ def touch_and_note(target: Path, own_writes: dict[tuple[int, int], int]) -> None
     Every touch of a closure input must go through this rather than
     `Path.touch()`. `window_writes` tells the extractor's own writes from a
     peer's by comparing against the exact mtime recorded here, so a touch that
-    is not recorded is reported as a candidate on every clean run — and a
-    reviewer who sees four false alarms per run stops reading the output.
+    is not recorded is reported as a candidate on every clean run. Repeated
+    false positives would make the report unactionable.
 
     Pairing the write with its record in ONE call is what keeps them from
     drifting. There are already two touch sites (the crate root before the
@@ -1709,7 +1709,7 @@ def window_writes(
         if not lo_ns <= st.st_mtime_ns <= hi_ns:
             continue
         if own_writes.get((st.st_dev, st.st_ino)) == st.st_mtime_ns:
-            continue  # our own touch, to the nanosecond
+            continue  # the extractor's own touch, to the nanosecond
         candidates.append((st.st_mtime_ns, rel))
     candidates.sort()
     return candidates, len(inputs) - len(unresolved), unresolved
@@ -1815,6 +1815,12 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             # re-stamping it with the current HEAD would claim this checkout produced
             # bytes it did not.
             continue
+
+        # The stamp certifies the exact artefact bytes from the previous
+        # successful extraction. This run may replace those bytes before any
+        # of the validation below fails, so the old certificate must stop
+        # being publishable before Charon can write to `dest`.
+        stamp_path.unlink(missing_ok=True)
 
         # Opening half of the provenance pair, taken before the Charon build
         # that is about to run for minutes. See `provenance_for`.
@@ -2331,8 +2337,8 @@ def self_test_exclusion_diamond() -> None:
     package reaches, and must NOT drop what something else also reaches — and a
     fingerprint that gets this wrong still hashes to something, still compares
     equal to itself, and still passes `--check`. The pre-fix engine filtered at
-    emission and carried four unreferenced files for 30 days without a single
-    red run. So the property is checked here on a graph built for it.
+    emission and carried four unreferenced files without making any check fail.
+    So the property is checked here on a graph built for it.
 
     The graph, with `excluded` excluded:
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1130,6 +1130,262 @@ def file_mtime(path: Path) -> str:
     )
 
 
+# ---------------------------------------------------------------------------
+# PROVENANCE: what the repository looked like around the build. Recorded beside
+# the artefact, reported by `check`, and NEVER gated on.
+#
+# ⛔ This does not go in the fingerprint stamp, and must not be moved there.
+# Two independent reasons, either one sufficient:
+#
+#   * `check` compares the stamp as exact text and already has an arm for a
+#     stamp that "carries content this engine did not write". Extra lines in
+#     the stamp file are a REFUSAL, not extra information.
+#   * a commit sha moves on EVERY commit, including the overwhelming majority
+#     that touch nothing this artefact reads. A git field inside a compared
+#     stamp would report every artefact stale after every unrelated commit,
+#     which deletes the entire point of a content-addressed fingerprint —
+#     `source=` exists precisely so that an unrelated commit does not force a
+#     re-extraction.
+#
+# So the two files answer different questions and are kept apart on purpose:
+# the stamp answers "is this artefact current", the provenance answers "what
+# was going on when it was built". Only the first is allowed to fail a build.
+#
+# ⚠ THE FIRST SIDECARS THIS CODE WRITES DESCRIBE A TREE THAT CONTAINS THIS
+# CODE, and that is not an anomaly. This file is one of the engine sources
+# listed in every driver's base pathspecs, so it is hashed into `source=` for
+# EVERY crate: editing it re-stales all artefacts by construction, and the only
+# run that can produce a provenance sidecar is one made from a tree that
+# already holds the change. Committing before extracting is therefore not a
+# nicety — it is what makes that first sidecar read `dirty_in_closure=0`. Run
+# it the other way round and the change lists ITSELF as an in-closure dirty
+# file, which is the correct report and looks like a defect.
+# ---------------------------------------------------------------------------
+
+
+def git_head(root: Path) -> str:
+    """`HEAD`'s sha, or a LABELLED reason it is unavailable.
+
+    Never raises, and never returns the empty string. An unlabelled blank would
+    read as "no commit" when it means "could not ask", and those call for
+    opposite reactions from whoever reads the sidecar.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return "unavailable(git-not-runnable)"
+    if result.returncode != 0:
+        return "unavailable(rev-parse-failed)"
+    return result.stdout.decode("utf-8", errors="replace").strip() or "unavailable(empty)"
+
+
+def git_dirty(root: Path) -> tuple[str, list[tuple[str, str]]]:
+    """`(status, [(porcelain XY, path), …])` for the worktree at `root`.
+
+    `-uall` is load-bearing. The default collapses an untracked directory into
+    a single `?? dir/` entry, while the fingerprint's own untracked leg
+    (`git ls-files --others --exclude-standard`) works per FILE. Classifying a
+    directory against a set of files would report `?? majit/examples/new/` as
+    outside the closure while every file under it is inside it — the one
+    reading a person would act on, inverted.
+
+    The status is returned separately rather than folded into an empty list,
+    because "the tree is clean" and "git could not be asked" both produce no
+    entries and demand opposite reactions.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "status", "--porcelain", "-z", "-uall"],
+            cwd=root,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+    except OSError:
+        return "unavailable(git-not-runnable)", []
+    if result.returncode != 0:
+        return "unavailable(status-failed)", []
+
+    fields = result.stdout.decode("utf-8", errors="replace").split("\0")
+    entries: list[tuple[str, str]] = []
+    index = 0
+    while index < len(fields):
+        entry = fields[index]
+        index += 1
+        if not entry:
+            continue
+        # Porcelain v1 spends exactly two columns on the status and one on the
+        # separator, so slice rather than split: a path may itself begin with a
+        # space, and `-z` means it is not quoted to hide that.
+        code, path = entry[:2], entry[3:]
+        # An `R`/`C` entry spends a SECOND NUL-separated field on the original
+        # path. Not consuming it re-reads that path as a status code and mints
+        # a junk entry — and, worse, shifts every entry after it by one.
+        if "R" in code or "C" in code:
+            if index < len(fields):
+                path = f"{path} (from {fields[index]})"
+                index += 1
+        entries.append((code, path))
+    return "ok", entries
+
+
+# Ceiling on the per-file `dirty=` listing. Not a ceiling on the COUNTS, which
+# stay exact however far past this the tree is.
+DIRTY_LINE_LIMIT = 200
+
+
+def provenance_for(
+    *,
+    crate: str,
+    head_before: str,
+    head_after: str,
+    started: str,
+    finished: str,
+    dirty_status: str,
+    dirty: list[tuple[str, str]],
+    dirty_before: int | None,
+    closure: set[str],
+) -> str:
+    """The provenance sidecar's text: the HEAD pair, and dirt CLASSIFIED.
+
+    ⭐ Both halves exist because of a specific failure they each fix.
+
+    `head_before`/`head_after` are a PAIR because a build that straddles a
+    commit is only visible as one. A single post-hoc `rev-parse` records the
+    later sha and shows nothing unusual — the straddle that motivated this
+    (`e69f4388a3c` → `8dd18ba2bf4`, landing while an artefact was being
+    stamped) reads as an ordinary clean build under one sha, and as an obvious
+    straddle under two.
+
+    Every dirty path is classified against this crate's own fingerprint
+    closure, because the bare porcelain is not actionable: three files dirty
+    during an extraction is a run to kill if they are inputs and a non-event if
+    they are not, and only the classification distinguishes those. A reader
+    handed the unclassified list has to reconstruct the closure by hand, which
+    is the step nobody takes.
+
+    ⚠ `in-closure` covers the IN-ROOT half only. The out-of-root inputs
+    `external=` hashes live in sibling checkouts this `git status` never sees,
+    so `outside` means "not an input from this repository", never "cannot
+    affect the artefact".
+
+    A `dirty=` line is `<XY> <where> <path>` with the field widths FIXED at the
+    front: `value[:2]` is the porcelain status, `value[3:]` is
+    `<where> <path>`. Splitting the whole value on whitespace does not work and
+    the reason is easy to miss — a porcelain code is two columns of which
+    either may be a SPACE (` M`, `A `), so ` M in-closure x.rs` splits into an
+    empty first field. Positions, not separators.
+    """
+    lines = [
+        f"crate={crate}",
+        f"head_before={head_before}",
+        f"head_after={head_after}",
+        f"started={started}",
+        f"finished={finished}",
+        f"dirty_status={dirty_status}",
+    ]
+    # A count, not a second list: the pre-build snapshot is here for the same
+    # reason the HEAD pair is — so a tree that moved during the build is
+    # legible — and repeating the whole listing to say so would bury the one
+    # that describes the stamped state.
+    lines.append(
+        f"dirty_before={'unknown' if dirty_before is None else dirty_before}"
+    )
+    classified = [
+        (code, path, "in-closure" if path in closure else "outside")
+        for code, path in dirty
+    ]
+    in_closure = [entry for entry in classified if entry[2] == "in-closure"]
+    outside = [entry for entry in classified if entry[2] == "outside"]
+    # COUNTS ARE ALWAYS EXACT; only the per-file listing is bounded. `-uall`
+    # asks git to expand untracked directories file by file, so a single
+    # untracked tree of generated files could otherwise write a sidecar of
+    # unbounded size into `build/`. In-closure entries are listed first and
+    # never dropped: they are the actionable set, and a truncation that ate
+    # them would remove the only lines anyone acts on.
+    lines.append(f"dirty_in_closure={len(in_closure)}")
+    lines.append(f"dirty_outside={len(outside)}")
+    shown = in_closure + outside[: max(0, DIRTY_LINE_LIMIT - len(in_closure))]
+    # Always written, including as `0`, so a reader never has to decide what an
+    # absent key meant.
+    lines.append(f"dirty_omitted={len(classified) - len(shown)}")
+    for code, path, where in shown:
+        lines.append(f"dirty={code} {where} {path}")
+    return "\n".join(lines)
+
+
+def parse_provenance(text: str) -> tuple[dict[str, str], list[str]]:
+    """`({single-valued key: value}, [dirty line, …])`.
+
+    `dirty=` repeats, so it is returned as its own list; collapsing it into the
+    dict would keep the last entry and silently report one dirty file where
+    there were thirty.
+    """
+    fields: dict[str, str] = {}
+    dirty: list[str] = []
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if not sep:
+            continue
+        if key == "dirty":
+            dirty.append(value)
+        else:
+            fields[key] = value
+    return fields, dirty
+
+
+def report_provenance(dest: Path) -> None:
+    """Print an artefact's provenance. Returns nothing and gates nothing.
+
+    ⛔ Absence is NOT a staleness signal and must never become one. Every
+    artefact extracted before this sidecar existed lacks it, and so does every
+    artefact copied in from elsewhere; refusing on that would turn a reporting
+    aid into a second, weaker freshness gate answering a question `source=`
+    already answers properly.
+
+    The in-closure dirty entries are printed in full and the outside ones only
+    counted, because that is the asymmetry the classification exists to
+    express: an input dirty during the build is the thing to act on, and a
+    hundred unrelated edits are the noise that hid it.
+    """
+    path = dest.with_suffix(dest.suffix + ".provenance")
+    if not path.exists():
+        print(
+            "    no provenance sidecar (predates it, or was written by another"
+            " tool) — not a staleness signal"
+        )
+        return
+    fields, dirty = parse_provenance(path.read_text())
+    before, after = fields.get("head_before", "?"), fields.get("head_after", "?")
+    if before == after:
+        print(f"    built at HEAD {before}, {fields.get('started', '?')}")
+    else:
+        # Said plainly rather than as a warning: the artefact may be perfectly
+        # current — `source=` is content-addressed and does not care which
+        # commit the tree sat on. What a straddle costs is the ability to name
+        # ONE tree this artefact came from.
+        print(f"    ⚠ built ACROSS a commit: {before} -> {after}")
+    status = fields.get("dirty_status", "?")
+    if status != "ok":
+        print(f"    dirty state at build time: {status} — neither clean nor known")
+        return
+    # Positional, per `provenance_for`: the status occupies two fixed columns,
+    # so the classification starts at offset 3. A substring test would also
+    # match a PATH that happened to contain the word.
+    in_closure = [entry for entry in dirty if entry[3:].startswith("in-closure ")]
+    print(
+        f"    dirty at build time: {fields.get('dirty_in_closure', '?')} in this"
+        f" crate's closure, {fields.get('dirty_outside', '?')} outside"
+        f" (before the build: {fields.get('dirty_before', '?')})"
+    )
+    for entry in in_closure:
+        print(f"      {entry}")
+
+
 def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
     """Cross targets this crate emits a layout sidecar for.
 
@@ -1320,7 +1576,20 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             and stamp_path.read_text() == stamp + "\n"
         ):
             print(f"=== skipping {crate} -> {dest} (fingerprint unchanged) ===")
+            # No provenance is written here on purpose. The sidecar describes
+            # THE ARTEFACT, and the artefact is the one the previous run built:
+            # re-stamping it with today's HEAD would claim this tree produced
+            # bytes it did not.
             continue
+
+        # Opening half of the provenance pair, taken before the Charon build
+        # that is about to run for minutes. See `provenance_for`.
+        head_before = git_head(eng.root)
+        started = datetime.datetime.now().isoformat(timespec="seconds")
+        dirty_status_before, dirty_entries_before = git_dirty(eng.root)
+        dirty_before = (
+            len(dirty_entries_before) if dirty_status_before == "ok" else None
+        )
 
         print(f"=== extracting {crate} -> {dest} ===")
         # Charon writes the `.ullbc` only while rustc actually compiles
@@ -1405,6 +1674,48 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             write_layout_sidecar(full, sidecar)
             full.unlink()
             print(f"    wrote {sidecar} ({sidecar.stat().st_size} bytes)")
+        # Closing half of the provenance pair, and the sidecar write.
+        #
+        # ⚠ This precedes the two guards below, both of which can end the run,
+        # because the artefact at `dest` has ALREADY been rewritten by the
+        # Charon build above. The invariant worth holding is "the provenance
+        # beside an artefact describes the bytes in it" — leaving the write
+        # until after the guards would, on a guard failure, leave the previous
+        # run's provenance sitting beside this run's bytes, which is the same
+        # lie the skip path is careful not to tell.
+        #
+        # It is also the reason this is not gated: an artefact the stamp
+        # refuses is exactly the one whose provenance a reader needs.
+        head_after = git_head(eng.root)
+        finished = datetime.datetime.now().isoformat(timespec="seconds")
+        dirty_status, dirty_entries = git_dirty(eng.root)
+        closure = {
+            path.as_posix()
+            for path in fingerprint_inputs(eng, [crate], cargo_features)
+        }
+        provenance_path = dest.with_suffix(dest.suffix + ".provenance")
+        provenance_path.write_text(
+            provenance_for(
+                crate=crate,
+                head_before=head_before,
+                head_after=head_after,
+                started=started,
+                finished=finished,
+                dirty_status=dirty_status,
+                dirty=dirty_entries,
+                dirty_before=dirty_before,
+                closure=closure,
+            )
+            + "\n"
+        )
+        if head_after != head_before:
+            print(
+                f"    NOTE: HEAD moved during this build"
+                f" ({head_before[:11]} -> {head_after[:11]}); recorded in"
+                f" {provenance_path.name}. Whether that matters is answered by"
+                f" the source-hash check below, not by this line."
+            )
+
         # Guard the fingerprint exclusion (CrateSpec.excluded_deps): a package
         # dropped from this crate's fingerprint must not appear in its artefact,
         # else a later edit to that package would silently serve a stale cache.
@@ -1574,6 +1885,9 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             )
             continue
         print(f"    artefact {dest.stat().st_size} bytes, mtime {file_mtime(dest)}")
+        # Before the stamp arms, all of which can `continue`. Provenance is
+        # most useful on exactly the paths that refuse.
+        report_provenance(dest)
 
         for target in crate_layout_targets(eng, spec):
             sidecar = dest_dir / spec.layout_sidecar_name(target)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -2084,6 +2084,34 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
             f"{' '.join(group)}",
             file=sys.stderr,
         )
+    # Two things a reader needs at exactly this moment and can find nowhere
+    # near it: what makes the re-extraction stick, and what they may still do
+    # meanwhile. Both are printed here rather than left in a doc, because this
+    # banner is where someone learns they are blocked.
+    print(
+        "\n"
+        "  ⚠ Re-extracting while a closure input is dirty re-stales the result\n"
+        "  the moment that edit changes again. The fingerprint is over the\n"
+        "  WORKING TREE, so an uncommitted in-closure edit is invisible to\n"
+        "  `git log` and to a --check taken a minute earlier. On a shared\n"
+        "  checkout, require this intersection to be EMPTY first:\n"
+        f"      python3 {driver} --list-inputs {' '.join(crates)} | sort -u > cl.txt\n"
+        "      git status --porcelain | sed 's/^...//' | sort -u        > dirty.txt\n"
+        "      comm -12 dirty.txt cl.txt          # must print nothing\n"
+        "  Both sides are repo-relative, so they compare directly. If it comes\n"
+        "  back empty, confirm the instrument is live before believing it —\n"
+        "  `Cargo.lock` is an input, so seeding it into dirty.txt must produce\n"
+        "  a hit.\n"
+        "\n"
+        "  Meanwhile: COMPILING is available under PYRE_LLBC_STRICT=0, which\n"
+        "  demotes this to a warning rather than silencing it. MEASURING is\n"
+        "  not. Stale offsets can name the wrong bytes, and a miscompiled field\n"
+        "  access returns a NUMBER rather than an error, so an unsound run is\n"
+        "  indistinguishable from a real one. The criterion is whether the work\n"
+        "  READS FIELD OFFSETS, not which crate it lives in: a pure source-text\n"
+        "  audit is exempt, anything that runs a trace never is.",
+        file=sys.stderr,
+    )
     print("=" * 72, file=sys.stderr)
     raise SystemExit(1)
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -437,8 +437,8 @@ def refuse_inert_pathspecs(eng: Engine) -> None:
     today is then found on the next run, rather than the next time that one
     crate happens to be extracted.
 
-    ⛔ The DECISION is git's, and only git's. `Path.exists()` below feeds the
-    MESSAGE and nothing else — do not "simplify" this to an existence test. An
+    Git is the authority for this check. `Path.exists()` below feeds the
+    message and nothing else; do not replace the git query with it. An
     ignored file EXISTS on disk and is invisible to `git ls-files`, which is
     the entire defect. Filesystem-reachable and git-reachable are different
     predicates, and a check that conflates them answers a question nobody
@@ -446,15 +446,10 @@ def refuse_inert_pathspecs(eng: Engine) -> None:
     question about git. An `is_file()` test on a module about to be imported is
     a genuine filesystem question and stays correct.)
 
-    ⭐ The contrasting sibling now lives in ANOTHER REPO, so neither file shows
-    both halves of the rule on its own. A driver that declares
-    `external_inputs` may legitimately use `exists()` as a VERDICT on those,
-    and cel-jit's `refuse_absent_external_inputs` does: they are hashed by
-    reading their bytes, never through git, so the filesystem is the correct
-    oracle and the only one. Read alone, that function looks like the mistake
-    this one refuses; read alone, this one looks like a blanket ban on
-    `exists()`. Neither reading is right — the oracle has to match the channel
-    the input is carried on, and the two guards are on different channels.
+    Drivers may also declare `external_inputs`. Those inputs are hashed by
+    reading their bytes rather than through git, so filesystem existence is
+    the correct predicate for that separate channel. The authority must match
+    the channel that carries the input.
 
     `ls-files ∪ ls-files --others --exclude-standard` is the definition of
     git-reachable used here, matching `_collect_inputs` exactly. `ls-files
@@ -524,48 +519,28 @@ def _package_closure(
     """Path-dependency packages reachable from `target_ids` avoiding `exclude`.
 
     Pure graph reachability over cargo-metadata shapes: `by_id` maps package id
-    to package, `resolve_nodes` maps package id to its resolve node. Kept
+    to package, and `resolve_nodes` maps package id to its resolve node. Kept
     separate from `_collect_inputs` so `--self-test` can drive it on a synthetic
-    graph — the property below is about the WALK, and on a real tree it is
-    invisible, because a fingerprint that silently includes four extra files
-    still hashes to something and still compares equal to itself.
+    graph. A fingerprint with extra files still compares equal to itself, so a
+    real repository cannot expose an over-inclusive walk.
 
-    ⭐ The exclusion is applied HERE, in the walk, and not in the emission loop
+    The exclusion is applied here, in the walk, and not in the emission loop
     in `_collect_inputs` — excluding a package drops its whole EXCLUSIVELY-
     REACHED SUBTREE, not just its own files.
 
-    This used to filter only at emission, which dropped the named package's
-    sources and then walked through it anyway, so every dependency reachable
-    ONLY through it stayed in the fingerprint. Measured on this tree:
-    `pyre-interpreter` excludes `majit-translate`, and `majit-charon-reader` —
-    whose sole dependent-of-record IS `majit-translate` — rode in behind it, 4
-    files that no artefact references and that moved the fingerprint 3 times in
-    30 days.
-
     `continue` before appending is what makes it a subtree drop: the node is
-    neither emitted nor traversed. A package a NON-excluded parent also reaches
+    neither emitted nor traversed. A package a non-excluded parent also reaches
     is still pushed from that parent, so this computes "reachable by a path
     avoiding every excluded package" — which is the property the safety
     argument below needs, and it holds regardless of pop order. Both halves are
     load-bearing and `--self-test`'s diamond case checks them together: drop
     what only the excluded package reaches, keep what something else does.
 
-    ⛔ Do NOT ALSO widen `extract`'s artefact guard to the packages dropped
-    here. That guard's evidence is a substring search for the package's
-    underscored name, and its power is PER SYMBOL: `majit_translate` occurs 373
-    times in `pyre-jit.ullbc` (which excludes nothing), so the guard is
-    demonstrably able to fail for it. `majit_charon_reader` occurs 0 times in
-    ALL SIX artefacts this tree builds, `pyre-jit.ullbc` included — there is no
-    artefact that can serve as its positive control, so a widened guard would
-    pass for a reason unrelated to safety and read as verification.
-
-    The transitive drop is certified by INHERITANCE instead, and that is a
-    stronger argument than the substring test: the parent's guard establishes
-    the artefact holds zero references to the excluded package, and a package
-    reachable only through it cannot appear without it. The guard runs on every
-    extraction, so the certificate stays live — if the artefact ever does
-    reference the parent, the parent's guard fires and the exclusion (subtree
-    included) has to go.
+    Do not widen `extract`'s artefact guard to transitively dropped packages.
+    The guard searches for the explicitly excluded package's symbol, but a
+    transitive dependency may have no symbol that can serve as a positive
+    control. Its absence instead follows from the checked parent's absence: a
+    package reachable only through that parent cannot appear without it.
     """
     seen: set[str] = set()
     stack = list(target_ids)
@@ -622,10 +597,9 @@ def refuse_nested_repos(entries: list[str]) -> None:
     one shape where the fingerprint is WRONG rather than merely wide. The
     directory entry enters the input list, `source_fingerprint` finds it is not
     a file, and it hashes through the `<deleted>` branch — one constant token.
-    Measured on a synthetic tree: editing a file inside the nested repo, adding
-    a new `.rs` to it, and deleting the entire subtree all leave the digest
-    byte-identical. The stamp then claims to cover a path whose contents cannot
-    move it, and that digest is also the CI cache key.
+    Editing, adding, or deleting files inside such a repository leaves the
+    digest byte-identical. The stamp would then claim to cover a path whose
+    contents cannot move it, and that digest is also the CI cache key.
 
     Refusing rather than recursing is the direction the untracked leg's own
     argument points: it prefers a cost that is always a re-extraction over an
@@ -680,19 +654,9 @@ def _collect_inputs(
     admits path deps by `source is None`, which is how cargo spells BOTH an
     in-tree workspace member and a `[patch]` redirect into a sibling checkout —
     so a patched dependency was discovered, found to be out-of-root, and
-    discarded with no diagnostic. cel-jit patches `majit-{ir,macros,metainterp}`
-    to `../majit/*`, which pulls the rest of that workspace in by path, and
-    most of what that pulls landed here, `majit-macros` among them.
-
-    ⛔ NO NUMBER IS QUOTED FOR THAT CLOSURE, deliberately. Two careful
-    measurements of it disagree (11 members / 1 kept, and 10 packages / 9
-    out-of-root) and the disagreement is UNEXPLAINED — a `CARGO_FEATURES`
-    difference was proposed and then refuted, because swapping one backend
-    crate for another changes membership without changing the count. The
-    closure is not a stable set, and a figure written down here would be
-    quoted back as if it were. This is the empirical case for a driver
-    declaring a whole directory in `external_inputs` rather than a per-crate
-    list the walk derived.
+    discarded with no diagnostic. An out-of-tree consumer that patches a
+    dependency to a sibling workspace has this shape, including proc-macro
+    crates whose expansions become part of the extracted item bodies.
 
     `majit-macros` is a proc macro, so its expansion IS the extracted crate's
     item bodies. It was dropped by TWO independent gates, and finding the
@@ -770,17 +734,11 @@ def _collect_inputs(
                     external.append(package_dir / "Cargo.toml")
                 for target in package["targets"]:
                     kinds = set(target["kind"])
-                    # ⭐ A DENY-list, and the direction is the whole point. This
-                    # was `{"lib","bin","custom-build"} & kinds` — an allow-list
-                    # written from a remembered vocabulary rather than a
-                    # measured one, and it silently dropped THREE path-dep
-                    # packages in this tree: `majit-macros` and `pyre-macros`
-                    # (`proc-macro`) and `pyre-wasm` (`cdylib`). A proc macro is
-                    # the WORST possible omission — its expansion is inlined
-                    # into the consuming crate, so its sources are more coupled
-                    # to the artefact's item bodies than an ordinary `lib`'s
-                    # are. An allow-list that omits exactly that is the inverse
-                    # of the risk ordering.
+                    # This is a deny-list so new library-like target kinds are
+                    # admitted by default. The old allow-list omitted
+                    # `proc-macro` and `cdylib`; proc-macro expansions are
+                    # inlined into consuming crates, so their sources must be
+                    # fingerprinted.
                     #
                     # The package loop above appends `Cargo.toml` BEFORE this
                     # loop runs, which is what made the omission invisible: the
@@ -854,16 +812,15 @@ def external_input_groups(
     of `run_cli`, and a parameter of that name shadows the module-level
     function for the whole body.
 
-    ⭐ The GROUP, not the file and not the whole set, is the unit `external=`
+    The group, not the file and not the whole set, is the unit `external=`
     records a digest for, and that choice is the only reason `check` can name a
     mover. One digest over every out-of-root file fires identically whether a
     doc comment moved in a crate the artefact barely references or
     `majit-macros` did — a proc macro whose expansion IS the extracted crate's
     item bodies, so its movement voids every measurement already read out of
     the artefact. Same remedy (`--force`), very different consequence, and a
-    single digest cannot tell them apart. Per FILE is the other extreme and no
-    better: cel's declared closure is hundreds of files, and a report naming
-    hundreds of movers carries the same zero bits spelled longer.
+    single digest cannot tell them apart. Per-file reporting is the other
+    extreme and becomes unreadable for a large declared closure.
 
     Roots are deduped by label — the metadata walk runs once per layout
     platform and rediscovers the same packages — but files are NOT deduped
@@ -873,10 +830,10 @@ def external_input_groups(
 
     The label — not the absolute path — is what enters the digest, so two
     checkouts of the same layout in different directories agree. Labels are
-    relative to the artefact root, so a stamp survives relocating the whole
-    cohabitation (`<super>/{pyre,cel-jit,majit}`) as a unit; it does not
-    survive rearranging those repos RELATIVE to each other, which is the
-    correct sensitivity, because that changes which sources are compiled.
+    relative to the artefact root, so a stamp survives relocating a group of
+    sibling repositories as a unit. It does not survive rearranging them
+    relative to each other, which is correct because that changes which
+    sources are compiled.
 
     Directories are expanded here rather than at collection time so the walk
     sees the working tree at hashing time, matching `source=`'s
@@ -1217,11 +1174,10 @@ def file_mtime(path: Path) -> str:
     )
 
 
-# ---------------------------------------------------------------------------
-# PROVENANCE: what the repository looked like around the build. Recorded beside
-# the artefact, reported by `check`, and NEVER gated on.
+# Provenance records what the repository looked like around the build. It is
+# stored beside the artefact, reported by `check`, and never used as a gate.
 #
-# ⛔ This does not go in the fingerprint stamp, and must not be moved there.
+# This does not go in the fingerprint stamp and must not be moved there.
 # Two independent reasons, either one sufficient:
 #
 #   * `check` compares the stamp as exact text and already has an arm for a
@@ -1238,7 +1194,7 @@ def file_mtime(path: Path) -> str:
 # the stamp answers "is this artefact current", the provenance answers "what
 # was going on when it was built". Only the first is allowed to fail a build.
 #
-# ⚠ THE FIRST SIDECARS THIS CODE WRITES DESCRIBE A TREE THAT CONTAINS THIS
+# The first sidecars this code writes describe a tree that contains this
 # CODE, and that is not an anomaly. This file is one of the engine sources
 # listed in every driver's base pathspecs, so it is hashed into `source=` for
 # EVERY crate: editing it re-stales all artefacts by construction, and the only
@@ -1248,7 +1204,7 @@ def file_mtime(path: Path) -> str:
 # it the other way round and the change lists ITSELF as an in-closure dirty
 # file, which is the correct report and looks like a defect.
 #
-# ⚠ AND THE GENERAL FORM, which outlives that one occasion: A NONZERO
+# More generally, a nonzero
 # `dirty_in_closure` IS A REPORT, NOT A DEFECT. An extraction is normally
 # batched into a window several people's work lands in, so a sidecar routinely
 # names files somebody else was editing. What it tells you is narrow and worth
@@ -1256,9 +1212,6 @@ def file_mtime(path: Path) -> str:
 # FOR THAT TREE and is not reproducible from any commit. Kill such a run only
 # if commit-reproducible artefacts are what you came for; the freshness
 # question was already answered, by the stamp, and the answer was yes.
-# ---------------------------------------------------------------------------
-
-
 def git_head(root: Path) -> str:
     """`HEAD`'s sha, or a LABELLED reason it is unavailable.
 
@@ -1348,14 +1301,11 @@ def provenance_for(
 ) -> str:
     """The provenance sidecar's text: the HEAD pair, and dirt CLASSIFIED.
 
-    ⭐ Both halves exist because of a specific failure they each fix.
+    Both halves exist because each detects a distinct failure.
 
-    `head_before`/`head_after` are a PAIR because a build that straddles a
+    `head_before`/`head_after` are a pair because a build that straddles a
     commit is only visible as one. A single post-hoc `rev-parse` records the
-    later sha and shows nothing unusual — the straddle that motivated this
-    (`e69f4388a3c` → `8dd18ba2bf4`, landing while an artefact was being
-    stamped) reads as an ordinary clean build under one sha, and as an obvious
-    straddle under two.
+    later revision and hides that source changed while the artefact was built.
 
     Every dirty path is classified against this crate's own fingerprint
     closure, because the bare porcelain is not actionable: three files dirty
@@ -1364,7 +1314,7 @@ def provenance_for(
     handed the unclassified list has to reconstruct the closure by hand, which
     is the step nobody takes.
 
-    ⚠ `in-closure` covers the IN-ROOT half only. The out-of-root inputs
+    `in-closure` covers the in-root half only. The out-of-root inputs
     `external=` hashes live in sibling checkouts this `git status` never sees,
     so `outside` means "not an input from this repository", never "cannot
     affect the artefact".
@@ -1389,7 +1339,7 @@ def provenance_for(
     # legible — and repeating the whole listing to say so would bury the one
     # that describes the stamped state.
     #
-    # ⚠ It is the WHOLE PORCELAIN, UNCLASSIFIED. `dirty_in_closure` and
+    # This is the complete unclassified porcelain output. `dirty_in_closure` and
     # `dirty_outside` below are a partition of a LATER snapshot, so the only
     # valid comparison is against their SUM; reading `dirty_before` against
     # either half alone compares a total to a part. And the two are SUPPOSED to
@@ -1484,7 +1434,7 @@ def dirty_report_lines(fields: dict[str, str], in_closure: list[str]) -> list[st
     omitted = fields.get("dirty_omitted", "0")
     if omitted not in ("0", "?"):
         lines.append(
-            f"      ⚠ {omitted} further dirty path(s) not listed — do not count"
+            f"      WARNING: {omitted} further dirty path(s) not listed — do not count"
             " the rows, the counts above are the exact ones"
         )
     lines.extend(f"      {entry}" for entry in in_closure)
@@ -1494,7 +1444,7 @@ def dirty_report_lines(fields: dict[str, str], in_closure: list[str]) -> list[st
 def report_provenance(dest: Path) -> None:
     """Print an artefact's provenance. Returns nothing and gates nothing.
 
-    ⛔ Absence is NOT a staleness signal and must never become one. Every
+    Absence is not a staleness signal. Every
     artefact extracted before this sidecar existed lacks it, and so does every
     artefact copied in from elsewhere; refusing on that would turn a reporting
     aid into a second, weaker freshness gate answering a question `source=`
@@ -1521,7 +1471,7 @@ def report_provenance(dest: Path) -> None:
         # current — `source=` is content-addressed and does not care which
         # commit the tree sat on. What a straddle costs is the ability to name
         # ONE tree this artefact came from.
-        print(f"    ⚠ built ACROSS a commit: {before} -> {after}")
+        print(f"    WARNING: built across a commit: {before} -> {after}")
     status = fields.get("dirty_status", "?")
     if status != "ok":
         print(f"    dirty state at build time: {status} — neither clean nor known")
@@ -1800,8 +1750,8 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         ):
             print(f"=== skipping {crate} -> {dest} (fingerprint unchanged) ===")
             # No provenance is written here on purpose. The sidecar describes
-            # THE ARTEFACT, and the artefact is the one the previous run built:
-            # re-stamping it with today's HEAD would claim this tree produced
+            # the artefact, and the artefact is the one the previous run built:
+            # re-stamping it with the current HEAD would claim this checkout produced
             # bytes it did not.
             continue
 
@@ -1904,7 +1854,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             print(f"    wrote {sidecar} ({sidecar.stat().st_size} bytes)")
         # Closing half of the provenance pair, and the sidecar write.
         #
-        # ⚠ This precedes the two guards below, both of which can end the run,
+        # This precedes the two guards below, both of which can end the run,
         # because the artefact at `dest` has ALREADY been rewritten by the
         # Charon build above. The invariant worth holding is "the provenance
         # beside an artefact describes the bytes in it" — leaving the write
@@ -2068,20 +2018,15 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
           - it does not distinguish "the guard passed" from "the guard was
             vacuous". A spec with empty `excluded_deps` runs an empty loop and
             writes an indistinguishable stamp.
-          - it does not cover the EXCLUSIVELY-REACHED SUBTREE the exclusion
-            also drops, and ⛔ widening the loop to cover it would be worse
-            than leaving it uncovered, because the guard's power is PER
-            SYMBOL. `majit_charon_reader` — dropped as `majit-translate`'s
-            subtree — occurs 0 times in ALL SIX artefacts this tree builds,
-            `pyre-jit.ullbc` included, so no artefact can serve as its
-            positive control and a widened guard would pass without
-            evidence. What actually certifies the subtree is INHERITANCE:
-            the walk drops a package only when EVERY path to it runs through
+          - it does not cover the exclusively reached subtree the exclusion
+            also drops, and widening the loop to cover it would be worse
+            than leaving it uncovered, because the guard's power is per
+            symbol. A transitively dropped package may have no matching symbol
+            in any artefact, so no artefact can serve as its positive control.
+            The subtree is instead certified by inheritance: the walk drops a
+            package only when every path to it runs through
             an excluded one, and the named package's absence is checked
             here, so a package that cannot appear without it cannot appear.
-            `pyre-object` is NOT a second witness for that absence — it does
-            not depend on `majit-translate` at all, so its exclusion is an
-            inert declaration and its 0 is uninformative.
           - `--force` re-extracts with the skip bypassed, and an excluded
             package's sources changing is BY CONSTRUCTION invisible to
             `source=`. So a forced run can write a violating artefact, raise at
@@ -2109,7 +2054,7 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     platform_key, charon_dest, _ = charon_paths(eng.charon_root)
     charon_stamp = charon_version(charon_dest)
     dest_dir = llbc_dest(eng.out_dir, eng.root)
-    # ⚠ `crates` is what was REQUESTED, and the epilogue's `unaccounted` check
+    # `crates` is what was requested, and the epilogue's `unaccounted` check
     # depends on it staying that way. Rebuilding this list from resolved specs
     # would drop a name the loop could not process before the epilogue ever saw
     # it, turning "this crate was never confirmed" back into silent success.
@@ -2282,7 +2227,7 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     # banner is where someone learns they are blocked.
     print(
         "\n"
-        "  ⚠ Re-extracting while a closure input is dirty re-stales the result\n"
+        "  WARNING: re-extracting while a closure input is dirty re-stales the result\n"
         "  the moment that edit changes again. The fingerprint is over the\n"
         "  WORKING TREE, so an uncommitted in-closure edit is invisible to\n"
         "  `git log` and to a --check taken a minute earlier. On a shared\n"
@@ -2327,9 +2272,8 @@ def self_test_exclusion_diamond() -> None:
 
     Two-sided, and neither side alone is sufficient:
 
-    * `behind_excluded` must be ABSENT. An engine that filters at emission
-      keeps it — that is the #152 defect, and this is the only assertion that
-      sees it.
+    * `behind_excluded` must be absent. An engine that filters at emission
+      keeps it, and this is the only assertion that sees that defect.
     * `shared` must be PRESENT. An engine that prunes by ancestry instead
       (dropping everything downstream of an excluded node) also passes the
       first assertion, and drops a package the tree genuinely depends on. That
@@ -2341,7 +2285,7 @@ def self_test_exclusion_diamond() -> None:
     are being read off a graph that might reach neither, and the excluded run
     would pass for a reason unrelated to exclusion.
 
-    ⚠ Not covered here: the `dep_kinds`/dev-edge filter in the same walk. It is
+    Not covered here: the `dep_kinds`/dev-edge filter in the same walk. It is
     a different property with a different failure mode and no fixture yet.
     """
     def pkg(name, source=None):
@@ -2391,7 +2335,7 @@ def self_test_exclusion_diamond() -> None:
                 "'behind_excluded' survived the exclusion — the exclusion is "
                 "being applied at emission rather than in the walk, so a "
                 "package reachable ONLY through an excluded one still moves "
-                "the fingerprint (the #152 defect)"
+                "the fingerprint"
             )
         if "shared" not in excluded:
             failures.append(
@@ -2715,8 +2659,8 @@ def run_cli(
         # is silently wrong.
         self_test_exclusion_diamond()
         # Same reason, one artefact along: `--check` renders provenance on every
-        # run and exercises neither of its conditional lines, because no sidecar
-        # this tree has written is anything but steady and untruncated.
+        # run and exercises neither of its conditional lines, because ordinary
+        # sidecars describe steady, complete extractions.
         self_test_provenance_rendering()
         # Same reason again: this one builds its own repository in a
         # temporary directory and never touches the worktree.
@@ -2745,7 +2689,6 @@ def run_cli(
 if __name__ == "__main__":
     raise SystemExit(
         "llbc_extract.py is the shared extraction ENGINE, not an entry point.\n"
-        "  pyre crates:  python3 scripts/extract-llbc.py ...\n"
-        "  cel crates:   python3 cel-jit/scripts/extract-llbc.py ...\n"
-        "Those wrappers supply the CrateSpec table this module needs."
+        "Use the repository's scripts/extract-llbc.py wrapper instead.\n"
+        "The wrapper supplies the CrateSpec table this module needs."
     )

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1389,14 +1389,34 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
       * artefact and stamp mtimes are printed, never gated. `extract` writes
         both in one pass, and the source digest already answers the question a
         timestamp only approximates.
-      * NOT COVERED, as opposed to deliberately ungated: the `excluded_deps`
-        exclusion. `extract` re-reads the artefact and refuses if a package
-        dropped from the fingerprint is referenced by it, but that guard lives
-        in `extract` alone, so an artefact only ever `--check`ed never has its
-        exclusion re-validated. The guard's oracle does discriminate — the same
-        symbol is present in `pyre-jit.ullbc`, which excludes nothing, and
-        absent from the two artefacts that exclude it — so this is a coverage
-        gap in WHERE it runs, not a defect in WHAT it asks.
+      * the `excluded_deps` exclusion is not re-asked here, and MOSTLY DOES NOT
+        NEED TO BE — do not add a second checker without reading this first.
+        `extract` re-reads the artefact and refuses if a package dropped from
+        the fingerprint is referenced by it; `stamp_path.write_text` is the
+        stamp's ONLY writer and sits immediately after that guard, so a
+        violation raises before any stamp exists. A matching stamp is therefore
+        the guard's certificate: it could only have been written by an
+        extraction the guard passed. The skip path inherits this — it fires on
+        `stamp == recorded`, and that recorded stamp had the same provenance.
+        The oracle discriminates rather than being vacuous: the same symbol is
+        present in `pyre-jit.ullbc`, which excludes nothing, and absent from
+        the two artefacts that exclude it.
+
+        Two narrow things the certificate does NOT carry:
+
+          - it does not distinguish "the guard passed" from "the guard was
+            vacuous". A spec with empty `excluded_deps` runs an empty loop and
+            writes an indistinguishable stamp.
+          - `--force` re-extracts with the skip bypassed, and an excluded
+            package's sources changing is BY CONSTRUCTION invisible to
+            `source=`. So a forced run can write a violating artefact, raise at
+            the guard, and leave the previous stamp in place still matching the
+            tree — after which this function passes. It fails loud once, at the
+            forced extraction, and is silent on every check after. (Read from
+            the code path, not reproduced: reproducing it needs a real
+            extraction. The half that IS demonstrated is that `check` never
+            looks at artefact content — a stamp-matching fixture holding
+            arbitrary bytes passes.)
 
     Nothing here re-extracts. Re-extraction runs a whole-crate Charon build and
     writes into the working tree, so it stays a human's scheduling decision and

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1027,6 +1027,10 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     platform_key, charon_dest, _ = charon_paths(eng.charon_root)
     charon_stamp = charon_version(charon_dest)
     dest_dir = llbc_dest(eng.out_dir, eng.root)
+    # ⚠ `crates` is what was REQUESTED, and the epilogue's `unaccounted` check
+    # depends on it staying that way. Rebuilding this list from resolved specs
+    # would drop a name the loop could not process before the epilogue ever saw
+    # it, turning "this crate was never confirmed" back into silent success.
     crates = args.crates or eng.default_crates
 
     stale: list[str] = []

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1370,7 +1370,10 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     wrong" is what makes a gate decorative — a harness reads the exit status,
     not the output.
 
-    Two things are deliberately not gated:
+    Two things are deliberately not gated, and one is simply not covered here
+    — the list is written out because an incomplete "what this does not check"
+    reads as a complete one, which is the same shape as an allow-list that
+    silently omits a member:
 
       * `features=` is replayed out of the stamp rather than compared. The
         stamp records the configuration the artefact was built under, and the
@@ -1386,6 +1389,14 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
       * artefact and stamp mtimes are printed, never gated. `extract` writes
         both in one pass, and the source digest already answers the question a
         timestamp only approximates.
+      * NOT COVERED, as opposed to deliberately ungated: the `excluded_deps`
+        exclusion. `extract` re-reads the artefact and refuses if a package
+        dropped from the fingerprint is referenced by it, but that guard lives
+        in `extract` alone, so an artefact only ever `--check`ed never has its
+        exclusion re-validated. The guard's oracle does discriminate — the same
+        symbol is present in `pyre-jit.ullbc`, which excludes nothing, and
+        absent from the two artefacts that exclude it — so this is a coverage
+        gap in WHERE it runs, not a defect in WHAT it asks.
 
     Nothing here re-extracts. Re-extraction runs a whole-crate Charon build and
     writes into the working tree, so it stays a human's scheduling decision and

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -19,6 +19,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -591,6 +592,74 @@ def _package_closure(
     return closure
 
 
+def nested_repo_entries(entries: list[str]) -> list[str]:
+    """`--others` entries git reported as directories instead of descending.
+
+    `git ls-files --others` walks an ordinary untracked directory and lists the
+    FILES in it. At a directory holding its own `.git` it stops, and emits the
+    DIRECTORY, with a trailing slash. So a trailing slash in that output is
+    git's own statement that it did not look inside.
+
+    Keyed on the slash rather than on an `is_dir()` probe because the slash is
+    the producer's record of what it did, where a filesystem call re-derives a
+    guess about it — and the two can disagree while a build runs.
+
+    Measured, git 2.50.1, all under one covered pathspec: a nested repo with
+    commits and one freshly `git init`ed both carry the slash; an ordinary
+    untracked directory of sources, a directory whose files are all ignored, an
+    empty directory, and an ignored nested repo produce no directory entry at
+    all. The benign shapes are the ones that matter here — this refusal is
+    fail-closed, so a predicate that flagged any new module directory would
+    stop every extraction in the repository.
+    """
+    return sorted(entry for entry in entries if entry.endswith("/"))
+
+
+def refuse_nested_repos(entries: list[str]) -> None:
+    """Refuse when a nested repository sits under a fingerprinted pathspec.
+
+    Not a conservative over-hash like the untracked leg above it: this is the
+    one shape where the fingerprint is WRONG rather than merely wide. The
+    directory entry enters the input list, `source_fingerprint` finds it is not
+    a file, and it hashes through the `<deleted>` branch — one constant token.
+    Measured on a synthetic tree: editing a file inside the nested repo, adding
+    a new `.rs` to it, and deleting the entire subtree all leave the digest
+    byte-identical. The stamp then claims to cover a path whose contents cannot
+    move it, and that digest is also the CI cache key.
+
+    Refusing rather than recursing is the direction the untracked leg's own
+    argument points: it prefers a cost that is always a re-extraction over an
+    answer that is sometimes wrong. Recursing would mean deciding what a nested
+    repository's commit means for a source hash, which is a larger question
+    than this guard needs to answer.
+    """
+    nested = nested_repo_entries(entries)
+    if not nested:
+        return
+    lines = [
+        "extract-llbc.py: a nested git repository sits under a fingerprinted"
+        " pathspec:",
+        *(f"    {entry}" for entry in nested),
+        "",
+        "`git ls-files --others` does not descend into one, so every file"
+        " inside is",
+        "absent from `source=` while the directory itself hashes to a single"
+        " constant",
+        "token — the digest does not move when those contents change, grow, or"
+        " are",
+        "deleted outright. The stamp would claim a coverage it does not have.",
+        "",
+        "Move it outside the fingerprinted pathspecs, or add it to"
+        " `.gitignore`",
+        "(an ignored nested repo is excluded here and is not compiled either).",
+        "Registering it as a SUBMODULE does not fix this: a gitlink arrives on"
+        " the",
+        "tracked leg, carries no trailing slash, and hashes through the same"
+        " branch.",
+    ]
+    raise SystemExit("\n".join(lines))
+
+
 def _collect_inputs(
     eng: Engine, crates: list[str], cargo_features: str
 ) -> tuple[list[str], list[Path]]:
@@ -742,37 +811,28 @@ def _collect_inputs(
                         if "custom-build" not in kinds:
                             external.append(src_path.parent)
 
-    # git is the enumerator, but the index is not the input set: Charon and
-    # rustc read the working tree, so a source file that is on disk and not yet
-    # added belongs in the digest. `--cached` alone leaves it out, and a crate
-    # extracted while one of its files was untracked then fingerprints as fresh
-    # against sources the artefact was never built from — staging that same
-    # file later flips the identical bytes to STALE.
+    def ls_files_raw(*extra_flags: str) -> list[str]:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", *extra_flags, "--", *pathspecs],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        return [raw.decode("utf-8") for raw in result.stdout.split(b"\0") if raw]
+
+    def ls_files(*extra_flags: str) -> set[Path]:
+        # `Path()` normalises the trailing slash away, so a caller that needs to
+        # tell a directory entry from a file entry must read `ls_files_raw`.
+        # That erasure is why the nested-repo blindness was invisible here.
+        return {Path(entry) for entry in ls_files_raw(*extra_flags)}
+
+    # Charon reads the working tree, so include untracked, non-ignored files.
+    # Keep the raw spelling until nested repositories have been rejected:
+    # converting a directory entry to `Path` erases its trailing slash.
     #
-    # `--exclude-standard` is what keeps the generated trees out. Everything it
-    # drops under these pathspecs today is produced by a build —
-    # `majit/charon-corpus/{target/,Cargo.lock}` and `pyre/check.snap/` — and
-    # nothing a crate compiles.
-    result = subprocess.run(
-        [
-            "git",
-            "ls-files",
-            "-z",
-            "--cached",
-            "--others",
-            "--exclude-standard",
-            "--",
-            *pathspecs,
-        ],
-        cwd=root,
-        check=True,
-        stdout=subprocess.PIPE,
-    )
-    files = {
-        Path(raw.decode("utf-8"))
-        for raw in result.stdout.split(b"\0")
-        if raw
-    }
+    others = ls_files_raw("--others", "--exclude-standard")
+    refuse_nested_repos(others)
+    files = ls_files() | {Path(entry) for entry in others}
     files |= include_closure(root, files)
     return sorted(files, key=lambda path: path.as_posix()), external
 
@@ -987,6 +1047,19 @@ def source_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> s
         full_path = eng.root / path
         if full_path.is_file():
             digest.update(full_path.read_bytes())
+        elif full_path.exists():
+            # A directory in the input list is never a source file. Hashing it
+            # below would fold it to one constant token that no edit inside it
+            # can move — the nested-repo defect, and equally a registered
+            # submodule, which `refuse_nested_repos` cannot see because a
+            # gitlink arrives tracked and unslashed.
+            raise SystemExit(
+                "extract-llbc.py: a fingerprint input is a DIRECTORY, not a"
+                f" file:\n    {path.as_posix()}\n"
+                "Hashing it would record one constant token for the whole"
+                " subtree.\nIf it is a submodule or a nested repository, move"
+                " it out of the\nfingerprinted pathspecs or ignore it."
+            )
         else:
             # The `--cached` half of the enumeration includes tracked paths
             # deleted in the working tree. A deletion is part of the source
@@ -2388,6 +2461,103 @@ def self_test_provenance_rendering() -> None:
         raise SystemExit(1)
 
 
+def self_test_nested_repo_detection() -> None:
+    """Drive the nested-repo refusal on a synthetic tree, BOTH arms.
+
+    `self_test` below draws its probe from `fingerprint_inputs`, i.e. from a
+    directory the fingerprint already covers, so it can never place one where
+    coverage fails — it would keep passing whatever this guard did. Hence a
+    separate case with its own tree.
+
+    Runs real `git` against a real nested repository rather than handing
+    `nested_repo_entries` a list of strings: the load-bearing fact is what git
+    DOES with a nested repo, and a list written here would only ever agree with
+    what its author believed. If a future git stops emitting the trailing
+    slash, this fails; a string fixture would not.
+
+    The BENIGN arm carries as much weight as the hazard one. This refusal is
+    fail-closed, so a predicate that flagged every untracked directory would
+    satisfy a detection-only test and then stop every extraction that follows a
+    new module directory.
+
+    Everything happens inside a temporary directory. `self_test` writes its
+    probe into the shared worktree, a brief real mutation; doing that with a
+    nested repo would be a worse one, because a peer extracting in that instant
+    would take this very refusal instead of merely seeing a moved hash.
+    """
+    def ls_others(root: Path) -> list[str]:
+        result = subprocess.run(
+            ["git", "ls-files", "-z", "--others", "--exclude-standard", "--", "covered"],
+            cwd=root,
+            check=True,
+            stdout=subprocess.PIPE,
+        )
+        return [raw.decode("utf-8") for raw in result.stdout.split(b"\0") if raw]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+
+        def git(*args: str, cwd: Path | None = None) -> None:
+            subprocess.run(
+                ["git", *args],
+                cwd=cwd or root,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+
+        git("init", "-q", ".")
+        git("config", "user.email", "self-test@example.invalid")
+        git("config", "user.name", "llbc self-test")
+        (root / "covered").mkdir()
+        (root / "covered" / "tracked.rs").write_text("// tracked\n")
+        git("add", "-A")
+        git("commit", "-q", "-m", "base")
+
+        # Benign: an ordinary untracked directory holding a new module. This is
+        # also the liveness control — the leg must LIST it, so a git that
+        # returned nothing at all cannot pass this test by being empty.
+        (root / "covered" / "plain").mkdir()
+        (root / "covered" / "plain" / "new_module.rs").write_text("// new\n")
+        benign_entries = ls_others(root)
+        benign_flagged = nested_repo_entries(benign_entries)
+
+        # Hazard: a nested repository under the same covered path.
+        nested = root / "covered" / "nested"
+        nested.mkdir()
+        git("init", "-q", ".", cwd=nested)
+        (nested / "inside.rs").write_text("// invisible to the outer repo\n")
+        hazard_entries = ls_others(root)
+        hazard_flagged = nested_repo_entries(hazard_entries)
+
+    print("    benign tree    " + " ".join(benign_entries))
+    print(f"      flagged      {benign_flagged}")
+    print("    + nested repo  " + " ".join(hazard_entries))
+    print(f"      flagged      {hazard_flagged}")
+
+    failures = []
+    if "covered/plain/new_module.rs" not in benign_entries:
+        failures.append(
+            "the untracked leg did not list a new module — the test measured nothing"
+        )
+    if benign_flagged:
+        failures.append(
+            f"an ordinary untracked directory was flagged {benign_flagged} —"
+            " this refusal would stop every extraction after a new module dir"
+        )
+    if hazard_flagged != ["covered/nested/"]:
+        failures.append(
+            f"a nested repository was not flagged: got {hazard_flagged} —"
+            " the fingerprint would hash its whole subtree as one constant"
+        )
+    if failures:
+        sys.stdout.flush()  # as in check(): the verdict must not outrun its evidence
+        for line in failures:
+            print(f"self-test FAILED: {line}", file=sys.stderr)
+        raise SystemExit(1)
+    print("\nself-test passed: nested-repo refusal (hazard flagged, benign not)")
+
+
 def self_test(eng: Engine, crates: list[str], cargo_features: str) -> None:
     """A/B/A the fingerprint against a new untracked `.rs` under a covered path.
 
@@ -2548,6 +2718,9 @@ def run_cli(
         # run and exercises neither of its conditional lines, because no sidecar
         # this tree has written is anything but steady and untruncated.
         self_test_provenance_rendering()
+        # Same reason again: this one builds its own repository in a
+        # temporary directory and never touches the worktree.
+        self_test_nested_repo_detection()
         self_test(eng, crates, cargo_features)
         return
     if args.check:

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -610,28 +610,62 @@ def refuse_nested_repos(entries: list[str]) -> None:
     nested = nested_repo_entries(entries)
     if not nested:
         return
+    # Each parenthesised pair is ONE message line: without the parentheses a
+    # dropped comma reads exactly like the wrapping, and would silently join two
+    # lines of the refusal into one.
     lines = [
-        "extract-llbc.py: a nested git repository sits under a fingerprinted"
-        " pathspec:",
+        (
+            "extract-llbc.py: a nested git repository sits under a fingerprinted"
+            " pathspec:"
+        ),
         *(f"    {entry}" for entry in nested),
         "",
-        "`git ls-files --others` does not descend into one, so every file"
-        " inside is",
-        "absent from `source=` while the directory itself hashes to a single"
-        " constant",
-        "token — the digest does not move when those contents change, grow, or"
-        " are",
+        (
+            "`git ls-files --others` does not descend into one, so every file"
+            " inside is"
+        ),
+        (
+            "absent from `source=` while the directory itself hashes to a single"
+            " constant"
+        ),
+        (
+            "token — the digest does not move when those contents change, grow, or"
+            " are"
+        ),
         "deleted outright. The stamp would claim a coverage it does not have.",
         "",
-        "Move it outside the fingerprinted pathspecs, or add it to"
-        " `.gitignore`",
+        (
+            "Move it outside the fingerprinted pathspecs, or add it to"
+            " `.gitignore`"
+        ),
         "(an ignored nested repo is excluded here and is not compiled either).",
-        "Registering it as a SUBMODULE does not fix this: a gitlink arrives on"
-        " the",
-        "tracked leg, carries no trailing slash, and hashes through the same"
-        " branch.",
+        (
+            "Registering it as a SUBMODULE does not fix this: a gitlink arrives on"
+            " the"
+        ),
+        (
+            "tracked leg, carries no trailing slash, and hashes through the same"
+            " branch."
+        ),
     ]
     raise SystemExit("\n".join(lines))
+
+
+_inputs_cache: dict[tuple, tuple[list[str], list[Path]]] = {}
+
+
+def forget_collected_inputs() -> None:
+    """Drop the memoised input sets, because the tree they describe has moved.
+
+    The memo below answers "what does this crate compile" for a tree as it was
+    when the walk ran, so anything in this process that CHANGES the tree has to
+    call this before the next walk reads it. Two do, and each would otherwise
+    get a stale answer at exactly the moment it needs a fresh one: `extract`,
+    whose whole post-build re-hash exists to catch a tree that moved while
+    Charon ran, and `self_test`, whose probe file exists precisely to move the
+    input set.
+    """
+    _inputs_cache.clear()
 
 
 def _collect_inputs(
@@ -664,7 +698,30 @@ def _collect_inputs(
     below, which admitted neither `proc-macro` nor `cdylib` until it was
     inverted into a deny-list. Both are fixed; do not read that as the class
     being closed, since each was found only after the previous one was.
+
+    Memoised, because none of this is cheap: two `git ls-files` subprocesses per
+    call plus `include_closure`, which reads the text of every `.rs` input. One
+    `extract` of one crate reaches here five times — twice through `stamp_for`,
+    then the provenance closure, `window_writes` and the post-build digest — and
+    `--fingerprint` twice, under a caller-imposed budget (120s in
+    `pyre-jit-trace/build.rs`) past which freshness degrades to UNKNOWN for
+    every crate. The key spells out the engine fields this walk reads, except
+    the SPEC TABLE, which the crate names stand for: `run_cli` builds one
+    Engine from a driver's specs and nothing edits them afterwards.
+    `forget_collected_inputs` is how a caller that moved the tree says so.
     """
+    key = (
+        str(eng.root),
+        eng.metadata_feature_crates,
+        tuple(eng.base_pathspecs),
+        eng.external_inputs,
+        eng.layout_targets,
+        tuple(crates),
+        cargo_features,
+    )
+    if key in _inputs_cache:
+        return _inputs_cache[key]
+
     root = eng.root
     target_names: list[str] = []
     pathspecs = list(eng.base_pathspecs)
@@ -792,7 +849,9 @@ def _collect_inputs(
     refuse_nested_repos(others)
     files = ls_files() | {Path(entry) for entry in others}
     files |= include_closure(root, files)
-    return sorted(files, key=lambda path: path.as_posix()), external
+    result = (sorted(files, key=lambda path: path.as_posix()), external)
+    _inputs_cache[key] = result
+    return result
 
 
 def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> list[Path]:
@@ -1142,6 +1201,8 @@ STAMP_KEYS = (
     "crate",
     "platform",
     "charon",
+    "fingerprint_schema",
+    "extraction_abi",
     "features",
     "flags",
     "charon_flags",
@@ -1852,6 +1913,15 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
             write_layout_sidecar(full, sidecar)
             full.unlink()
             print(f"    wrote {sidecar} ({sidecar.stat().st_size} bytes)")
+        # Every walk from here on reports on the tree AFTER the builds above,
+        # so the memoised pre-build input sets are dropped first. The three
+        # readers below — the provenance closure, `window_writes` and the
+        # post-build digest — exist to see a tree that moved while Charon ran,
+        # and an input set carried over from before it would hide exactly the
+        # movement they are looking for. They still share one walk with each
+        # other, which is the intent.
+        forget_collected_inputs()
+
         # Closing half of the provenance pair, and the sidecar write.
         #
         # This precedes the two guards below, both of which can end the run,
@@ -2531,10 +2601,16 @@ def self_test(eng: Engine, crates: list[str], cargo_features: str) -> None:
     before = source_fingerprint(eng, crates, cargo_features)
     try:
         probe.write_text("// transient probe written by --self-test; safe to delete\n")
+        # Both legs of this test are a deliberate change to the input SET, which
+        # is the one thing `_collect_inputs` memoises. Reading a carried-over set
+        # here would report the guard blind and the removal residual — a failure
+        # printed by the cache rather than by the code under test.
+        forget_collected_inputs()
         moved = source_fingerprint(eng, crates, cargo_features)
         listed = probe.relative_to(eng.root) in set(fingerprint_inputs(eng, crates, cargo_features))
     finally:
         probe.unlink(missing_ok=True)
+        forget_collected_inputs()
     after = source_fingerprint(eng, crates, cargo_features)
     print(f"    probe          {probe.relative_to(eng.root).as_posix()}")
     print(f"    before         {before}")
@@ -2573,15 +2649,21 @@ def run_cli(
         description="Extract Charon ULLBC artefacts with source-fingerprint skip logic."
     )
     parser.add_argument("crates", nargs="*", help=f"known: {all_crates}")
-    parser.add_argument("--fingerprint", action="store_true")
-    parser.add_argument("--list-inputs", action="store_true")
-    parser.add_argument(
+    # The dispatch below takes the FIRST of these that is set and returns, so
+    # accepting two would perform one and drop the other with no output saying
+    # so — `--check --self-test` would run the self-test and report success for
+    # a freshness check that never ran. That is the shape this file refuses
+    # everywhere else, and argparse can refuse it here.
+    modes = parser.add_mutually_exclusive_group()
+    modes.add_argument("--fingerprint", action="store_true")
+    modes.add_argument("--list-inputs", action="store_true")
+    modes.add_argument(
         "--check",
         action="store_true",
         help="compare the existing artefacts against the tree and exit nonzero "
         "if any is stale; never extracts",
     )
-    parser.add_argument(
+    modes.add_argument(
         "--self-test",
         action="store_true",
         help="prove the source fingerprint still sees a new untracked .rs; "

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -10,6 +10,7 @@ declared by the driver, so the engine stays neutral about which consumer
 from __future__ import annotations
 
 import argparse
+import datetime
 import hashlib
 import json
 import os
@@ -660,6 +661,44 @@ def stamp_for(
     )
 
 
+# Every field `stamp_for` writes, in order. A stamp that does not carry all of
+# them was not written by this engine — or was truncated mid-write — and the
+# comparison in `check` would then quietly skip whatever is absent.
+STAMP_KEYS = (
+    "crate",
+    "platform",
+    "charon",
+    "features",
+    "flags",
+    "charon_flags",
+    "layout_targets",
+    "layout_flags",
+    "layout_rustflags",
+    "source",
+)
+
+
+def parse_stamp(text: str) -> dict[str, str]:
+    """Split a stamp into its `key=value` fields.
+
+    Only used to replay `features=` and to render a readable per-field diff;
+    the verdict in `check` is an exact text comparison, so a line this drops
+    (blank, or without a `=`) still fails the check.
+    """
+    fields: dict[str, str] = {}
+    for line in text.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            fields[key] = value
+    return fields
+
+
+def file_mtime(path: Path) -> str:
+    return datetime.datetime.fromtimestamp(path.stat().st_mtime).isoformat(
+        timespec="seconds"
+    )
+
+
 def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
     """Cross targets this crate emits a layout sidecar for.
 
@@ -941,6 +980,181 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
     print(f"all extractions complete. artefacts under: {dest_dir}")
 
 
+def check(eng: Engine, args: argparse.Namespace) -> None:
+    """Refuse an artefact whose stamp does not match the tree it sits beside.
+
+    `extract` already computes this comparison — it is the `skipping <crate>
+    (fingerprint unchanged)` test — but only a caller who runs the extractor
+    ever benefits from it. A consumer that opens `<out_dir>/<crate>.ullbc` as
+    found gets whatever was last written there, and a stale artefact does not
+    fail: it answers, in detail, about sources that no longer exist. So this is
+    the same comparison, run by the consumer, reported through the exit status.
+    Nonzero means DO NOT READ the artefact.
+
+    Every way of reaching the end WITHOUT having compared the stamp against a
+    freshly computed one is a refusal, not a pass: an absent stamp, an empty
+    stamp, a stamp missing fields. Treating "nothing to compare" as "nothing
+    wrong" is what makes a gate decorative — a harness reads the exit status,
+    not the output.
+
+    Two things are deliberately not gated:
+
+      * `features=` is replayed out of the stamp rather than compared. The
+        stamp records the configuration the artefact was built under, and the
+        question here is whether the artefact is current FOR that
+        configuration; comparing it against this process's `CARGO_FEATURES`
+        would refuse a byte-correct artefact whenever the caller left the
+        default in place. Replaying keeps `flags=`, `charon_flags=`,
+        `layout_flags=` and `source=` real comparisons — all four are
+        recomputed from the replayed value.
+      * artefact and stamp mtimes are printed, never gated. `extract` writes
+        both in one pass, and the source digest already answers the question a
+        timestamp only approximates.
+
+    Nothing here re-extracts. Re-extraction is a whole-crate Charon build —
+    multi-GB RSS — that writes into the working tree, so it stays a human's
+    scheduling decision and the refusal names the command instead. `LLBC_DEST`
+    points the check at a directory other than the driver's default, which is
+    what a caller who must not disturb the live artefacts uses.
+    """
+    platform_key, charon_dest, _ = charon_paths(eng.charon_root)
+    charon_stamp = charon_version(charon_dest)
+    dest_dir = llbc_dest(eng.out_dir, eng.root)
+    crates = args.crates or eng.default_crates
+
+    stale: list[str] = []
+    # Feature set to re-extract each crate under: the one its stamp records, so
+    # a mixed set does not collapse into one wrong remedy command. A crate whose
+    # stamp never got read keeps this process's feature set.
+    stamped_features: dict[str, str] = {crate: eng.cargo_features for crate in crates}
+
+    for crate in crates:
+        spec = eng.spec(crate)
+        dest = dest_dir / spec.output_name
+        stamp_path = dest.with_suffix(dest.suffix + ".fingerprint")
+        print(f"=== checking {crate} -> {dest} ===")
+
+        if not dest.exists():
+            stale.append(f"{crate}: no artefact at {dest}")
+            continue
+        if dest.stat().st_size == 0:
+            stale.append(
+                f"{crate}: artefact {dest} is 0 bytes — Charon aborted before "
+                f"writing it"
+            )
+            continue
+        print(f"    artefact {dest.stat().st_size} bytes, mtime {file_mtime(dest)}")
+
+        for target in crate_layout_targets(eng, spec):
+            sidecar = dest_dir / spec.layout_sidecar_name(target)
+            if not sidecar.exists() or sidecar.stat().st_size == 0:
+                stale.append(
+                    f"{crate}: {target} layout sidecar {sidecar} is missing or "
+                    f"empty — field offsets for that target would be read out "
+                    f"of the extraction host's layouts"
+                )
+
+        if not stamp_path.exists():
+            stale.append(
+                f"{crate}: no fingerprint stamp at {stamp_path} — the artefact "
+                f"records nothing about the sources it came from, so there is "
+                f"nothing to compare it against"
+            )
+            continue
+        stamp_bytes = stamp_path.read_bytes()
+        if not stamp_bytes:
+            stale.append(
+                f"{crate}: fingerprint stamp {stamp_path} is 0 bytes — it "
+                f"records no source digest, so it cannot match the tree"
+            )
+            continue
+        text = stamp_bytes.decode("utf-8", errors="replace")
+        if not text.strip():
+            stale.append(
+                f"{crate}: fingerprint stamp {stamp_path} holds only whitespace"
+            )
+            continue
+        print(f"    stamp {len(stamp_bytes)} bytes, mtime {file_mtime(stamp_path)}")
+
+        recorded = parse_stamp(text)
+        missing = [key for key in STAMP_KEYS if key not in recorded]
+        if missing:
+            stale.append(
+                f"{crate}: fingerprint stamp {stamp_path} has no "
+                f"{', '.join(missing)} field — it was not written by this "
+                f"engine, or was truncated"
+            )
+            continue
+
+        features = recorded["features"]
+        stamped_features[crate] = features
+        flags = crate_flags(spec, features)
+        expected = stamp_for(
+            eng,
+            crate=crate,
+            platform_key=platform_key,
+            charon_stamp=charon_stamp,
+            cargo_features=features,
+            flags=flags,
+            charon_flags=charon_crate_flags(spec, features),
+            layout_targets=crate_layout_targets(eng, spec),
+            layout_flags=crate_layout_flags(spec, features, flags),
+        )
+        if text == expected + "\n":
+            print(f"    fingerprint matches the tree (source={recorded['source']})")
+            continue
+
+        want = parse_stamp(expected)
+        differing = [key for key in STAMP_KEYS if recorded[key] != want.get(key)]
+        if not differing:
+            # The text differs while every modelled field agrees, so the stamp
+            # carries content this engine does not write. Reporting nothing
+            # here would turn a mismatch into a silent pass.
+            stale.append(
+                f"{crate}: fingerprint stamp {stamp_path} does not match "
+                f"byte-for-byte although every field agrees — it carries "
+                f"content this engine did not write"
+            )
+            continue
+        for key in differing:
+            stale.append(
+                f"{crate}: {key}: artefact says {recorded[key]!r}, "
+                f"tree says {want.get(key)!r}"
+            )
+
+    if not stale:
+        print()
+        print(f"llbc artefacts current: {' '.join(crates)}")
+        return
+
+    driver = sys.argv[0] or "scripts/extract-llbc.py"
+    # The per-crate lines above went to stdout, which is block-buffered when
+    # this runs under a harness; flush so the verdict does not land before the
+    # evidence it was drawn from.
+    sys.stdout.flush()
+    print(file=sys.stderr)
+    print("=" * 72, file=sys.stderr)
+    print("LLBC STALE — do not read these artefacts", file=sys.stderr)
+    for line in stale:
+        print(f"  {line}", file=sys.stderr)
+    print(
+        "\n"
+        "  Re-extract before reading. This is a whole-crate Charon build —\n"
+        "  multi-GB RSS, and it writes into the working tree — so nothing\n"
+        "  here runs it for you. Schedule it:",
+        file=sys.stderr,
+    )
+    for features in dict.fromkeys(stamped_features.values()):
+        group = [c for c in crates if stamped_features[c] == features]
+        print(
+            f"      CARGO_FEATURES={features} python3 {driver} --force "
+            f"{' '.join(group)}",
+            file=sys.stderr,
+        )
+    print("=" * 72, file=sys.stderr)
+    raise SystemExit(1)
+
+
 def run_cli(
     specs: dict[str, CrateSpec],
     default_crates: list[str],
@@ -962,6 +1176,12 @@ def run_cli(
     parser.add_argument("crates", nargs="*", help=f"known: {all_crates}")
     parser.add_argument("--fingerprint", action="store_true")
     parser.add_argument("--list-inputs", action="store_true")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare the existing artefacts against the tree and exit nonzero "
+        "if any is stale; never extracts",
+    )
     parser.add_argument(
         "--force",
         action="store_true",
@@ -1002,5 +1222,8 @@ def run_cli(
         return
     if args.fingerprint:
         print(source_fingerprint(eng, crates, cargo_features))
+        return
+    if args.check:
+        check(eng, args)
         return
     extract(eng, args)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -89,6 +89,12 @@ class Engine:
     metadata_feature_crates: tuple[str, ...] = ()
     layout_targets: tuple[str, ...] = ()
     layout_target_rustflags: str = ""
+    # Files/directories outside `root` that a driver declares by hand, for
+    # inputs the dependency walk cannot find: the engine module itself, and
+    # any build-determining file `git ls-files` refuses to list (an ignored
+    # `.cargo/config.toml`, a lockfile a repo does not commit). Patched path
+    # deps need no declaration — `_collect_inputs` discovers those.
+    external_inputs: tuple[Path, ...] = ()
 
     def spec(self, crate: str) -> CrateSpec:
         try:
@@ -371,10 +377,34 @@ def _reject_unresolvable_include(where: str, tail: str) -> None:
     )
 
 
-def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> list[Path]:
+def _collect_inputs(
+    eng: Engine, crates: list[str], cargo_features: str
+) -> tuple[list[str], list[Path]]:
+    """Split the fingerprint's inputs by which channel can carry them.
+
+    Returns `(pathspecs, external)`:
+
+    * `pathspecs` — repo-relative, resolved through `git ls-files` below, so
+      the working tree (including untracked-not-ignored files) is what gets
+      hashed.
+    * `external` — absolute paths OUTSIDE `eng.root`, which `git ls-files`
+      cannot name at all: it refuses a pathspec that leaves the repository.
+      These are hashed by content instead, by `external_fingerprint`.
+
+    The second list used to be dropped on the floor. The dependency walk below
+    admits path deps by `source is None`, which is how cargo spells BOTH an
+    in-tree workspace member and a `[patch]` redirect into a sibling checkout —
+    so a patched dependency was discovered, found to be out-of-root, and
+    discarded with no diagnostic. cel-jit patches `majit-{ir,macros,metainterp}`
+    to `../majit/*`, which pulls the rest of that workspace by path: 10 of the
+    11 closure members landed here, `majit-macros` among them. That one is a
+    proc macro, so its expansion IS the extracted crate's bodies, and editing it
+    changed the artefact's content without moving its fingerprint.
+    """
     root = eng.root
     target_names: list[str] = []
     pathspecs = list(eng.base_pathspecs)
+    external: list[Path] = [Path(p).resolve() for p in eng.external_inputs]
 
     for crate in crates:
         spec = eng.spec(crate)
@@ -461,6 +491,8 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
                 if package_dir.is_relative_to(root):
                     rel_dir = package_dir.relative_to(root).as_posix()
                     pathspecs.append(f"{rel_dir}/Cargo.toml")
+                else:
+                    external.append(package_dir / "Cargo.toml")
                 for target in package["targets"]:
                     kinds = set(target["kind"])
                     if not ({"lib", "bin", "custom-build"} & kinds):
@@ -471,6 +503,16 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
                         pathspecs.append(rel_src)
                         if "custom-build" not in kinds:
                             pathspecs.append(str(Path(rel_src).parent) + "/")
+                    else:
+                        # Same shape as the in-root arm, one channel over: the
+                        # entry point always, its directory only for a real
+                        # target. A `custom-build`'s src_path is the crate's
+                        # own `build.rs`, so its parent is the CRATE ROOT —
+                        # walking that would pull in `target/` and every
+                        # sibling target's sources.
+                        external.append(src_path)
+                        if "custom-build" not in kinds:
+                            external.append(src_path.parent)
 
     # git is the enumerator, but the index is not the input set: Charon and
     # rustc read the working tree, so a source file that is on disk and not yet
@@ -504,7 +546,77 @@ def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> l
         if raw
     }
     files |= include_closure(root, files)
-    return sorted(files, key=lambda path: path.as_posix())
+    return sorted(files, key=lambda path: path.as_posix()), external
+
+
+def fingerprint_inputs(eng: Engine, crates: list[str], cargo_features: str) -> list[Path]:
+    """Repo-relative inputs hashed into `source=`."""
+    return _collect_inputs(eng, crates, cargo_features)[0]
+
+
+def external_input_entries(
+    eng: Engine, crates: list[str], cargo_features: str
+) -> list[tuple[str, Path]]:
+    """Out-of-root inputs hashed into `external=`, as `(label, absolute path)`.
+
+    Deliberately NOT named `external_inputs`: that is the driver-facing keyword
+    of `run_cli`, and a parameter of that name shadows the module-level
+    function for the whole body.
+
+    The label — not the absolute path — is what enters the digest, so two
+    checkouts of the same layout in different directories agree. Directories
+    are expanded here rather than at collection time so the walk sees the
+    working tree at hashing time, matching `source=`'s
+    save-not-commit behaviour for the in-root half.
+    """
+    _, roots = _collect_inputs(eng, crates, cargo_features)
+
+    def label_for(path: Path) -> str:
+        # Relative to the artefact root, so the stamp survives relocating the
+        # whole cohabitation (`<super>/{pyre,cel-jit,majit}`) as a unit. It
+        # does not survive rearranging the repos RELATIVE to each other, which
+        # is the correct sensitivity: that changes which sources are compiled.
+        return Path(os.path.relpath(path, eng.root)).as_posix()
+
+    found: dict[str, Path] = {}
+    for entry in roots:
+        if entry.is_file():
+            found[label_for(entry)] = entry
+            continue
+        if not entry.is_dir():
+            # A declared input that does not exist still has to move the
+            # digest, exactly as a deleted tracked file does in `source=`.
+            found.setdefault(label_for(entry), entry)
+            continue
+        for sub in entry.rglob("*"):
+            # `target/` is build output and dot-dirs are VCS/tooling state;
+            # neither is a compiler input, and `target/` alone is tens of GB.
+            parts = set(sub.relative_to(entry).parts[:-1])
+            if "target" in parts or any(p.startswith(".") for p in parts):
+                continue
+            if sub.is_file():
+                found[label_for(sub)] = sub
+    return sorted(found.items())
+
+
+def external_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
+    """Digest of the out-of-root inputs, or `""` when there are none.
+
+    Empty is the common case (a consumer whose whole dependency closure lives
+    inside its own repo, which is every pyre crate today) and it is spelled as
+    an empty value rather than a digest-of-nothing so the stamp says plainly
+    that nothing outside the repo was folded in.
+    """
+    entries = external_input_entries(eng, crates, cargo_features)
+    if not entries:
+        return ""
+    digest = hashlib.sha256()
+    for label, path in entries:
+        digest.update(label.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes() if path.is_file() else b"<absent>")
+        digest.update(b"\0")
+    return digest.hexdigest()
 
 
 def source_fingerprint(eng: Engine, crates: list[str], cargo_features: str) -> str:
@@ -657,6 +769,13 @@ def stamp_for(
             f"layout_flags={' '.join(layout_flags)}",
             f"layout_rustflags={eng.layout_target_rustflags}",
             f"source={source_fingerprint(eng, [crate], cargo_features)}",
+            # Inputs `source=` structurally cannot cover: everything outside
+            # this repo. Kept as its own field rather than folded into
+            # `source=` so `check`'s per-field diff can say WHICH side moved —
+            # "your own sources changed" and "a patched dependency in another
+            # checkout changed" call for different actions, and collapsing
+            # them would repeat the mistake this field exists to fix.
+            f"external={external_fingerprint(eng, [crate], cargo_features)}",
         ]
     )
 
@@ -675,6 +794,7 @@ STAMP_KEYS = (
     "layout_flags",
     "layout_rustflags",
     "source",
+    "external",
 )
 
 
@@ -1240,6 +1360,7 @@ def run_cli(
     metadata_feature_crates: tuple[str, ...] = (),
     layout_targets: tuple[str, ...] = (),
     layout_target_rustflags: str = "",
+    external_inputs: tuple[Path, ...] = (),
 ) -> None:
     """Argparse UX shared by every driver (positional crates, --force, …)."""
     all_crates = " ".join(specs)
@@ -1292,15 +1413,25 @@ def run_cli(
         metadata_feature_crates=metadata_feature_crates,
         layout_targets=layout_targets,
         layout_target_rustflags=layout_target_rustflags,
+        external_inputs=tuple(external_inputs),
     )
 
     crates = args.crates or default_crates
     if args.list_inputs:
         for path in fingerprint_inputs(eng, crates, cargo_features):
             print(path.as_posix())
+        # Marked, because the two channels are hashed into different stamp
+        # fields and an unmarked union would read as one list of repo-relative
+        # paths — which is what made the out-of-root inputs easy to miss.
+        for label, _ in external_input_entries(eng, crates, cargo_features):
+            print(f"external:{label}")
         return
     if args.fingerprint:
-        print(source_fingerprint(eng, crates, cargo_features))
+        # BOTH fields. Printing only `source=` here previously cost a session:
+        # three legs returned identical hashes that were consistent with every
+        # hypothesis, because the field under test was not in the output.
+        print(f"source={source_fingerprint(eng, crates, cargo_features)}")
+        print(f"external={external_fingerprint(eng, crates, cargo_features)}")
         return
     if args.self_test:
         self_test(eng, crates, cargo_features)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1179,6 +1179,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
 
     dest_dir = llbc_dest(eng.out_dir, eng.root)
     charon_stamp = charon_version(charon_dest)
+    unstamped: list[str] = []
     env = os.environ.copy()
     prepend_msvc_link(env)
 
@@ -1346,10 +1347,34 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                     f" — its source now affects this artefact, so the artefact"
                     f" must re-extract when it changes."
                 )
+        # `stamp` was computed at the top of this iteration, BEFORE the charon
+        # build that has just run for minutes. If the tree moved in between it
+        # names a source hash this artefact was not built from, and the wrong
+        # direction is a RETURN to the stamped state — a reverted edit, a branch
+        # switched back — where `check` then reports FRESH over an artefact
+        # built from other sources. Re-stamping with the post-build value would
+        # be equally untrue: the artefact straddles both trees and belongs to
+        # neither, and a stamp that looks authoritative is worse than none.
+        if source_fingerprint(eng, [crate], cargo_features) != parse_stamp(stamp)["source"]:
+            stamp_path.unlink(missing_ok=True)
+            unstamped.append(crate)
+            print(
+                f"    REFUSING to stamp {dest.name}: the tree moved during its"
+                f" build, so no source hash describes this artefact. Left"
+                f" unstamped — reported as freshness UNKNOWN, not as fresh."
+            )
+            continue
         stamp_path.write_text(stamp + "\n")
         print(f"    wrote {dest} ({dest.stat().st_size} bytes)")
 
     print()
+    if unstamped:
+        raise SystemExit(
+            "extract-llbc.py: the tree moved while extracting "
+            + ", ".join(unstamped)
+            + ".\n  Those artefacts are written but deliberately unstamped."
+            "\n  Re-run with --force once the tree is quiet."
+        )
     print(f"all extractions complete. artefacts under: {dest_dir}")
 
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1177,6 +1177,57 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     raise SystemExit(1)
 
 
+def self_test(eng: Engine, crates: list[str], cargo_features: str) -> None:
+    """A/B/A the fingerprint against a new untracked `.rs` under a covered path.
+
+    The blind spot being guarded is silent by construction: `git ls-files` lists
+    tracked paths only, so before `fingerprint_inputs` folded in `--others
+    --exclude-standard`, adding a brand-new module left the hash unmoved and
+    `--check` blessed an artefact built from different source. A wrong answer
+    there prints nothing, so the guard needs a demonstration rather than a
+    reading of the patch. Both legs are required: that the hash *moves* for the
+    new file, and that removing the probe *restores* it, so a change which
+    invalidated every stamp cannot pass by refusing everything.
+
+    The probe exists for one `source_fingerprint` call and is removed in a
+    `finally`. On a shared worktree that is a real if brief mutation — anyone
+    fingerprinting the same crate in that instant sees the moved hash.
+    """
+    inputs = fingerprint_inputs(eng, crates, cargo_features)
+    # Deepest `.rs`: exact-file pathspecs (Cargo.toml, target roots, build.rs)
+    # sit shallow, so a deeply nested file was listed by a `dir/` pathspec and
+    # its directory is therefore covered for new files too.
+    covered = max((p for p in inputs if p.suffix == ".rs"), key=lambda p: (len(p.parts), p.as_posix()), default=None)
+    if covered is None:
+        raise SystemExit(f"self-test: no .rs input for {' '.join(crates)}")
+    probe = eng.root / covered.parent / "__llbc_self_test_probe.rs"
+    if probe.exists():
+        raise SystemExit(f"self-test: {probe} already exists; refusing to clobber it")
+    before = source_fingerprint(eng, crates, cargo_features)
+    try:
+        probe.write_text("// transient probe written by --self-test; safe to delete\n")
+        moved = source_fingerprint(eng, crates, cargo_features)
+        listed = probe.relative_to(eng.root) in set(fingerprint_inputs(eng, crates, cargo_features))
+    finally:
+        probe.unlink(missing_ok=True)
+    after = source_fingerprint(eng, crates, cargo_features)
+    print(f"    probe          {probe.relative_to(eng.root).as_posix()}")
+    print(f"    before         {before}")
+    print(f"    with probe     {moved}  (listed as an input: {listed})")
+    print(f"    after removal  {after}")
+    failures = []
+    if moved == before:
+        failures.append("a new untracked .rs did not move the fingerprint — the guard is blind")
+    if after != before:
+        failures.append("removing the probe did not restore the fingerprint — it left residue")
+    if failures:
+        sys.stdout.flush()  # as in check(): the verdict must not outrun its evidence
+        for line in failures:
+            print(f"self-test FAILED: {line}", file=sys.stderr)
+        raise SystemExit(1)
+    print(f"\nself-test passed: {' '.join(crates)}")
+
+
 def run_cli(
     specs: dict[str, CrateSpec],
     default_crates: list[str],
@@ -1203,6 +1254,12 @@ def run_cli(
         action="store_true",
         help="compare the existing artefacts against the tree and exit nonzero "
         "if any is stale; never extracts",
+    )
+    parser.add_argument(
+        "--self-test",
+        action="store_true",
+        help="prove the source fingerprint still sees a new untracked .rs; "
+        "writes and removes one transient probe file, never extracts",
     )
     parser.add_argument(
         "--force",
@@ -1244,6 +1301,9 @@ def run_cli(
         return
     if args.fingerprint:
         print(source_fingerprint(eng, crates, cargo_features))
+        return
+    if args.self_test:
+        self_test(eng, crates, cargo_features)
         return
     if args.check:
         check(eng, args)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -281,6 +281,19 @@ def metadata(
     args = [
         "cargo",
         "metadata",
+        # `--locked` because this call is reached from `--list-inputs`, which
+        # callers run as a read-only membership check before deciding whether
+        # a file they are about to edit is a fingerprint input. Without it
+        # `cargo metadata` refreshes `Cargo.lock` when the lock is out of
+        # date — and `Cargo.lock` is itself one of the inputs this driver
+        # fingerprints, so the check would edit the thing it is asked about.
+        # The hazard is conditional (a current lock makes it a no-op), which
+        # is the worse shape: it is harmless until it is not.
+        #
+        # A stale lock now fails loudly here instead of being silently
+        # updated. That is the intent: refreshing the lock is an action a
+        # caller should take deliberately, not one a query performs for them.
+        "--locked",
         "--format-version=1",
         "--filter-platform",
         platform,

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -50,6 +50,12 @@ class CrateSpec:
     - `excluded_deps`: path-dependency package names dropped from this crate's
       fingerprint because the artefact holds zero references to them; the
       extraction guard re-checks the artefact and fails loud if that drifts.
+      Naming a package drops its EXCLUSIVELY-REACHED SUBTREE too — anything
+      reachable only by going through it. A package some non-excluded parent
+      also reaches is kept, so listing a widely-shared package removes only
+      its own files. The guard checks the NAMED packages; the subtree is
+      covered by inheritance (see `_collect_inputs`), which is why the two
+      are not, and must not be, the same set.
     - `layout_targets`: target triples, besides the extraction host, this
       crate also emits a layout sidecar for (see `layout_sidecar_name`).
       `None` takes the driver's default; `()` opts out. Every listed target
@@ -1416,22 +1422,36 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         timestamp only approximates.
       * the `excluded_deps` exclusion is not re-asked here, and MOSTLY DOES NOT
         NEED TO BE — do not add a second checker without reading this first.
-        `extract` re-reads the artefact and refuses if a package dropped from
-        the fingerprint is referenced by it; `stamp_path.write_text` is the
+        `extract` re-reads the artefact and refuses if a NAMED excluded
+        package is referenced by it; `stamp_path.write_text` is the
         stamp's ONLY writer and sits immediately after that guard, so a
         violation raises before any stamp exists. A matching stamp is therefore
         the guard's certificate: it could only have been written by an
         extraction the guard passed. The skip path inherits this — it fires on
         `stamp == recorded`, and that recorded stamp had the same provenance.
-        The oracle discriminates rather than being vacuous: the same symbol is
-        present in `pyre-jit.ullbc`, which excludes nothing, and absent from
-        the two artefacts that exclude it.
+        The oracle discriminates rather than being vacuous: `majit_translate`
+        occurs 373 times in `pyre-jit.ullbc`, which excludes nothing, and 0
+        times in `pyre-interpreter.ullbc`, which excludes it.
 
-        Two narrow things the certificate does NOT carry:
+        Three narrow things the certificate does NOT carry:
 
           - it does not distinguish "the guard passed" from "the guard was
             vacuous". A spec with empty `excluded_deps` runs an empty loop and
             writes an indistinguishable stamp.
+          - it does not cover the EXCLUSIVELY-REACHED SUBTREE the exclusion
+            also drops, and ⛔ widening the loop to cover it would be worse
+            than leaving it uncovered, because the guard's power is PER
+            SYMBOL. `majit_charon_reader` — dropped as `majit-translate`'s
+            subtree — occurs 0 times in ALL SIX artefacts this tree builds,
+            `pyre-jit.ullbc` included, so no artefact can serve as its
+            positive control and a widened guard would pass without
+            evidence. What actually certifies the subtree is INHERITANCE:
+            the walk drops a package only when EVERY path to it runs through
+            an excluded one, and the named package's absence is checked
+            here, so a package that cannot appear without it cannot appear.
+            `pyre-object` is NOT a second witness for that absence — it does
+            not depend on `majit-translate` at all, so its exclusion is an
+            inert declaration and its 0 is uninformative.
           - `--force` re-extracts with the skip bypassed, and an excluded
             package's sources changing is BY CONSTRUCTION invisible to
             `source=`. So a forced run can write a violating artefact, raise at

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -604,7 +604,29 @@ def _collect_inputs(
                     external.append(package_dir / "Cargo.toml")
                 for target in package["targets"]:
                     kinds = set(target["kind"])
-                    if not ({"lib", "bin", "custom-build"} & kinds):
+                    # ⭐ A DENY-list, and the direction is the whole point. This
+                    # was `{"lib","bin","custom-build"} & kinds` — an allow-list
+                    # written from a remembered vocabulary rather than a
+                    # measured one, and it silently dropped THREE path-dep
+                    # packages in this tree: `majit-macros` and `pyre-macros`
+                    # (`proc-macro`) and `pyre-wasm` (`cdylib`). A proc macro is
+                    # the WORST possible omission — its expansion is inlined
+                    # into the consuming crate, so its sources are more coupled
+                    # to the artefact's item bodies than an ordinary `lib`'s
+                    # are. An allow-list that omits exactly that is the inverse
+                    # of the risk ordering.
+                    #
+                    # The package loop above appends `Cargo.toml` BEFORE this
+                    # loop runs, which is what made the omission invisible: the
+                    # dropped crate still showed up in `--list-inputs`, so it
+                    # read as covered while none of its sources were hashed.
+                    #
+                    # Naming what is NOT compiled into the artefact is a short,
+                    # closed list; naming what IS grows silently with every
+                    # crate type cargo adds. Getting this wrong now costs a
+                    # re-extraction, never a wrong answer — the same direction
+                    # the untracked-file leg below is deliberately biased in.
+                    if kinds & {"example", "test", "bench"}:
                         continue
                     src_path = Path(target["src_path"]).resolve()
                     if src_path.is_relative_to(root):

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1011,11 +1011,18 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         both in one pass, and the source digest already answers the question a
         timestamp only approximates.
 
-    Nothing here re-extracts. Re-extraction is a whole-crate Charon build —
-    multi-GB RSS — that writes into the working tree, so it stays a human's
-    scheduling decision and the refusal names the command instead. `LLBC_DEST`
-    points the check at a directory other than the driver's default, which is
-    what a caller who must not disturb the live artefacts uses.
+    Nothing here re-extracts. Re-extraction runs a whole-crate Charon build and
+    writes into the working tree, so it stays a human's scheduling decision and
+    the refusal names the command instead. No cost figure is quoted anywhere in
+    this function: what it costs depends on how warm the cargo cache is, and a
+    number carried over from one cold run reads as measured when it is not.
+    `LLBC_DEST` points the check at a directory other than the driver's default,
+    which is what a caller who must not disturb the live artefacts uses.
+
+    Exit 0 has to be EARNED, never fallen into. `verified` records the crates
+    that positively matched, and the epilogue refuses unless every requested
+    crate is in it — so an empty crate list, or any future branch that forgets
+    to file a failure, refuses instead of reporting success by default.
     """
     platform_key, charon_dest, _ = charon_paths(eng.charon_root)
     charon_stamp = charon_version(charon_dest)
@@ -1023,6 +1030,7 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     crates = args.crates or eng.default_crates
 
     stale: list[str] = []
+    verified: set[str] = set()
     # Feature set to re-extract each crate under: the one its stamp records, so
     # a mixed set does not collapse into one wrong remedy command. A crate whose
     # stamp never got read keeps this process's feature set.
@@ -1102,6 +1110,7 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         )
         if text == expected + "\n":
             print(f"    fingerprint matches the tree (source={recorded['source']})")
+            verified.add(crate)
             continue
 
         want = parse_stamp(expected)
@@ -1122,6 +1131,15 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
                 f"tree says {want.get(key)!r}"
             )
 
+    # Exit 0 requires a positive match for every requested crate, and at least
+    # one crate to have been requested. Both halves matter: an empty list has no
+    # unaccounted crates, so testing only for those would let "checked nothing"
+    # through as success — the exact shape this whole function exists to refuse.
+    unaccounted = [crate for crate in crates if crate not in verified]
+    if not stale and (not crates or unaccounted):
+        stale.append(
+            "checked nothing for: " + (" ".join(unaccounted) or "(no crates requested)")
+        )
     if not stale:
         print()
         print(f"llbc artefacts current: {' '.join(crates)}")
@@ -1139,9 +1157,9 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         print(f"  {line}", file=sys.stderr)
     print(
         "\n"
-        "  Re-extract before reading. This is a whole-crate Charon build —\n"
-        "  multi-GB RSS, and it writes into the working tree — so nothing\n"
-        "  here runs it for you. Schedule it:",
+        "  Re-extract before reading. This runs a whole-crate Charon build and\n"
+        "  writes into the working tree, so nothing here runs it for you —\n"
+        "  how long it takes depends on how warm the cargo cache is:",
         file=sys.stderr,
     )
     for features in dict.fromkeys(stamped_features.values()):

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1160,6 +1160,15 @@ def file_mtime(path: Path) -> str:
 # nicety — it is what makes that first sidecar read `dirty_in_closure=0`. Run
 # it the other way round and the change lists ITSELF as an in-closure dirty
 # file, which is the correct report and looks like a defect.
+#
+# ⚠ AND THE GENERAL FORM, which outlives that one occasion: A NONZERO
+# `dirty_in_closure` IS A REPORT, NOT A DEFECT. An extraction is normally
+# batched into a window several people's work lands in, so a sidecar routinely
+# names files somebody else was editing. What it tells you is narrow and worth
+# saying exactly: `source=` hashes the WORKING TREE, so the artefact is correct
+# FOR THAT TREE and is not reproducible from any commit. Kill such a run only
+# if commit-reproducible artefacts are what you came for; the freshness
+# question was already answered, by the stamp, and the answer was yes.
 # ---------------------------------------------------------------------------
 
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1498,10 +1498,21 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
         recorded = parse_stamp(text)
         missing = [key for key in STAMP_KEYS if key not in recorded]
         if missing:
+            # Order matters: the LIKELIEST cause is listed first, and it is the
+            # one the two original guesses both excluded. Adding a key to
+            # STAMP_KEYS makes EVERY stamp already on disk land here at once,
+            # so right after such a change this arm fires for a reason that is
+            # neither "a foreign tool wrote it" nor "it was truncated" — the
+            # stamp is this engine's own output from before the field existed.
+            # Saying only those two sends a reader hunting a corruption that is
+            # not there. Measured after `external=` was added: all five live
+            # pyre stamps refuse through here, none of them damaged.
             stale.append(
                 f"{crate}: fingerprint stamp {stamp_path} has no "
-                f"{', '.join(missing)} field — it was not written by this "
-                f"engine, or was truncated"
+                f"{', '.join(missing)} field — written before this engine "
+                f"recorded that field, or by another tool, or truncated. "
+                f"Re-extract either way; the artefact predates what the stamp "
+                f"is now required to cover, so it cannot be compared"
             )
             continue
 

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -425,6 +425,16 @@ def refuse_inert_pathspecs(eng: Engine) -> None:
     question about git. An `is_file()` test on a module about to be imported is
     a genuine filesystem question and stays correct.)
 
+    ⭐ The contrasting sibling now lives in ANOTHER REPO, so neither file shows
+    both halves of the rule on its own. A driver that declares
+    `external_inputs` may legitimately use `exists()` as a VERDICT on those,
+    and cel-jit's `refuse_absent_external_inputs` does: they are hashed by
+    reading their bytes, never through git, so the filesystem is the correct
+    oracle and the only one. Read alone, that function looks like the mistake
+    this one refuses; read alone, this one looks like a blanket ban on
+    `exists()`. Neither reading is right — the oracle has to match the channel
+    the input is carried on, and the two guards are on different channels.
+
     `ls-files ∪ ls-files --others --exclude-standard` is the definition of
     git-reachable used here, matching `_collect_inputs` exactly. `ls-files
     --error-unmatch` alone is TRACKED-only, and would call a brand-new unadded
@@ -505,10 +515,25 @@ def _collect_inputs(
     in-tree workspace member and a `[patch]` redirect into a sibling checkout —
     so a patched dependency was discovered, found to be out-of-root, and
     discarded with no diagnostic. cel-jit patches `majit-{ir,macros,metainterp}`
-    to `../majit/*`, which pulls the rest of that workspace by path: 10 of the
-    11 closure members landed here, `majit-macros` among them. That one is a
-    proc macro, so its expansion IS the extracted crate's bodies, and editing it
-    changed the artefact's content without moving its fingerprint.
+    to `../majit/*`, which pulls the rest of that workspace in by path, and
+    most of what that pulls landed here, `majit-macros` among them.
+
+    ⛔ NO NUMBER IS QUOTED FOR THAT CLOSURE, deliberately. Two careful
+    measurements of it disagree (11 members / 1 kept, and 10 packages / 9
+    out-of-root) and the disagreement is UNEXPLAINED — a `CARGO_FEATURES`
+    difference was proposed and then refuted, because swapping one backend
+    crate for another changes membership without changing the count. The
+    closure is not a stable set, and a figure written down here would be
+    quoted back as if it were. This is the empirical case for a driver
+    declaring a whole directory in `external_inputs` rather than a per-crate
+    list the walk derived.
+
+    `majit-macros` is a proc macro, so its expansion IS the extracted crate's
+    item bodies. It was dropped by TWO independent gates, and finding the
+    first hid the second: this out-of-root discard, and the target-kind filter
+    below, which admitted neither `proc-macro` nor `cdylib` until it was
+    inverted into a deny-list. Both are fixed; do not read that as the class
+    being closed, since each was found only after the previous one was.
     """
     root = eng.root
     target_names: list[str] = []

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1309,3 +1309,25 @@ def run_cli(
         check(eng, args)
         return
     extract(eng, args)
+
+
+# This module is the shared extraction ENGINE. Every consumer imports it — the
+# per-repo wrappers call `run_cli` with their own `SPECS` — and nothing has ever
+# invoked it as a program.
+#
+# Without this block, running it directly defined `main()` and fell off the end:
+# zero output, **exit 0**, for every argument including `--check`, `--fingerprint`
+# and `--help`. A freshness check aimed here reported success without executing,
+# which is worse than the staleness it was run to detect.
+#
+# The body refuses instead of dispatching. Adding a `main()` call would make
+# direct invocation *work* and mint a second, under-specified entry point: the
+# engine alone cannot know which crates to extract or where their sources live —
+# that is exactly what a wrapper's `CrateSpec` and `PYRE_ROOT` resolution supply.
+if __name__ == "__main__":
+    raise SystemExit(
+        "llbc_extract.py is the shared extraction ENGINE, not an entry point.\n"
+        "  pyre crates:  python3 scripts/extract-llbc.py ...\n"
+        "  cel crates:   python3 cel-jit/scripts/extract-llbc.py ...\n"
+        "Those wrappers supply the CrateSpec table this module needs."
+    )

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -500,6 +500,83 @@ def refuse_inert_pathspecs(eng: Engine) -> None:
     raise SystemExit("\n".join(lines))
 
 
+def _package_closure(
+    target_ids: list[str],
+    by_id: dict,
+    resolve_nodes: dict,
+    exclude: set[str],
+) -> list[dict]:
+    """Path-dependency packages reachable from `target_ids` avoiding `exclude`.
+
+    Pure graph reachability over cargo-metadata shapes: `by_id` maps package id
+    to package, `resolve_nodes` maps package id to its resolve node. Kept
+    separate from `_collect_inputs` so `--self-test` can drive it on a synthetic
+    graph — the property below is about the WALK, and on a real tree it is
+    invisible, because a fingerprint that silently includes four extra files
+    still hashes to something and still compares equal to itself.
+
+    ⭐ The exclusion is applied HERE, in the walk, and not in the emission loop
+    in `_collect_inputs` — excluding a package drops its whole EXCLUSIVELY-
+    REACHED SUBTREE, not just its own files.
+
+    This used to filter only at emission, which dropped the named package's
+    sources and then walked through it anyway, so every dependency reachable
+    ONLY through it stayed in the fingerprint. Measured on this tree:
+    `pyre-interpreter` excludes `majit-translate`, and `majit-charon-reader` —
+    whose sole dependent-of-record IS `majit-translate` — rode in behind it, 4
+    files that no artefact references and that moved the fingerprint 3 times in
+    30 days.
+
+    `continue` before appending is what makes it a subtree drop: the node is
+    neither emitted nor traversed. A package a NON-excluded parent also reaches
+    is still pushed from that parent, so this computes "reachable by a path
+    avoiding every excluded package" — which is the property the safety
+    argument below needs, and it holds regardless of pop order. Both halves are
+    load-bearing and `--self-test`'s diamond case checks them together: drop
+    what only the excluded package reaches, keep what something else does.
+
+    ⛔ Do NOT ALSO widen `extract`'s artefact guard to the packages dropped
+    here. That guard's evidence is a substring search for the package's
+    underscored name, and its power is PER SYMBOL: `majit_translate` occurs 373
+    times in `pyre-jit.ullbc` (which excludes nothing), so the guard is
+    demonstrably able to fail for it. `majit_charon_reader` occurs 0 times in
+    ALL SIX artefacts this tree builds, `pyre-jit.ullbc` included — there is no
+    artefact that can serve as its positive control, so a widened guard would
+    pass for a reason unrelated to safety and read as verification.
+
+    The transitive drop is certified by INHERITANCE instead, and that is a
+    stronger argument than the substring test: the parent's guard establishes
+    the artefact holds zero references to the excluded package, and a package
+    reachable only through it cannot appear without it. The guard runs on every
+    extraction, so the certificate stays live — if the artefact ever does
+    reference the parent, the parent's guard fires and the exclusion (subtree
+    included) has to go.
+    """
+    seen: set[str] = set()
+    stack = list(target_ids)
+    closure = []
+    while stack:
+        package_id = stack.pop()
+        if package_id in seen:
+            continue
+        seen.add(package_id)
+        package = by_id[package_id]
+        if package["name"] in exclude:
+            continue
+        closure.append(package)
+
+        for dep in resolve_nodes.get(package_id, {}).get("deps", []):
+            dep_kinds = dep.get("dep_kinds", [])
+            # An empty `dep_kinds` is a normal (non-dev) edge; only drop deps
+            # whose every listed kind is `dev`.
+            if dep_kinds and all(kind.get("kind") == "dev" for kind in dep_kinds):
+                continue
+            dep_package = by_id.get(dep["pkg"])
+            if dep_package is not None and dep_package.get("source") is None:
+                stack.append(dep_package["id"])
+    return closure
+
+
 def _collect_inputs(
     eng: Engine, crates: list[str], cargo_features: str
 ) -> tuple[list[str], list[Path]]:
@@ -594,37 +671,12 @@ def _collect_inputs(
                     "extract-llbc.py: unknown crate(s): " + ", ".join(sorted(missing))
                 )
 
-            seen: set[str] = set()
-            stack = [by_name[name]["id"] for name in target_names]
-            closure = []
-            while stack:
-                package_id = stack.pop()
-                if package_id in seen:
-                    continue
-                seen.add(package_id)
-                package = by_id[package_id]
-                # Apply the exclusion in the walk, not after it. This drops a
-                # package's exclusively-reached subtree as well as the named
-                # package. A node also reachable from a non-excluded parent is
-                # still pushed along that path and therefore remains present.
-                # The extracted artefact guard certifies the named package's
-                # absence; a subtree that has no path avoiding that package
-                # cannot occur without it.
-                if package["name"] in exclude:
-                    continue
-                closure.append(package)
-
-                for dep in resolve_nodes.get(package_id, {}).get("deps", []):
-                    dep_kinds = dep.get("dep_kinds", [])
-                    # An empty `dep_kinds` is a normal (non-dev) edge; only
-                    # drop deps whose every listed kind is `dev`.
-                    if dep_kinds and all(
-                        kind.get("kind") == "dev" for kind in dep_kinds
-                    ):
-                        continue
-                    dep_package = by_id.get(dep["pkg"])
-                    if dep_package is not None and dep_package.get("source") is None:
-                        stack.append(dep_package["id"])
+            closure = _package_closure(
+                [by_name[name]["id"] for name in target_names],
+                by_id,
+                resolve_nodes,
+                exclude,
+            )
 
             for package in closure:
                 package_dir = Path(package["manifest_path"]).resolve().parent
@@ -1647,6 +1699,107 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
     raise SystemExit(1)
 
 
+def self_test_exclusion_diamond() -> None:
+    """Drive `_package_closure` on a synthetic diamond; check BOTH its halves.
+
+    `excluded_deps` has to do two opposite things at once, and a real tree
+    cannot demonstrate either. Excluding a package must drop what only that
+    package reaches, and must NOT drop what something else also reaches — and a
+    fingerprint that gets this wrong still hashes to something, still compares
+    equal to itself, and still passes `--check`. The pre-fix engine filtered at
+    emission and carried four unreferenced files for 30 days without a single
+    red run. So the property is checked here on a graph built for it.
+
+    The graph, with `excluded` excluded:
+
+        root ──► keep_via_both ──► shared
+          └────► excluded ──┬────► shared           (also reached from above)
+                            └────► behind_excluded  (reached ONLY via excluded)
+
+    Two-sided, and neither side alone is sufficient:
+
+    * `behind_excluded` must be ABSENT. An engine that filters at emission
+      keeps it — that is the #152 defect, and this is the only assertion that
+      sees it.
+    * `shared` must be PRESENT. An engine that prunes by ancestry instead
+      (dropping everything downstream of an excluded node) also passes the
+      first assertion, and drops a package the tree genuinely depends on. That
+      is a wrong answer in the unsafe direction — an under-fingerprinted crate
+      whose artefact goes stale silently.
+
+    The unexcluded control runs first and is not a formality: it establishes
+    that both nodes are reachable AT ALL. Without it, "absent" and "present"
+    are being read off a graph that might reach neither, and the excluded run
+    would pass for a reason unrelated to exclusion.
+
+    ⚠ Not covered here: the `dep_kinds`/dev-edge filter in the same walk. It is
+    a different property with a different failure mode and no fixture yet.
+    """
+    def pkg(name, source=None):
+        return {"id": f"{name} 0.0.0", "name": name, "source": source}
+
+    def node(name, *deps):
+        return (
+            f"{name} 0.0.0",
+            {"deps": [{"pkg": f"{d} 0.0.0", "dep_kinds": []} for d in deps]},
+        )
+
+    names = ["root", "keep_via_both", "excluded", "shared", "behind_excluded"]
+    by_id = {p["id"]: p for p in (pkg(n) for n in names)}
+    resolve_nodes = dict(
+        [
+            node("root", "keep_via_both", "excluded"),
+            node("keep_via_both", "shared"),
+            node("excluded", "shared", "behind_excluded"),
+            node("shared"),
+            node("behind_excluded"),
+        ]
+    )
+    root_ids = ["root 0.0.0"]
+
+    def walk(exclude):
+        return sorted(
+            p["name"] for p in _package_closure(root_ids, by_id, resolve_nodes, exclude)
+        )
+
+    control = walk(set())
+    excluded = walk({"excluded"})
+    print("  exclusion diamond")
+    print(f"    exclude {{}}            {control}")
+    print(f"    exclude {{excluded}}    {excluded}")
+
+    failures = []
+    # The control first: an unreachable node proves nothing by being absent.
+    for name in ("shared", "behind_excluded"):
+        if name not in control:
+            failures.append(
+                f"control walk does not reach {name!r} — the fixture graph is "
+                f"broken, and every verdict below it is vacuous"
+            )
+    if not failures:
+        if "behind_excluded" in excluded:
+            failures.append(
+                "'behind_excluded' survived the exclusion — the exclusion is "
+                "being applied at emission rather than in the walk, so a "
+                "package reachable ONLY through an excluded one still moves "
+                "the fingerprint (the #152 defect)"
+            )
+        if "shared" not in excluded:
+            failures.append(
+                "'shared' was dropped by the exclusion — the walk is pruning "
+                "by ancestry rather than by reachability-avoiding-the-excluded, "
+                "so a package the tree still depends on left the fingerprint "
+                "and its artefact can go stale unnoticed"
+            )
+        if "excluded" in excluded:
+            failures.append("the excluded package itself is in the closure")
+    if failures:
+        sys.stdout.flush()  # as in check(): the verdict must not outrun its evidence
+        for line in failures:
+            print(f"self-test FAILED: {line}", file=sys.stderr)
+        raise SystemExit(1)
+
+
 def self_test(eng: Engine, crates: list[str], cargo_features: str) -> None:
     """A/B/A the fingerprint against a new untracked `.rs` under a covered path.
 
@@ -1796,6 +1949,13 @@ def run_cli(
         print(f"external={external_fingerprint(eng, crates, cargo_features)}")
         return
     if args.self_test:
+        # The diamond runs first because it mutates nothing: on a shared
+        # worktree, a broken input-set computation should be reported without
+        # writing a probe file into the tree to find it out. It is also the
+        # case `self_test` structurally cannot cover — that one compares the
+        # fingerprint against itself, so it stays green over an input set that
+        # is silently wrong.
+        self_test_exclusion_diamond()
         self_test(eng, crates, cargo_features)
         return
     if args.check:

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -19,6 +19,7 @@ import re
 import shlex
 import subprocess
 import sys
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -1555,6 +1556,81 @@ def ensure_charon_std(charon_bin: Path, targets: list[str], root: Path) -> None:
             )
 
 
+def touch_and_note(target: Path, own_writes: dict[tuple[int, int], int]) -> None:
+    """`touch` a path and record the mtime that touch produced.
+
+    Every touch of a closure input must go through this rather than
+    `Path.touch()`. `window_writes` tells the extractor's own writes from a
+    peer's by comparing against the exact mtime recorded here, so a touch that
+    is not recorded is reported as a candidate on every clean run — and a
+    reviewer who sees four false alarms per run stops reading the output.
+
+    Pairing the write with its record in ONE call is what keeps them from
+    drifting. There are already two touch sites (the crate root before the
+    charon build, and again before each cross-target layout build), the second
+    is easy to miss, and the failure it causes is a permanent false positive
+    rather than an error.
+
+    Keyed by `(st_dev, st_ino)` rather than by path so it cannot be defeated by
+    two spellings of one file, and in nanoseconds because `st_mtime` is a float
+    whose rounding makes exact equality unreliable.
+    """
+    target.touch()
+    st = target.stat()
+    own_writes[(st.st_dev, st.st_ino)] = st.st_mtime_ns
+
+
+def window_writes(
+    inputs: list[Path],
+    root: Path,
+    lo_ns: int,
+    hi_ns: int,
+    own_writes: dict[tuple[int, int], int],
+) -> tuple[list[tuple[int, Path]], int, list[str]]:
+    """Closure inputs written while this crate was being extracted.
+
+    The stamp comparison beside this one is an ENDPOINT check: it hashes the
+    tree before the build and again after. That is blind to the write that
+    matters most — an edit that opens and closes INSIDE the build re-converges,
+    so both hashes agree, `git status` and `git diff` are clean, and the
+    artefact is stamped over a tree that briefly was not the one it names.
+
+    A restore is itself a write, so mtime lands inside the window even when the
+    bytes came back. That is the only channel that retains the event, and it
+    retains it for a short time: mtime holds ONE value, so the next ordinary
+    write destroys it. That is why this runs here, in the producer, at the
+    moment the window closes — a sweep run later is not a weaker version of
+    this check, it silently answers a different question.
+
+    Returns `(candidates, covered, unresolved)`. `candidates` is the word on
+    purpose: this names files, never an author.
+
+    KNOWN LIMITS, printed by the caller rather than filed elsewhere:
+      * An mtime-preserving restore (`cp -p`) defeats it completely.
+      * A write that landed before this crate's own `touch` of the same file is
+        overwritten by that touch and cannot be seen.
+      * It has never produced a real-world true positive; it is proven to fire
+        on a constructed edit-and-restore only.
+    """
+    candidates: list[tuple[int, Path]] = []
+    unresolved: list[str] = []
+    for rel in inputs:
+        try:
+            st = (root / rel).stat()
+        except OSError as exc:
+            # Reported, never skipped silently: an input the sweep could not
+            # read is a hole in its own denominator.
+            unresolved.append(f"{rel.as_posix()} ({exc.strerror})")
+            continue
+        if not lo_ns <= st.st_mtime_ns <= hi_ns:
+            continue
+        if own_writes.get((st.st_dev, st.st_ino)) == st.st_mtime_ns:
+            continue  # our own touch, to the nanosecond
+        candidates.append((st.st_mtime_ns, rel))
+    candidates.sort()
+    return candidates, len(inputs) - len(unresolved), unresolved
+
+
 def extract(eng: Engine, args: argparse.Namespace) -> None:
     cargo_features = eng.cargo_features
     platform_key, charon_dest, charon_bin = charon_paths(eng.charon_root)
@@ -1660,6 +1736,11 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         # that is about to run for minutes. See `provenance_for`.
         head_before = git_head(eng.root)
         started = datetime.datetime.now().isoformat(timespec="seconds")
+        # The window is opened from THIS process's clock, not from an
+        # argument: a bound supplied by a caller is a bound nobody can
+        # check, and a guessed one reads exactly like a measured one.
+        window_lo_ns = time.time_ns()
+        own_writes: dict[tuple[int, int], int] = {}
         dirty_status_before, dirty_entries_before = git_dirty(eng.root)
         dirty_before = (
             len(dirty_entries_before) if dirty_status_before == "ok" else None
@@ -1678,7 +1759,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         crate_root = path / "src" / "lib.rs"
         if not crate_root.exists():
             crate_root = path / "src" / "main.rs"
-        crate_root.touch()
+        touch_and_note(crate_root, own_writes)
 
         host_env = {**env, **host_config_env}
         command = [
@@ -1723,7 +1804,7 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                     layout_env.get("RUSTFLAGS", "") + " " + eng.layout_target_rustflags
                 ).strip()
             full = sidecar.with_suffix(sidecar.suffix + ".full")
-            crate_root.touch()
+            touch_and_note(crate_root, own_writes)
             subprocess.run(
                 [
                     str(charon_bin),
@@ -1812,6 +1893,31 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
         # built from other sources. Re-stamping with the post-build value would
         # be equally untrue: the artefact straddles both trees and belongs to
         # neither, and a stamp that looks authoritative is worse than none.
+        # Sited BEFORE the stamp decision so it reports on both branches:
+        # when the stamp is refused, "the tree moved" is exactly when a reader
+        # wants the file names, and when it is accepted this is the only check
+        # that saw the middle of the window at all.
+        moved, covered, unresolved = window_writes(
+            fingerprint_inputs(eng, [crate], cargo_features),
+            eng.root,
+            window_lo_ns,
+            time.time_ns(),
+            own_writes,
+        )
+        print(
+            f"    window writes: {len(moved)} candidate(s) over {covered} of"
+            f" {covered + len(unresolved)} closure inputs"
+        )
+        for _, rel in moved:
+            print(f"        {rel.as_posix()}")
+        for line in unresolved:
+            print(f"        UNRESOLVED {line}")
+        if moved:
+            print(
+                "      Those paths were written while this artefact was being"
+                " built. Candidates, not an accusation, and blind to an"
+                " mtime-preserving restore."
+            )
         if source_fingerprint(eng, [crate], cargo_features) != parse_stamp(stamp)["source"]:
             stamp_path.unlink(missing_ok=True)
             unstamped.append(crate)

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1301,6 +1301,13 @@ def provenance_for(
     # reason the HEAD pair is — so a tree that moved during the build is
     # legible — and repeating the whole listing to say so would bury the one
     # that describes the stamped state.
+    #
+    # ⚠ It is the WHOLE PORCELAIN, UNCLASSIFIED. `dirty_in_closure` and
+    # `dirty_outside` below are a partition of a LATER snapshot, so the only
+    # valid comparison is against their SUM; reading `dirty_before` against
+    # either half alone compares a total to a part. And the two are SUPPOSED to
+    # be free to differ — that difference is the whole instrument, and making
+    # them agree would delete it.
     lines.append(
         f"dirty_before={'unknown' if dirty_before is None else dirty_before}"
     )
@@ -1347,6 +1354,56 @@ def parse_provenance(text: str) -> tuple[dict[str, str], list[str]]:
     return fields, dirty
 
 
+def dirty_report_lines(fields: dict[str, str], in_closure: list[str]) -> list[str]:
+    """The dirty half of `report_provenance`'s output, as text.
+
+    Split out from the printer so `--self-test` can drive it. Both conditional
+    lines below are SILENT on a healthy sidecar — the delta is zero and nothing
+    is omitted — so a run against the real tree cannot tell a correct branch
+    from a dead one, and every sidecar this repository has ever written is
+    healthy in exactly that way. Keeping it a pure function also keeps the
+    self-test off the disk, for the reason `self_test_exclusion_diamond` gives.
+
+    Two moments, on two lines. Printed as one line with the pre-build count in a
+    parenthetical, this reads as a single measurement whose parts should sum,
+    and it silently mixes three bases: a stamp-time in-closure count, a
+    stamp-time outside count, and a pre-build UNCLASSIFIED whole-tree total.
+    That reading is what has to be prevented — the numbers were never wrong, and
+    a disagreement between the moments is the instrument, not a fault.
+    """
+    at_stamp_in = fields.get("dirty_in_closure", "?")
+    at_stamp_out = fields.get("dirty_outside", "?")
+    before = fields.get("dirty_before", "?")
+    lines = [
+        f"    dirty when stamped: {at_stamp_in} in this crate's closure,"
+        f" {at_stamp_out} outside",
+        f"    dirty before the build: {before} (whole tree, unclassified)",
+    ]
+    # Computed, not left to the reader to do in their head. The two TOTALS are
+    # comparable — `dirty_before` and `in_closure + outside` are both whole
+    # porcelain — and it is the naive comparison against one HALF, or against a
+    # count of the rows below, that is invalid. Silent at zero, and silent when
+    # `dirty_before` is `unknown`, which is not the same as zero.
+    if at_stamp_in.isdigit() and at_stamp_out.isdigit() and before.isdigit():
+        delta = int(at_stamp_in) + int(at_stamp_out) - int(before)
+        if delta:
+            lines.append(
+                f"    ⇒ the tree MOVED during the build: {delta:+d} dirty"
+                " path(s) between the two snapshots — the pair exists to say so"
+            )
+    # The `dirty=` rows are a bounded DISPLAY while the counts above are exact,
+    # so counting the rows is not a check on the counts. Said here because the
+    # bound lives in the writer and no reader of this output would find it.
+    omitted = fields.get("dirty_omitted", "0")
+    if omitted not in ("0", "?"):
+        lines.append(
+            f"      ⚠ {omitted} further dirty path(s) not listed — do not count"
+            " the rows, the counts above are the exact ones"
+        )
+    lines.extend(f"      {entry}" for entry in in_closure)
+    return lines
+
+
 def report_provenance(dest: Path) -> None:
     """Print an artefact's provenance. Returns nothing and gates nothing.
 
@@ -1386,13 +1443,8 @@ def report_provenance(dest: Path) -> None:
     # so the classification starts at offset 3. A substring test would also
     # match a PATH that happened to contain the word.
     in_closure = [entry for entry in dirty if entry[3:].startswith("in-closure ")]
-    print(
-        f"    dirty at build time: {fields.get('dirty_in_closure', '?')} in this"
-        f" crate's closure, {fields.get('dirty_outside', '?')} outside"
-        f" (before the build: {fields.get('dirty_before', '?')})"
-    )
-    for entry in in_closure:
-        print(f"      {entry}")
+    for line in dirty_report_lines(fields, in_closure):
+        print(line)
 
 
 def crate_layout_targets(eng: Engine, spec: CrateSpec) -> list[str]:
@@ -2137,6 +2189,58 @@ def self_test_exclusion_diamond() -> None:
         raise SystemExit(1)
 
 
+def self_test_provenance_rendering() -> None:
+    """Drive `dirty_report_lines` over cases the live sidecars cannot produce.
+
+    Both of its conditional lines are silent on every artefact this repository
+    has ever stamped — the delta is zero and nothing is omitted — so `--check`
+    against the real tree exercises neither, and a dead branch would read
+    exactly like a correct one. The movement line especially: it exists for a
+    build that straddled a peer's edit, which is the case nobody can arrange on
+    demand and everybody needs reported.
+
+    The three negatives are load-bearing, not padding. A renderer that emitted
+    the movement line unconditionally satisfies every positive row here and is
+    worse than no line at all, because it accuses a clean build of moving; and
+    `unknown` is not zero, so a renderer that coerced it would report a delta
+    against a count it never had.
+    """
+    base = {
+        "dirty_before": "3",
+        "dirty_in_closure": "0",
+        "dirty_outside": "3",
+        "dirty_omitted": "0",
+    }
+    cases = [
+        ("steady tree", {}, False, False),
+        ("grew by 2", {"dirty_in_closure": "1", "dirty_outside": "4"}, True, False),
+        ("shrank by 2", {"dirty_before": "5"}, True, False),
+        ("moved inside the closure", {"dirty_in_closure": "1"}, True, False),
+        ("pre-build count unknown", {"dirty_before": "unknown"}, False, False),
+        ("listing truncated", {"dirty_omitted": "7"}, False, True),
+        ("moved AND truncated", {"dirty_before": "9", "dirty_omitted": "4"}, True, True),
+    ]
+
+    print("  provenance rendering")
+    failures = []
+    for label, over, want_moved, want_omitted in cases:
+        text = "\n".join(dirty_report_lines({**base, **over}, []))
+        got_moved = "MOVED during the build" in text
+        got_omitted = "do not count" in text
+        verdict = "ok" if (got_moved, got_omitted) == (want_moved, want_omitted) else "FAILED"
+        print(f"    {verdict:<6} {label}: moved={got_moved} truncated={got_omitted}")
+        if verdict == "FAILED":
+            failures.append(
+                f"{label!r}: expected moved={want_moved} truncated={want_omitted},"
+                f" got moved={got_moved} truncated={got_omitted}"
+            )
+    if failures:
+        sys.stdout.flush()  # as in check(): the verdict must not outrun its evidence
+        for line in failures:
+            print(f"self-test FAILED: {line}", file=sys.stderr)
+        raise SystemExit(1)
+
+
 def self_test(eng: Engine, crates: list[str], cargo_features: str) -> None:
     """A/B/A the fingerprint against a new untracked `.rs` under a covered path.
 
@@ -2293,6 +2397,10 @@ def run_cli(
         # fingerprint against itself, so it stays green over an input set that
         # is silently wrong.
         self_test_exclusion_diamond()
+        # Same reason, one artefact along: `--check` renders provenance on every
+        # run and exercises neither of its conditional lines, because no sidecar
+        # this tree has written is anything but steady and untruncated.
+        self_test_provenance_rendering()
         self_test(eng, crates, cargo_features)
         return
     if args.check:

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1251,6 +1251,20 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
     # rustc), so this never thrashes the runtime build's cache, and the LLBC is
     # independent of debuginfo so the artefact is byte-identical.
     env.setdefault("CARGO_PROFILE_DEV_DEBUG", "0")
+    # The dev profile enables incremental compilation, which splits a crate into
+    # codegen units and reuses object files from the previous session. Charon
+    # drives rustc for the crates it extracts while plain rustc builds the rest,
+    # and the two disagree about which CGUs are still valid: the resulting
+    # archive fuses objects from different sessions, so CGU-local symbols
+    # (`...drop_in_place...llvm.<hash>`) are referenced by one object and
+    # defined in none. The failure surfaces far from its cause, as
+    # `Undefined symbols for architecture arm64` while LINKING the
+    # `pyre-jit-trace` BUILD SCRIPT, which is a host binary and therefore the
+    # first thing in the graph that has to resolve real code out of
+    # `libmajit_translate`. The tell is that the `.rcgu.o` files named in the
+    # linker error carry a different session tag than the loose ones on disk.
+    # Extraction only needs MIR, so incremental buys nothing here.
+    env["CARGO_INCREMENTAL"] = "0"
     # Dependency build scripts run while Charon extracts a target crate. They
     # must not recursively demand the very LLBC artefact currently being
     # produced (pyre-jit -> pyre-jit-trace -> pyre-jit.ullbc). Consumers may

--- a/scripts/llbc_extract_selftest.py
+++ b/scripts/llbc_extract_selftest.py
@@ -150,6 +150,10 @@ def run_fingerprint(engine) -> int:
 
         untracked = root / "src" / "new.rs"
         untracked.write_text("pub fn new_item() {}\n")
+        # The input walk is memoised for one stable extraction snapshot. This
+        # test deliberately changes the input set, so begin a new snapshot
+        # before asking whether the added path moves the fingerprint.
+        engine.forget_collected_inputs()
         before_stage = fingerprint(eng)
         expect("untracked source moves the source key", before_stage != base)
         subprocess.run(["git", "add", "src/new.rs"], cwd=root, check=True)


### PR DESCRIPTION
## Summary

- make LLBC fingerprints cover untracked inputs, out-of-tree dependencies, all extraction-relevant target kinds, and the dependency closure actually consumed by Charon
- refuse unverifiable artefacts: inert pathspecs, nested repositories, source movement during extraction, malformed or incomplete stamps, contradictory freshness settings, and failed forced extractions retaining an old certificate
- add producer/consumer freshness checks, provenance sidecars, format and policy tests, and opt-in code-generation determinism checks that distinguish address-bearing outputs across processes
- include the general maintenance originally selected with this patch: CPython SKIP reconciliation, MIR unwind diagnostics, tagged-int/getsizeof documentation, and stable symbol-based citations
- incorporate PR review fixes, including external fingerprint comparison, cache-safe address exclusions, timeout child termination, complete stamp keys, memoized input walks, mutually exclusive read-only modes, and review-driven test coverage

This PR intentionally contains no CEL-specific restoration, CEL fixtures, or cel_new_int work.

## Validation

- cargo fmt --all -- --check
- python3 -m py_compile pyre/cpython_tests/run.py pyre/scripts/extract-llbc.py scripts/llbc_extract.py scripts/llbc_extract_selftest.py
- python3 scripts/llbc_extract_selftest.py
- python3 scripts/extract-llbc.py --self-test pyre-object
- cargo check --features dynasm
- cargo test --features dynasm
- cargo test -p pyre-jit-trace --features dynasm (352 passed, 6 ignored; fingerprint format 8 passed/1 ignored; freshness policy 9 passed)

The local pre-existing LLBC stamps predate the new external= field, so Cargo reports their freshness as UNKNOWN instead of silently treating them as current; compilation and tests complete successfully.