### PR TITLE
jit: preserve vable guard snapshots and re-arm frame array barriers

### DIFF
--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2895,7 +2895,7 @@ impl TraceCtx {
     /// Like [`Self::capture_snapshot_for_last_guard_multi_frame_with_vable_vref`] but
     /// stamps the resume position on the guard op `from_end` guards back from
     /// the most recent one rather than the last recorded op — the multi-frame
-    /// analog of [`Self::capture_snapshot_for_last_guard_op_with_vable_vref`]. Used when a
+    /// analog of [`Self::capture_snapshot_for_last_guard_op_with_vable_vref`].  Used when a
     /// guard emitted inside a helper (the `_nonstandard_virtualizable` PTR_EQ
     /// promote) records further non-guard ops (`emit_force_virtualizable`'s
     /// GETFIELD_GC / PTR_NE / COND_CALL) before the caller captures, yet the

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2804,10 +2804,11 @@ impl TraceCtx {
     }
 
     /// Like [`Self::capture_snapshot_for_last_guard_with_vable_vref`] but stamps
-    /// the resume position on the most-recent *guard* op rather than the
-    /// last recorded op.  Used when a guard is emitted inside a helper
-    /// (the `_nonstandard_virtualizable` PTR_EQ promote) that records
-    /// further non-guard ops before the caller can capture.
+    /// the resume position on the guard op `from_end` guards back from the
+    /// most recent one rather than the last recorded op.  Used when a guard is
+    /// emitted inside a helper (the `_nonstandard_virtualizable` PTR_EQ
+    /// promote) that records further ops before the caller can capture, and
+    /// when one opcode emits more than one guard.
     pub fn capture_snapshot_for_last_guard_op_with_vable_vref(
         &mut self,
         active_boxes: &[OpRef],
@@ -2816,6 +2817,7 @@ impl TraceCtx {
         py_pc: u32,
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
+        from_end: usize,
     ) {
         let boxes = self.encode_snapshot_boxes(active_boxes);
         let snapshot_id = self.capture_resumedata(crate::recorder::Snapshot {
@@ -2828,7 +2830,7 @@ impl TraceCtx {
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
         });
-        self.set_last_guard_op_resume_position(snapshot_id);
+        self.set_guard_op_resume_position_from_end(from_end, snapshot_id);
     }
 
     /// Multi-frame variant of [`Self::capture_snapshot_for_last_guard`].
@@ -2891,9 +2893,9 @@ impl TraceCtx {
     }
 
     /// Like [`Self::capture_snapshot_for_last_guard_multi_frame_with_vable_vref`] but
-    /// stamps the resume position on the most-recent *guard* op rather than the
-    /// last recorded op — the multi-frame analog of
-    /// [`Self::capture_snapshot_for_last_guard_op_with_vable_vref`].  Used when a
+    /// stamps the resume position on the guard op `from_end` guards back from
+    /// the most recent one rather than the last recorded op — the multi-frame
+    /// analog of [`Self::capture_snapshot_for_last_guard_op_with_vable_vref`]. Used when a
     /// guard emitted inside a helper (the `_nonstandard_virtualizable` PTR_EQ
     /// promote) records further non-guard ops (`emit_force_virtualizable`'s
     /// GETFIELD_GC / PTR_NE / COND_CALL) before the caller captures, yet the
@@ -2903,6 +2905,7 @@ impl TraceCtx {
         frames: &[(u32, u32, u32, &[OpRef])],
         vable_boxes: &[crate::recorder::SnapshotTagged],
         vref_boxes: &[crate::recorder::SnapshotTagged],
+        from_end: usize,
     ) {
         let recorder_frames: Vec<crate::recorder::SnapshotFrame> = frames
             .iter()
@@ -2922,7 +2925,7 @@ impl TraceCtx {
             vable_boxes: vable_boxes.to_vec(),
             vref_boxes: vref_boxes.to_vec(),
         });
-        self.set_last_guard_op_resume_position(snapshot_id);
+        self.set_guard_op_resume_position_from_end(from_end, snapshot_id);
     }
 
     fn encode_snapshot_boxes(

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -172,6 +172,7 @@ pub use trace_ctx::MergePoint;
 pub use trace_ctx::ReconstructRecipe;
 pub use trace_ctx::TraceCtx;
 pub use trace_ctx::VableArrayStore;
+pub use trace_ctx::VableEntryWrite;
 
 /// Compute green key from code pointer and PC.
 /// Must use the same hash as the front-end's make_green_key — the full

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -4797,10 +4797,21 @@ impl TraceCtx {
 
     /// pyjitpl.py:1236-1247 `_opimpl_setarrayitem_vable(box, indexbox, valuebox, fdescr, adescr, pc)`.
     ///
-    /// Returns `false` when the promoted index does not resolve to a standard
-    /// virtualizable slot (e.g. a transient out-of-bounds index during state-
-    /// field tracing). The caller aborts the trace in that case, mirroring the
-    /// read path's graceful handling in `vable_getarrayitem_int_indexed`.
+    /// `VableArrayStore::OutOfVable` means the promoted index did not resolve
+    /// to a standard virtualizable slot: it was negative, or `fdescr` is not
+    /// one of the virtualizable's array fields. Nothing was stored.
+    /// `VableArrayStore::Stored(Some(write))` is a standard-leg store; `write`
+    /// identifies the overwritten shadow slot and its prior box and value so a
+    /// caller capturing a promote guard can roll it back during the capture.
+    /// `VableArrayStore::Stored(None)` means the non-standard leg recorded a
+    /// plain `SETARRAYITEM_GC`, with no virtualizable shadow slot to roll back.
+    ///
+    /// The three `MetaInterp::opimpl_setarrayitem_vable_*` wrappers deliberately
+    /// assert `Stored`: `_get_arrayitem_vable_index` in
+    /// `rpython/jit/metainterp/pyjitpl.py:1215` asserts that the index is within
+    /// the virtualizable array, making `OutOfVable` an invariant violation on
+    /// that path. Graceful handling belongs to dispatcher/walker callers that
+    /// have a trace to abort.
     pub fn vable_setarrayitem_indexed(
         &mut self,
         pc: usize,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -183,7 +183,7 @@
 use crate::jitcode_runtime::{DecodedOp, decode_op_at};
 use crate::state::{ConcreteValue, MIFrame, WalkSym};
 use majit_ir::{DescrRef, OopSpecIndex, OpCode, OpRef, Type, Value};
-use majit_metainterp::{TraceCtx, default_effect_info};
+use majit_metainterp::{TraceCtx, VableArrayStore, default_effect_info};
 
 // jitcode_dispatch submodules (extracted from this file). Their `pub`
 // items are re-exported so `crate::jitcode_dispatch::` paths stay stable.
@@ -5612,14 +5612,27 @@ pub(crate) struct GuardCaptureScope<'a> {
     /// gated kept-stack path.
     pub branch_guard_kept_recovered: &'a [(u16, OpRef)],
 
-    /// Stamp the resume position on the most-recent *guard* op instead of the
-    /// last recorded op. Needed whenever the guard being captured is not the
-    /// last thing recorded: `_nonstandard_virtualizable` (pyjitpl.py:1120)
-    /// emits its promote `GUARD_VALUE` and then `emit_force_virtualizable`
-    /// records GETFIELD_GC / PTR_NE / COND_CALL on top of it, so the default
-    /// last-op stamp lands on the COND_CALL and leaves the guard holding the
-    /// recorder's placeholder resume position.
-    pub stamp_last_guard_op: bool,
+    /// Select which already-recorded guard op receives the resume position.
+    /// Needed whenever the guard being captured is not the last thing recorded:
+    /// `_nonstandard_virtualizable` (pyjitpl.py:1120) emits its promote
+    /// `GUARD_VALUE` and then `emit_force_virtualizable` records GETFIELD_GC /
+    /// PTR_NE / COND_CALL on top of it, so the default last-op stamp lands on
+    /// the COND_CALL and leaves the guard holding the recorder's placeholder
+    /// resume position.
+    pub guard_stamp: GuardStampTarget,
+}
+
+/// Which already-recorded guard op a capture stamps its resume position on.
+#[derive(Clone, Copy, Default, PartialEq, Eq, Debug)]
+pub(crate) enum GuardStampTarget {
+    /// The last recorded op — the guard IS that op.
+    #[default]
+    LastOp,
+    /// The guard op `from_end` guards back from the most recent one
+    /// (`0` == the most recent). Needed when a guard is emitted inside a
+    /// helper that records further ops before the caller can capture, and
+    /// when one opcode emits more than one guard.
+    GuardFromEnd(usize),
 }
 
 /// `rlib/jit.py` `max_unroll_recursion` default (= warmstate

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4075,7 +4075,7 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
     for (slot, value, concrete) in slots {
         let index = ctx.trace_ctx.const_int(slot);
         let guards_before = ctx.trace_ctx.num_guards();
-        ctx.trace_ctx.vable_setarrayitem_indexed(
+        let write = match ctx.trace_ctx.vable_setarrayitem_indexed(
             pc,
             callee_frame,
             index,
@@ -4085,8 +4085,14 @@ pub(crate) fn disarm_folded_inline_callee_after_escape<Sym: WalkSym>(
             value,
             concrete,
             false,
-        );
-        walker_capture_inline_nonstandard_vable_guard(ctx, pc, guards_before)?;
+        ) {
+            VableArrayStore::Stored(write) => write,
+            // The out-of-vable store recorded nothing, so there is no pre-store
+            // entry to roll back. Whether it should abort the trace is tracked
+            // separately.
+            VableArrayStore::OutOfVable => None,
+        };
+        walker_capture_inline_nonstandard_vable_guard(ctx, pc, guards_before, write)?;
     }
     if let Some(shadow) = ctx.callee_shadow.as_mut()
         && shadow.frame_box == callee_frame

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -113,13 +113,14 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_scoped<Sym: WalkSym>(
 /// emits nothing — gate on a full-body walk being active so this is a
 /// no-op (one cheap `num_guards` read) outside it.  The non-standard
 /// fact is cached per box
-/// after the first access, so at most one such guard is emitted per
-/// inlined frame and `walker_capture_snapshot_for_last_guard`'s
-/// "last guard" target is unambiguous.
+/// after the first access. An array access can still emit a second promote
+/// guard for its index, so every guard minted by one opcode is captured in
+/// emission order.
 pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
     guards_before: usize,
+    write: Option<majit_metainterp::VableEntryWrite>,
 ) -> Result<(), DispatchError> {
     // The non-standard virtualizable's internal promote GuardValue is
     // emitted only inside a full-body walk against a callee frame that is
@@ -137,6 +138,24 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
         // guard, so there is nothing to capture.
         return Ok(());
     }
+    let restored = write.and_then(|w| {
+        ctx.trace_ctx
+            .swap_virtualizable_entry(w.index, w.prev_box, w.prev_value)
+            .map(|current| (w.index, current))
+    });
+    let result = walker_capture_inline_nonstandard_vable_guard_inner(ctx, op_pc, guards_before);
+    if let Some((index, (op, value))) = restored {
+        ctx.trace_ctx.swap_virtualizable_entry(index, op, value);
+    }
+    result
+}
+
+fn walker_capture_inline_nonstandard_vable_guard_inner<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op_pc: usize,
+    guards_before: usize,
+) -> Result<(), DispatchError> {
+    let minted = ctx.trace_ctx.num_guards() - guards_before;
     if !ctx.fbw_mode.inline_subwalk {
         // The walk's own root frame reached the non-standard path: it is
         // writing a `vable` field of a frame that is not
@@ -163,14 +182,17 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
         // `record_guard_with_snapshot`), which is not a decodable resume
         // coordinate — `frame_value_count_at` fails loud on it if the
         // optimizer does not remove the guard.
-        return walker_capture_snapshot_for_last_guard_scoped(
-            ctx,
-            op_pc,
-            GuardCaptureScope {
-                stamp_last_guard_op: true,
-                ..GuardCaptureScope::default()
-            },
-        );
+        for from_end in (0..minted).rev() {
+            walker_capture_snapshot_for_last_guard_scoped(
+                ctx,
+                op_pc,
+                GuardCaptureScope {
+                    guard_stamp: GuardStampTarget::GuardFromEnd(from_end),
+                    ..GuardCaptureScope::default()
+                },
+            )?;
+        }
+        return Ok(());
     }
     // Same buildability precondition as `walker_capture_snapshot_for_last_guard`:
     // every virtualizable box must carry `OpRef::ty()` or the snapshot
@@ -209,14 +231,17 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     let publish_inline_frames =
         (n_parents == 0 && n_callees == 1) || (n_parents > 0 && n_parents == n_callees);
     if publish_inline_frames {
-        return walker_capture_multi_frame_inline_snapshot(
-            ctx,
-            op_pc,
-            false,
-            parent_frames,
-            GuardCaptureScope::default(),
-            true,
-        );
+        for from_end in (0..minted).rev() {
+            walker_capture_multi_frame_inline_snapshot(
+                ctx,
+                op_pc,
+                false,
+                parent_frames.clone(),
+                GuardCaptureScope::default(),
+                GuardStampTarget::GuardFromEnd(from_end),
+            )?;
+        }
+        return Ok(());
     }
     // The guard is not the last recorded op: `emit_force_virtualizable`
     // records GETFIELD_GC / PTR_NE / COND_CALL after the promote, so stamp
@@ -240,17 +265,20 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     else {
         return Err(DispatchError::GuardResumeCoordinateUnavailable { pc: op_pc });
     };
-    let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
     let nsvable_py_pc = forward_snapshot_py_pc(ctx.outer_jitcode_index, nsvable_pc_word)?;
-    ctx.trace_ctx
-        .capture_snapshot_for_last_guard_op_with_vable_vref(
-            &ctx.outer_active_boxes,
-            ctx.outer_jitcode_index,
-            nsvable_pc_word,
-            nsvable_py_pc,
-            &vable_boxes,
-            &vref_boxes,
-        );
+    for from_end in (0..minted).rev() {
+        let (vable_boxes, vref_boxes) = ctx.trace_ctx.build_snapshot_vable_vref_boxes();
+        ctx.trace_ctx
+            .capture_snapshot_for_last_guard_op_with_vable_vref(
+                &ctx.outer_active_boxes,
+                ctx.outer_jitcode_index,
+                nsvable_pc_word,
+                nsvable_py_pc,
+                &vable_boxes,
+                &vref_boxes,
+                from_end,
+            );
+    }
     Ok(())
 }
 
@@ -378,7 +406,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
                 after_residual_call,
                 parent_frames,
                 scope,
-                false,
+                GuardStampTarget::LastOp,
             );
         }
     }
@@ -1140,7 +1168,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
             let forward_py_pc = forward_snapshot_py_pc(jitcode_index, pc_word)?;
             publish_single_frame_snapshot(
                 ctx,
-                scope.stamp_last_guard_op,
+                scope.guard_stamp,
                 &active,
                 jitcode_index,
                 pc_word,
@@ -1175,7 +1203,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
     let active = std::mem::take(&mut ctx.outer_active_boxes);
     publish_single_frame_snapshot(
         ctx,
-        scope.stamp_last_guard_op,
+        scope.guard_stamp,
         &active,
         ctx.outer_jitcode_index,
         arm_pc_word,
@@ -1188,16 +1216,16 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_impl<Sym: WalkSym>(
 }
 
 /// Attach a freshly built single-frame snapshot to the guard this capture is
-/// for.  `stamp_last_guard_op` picks the recorder-side target: the default
-/// stamps the last recorded op (the guard IS that op), while a guard that
-/// records further non-guard ops after itself — the
-/// `_nonstandard_virtualizable` promote, whose `emit_force_virtualizable`
-/// tail records GETFIELD_GC / PTR_NE / COND_CALL — must stamp the last
-/// *guard* op instead.
+/// for. `guard_stamp` picks the recorder-side target: the default stamps the
+/// last recorded op (the guard IS that op), while a guard that records further
+/// ops after itself — the `_nonstandard_virtualizable` promote, whose
+/// `emit_force_virtualizable` tail records GETFIELD_GC / PTR_NE / COND_CALL —
+/// or shares an opcode with another guard must stamp the corresponding guard
+/// op instead.
 #[allow(clippy::too_many_arguments)]
 fn publish_single_frame_snapshot<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
-    stamp_last_guard_op: bool,
+    guard_stamp: GuardStampTarget,
     active: &[OpRef],
     jitcode_index: u32,
     pc: u32,
@@ -1205,20 +1233,29 @@ fn publish_single_frame_snapshot<Sym: WalkSym>(
     vable_boxes: &[majit_metainterp::recorder::SnapshotTagged],
     vref_boxes: &[majit_metainterp::recorder::SnapshotTagged],
 ) {
-    let capture = if stamp_last_guard_op {
-        majit_metainterp::TraceCtx::capture_snapshot_for_last_guard_op_with_vable_vref
-    } else {
-        majit_metainterp::TraceCtx::capture_snapshot_for_last_guard_with_vable_vref
-    };
-    capture(
-        ctx.trace_ctx,
-        active,
-        jitcode_index,
-        pc,
-        py_pc,
-        vable_boxes,
-        vref_boxes,
-    );
+    match guard_stamp {
+        GuardStampTarget::LastOp => ctx
+            .trace_ctx
+            .capture_snapshot_for_last_guard_with_vable_vref(
+                active,
+                jitcode_index,
+                pc,
+                py_pc,
+                vable_boxes,
+                vref_boxes,
+            ),
+        GuardStampTarget::GuardFromEnd(from_end) => ctx
+            .trace_ctx
+            .capture_snapshot_for_last_guard_op_with_vable_vref(
+                active,
+                jitcode_index,
+                pc,
+                py_pc,
+                vable_boxes,
+                vref_boxes,
+                from_end,
+            ),
+    }
 }
 
 /// Build the paused caller frame for a multi-frame inline snapshot (#68),
@@ -2270,7 +2307,7 @@ fn walker_capture_transparent_helper_snapshot<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
     parent_frames: Vec<InlineParentFrame>,
-    stamp_last_guard_op: bool,
+    guard_stamp: GuardStampTarget,
 ) -> Result<(), DispatchError> {
     if parent_frames.is_empty() || !ctx.trace_ctx.vable_snapshot_buildable() {
         return Err(DispatchError::callee_inline_unsupported(op_pc));
@@ -2292,20 +2329,22 @@ fn walker_capture_transparent_helper_snapshot<Sym: WalkSym>(
         let py_pc = forward_snapshot_py_pc(frame.jitcode_index, pc_word)?;
         frames.push((frame.jitcode_index, pc_word, py_pc, frame.boxes.as_slice()));
     }
-    if stamp_last_guard_op {
-        ctx.trace_ctx
+    match guard_stamp {
+        GuardStampTarget::GuardFromEnd(from_end) => ctx
+            .trace_ctx
             .capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref(
                 &frames,
                 &vable_boxes,
                 &vref_boxes,
-            );
-    } else {
-        ctx.trace_ctx
+                from_end,
+            ),
+        GuardStampTarget::LastOp => ctx
+            .trace_ctx
             .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
                 &frames,
                 &vable_boxes,
                 &vref_boxes,
-            );
+            ),
     }
     Ok(())
 }
@@ -2326,15 +2365,15 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
     // The `_nonstandard_virtualizable` promote guard is not the last recorded op
     // (`emit_force_virtualizable` records GETFIELD_GC / PTR_NE / COND_CALL after
     // it), so its caller stamps the resume position on the last *guard* op.
-    // Straight-line / branch inline guards ARE the last op and pass `false`.
-    stamp_last_guard_op: bool,
+    // Straight-line / branch inline guards ARE the last op and pass `LastOp`.
+    guard_stamp: GuardStampTarget,
 ) -> Result<(), DispatchError> {
     if ctx.fbw_mode.transparent_helper_subwalk {
         return walker_capture_transparent_helper_snapshot(
             ctx,
             callee_op_pc,
             parent_frames,
-            stamp_last_guard_op,
+            guard_stamp,
         );
     }
     if !ctx.trace_ctx.vable_snapshot_buildable() {
@@ -2656,20 +2695,22 @@ pub(crate) fn walker_capture_multi_frame_inline_snapshot<Sym: WalkSym>(
         callee_boxes.as_slice(),
     ));
 
-    if stamp_last_guard_op {
-        ctx.trace_ctx
+    match guard_stamp {
+        GuardStampTarget::GuardFromEnd(from_end) => ctx
+            .trace_ctx
             .capture_snapshot_for_last_guard_op_multi_frame_with_vable_vref(
                 &frames,
                 &vable_boxes,
                 &vref_boxes,
-            );
-    } else {
-        ctx.trace_ctx
+                from_end,
+            ),
+        GuardStampTarget::LastOp => ctx
+            .trace_ctx
             .capture_snapshot_for_last_guard_multi_frame_with_vable_vref(
                 &frames,
                 &vable_boxes,
                 &vref_boxes,
-            );
+            ),
     }
     Ok(())
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -116,6 +116,22 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_scoped<Sym: WalkSym>(
 /// after the first access. An array access can still emit a second promote
 /// guard for its index, so every guard minted by one opcode is captured in
 /// emission order.
+///
+/// `write` rolls the virtualizable shadow entry back to its pre-store value
+/// for the capture window: a setter stores before this runs, so without the
+/// swap the promote guard's resume data would carry the very write its resume
+/// pc re-executes.
+///
+/// Both that rollback and the per-guard loop only have a subject when a vable
+/// op's frame operand is an `OpRef` that is not `standard_virtualizable_box()`
+/// yet points at the same frame, so the PTR_EQ reads equal. Nothing mints one
+/// today: `lower_vable_field_read` and its siblings lower a field access to a
+/// vable op only when the base is literally the declared virtualizable
+/// variable, and `run_perfn_walk`, `fbw_force_virtualizable_before_return` and
+/// `fbw_publish_exit_last_instr` all seed that variable from
+/// `standard_virtualizable_box()` itself, so an aliasing box returns early on
+/// the identity check. A new seeding site, or a base other than the declared
+/// variable reaching a vable op, makes both live at once.
 pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -582,7 +582,7 @@ fn vable_store_tracks_live_null_without_changing_the_recorded_trace() {
             null,
             true,
         ),
-        VableArrayStore::Stored(_)
+        VableArrayStore::Stored(Some(_))
     ));
     assert!(tc.virtualizable_slot_stored_live_null(flat_base));
     assert!(
@@ -613,7 +613,7 @@ fn vable_store_tracks_live_null_without_changing_the_recorded_trace() {
             null,
             false,
         ),
-        VableArrayStore::Stored(_)
+        VableArrayStore::Stored(Some(_))
     ));
     assert!(!tc.virtualizable_slot_stored_live_null(flat_base));
 
@@ -631,13 +631,13 @@ fn vable_store_tracks_live_null_without_changing_the_recorded_trace() {
             Value::Ref(majit_ir::GcRef(2)),
             true,
         ),
-        VableArrayStore::Stored(_)
+        VableArrayStore::Stored(Some(_))
     ));
     assert!(!tc.virtualizable_slot_stored_live_null(flat_base + 1));
 
     assert!(matches!(
         tc.vable_setarrayitem_indexed(0, vable, index0, 0, fdescr, adescr, const_null, null, true,),
-        VableArrayStore::Stored(_)
+        VableArrayStore::Stored(Some(_))
     ));
     assert!(tc.virtualizable_slot_stored_live_null(flat_base));
     tc.set_virtualizable_entry_at(flat_base, const_null, null);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -184,7 +184,7 @@ pub(crate) fn getfield_vable_via_metainterp<Sym: WalkSym>(
             .vable_getfield_float(pc, obj, vable_struct_ptr, descr),
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     };
-    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, None)?;
     // RPython `opimpl_getfield_vable_{i,r,f}` returns
     // `virtualizable_boxes[index]` (`pyjitpl.py`) — a Box whose
     // `_resint`/`_resref`/`_resfloat` is filled at construction time.
@@ -331,7 +331,8 @@ pub(crate) fn setfield_vable_via_metainterp<Sym: WalkSym>(
     // `_nonstandard_virtualizable(pc, ...)`; walker has `op.pc` for the
     // JitCode PC, pass through.
     let guards_before = ctx.trace_ctx.num_guards();
-    ctx.trace_ctx
+    let write = ctx
+        .trace_ctx
         .vable_setfield(op.pc, obj, descr, value, concrete);
     // `MIFrame` owns one red frame per inlined call.  The trace shadow remains
     // authoritative for optimization, while the matching concrete frame is
@@ -344,7 +345,7 @@ pub(crate) fn setfield_vable_via_metainterp<Sym: WalkSym>(
     ) {
         crate::state::store_live_frame_static_int(frame, field_index, value);
     }
-    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, write)?;
     Ok((DispatchOutcome::Continue, op.next_pc))
 }
 
@@ -535,7 +536,7 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
         ),
         _ => unreachable!("dst_bank must be 'i', 'r' or 'f'"),
     };
-    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, None)?;
     let shadow_value = shadow_value.unwrap_or(Value::Void);
     // When the read missed every concrete channel (`Void`) but we are inside
     // an inlined callee, fall back to the per-frame concrete-locals shadow —
@@ -810,7 +811,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             .unwrap_or(Value::Void);
     let is_stack_push = value_bank == 'r' && vable_store_is_stack_push(ctx, index_value);
     let guards_before = ctx.trace_ctx.num_guards();
-    ctx.trace_ctx.vable_setarrayitem_indexed(
+    let write = match ctx.trace_ctx.vable_setarrayitem_indexed(
         op.pc,
         vable,
         index,
@@ -820,7 +821,13 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
         value,
         concrete,
         is_stack_push,
-    );
+    ) {
+        VableArrayStore::Stored(write) => write,
+        // The out-of-vable store recorded nothing, so there is no pre-store
+        // entry to roll back. Whether it should abort the trace is tracked
+        // separately.
+        VableArrayStore::OutOfVable => None,
+    };
     if index_value >= 0
         && let Some(frame) = current_inline_vable_target(ctx, vable)
     {
@@ -836,7 +843,7 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
         shadow.set_opref(index_value, value);
         shadow.set_concrete(code[op.pc + 1] as u16, index_value, concrete);
     }
-    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, write)?;
     // A Ref stored to the operand-stack region of the vable array is an
     // operand-stack push (`pyframe.pushvalue` lowers to
     // `setarrayitem_vable_r(locals_cells_stack_w, depth, w_obj)`). Retain the
@@ -908,7 +915,7 @@ pub(crate) fn arraylen_vable_via_metainterp<Sym: WalkSym>(
     let result = ctx
         .trace_ctx
         .vable_arraylen_vable(op.pc, vable, vable_struct_ptr, fdescr, adescr);
-    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before)?;
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, guards_before, None)?;
     let dst = code[op.pc + 6] as usize;
     let concrete_for_shadow = concrete_from_recorded_opref(ctx, result);
     write_int_reg(ctx, op.pc, dst, result, concrete_for_shadow)?;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -7177,15 +7177,29 @@ impl PyreJitState {
         concrete_nlocals(self.frame).unwrap_or(0)
     }
 
-    pub fn set_local_at(&mut self, idx: usize, value: PyObjectRef) -> bool {
+    /// Store one absolute slot of `locals_cells_stack_w` and re-arm the write
+    /// barrier, as `store_live_frame_array_slot` and `write_back_outer_locals`
+    /// do for the same array: the callers box Int/Float slots in a loop, so the
+    /// next iteration can allocate, and each minor consumes the array's
+    /// remembered-set entry.
+    fn set_array_slot_at(&mut self, abs: usize, value: PyObjectRef) -> bool {
+        let Some(frame) = self.frame_ptr() else {
+            return false;
+        };
         let Some(arr) = self.locals_cells_stack_array_mut() else {
             return false;
         };
-        let Some(slot) = arr.as_mut_slice().get_mut(idx) else {
+        let arr_ptr = arr as *mut pyre_object::FixedObjectArray;
+        let Some(slot) = arr.as_mut_slice().get_mut(abs) else {
             return false;
         };
         *slot = value;
+        frame_array_write_barrier(frame, arr_ptr);
         true
+    }
+
+    pub fn set_local_at(&mut self, idx: usize, value: PyObjectRef) -> bool {
+        self.set_array_slot_at(idx, value)
     }
 
     /// Read a stack value at stack-relative index `idx` (0-based from stack bottom).
@@ -7205,14 +7219,7 @@ impl PyreJitState {
     /// Set a stack value at stack-relative index `idx`.
     pub fn set_stack_at(&mut self, idx: usize, value: PyObjectRef) -> bool {
         let nlocals = self.local_count();
-        let Some(arr) = self.locals_cells_stack_array_mut() else {
-            return false;
-        };
-        let Some(slot) = arr.as_mut_slice().get_mut(nlocals + idx) else {
-            return false;
-        };
-        *slot = value;
-        true
+        self.set_array_slot_at(nlocals + idx, value)
     }
 
     // ── Heap accessors: single source of truth (RPython parity) ──


### PR DESCRIPTION
## Summary

- carry the virtualizable pre-store entry through the production full-body walker so guard resume snapshots see the state from before a setter executes
- stamp every guard emitted by one virtualizable opcode, including multi-frame captures, instead of only the most recent guard
- strengthen the standard-leg store assertions and document the lowering/seeding assumptions behind guard capture
- re-arm the frame array write barrier after `set_local_at` / `set_stack_at` stores

## Why

The production walker had retained two defects already fixed in the experimental dispatcher: a virtualizable setter could publish resume data containing its own post-store value, and an opcode that minted multiple guards could leave earlier guards pointing at unstamped resume frames. Separately, the frame restoration setters wrote boxed values into `locals_cells_stack_w` without re-arming its remembered-set barrier; boxing can allocate between looped stores and consume the prior remembered-set entry.

These changes preserve pre-operation resume semantics per guard and keep frame-array references visible to the collector throughout restoration.

## Validation

- `python3 scripts/extract-llbc.py majit-rlib pyre-object pyre-interpreter pyre-jit`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- before the rebase, the committed changes were also validated with:
  - `cargo check --workspace --all-targets`
  - `cargo test -p majit-metainterp`
  - `cargo test -p pyre-jit-trace`
  - synthetic suite: dynasm 402/402, cranelift 402/402, wasm 400/400


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved snapshot handling when multiple guards are generated by a single operation, helping each guard resume from the correct position.
  - Improved recovery and rollback behavior for virtualized array writes, including writes that fall outside the virtualized range.
  - Ensured local and stack updates consistently restore required tracking protections after changes.

- **Documentation**
  - Clarified virtualized array-store outcomes, rollback behavior, and error-handling expectations.

- **Refactor**
  - Exposed an additional tracing component for broader integration and tooling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->