### PR TITLE
cpyext: add initial PyPy-style extension support

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -314,8 +314,15 @@ jobs:
       # backend through `majit-metainterp/{dynasm,cranelift}`). Test EXECUTION is
       # cheap (~7s for the whole workspace); the cost this avoids is the second
       # backend's compile+link of those otherwise-identical harnesses.
+      #
+      # `cpyext` rides along here rather than in its own step. It is off by
+      # default (see pyre-interpreter's feature table), so its one test —
+      # pyrex's cpyext_smoke, which is backend-independent and compiles out
+      # off macOS/Linux — needs SOME leg that enables it, and this leg already
+      # recompiles the pyrex/pyre-interpreter stack under a second feature set.
+      # A dedicated step would compile that stack a third time instead.
       run: |
-        cargo test --no-default-features --features cranelift \
+        cargo test --no-default-features --features cranelift,cpyext \
           -p majit-metainterp -p majit-backend-cranelift \
           -p pyre-jit -p pyre-jit-trace -p pyrex -p pyre-interpreter -p majit \
           -p tlr -p tl -p tla -p tiny2 -p tiny3 -p tinyframe \

--- a/pyre/docs/cpyext.md
+++ b/pyre/docs/cpyext.md
@@ -6,6 +6,34 @@ Instead, a C extension sees a fixed-address, reference-counted mirror carrying
 an `ob_pyre_link` to the interpreter's GC object.  The interpreter's global GC
 root walker forwards that link while an external C reference owns it.
 
+## Build option
+
+Extension loading is behind the non-default `cpyext` cargo feature. The switch
+itself is upstream's: `has_so_extension` (`pypy/module/imp/importing.py:60`)
+reads `config.objspace.usemodules.cpyext` and gates `create_dynamic`
+(`pypy/module/imp/interp_imp.py:49-51`). Build it with
+
+```sh
+cargo build --release -p pyrex --bin pyre-dynasm \
+  --no-default-features --features dynasm,cpyext
+```
+
+The feature also decides whether `_imp.extension_suffixes()` answers with a
+suffix. **That part is a deliberate divergence**: upstream
+`extension_suffixes` (`pypy/module/imp/interp_imp.py:11-15`) answers
+unconditionally, so a `--withoutmod-cpyext` PyPy still names a suffix whose
+`create_dynamic` then raises. A suffix names a loader, so pyre keeps the two
+together — without the feature the import path advertises nothing it cannot
+load, which is also what pyre answered before extension loading existed.
+
+The consequence is why the feature is off rather than on:
+`importlib._bootstrap_external.EXTENSION_SUFFIXES` is that call's result, and
+`test_importlib/extension` skips its whole suite while the list is empty. A
+non-empty list un-skips 39 tests that load CPython's `_testsinglephase` and
+`_testmultiphase`; the ABI header below builds neither yet. Turn the feature on
+by default once slices 1–5 below land and both modules build (slice 6 is
+Windows packaging, which the os gates make irrelevant to the default).
+
 The initial macOS/Linux supported slice is deliberately narrow but end-to-end:
 
 - a pyre-specific Python 3.14 ABI header and extension suffix;

--- a/pyre/docs/cpyext.md
+++ b/pyre/docs/cpyext.md
@@ -1,0 +1,52 @@
+# cpyext in pyre
+
+Pyre follows PyPy's `pypy/module/cpyext` architecture.  It does not expose an
+internal pyre object as a CPython `PyObject *`: the two layouts are unrelated.
+Instead, a C extension sees a fixed-address, reference-counted mirror carrying
+an `ob_pyre_link` to the interpreter's GC object.  The interpreter's global GC
+root walker forwards that link while an external C reference owns it.
+
+The initial macOS/Linux supported slice is deliberately narrow but end-to-end:
+
+- a pyre-specific Python 3.14 ABI header and extension suffix;
+- `_imp.extension_suffixes()`, `_imp.create_dynamic()` and
+  `_imp.exec_dynamic()`;
+- `dlopen`/`dlsym` of `PyInit_<name>` with the library handle retained;
+- `PyModuleDef_Init` and single-phase `PyModule_Create2`;
+- PyPy-style path-to-module-dictionary extension caching;
+- GC forwarding for C mirror links and cached dictionaries.
+
+The loader serializes extension initialization in the current import path;
+the complete port must move that ownership into interpreter/execution-context
+state before subinterpreters or parallel no-GIL imports are enabled.
+
+This imports a single-phase, method-less, stateless `PyModuleDef` extension. A
+non-empty `PyMethodDef` table, module state/finalizer fields, and PEP 489 slots
+are rejected rather than silently ignored. The following slices remain, in
+upstream dependency order:
+
+1. execution-context-owned C exception indicator and `PyErr_*`;
+2. a dedicated `PyCFunction` carrier with `METH_NOARGS`, `METH_O`, then
+   `METH_VARARGS`/keywords;
+3. primitive object mirrors and APIs (`long`, Unicode, bytes, tuple/list);
+4. PEP 489 create/exec slots and module state;
+5. C-defined types, slots, buffers, capsules and the remaining generated API;
+6. Windows API DLL/import-library packaging.
+
+The public suffix uses `pyre314`, not `cpython-314`: accepting a CPython-tagged
+binary would falsely claim that CPython's private object layouts and symbols
+are ABI-compatible with pyre.
+
+## PyPy reference map
+
+- `pypy/module/cpyext/api.py`: API declaration/generation, C-call boundary,
+  extension loader and initialization checks.
+- `pypy/module/cpyext/pyobject.py`: raw mirror descriptors and W_Root ↔
+  `PyObject *` conversion.
+- `rpython/rlib/rawrefcount.py` and `pypy/doc/discussion/rawrefcount.rst`:
+  collector ownership and delayed deallocation.
+- `pypy/module/cpyext/state.py`: exception state, extension cache and GC dead
+  queue.
+- `pypy/module/cpyext/modsupport.py`: module definitions, method conversion and
+  PEP 489 slots.
+- `pypy/module/imp/interp_imp.py`: `_imp` entry points.

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -20,6 +20,21 @@ test-hooks = []
 # trampoline instead of the real syscall. Implies host_env (same call surface,
 # swapped bodies); the real-vs-trampoline choice lives only inside host_seam.
 sandbox = ["host_env", "dep:pyre-sandbox"]
+# Load C extension modules built against pyre's own ABI. The build-time switch
+# is upstream's: `has_so_extension` reads `config.objspace.usemodules.cpyext`
+# (imp/importing.py:60) and gates `create_dynamic` (imp/interp_imp.py:49-51).
+# Implies host_env — the loader is a host `dlopen` — and stays unavailable
+# under `sandbox`, which exists to keep the process off exactly those calls.
+#
+# It also gates `extension_suffixes`, which upstream answers unconditionally
+# (imp/interp_imp.py:11-15). Deliberate divergence: a suffix names a loader, so
+# without one nothing on the import path should advertise it. The consequence
+# is why the feature is off by default —
+# `importlib._bootstrap_external.EXTENSION_SUFFIXES` is that call's result, and
+# a non-empty list un-skips `test_importlib/extension`, whose tests load
+# CPython's `_testsinglephase` / `_testmultiphase`. The ABI header pyre ships
+# builds neither yet. See pyre/docs/cpyext.md.
+cpyext = ["host_env"]
 cranelift = ["majit-metainterp/cranelift"]
 dynasm = ["majit-metainterp/dynasm"]
 # Embed the pure-Python stdlib closure needed for `import re` into the binary

--- a/pyre/pyre-interpreter/include/pyre3.14/Python.h
+++ b/pyre/pyre-interpreter/include/pyre3.14/Python.h
@@ -1,0 +1,98 @@
+#ifndef PYRE_PYTHON_H
+#define PYRE_PYTHON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define PY_MAJOR_VERSION 3
+#define PY_MINOR_VERSION 14
+#define PY_VERSION_HEX 0x030E0000
+#define PYTHON_API_VERSION 1013
+
+#if defined(_WIN32)
+#  define PyAPI_FUNC(RTYPE) __declspec(dllimport) RTYPE
+#  define PyMODINIT_FUNC __declspec(dllexport) PyObject *
+#elif defined(__cplusplus)
+#  define PyAPI_FUNC(RTYPE) __attribute__((visibility("default"))) RTYPE
+#  define PyMODINIT_FUNC extern "C" __attribute__((visibility("default"))) PyObject *
+#else
+#  define PyAPI_FUNC(RTYPE) __attribute__((visibility("default"))) RTYPE
+#  define PyMODINIT_FUNC __attribute__((visibility("default"))) PyObject *
+#endif
+
+typedef intptr_t Py_ssize_t;
+typedef struct _typeobject PyTypeObject;
+typedef struct _object {
+    Py_ssize_t ob_refcnt;
+    Py_ssize_t ob_pyre_link;
+    PyTypeObject *ob_type;
+} PyObject;
+
+#define PyObject_HEAD PyObject ob_base;
+#define Py_REFCNT(ob) (((PyObject *)(ob))->ob_refcnt)
+#define Py_TYPE(ob) (((PyObject *)(ob))->ob_type)
+PyAPI_FUNC(void) Py_IncRef(PyObject *ob);
+PyAPI_FUNC(void) Py_DecRef(PyObject *ob);
+#define Py_INCREF(ob) Py_IncRef((PyObject *)(ob))
+#define Py_DECREF(ob) Py_DecRef((PyObject *)(ob))
+#define Py_XINCREF(ob) do { if ((ob) != NULL) Py_INCREF(ob); } while (0)
+#define Py_XDECREF(ob) do { if ((ob) != NULL) Py_DECREF(ob); } while (0)
+
+typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
+typedef int (*visitproc)(PyObject *, void *);
+typedef int (*traverseproc)(PyObject *, visitproc, void *);
+typedef int (*inquiry)(PyObject *);
+typedef void (*freefunc)(void *);
+typedef struct PyMethodDef {
+    const char *ml_name;
+    PyCFunction ml_meth;
+    int ml_flags;
+    const char *ml_doc;
+} PyMethodDef;
+
+#define METH_VARARGS 0x0001
+#define METH_KEYWORDS 0x0002
+#define METH_NOARGS 0x0004
+#define METH_O 0x0008
+
+typedef struct PyModuleDef_Base {
+    PyObject ob_base;
+    PyObject *(*m_init)(void);
+    Py_ssize_t m_index;
+    PyObject *m_copy;
+} PyModuleDef_Base;
+
+typedef struct PyModuleDef_Slot {
+    int slot;
+    void *value;
+} PyModuleDef_Slot;
+
+typedef struct PyModuleDef {
+    PyModuleDef_Base m_base;
+    const char *m_name;
+    const char *m_doc;
+    Py_ssize_t m_size;
+    PyMethodDef *m_methods;
+    PyModuleDef_Slot *m_slots;
+    traverseproc m_traverse;
+    inquiry m_clear;
+    freefunc m_free;
+} PyModuleDef;
+
+#define PyModuleDef_HEAD_INIT \
+    { { 1, 0, NULL }, NULL, 0, NULL }
+
+PyAPI_FUNC(PyObject *) PyModuleDef_Init(PyModuleDef *def);
+PyAPI_FUNC(PyObject *) PyModule_Create2(PyModuleDef *def, int api_version);
+#define PyModule_Create(module) PyModule_Create2((module), PYTHON_API_VERSION)
+
+#define PyDoc_STRVAR(name, str) static const char name[] = str
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/pyre/pyre-interpreter/src/cpyext.rs
+++ b/pyre/pyre-interpreter/src/cpyext.rs
@@ -6,7 +6,7 @@
 //! refcounted mirror (`cpyext/pyobject.py`) and links it to the moving GC object.
 
 #![cfg(all(
-    feature = "host_env",
+    feature = "cpyext",
     not(feature = "sandbox"),
     any(target_os = "macos", target_os = "linux")
 ))]

--- a/pyre/pyre-interpreter/src/cpyext.rs
+++ b/pyre/pyre-interpreter/src/cpyext.rs
@@ -1,0 +1,602 @@
+//! CPython C-API compatibility layer -- PyPy `pypy/module/cpyext/`.
+//!
+//! This first vertical slice implements the object bridge and the single-phase
+//! `PyModule_Create` import path.  The C-visible object is deliberately *not*
+//! pyre's internal [`pyre_object::PyObject`]: PyPy likewise uses a separate raw
+//! refcounted mirror (`cpyext/pyobject.py`) and links it to the moving GC object.
+
+#![cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+
+use parking_lot::ReentrantMutex;
+use pyre_object::{PY_NULL, PyObjectRef};
+use std::cell::UnsafeCell;
+use std::collections::HashMap;
+use std::ffi::{CStr, c_char, c_int, c_void};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
+use std::sync::{LazyLock, Mutex};
+
+/// The large ownership contribution held by the linked pyre object.
+///
+/// PyPy calls this `rawrefcount.REFCNT_FROM_PYPY`.  Ordinary C references are
+/// added above it by the public `Py_INCREF`/`Py_DECREF` inline functions.
+pub const REFCNT_FROM_PYRE: isize = 1 << (isize::BITS - 3);
+
+/// C-visible `PyObject`, matching PyPy's `parse/cpyext_object.h` shape.
+#[repr(C)]
+pub struct CPyObject {
+    pub ob_refcnt: isize,
+    pub ob_pyre_link: PyObjectRef,
+    pub ob_type: *mut CPyTypeObject,
+}
+
+/// Opaque in the initial public header.  A real mirror, rather than the
+/// internal RPython-vtable-like `pyre_object::PyType`, is nevertheless used so
+/// the two ABIs can never be confused accidentally.
+#[repr(C)]
+pub struct CPyTypeObject {
+    _opaque: usize,
+}
+
+// Process-global immortal type mirrors, matching PyPy's static API objects.
+static mut CPY_MODULE_TYPE: CPyTypeObject = CPyTypeObject { _opaque: 0 };
+static mut CPY_MODULE_DEF_TYPE: CPyTypeObject = CPyTypeObject { _opaque: 0 };
+static NEXT_MODULE_INDEX: AtomicIsize = AtomicIsize::new(1);
+
+#[repr(C)]
+pub struct CPyModuleDefBase {
+    pub ob_base: CPyObject,
+    pub m_init: Option<unsafe extern "C" fn() -> *mut CPyObject>,
+    pub m_index: isize,
+    pub m_copy: *mut CPyObject,
+}
+
+#[repr(C)]
+pub struct CPyMethodDef {
+    pub ml_name: *const c_char,
+    pub ml_meth: *const c_void,
+    pub ml_flags: c_int,
+    pub ml_doc: *const c_char,
+}
+
+#[repr(C)]
+pub struct CPyModuleDefSlot {
+    pub slot: c_int,
+    pub value: *mut c_void,
+}
+
+#[repr(C)]
+pub struct CPyModuleDef {
+    pub m_base: CPyModuleDefBase,
+    pub m_name: *const c_char,
+    pub m_doc: *const c_char,
+    pub m_size: isize,
+    pub m_methods: *mut CPyMethodDef,
+    pub m_slots: *mut CPyModuleDefSlot,
+    pub m_traverse: *const c_void,
+    pub m_clear: *const c_void,
+    pub m_free: *const c_void,
+}
+
+struct ExtensionCacheEntry {
+    /// Copy of the module dict, exactly PyPy `State.extensions[path]`.
+    dict: usize,
+    /// Keeps the library and its static module definition alive.
+    _handle: usize,
+}
+
+/// PyPy `State.extensions`: the upstream owner is a process/interpreter state
+/// dictionary, so a `HashMap` is intentional here rather than a side-table
+/// workaround.  The values are copied module dictionaries, not per-object
+/// optimization metadata.
+static EXTENSIONS: LazyLock<Mutex<HashMap<PathBuf, ExtensionCacheEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// PyPy/rawrefcount's P-list analogue.  The relationship itself lives on the
+/// raw object (`ob_pyre_link`); this Vec is only the collector's census of
+/// mirrors whose inline link must be visited.
+static RAW_OBJECTS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static CPYEXT_GC_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// `State.package_context`, consumed by `PyModule_Create2` while `PyInit_*`
+/// runs. Imports are serialized by the import lock, as in PyPy.
+static PACKAGE_CONTEXT: LazyLock<Mutex<Option<(String, PathBuf)>>> =
+    LazyLock::new(|| Mutex::new(None));
+
+/// PyPy performs cpyext initialization under the GIL. Pyre currently has no
+/// process GIL, so this reentrant boundary preserves the same serialization
+/// while still allowing an init function to import another extension.
+struct ForkExtensionLoadLock(UnsafeCell<ReentrantMutex<()>>);
+unsafe impl Sync for ForkExtensionLoadLock {}
+
+impl ForkExtensionLoadLock {
+    const fn new() -> Self {
+        Self(UnsafeCell::new(ReentrantMutex::new(())))
+    }
+
+    fn get(&self) -> &ReentrantMutex<()> {
+        unsafe { &*self.0.get() }
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        unsafe { self.0.get().write(ReentrantMutex::new(())) };
+    }
+}
+
+static EXTENSION_LOAD_LOCK: ForkExtensionLoadLock = ForkExtensionLoadLock::new();
+static DLOPEN_FLAGS: AtomicIsize = AtomicIsize::new((libc::RTLD_NOW | libc::RTLD_LOCAL) as isize);
+
+pub fn register_sys_dlopenflags(ns: PyObjectRef) {
+    crate::module_ns_store(
+        ns,
+        "getdlopenflags",
+        crate::make_builtin_function_with_arity(
+            "getdlopenflags",
+            |_| {
+                Ok(pyre_object::w_int_new(
+                    DLOPEN_FLAGS.load(Ordering::Relaxed) as i64
+                ))
+            },
+            0,
+        ),
+    );
+    crate::module_ns_store(
+        ns,
+        "setdlopenflags",
+        crate::make_builtin_function_with_arity(
+            "setdlopenflags",
+            |args| {
+                DLOPEN_FLAGS.store(
+                    crate::baseobjspace::gateway_int_w(args[0])? as isize,
+                    Ordering::Relaxed,
+                );
+                Ok(pyre_object::w_none())
+            },
+            1,
+        ),
+    );
+}
+
+type ExtensionLoadGuard = parking_lot::lock_api::ReentrantMutexGuard<
+    'static,
+    parking_lot::RawMutex,
+    parking_lot::RawThreadId,
+    (),
+>;
+
+#[majit_macros::dont_look_inside]
+fn extension_load_lock() -> ExtensionLoadGuard {
+    if let Some(guard) = EXTENSION_LOAD_LOCK.get().try_lock() {
+        return guard;
+    }
+    let blocked = crate::module::thread::before_external_block();
+    let guard = EXTENSION_LOAD_LOCK.get().lock();
+    drop(blocked);
+    guard
+}
+
+pub fn after_fork_child() {
+    unsafe { EXTENSION_LOAD_LOCK.reinit_after_fork() };
+    *PACKAGE_CONTEXT.lock().unwrap() = None;
+}
+
+pub const fn soabi() -> &'static str {
+    if cfg!(target_os = "macos") {
+        "pyre314-darwin"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "pyre314-x86_64-linux-gnu"
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        "pyre314-aarch64-linux-gnu"
+    } else {
+        "pyre314-linux-gnu"
+    }
+}
+
+pub const fn extension_suffix() -> &'static str {
+    if cfg!(target_os = "macos") {
+        ".pyre314-darwin.so"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        ".pyre314-x86_64-linux-gnu.so"
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        ".pyre314-aarch64-linux-gnu.so"
+    } else {
+        ".pyre314-linux-gnu.so"
+    }
+}
+
+fn attach_module(module: PyObjectRef) -> *mut CPyObject {
+    let raw = Box::into_raw(Box::new(CPyObject {
+        // New reference returned by PyModule_Create, plus PyPy's link share.
+        ob_refcnt: REFCNT_FROM_PYRE + 1,
+        ob_pyre_link: module,
+        ob_type: (&raw mut CPY_MODULE_TYPE),
+    }));
+    RAW_OBJECTS.lock().unwrap().push(raw as usize);
+    CPYEXT_GC_ACTIVE.store(true, Ordering::Release);
+    raw
+}
+
+unsafe fn detach_unowned_module_mirror(raw: *mut CPyObject) {
+    if raw.is_null()
+        || unsafe { (*raw).ob_refcnt != REFCNT_FROM_PYRE }
+        || unsafe { !std::ptr::eq((*raw).ob_type, &raw mut CPY_MODULE_TYPE) }
+    {
+        return;
+    }
+    let address = raw as usize;
+    RAW_OBJECTS
+        .lock()
+        .unwrap()
+        .retain(|&candidate| candidate != address);
+    unsafe {
+        (*raw).ob_pyre_link = PY_NULL;
+        (*raw).ob_refcnt -= REFCNT_FROM_PYRE;
+        drop(Box::from_raw(raw));
+    }
+}
+
+/// Forward/mark C-mirror links and cached module dictionaries.
+///
+/// External C ownership (`refcnt > REFCNT_FROM_PYRE`) keeps the linked object
+/// alive, which is the essential P-link rule from `rawrefcount.rst`. Cached
+/// dicts are interpreter-state roots just like PyPy's `State.extensions`.
+pub fn walk_gc_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
+    if !CPYEXT_GC_ACTIVE.load(Ordering::Acquire) {
+        return;
+    }
+    for &address in RAW_OBJECTS.lock().unwrap().iter() {
+        let raw = address as *mut CPyObject;
+        unsafe {
+            if (*raw).ob_refcnt > REFCNT_FROM_PYRE && !(*raw).ob_pyre_link.is_null() {
+                visitor(&mut (*raw).ob_pyre_link);
+            }
+        }
+    }
+    for entry in EXTENSIONS.lock().unwrap().values_mut() {
+        let mut dict = entry.dict as PyObjectRef;
+        if !dict.is_null() {
+            visitor(&mut dict);
+            entry.dict = dict as usize;
+        }
+    }
+}
+
+fn module_from_cached_dict(name: &str, dict: PyObjectRef) -> PyObjectRef {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(dict);
+    let module = pyre_object::w_module_new_managed(name);
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(module);
+    let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+    let module_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    crate::type_methods::dict_update1(
+        module_dict,
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+    )
+    .expect("cpyext cached module dictionaries are ordinary dicts");
+    pyre_object::gc_roots::shadow_stack_get(module_slot)
+}
+
+fn cached_extension(name: &str, path: &Path) -> Option<PyObjectRef> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = {
+        let cache = EXTENSIONS.lock().unwrap();
+        let dict = cache.get(path)?.dict as PyObjectRef;
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        roots.pin_root(dict);
+        slot
+    };
+    Some(module_from_cached_dict(
+        name,
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+    ))
+}
+
+fn cached_extension_handle(path: &Path) -> Option<usize> {
+    EXTENSIONS
+        .lock()
+        .unwrap()
+        .get(path)
+        .map(|entry| entry._handle)
+}
+
+fn fixup_extension(module: PyObjectRef, name: &str, path: &Path, handle: usize) {
+    let roots = pyre_object::gc_roots::push_roots();
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(module);
+    crate::importing::set_sys_module(name, module);
+    let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+    let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+    let dict_copy = unsafe { pyre_object::dictmultiobject::w_dict_copy(dict) };
+    EXTENSIONS.lock().unwrap().insert(
+        path.to_path_buf(),
+        ExtensionCacheEntry {
+            dict: dict_copy as usize,
+            _handle: handle,
+        },
+    );
+    CPYEXT_GC_ACTIVE.store(true, Ordering::Release);
+}
+
+fn init_symbol(name: &str) -> Result<String, crate::PyError> {
+    let basename = name.rsplit('.').next().unwrap_or(name);
+    if !basename.is_ascii() {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::ImportError,
+            format!("non-ASCII cpyext init names are not implemented yet: {basename}"),
+        ));
+    }
+    Ok(format!("PyInit_{basename}"))
+}
+
+fn extension_import_error(message: String, name: &str, path: &Path) -> crate::PyError {
+    let roots = pyre_object::gc_roots::push_roots();
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(pyre_object::w_str_new(name));
+    let path_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(crate::gateway::fsdecode_os_str(path.as_os_str()));
+    crate::PyError::import_error_name_path(
+        message,
+        pyre_object::gc_roots::shadow_stack_get(name_slot),
+        pyre_object::gc_roots::shadow_stack_get(path_slot),
+    )
+}
+
+/// PyPy `cpyext.api.create_extension_module`, single-phase branch.
+pub fn load_extension_module(name: &str, path: &Path) -> Result<PyObjectRef, crate::PyError> {
+    let _load_guard = extension_load_lock();
+    ensure_linked();
+    // `host_env::ctypes` deduplicates libraries by the native handle without
+    // maintaining an open count. A second open followed by drop would unload
+    // the one library owned by `EXTENSIONS`, so resolve PyPy's cache before
+    // opening on this host abstraction.
+    if let Some(handle) = cached_extension_handle(path) {
+        let symbol = init_symbol(name)?;
+        rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol.as_bytes())
+            .map_err(|_error| {
+                extension_import_error(
+                    format!(
+                        "function {symbol} not found in library '{}'",
+                        path.display()
+                    ),
+                    name,
+                    path,
+                )
+            })?;
+        if let Some(module) = cached_extension(name, path) {
+            let roots = pyre_object::gc_roots::push_roots();
+            let module_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(module);
+            crate::importing::set_sys_module(
+                name,
+                pyre_object::gc_roots::shadow_stack_get(module_slot),
+            );
+            return Ok(pyre_object::gc_roots::shadow_stack_get(module_slot));
+        }
+    }
+    let mut mode = DLOPEN_FLAGS.load(Ordering::Relaxed) as c_int;
+    if mode & (libc::RTLD_LAZY | libc::RTLD_NOW) == 0 {
+        mode |= libc::RTLD_NOW;
+    }
+    let handle =
+        rustpython_host_env::ctypes::open_library_with_mode(path, mode).map_err(|error| {
+            extension_import_error(
+                format!("cannot load extension '{}': {error}", path.display()),
+                name,
+                path,
+            )
+        })?;
+
+    let symbol = match init_symbol(name) {
+        Ok(symbol) => symbol,
+        Err(error) => {
+            rustpython_host_env::ctypes::drop_library(handle);
+            return Err(error);
+        }
+    };
+    let address =
+        rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol.as_bytes())
+            .map_err(|_error| {
+                rustpython_host_env::ctypes::drop_library(handle);
+                extension_import_error(
+                    format!(
+                        "function {symbol} not found in library '{}'",
+                        path.display()
+                    ),
+                    name,
+                    path,
+                )
+            })?;
+
+    let old_context = PACKAGE_CONTEXT
+        .lock()
+        .unwrap()
+        .replace((name.to_string(), path.to_path_buf()));
+    let init: unsafe extern "C" fn() -> *mut CPyObject = unsafe { std::mem::transmute(address) };
+    let result = unsafe { init() };
+    *PACKAGE_CONTEXT.lock().unwrap() = old_context;
+
+    if result.is_null() {
+        rustpython_host_env::ctypes::drop_library(handle);
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!("initialization of {name} failed without raising an exception"),
+        ));
+    }
+    let module = unsafe { (*result).ob_pyre_link };
+    if unsafe { (*result).ob_type.is_null() } {
+        rustpython_host_env::ctypes::drop_library(handle);
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!("init function of {name} returned an uninitialized object"),
+        ));
+    }
+    if module.is_null() {
+        rustpython_host_env::ctypes::drop_library(handle);
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!("init function of {name} returned an unsupported object"),
+        ));
+    }
+    unsafe {
+        // Transfer the init function's owned result to the interpreter object,
+        // exactly `get_w_obj_and_decref` in PyPy.
+        (*result).ob_refcnt -= 1;
+        detach_unowned_module_mirror(result);
+    }
+    fixup_extension(module, name, path, handle);
+    Ok(module)
+}
+
+pub fn create_dynamic(spec: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let spec_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(spec);
+    let w_name = crate::baseobjspace::getattr_str(
+        pyre_object::gc_roots::shadow_stack_get(spec_slot),
+        "name",
+    )?;
+    let name_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(w_name);
+    let w_origin = crate::baseobjspace::getattr_str(
+        pyre_object::gc_roots::shadow_stack_get(spec_slot),
+        "origin",
+    )?;
+    let origin_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(w_origin);
+    let name =
+        crate::baseobjspace::text0_wtf8_w(pyre_object::gc_roots::shadow_stack_get(name_slot))?
+            .to_string();
+    crate::baseobjspace::text0_wtf8_w(pyre_object::gc_roots::shadow_stack_get(origin_slot))?;
+    let path = PathBuf::from(crate::gateway::os_string_from_fs_bytes(
+        &crate::gateway::fsencode(pyre_object::gc_roots::shadow_stack_get(origin_slot))?,
+    ));
+    let path = if path.components().count() == 1 {
+        PathBuf::from(".").join(path)
+    } else {
+        path
+    };
+    load_extension_module(&name, &path)
+}
+
+/// `PyModuleDef_Init` -- also the marker returned by PEP 489 init functions.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyModuleDef_Init(def: *mut CPyModuleDef) -> *mut CPyObject {
+    if def.is_null() {
+        return std::ptr::null_mut();
+    }
+    unsafe {
+        if (*def).m_base.m_index == 0 {
+            (*def).m_base.ob_base.ob_refcnt = 1;
+            (*def).m_base.ob_base.ob_pyre_link = PY_NULL;
+            (*def).m_base.ob_base.ob_type = &raw mut CPY_MODULE_DEF_TYPE;
+            (*def).m_base.m_index = NEXT_MODULE_INDEX.fetch_add(1, Ordering::Relaxed);
+        }
+        &mut (*def).m_base.ob_base
+    }
+}
+
+/// `PyModule_Create2` -- PyPy `modsupport.py:PyModule_Create2`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyModule_Create2(
+    def: *mut CPyModuleDef,
+    _api_version: c_int,
+) -> *mut CPyObject {
+    if def.is_null() || unsafe { (*def).m_name.is_null() } {
+        return std::ptr::null_mut();
+    }
+    // Method conversion is the next cpyext slice. Reject rather than silently
+    // constructing a module that drops a non-empty PyMethodDef table.
+    if unsafe { !(*def).m_methods.is_null() && !(*(*def).m_methods).ml_name.is_null() } {
+        return std::ptr::null_mut();
+    }
+    if unsafe {
+        !(*def).m_slots.is_null()
+            || (*def).m_size != -1
+            || !(*def).m_traverse.is_null()
+            || !(*def).m_clear.is_null()
+            || !(*def).m_free.is_null()
+    } {
+        return std::ptr::null_mut();
+    }
+
+    let declared_name = unsafe { CStr::from_ptr((*def).m_name) }.to_string_lossy();
+    // PyPy `PyModule_Create2` consumes package_context before allocating the
+    // module. Releasing the mutex here also avoids holding it across GC.
+    let context = PACKAGE_CONTEXT.lock().unwrap().take();
+    let (name, path) = context
+        .as_ref()
+        .map(|(name, path)| (name.as_str(), Some(path.as_path())))
+        .unwrap_or((&declared_name, None));
+    let module = pyre_object::w_module_new_managed(name);
+    let roots = pyre_object::gc_roots::push_roots();
+    let module_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(module);
+
+    if unsafe { !(*def).m_doc.is_null() } {
+        let doc = unsafe { CStr::from_ptr((*def).m_doc) }.to_string_lossy();
+        if !doc.is_empty() {
+            let value = pyre_object::w_str_new(&doc);
+            let value_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(value);
+            let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+            crate::module_ns_store(
+                unsafe { pyre_object::w_module_get_w_dict(module) },
+                "__doc__",
+                pyre_object::gc_roots::shadow_stack_get(value_slot),
+            );
+        }
+    }
+    if let Some(path) = path {
+        let value = crate::gateway::fsdecode_os_str(path.as_os_str());
+        let value_slot = pyre_object::gc_roots::shadow_stack_len();
+        roots.pin_root(value);
+        let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+        crate::module_ns_store(
+            unsafe { pyre_object::w_module_get_w_dict(module) },
+            "__file__",
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
+        );
+    }
+    attach_module(pyre_object::gc_roots::shadow_stack_get(module_slot))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_IncRef(object: *mut CPyObject) {
+    if !object.is_null() {
+        unsafe { (*object).ob_refcnt += 1 };
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Py_DecRef(object: *mut CPyObject) {
+    if object.is_null() {
+        return;
+    }
+    unsafe { (*object).ob_refcnt -= 1 };
+    if unsafe { (*object).ob_refcnt } == REFCNT_FROM_PYRE {
+        unsafe { detach_unowned_module_mirror(object) };
+        return;
+    }
+    if unsafe { (*object).ob_refcnt } != 0 {
+        return;
+    }
+    // Type-specific `_Py_Dealloc` is introduced with C-defined types. The
+    // first slice never exposes a heap mirror whose zero path is not handled
+    // by `detach_unowned_module_mirror` above.
+}
+
+/// Force the linker to retain the public C entry points in every native pyre
+/// executable. `pyrex/build.rs` additionally exports these names from the main
+/// program so a bundle/shared object can resolve them at `dlopen` time.
+pub fn ensure_linked() {
+    std::hint::black_box(PyModuleDef_Init as *const ());
+    std::hint::black_box(PyModule_Create2 as *const ());
+    std::hint::black_box(Py_IncRef as *const ());
+    std::hint::black_box(Py_DecRef as *const ());
+}

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1166,6 +1166,17 @@ pub unsafe fn walk_pyframe_roots_area(
 /// faulthandler's — so it registers once for the process.
 fn walk_interpreter_global_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     walk_global_prebuilt_roots(visitor);
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    {
+        let mut forward = |slot: &mut PyObjectRef| {
+            visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef) });
+        };
+        crate::cpyext::walk_gc_roots(&mut forward);
+    }
     crate::executioncontext::walk_space_user_del_action_roots(visitor);
     crate::module::gc::hook::walk_hook_roots(visitor);
     crate::module::thread::walk_thread_roots(visitor);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1167,7 +1167,7 @@ pub unsafe fn walk_pyframe_roots_area(
 fn walk_interpreter_global_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     walk_global_prebuilt_roots(visitor);
     #[cfg(all(
-        feature = "host_env",
+        feature = "cpyext",
         not(feature = "sandbox"),
         any(target_os = "macos", target_os = "linux")
     ))]

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -858,7 +858,9 @@ fn init_string_module(ns: PyObjectRef) {
 /// first `get_config_var` call rather than the `None` the `.get()` readers
 /// take. Both are 0 here — pyre is neither build, which is what an empty
 /// `sys.abiflags` already says. `EXT_SUFFIX` and `SOABI` name pyre's own
-/// cpyext ABI (never CPython's ABI tag), matching `_imp.extension_suffixes()`.
+/// cpyext ABI (never CPython's ABI tag) and track `_imp.extension_suffixes()`:
+/// a `cpyext` build names one, and without the feature there is no extension
+/// ABI to name, so both keys stay absent for the `.get()` readers.
 fn init_sysconfig_stub(ns: PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -874,7 +876,7 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
                     );
                 }
                 #[cfg(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 ))]
@@ -2048,14 +2050,14 @@ enum FindInfo {
     SourceFile { pathname: PathBuf },
     /// A pyre-ABI C extension was found.
     #[cfg(all(
-        feature = "host_env",
+        feature = "cpyext",
         not(feature = "sandbox"),
         any(target_os = "macos", target_os = "linux")
     ))]
     ExtensionFile { pathname: PathBuf },
     /// A package whose initializer is a pyre-ABI C extension.
     #[cfg(all(
-        feature = "host_env",
+        feature = "cpyext",
         not(feature = "sandbox"),
         any(target_os = "macos", target_os = "linux")
     ))]
@@ -2161,6 +2163,7 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
         // Check for package: <dir>/<partname>/__init__.py
         let pkg_dir = dir.join(partname);
         #[cfg(all(
+            feature = "cpyext",
             not(feature = "sandbox"),
             any(target_os = "macos", target_os = "linux")
         ))]
@@ -2183,6 +2186,7 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
         // accepted: advertising CPython's tag would falsely promise its object
         // layout ABI.
         #[cfg(all(
+            feature = "cpyext",
             not(feature = "sandbox"),
             any(target_os = "macos", target_os = "linux")
         ))]
@@ -3021,7 +3025,7 @@ fn load_part(
 
     let module = match info {
         #[cfg(all(
-            feature = "host_env",
+            feature = "cpyext",
             not(feature = "sandbox"),
             any(target_os = "macos", target_os = "linux")
         ))]
@@ -3029,7 +3033,7 @@ fn load_part(
             crate::cpyext::load_extension_module(modulename, &pathname)?
         }
         #[cfg(all(
-            feature = "host_env",
+            feature = "cpyext",
             not(feature = "sandbox"),
             any(target_os = "macos", target_os = "linux")
         ))]

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -857,9 +857,8 @@ fn init_string_module(ns: PyObjectRef) {
 /// spell `ABIFLAGS`, so on Windows a missing key is a `KeyError` out of the
 /// first `get_config_var` call rather than the `None` the `.get()` readers
 /// take. Both are 0 here — pyre is neither build, which is what an empty
-/// `sys.abiflags` already says. The other two keys `config_vars` carries,
-/// `EXT_SUFFIX` and `SOABI`, name an extension ABI; `_imp.extension_suffixes()`
-/// is empty, so there is none to name and they stay absent for `.get()`.
+/// `sys.abiflags` already says. `EXT_SUFFIX` and `SOABI` name pyre's own
+/// cpyext ABI (never CPython's ABI tag), matching `_imp.extension_suffixes()`.
 fn init_sysconfig_stub(ns: PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -872,6 +871,23 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
                         vars,
                         pyre_object::w_str_new(name),
                         pyre_object::w_int_new(0),
+                    );
+                }
+                #[cfg(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                ))]
+                {
+                    pyre_object::w_dict_store(
+                        vars,
+                        pyre_object::w_str_new("SOABI"),
+                        pyre_object::w_str_new(crate::cpyext::soabi()),
+                    );
+                    pyre_object::w_dict_store(
+                        vars,
+                        pyre_object::w_str_new("EXT_SUFFIX"),
+                        pyre_object::w_str_new(crate::cpyext::extension_suffix()),
                     );
                 }
             }
@@ -2030,6 +2046,20 @@ enum FindInfo {
     /// A .py source file was found.
     #[cfg(feature = "host_env")]
     SourceFile { pathname: PathBuf },
+    /// A pyre-ABI C extension was found.
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    ExtensionFile { pathname: PathBuf },
+    /// A package whose initializer is a pyre-ABI C extension.
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    ExtensionPackage { dirpath: PathBuf, pathname: PathBuf },
     /// A package directory with __init__.py was found.
     #[cfg(feature = "host_env")]
     Package { dirpath: PathBuf },
@@ -2130,9 +2160,39 @@ fn find_in_dirs(partname: &str, dirs: &[PathBuf]) -> Option<FindInfo> {
     for dir in dirs {
         // Check for package: <dir>/<partname>/__init__.py
         let pkg_dir = dir.join(partname);
+        #[cfg(all(
+            not(feature = "sandbox"),
+            any(target_os = "macos", target_os = "linux")
+        ))]
+        {
+            let init_extension =
+                pkg_dir.join(format!("__init__{}", crate::cpyext::extension_suffix()));
+            if with_source_provider(|p| p.is_file(&init_extension)) {
+                return Some(FindInfo::ExtensionPackage {
+                    dirpath: pkg_dir,
+                    pathname: init_extension,
+                });
+            }
+        }
         let init_file = pkg_dir.join("__init__.py");
         if with_source_provider(|p| p.is_file(&init_file)) {
             return Some(FindInfo::Package { dirpath: pkg_dir });
+        }
+
+        // FileFinder probes packages before files. Only pyre's own suffix is
+        // accepted: advertising CPython's tag would falsely promise its object
+        // layout ABI.
+        #[cfg(all(
+            not(feature = "sandbox"),
+            any(target_os = "macos", target_os = "linux")
+        ))]
+        {
+            let extension = dir.join(format!("{partname}{}", crate::cpyext::extension_suffix()));
+            if with_source_provider(|p| p.is_file(&extension)) {
+                return Some(FindInfo::ExtensionFile {
+                    pathname: extension,
+                });
+            }
         }
 
         // Check for source file: <dir>/<partname>.py
@@ -2960,6 +3020,37 @@ fn load_part(
     };
 
     let module = match info {
+        #[cfg(all(
+            feature = "host_env",
+            not(feature = "sandbox"),
+            any(target_os = "macos", target_os = "linux")
+        ))]
+        FindInfo::ExtensionFile { pathname } => {
+            crate::cpyext::load_extension_module(modulename, &pathname)?
+        }
+        #[cfg(all(
+            feature = "host_env",
+            not(feature = "sandbox"),
+            any(target_os = "macos", target_os = "linux")
+        ))]
+        FindInfo::ExtensionPackage { dirpath, pathname } => {
+            let module = crate::cpyext::load_extension_module(modulename, &pathname)?;
+            let roots = pyre_object::gc_roots::push_roots();
+            let module_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(module);
+            let path = crate::gateway::fsdecode_os_str(dirpath.as_os_str());
+            let path_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(path);
+            let path_list =
+                pyre_object::w_list_new(vec![pyre_object::gc_roots::shadow_stack_get(path_slot)]);
+            let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
+            crate::module_ns_store(
+                unsafe { pyre_object::w_module_get_w_dict(module) },
+                "__path__",
+                path_list,
+            );
+            module
+        }
         #[cfg(feature = "host_env")]
         FindInfo::SourceFile { pathname } => {
             match load_source_module(modulename, &pathname, None, execution_context) {

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -65,7 +65,7 @@ pub mod astcompiler;
 pub mod baseobjspace;
 pub mod builtins;
 #[cfg(all(
-    feature = "host_env",
+    feature = "cpyext",
     not(feature = "sandbox"),
     any(target_os = "macos", target_os = "linux")
 ))]

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -64,6 +64,12 @@ pub mod argument;
 pub mod astcompiler;
 pub mod baseobjspace;
 pub mod builtins;
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+pub mod cpyext;
 pub mod display;
 pub mod error;
 pub mod executioncontext;

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1102,20 +1102,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "exec_dynamic",
         crate::make_builtin_function_with_arity(
             "exec_dynamic",
-            |_| Ok(pyre_object::w_int_new(0)),
+            |_| Ok(pyre_object::w_none()),
             1,
         ),
     );
     crate::module_ns_store(
         ns,
         "create_dynamic",
-        // interp_imp.py:49 create_dynamic — no C-extension support, the
-        // `has_so_extension() == False` branch. The spec's `name` and `origin`
-        // are read and rejected for an embedded null before reporting the
-        // unsupported load, matching `_imp_create_dynamic_impl`. Raising
-        // ImportError (rather than being absent) matches the meta-path
-        // `hasattr` probe while still letting `except ImportError` fall back to
-        // a pure-Python module.
         crate::make_builtin_function_with_arity(
             "create_dynamic",
             |args| {
@@ -1124,14 +1117,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "create_dynamic() missing required argument 'spec'",
                     ));
                 };
-                crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(spec, "name")?)?;
-                crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(
-                    spec, "origin",
-                )?)?;
-                Err(crate::PyError::new(
-                    crate::PyErrorKind::ImportError,
-                    "Not implemented".to_string(),
-                ))
+                #[cfg(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                ))]
+                {
+                    return crate::cpyext::create_dynamic(spec);
+                }
+                #[cfg(not(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                )))]
+                {
+                    crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(
+                        spec, "name",
+                    )?)?;
+                    crate::baseobjspace::text0_wtf8_w(crate::baseobjspace::getattr_str(
+                        spec, "origin",
+                    )?)?;
+                    Err(crate::PyError::new(
+                        crate::PyErrorKind::ImportError,
+                        "Not implemented".to_string(),
+                    ))
+                }
             },
             1,
         ),
@@ -1202,7 +1212,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "extension_suffixes",
         crate::make_builtin_function_with_arity(
             "extension_suffixes",
-            |_| Ok(pyre_object::w_list_new(vec![])),
+            |_| {
+                #[cfg(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                ))]
+                {
+                    return Ok(pyre_object::w_list_new(vec![pyre_object::w_str_new(
+                        crate::cpyext::extension_suffix(),
+                    )]));
+                }
+                #[cfg(not(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                )))]
+                {
+                    Ok(pyre_object::w_list_new(vec![]))
+                }
+            },
             0,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1109,6 +1109,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "create_dynamic",
+        // interp_imp.py:49 create_dynamic. Without the `cpyext` feature this is
+        // the `has_so_extension() == False` branch, which is the default build:
+        // the spec's `name` and `origin` are read and rejected for an embedded
+        // null before reporting the unsupported load, matching
+        // `_imp_create_dynamic_impl`. Raising ImportError (rather than being
+        // absent) matches the meta-path `hasattr` probe while still letting
+        // `except ImportError` fall back to a pure-Python module.
         crate::make_builtin_function_with_arity(
             "create_dynamic",
             |args| {
@@ -1118,7 +1125,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ));
                 };
                 #[cfg(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 ))]
@@ -1126,7 +1133,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     return crate::cpyext::create_dynamic(spec);
                 }
                 #[cfg(not(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 )))]
@@ -1214,7 +1221,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "extension_suffixes",
             |_| {
                 #[cfg(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 ))]
@@ -1224,7 +1231,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     )]));
                 }
                 #[cfg(not(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 )))]

--- a/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
+++ b/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
@@ -109,7 +109,7 @@ pub fn register_machinery(ns: pyre_object::PyObjectRef) {
         "EXTENSION_SUFFIXES",
         pyre_object::w_list_new({
             #[cfg(all(
-                feature = "host_env",
+                feature = "cpyext",
                 not(feature = "sandbox"),
                 any(target_os = "macos", target_os = "linux")
             ))]
@@ -117,7 +117,7 @@ pub fn register_machinery(ns: pyre_object::PyObjectRef) {
                 vec![pyre_object::w_str_new(crate::cpyext::extension_suffix())]
             }
             #[cfg(not(all(
-                feature = "host_env",
+                feature = "cpyext",
                 not(feature = "sandbox"),
                 any(target_os = "macos", target_os = "linux")
             )))]
@@ -147,7 +147,7 @@ pub fn register_machinery(ns: pyre_object::PyObjectRef) {
                     pyre_object::w_str_new(".pyc"),
                 ];
                 #[cfg(all(
-                    feature = "host_env",
+                    feature = "cpyext",
                     not(feature = "sandbox"),
                     any(target_os = "macos", target_os = "linux")
                 ))]

--- a/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
+++ b/pyre/pyre-interpreter/src/module/importlib/interp_importlib.rs
@@ -107,7 +107,24 @@ pub fn register_machinery(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
         "EXTENSION_SUFFIXES",
-        pyre_object::w_list_new(vec![pyre_object::w_str_new(".so")]),
+        pyre_object::w_list_new({
+            #[cfg(all(
+                feature = "host_env",
+                not(feature = "sandbox"),
+                any(target_os = "macos", target_os = "linux")
+            ))]
+            {
+                vec![pyre_object::w_str_new(crate::cpyext::extension_suffix())]
+            }
+            #[cfg(not(all(
+                feature = "host_env",
+                not(feature = "sandbox"),
+                any(target_os = "macos", target_os = "linux")
+            )))]
+            {
+                vec![]
+            }
+        }),
     );
     crate::module_ns_store(
         ns,
@@ -125,11 +142,17 @@ pub fn register_machinery(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "all_suffixes",
             |_| {
-                Ok(pyre_object::w_list_new(vec![
+                let mut suffixes = vec![
                     pyre_object::w_str_new(".py"),
                     pyre_object::w_str_new(".pyc"),
-                    pyre_object::w_str_new(".so"),
-                ]))
+                ];
+                #[cfg(all(
+                    feature = "host_env",
+                    not(feature = "sandbox"),
+                    any(target_os = "macos", target_os = "linux")
+                ))]
+                suffixes.push(pyre_object::w_str_new(crate::cpyext::extension_suffix()));
+                Ok(pyre_object::w_list_new(suffixes))
             },
             0,
         ),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1139,7 +1139,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "maxsize", w_int_new(i64::MAX));
     module_ns_store(ns, "maxunicode", w_int_new(0x10FFFF));
     #[cfg(all(
-        feature = "host_env",
+        feature = "cpyext",
         not(feature = "sandbox"),
         any(target_os = "macos", target_os = "linux")
     ))]

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1138,6 +1138,12 @@ pub fn exc_info_direct() -> PyObjectRef {
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "maxsize", w_int_new(i64::MAX));
     module_ns_store(ns, "maxunicode", w_int_new(0x10FFFF));
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    crate::cpyext::register_sys_dlopenflags(ns);
     module_ns_store(
         ns,
         "orig_argv",

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -442,6 +442,12 @@ pub(crate) fn after_fork_child() {
     crate::objspace::std::mapdict::after_fork_child();
     pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
     crate::module::_collections::deque_locks_after_fork_child();
+    #[cfg(all(
+        feature = "host_env",
+        not(feature = "sandbox"),
+        any(target_os = "macos", target_os = "linux")
+    ))]
+    crate::cpyext::after_fork_child();
     majit_gc::shadow_stack::after_fork_child();
     majit_gc::gc_sync::after_fork_child();
 }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -443,7 +443,7 @@ pub(crate) fn after_fork_child() {
     pyre_object::dictmultiobject::module_dict_locks_after_fork_child();
     crate::module::_collections::deque_locks_after_fork_child();
     #[cfg(all(
-        feature = "host_env",
+        feature = "cpyext",
         not(feature = "sandbox"),
         any(target_os = "macos", target_os = "linux")
     ))]

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -41,6 +41,10 @@ mimalloc = ["dep:mimalloc"]
 # Build the interpreter as an RPython-style sandbox client: every mediated OS
 # call routes through host_seam's marshalling trampoline (see pyre-interpreter).
 sandbox = ["pyre-interpreter/sandbox", "pyre-jit/sandbox"]
+# Load C extension modules built against pyre's own ABI (see pyre-interpreter).
+# Off by default; it also exports the C-API entry points the loaded object
+# resolves against, see build.rs.
+cpyext = ["pyre-interpreter/cpyext"]
 # Backwards-compatible alias. The seccomp-bpf syscall allowlist is now installed
 # by default in any Linux `sandbox` build (see the install site in lib.rs and
 # pyre-sandbox::seccomp), so this adds nothing over `sandbox`; it is retained so

--- a/pyre/pyrex/build.rs
+++ b/pyre/pyrex/build.rs
@@ -5,7 +5,11 @@ fn main() {
         "PyGILState_Ensure",
         "PyGILState_Release",
     ];
-    if std::env::var_os("CARGO_FEATURE_SANDBOX").is_none()
+    // The C-API entry points a loaded extension resolves against. They exist
+    // only in a `cpyext` build, and the same predicate gates the loader itself
+    // (see pyre-interpreter's `cpyext` feature).
+    if std::env::var_os("CARGO_FEATURE_CPYEXT").is_some()
+        && std::env::var_os("CARGO_FEATURE_SANDBOX").is_none()
         && matches!(target.as_str(), "macos" | "linux")
     {
         symbols.extend([

--- a/pyre/pyrex/build.rs
+++ b/pyre/pyrex/build.rs
@@ -1,10 +1,21 @@
 fn main() {
     let target = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    for symbol in [
+    let mut symbols = vec![
         "PyThreadState_SetAsyncExc",
         "PyGILState_Ensure",
         "PyGILState_Release",
-    ] {
+    ];
+    if std::env::var_os("CARGO_FEATURE_SANDBOX").is_none()
+        && matches!(target.as_str(), "macos" | "linux")
+    {
+        symbols.extend([
+            "PyModuleDef_Init",
+            "PyModule_Create2",
+            "Py_IncRef",
+            "Py_DecRef",
+        ]);
+    }
+    for symbol in symbols {
         match target.as_str() {
             "macos" => println!(
                 "cargo::rustc-link-arg-bins=-Wl,-exported_symbol,_{}",

--- a/pyre/pyrex/tests/cpyext_smoke.rs
+++ b/pyre/pyrex/tests/cpyext_smoke.rs
@@ -1,0 +1,149 @@
+//! End-to-end check for the first PyPy-cpyext vertical slice.
+//!
+//! The fixture is compiled against pyre's own 3.14 ABI header, discovered by
+//! the normal import path, loaded through `PyInit_*`, and created by the C call
+//! back into the executable's exported `PyModule_Create2`.
+
+#![cfg(all(
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn repo_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("pyrex manifest sits two levels below the repo root")
+        .to_path_buf()
+}
+
+#[cfg(feature = "dynasm")]
+fn pyre_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_pyre-dynasm")
+}
+
+#[cfg(all(not(feature = "dynasm"), feature = "cranelift"))]
+fn pyre_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_pyre-cranelift")
+}
+
+#[cfg(not(any(feature = "dynasm", feature = "cranelift")))]
+fn pyre_binary() -> &'static str {
+    env!("CARGO_BIN_EXE_pyre")
+}
+
+#[test]
+fn imports_single_phase_module_created_through_c_api() {
+    let root = repo_root();
+    let unique = format!(
+        "pyre-cpyext-smoke-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let out_dir = std::env::temp_dir().join(unique);
+    std::fs::create_dir(&out_dir).expect("create cpyext test directory");
+
+    let suffix = if cfg!(target_os = "macos") {
+        ".pyre314-darwin.so"
+    } else if cfg!(target_arch = "x86_64") {
+        ".pyre314-x86_64-linux-gnu.so"
+    } else if cfg!(target_arch = "aarch64") {
+        ".pyre314-aarch64-linux-gnu.so"
+    } else {
+        ".pyre314-linux-gnu.so"
+    };
+    let extension = out_dir.join(format!("cpyext_smoke{suffix}"));
+    let init_marker = out_dir.join("initialized");
+    let unload_marker = out_dir.join("unloaded");
+    let source = root.join("pyre/pyrex/tests/fixtures/cpyext_smoke.c");
+    let include = root.join("pyre/pyre-interpreter/include/pyre3.14");
+    let mut cc = Command::new(std::env::var_os("CC").unwrap_or_else(|| "cc".into()));
+    cc.arg(&source)
+        .arg("-I")
+        .arg(&include)
+        .arg("-o")
+        .arg(&extension);
+    if cfg!(target_os = "macos") {
+        cc.args(["-bundle", "-undefined", "dynamic_lookup"]);
+    } else {
+        cc.args(["-fPIC", "-shared"]);
+    }
+    let output = cc.output().expect("run C compiler");
+    assert!(
+        output.status.success(),
+        "C compiler failed:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let code = r#"
+import _imp
+import _sysconfig
+import sys
+expected_suffix = %SUFFIX%
+assert _imp.extension_suffixes() == [expected_suffix]
+config = _sysconfig.config_vars()
+assert config['EXT_SUFFIX'] == expected_suffix
+assert expected_suffix == '.' + config['SOABI'] + '.so'
+old_dlopenflags = sys.getdlopenflags()
+sys.setdlopenflags(0)
+try:
+    import cpyext_smoke
+finally:
+    sys.setdlopenflags(old_dlopenflags)
+again = __import__('cpyext_smoke')
+assert cpyext_smoke is again
+assert cpyext_smoke.__name__ == 'cpyext_smoke'
+assert cpyext_smoke.__doc__ == 'pyre cpyext smoke module'
+assert cpyext_smoke.__file__.endswith(_imp.extension_suffixes()[0])
+first = cpyext_smoke
+first.__doc__ = 'mutated'
+first.runtime_only = 1
+del sys.modules['cpyext_smoke']
+del cpyext_smoke
+reloaded = __import__('cpyext_smoke')
+assert reloaded is not first
+assert reloaded.__name__ == 'cpyext_smoke'
+assert reloaded.__doc__ == 'pyre cpyext smoke module'
+assert not hasattr(reloaded, 'runtime_only')
+try:
+    with open(%UNLOAD_MARKER%, 'rb'):
+        pass
+except FileNotFoundError:
+    pass
+else:
+    raise AssertionError('extension unloaded during cache restore')
+print('cpyext-smoke-ok')
+"#
+    .replace("%SUFFIX%", &format!("{suffix:?}"))
+    .replace(
+        "%UNLOAD_MARKER%",
+        &format!("{:?}", unload_marker.to_string_lossy()),
+    );
+    let output = Command::new(pyre_binary())
+        .arg("-S")
+        .arg("-c")
+        .arg(&code)
+        .env("PYTHONPATH", &out_dir)
+        .env("PYRE_CPYEXT_INIT_MARKER", &init_marker)
+        .env("PYRE_CPYEXT_UNLOAD_MARKER", &unload_marker)
+        .output()
+        .expect("run pyre cpyext fixture");
+    assert!(
+        output.status.success(),
+        "pyre failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "cpyext-smoke-ok"
+    );
+
+    let _ = std::fs::remove_dir_all(out_dir);
+}

--- a/pyre/pyrex/tests/cpyext_smoke.rs
+++ b/pyre/pyrex/tests/cpyext_smoke.rs
@@ -5,6 +5,7 @@
 //! back into the executable's exported `PyModule_Create2`.
 
 #![cfg(all(
+    feature = "cpyext",
     not(feature = "sandbox"),
     any(target_os = "macos", target_os = "linux")
 ))]

--- a/pyre/pyrex/tests/fixtures/cpyext_smoke.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_smoke.c
@@ -1,0 +1,48 @@
+#include <Python.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static void touch_marker(const char *env_name)
+{
+    const char *path = getenv(env_name);
+    if (path != NULL) {
+        FILE *marker = fopen(path, "wx");
+        if (marker != NULL) {
+            fclose(marker);
+        }
+    }
+}
+
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((destructor))
+static void cpyext_smoke_unloaded(void)
+{
+    touch_marker("PYRE_CPYEXT_UNLOAD_MARKER");
+}
+#endif
+
+static struct PyModuleDef moduledef = {
+    PyModuleDef_HEAD_INIT,
+    "cpyext_smoke",
+    "pyre cpyext smoke module",
+    -1,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC
+PyInit_cpyext_smoke(void)
+{
+    const char *path = getenv("PYRE_CPYEXT_INIT_MARKER");
+    FILE *marker = path == NULL ? NULL : fopen(path, "wx");
+    if (path != NULL && marker == NULL) {
+        return NULL;
+    }
+    if (marker != NULL) {
+        fclose(marker);
+    }
+    return PyModule_Create(&moduledef);
+}


### PR DESCRIPTION
## Summary

- introduce a separate C ABI object mirror and GC/raw-reference bridge instead of exposing pyre's internal object layout
- wire pyre-specific extension suffixes, `_imp.create_dynamic`, native extension discovery, `dlopen`/`dlsym`, module initialization, and PyPy-style extension caching
- export a minimal Python 3.14 C API surface for stateless, method-less, single-phase modules
- add macOS/Linux integration coverage for initialization caching, module-dict snapshots, dlopen flag handling, and library lifetime
- document the upstream PyPy architecture and the remaining dependency-ordered implementation slices

## Why

Pyre previously advertised partial extension machinery while `_imp.extension_suffixes()` returned an empty list and `create_dynamic` always raised `ImportError("Not implemented")`. PyPy cpyext compatibility requires more than loading a shared library: C objects need a fixed-layout mirror linked to moving GC objects, extension handles must remain alive, and module creation/cache behavior must follow the cpyext state model.

This is the first end-to-end vertical slice. It deliberately rejects method tables, module state/finalizers, and PEP 489 slots until their supporting exception, callable, and object APIs are added.

## Supported scope

- macOS and Linux
- pyre-specific Python 3.14 ABI suffix
- single-phase `PyModuleDef`
- method-less, stateless modules
- `PyModuleDef_Init`, `PyModule_Create2`, `Py_IncRef`, and `Py_DecRef`

## Validation

- `python3 scripts/extract-llbc.py pyre-interpreter pyre-jit`
- `cargo check -p pyrex --no-default-features --features dynasm`
- `cargo test -p pyre-interpreter --features dynasm` — 524 passed
- `cargo test -p pyrex --no-default-features --features dynasm`
- `cargo test -p pyrex --no-default-features --features cranelift --test cpyext_smoke -- --nocapture`
- `python3 pyre/check.py target/release/pyre-dynasm --backend dynasm --no-synthetic --no-cpython-suite` — 17/17 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional support for loading compatible CPython C extension modules on macOS and Linux.
  - Added extension discovery, platform-specific suffix reporting, module metadata, caching, and reload handling.
  - Added a Python 3.14-compatible C API header for building supported extensions.
  - Added safeguards for unsupported module features and sandboxed environments.

- **Documentation**
  - Documented the supported C extension architecture, configuration, limitations, and implementation scope.

- **Tests**
  - Added end-to-end coverage for building, importing, reloading, and caching C extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->