### PR TITLE
wasm: direct-call the caught-exception root clear

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1220,6 +1220,35 @@ fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
     Some(nargs)
 }
 
+/// Whether `op` is the exact `() -> ()` helper that clears the caught-
+/// exception propagation root after `PUSH_EXC_INFO` publishes the exception
+/// on the execution context.
+///
+/// A plain void call descr (`result_size == 0`) is not enough to select this
+/// ABI: pyre also records word-returning helpers as void when their result is
+/// ignored, and only the reflective host trampoline can absorb that mismatch.
+/// `ClearInFlightException` is codewriter-stamped onto the one genuinely
+/// nullary, genuinely void target (`bh_clear_in_flight_exception`), so this
+/// exact tag + descr + operand shape is safe to call through a `() -> ()`
+/// table type. Keeping the allow-list singular also prevents an unrelated
+/// void helper from silently bypassing the signature audit.
+fn residual_call_true_void(op: &Op) -> bool {
+    if op.opcode != OpCode::CallN {
+        return false;
+    }
+    let Some(descr) = op.getdescr() else {
+        return false;
+    };
+    let Some(cd) = descr.as_call_descr() else {
+        return false;
+    };
+    cd.result_type() == Type::Void
+        && cd.result_size() == 0
+        && cd.arg_types().is_empty()
+        && op.getarglist().len() == 1
+        && cd.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ClearInFlightException
+}
+
 /// Arity of `op`'s in-module `(i64×n) -> i64` lowering, if it has one: an
 /// eligible residual CALL (word-result or word-ABI void), a `New*`
 /// allocation (the `wasm_jit_alloc*` helper targets are plain
@@ -1289,6 +1318,7 @@ fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -> bo
         _ if op.opcode.is_call() => {
             direct_helper_i64_arity(op, &ref_values).is_none()
                 && residual_call_float_sig(op).is_none()
+                && !residual_call_true_void(op)
         }
         // `New*` and ref-store write barriers are covered by
         // `direct_helper_i64_arity`, so their direct-family arms do not touch
@@ -1716,12 +1746,18 @@ pub fn build_wasm_module(
             }
         }
     }
+    // `PUSH_EXC_INFO`'s propagation-root clear is the one signature-audited
+    // true-void residual helper. It gets a dedicated `() -> ()` type instead
+    // of being mixed into the `(i64×n) -> i64` family.
+    let has_true_void_residual =
+        WASM_DIRECT_RESIDUAL_CALL && ops.iter().any(residual_call_true_void);
     // The shared indirect-function table backs direct residual helpers as well
     // as host-trampoline dispatch, chained bridges, and CA recursion.
     let needs_table = needs_call
         || bridge_dispatch
         || residual_max_arity.is_some()
         || !float_residual_sigs.is_empty()
+        || has_true_void_residual
         || ca.emit_ca;
     // `ca.emit_ca` forces the direct helper family to include arities 0..=2,
     // so all CA frame-helper trampoline `else` arms below are baseline-only.
@@ -1773,6 +1809,11 @@ pub fn build_wasm_module(
         .collect::<indexmap::IndexMap<_, _>>();
     for sig in float_residual_type_indices.keys() {
         types.ty().function(sig.clone(), vec![ValType::F64]);
+    }
+    let true_void_residual_type_idx =
+        float_residual_type_base + float_residual_type_indices.len() as u32;
+    if has_true_void_residual {
+        types.ty().function(vec![], vec![]);
     }
     module.section(&types);
 
@@ -1854,6 +1895,7 @@ pub fn build_wasm_module(
         frame,
         residual_max_arity.map(|_| residual_type_base),
         &float_residual_type_indices,
+        has_true_void_residual.then_some(true_void_residual_type_idx),
         ca,
         bridge_finish_fi,
         ca_helper_type_idx,
@@ -1908,6 +1950,9 @@ fn build_function(
     // descr-derived parameter sequence. These types return `f64`; Float SSA
     // values are converted to/from their i64 bit carrier around the call.
     float_residual_type_indices: &indexmap::IndexMap<Vec<ValType>, u32>,
+    // Dedicated `() -> ()` type for the signature-audited
+    // ClearInFlightException residual, or `None` when absent.
+    true_void_residual_type_idx: Option<u32>,
     // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`). `ca.emit_ca` off keeps
     // the body byte-identical.
     ca: CaParams,
@@ -3969,6 +4014,16 @@ fn build_function(
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                         frame,
                     );
+                } else if let Some(type_idx) =
+                    true_void_residual_type_idx.filter(|_| residual_call_true_void(op))
+                {
+                    // Exact `() -> ()` in-module helper. Unlike the generic
+                    // trampoline path, this cannot allocate, collect, force,
+                    // or replace the frame, so no frame/ref-home reload is
+                    // needed after the call.
+                    emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
+                    sink.i32_wrap_i64();
+                    sink.call_indirect(0, type_idx);
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use majit_backend_wasm::codegen;
 use majit_ir::operand::Operand;
-use majit_ir::{InputArg, Op, OpCode, OpRef, Type};
+use majit_ir::{EffectInfo, ExtraEffect, InputArg, Op, OpCode, OpRef, PyreHelperKind, Type};
 use smallvec::smallvec;
 use wasmi::{Engine, Linker, Memory, MemoryType, Module, Store};
 
@@ -109,6 +109,58 @@ fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
             "{bench} fell back to the allocating interpreter loop:\n{stderr}"
         );
     }
+}
+
+#[test]
+#[ignore = "runtime integration test: needs the release pyre-dynasm, pyre-wasm-runner, and wasm-host module; \
+            run via `cargo test -- --ignored` in the check.py job, which builds them"]
+fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
+    let root = workspace_root();
+    let dynasm = root.join("target/release/pyre-dynasm");
+    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let host_module = root.join("target/wasm32-unknown-unknown/release/pyre_wasm.wasm-host.wasm");
+    let plain_module = root.join("target/wasm32-unknown-unknown/release/pyre_wasm.wasm");
+    let wasm_module = if host_module.exists() {
+        host_module
+    } else {
+        plain_module
+    };
+    let script = root.join("pyre/bench/raise_catch_loop.py");
+
+    for artifact in [&dynasm, &wasm_runner, &wasm_module] {
+        assert!(
+            artifact.exists(),
+            "runtime raise/catch regression needs {}; build the requested dynasm and wasm-host artifacts first",
+            artifact.display()
+        );
+    }
+
+    let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
+    assert!(
+        dynasm_run.status.success(),
+        "dynasm failed:\n{}",
+        String::from_utf8_lossy(&dynasm_run.stderr)
+    );
+    let module = wasm_module.to_str().expect("workspace paths must be UTF-8");
+    let wasm_run = run_runtime_program(
+        &wasm_runner,
+        &script,
+        &[
+            ("PYRE_WASM_MODULE", module),
+            ("PYRE_WASM_ENGINE", "wasmtime"),
+            ("PYRE_WASM_JIT_STATS", "1"),
+        ],
+    );
+    let stderr = String::from_utf8_lossy(&wasm_run.stderr);
+    assert!(wasm_run.status.success(), "wasm failed:\n{stderr}");
+    assert_eq!(
+        wasm_run.stdout, dynasm_run.stdout,
+        "wasm raise/catch output diverged from dynasm:\n{stderr}"
+    );
+    assert!(
+        stat_value(&stderr, "jit_calls") < 100_000,
+        "caught-exception root clearing crossed the host trampoline per iteration:\n{stderr}"
+    );
 }
 
 #[test]
@@ -580,6 +632,151 @@ fn test_call_generates_import() {
         }
     }
     assert!(has_jit_call, "module should import jit_call_compact");
+}
+
+fn true_void_call(helper: PyreHelperKind) -> Op {
+    let mut effect = EffectInfo::default();
+    effect.extraeffect = ExtraEffect::CannotRaise;
+    effect.can_collect = false;
+    effect.pyre_helper = helper;
+    let op = Op::new(OpCode::CallN, &[rb(OpRef::const_int(42))]);
+    op.setdescr(majit_ir::make_call_descr(vec![], Type::Void, effect));
+    op
+}
+
+fn import_func_type(bytes: &[u8], name: &str) -> Option<u32> {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::ImportSection(imports) = payload.unwrap() {
+            for import in imports {
+                let import = import.unwrap();
+                if import.name == name {
+                    return match import.ty {
+                        wasmparser::TypeRef::Func(type_idx) => Some(type_idx),
+                        _ => None,
+                    };
+                }
+            }
+        }
+    }
+    None
+}
+
+fn has_table_import(bytes: &[u8]) -> bool {
+    wasmparser::Parser::new(0).parse_all(bytes).any(|payload| {
+        let Ok(wasmparser::Payload::ImportSection(imports)) = payload else {
+            return false;
+        };
+        imports
+            .into_iter()
+            .any(|import| import.is_ok_and(|import| import.name == "__indirect_function_table"))
+    })
+}
+
+fn indirect_call_types_and_drop_count(bytes: &[u8]) -> (Vec<(u32, u32)>, usize) {
+    let mut indirect_calls = Vec::new();
+    let mut drops = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            while !operators.eof() {
+                match operators.read().unwrap() {
+                    wasmparser::Operator::CallIndirect {
+                        type_index,
+                        table_index,
+                        ..
+                    } => indirect_calls.push((type_index, table_index)),
+                    wasmparser::Operator::Drop => drops += 1,
+                    _ => {}
+                }
+            }
+        }
+    }
+    (indirect_calls, drops)
+}
+
+#[test]
+fn test_clear_in_flight_exception_uses_true_void_indirect_call() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let ops = vec![
+        true_void_call(PyreHelperKind::ClearInFlightException),
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert!(has_table_import(&bytes));
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), None);
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(1, 0)]);
+    assert_eq!(drops, 0, "a genuine () -> () helper needs no result drop");
+}
+
+#[test]
+fn test_untagged_size_zero_void_call_keeps_trampoline() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let ops = vec![
+        true_void_call(PyreHelperKind::None),
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), Some(1));
+    let (indirect_calls, _) = indirect_call_types_and_drop_count(&bytes);
+    assert!(indirect_calls.is_empty());
+}
+
+#[test]
+fn test_malformed_tagged_void_call_keeps_trampoline() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let mut effect = EffectInfo::default();
+    effect.extraeffect = ExtraEffect::CannotRaise;
+    effect.can_collect = false;
+    effect.pyre_helper = PyreHelperKind::ClearInFlightException;
+    let call = Op::new(
+        OpCode::CallN,
+        &[rb(OpRef::const_int(42)), rb(OpRef::input_arg_int(0))],
+    );
+    call.setdescr(majit_ir::make_call_descr(
+        vec![Type::Int],
+        Type::Void,
+        effect,
+    ));
+    let ops = vec![
+        call,
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), Some(1));
+    let (indirect_calls, _) = indirect_call_types_and_drop_count(&bytes);
+    assert!(indirect_calls.is_empty());
+}
+
+#[test]
+fn test_true_void_type_index_accounts_for_trampoline_type() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let ops = vec![
+        make_op(
+            OpCode::CallI,
+            &[OpRef::const_int(43), OpRef::input_arg_int(0)],
+            OpRef::int_op(1),
+        ),
+        true_void_call(PyreHelperKind::ClearInFlightException),
+        Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), Some(1));
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(2, 0)]);
+    assert_eq!(drops, 0);
 }
 
 #[test]


### PR DESCRIPTION
## What changed

- Direct-lower the signature-audited `ClearInFlightException` residual as an in-module Wasm `() -> ()` `call_indirect`.
- Keep every untagged or malformed size-zero void call on `jit_call_compact`, because the generic void descriptor ABI is ambiguous.
- Add codegen coverage for the dedicated type, trampoline/type-index coexistence, malformed-call fallback, and no result `drop`.
- Add a runtime raise/catch canary that verifies output parity with dynasm and prevents host-call count from scaling with caught exceptions.

## Why

`PUSH_EXC_INFO` must clear pyre's non-semantic in-flight exception GC root after publishing the caught exception to the execution context. Removing that clear is unsound, but routing it through the Wasm host trampoline once per caught exception made `raise_catch_loop.py` slow.

The helper is already identified by `PyreHelperKind::ClearInFlightException` and its actual ABI is exactly `extern "C" fn()`, so it can safely use the shared indirect table without a host round trip.

## Impact

On the full raise/catch benchmark, Wasm `jit_calls` drops from **14,288,569** to **3,203**. The focused Wasm harness improved from about **0.99s** to **0.29s** on the same machine/run setup while preserving one loop, one bridge, and identical program output.

## Validation

- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test -p majit-backend-wasm --test codegen_test -- --skip runtime`
- focused ignored runtime canary for `raise_catch_loop.py`
- `python3 pyre/check.py --backend wasm --no-synthetic --no-cpython-suite` — Wasm 14/14
- `python3 pyre/check.py --no-synthetic --no-cpython-suite` — dynasm 17/17, cranelift 17/17, Wasm 14/14
