### PR TITLE
backend: reusable assembler arena 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,9 +553,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
 dependencies = [
  "cfg-if",
 ]
@@ -586,27 +586,27 @@ dependencies = [
 
 [[package]]
 name = "cranelift-assembler-x64"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d521bdbc6098937af83ef4ab6d5c07398126bc71878f7ef4ea9499977978ef5"
+checksum = "d552bd33b7a56dc70aeb1e1c960e51a218fa0db50f23873b500a310379450b2d"
 dependencies = [
  "cranelift-assembler-x64-meta",
 ]
 
 [[package]]
 name = "cranelift-assembler-x64-meta"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dde0b83164d4a497860af4236271178bc640512b067101e0853e4f74eaa4df5"
+checksum = "078e80e4c222279e3330f6aa1a256ca77ddf156d4453166a9f09defedc4594dd"
 dependencies = [
  "cranelift-srcgen",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+checksum = "820ce15d4ad3562d613c31a67b6d0434d403e7091a68d1349903842f7d31737e"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -614,9 +614,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+checksum = "61bca563d4b86d285928d9e27f97f27039bb33a0fc524fa130d7d0c106bf8ab3"
 dependencies = [
  "serde",
  "serde_derive",
@@ -625,9 +625,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cd2563bead0090c3879a7ff7327f7550c9d59bb5d05ecc8cd7886977aa3125a"
+checksum = "709f4b7c0fb57d952658d5b5c07fbdc4149acd7b7f0de9678ae754b9c981949a"
 dependencies = [
  "bumpalo",
  "cranelift-assembler-x64",
@@ -642,10 +642,13 @@ dependencies = [
  "hashbrown 0.17.1",
  "libm",
  "log",
+ "postcard",
  "pulley-interpreter",
  "regalloc2",
  "rustc-hash",
  "serde",
+ "serde_derive",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasmtime-internal-core",
@@ -653,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9640d250d26f9381a73dc7f9862b27928d4809119aec73be0e556612e67b6a99"
+checksum = "903dc8915af62aad1d9d0f39a5968d33fa80b9aa899ed6f56e47f40ca4512e1e"
 dependencies = [
  "cranelift-assembler-x64-meta",
  "cranelift-codegen-shared",
@@ -666,24 +669,24 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07f156b90efc94371ddb3536f76e4ab671ad2e093bfa5511e10198cadbb0c47"
+checksum = "0522d74c227e49f3fd49ab055311486ae4f09083262b66705bed676952491469"
 
 [[package]]
 name = "cranelift-control"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a76fd9dd37dcbc3d2d2e00abe3281a7e88adc035fba3b8114cc69981576ec"
+checksum = "66560ea1c5cef72e170b18e46d263dba2d3169c9d39e8cafdab2173c6362cc1a"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+checksum = "b62ef5b17cc814d27e96b66a5b46da0e4ce2b8ac55a6d478048bb99d04b05526"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -693,11 +696,12 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efa2826c80dff1d93b19b3cfbcaf9fae44c78d739a98d146dd5bd89c51e14367"
+checksum = "a87e0aaa39dbf70693b348a221e45904111704ee8f9fef140498471005f9842d"
 dependencies = [
  "cranelift-codegen",
+ "hashbrown 0.17.1",
  "log",
  "smallvec",
  "target-lexicon",
@@ -705,15 +709,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e238a69b95c5415456f22189494a12db94f313bb72b6ec9cc88ddf2f1056e28e"
+checksum = "cf79003ebfa1eed5e87f3b84446ad5236f540268289960e14f387dc9b28e40b7"
 
 [[package]]
 name = "cranelift-jit"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7def01f2b14f97421558d1db33e396b97b97ab2ed40dedc8165ba00d13088e6"
+checksum = "2336d9ac773a092b1bff25988b298fe47d7921c2e6019d8243f5bb52d1c78d0d"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -723,7 +727,7 @@ dependencies = [
  "cranelift-native",
  "libc",
  "log",
- "memmap2 0.2.3",
+ "memmap2",
  "region",
  "target-lexicon",
  "wasmtime-internal-jit-icache-coherence",
@@ -732,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-module"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "985df7eceefc91cb75bf7f51b32b7f1739d0fc0e25ddf023b1de407cb3c93d77"
+checksum = "8c89882b932e6ae6b9c9a9c0d4ee784c53208d2db5cccb6e099e298cf35572cf"
 dependencies = [
  "anyhow",
  "cranelift-codegen",
@@ -743,9 +747,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-native"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eceb0ebd8d6aef6bb287e8d532a164b0db1c0062961211e9c22a91f67521c098"
+checksum = "05bf4f235743c81e67ee4db617c5a4a0b65d58d3f0cfc575ee0f1a4e0cd58273"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -754,9 +758,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-srcgen"
-version = "0.132.3"
+version = "0.134.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "004643f39a7bec553de5263d650db30e5b9caec1d5cbe065fd732b7ec9ae40d0"
+checksum = "f6977c2a71ab1e0d1e62f966b411a498aa04c4dce47d93d52f8a360a06058922"
 
 [[package]]
 name = "crc32fast"
@@ -1012,7 +1016,7 @@ dependencies = [
  "byteorder",
  "dynasm",
  "fnv",
- "memmap2 0.9.11",
+ "memmap2",
 ]
 
 [[package]]
@@ -1875,6 +1879,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae608c151f68243f2b000364e1f7b186d9c29845f7d2d85bd31b9ad77ad552b"
+
+[[package]]
 name = "majit"
 version = "0.0.2"
 dependencies = [
@@ -1895,6 +1905,7 @@ dependencies = [
  "majit-ir",
  "majit-translate",
  "parking_lot",
+ "region",
 ]
 
 [[package]]
@@ -1911,6 +1922,8 @@ dependencies = [
  "majit-gc",
  "majit-ir",
  "majit-translate",
+ "parking_lot",
+ "region",
  "smallvec",
  "target-lexicon",
 ]
@@ -2146,15 +2159,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
 dependencies = [
  "rustix",
-]
-
-[[package]]
-name = "memmap2"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "723e3ebdcdc5c023db1df315364573789f8857c11b631a2fdfad7c00f5c046b4"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -2644,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-interpreter"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04adf8f93264685f2c70a3edb8f828c791e71b22659253319c33f29d1165aef"
+checksum = "bc5c8c21ea032e4efbdf2d067dc45171779dbe0c8ecf20ef4a57efa7474f2b0a"
 dependencies = [
  "cranelift-bitset",
  "log",
@@ -2656,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "pulley-macros"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c120a6af1a574a42efcd9df2ad27cb78bc04118c5e0c69e90599f17301a1c7a"
+checksum = "9f10925455d5dde962e3604eade797ba5488644c8ee14a44191e2f2b58980574"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2858,7 +2862,7 @@ version = "0.0.2"
 dependencies = [
  "sha2 0.10.9",
  "wasmi",
- "wasmprinter",
+ "wasmprinter 0.248.0",
  "wasmtime",
 ]
 
@@ -3083,6 +3087,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "rustc-hash",
+ "serde",
  "smallvec",
 ]
 
@@ -3100,7 +3105,7 @@ checksum = "e6b6ebd13bc009aef9cd476c1310d49ac354d36e240cf1bd753290f3dc7199a7"
 dependencies = [
  "bitflags 1.3.2",
  "libc",
- "mach2",
+ "mach2 0.4.3",
  "windows-sys 0.52.0",
 ]
 
@@ -3300,7 +3305,7 @@ dependencies = [
  "libloading",
  "mac_address",
  "memchr",
- "memmap2 0.9.11",
+ "memmap2",
  "nix 0.31.3",
  "num-traits",
  "num_cpus",
@@ -4125,12 +4130,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unicode_names2"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4300,9 +4299,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-compose"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba953e2b9b4b4b52a31cf4e3ee1c1374c872b6e012cf2138d1c37cba00bfd6"
+checksum = "d59b710751a35d54732a63851cdfacbfb2266b7160ce174faf269d3f4e84e31b"
 dependencies = [
  "anyhow",
  "heck",
@@ -4310,8 +4309,8 @@ dependencies = [
  "log",
  "petgraph",
  "smallvec",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wat",
 ]
 
@@ -4326,12 +4325,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.248.0",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]
@@ -4415,6 +4414,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
 dependencies = [
  "bitflags 2.13.0",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.252.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+dependencies = [
+ "bitflags 2.13.0",
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
@@ -4444,10 +4454,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime"
-version = "45.0.3"
+name = "wasmprinter"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a83ef84ac8bab735c89e27b0268b0586099fbe81281ae45be2b8e4f407b2daa"
+checksum = "7142797de29b35ab8dbf15c00f55fda75d409da4c423a8ab8bd6b667a785824b"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.252.0",
+]
+
+[[package]]
+name = "wasmtime"
+version = "47.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c80ca6098e0d4d06886d91d7f2cc3cb6623eb583c4c0ab3c89cbfb6098c8586c"
 dependencies = [
  "addr2line",
  "async-trait",
@@ -4462,7 +4483,7 @@ dependencies = [
  "ittapi",
  "libc",
  "log",
- "mach2",
+ "mach2 0.6.0",
  "memfd",
  "object 0.39.1",
  "once_cell",
@@ -4478,8 +4499,8 @@ dependencies = [
  "target-lexicon",
  "tempfile",
  "wasm-compose",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-cache",
  "wasmtime-internal-component-macro",
@@ -4491,16 +4512,16 @@ dependencies = [
  "wasmtime-internal-jit-icache-coherence",
  "wasmtime-internal-unwinder",
  "wasmtime-internal-versioned-export-macros",
- "wasmtime-internal-winch",
  "wat",
  "windows-sys 0.61.2",
+ "wit-parser",
 ]
 
 [[package]]
 name = "wasmtime-environ"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439686d3deb38525c86b88bbc90f7ba669f70c8edc7d6b35147c738bbef5ff76"
+checksum = "134f9d136d29c76f6c1b4c9b468e97a2efc38c7d49fd188e39b64870b2fea701"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -4520,18 +4541,18 @@ dependencies = [
  "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter",
+ "wasm-encoder 0.252.0",
+ "wasmparser 0.252.0",
+ "wasmprinter 0.252.0",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-cache"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2799e6c35393c2a38999f13e4c80ab5d5d9756082bb554cbd1f60485a18293"
+checksum = "65db2eb1bfc5371a3b4107dbf539d0b93d05016fc29625b1648146b47db02071"
 dependencies = [
  "base64",
  "directories-next",
@@ -4549,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-macro"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d2c5850fb8c448792453765d97f6f01096a32708f3c36798e86220763c90c0"
+checksum = "2bf7b91fed3fc34781d57f9c6654ea2513bf0a99f7b0b0523c00de1e6efebe1c"
 dependencies = [
  "anyhow",
  "proc-macro2",
@@ -4564,15 +4585,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed79c4e9ab416dcc5e46b9d1ec9b7c2e3c730deab525996b0de45a35fc8b2c3"
+checksum = "fc8a678149885cae00289f806fbe74c7863084cf74cace0b8dc73602279400e1"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+checksum = "8a0092c4b9d070ac5e278b6d0db10f5e71214190f0347ca57502b4692f796321"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4582,9 +4603,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-cranelift"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a15981261d361f9c93b42929f446b4009840853ceea181ad6e17730f4016a0b"
+checksum = "6851ebc9e03cab23d9821d2b2505d380bdfe38f35ccec945247b05274d85c98b"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4600,7 +4621,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "thiserror 2.0.18",
- "wasmparser 0.248.0",
+ "wasmparser 0.252.0",
  "wasmtime-environ",
  "wasmtime-internal-core",
  "wasmtime-internal-unwinder",
@@ -4609,9 +4630,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-fiber"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33aed9d91d54c9f861ba7e3c3130bded8a7a63e01fe58c3a9a36b45d6ee0fb57"
+checksum = "9b26da6d5f60d4c438da70bba3553fe810a840533a64156be287dca2081c6991"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4624,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-debug"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944942118aab67e7b4febfe88a65d0af4cfd10af8ed0e79fd6cf39d75359ab7e"
+checksum = "ed621ba25d7bf78b7edd7b4749abbb27c2e5cdba836c9504a424ee74b6c23149"
 dependencies = [
  "cc",
  "object 0.39.1",
@@ -4636,9 +4657,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-jit-icache-coherence"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37dee05e8c35759826f6b926cd949c51f771b6a58619d8e60c63c3f3d3e5e59b"
+checksum = "5684ba160951baad06a725696f3c590e2fb0e8067c2aebee27bf7f9259058e85"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4648,9 +4669,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-unwinder"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a83f7ebe911a6f1605ff0d3a678472ddb1fcc57c3e2f6bae5dd4d170b625b3ed"
+checksum = "112eead527bffa8ff0646a11fb4339a9d52ddd1da2b9a6fce4aff84c815dd94f"
 dependencies = [
  "cfg-if",
  "cranelift-codegen",
@@ -4661,9 +4682,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-internal-versioned-export-macros"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75980644456dc003238766254b0e5f002704630237ccd0728747991fe2739d7"
+checksum = "153592e0bed824fc13c6696203fa1bd7bd20eb355316475e39a55f081ef80eca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4671,27 +4692,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-internal-winch"
-version = "45.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81af36995b4720b32e3d667541b548a27184a859d09a6ee745eaba095f5a6f6e"
-dependencies = [
- "cranelift-codegen",
- "gimli",
- "log",
- "object 0.39.1",
- "target-lexicon",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-cranelift",
- "winch-codegen",
-]
-
-[[package]]
 name = "wasmtime-internal-wit-bindgen"
-version = "45.0.3"
+version = "47.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ada06667b7948892703fcc9f0b9b337c2e78c334d74d4fa62e2f75f07fbb3659"
+checksum = "c456ad6e81e0f46abfeca43687d18ea15e289c395b262ea6e0023e2682e088be"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -4777,25 +4781,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "winch-codegen"
-version = "45.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73bc25d27222248f9bafc7e9945f61e74275360c3ea0d34008810d436140a53"
-dependencies = [
- "cranelift-assembler-x64",
- "cranelift-codegen",
- "gimli",
- "regalloc2",
- "smallvec",
- "target-lexicon",
- "thiserror 2.0.18",
- "wasmparser 0.248.0",
- "wasmtime-environ",
- "wasmtime-internal-core",
- "wasmtime-internal-cranelift",
-]
 
 [[package]]
 name = "windows-link"
@@ -4973,9 +4958,9 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-parser"
-version = "0.248.0"
+version = "0.252.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247ad505da2915a082fe13204c5ba8788425aea1de54f43b284818cf82637856"
+checksum = "4266bea110371c620ccf3201c5023676046bc4556e5c7cfb5d500bda5ebc162d"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -4986,8 +4971,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.248.0",
+ "unicode-ident",
+ "wasmparser 0.252.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,12 +119,13 @@ smallvec = "1"
 linkme = "0.3"
 
 # cranelift backend
-cranelift-codegen = "0.132"
-cranelift-frontend = "0.132"
-cranelift-jit = "0.132"
-cranelift-module = "0.132"
-cranelift-native = "0.132"
+cranelift-codegen = "0.134"
+cranelift-frontend = "0.134"
+cranelift-jit = "0.134"
+cranelift-module = "0.134"
+cranelift-native = "0.134"
 target-lexicon = "0.13"
+region = "3"
 
 # dynasm backend
 dynasm = "5"
@@ -141,10 +142,10 @@ wasmparser = "0.225"
 # the `web` build's `getrandom/wasm_js` feature reaches that shared instance.
 getrandom = "0.4.2"
 # Native host runtime for the wasm runner. Pinned to the wasmtime release whose
-# `wasmtime-internal-*` support crates already ride along with cranelift 0.132
+# `wasmtime-internal-*` support crates already ride along with cranelift 0.134
 # (the version the dynasm/cranelift backends use), so it reuses the existing
 # cranelift rather than duplicating it.
-wasmtime = "45"
+wasmtime = "47"
 
 # system
 libc = "0.2"

--- a/majit/majit-backend-cranelift/Cargo.toml
+++ b/majit/majit-backend-cranelift/Cargo.toml
@@ -18,6 +18,8 @@ cranelift-jit = { workspace = true }
 cranelift-module = { workspace = true }
 cranelift-native = { workspace = true }
 target-lexicon = { workspace = true }
+parking_lot = { workspace = true }
+region = { workspace = true }
 
 [dev-dependencies]
 majit-gc = { workspace = true, features = ["gc_box"] }

--- a/majit/majit-backend-cranelift/src/asm_memory.rs
+++ b/majit/majit-backend-cranelift/src/asm_memory.rs
@@ -1,0 +1,111 @@
+use std::io;
+use std::sync::Arc;
+
+use cranelift_jit::{BranchProtection, JITMemoryKind, JITMemoryProvider};
+use cranelift_module::{ModuleError, ModuleResult};
+use majit_backend::{AsmMemoryBlock, AsmMemoryManager};
+
+struct Allocation {
+    block: AsmMemoryBlock,
+    kind: JITMemoryKind,
+    finalized: bool,
+}
+
+struct Shared {
+    arena: Arc<AsmMemoryManager>,
+    allocations: parking_lot::Mutex<Vec<Allocation>>,
+}
+
+/// Handle retained by the backend after the provider itself moves into
+/// `JITModule`. It transfers finalized executable ranges to the owning
+/// `CompiledLoopToken`, matching `BaseAssembler.get_asmmemmgr_blocks`.
+pub(crate) struct CraneliftArenaHandle {
+    shared: Arc<Shared>,
+}
+
+impl CraneliftArenaHandle {
+    pub(crate) fn take_executable(&self, ptr: *const u8) -> Option<AsmMemoryBlock> {
+        let mut allocations = self.shared.allocations.lock();
+        let position = allocations.iter().position(|allocation| {
+            matches!(allocation.kind, JITMemoryKind::Executable)
+                && allocation.finalized
+                && allocation.block.contains(ptr)
+        })?;
+        Some(allocations.remove(position).block)
+    }
+}
+
+/// Cranelift's `ArenaMemoryProvider` proves that one provider may suballocate
+/// a retained mapping. This provider delegates those allocations to pyre's
+/// RPython-compatible free list and leaves lifetime ownership with CLTs.
+pub(crate) struct CraneliftArenaMemoryProvider {
+    shared: Arc<Shared>,
+}
+
+impl CraneliftArenaMemoryProvider {
+    pub(crate) fn new(arena: Arc<AsmMemoryManager>) -> (Self, CraneliftArenaHandle) {
+        let shared = Arc::new(Shared {
+            arena,
+            allocations: parking_lot::Mutex::new(Vec::new()),
+        });
+        (
+            Self {
+                shared: Arc::clone(&shared),
+            },
+            CraneliftArenaHandle { shared },
+        )
+    }
+}
+
+impl JITMemoryProvider for CraneliftArenaMemoryProvider {
+    fn allocate(&mut self, size: usize, align: u64, kind: JITMemoryKind) -> io::Result<*mut u8> {
+        let align = usize::try_from(align)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "JIT alignment overflow"))?;
+        if !align.is_power_of_two() || align > region::page::size() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "JIT alignment must be a power of two no larger than a page",
+            ));
+        }
+        let used = if matches!(kind, JITMemoryKind::Executable) {
+            size
+        } else {
+            0
+        };
+        let block = self.shared.arena.allocate(size, used)?;
+        let ptr = block.ptr() as *mut u8;
+        self.shared.allocations.lock().push(Allocation {
+            block,
+            kind,
+            finalized: false,
+        });
+        Ok(ptr)
+    }
+
+    unsafe fn free_memory(&mut self) {
+        self.shared.allocations.lock().clear();
+    }
+
+    fn finalize(&mut self, branch_protection: BranchProtection) -> ModuleResult<()> {
+        if branch_protection != BranchProtection::None {
+            return Err(ModuleError::Backend(
+                io::Error::new(
+                    io::ErrorKind::Unsupported,
+                    "branch-protected Cranelift arena mappings are not configured",
+                )
+                .into(),
+            ));
+        }
+        let mut allocations = self.shared.allocations.lock();
+        for allocation in allocations.iter_mut().filter(|entry| !entry.finalized) {
+            let result = match allocation.kind {
+                JITMemoryKind::Executable => allocation.block.make_executable(),
+                JITMemoryKind::ReadOnly => allocation.block.make_read_only(),
+                JITMemoryKind::Writable => Ok(()),
+            };
+            result.map_err(|error| ModuleError::Backend(error.into()))?;
+            allocation.finalized = true;
+        }
+        Ok(())
+    }
+}

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -15985,7 +15985,13 @@ impl majit_backend::Backend for CraneliftBackend {
         // between codegen and metainterp.  The stamp here lands on the
         // same `op.descr` Arc that `pyjitpl.rs::record_loop_or_bridge`
         // touches; the two writes converge on a single identity per fail.
-        if let Some(clt) = token.compiled_loop_token() {
+        // `JitCellToken::new` fills the CLT eagerly and nothing ever clears it,
+        // so an absent one is a bug rather than a state to skip. Skipping would
+        // drop `asm_memory_blocks` below, returning the arena range this loop
+        // was just written into to the free list while the loop still runs from
+        // it; `compiled_loop_token_expect` fails loudly instead.
+        {
+            let clt = token.compiled_loop_token_expect();
             for descr in &compiled.fail_descrs {
                 // `compile.py:185` `isinstance(descr, ResumeDescr)`
                 // covers both `ResumeGuardDescr` and
@@ -16147,7 +16153,10 @@ impl majit_backend::Backend for CraneliftBackend {
             caller_layout.as_ref(),
         );
         let mut compiled = compiled?;
-        if let Some(clt) = original_token.compiled_loop_token() {
+        // Same invariant as the loop path above: skipping would free the arena
+        // range the bridge was just written into.
+        {
+            let clt = original_token.compiled_loop_token_expect();
             clt.asmmemmgr_blocks.lock().extend(
                 compiled
                     .asm_memory_blocks

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8014,17 +8014,24 @@ pub struct CraneliftBackend {
     cpu_tracker: Arc<majit_backend::CpuTotalTracker>,
     /// `asmmemmgr.py:28` `AsmMemoryManager` parity — the CPU owns the
     /// accounting `jit_hooks.stats_asmmemmgr_{allocated,used}` reads. Cranelift
-    /// has no `AsmMemoryManager` of its own: `JITModule` owns the executable
-    /// mapping and does not publish its arena size, so `record_block` is given
-    /// the finalized code size for both figures rather than a page-rounded
-    /// number nothing measured.
+    /// has no `AsmMemoryManager` of its own: the memory lives inside
+    /// `JITModule`'s provider, which does not publish what it mapped, so
+    /// `record_block` is given the finalized code size for both figures.
+    ///
+    /// That makes `allocated` an *under*count, not a page-rounded one: the
+    /// default `SystemMemoryProvider` page-rounds its anonymous mappings, so
+    /// the pages it holds exceed the machine-code length recorded here.
     asm_memory_stats: Arc<majit_backend::AsmMemoryManagerStats>,
-    /// Lifetime tokens for the blocks recorded above. `JITModule` frees its
-    /// mapping when this backend drops, so holding the tokens for the
-    /// backend's whole life gives back `used` at exactly the point the code
-    /// stops existing. `allocated` is not given back, which is
-    /// `asmmemmgr.py:90`'s shape: an arena counts once and is never
-    /// un-counted.
+    /// Lifetime tokens for the blocks recorded above. They are held for the
+    /// backend's whole life because nothing shorter is correct: the default
+    /// provider does not free on drop. `Memory`'s `Drop` `mem::forget`s every
+    /// allocation ("leak memory to guarantee validity of function pointers"),
+    /// and the only release is `unsafe JITModule::free_memory(self)`, which
+    /// consumes the module and which this backend never calls. So the code
+    /// outlives the process's use of it, and `used` is given back at backend
+    /// teardown rather than when the code stops existing. `allocated` is never
+    /// given back, which is `asmmemmgr.py:90`'s shape: an arena counts once
+    /// and is never un-counted.
     asm_memory_blocks: Vec<majit_backend::AsmMemoryBlock>,
     module: JITModule,
     func_ctx: FunctionBuilderContext,

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -13,7 +13,8 @@ use cranelift_codegen::Context;
 use cranelift_codegen::ir::condcodes::{FloatCC, IntCC};
 use cranelift_codegen::ir::types as cl_types;
 use cranelift_codegen::ir::{
-    AbiParam, BlockArg, Function, InstBuilder, MemFlags, Signature, StackSlotData, StackSlotKind,
+    AbiParam, BlockArg, Function, InstBuilder, MemFlagsData, Signature, StackSlotData,
+    StackSlotKind,
 };
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext, Variable};
@@ -89,6 +90,7 @@ fn majit_verify_enabled() -> bool {
     *ENABLED
 }
 
+use crate::asm_memory::{CraneliftArenaHandle, CraneliftArenaMemoryProvider};
 use crate::guard::{BridgeData, JitFrameDeadFrame, drop_bridge_payload};
 
 // `compile.py:665-674` `done_with_this_frame` singletons
@@ -1237,7 +1239,7 @@ fn coerce_ty(
     if builder.func.dfg.value_type(val) == want {
         val
     } else {
-        builder.ins().bitcast(want, MemFlags::new(), val)
+        builder.ins().bitcast(want, MemFlagsData::new(), val)
     }
 }
 
@@ -1377,7 +1379,9 @@ fn resolve_opref_vec_int(
         let v = builder.use_var(var(opref.raw()));
         if vec_float_oprefs.contains(&opref.raw()) {
             // Variable is F64X2, bitcast to I64X2
-            return builder.ins().bitcast(cl_types::I64X2, MemFlags::new(), v);
+            return builder
+                .ins()
+                .bitcast(cl_types::I64X2, MemFlagsData::new(), v);
         }
         return v;
     }
@@ -1400,7 +1404,7 @@ fn resolve_opref_vec_float(
         let scalar_i = builder.ins().iconst(cl_types::I64, c);
         let scalar_f = builder
             .ins()
-            .bitcast(cl_types::F64, MemFlags::new(), scalar_i);
+            .bitcast(cl_types::F64, MemFlagsData::new(), scalar_i);
         return builder.ins().splat(cl_types::F64X2, scalar_f);
     }
     if vec_oprefs.contains(&opref.raw()) {
@@ -1410,7 +1414,9 @@ fn resolve_opref_vec_float(
             return v;
         }
         // I64X2 -> F64X2 bitcast
-        return builder.ins().bitcast(cl_types::F64X2, MemFlags::new(), v);
+        return builder
+            .ins()
+            .bitcast(cl_types::F64X2, MemFlagsData::new(), v);
     }
     // Scalar variable: reinterpret as f64 (a float var is already F64) then splat
     let scalar = builder.use_var(var(opref.raw()));
@@ -3319,10 +3325,10 @@ fn emit_call_header_shadowstack(
     // MOV ebx, [root_stack_top_addr]
     let rst = builder
         .ins()
-        .load(ptr_type, MemFlags::trusted(), rst_addr_val, 0);
+        .load(ptr_type, MemFlagsData::trusted(), rst_addr_val, 0);
     // MOV [ebx], 1   — is_minor marker
     let one = builder.ins().iconst(ptr_type, 1);
-    builder.ins().store(MemFlags::trusted(), one, rst, 0);
+    builder.ins().store(MemFlagsData::trusted(), one, rst, 0);
     // MOV [ebx + WORD], ebp
     let jf_as_ptr = if builder.func.dfg.value_type(jf_ptr) != ptr_type {
         builder.ins().ireduce(ptr_type, jf_ptr)
@@ -3331,13 +3337,13 @@ fn emit_call_header_shadowstack(
     };
     builder
         .ins()
-        .store(MemFlags::trusted(), jf_as_ptr, rst, word as i32);
+        .store(MemFlagsData::trusted(), jf_as_ptr, rst, word as i32);
     // ADD ebx, 2*WORD
     let new_rst = builder.ins().iadd_imm(rst, 2 * word);
     // MOV [root_stack_top_addr], ebx
     builder
         .ins()
-        .store(MemFlags::trusted(), new_rst, rst_addr_val, 0);
+        .store(MemFlagsData::trusted(), new_rst, rst_addr_val, 0);
 }
 
 /// assembler.py:1130-1136 _call_footer_shadowstack — inline Cranelift IR.
@@ -3357,11 +3363,11 @@ fn emit_call_footer_shadowstack(
     );
     let rst = builder
         .ins()
-        .load(ptr_type, MemFlags::trusted(), rst_addr_val, 0);
+        .load(ptr_type, MemFlagsData::trusted(), rst_addr_val, 0);
     let new_rst = builder.ins().iadd_imm(rst, -(2 * word));
     builder
         .ins()
-        .store(MemFlags::trusted(), new_rst, rst_addr_val, 0);
+        .store(MemFlagsData::trusted(), new_rst, rst_addr_val, 0);
 }
 
 /// x86/assembler.py:1630-1641 `genop_discard_check_memory_error` /
@@ -3404,25 +3410,25 @@ fn emit_memory_error_check(
         let exc_val_addr = builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
         let exc_val = builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), exc_val_addr, 0);
+            .load(cl_types::I64, MemFlagsData::trusted(), exc_val_addr, 0);
         builder
             .ins()
-            .store(MemFlags::trusted(), zero, exc_val_addr, 0);
+            .store(MemFlagsData::trusted(), zero, exc_val_addr, 0);
         let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
         builder
             .ins()
-            .store(MemFlags::trusted(), zero, exc_type_addr, 0);
+            .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
         // assembler.py:336-340 — MOV [jf_guard_exc], tmp; MOV [jf_descr], descr.
         let cur_jf = builder.ins().get_pinned_reg(ptr_type);
         builder
             .ins()
-            .store(MemFlags::trusted(), exc_val, cur_jf, JF_GUARD_EXC_OFS);
+            .store(MemFlagsData::trusted(), exc_val, cur_jf, JF_GUARD_EXC_OFS);
         let descr_val = builder
             .ins()
             .iconst(ptr_type, propagate_exception_descr_ptr as i64);
         builder
             .ins()
-            .store(MemFlags::trusted(), descr_val, cur_jf, JF_DESCR_OFS);
+            .store(MemFlagsData::trusted(), descr_val, cur_jf, JF_DESCR_OFS);
         emit_call_footer_shadowstack(builder, ptr_type);
         builder.ins().return_(&[cur_jf]);
     }
@@ -5500,7 +5506,7 @@ fn resolve_failarg_opref(
     if let Some(offset) = demoted_failarg_offset(demoted_failarg_slots, opref.raw()) {
         return builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), jf_ptr, offset);
+            .load(cl_types::I64, MemFlagsData::trusted(), jf_ptr, offset);
     }
     if let Some((_, root_slot)) = ref_root_slots
         .iter()
@@ -5509,7 +5515,7 @@ fn resolve_failarg_opref(
         let root_offset = ref_root_base_ofs + (*root_slot as i32) * 8;
         return builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), jf_ptr, root_offset);
+            .load(cl_types::I64, MemFlagsData::trusted(), jf_ptr, root_offset);
     }
     resolve_opref(builder, constants, opref)
 }
@@ -5539,7 +5545,7 @@ fn resolve_local_jump_arg(
         let jf_ptr = cached_pinned_reg(builder, ptr_type, cached_jf_ptr);
         return builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), jf_ptr, offset);
+            .load(cl_types::I64, MemFlagsData::trusted(), jf_ptr, offset);
     }
     resolve_opref(builder, constants, opref)
 }
@@ -5659,12 +5665,12 @@ fn emit_load_from_addr(
     signed: bool,
     opcode: OpCode,
 ) -> Result<CValue, BackendError> {
-    // Use non-trusted MemFlags so Cranelift does NOT speculate loads
+    // Use non-trusted MemFlagsData so Cranelift does NOT speculate loads
     // past guards. With trusted(), Cranelift can hoist a load before
     // a GuardNonnull branch, causing SEGFAULT on null pointers.
     // RPython's x86 backend emits in IR order (no scheduling), so
     // loads after guards are safe. Cranelift needs this annotation.
-    let heap_flags = MemFlags::new();
+    let heap_flags = MemFlagsData::new();
     match value_type {
         Type::Float => {
             if size != 8 {
@@ -5723,7 +5729,7 @@ fn emit_store_to_addr(
                 ));
             }
             let fval = coerce_ty(builder, value, cl_types::F64);
-            builder.ins().store(MemFlags::trusted(), fval, addr, 0);
+            builder.ins().store(MemFlagsData::trusted(), fval, addr, 0);
         }
         Type::Int | Type::Ref => {
             if value_type == Type::Ref && size != 8 {
@@ -5742,7 +5748,9 @@ fn emit_store_to_addr(
             } else {
                 builder.ins().ireduce(mem_ty, value)
             };
-            builder.ins().store(MemFlags::trusted(), store_val, addr, 0);
+            builder
+                .ins()
+                .store(MemFlagsData::trusted(), store_val, addr, 0);
         }
         Type::Void => {
             return Err(unsupported_semantics(
@@ -5846,7 +5854,9 @@ fn spill_ref_roots(
         }
         let offset = ref_root_base_ofs + (slot as i32) * 8;
         let val = builder.use_var(var(var_idx));
-        builder.ins().store(MemFlags::new(), val, jf_ptr, offset);
+        builder
+            .ins()
+            .store(MemFlagsData::new(), val, jf_ptr, offset);
     }
 }
 
@@ -5877,7 +5887,7 @@ fn reload_ref_roots(
         let offset = ref_root_base_ofs + (slot as i32) * 8;
         let val = builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), jf_ptr, offset);
+            .load(cl_types::I64, MemFlagsData::trusted(), jf_ptr, offset);
         builder.def_var(var(var_idx), val);
     }
 }
@@ -5895,7 +5905,9 @@ fn sync_ref_root_var(
     if let Some((_, slot)) = ref_root_slots.iter().find(|(idx, _)| *idx == var_idx) {
         let offset = ref_root_base_ofs + (*slot as i32) * 8;
         let jf_ptr = cached_pinned_reg(builder, ptr_type, cached_jf_ptr);
-        builder.ins().store(MemFlags::new(), value, jf_ptr, offset);
+        builder
+            .ins()
+            .store(MemFlagsData::new(), value, jf_ptr, offset);
         synced_ref_vars.insert(var_idx);
     }
 }
@@ -6086,11 +6098,11 @@ fn emit_reload_frame_if_necessary(
     );
     let rst = builder
         .ins()
-        .load(ptr_type, MemFlags::trusted(), rst_addr, 0);
+        .load(ptr_type, MemFlagsData::trusted(), rst_addr, 0);
     // MOV ebp, [ecx - WORD]  — jf_ptr is at top - WORD
     builder
         .ins()
-        .load(ptr_type, MemFlags::trusted(), rst, -word)
+        .load(ptr_type, MemFlagsData::trusted(), rst, -word)
 }
 
 /// llsupport/llmodel.py:229-234 `insert_stack_check` plus
@@ -6115,11 +6127,11 @@ fn emit_stack_check_result(
         let end_addr = builder.ins().iconst(ptr_type, addrs.end_adr as i64);
         let end = builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), end_addr, 0);
+            .load(cl_types::I64, MemFlagsData::trusted(), end_addr, 0);
         let length_addr = builder.ins().iconst(ptr_type, addrs.length_adr as i64);
         let length = builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), length_addr, 0);
+            .load(cl_types::I64, MemFlagsData::trusted(), length_addr, 0);
         let ofs = builder.ins().isub(end, current);
         let overflow_candidate = builder.ins().icmp(IntCC::UnsignedGreaterThan, ofs, length);
 
@@ -6181,7 +6193,7 @@ fn emit_push_gcmap(builder: &mut FunctionBuilder, jf_ptr: CValue, per_call_gcmap
     let gcmap_val = builder.ins().iconst(cl_types::I64, per_call_gcmap);
     builder
         .ins()
-        .store(MemFlags::new(), gcmap_val, jf_ptr, JF_GCMAP_OFS);
+        .store(MemFlagsData::new(), gcmap_val, jf_ptr, JF_GCMAP_OFS);
 }
 
 /// RPython pop_gcmap (assembler.py:2024-2027):
@@ -6192,7 +6204,7 @@ fn emit_pop_gcmap(builder: &mut FunctionBuilder, jf_ptr: CValue, _per_call_gcmap
     let zero = builder.ins().iconst(cl_types::I64, 0);
     builder
         .ins()
-        .store(MemFlags::new(), zero, jf_ptr, JF_GCMAP_OFS);
+        .store(MemFlagsData::new(), zero, jf_ptr, JF_GCMAP_OFS);
 }
 
 fn emit_jitframe_write_barrier(
@@ -6426,7 +6438,7 @@ fn emit_cmp_guard_class(
         // x86/assembler.py:1884-1885 vtable_offset path: full classptr CMP.
         let actual_class = builder
             .ins()
-            .load(ptr_type, MemFlags::trusted(), obj, off as i32);
+            .load(ptr_type, MemFlagsData::trusted(), obj, off as i32);
         builder
             .ins()
             .icmp(IntCC::NotEqual, actual_class, expected_class)
@@ -6461,7 +6473,7 @@ fn emit_cmp_guard_class(
         // typeid is a 32-bit half-word at offset 0 of the object.
         let actual_typeid = builder
             .ins()
-            .load(cl_types::I32, MemFlags::trusted(), obj, 0);
+            .load(cl_types::I32, MemFlagsData::trusted(), obj, 0);
         let expected_typeid_val = builder.ins().iconst(cl_types::I32, expected_typeid as i64);
         builder
             .ins()
@@ -6514,7 +6526,7 @@ fn emit_attached_bridge_dispatch(
     let bridge_body =
         builder
             .ins()
-            .atomic_load(ptr_type, MemFlags::trusted(), bridge_body_cache_ptr);
+            .atomic_load(ptr_type, MemFlagsData::trusted(), bridge_body_cache_ptr);
     let null_ptr = builder.ins().iconst(ptr_type, 0);
     let has_bridge = builder.ins().icmp(IntCC::NotEqual, bridge_body, null_ptr);
     let bridge_block = builder.create_block();
@@ -6595,7 +6607,7 @@ fn emit_attached_loop_dispatch(
     let cell_ptr = builder.ins().iconst(ptr_type, ll_loop_code_addr as i64);
     let entry = builder
         .ins()
-        .atomic_load(ptr_type, MemFlags::trusted(), cell_ptr);
+        .atomic_load(ptr_type, MemFlagsData::trusted(), cell_ptr);
     let null = builder.ins().iconst(ptr_type, 0);
     let has_entry = builder.ins().icmp(IntCC::NotEqual, entry, null);
     let check_block_id = builder.create_block();
@@ -6625,7 +6637,7 @@ fn emit_attached_loop_dispatch(
     let lbid_ptr = builder.ins().iconst(ptr_type, label_block_id_addr as i64);
     let lbid = builder
         .ins()
-        .load(cl_types::I32, MemFlags::trusted(), lbid_ptr, 0);
+        .load(cl_types::I32, MemFlagsData::trusted(), lbid_ptr, 0);
     let check_depth_block = builder.create_block();
     builder.append_block_param(check_depth_block, ptr_type);
     builder
@@ -6652,12 +6664,13 @@ fn emit_attached_loop_dispatch(
     let depth_cell_ptr = builder
         .ins()
         .iconst(ptr_type, target_frame_depth_addr as i64);
-    let target_depth = builder
-        .ins()
-        .load(cl_types::I64, MemFlags::trusted(), depth_cell_ptr, 0);
+    let target_depth =
+        builder
+            .ins()
+            .load(cl_types::I64, MemFlagsData::trusted(), depth_cell_ptr, 0);
     let frame_len = builder.ins().load(
         cl_types::I64,
-        MemFlags::trusted(),
+        MemFlagsData::trusted(),
         jf_ptr,
         JF_FRAME_LENGTH_OFS,
     );
@@ -6806,7 +6819,7 @@ fn emit_guard_exit(
                 };
                 builder
                     .ins()
-                    .bitcast(cl_types::I64, MemFlags::new(), scalar_f)
+                    .bitcast(cl_types::I64, MemFlagsData::new(), scalar_f)
             } else {
                 // _accum_reduce_sum INT (vector_ext.py:174-179):
                 // PEXTRQ lane0, PEXTRQ lane1, ADD
@@ -6820,7 +6833,7 @@ fn emit_guard_exit(
             };
             builder
                 .ins()
-                .store(MemFlags::trusted(), reduced, jf_ptr, offset);
+                .store(MemFlagsData::trusted(), reduced, jf_ptr, offset);
         } else {
             let val = resolve_failarg_opref(
                 builder,
@@ -6834,7 +6847,7 @@ fn emit_guard_exit(
             );
             builder
                 .ins()
-                .store(MemFlags::trusted(), val, jf_ptr, offset);
+                .store(MemFlagsData::trusted(), val, jf_ptr, offset);
         }
     }
     // assembler.py:2126 get_gcref_from_faildescr → MOV [ebp+jf_descr], gcref
@@ -6919,7 +6932,7 @@ fn emit_guard_exit(
             .iconst(cl_types::I64, gcmap_arr.as_ptr() as i64);
         builder
             .ins()
-            .store(MemFlags::new(), gcmap_val, jf_ptr, JF_GCMAP_OFS); // #2104
+            .store(MemFlagsData::new(), gcmap_val, jf_ptr, JF_GCMAP_OFS); // #2104
     }
     // _build_failure_recovery (assembler.py:2089-2096) parity:
     // if exc: MOV ebx, [pos_exc_value]; MOV [pos_exception], 0;
@@ -6933,18 +6946,20 @@ fn emit_guard_exit(
             .iconst(cl_types::I64, jit_exc_value_addr() as i64);
         let exc_val = builder
             .ins()
-            .load(cl_types::I64, MemFlags::trusted(), exc_addr, 0);
+            .load(cl_types::I64, MemFlagsData::trusted(), exc_addr, 0);
         builder
             .ins()
-            .store(MemFlags::trusted(), exc_val, jf_ptr, JF_GUARD_EXC_OFS);
+            .store(MemFlagsData::trusted(), exc_val, jf_ptr, JF_GUARD_EXC_OFS);
         let zero = builder.ins().iconst(cl_types::I64, 0);
-        builder.ins().store(MemFlags::trusted(), zero, exc_addr, 0);
+        builder
+            .ins()
+            .store(MemFlagsData::trusted(), zero, exc_addr, 0);
         let exc_type_addr = builder
             .ins()
             .iconst(cl_types::I64, jit_exc_type_addr() as i64);
         builder
             .ins()
-            .store(MemFlags::trusted(), zero, exc_type_addr, 0);
+            .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
     }
     if info.gcmap != 0 || info.must_save_exception {
         // aarch64/assembler.py:967-980 `_reload_frame_if_necessary`:
@@ -6959,7 +6974,7 @@ fn emit_guard_exit(
     }
     builder
         .ins()
-        .store(MemFlags::trusted(), descr_val, jf_ptr, JF_DESCR_OFS); // #2105
+        .store(MemFlagsData::trusted(), descr_val, jf_ptr, JF_DESCR_OFS); // #2105
     // assembler.py:1101 _call_footer → _call_footer_shadowstack:
     // SUB [rootstacktop], 2*WORD — inline, no function call.
     emit_call_footer_shadowstack(builder, ptr_type);
@@ -6983,6 +6998,8 @@ struct CompiledLoop {
     /// bridge dispatched from a parent guard.
     body_ptr: *const u8,
     code_size: usize,
+    /// Finalized native ranges awaiting transfer to the owning CLT.
+    asm_memory_blocks: Vec<majit_backend::AsmMemoryBlock>,
     fail_descrs: Box<[DescrRef]>,
     /// Position-aligned `FailDescrCell` wrappers (see
     /// `RegisteredLoopTarget::fail_descr_cells`).
@@ -8012,27 +8029,8 @@ pub struct CraneliftBackend {
     /// counterpart for the shared-Arc pairing rationale with the
     /// metainterp `JitProfiler`.
     cpu_tracker: Arc<majit_backend::CpuTotalTracker>,
-    /// `asmmemmgr.py:28` `AsmMemoryManager` parity — the CPU owns the
-    /// accounting `jit_hooks.stats_asmmemmgr_{allocated,used}` reads. Cranelift
-    /// has no `AsmMemoryManager` of its own: the memory lives inside
-    /// `JITModule`'s provider, which does not publish what it mapped, so
-    /// `record_block` is given the finalized code size for both figures.
-    ///
-    /// That makes `allocated` an *under*count, not a page-rounded one: the
-    /// default `SystemMemoryProvider` page-rounds its anonymous mappings, so
-    /// the pages it holds exceed the machine-code length recorded here.
-    asm_memory_stats: Arc<majit_backend::AsmMemoryManagerStats>,
-    /// Lifetime tokens for the blocks recorded above. They are held for the
-    /// backend's whole life because nothing shorter is correct: the default
-    /// provider does not free on drop. `Memory`'s `Drop` `mem::forget`s every
-    /// allocation ("leak memory to guarantee validity of function pointers"),
-    /// and the only release is `unsafe JITModule::free_memory(self)`, which
-    /// consumes the module and which this backend never calls. So the code
-    /// outlives the process's use of it, and `used` is given back at backend
-    /// teardown rather than when the code stops existing. `allocated` is never
-    /// given back, which is `asmmemmgr.py:90`'s shape: an arena counts once
-    /// and is never un-counted.
-    asm_memory_blocks: Vec<majit_backend::AsmMemoryBlock>,
+    /// `cpu.asmmemmgr` view into the provider moved into `JITModule`.
+    asm_memory_handle: CraneliftArenaHandle,
     module: JITModule,
     func_ctx: FunctionBuilderContext,
     /// Constant pool keyed by OpRef raw index. Each `Const` carries its
@@ -8286,14 +8284,18 @@ impl CraneliftBackend {
             .finish(settings::Flags::new(flag_builder))
             .unwrap();
 
-        let jit_builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        let asm_memory_stats = Arc::new(majit_backend::AsmMemoryManagerStats::default());
+        let asm_memory_manager =
+            majit_backend::AsmMemoryManager::new(Arc::clone(&asm_memory_stats));
+        let (provider, asm_memory_handle) = CraneliftArenaMemoryProvider::new(asm_memory_manager);
+        let mut jit_builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
+        jit_builder.memory_provider(Box::new(provider));
         let module = JITModule::new(jit_builder);
         let func_ctx = FunctionBuilderContext::new();
 
         CraneliftBackend {
             cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
-            asm_memory_stats: Arc::new(majit_backend::AsmMemoryManagerStats::default()),
-            asm_memory_blocks: Vec::new(),
+            asm_memory_handle,
             module,
             func_ctx,
             constants: majit_ir::ConstMap::new(),
@@ -8458,7 +8460,7 @@ impl CraneliftBackend {
                 .get()
                 .and_then(|info| info.jitframe_descrs.clone()),
             // llmodel.py:39 default. Cranelift lowers GcStoreIndexed via
-            // ir::MemFlags and explicit offset arithmetic rather than an
+            // ir::MemFlagsData and explicit offset arithmetic rather than an
             // ISA scaled addressing mode, so we keep the rewriter in the
             // "pre-scale everything" contract that the lowering expects.
             load_supported_factors: &[1],
@@ -8835,7 +8837,8 @@ impl CraneliftBackend {
         // build-time store, which decodes the same `-live-` marker to a
         // different — and silently plausible — count.
         let frame_value_count_fn = self.next_frame_value_count_fn.take();
-        let ptr_type = self.module.target_config().pointer_type();
+        let frontend_config = self.module.target_config();
+        let ptr_type = frontend_config.pointer_type();
         let call_conv = self.module.target_config().default_call_conv;
         // The body uses CallConv::Tail so it can `return_call_indirect` to
         // another body's entry — `assembler.py:2456-2462 closing_jump` raw
@@ -9160,7 +9163,7 @@ impl CraneliftBackend {
             // `LDR_ri(r.ip0.value, r.fp.value, ofs)` parity.
             let frame_len = builder.ins().load(
                 cl_types::I64,
-                MemFlags::trusted(),
+                MemFlagsData::trusted(),
                 initial_jf_ptr,
                 JF_FRAME_LENGTH_OFS,
             );
@@ -9519,7 +9522,7 @@ impl CraneliftBackend {
                 let offset = JF_FRAME_ITEM0_OFS + (i as i32) * 8;
                 builder
                     .ins()
-                    .load(cl_types::I64, MemFlags::trusted(), inputs_ptr, offset)
+                    .load(cl_types::I64, MemFlagsData::trusted(), inputs_ptr, offset)
             })
             .collect();
 
@@ -9718,7 +9721,7 @@ impl CraneliftBackend {
                     for &(i, raw, root_ofs) in positions {
                         let v = builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             cur_jf,
                             JF_FRAME_ITEM0_OFS + (i as i32) * 8,
                         );
@@ -9737,7 +9740,7 @@ impl CraneliftBackend {
                     for &(i, _raw, home_ofs) in positions {
                         let v = builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             cur_jf,
                             JF_FRAME_ITEM0_OFS + (i as i32) * 8,
                         );
@@ -9750,7 +9753,7 @@ impl CraneliftBackend {
                         let offset = JF_FRAME_ITEM0_OFS + (i as i32) * 8;
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), cur_jf, offset)
+                            .load(cl_types::I64, MemFlagsData::trusted(), cur_jf, offset)
                     })
                     .collect();
                 // Ref-root re-syncs go after every dense carried-slot load:
@@ -9760,7 +9763,9 @@ impl CraneliftBackend {
                 // read (same hazard `deferred_entry_root_syncs` defers past
                 // the dispatch above).
                 for &(v, root_ofs) in &demoted_root_syncs {
-                    builder.ins().store(MemFlags::new(), v, cur_jf, root_ofs);
+                    builder
+                        .ins()
+                        .store(MemFlagsData::new(), v, cur_jf, root_ofs);
                 }
                 let args = block_args_to(&mut builder, label_block, &vals);
                 builder.ins().jump(label_block, &args);
@@ -9852,7 +9857,7 @@ impl CraneliftBackend {
                                 let opref = label_args[i].to_opref();
                                 let v = resolve_opref(&mut builder, &constants, opref);
                                 let v = coerce_ty(&mut builder, v, cl_types::I64);
-                                builder.ins().store(MemFlags::new(), v, cur_jf, ofs);
+                                builder.ins().store(MemFlagsData::new(), v, cur_jf, ofs);
                                 synced_ref_vars.insert(raw);
                                 demoted_failarg_slots.insert(raw, ofs);
                             }
@@ -9868,7 +9873,9 @@ impl CraneliftBackend {
                                 let opref = label_args[i].to_opref();
                                 let v = resolve_opref(&mut builder, &constants, opref);
                                 let v = coerce_ty(&mut builder, v, cl_types::I64);
-                                builder.ins().store(MemFlags::new(), v, cur_jf, home_ofs);
+                                builder
+                                    .ins()
+                                    .store(MemFlagsData::new(), v, cur_jf, home_ofs);
                                 demoted_failarg_slots.insert(raw, home_ofs);
                             }
                         }
@@ -9890,10 +9897,12 @@ impl CraneliftBackend {
                     if let Some(positions) = demoted_ref_positions_by_label.get(&op_idx) {
                         let cur_jf = builder.ins().get_pinned_reg(ptr_type);
                         for &(_, raw, ofs) in positions {
-                            let value =
-                                builder
-                                    .ins()
-                                    .load(cl_types::I64, MemFlags::trusted(), cur_jf, ofs);
+                            let value = builder.ins().load(
+                                cl_types::I64,
+                                MemFlagsData::trusted(),
+                                cur_jf,
+                                ofs,
+                            );
                             builder.def_var(var(raw), value);
                         }
                     }
@@ -10425,7 +10434,7 @@ impl CraneliftBackend {
                     let exc_addr = builder.ins().iconst(ptr_type, jit_exc_value_addr() as i64);
                     let exc_val = builder.ins().load(
                         cl_types::I64,
-                        cranelift_codegen::ir::MemFlags::trusted(),
+                        cranelift_codegen::ir::MemFlagsData::trusted(),
                         exc_addr,
                         0,
                     );
@@ -10476,10 +10485,12 @@ impl CraneliftBackend {
                         resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     // Inline: load pos_exception (exc type)
                     let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
-                    let exc_type =
-                        builder
-                            .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), exc_type_addr, 0);
+                    let exc_type = builder.ins().load(
+                        cl_types::I64,
+                        MemFlagsData::trusted(),
+                        exc_type_addr,
+                        0,
+                    );
                     // CMP exc_type, expected
                     let mismatch = builder.ins().icmp(IntCC::NotEqual, exc_type, expected_type);
                     let exit_block = builder.create_block();
@@ -10519,14 +10530,14 @@ impl CraneliftBackend {
                     let exc_val =
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), exc_val_addr, 0);
+                            .load(cl_types::I64, MemFlagsData::trusted(), exc_val_addr, 0);
                     let zero = builder.ins().iconst(cl_types::I64, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), zero, exc_type_addr, 0);
+                        .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), zero, exc_val_addr, 0);
+                        .store(MemFlagsData::trusted(), zero, exc_val_addr, 0);
                     let vi = op_var_index(op, op_idx, inputargs.len());
                     builder.def_var(var(vi as u32), exc_val);
                 }
@@ -10625,7 +10636,7 @@ impl CraneliftBackend {
 
                     let jf_descr = builder.ins().load(
                         cl_types::I64,
-                        MemFlags::trusted(),
+                        MemFlagsData::trusted(),
                         jf_ptr,
                         JF_DESCR_OFS,
                     );
@@ -10679,9 +10690,12 @@ impl CraneliftBackend {
                     // _store_force_index(op): store descr to jf_force_descr
                     let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
                     let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-                    builder
-                        .ins()
-                        .store(MemFlags::trusted(), descr_val, cur_jf, JF_FORCE_DESCR_OFS);
+                    builder.ins().store(
+                        MemFlagsData::trusted(),
+                        descr_val,
+                        cur_jf,
+                        JF_FORCE_DESCR_OFS,
+                    );
 
                     // implement_guard_recovery / _update_at_exit parity:
                     // Write fail_arg values to jf_frame[0..n] in fail_args order.
@@ -10697,7 +10711,7 @@ impl CraneliftBackend {
                             arg_ref,
                         );
                         builder.ins().store(
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             raw,
                             cur_jf,
                             JF_FRAME_ITEM0_OFS + (index as i32) * 8,
@@ -10719,7 +10733,7 @@ impl CraneliftBackend {
                         let flag_val =
                             builder
                                 .ins()
-                                .load(cl_types::I8, MemFlags::trusted(), addr_val, 0);
+                                .load(cl_types::I8, MemFlagsData::trusted(), addr_val, 0);
                         let zero = builder.ins().iconst(cl_types::I8, 0);
                         let is_invalidated = builder.ins().icmp(IntCC::NotEqual, flag_val, zero);
 
@@ -10835,7 +10849,7 @@ impl CraneliftBackend {
                     let hdr_word =
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), hdr_addr, 0);
+                            .load(cl_types::I64, MemFlagsData::trusted(), hdr_addr, 0);
                     // Extract type_id (lower 32 bits)
                     let tid_mask = builder.ins().iconst(cl_types::I64, TYPE_ID_MASK as i64);
                     let actual_tid = builder.ins().band(hdr_word, tid_mask);
@@ -10915,7 +10929,7 @@ impl CraneliftBackend {
                     let hdr_word =
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), hdr_addr, 0);
+                            .load(cl_types::I64, MemFlagsData::trusted(), hdr_addr, 0);
                     let tid_mask = builder.ins().iconst(cl_types::I64, TYPE_ID_MASK as i64);
                     let loc_typeid = builder.ins().band(hdr_word, tid_mask);
 
@@ -10943,7 +10957,7 @@ impl CraneliftBackend {
                     let byte =
                         builder
                             .ins()
-                            .load(cl_types::I8, MemFlags::trusted(), loc_infobits, 0);
+                            .load(cl_types::I8, MemFlagsData::trusted(), loc_infobits, 0);
                     let mask = builder.ins().iconst(cl_types::I8, is_object_flag as i64);
                     let masked = builder.ins().band(byte, mask);
                     let zero_i8 = builder.ins().iconst(cl_types::I8, 0);
@@ -11049,13 +11063,13 @@ impl CraneliftBackend {
                         //     self.mc.MOV_rm(loc_tmp, (loc_tmp, offset2))
                         let vtable_ptr_val = builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             loc_object,
                             vtable_off as i32,
                         );
                         builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             vtable_ptr_val,
                             offset2 as i32,
                         )
@@ -11070,7 +11084,7 @@ impl CraneliftBackend {
                         let hdr_word =
                             builder
                                 .ins()
-                                .load(cl_types::I64, MemFlags::trusted(), hdr_addr, 0);
+                                .load(cl_types::I64, MemFlagsData::trusted(), hdr_addr, 0);
                         let tid_mask = builder.ins().iconst(cl_types::I64, TYPE_ID_MASK as i64);
                         let typeid = builder.ins().band(hdr_word, tid_mask);
                         let (base_type_info, shift_by, sizeof_ti) =
@@ -11087,7 +11101,7 @@ impl CraneliftBackend {
                             .iadd_imm(addr_base, (sizeof_ti + offset2) as i64);
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), addr, 0)
+                            .load(cl_types::I64, MemFlagsData::trusted(), addr, 0)
                     };
 
                     // assembler.py:1971-1974 read the bounds from the
@@ -11152,15 +11166,15 @@ impl CraneliftBackend {
                     let exc_val =
                         builder
                             .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), exc_val_addr, 0);
+                            .load(cl_types::I64, MemFlagsData::trusted(), exc_val_addr, 0);
                     let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
                     let zero = builder.ins().iconst(cl_types::I64, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), zero, exc_type_addr, 0);
+                        .store(MemFlagsData::trusted(), zero, exc_type_addr, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), zero, exc_val_addr, 0);
+                        .store(MemFlagsData::trusted(), zero, exc_val_addr, 0);
                     let vi = op_var_index(op, op_idx, inputargs.len());
                     builder.def_var(var(vi as u32), exc_val);
                 }
@@ -11168,10 +11182,12 @@ impl CraneliftBackend {
                     // x86/assembler.py:1817-1818 genop_save_exc_class:
                     //   MOV resloc, [pos_exception]
                     let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
-                    let exc_type =
-                        builder
-                            .ins()
-                            .load(cl_types::I64, MemFlags::trusted(), exc_type_addr, 0);
+                    let exc_type = builder.ins().load(
+                        cl_types::I64,
+                        MemFlagsData::trusted(),
+                        exc_type_addr,
+                        0,
+                    );
                     let vi = op_var_index(op, op_idx, inputargs.len());
                     builder.def_var(var(vi as u32), exc_type);
                 }
@@ -11185,10 +11201,10 @@ impl CraneliftBackend {
                     let exc_type_addr = builder.ins().iconst(ptr_type, jit_exc_type_addr() as i64);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), value, exc_val_addr, 0);
+                        .store(MemFlagsData::trusted(), value, exc_val_addr, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), exc_type, exc_type_addr, 0);
+                        .store(MemFlagsData::trusted(), exc_type, exc_type_addr, 0);
                 }
                 OpCode::CheckMemoryError => {
                     // x86/assembler.py:1630-1641 `genop_discard_check_memory_error`
@@ -11313,7 +11329,7 @@ impl CraneliftBackend {
                         let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
                         let cur_jf = builder.ins().get_pinned_reg(ptr_type);
                         builder.ins().store(
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             descr_val,
                             cur_jf,
                             JF_FORCE_DESCR_OFS,
@@ -11324,7 +11340,7 @@ impl CraneliftBackend {
                         let zero = builder.ins().iconst(cl_types::I64, 0);
                         builder
                             .ins()
-                            .store(MemFlags::trusted(), zero, cur_jf, JF_DESCR_OFS);
+                            .store(MemFlagsData::trusted(), zero, cur_jf, JF_DESCR_OFS);
                     }
 
                     // rewrite.py:613-653 gen_malloc_frame parity:
@@ -11391,7 +11407,7 @@ impl CraneliftBackend {
                             let entry_ptr = builder.ins().iconst(ptr_type, addr_slot as i64);
                             builder
                                 .ins()
-                                .load(ptr_type, MemFlags::trusted(), entry_ptr, 0)
+                                .load(ptr_type, MemFlagsData::trusted(), entry_ptr, 0)
                         };
                         let expected_finish_descr_ptr = self
                             .attached_descr_ptrs()
@@ -11483,7 +11499,7 @@ impl CraneliftBackend {
                         //   CMP [eax + jf_descr_ofs], done_with_this_frame_descr
                         let fail_idx_raw = builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             result_jf,
                             JF_DESCR_OFS,
                         );
@@ -11517,7 +11533,7 @@ impl CraneliftBackend {
                         builder.seal_block(direct_finish_block);
                         let direct_result = builder.ins().load(
                             cl_types::I64,
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             result_jf,
                             JF_FRAME_ITEM0_OFS,
                         );
@@ -11659,7 +11675,10 @@ impl CraneliftBackend {
                     );
                     mark_ref_roots_fresh(&mut stale_ref_vars, &live_ref_root_slots);
 
-                    let outcome_kind = builder.ins().stack_load(cl_types::I64, outcome_slot, 0);
+                    let outcome_kind =
+                        builder
+                            .ins()
+                            .stack_load(ptr_type, cl_types::I64, outcome_slot, 0);
                     let finish_kind = builder
                         .ins()
                         .iconst(cl_types::I64, CALL_ASSEMBLER_OUTCOME_FINISH);
@@ -11676,9 +11695,12 @@ impl CraneliftBackend {
 
                     builder.switch_to_block(exit_block);
                     builder.seal_block(exit_block);
-                    let deadframe_handle = builder.ins().stack_load(cl_types::I64, outcome_slot, 8);
+                    let deadframe_handle =
+                        builder
+                            .ins()
+                            .stack_load(ptr_type, cl_types::I64, outcome_slot, 8);
                     builder.ins().store(
-                        MemFlags::trusted(),
+                        MemFlagsData::trusted(),
                         deadframe_handle,
                         jf_ptr,
                         JF_FRAME_ITEM0_OFS,
@@ -11688,7 +11710,7 @@ impl CraneliftBackend {
                         .iconst(cl_types::I64, CALL_ASSEMBLER_DEADFRAME_SENTINEL as i64);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), sentinel, jf_ptr, JF_DESCR_OFS);
+                        .store(MemFlagsData::trusted(), sentinel, jf_ptr, JF_DESCR_OFS);
                     // assembler.py:1130-1136 _call_footer_shadowstack — inline SUB
                     emit_call_footer_shadowstack(&mut builder, ptr_type);
                     builder.ins().return_(&[jf_ptr]);
@@ -11731,9 +11753,12 @@ impl CraneliftBackend {
                     // forces the frame, force() reads this to set jf_descr.
                     let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
                     let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-                    builder
-                        .ins()
-                        .store(MemFlags::trusted(), descr_val, cur_jf, JF_FORCE_DESCR_OFS);
+                    builder.ins().store(
+                        MemFlagsData::trusted(),
+                        descr_val,
+                        cur_jf,
+                        JF_FORCE_DESCR_OFS,
+                    );
 
                     // regalloc.py before_call() parity: spill fail_args to
                     // jf_frame so force_token_to_dead_frame() reads correct
@@ -11762,7 +11787,7 @@ impl CraneliftBackend {
                             )
                         };
                         builder.ins().store(
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             raw,
                             cur_jf,
                             JF_FRAME_ITEM0_OFS + (index as i32) * 8,
@@ -11812,9 +11837,12 @@ impl CraneliftBackend {
                     let info = &guard_infos[guard_idx];
                     let descr_val = builder.ins().iconst(cl_types::I64, info.fail_descr_ptr);
                     let cur_jf = builder.ins().get_pinned_reg(ptr_type);
-                    builder
-                        .ins()
-                        .store(MemFlags::trusted(), descr_val, cur_jf, JF_FORCE_DESCR_OFS);
+                    builder.ins().store(
+                        MemFlagsData::trusted(),
+                        descr_val,
+                        cur_jf,
+                        JF_FORCE_DESCR_OFS,
+                    );
 
                     // regalloc.py before_call() parity: spill fail_args to
                     // jf_frame so force_token_to_dead_frame() reads correct
@@ -11842,7 +11870,7 @@ impl CraneliftBackend {
                             )
                         };
                         builder.ins().store(
-                            MemFlags::trusted(),
+                            MemFlagsData::trusted(),
                             raw,
                             cur_jf,
                             JF_FRAME_ITEM0_OFS + (index as i32) * 8,
@@ -12119,7 +12147,7 @@ impl CraneliftBackend {
                     // `nursery_top` reported as 0) the op stays on the helper.
                     let inline_bump = gc_nursery_addrs.filter(|&(nf, nt)| nf != 0 && nt != 0);
                     if let Some((nf_addr, nt_addr)) = inline_bump {
-                        let flags = MemFlags::trusted();
+                        let flags = MemFlagsData::trusted();
                         let nf_ptr = builder.ins().iconst(ptr_type, nf_addr as i64);
                         let nt_ptr = builder.ins().iconst(ptr_type, nt_addr as i64);
                         let free = builder.ins().load(ptr_type, flags, nf_ptr, 0);
@@ -12294,7 +12322,7 @@ impl CraneliftBackend {
                         // Slow path passes GC-updated values from jitframe.
                         let (nf_addr, nt_addr) =
                             gc_nursery_addrs.ok_or_else(|| missing_gc_runtime(op.opcode))?;
-                        let flags = MemFlags::trusted();
+                        let flags = MemFlagsData::trusted();
                         // history.py:227 ConstInt.value inline — read directly
                         // from `OpRef::ConstInt(v)`, fall through to the
                         // legacy pool for `OpRef::ConstInt(idx)` arms.
@@ -12340,7 +12368,9 @@ impl CraneliftBackend {
                         builder.seal_block(fast_block);
                         builder.ins().store(flags, new_free, nf_ptr, 0);
                         let zero_hdr = builder.ins().iconst(cl_types::I64, 0);
-                        builder.ins().store(MemFlags::trusted(), zero_hdr, free, 0);
+                        builder
+                            .ins()
+                            .store(MemFlagsData::trusted(), zero_hdr, free, 0);
                         let hdr_sz = builder.ins().iconst(ptr_type, GcHeader::SIZE as i64);
                         let obj = builder.ins().iadd(free, hdr_sz);
                         // Pass original values through block params
@@ -12485,7 +12515,7 @@ impl CraneliftBackend {
                     // slow path installs the gcmap and spills/reloads roots.
                     let (nf_addr, nt_addr) =
                         gc_nursery_addrs.ok_or_else(|| missing_gc_runtime(op.opcode))?;
-                    let flags = MemFlags::trusted();
+                    let flags = MemFlagsData::trusted();
                     let size_total = resolve_opref_or_imm(
                         &mut builder,
                         &constants,
@@ -12525,7 +12555,9 @@ impl CraneliftBackend {
                     builder.seal_block(fast_block);
                     builder.ins().store(flags, new_free, nf_ptr, 0);
                     let zero_hdr = builder.ins().iconst(cl_types::I64, 0);
-                    builder.ins().store(MemFlags::trusted(), zero_hdr, free, 0);
+                    builder
+                        .ins()
+                        .store(MemFlagsData::trusted(), zero_hdr, free, 0);
                     let header_size = builder.ins().iconst(ptr_type, GcHeader::SIZE as i64);
                     let obj_ptr = builder.ins().iadd(free, header_size);
                     let mut fast_args: Vec<BlockArg> =
@@ -12610,7 +12642,7 @@ impl CraneliftBackend {
                     let zero_gcmap = builder.ins().iconst(cl_types::I64, 0);
                     builder
                         .ins()
-                        .store(MemFlags::trusted(), zero_gcmap, result, JF_GCMAP_OFS);
+                        .store(MemFlagsData::trusted(), zero_gcmap, result, JF_GCMAP_OFS);
                     builder.def_var(var(vi), result);
                 }
 
@@ -12646,7 +12678,7 @@ impl CraneliftBackend {
                     let flag_byte =
                         builder
                             .ins()
-                            .load(cl_types::I8, MemFlags::trusted(), obj, wb_byteofs);
+                            .load(cl_types::I8, MemFlagsData::trusted(), obj, wb_byteofs);
                     let flag_ext = builder.ins().uextend(cl_types::I64, flag_byte);
                     let mask_val = builder.ins().iconst(cl_types::I64, wb_mask & 0xFF);
                     let test = builder.ins().band(flag_ext, mask_val);
@@ -12690,10 +12722,12 @@ impl CraneliftBackend {
                         );
 
                         // opassembler.py:982-987: post-helper re-load + re-test CARDS_SET.
-                        let flag_byte2 =
-                            builder
-                                .ins()
-                                .load(cl_types::I8, MemFlags::trusted(), obj, wb_byteofs);
+                        let flag_byte2 = builder.ins().load(
+                            cl_types::I8,
+                            MemFlagsData::trusted(),
+                            obj,
+                            wb_byteofs,
+                        );
                         let flag_ext2 = builder.ins().uextend(cl_types::I64, flag_byte2);
                         let cards_test2 = builder.ins().band(flag_ext2, cards_mask);
                         let has_cards2 = builder.ins().icmp(IntCC::NotEqual, cards_test2, zero);
@@ -12720,13 +12754,13 @@ impl CraneliftBackend {
                         let card_byte =
                             builder
                                 .ins()
-                                .load(cl_types::I8, MemFlags::trusted(), card_addr, 0);
+                                .load(cl_types::I8, MemFlagsData::trusted(), card_addr, 0);
                         let card_ext = builder.ins().uextend(cl_types::I64, card_byte);
                         let card_new = builder.ins().bor(card_ext, bit_mask);
                         let card_trunc = builder.ins().ireduce(cl_types::I8, card_new);
                         builder
                             .ins()
-                            .store(MemFlags::trusted(), card_trunc, card_addr, 0);
+                            .store(MemFlagsData::trusted(), card_trunc, card_addr, 0);
                         builder.ins().jump(cont_block, &[]);
                     } else {
                         // Simple write barrier (no card marking).
@@ -13859,8 +13893,8 @@ impl CraneliftBackend {
                     } else {
                         let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                         let b = resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
-                        let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
-                        let fb = builder.ins().bitcast(cl_types::F64, MemFlags::new(), b);
+                        let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
+                        let fb = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), b);
                         let fresult = match op.opcode {
                             OpCode::VecFloatAdd => builder.ins().fadd(fa, fb),
                             OpCode::VecFloatSub => builder.ins().fsub(fa, fb),
@@ -13868,9 +13902,10 @@ impl CraneliftBackend {
                             OpCode::VecFloatTrueDiv => builder.ins().fdiv(fa, fb),
                             _ => unreachable!(),
                         };
-                        let result = builder
-                            .ins()
-                            .bitcast(cl_types::I64, MemFlags::new(), fresult);
+                        let result =
+                            builder
+                                .ins()
+                                .bitcast(cl_types::I64, MemFlagsData::new(), fresult);
                         builder.def_var(var(vi), result);
                     }
                 }
@@ -13888,11 +13923,12 @@ impl CraneliftBackend {
                         builder.def_var(var(vi), result);
                     } else {
                         let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                        let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
+                        let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
                         let fresult = builder.ins().fneg(fa);
-                        let result = builder
-                            .ins()
-                            .bitcast(cl_types::I64, MemFlags::new(), fresult);
+                        let result =
+                            builder
+                                .ins()
+                                .bitcast(cl_types::I64, MemFlagsData::new(), fresult);
                         builder.def_var(var(vi), result);
                     }
                 }
@@ -13910,11 +13946,12 @@ impl CraneliftBackend {
                         builder.def_var(var(vi), result);
                     } else {
                         let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                        let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
+                        let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
                         let fresult = builder.ins().fabs(fa);
-                        let result = builder
-                            .ins()
-                            .bitcast(cl_types::I64, MemFlags::new(), fresult);
+                        let result =
+                            builder
+                                .ins()
+                                .bitcast(cl_types::I64, MemFlagsData::new(), fresult);
                         builder.def_var(var(vi), result);
                     }
                 }
@@ -13938,9 +13975,10 @@ impl CraneliftBackend {
                         );
                         let xored = builder.ins().bxor(a, b);
                         // Result is declared as F64X2, bitcast from I64X2
-                        let result = builder
-                            .ins()
-                            .bitcast(cl_types::F64X2, MemFlags::new(), xored);
+                        let result =
+                            builder
+                                .ins()
+                                .bitcast(cl_types::F64X2, MemFlagsData::new(), xored);
                         builder.def_var(var(vi), result);
                     } else {
                         let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
@@ -13955,8 +13993,8 @@ impl CraneliftBackend {
                 OpCode::VecFloatEq => {
                     let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     let b = resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
-                    let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
-                    let fb = builder.ins().bitcast(cl_types::F64, MemFlags::new(), b);
+                    let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
+                    let fb = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), b);
                     let cmp = builder.ins().fcmp(FloatCC::Equal, fa, fb);
                     let result = builder.ins().uextend(cl_types::I64, cmp);
                     builder.def_var(var(vi), result);
@@ -13965,8 +14003,8 @@ impl CraneliftBackend {
                 OpCode::VecFloatNe => {
                     let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     let b = resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
-                    let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
-                    let fb = builder.ins().bitcast(cl_types::F64, MemFlags::new(), b);
+                    let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
+                    let fb = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), b);
                     let cmp = builder.ins().fcmp(FloatCC::NotEqual, fa, fb);
                     let result = builder.ins().uextend(cl_types::I64, cmp);
                     builder.def_var(var(vi), result);
@@ -14006,7 +14044,7 @@ impl CraneliftBackend {
                 // These operate on scalar elements, not full vectors.
                 OpCode::VecCastFloatToInt => {
                     let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
+                    let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
                     let result = builder.ins().fcvt_to_sint(cl_types::I64, fa);
                     builder.def_var(var(vi), result);
                 }
@@ -14016,17 +14054,17 @@ impl CraneliftBackend {
                     let fresult = builder.ins().fcvt_from_sint(cl_types::F64, a);
                     let result = builder
                         .ins()
-                        .bitcast(cl_types::I64, MemFlags::new(), fresult);
+                        .bitcast(cl_types::I64, MemFlagsData::new(), fresult);
                     builder.def_var(var(vi), result);
                 }
 
                 OpCode::VecCastFloatToSinglefloat => {
                     let a = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let fa = builder.ins().bitcast(cl_types::F64, MemFlags::new(), a);
+                    let fa = builder.ins().bitcast(cl_types::F64, MemFlagsData::new(), a);
                     let f32val = builder.ins().fdemote(cl_types::F32, fa);
                     let result = builder
                         .ins()
-                        .bitcast(cl_types::I32, MemFlags::new(), f32val);
+                        .bitcast(cl_types::I32, MemFlagsData::new(), f32val);
                     let result_ext = builder.ins().uextend(cl_types::I64, result);
                     builder.def_var(var(vi), result_ext);
                 }
@@ -14036,11 +14074,11 @@ impl CraneliftBackend {
                     let a_trunc = builder.ins().ireduce(cl_types::I32, a);
                     let f32val = builder
                         .ins()
-                        .bitcast(cl_types::F32, MemFlags::new(), a_trunc);
+                        .bitcast(cl_types::F32, MemFlagsData::new(), a_trunc);
                     let f64val = builder.ins().fpromote(cl_types::F64, f32val);
                     let result = builder
                         .ins()
-                        .bitcast(cl_types::I64, MemFlags::new(), f64val);
+                        .bitcast(cl_types::I64, MemFlagsData::new(), f64val);
                     builder.def_var(var(vi), result);
                 }
 
@@ -14053,7 +14091,7 @@ impl CraneliftBackend {
                             let zero_f =
                                 builder
                                     .ins()
-                                    .bitcast(cl_types::F64, MemFlags::new(), zero_i);
+                                    .bitcast(cl_types::F64, MemFlagsData::new(), zero_i);
                             let result = builder.ins().splat(cl_types::F64X2, zero_f);
                             builder.def_var(var(vi), result);
                         } else {
@@ -14105,7 +14143,7 @@ impl CraneliftBackend {
                         let scalar_f =
                             builder
                                 .ins()
-                                .bitcast(cl_types::F64, MemFlags::new(), scalar_i);
+                                .bitcast(cl_types::F64, MemFlagsData::new(), scalar_i);
                         let lane =
                             lookup_const_i64(&constants, op.arg(2).to_opref()).unwrap_or(0) as u8;
                         let result = builder.ins().insertlane(vec_val, scalar_f, lane);
@@ -14152,7 +14190,7 @@ impl CraneliftBackend {
                         let result =
                             builder
                                 .ins()
-                                .bitcast(cl_types::I64, MemFlags::new(), scalar_f);
+                                .bitcast(cl_types::I64, MemFlagsData::new(), scalar_f);
                         builder.def_var(var(vi), result);
                     } else {
                         let vec_val = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
@@ -14180,7 +14218,7 @@ impl CraneliftBackend {
                         let scalar_f =
                             builder
                                 .ins()
-                                .bitcast(cl_types::F64, MemFlags::new(), scalar_i);
+                                .bitcast(cl_types::F64, MemFlagsData::new(), scalar_i);
                         let result = builder.ins().splat(cl_types::F64X2, scalar_f);
                         builder.def_var(var(vi), result);
                     } else {
@@ -14205,7 +14243,10 @@ impl CraneliftBackend {
                         } else {
                             cl_types::I64X2
                         };
-                        let result = builder.ins().load(load_type, MemFlags::trusted(), addr, 0);
+                        let result =
+                            builder
+                                .ins()
+                                .load(load_type, MemFlagsData::trusted(), addr, 0);
                         builder.def_var(var(vi), result);
                     } else {
                         let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
@@ -14218,7 +14259,7 @@ impl CraneliftBackend {
                         let result =
                             builder
                                 .ins()
-                                .load(cl_types::I64, MemFlags::trusted(), addr, 0);
+                                .load(cl_types::I64, MemFlagsData::trusted(), addr, 0);
                         builder.def_var(var(vi), result);
                     }
                 }
@@ -14239,7 +14280,7 @@ impl CraneliftBackend {
                             resolve_opref(&mut builder, &constants, value_ref.to_opref())
                         };
                         let addr = builder.ins().iadd(base, offset_val);
-                        builder.ins().store(MemFlags::trusted(), value, addr, 0);
+                        builder.ins().store(MemFlagsData::trusted(), value, addr, 0);
                     } else {
                         let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                         let offset_val = if op.num_args() > 2 {
@@ -14253,7 +14294,7 @@ impl CraneliftBackend {
                             op.arg(op.num_args() - 1).to_opref(),
                         );
                         let addr = builder.ins().iadd(base, offset_val);
-                        builder.ins().store(MemFlags::trusted(), value, addr, 0);
+                        builder.ins().store(MemFlagsData::trusted(), value, addr, 0);
                     }
                 }
 
@@ -14308,7 +14349,7 @@ impl CraneliftBackend {
                         if write_vtable {
                             let vtable_val = builder.ins().iconst(cl_types::I64, vtable as i64);
                             builder.ins().store(
-                                cranelift_codegen::ir::MemFlags::trusted(),
+                                cranelift_codegen::ir::MemFlagsData::trusted(),
                                 vtable_val,
                                 result,
                                 vtable_off_i32,
@@ -14343,7 +14384,7 @@ impl CraneliftBackend {
                         if write_vtable {
                             let vtable_val = builder.ins().iconst(cl_types::I64, vtable as i64);
                             builder.ins().store(
-                                cranelift_codegen::ir::MemFlags::trusted(),
+                                cranelift_codegen::ir::MemFlagsData::trusted(),
                                 vtable_val,
                                 result,
                                 vtable_off_i32,
@@ -14444,9 +14485,10 @@ impl CraneliftBackend {
                     // f64 → f32 → zero-extend to i64 (singlefloat is Int-typed)
                     let f64_val = coerce_ty(&mut builder, val, cl_types::F64);
                     let f32_val = builder.ins().fdemote(cl_types::F32, f64_val);
-                    let i32_val = builder
-                        .ins()
-                        .bitcast(cl_types::I32, MemFlags::new(), f32_val);
+                    let i32_val =
+                        builder
+                            .ins()
+                            .bitcast(cl_types::I32, MemFlagsData::new(), f32_val);
                     let result = builder.ins().uextend(cl_types::I64, i32_val);
                     builder.def_var(var(vi), result);
                 }
@@ -14455,9 +14497,10 @@ impl CraneliftBackend {
                     let val = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     // i64 (lower 32 bits = f32) → f32 → f64 → i64
                     let i32_val = builder.ins().ireduce(cl_types::I32, val);
-                    let f32_val = builder
-                        .ins()
-                        .bitcast(cl_types::F32, MemFlags::new(), i32_val);
+                    let f32_val =
+                        builder
+                            .ins()
+                            .bitcast(cl_types::F32, MemFlagsData::new(), i32_val);
                     let f64_val = builder.ins().fpromote(cl_types::F64, f32_val);
                     let want = var_types.get(&vi).copied().unwrap_or(cl_types::I64);
                     let result = coerce_ty(&mut builder, f64_val, want);
@@ -14471,9 +14514,10 @@ impl CraneliftBackend {
                     let scale = builder.ins().iconst(cl_types::I64, 8);
                     let offset = builder.ins().imul(index, scale);
                     let addr = builder.ins().iadd(base, offset);
-                    let result = builder
-                        .ins()
-                        .load(cl_types::I64, MemFlags::trusted(), addr, 0);
+                    let result =
+                        builder
+                            .ins()
+                            .load(cl_types::I64, MemFlagsData::trusted(), addr, 0);
                     builder.def_var(var(vi), result);
                     sync_ref_root_var(
                         &mut builder,
@@ -14532,7 +14576,7 @@ impl CraneliftBackend {
                     let slot_addr = builder.ins().iadd(base, byte_ofs);
                     let value = builder
                         .ins()
-                        .load(ptr_type, MemFlags::trusted(), slot_addr, 0);
+                        .load(ptr_type, MemFlagsData::trusted(), slot_addr, 0);
                     builder.def_var(var(vi), value);
                 }
 
@@ -14624,7 +14668,7 @@ impl CraneliftBackend {
         if label_blocks.is_empty() && loop_block != entry_block {
             builder.seal_block(loop_block);
         }
-        builder.finalize();
+        builder.finalize(frontend_config);
         self.func_ctx = func_ctx;
 
         // Compile
@@ -14699,7 +14743,7 @@ impl CraneliftBackend {
             let ret = wb.inst_results(call_inst)[0];
             wb.ins().set_pinned_reg(host_pinned);
             wb.ins().return_(&[ret]);
-            wb.finalize();
+            wb.finalize(frontend_config);
             self.func_ctx = wrapper_ctx;
         }
         let mut wrapper_compile_ctx = Context::for_function(wrapper_func);
@@ -14725,18 +14769,24 @@ impl CraneliftBackend {
         self.module.clear_context(&mut wrapper_compile_ctx);
 
         self.module.finalize_definitions().unwrap();
-        // `JITModule` owns the executable mapping and publishes no arena size,
-        // so `allocated` and `used` are both the finalized code size. The token
-        // is kept for this backend's lifetime because that is exactly how long
-        // the mapping lives.
         let code_bytes = body_code_bytes + wrapper_code_bytes;
-        if code_bytes != 0 {
-            let block = self.asm_memory_stats.record_block(code_bytes, code_bytes);
-            self.asm_memory_blocks.push(block);
-        }
-
         let body_ptr = self.module.get_finalized_function(func_id);
         let code_ptr = self.module.get_finalized_function(entry_id);
+        let mut asm_memory_blocks = Vec::with_capacity(2);
+        for ptr in [body_ptr, code_ptr] {
+            if asm_memory_blocks
+                .iter()
+                .any(|block: &majit_backend::AsmMemoryBlock| block.contains(ptr))
+            {
+                continue;
+            }
+            let block = self.asm_memory_handle.take_executable(ptr).ok_or_else(|| {
+                BackendError::CompilationFailed(format!(
+                    "Cranelift arena did not retain finalized function {ptr:p}"
+                ))
+            })?;
+            asm_memory_blocks.push(block);
+        }
         if std::env::var_os("MAJIT_LOG").is_some() {
             let fail_descr_preview: Vec<(u32, usize)> = fail_descrs
                 .iter()
@@ -14857,7 +14907,8 @@ impl CraneliftBackend {
             _func_id: func_id,
             code_ptr,
             body_ptr,
-            code_size: 0,
+            code_size: code_bytes,
+            asm_memory_blocks,
             fail_descrs,
             fail_descr_cells,
             terminal_exit_layouts: UnsafeCell::new(terminal_exit_layouts),
@@ -15879,7 +15930,7 @@ impl majit_backend::Backend for CraneliftBackend {
     }
 
     fn assembler_memory_stats(&self) -> (usize, usize) {
-        self.asm_memory_stats.get_stats()
+        majit_backend::process_assembler_memory_stats()
     }
 
     fn compile_loop(
@@ -15948,6 +15999,12 @@ impl majit_backend::Backend for CraneliftBackend {
                     std::sync::Arc::clone(&clt) as std::sync::Arc<dyn std::any::Any + Send + Sync>
                 );
             }
+            clt.asmmemmgr_blocks.lock().extend(
+                compiled
+                    .asm_memory_blocks
+                    .drain(..)
+                    .map(|block| Box::new(block) as Box<dyn std::any::Any + Send>),
+            );
         }
 
         token.set_compiled(Box::new(compiled));
@@ -16089,7 +16146,15 @@ impl majit_backend::Backend for CraneliftBackend {
             Some((source_trace_id, fail_descr.fail_index_per_trace())),
             caller_layout.as_ref(),
         );
-        let compiled = compiled?;
+        let mut compiled = compiled?;
+        if let Some(clt) = original_token.compiled_loop_token() {
+            clt.asmmemmgr_blocks.lock().extend(
+                compiled
+                    .asm_memory_blocks
+                    .drain(..)
+                    .map(|block| Box::new(block) as Box<dyn std::any::Any + Send>),
+            );
+        }
         // x86/assembler.py:691-693 assemble_bridge parity:
         // bridge compilation can increase the frame depth required by
         // CALL_ASSEMBLER callee frames.  The GC rewriter reads the

--- a/majit/majit-backend-cranelift/src/lib.rs
+++ b/majit/majit-backend-cranelift/src/lib.rs
@@ -1,3 +1,5 @@
+mod asm_memory;
+
 /// Cranelift-based JIT code generation backend for majit.
 ///
 /// This crate implements the `majit_backend::Backend` trait using Cranelift

--- a/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
+++ b/majit/majit-backend-cranelift/tests/tail_sp_leak.rs
@@ -13,7 +13,9 @@
 use cranelift_codegen::Context;
 use cranelift_codegen::ir::condcodes::IntCC;
 use cranelift_codegen::ir::types as cl_types;
-use cranelift_codegen::ir::{AbiParam, Function, InstBuilder, MemFlags, Signature, UserFuncName};
+use cranelift_codegen::ir::{
+    AbiParam, Function, InstBuilder, MemFlagsData, Signature, UserFuncName,
+};
 use cranelift_codegen::isa::CallConv;
 use cranelift_codegen::settings::{self, Configurable};
 use cranelift_frontend::{FunctionBuilder, FunctionBuilderContext};
@@ -52,6 +54,7 @@ fn tail_call_sp_drift_repro() {
 
     let jit_builder = JITBuilder::with_isa(isa, cranelift_module::default_libcall_names());
     let mut module = JITModule::new(jit_builder);
+    let frontend_config = module.target_config();
     let ptr_type = cl_types::I64;
 
     // body signature: (i64) -> i64 (Tail conv)
@@ -87,7 +90,9 @@ fn tail_call_sp_drift_repro() {
         let arg = bx.block_params(entry)[0];
 
         let cap_addr = bx.ins().iconst(ptr_type, &CHAIN_CAP as *const _ as i64);
-        let cap = bx.ins().load(ptr_type, MemFlags::trusted(), cap_addr, 0);
+        let cap = bx
+            .ins()
+            .load(ptr_type, MemFlagsData::trusted(), cap_addr, 0);
         let cont = bx.ins().icmp(IntCC::SignedLessThan, arg, cap);
         let tail = bx.create_block();
         let exit = bx.create_block();
@@ -119,7 +124,7 @@ fn tail_call_sp_drift_repro() {
         bx.switch_to_block(exit);
         bx.seal_block(exit);
         bx.ins().return_(&[arg]);
-        bx.finalize();
+        bx.finalize(frontend_config);
     }
     let mut ctx = Context::for_function(body_func);
     module.define_function(body_id, &mut ctx).unwrap();
@@ -142,7 +147,7 @@ fn tail_call_sp_drift_repro() {
         let big_slot =
             bx.create_sized_stack_slot(StackSlotData::new(StackSlotKind::ExplicitSlot, 128, 3));
         let big_addr = bx.ins().stack_addr(ptr_type, big_slot, 0);
-        bx.ins().store(MemFlags::trusted(), arg, big_addr, 0);
+        bx.ins().store(MemFlagsData::trusted(), arg, big_addr, 0);
 
         // Always tail-call back to body with arg+1.
         let one = bx.ins().iconst(ptr_type, 1);
@@ -155,7 +160,7 @@ fn tail_call_sp_drift_repro() {
         let tail_sig_ref = bx.import_signature(tail_sig);
         bx.ins()
             .return_call_indirect(tail_sig_ref, body_addr, &[next]);
-        bx.finalize();
+        bx.finalize(frontend_config);
     }
     let mut ctx = Context::for_function(body2_func);
     module.define_function(body2_id, &mut ctx).unwrap();
@@ -177,7 +182,7 @@ fn tail_call_sp_drift_repro() {
         let call = bx.ins().call(body_ref, &[arg]);
         let r = bx.inst_results(call)[0];
         bx.ins().return_(&[r]);
-        bx.finalize();
+        bx.finalize(frontend_config);
     }
     let mut ctx = Context::for_function(wrapper_func);
     module.define_function(wrapper_id, &mut ctx).unwrap();

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -15,9 +15,9 @@ use std::sync::Arc;
 
 // aarch64/assembler.py parity: aarch64-only backend.
 use dynasmrt::aarch64::Assembler;
-use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, ExecutableBuffer, dynasm};
+use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
-use majit_backend::{BackendError, JitCellToken};
+use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
 use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRef, OpTypeIndex, TargetArgLoc, Type};
 
 use crate::arch::*;
@@ -264,6 +264,8 @@ fn invert_cc(cc: u8) -> u8 {
 pub struct AssemblerARM64<'a> {
     /// The dynasm assembler (rx86.py + codebuf.py combined).
     pub(crate) mc: Assembler,
+    /// `BaseAssembler.asmmemmgr`: destination arena for materialization.
+    asm_memory_manager: Arc<AsmMemoryManager>,
     /// assembler.py:83 pending_guard_tokens — guards awaiting recovery stubs.
     pending_guard_tokens: Vec<GuardToken>,
     /// GC bitmap to push before the current collecting call (e.g.,
@@ -471,11 +473,7 @@ struct GuardToken {
 /// Compiled output from assemble_loop/assemble_bridge.
 pub struct CompiledCode {
     /// Executable memory buffer (keeps code alive).
-    pub buffer: ExecutableBuffer,
-    /// `llmodel.py:252 asmmemmgr_blocks` lifetime accounting token for this
-    /// executable allocation. It is stored on the same object that owns the
-    /// buffer, matching AsmMemoryManager's block ownership upstream.
-    pub(crate) _asmmemmgr_block: Option<majit_backend::AsmMemoryBlock>,
+    pub buffer: codebuf::ArenaExecutableBuffer,
     /// Entry point offset within the buffer.
     pub entry_offset: AssemblyOffset,
     /// Fail descriptors for guards + FINISH ops.
@@ -530,6 +528,7 @@ impl<'a> AssemblerARM64<'a> {
 
     /// assembler.py:54 __init__
     pub(crate) fn new(
+        asm_memory_manager: Arc<AsmMemoryManager>,
         trace_id: u64,
         header_pc: u64,
         constants: majit_ir::ConstMap<majit_ir::Const>,
@@ -546,6 +545,7 @@ impl<'a> AssemblerARM64<'a> {
         let op_pos = OpTypeIndex::build_op_pos(operations);
         AssemblerARM64 {
             mc: Assembler::new().unwrap(),
+            asm_memory_manager,
             pending_guard_tokens: Vec::new(),
             pending_malloc_nursery_gcmap: None,
             frame_depth: JITFRAME_FIXED_SIZE,
@@ -1935,10 +1935,7 @@ impl<'a> AssemblerARM64<'a> {
         // assembler.py:556 materialize_loop — finalize to executable memory
         let tokens = std::mem::take(&mut self.compiled_target_tokens);
         let frame_depth = self.frame_depth;
-        let buffer = self
-            .mc
-            .finalize()
-            .map_err(|_| BackendError::CompilationFailed("dynasm finalize failed".to_string()))?;
+        let mut buffer = codebuf::finalize_writable(self.mc, &self.asm_memory_manager)?;
 
         // assembler.py:849 patch_pending_failure_recoveries
         let rawstart = codebuf::buffer_ptr(&buffer) as usize;
@@ -1954,6 +1951,7 @@ impl<'a> AssemblerARM64<'a> {
         unsafe { *self.self_entry_addr_ptr = rawstart + entry.0 };
 
         Self::fixup_target_tokens(tokens, frame_depth, rawstart);
+        buffer.make_executable()?;
 
         // Position is the canonical fail_index identity (matching
         // `llsupport/assembler.py`'s `_allgcrefs` index — PyPy does not
@@ -1966,7 +1964,6 @@ impl<'a> AssemblerARM64<'a> {
         // for `fail_index_per_trace()` regardless of their Vec position.
         Ok(CompiledCode {
             buffer,
-            _asmmemmgr_block: None,
             entry_offset: entry,
             fail_descrs: self.fail_descrs.into_boxed_slice(),
             input_types: self.input_types,
@@ -2077,10 +2074,7 @@ impl<'a> AssemblerARM64<'a> {
 
         let tokens = std::mem::take(&mut self.compiled_target_tokens);
         let frame_depth = self.frame_depth;
-        let buffer = self
-            .mc
-            .finalize()
-            .map_err(|_| BackendError::CompilationFailed("dynasm finalize failed".to_string()))?;
+        let mut buffer = codebuf::finalize_writable(self.mc, &self.asm_memory_manager)?;
 
         let rawstart = codebuf::buffer_ptr(&buffer) as usize;
         Self::patch_pending_failure_recoveries(rawstart, &stub_offsets);
@@ -2090,6 +2084,7 @@ impl<'a> AssemblerARM64<'a> {
         // frame depth (max of loop/bridge), now known post-finalize.
         Self::patch_stack_checks(self.frame_depth, rawstart, &self.frame_depth_to_patch);
         Self::fixup_target_tokens(tokens, frame_depth, rawstart);
+        buffer.make_executable()?;
 
         if crate::majit_dump_enabled() {
             let code = unsafe { std::slice::from_raw_parts(rawstart as *const u8, buffer.len()) };
@@ -2125,7 +2120,6 @@ impl<'a> AssemblerARM64<'a> {
         // for `fail_index_per_trace()` regardless of their Vec position.
         Ok(CompiledCode {
             buffer,
-            _asmmemmgr_block: None,
             entry_offset: entry,
             fail_descrs: self.fail_descrs.into_boxed_slice(),
             input_types: self.input_types,

--- a/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/cpu_ext.rs
@@ -17,7 +17,7 @@ pub(crate) struct Aarch64CpuExt;
 
 impl Aarch64CpuExt {
     pub(crate) fn new(
-        _asm_memory_stats: std::sync::Arc<majit_backend::AsmMemoryManagerStats>,
+        _asm_memory_manager: std::sync::Arc<majit_backend::AsmMemoryManager>,
     ) -> Self {
         Self
     }

--- a/majit/majit-backend-dynasm/src/codebuf.rs
+++ b/majit/majit-backend-dynasm/src/codebuf.rs
@@ -1,23 +1,100 @@
 //! codebuf.py: Code buffer management.
 //!
-//! In RPython, MachineCodeBlockWrapper wraps rx86 code builders with
-//! block management. In the dynasm backend, dynasmrt::Assembler
-//! handles this natively — this module provides any extra utilities.
+//! In RPython, MachineCodeBlockWrapper wraps rx86 code builders with block
+//! management. Here dynasm emits into a temporary mapping, which is copied
+//! into the CPU's `AsmMemoryManager` to return the final arena-owned buffer.
 
 /// codebuf.py:34 MachineCodeBlockWrapper
-/// dynasm-rs handles code buffer management internally.
-/// This module is kept for RPython naming parity and any extra utilities.
-use dynasmrt::ExecutableBuffer;
+/// The arena/free-list ownership below is the `MachineCodeBlockWrapper` role.
+use std::sync::Arc;
 
-/// Make a memory region writable for patching, execute the closure,
-/// then restore execute permission.
+use dynasmrt::relocations::Relocation;
+use dynasmrt::{AssemblyOffset, DynasmApi};
+use majit_backend::{AsmMemoryBlock, AsmMemoryManager, BackendError};
+
+/// Executable code owned by pyre's reusable assembler arena.
+pub struct ArenaExecutableBuffer {
+    block: AsmMemoryBlock,
+}
+
+impl ArenaExecutableBuffer {
+    pub fn ptr(&self, offset: AssemblyOffset) -> *const u8 {
+        assert!(offset.0 <= self.block.len());
+        unsafe { self.block.ptr().add(offset.0) }
+    }
+
+    pub fn len(&self) -> usize {
+        self.block.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.block.is_empty()
+    }
+
+    pub fn size(&self) -> usize {
+        self.block.capacity()
+    }
+
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        self.block.as_mut_slice()
+    }
+
+    pub fn make_executable(&mut self) -> Result<(), BackendError> {
+        self.block
+            .make_executable()
+            .map_err(|error| BackendError::CompilationFailed(error.to_string()))
+    }
+}
+
+impl std::ops::Deref for ArenaExecutableBuffer {
+    type Target = [u8];
+
+    fn deref(&self) -> &[u8] {
+        unsafe { std::slice::from_raw_parts(self.block.ptr(), self.block.len()) }
+    }
+}
+
+/// Copy the assembled code into an arena-owned RW block. The caller may patch
+/// backend placeholders before switching the block to RX.
 ///
-/// On macOS ARM64, W^X requires explicit permission toggling.
-/// On x86_64 Linux, mprotect is used.
+/// Relocating finalized code to a different address is only sound while no
+/// relocation encodes an address. dynasm keeps those (`RelToAbs`, `AbsToRel`)
+/// in a private `managed` list and re-applies them when it moves its own
+/// buffer; nothing outside that crate can re-apply them here. This backend
+/// emits neither kind: aarch64 encodes every jump target PC-relative, and the
+/// x86 emitter uses no `extern` targets and no 8-byte label operands — the two
+/// forms that produce one. `tests/relocation_guard.rs` holds that in place.
+pub fn finalize_writable<R: Relocation>(
+    mut assembler: dynasmrt::Assembler<R>,
+    arena: &Arc<AsmMemoryManager>,
+) -> Result<ArenaExecutableBuffer, BackendError> {
+    let len = assembler.offset().0;
+    // Surface relocation errors as an `Err`; `finalize` panics on them.
+    assembler
+        .commit()
+        .map_err(|error| BackendError::CompilationFailed(error.to_string()))?;
+    let source = assembler.finalize().map_err(|_| {
+        BackendError::CompilationFailed("assembler is still borrowed by an Executor".to_string())
+    })?;
+    let mut block = arena
+        .allocate(len, len)
+        .map_err(|error| BackendError::CompilationFailed(error.to_string()))?;
+    block.as_mut_slice()[..len].copy_from_slice(&source[..len]);
+    Ok(ArenaExecutableBuffer { block })
+}
+
+pub fn finalize_executable<R: Relocation>(
+    assembler: dynasmrt::Assembler<R>,
+    arena: &Arc<AsmMemoryManager>,
+) -> Result<ArenaExecutableBuffer, BackendError> {
+    let mut buffer = finalize_writable(assembler, arena)?;
+    buffer.make_executable()?;
+    Ok(buffer)
+}
+
 /// Make a memory region writable for in-place patching, execute the
-/// closure, then restore execute permission. dynasmrt uses memmap2
-/// which maps executable pages as PROT_READ|PROT_EXEC after finalize,
-/// so we must use mprotect to toggle.
+/// closure, then restore execute permission. Arena blocks are page-isolated,
+/// so this does not change a neighboring live block's protection.
 pub fn with_writable<F: FnOnce()>(addr: *mut u8, len: usize, f: F) {
     #[cfg(unix)]
     {
@@ -156,7 +233,7 @@ fn flush_icache_range(addr: *const u8, len: usize) {
     }
 }
 
-/// Get the raw pointer to an ExecutableBuffer's code.
-pub fn buffer_ptr(buffer: &ExecutableBuffer) -> *const u8 {
+/// Get the raw pointer to an arena buffer's code.
+pub fn buffer_ptr(buffer: &ArenaExecutableBuffer) -> *const u8 {
     buffer.ptr(dynasmrt::AssemblyOffset(0))
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1360,10 +1360,10 @@ pub struct DynasmBackend {
     /// store.
     cpu_tracker: Arc<majit_backend::CpuTotalTracker>,
     /// `llsupport/asmmemmgr.py:38-40` `cpu.asmmemmgr` parity.  The
-    /// manager is owned by this CPU/backend and shared with every compiled
-    /// code block and per-CPU helper buffer so `get_stats()` observes the
-    /// same allocation/lifetime boundary as upstream.
-    asm_memory_stats: Arc<majit_backend::AsmMemoryManagerStats>,
+    /// handle is owned by this CPU/backend and shared with every compiled code
+    /// block and per-CPU helper buffer; its retained inner arena is
+    /// process-owned so worker-backend teardown cannot discard reusable pages.
+    asm_memory_manager: Arc<majit_backend::AsmMemoryManager>,
     /// Next unique trace ID.
     next_trace_id: u64,
     /// Next header PC (green key).
@@ -1474,9 +1474,11 @@ impl DynasmBackend {
         // `compile.make_and_attach_done_descrs([self, cpu])` during
         // `MetaInterpStaticData.finish_setup` (pyjitpl.py:2222).
         let asm_memory_stats = Arc::new(majit_backend::AsmMemoryManagerStats::default());
+        let asm_memory_manager =
+            majit_backend::AsmMemoryManager::new(Arc::clone(&asm_memory_stats));
         DynasmBackend {
             cpu_tracker: Arc::new(majit_backend::CpuTotalTracker::default()),
-            asm_memory_stats: Arc::clone(&asm_memory_stats),
+            asm_memory_manager: Arc::clone(&asm_memory_manager),
             next_trace_id: 1,
             next_header_pc: 0,
             constants: majit_ir::ConstMap::new(),
@@ -1484,7 +1486,7 @@ impl DynasmBackend {
             descr_attachments: Arc::new(std::sync::RwLock::new(
                 crate::guard::CpuDescrAttachments::default(),
             )),
-            arch_cpu_ext: ArchCpuExt::new(asm_memory_stats),
+            arch_cpu_ext: ArchCpuExt::new(asm_memory_manager),
         }
     }
 
@@ -2344,7 +2346,7 @@ impl Backend for DynasmBackend {
     }
 
     fn assembler_memory_stats(&self) -> (usize, usize) {
-        self.asm_memory_stats.get_stats()
+        majit_backend::process_assembler_memory_stats()
     }
 
     fn compile_loop(
@@ -2416,6 +2418,7 @@ impl Backend for DynasmBackend {
             .arch_cpu_ext
             .ensure_malloc_slowpath_headerless(&self.descr_attachments);
         let mut asm = Asm::new(
+            Arc::clone(&self.asm_memory_manager),
             trace_id,
             header_pc,
             const_pool,
@@ -2441,11 +2444,7 @@ impl Backend for DynasmBackend {
             asm.set_gc_table_base(table.base_addr());
         }
         asm.set_invalidated_flag_addr(std::sync::Arc::as_ptr(&token.invalidated) as usize);
-        let mut compiled = asm.assemble_loop()?;
-        compiled._asmmemmgr_block = Some(
-            self.asm_memory_stats
-                .record_block(compiled.buffer.size(), compiled.buffer.len()),
-        );
+        let compiled = asm.assemble_loop()?;
 
         let code_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
         let code_size = compiled.buffer.len();
@@ -2672,6 +2671,7 @@ impl Backend for DynasmBackend {
             .arch_cpu_ext
             .ensure_malloc_slowpath_headerless(&self.descr_attachments);
         let mut asm = Asm::new(
+            Arc::clone(&self.asm_memory_manager),
             trace_id,
             0,
             const_pool,
@@ -2711,11 +2711,7 @@ impl Backend for DynasmBackend {
                 .expect("guard_descr is FailDescr"),
             inputargs,
         );
-        let mut compiled = asm.assemble_bridge(fail_descr, &arglocs)?;
-        compiled._asmmemmgr_block = Some(
-            self.asm_memory_stats
-                .record_block(compiled.buffer.size(), compiled.buffer.len()),
-        );
+        let compiled = asm.assemble_bridge(fail_descr, &arglocs)?;
 
         let bridge_addr = codebuf::buffer_ptr(&compiled.buffer) as usize;
         let code_size = compiled.buffer.len();
@@ -2778,7 +2774,7 @@ impl Backend for DynasmBackend {
 
         // llmodel.py:252 asmmemmgr_blocks parity: store the entire
         // bridge CompiledCode on the owning loop token. This keeps
-        // both the ExecutableBuffer (mapped code) AND the fail_descrs
+        // both the arena-backed mapped code AND the fail_descrs
         // (DescrRef) alive. Recovery stubs embed raw pointers to
         // these Arcs — dropping them would create dangling pointers
         // when a bridge-internal guard fires.  RPython's asmmemmgr

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -14,10 +14,11 @@ use std::sync::Arc;
 
 // x86/assembler.py parity: x86_64-only backend.
 use dynasmrt::x64::Assembler;
-use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, ExecutableBuffer, dynasm};
+use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
 use majit_backend::{
-    BackendError, ExitFrameLayout, ExitRecoveryLayout, ExitValueSourceLayout, JitCellToken,
+    AsmMemoryManager, BackendError, ExitFrameLayout, ExitRecoveryLayout, ExitValueSourceLayout,
+    JitCellToken,
 };
 use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRc, OpRef, OpTypeIndex, TargetArgLoc, Type};
 
@@ -323,13 +324,13 @@ pub(crate) fn emit_call_footer_raw(asm: &mut Assembler) {
 /// fail at `handle_fail` dispatch time); pyre prefers a build-time
 /// fail-fast for the same invariant.
 ///
-/// Returns `(buffer, entry_addr)`.  The caller (`X86CpuExt`) owns the
-/// `ExecutableBuffer` for the lifetime of the per-CPU stash so the RX
-/// page is unmapped when the CPU drops — matches PyPy's `asmmemmgr`,
-/// which roots helper buffers on the CPU.
+/// Returns `(buffer, entry_addr)`. The caller (`X86CpuExt`) owns the arena
+/// block for the lifetime of the per-CPU stash, matching the helper blocks
+/// rooted by PyPy's `asmmemmgr`.
 pub(crate) fn build_propagate_exception_path(
     cpu_handle: &crate::guard::CpuDescrHandle,
-) -> (ExecutableBuffer, usize) {
+    arena: &Arc<AsmMemoryManager>,
+) -> (codebuf::ArenaExecutableBuffer, usize) {
     let mut asm = Assembler::new().expect("propagate_exception_path: new Assembler");
     let propagate_descr = cpu_handle
         .read()
@@ -365,7 +366,8 @@ pub(crate) fn build_propagate_exception_path(
     // assembler.py:342 `self._call_footer()` — restore callee-save,
     // set rax = rbp, ADD rsp, prologue_size, RET.
     emit_call_footer_raw(&mut asm);
-    let buffer = asm.finalize().expect("propagate_exception_path: finalize");
+    let buffer =
+        codebuf::finalize_executable(asm, arena).expect("propagate_exception_path: finalize");
     let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
     (buffer, ptr)
 }
@@ -405,11 +407,12 @@ pub(crate) fn build_propagate_exception_path(
 ///
 /// Returns `(buffer, entry_addr)`.  Same ownership rule as
 /// `build_propagate_exception_path` — the caller (`X86CpuExt`) holds
-/// the `ExecutableBuffer` so the RX page lives as long as the CPU.
+/// the arena buffer so the RX page lives as long as the CPU.
 pub(crate) fn build_malloc_slowpath_fixed(
     cpu_handle: &crate::guard::CpuDescrHandle,
     propagate_path: usize,
-) -> (ExecutableBuffer, usize) {
+    arena: &Arc<AsmMemoryManager>,
+) -> (codebuf::ArenaExecutableBuffer, usize) {
     // `cpu_handle` is still threaded through for symmetry with PyPy
     // (where `_build_malloc_slowpath` reads several `self.cpu`-rooted
     // attrs).  The propagate descr itself is now baked once into the
@@ -428,7 +431,7 @@ pub(crate) fn build_malloc_slowpath_fixed(
     let slowpath_fn = crate::runner::dynasm_nursery_slowpath as *const () as i64;
     build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
 
-    let buffer = asm.finalize().expect("malloc_slowpath: finalize");
+    let buffer = codebuf::finalize_executable(asm, arena).expect("malloc_slowpath: finalize");
     let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
     (buffer, ptr)
 }
@@ -436,7 +439,8 @@ pub(crate) fn build_malloc_slowpath_fixed(
 pub(crate) fn build_malloc_slowpath_headerless(
     cpu_handle: &crate::guard::CpuDescrHandle,
     propagate_path: usize,
-) -> (ExecutableBuffer, usize) {
+    arena: &Arc<AsmMemoryManager>,
+) -> (codebuf::ArenaExecutableBuffer, usize) {
     let _ = cpu_handle;
     let mut asm = Assembler::new().expect("malloc_slowpath_headerless: new Assembler");
 
@@ -445,9 +449,8 @@ pub(crate) fn build_malloc_slowpath_headerless(
     let slowpath_fn = crate::runner::dynasm_nursery_slowpath_headerless as *const () as i64;
     build_malloc_slowpath_body(&mut asm, slowpath_fn, propagate_path);
 
-    let buffer = asm
-        .finalize()
-        .expect("malloc_slowpath_headerless: finalize");
+    let buffer =
+        codebuf::finalize_executable(asm, arena).expect("malloc_slowpath_headerless: finalize");
     let ptr = crate::codebuf::buffer_ptr(&buffer) as usize;
     (buffer, ptr)
 }
@@ -597,9 +600,9 @@ fn build_malloc_slowpath_body(asm: &mut Assembler, slowpath_fn: i64, propagate_p
     // (line 322).  Stage `propagate_path` into a scratch register and
     // jump indirectly so the transfer is range-independent: dynasm-rs's
     // `jmp extern` would lower to `E9 + rel32`, but the malloc slowpath
-    // and propagate trampoline live in separately-finalized
-    // `ExecutableBuffer`s that aren't guaranteed to land within ±2GB
-    // under ASLR, so `finalize()` would otherwise fail with
+    // and propagate trampoline are separate arena blocks that may belong to
+    // different retained mappings and are not guaranteed to land within ±2GB,
+    // so a relative external jump could otherwise fail with
     // `ImpossibleRelocation` and trip the caller's `expect("malloc_slowpath:
     // finalize")` on affected layouts.
     let propagate_scratch = crate::regloc::X86_64_SCRATCH_REG.value;
@@ -755,6 +758,8 @@ fn invert_cc(cc: u8) -> u8 {
 pub struct Assembler386<'a> {
     /// The dynasm assembler (rx86.py + codebuf.py combined).
     pub(crate) mc: Assembler,
+    /// `BaseAssembler.asmmemmgr`: destination arena for materialization.
+    asm_memory_manager: Arc<AsmMemoryManager>,
     /// assembler.py:83 pending_guard_tokens — guards awaiting recovery stubs.
     pending_guard_tokens: Vec<GuardToken>,
     /// GC bitmap to push before the current collecting call (e.g.,
@@ -945,11 +950,7 @@ struct GuardToken {
 /// Compiled output from assemble_loop/assemble_bridge.
 pub struct CompiledCode {
     /// Executable memory buffer (keeps code alive).
-    pub buffer: ExecutableBuffer,
-    /// `llmodel.py:252 asmmemmgr_blocks` lifetime accounting token for this
-    /// executable allocation. It is stored on the same object that owns the
-    /// buffer, matching AsmMemoryManager's block ownership upstream.
-    pub(crate) _asmmemmgr_block: Option<majit_backend::AsmMemoryBlock>,
+    pub buffer: codebuf::ArenaExecutableBuffer,
     /// Entry point offset within the buffer.
     pub entry_offset: AssemblyOffset,
     /// Fail descriptors for guards + FINISH ops.
@@ -1002,6 +1003,7 @@ impl<'a> Assembler386<'a> {
     }
     /// assembler.py:54 __init__
     pub(crate) fn new(
+        asm_memory_manager: Arc<AsmMemoryManager>,
         trace_id: u64,
         header_pc: u64,
         constants: majit_ir::ConstMap<majit_ir::Const>,
@@ -1020,6 +1022,7 @@ impl<'a> Assembler386<'a> {
         let op_pos = OpTypeIndex::build_op_pos(operations);
         Assembler386 {
             mc: Assembler::new().unwrap(),
+            asm_memory_manager,
             pending_guard_tokens: Vec::new(),
             pending_malloc_nursery_gcmap: None,
             frame_depth: JITFRAME_FIXED_SIZE,
@@ -2586,10 +2589,7 @@ impl<'a> Assembler386<'a> {
         // assembler.py:556 materialize_loop — finalize to executable memory
         let tokens = std::mem::take(&mut self.compiled_target_tokens);
         let frame_depth = self.frame_depth;
-        let buffer = self
-            .mc
-            .finalize()
-            .map_err(|_| BackendError::CompilationFailed("dynasm finalize failed".to_string()))?;
+        let mut buffer = codebuf::finalize_writable(self.mc, &self.asm_memory_manager)?;
 
         // assembler.py:849 patch_pending_failure_recoveries
         let rawstart = codebuf::buffer_ptr(&buffer) as usize;
@@ -2607,6 +2607,7 @@ impl<'a> Assembler386<'a> {
         unsafe { *self.self_entry_addr_ptr = rawstart + entry.0 };
 
         Self::fixup_target_tokens(tokens, frame_depth, rawstart);
+        buffer.make_executable()?;
 
         // Position is the canonical fail_index identity (matching
         // `llsupport/assembler.py`'s `_allgcrefs` index — PyPy does not
@@ -2619,7 +2620,6 @@ impl<'a> Assembler386<'a> {
         // for `fail_index_per_trace()` regardless of their Vec position.
         Ok(CompiledCode {
             buffer,
-            _asmmemmgr_block: None,
             entry_offset: entry,
             fail_descrs: self.fail_descrs.into_boxed_slice(),
             input_types: self.input_types,
@@ -2722,10 +2722,7 @@ impl<'a> Assembler386<'a> {
 
         let tokens = std::mem::take(&mut self.compiled_target_tokens);
         let frame_depth = self.frame_depth;
-        let buffer = self
-            .mc
-            .finalize()
-            .map_err(|_| BackendError::CompilationFailed("dynasm finalize failed".to_string()))?;
+        let mut buffer = codebuf::finalize_writable(self.mc, &self.asm_memory_manager)?;
 
         let rawstart = codebuf::buffer_ptr(&buffer) as usize;
         Self::patch_pending_failure_recoveries(rawstart, &stub_offsets);
@@ -2737,6 +2734,7 @@ impl<'a> Assembler386<'a> {
         // CMP at bridge entry reflects the bridge's true requirement.
         Self::patch_stack_checks(self.frame_depth, rawstart, &self.frame_depth_to_patch);
         Self::fixup_target_tokens(tokens, frame_depth, rawstart);
+        buffer.make_executable()?;
 
         if crate::majit_dump_enabled() {
             let code = unsafe { std::slice::from_raw_parts(rawstart as *const u8, buffer.len()) };
@@ -2772,7 +2770,6 @@ impl<'a> Assembler386<'a> {
         // for `fail_index_per_trace()` regardless of their Vec position.
         Ok(CompiledCode {
             buffer,
-            _asmmemmgr_block: None,
             entry_offset: entry,
             fail_descrs: self.fail_descrs.into_boxed_slice(),
             input_types: self.input_types,

--- a/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
+++ b/majit/majit-backend-dynasm/src/x86/cpu_ext.rs
@@ -13,20 +13,20 @@
 //! currently a no-op placeholder — aarch64 inlines the slowpath
 //! sequences today and has no per-CPU trampoline to memoise.
 
+use crate::codebuf::ArenaExecutableBuffer;
 use crate::guard::CpuDescrHandle;
-use dynasmrt::ExecutableBuffer;
-use majit_backend::{AsmMemoryBlock, AsmMemoryManagerStats};
+use majit_backend::AsmMemoryManager;
 use std::sync::Arc;
 
 /// Lazily-materialised per-CPU x86 trampolines.
 ///
 /// Both addresses are set once on first use and reused for every
 /// subsequent `compile_loop` / `compile_bridge` on this CPU.  The
-/// owning `ExecutableBuffer`s are kept alongside so the RX pages are
-/// unmapped exactly when the CPU is dropped — matching PyPy's
-/// `asmmemmgr`, which roots helper buffers on the CPU.
+/// owning arena buffers are kept alongside so their ranges stay live for the
+/// CPU and return to its reusable free list on drop, matching PyPy's
+/// `asmmemmgr` ownership.
 pub(crate) struct X86CpuExt {
-    asm_memory_stats: Arc<AsmMemoryManagerStats>,
+    asm_memory_manager: Arc<AsmMemoryManager>,
     /// `assembler.py:63 self.malloc_slowpath` parity.  Entry address
     /// of the shared malloc slowpath trampoline built by
     /// `build_malloc_slowpath_fixed`.  PyPy's `malloc_cond` (line
@@ -37,32 +37,26 @@ pub(crate) struct X86CpuExt {
     /// `_buffer` is the matching RX mapping kept for the lifetime of
     /// this struct.
     malloc_slowpath_fixed: Option<usize>,
-    _malloc_slowpath_fixed_buffer: Option<ExecutableBuffer>,
-    _malloc_slowpath_fixed_block: Option<AsmMemoryBlock>,
+    _malloc_slowpath_fixed_buffer: Option<ArenaExecutableBuffer>,
     malloc_slowpath_headerless: Option<usize>,
-    _malloc_slowpath_headerless_buffer: Option<ExecutableBuffer>,
-    _malloc_slowpath_headerless_block: Option<AsmMemoryBlock>,
+    _malloc_slowpath_headerless_buffer: Option<ArenaExecutableBuffer>,
     /// `assembler.py:344 self.propagate_exception_path` parity.
     /// Standalone trampoline that the malloc slowpath (and, in PyPy,
     /// the stack check slowpath) JMPs to on OOM / propagate.
     propagate_exception_path: Option<usize>,
-    _propagate_exception_path_buffer: Option<ExecutableBuffer>,
-    _propagate_exception_path_block: Option<AsmMemoryBlock>,
+    _propagate_exception_path_buffer: Option<ArenaExecutableBuffer>,
 }
 
 impl X86CpuExt {
-    pub(crate) fn new(asm_memory_stats: Arc<AsmMemoryManagerStats>) -> Self {
+    pub(crate) fn new(asm_memory_manager: Arc<AsmMemoryManager>) -> Self {
         Self {
-            asm_memory_stats,
+            asm_memory_manager,
             malloc_slowpath_fixed: None,
             _malloc_slowpath_fixed_buffer: None,
-            _malloc_slowpath_fixed_block: None,
             malloc_slowpath_headerless: None,
             _malloc_slowpath_headerless_buffer: None,
-            _malloc_slowpath_headerless_block: None,
             propagate_exception_path: None,
             _propagate_exception_path_buffer: None,
-            _propagate_exception_path_block: None,
         }
     }
 
@@ -78,15 +72,12 @@ impl X86CpuExt {
         if let Some(addr) = self.propagate_exception_path {
             return addr;
         }
-        let (buffer, addr) = super::assembler::build_propagate_exception_path(cpu_handle);
+        let (buffer, addr) =
+            super::assembler::build_propagate_exception_path(cpu_handle, &self.asm_memory_manager);
         debug_assert!(
             addr != 0,
             "build_propagate_exception_path returned NULL entry address — \
              dynasm finalize is expected to yield a non-zero buffer_ptr"
-        );
-        self._propagate_exception_path_block = Some(
-            self.asm_memory_stats
-                .record_block(buffer.size(), buffer.len()),
         );
         self._propagate_exception_path_buffer = Some(buffer);
         self.propagate_exception_path = Some(addr);
@@ -108,16 +99,15 @@ impl X86CpuExt {
             return addr;
         }
         let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
-        let (buffer, addr) =
-            super::assembler::build_malloc_slowpath_fixed(cpu_handle, propagate_path);
+        let (buffer, addr) = super::assembler::build_malloc_slowpath_fixed(
+            cpu_handle,
+            propagate_path,
+            &self.asm_memory_manager,
+        );
         debug_assert!(
             addr != 0,
             "build_malloc_slowpath_fixed returned NULL entry address — \
              dynasm finalize is expected to yield a non-zero buffer_ptr"
-        );
-        self._malloc_slowpath_fixed_block = Some(
-            self.asm_memory_stats
-                .record_block(buffer.size(), buffer.len()),
         );
         self._malloc_slowpath_fixed_buffer = Some(buffer);
         self.malloc_slowpath_fixed = Some(addr);
@@ -132,16 +122,15 @@ impl X86CpuExt {
             return addr;
         }
         let propagate_path = self.ensure_propagate_exception_path(cpu_handle);
-        let (buffer, addr) =
-            super::assembler::build_malloc_slowpath_headerless(cpu_handle, propagate_path);
+        let (buffer, addr) = super::assembler::build_malloc_slowpath_headerless(
+            cpu_handle,
+            propagate_path,
+            &self.asm_memory_manager,
+        );
         debug_assert!(
             addr != 0,
             "build_malloc_slowpath_headerless returned NULL entry address — \
              dynasm finalize is expected to yield a non-zero buffer_ptr"
-        );
-        self._malloc_slowpath_headerless_block = Some(
-            self.asm_memory_stats
-                .record_block(buffer.size(), buffer.len()),
         );
         self._malloc_slowpath_headerless_buffer = Some(buffer);
         self.malloc_slowpath_headerless = Some(addr);

--- a/majit/majit-backend-dynasm/tests/relocation_guard.rs
+++ b/majit/majit-backend-dynasm/tests/relocation_guard.rs
@@ -15,6 +15,11 @@
 //!
 //! Neither form appears in this backend today. This test fails if one lands, so
 //! the copy in `finalize_writable` stays sound.
+//!
+//! Both forms are assembly syntax, so the scan reads only the inside of a
+//! `dynasm!` body. Reading whole Rust files instead would collide with the host
+//! language: `unsafe extern "C" { .. }` is not a jump target, and a `match` arm
+//! next to an unrelated `QWORD` operand is not a label reference.
 
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -34,29 +39,156 @@ fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
     }
 }
 
-/// The pieces of a source line that can be dynasm statements. Statements are
-/// `;`-separated inside `dynasm!`, so anything after a `;` is a candidate;
-/// ordinary Rust statements end with `;` and leave an empty tail.
-fn statement_fragments(line: &str) -> impl Iterator<Item = &str> {
-    line.split(';')
-        .skip(1)
-        .map(|fragment| fragment.split("//").next().unwrap_or("").trim())
-        .filter(|fragment| !fragment.is_empty())
+/// One `;`-separated statement of a `dynasm!` body.
+#[derive(Debug, PartialEq, Eq)]
+struct Statement {
+    /// 1-based line the statement's first non-blank character sits on.
+    line: usize,
+    /// The statement with newlines and comments flattened to spaces.
+    text: String,
 }
 
-/// Why `fragment` would emit a relocation that a buffer move invalidates.
-fn address_dependent_reason(fragment: &str) -> Option<&'static str> {
-    if fragment
+/// Advance `index` past a `//` line comment or a `"…"` literal starting there,
+/// returning the index just after it, or `None` if neither starts at `index`.
+fn skip_comment_or_string(chars: &[char], index: usize) -> Option<usize> {
+    match (chars[index], chars.get(index + 1)) {
+        ('/', Some('/')) => {
+            let mut end = index;
+            while end < chars.len() && chars[end] != '\n' {
+                end += 1;
+            }
+            Some(end)
+        }
+        ('"', _) => {
+            let mut end = index + 1;
+            while end < chars.len() {
+                match chars[end] {
+                    '\\' => end += 2,
+                    '"' => return Some(end + 1),
+                    _ => end += 1,
+                }
+            }
+            Some(chars.len())
+        }
+        _ => None,
+    }
+}
+
+/// Every statement inside every `dynasm!` body in `text`, plus the number of
+/// bodies walked.
+///
+/// A dynasm statement is `;`-separated and freely wraps across lines, so a
+/// per-line split would let `; mov rax, QWORD` / `->label` through on the
+/// continuation line. Splitting only at the body's own nesting depth keeps a
+/// `;` inside an interpolated Rust expression from cutting a statement in two.
+///
+/// The body count is returned so a caller can tell "no statement uses an
+/// address-dependent form" apart from "the scan found no assembly at all".
+fn dynasm_statements(text: &str) -> (Vec<Statement>, usize) {
+    let chars: Vec<char> = text.chars().collect();
+    let needle: Vec<char> = "dynasm!".chars().collect();
+    let newlines: Vec<usize> = chars
+        .iter()
+        .enumerate()
+        .filter(|&(_, &c)| c == '\n')
+        .map(|(index, _)| index)
+        .collect();
+    let line_of = |index: usize| newlines.partition_point(|&nl| nl < index) + 1;
+
+    let mut statements = Vec::new();
+    let mut bodies = 0;
+    let mut index = 0;
+    while index < chars.len() {
+        if let Some(next) = skip_comment_or_string(&chars, index) {
+            index = next;
+            continue;
+        }
+        if !chars[index..].starts_with(&needle[..]) {
+            index += 1;
+            continue;
+        }
+        let mut open = index + needle.len();
+        while chars.get(open).is_some_and(|c| c.is_whitespace()) {
+            open += 1;
+        }
+        if chars.get(open) != Some(&'(') {
+            index += needle.len();
+            continue;
+        }
+        bodies += 1;
+
+        // `open` is depth 1, so statement separators are the `;` at depth 1.
+        let mut depth = 1usize;
+        let mut current = String::new();
+        let mut start = open + 1;
+        let mut cursor = open + 1;
+        let mut flush = |current: &mut String, start: usize| {
+            let piece = current.trim();
+            if !piece.is_empty() {
+                // Report the line the statement's first real character is on,
+                // not the separator's, so a wrapped statement points at its head.
+                let head = (start..chars.len())
+                    .find(|&i| !chars[i].is_whitespace())
+                    .unwrap_or(start);
+                statements.push(Statement {
+                    line: line_of(head),
+                    text: piece.to_string(),
+                });
+            }
+            current.clear();
+        };
+        while cursor < chars.len() && depth > 0 {
+            if let Some(next) = skip_comment_or_string(&chars, cursor) {
+                // A comment is not part of the statement; a string literal is
+                // kept so an interpolated operand still reads as one piece.
+                if chars[cursor] == '"' {
+                    current.extend(&chars[cursor..next]);
+                } else {
+                    current.push(' ');
+                }
+                cursor = next;
+                continue;
+            }
+            match chars[cursor] {
+                '(' | '[' | '{' => {
+                    depth += 1;
+                    current.push(chars[cursor]);
+                }
+                ')' | ']' | '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                    current.push(chars[cursor]);
+                }
+                ';' if depth == 1 => {
+                    flush(&mut current, start);
+                    start = cursor + 1;
+                }
+                '\n' => current.push(' '),
+                c => current.push(c),
+            }
+            cursor += 1;
+        }
+        flush(&mut current, start);
+        index = cursor + 1;
+    }
+    (statements, bodies)
+}
+
+/// Why `statement` would emit a relocation that a buffer move invalidates.
+fn address_dependent_reason(statement: &str) -> Option<&'static str> {
+    if statement
         .split_whitespace()
         .any(|token| token.trim_matches(',') == "extern")
     {
         return Some("`extern` jump target emits a RelToAbs relocation");
     }
-    let mentions_label = fragment.contains("->") || fragment.contains("=>");
+    let mentions_label = statement.contains("->") || statement.contains("=>");
     if mentions_label
         && ABSOLUTE_ENCODINGS
             .iter()
-            .any(|encoding| fragment.contains(encoding))
+            .any(|encoding| statement.contains(encoding))
     {
         return Some("absolutely encoded label operand emits an AbsToRel relocation");
     }
@@ -64,19 +196,13 @@ fn address_dependent_reason(fragment: &str) -> Option<&'static str> {
 }
 
 fn scan(text: &str) -> Vec<(usize, &'static str)> {
-    let mut hits = Vec::new();
-    for (index, line) in text.lines().enumerate() {
-        // A `//`-led line is prose; dynasm statements never start there.
-        if line.trim_start().starts_with("//") {
-            continue;
-        }
-        for fragment in statement_fragments(line) {
-            if let Some(reason) = address_dependent_reason(fragment) {
-                hits.push((index + 1, reason));
-            }
-        }
-    }
-    hits
+    let (statements, _) = dynasm_statements(text);
+    statements
+        .into_iter()
+        .filter_map(|statement| {
+            address_dependent_reason(&statement.text).map(|reason| (statement.line, reason))
+        })
+        .collect()
 }
 
 /// The scan above is what makes the corpus result below mean anything, so pin
@@ -91,18 +217,63 @@ fn scan_separates_address_dependent_forms() {
         );\n";
     assert_eq!(scan(relative), Vec::new(), "PC-relative forms must pass");
 
-    let rel_to_abs = "        ; call extern helper as _\n";
+    let rel_to_abs = "dynasm!(self.mc ; call extern helper as _);\n";
     assert_eq!(
         scan(rel_to_abs).len(),
         1,
         "an `extern` jump target must be caught"
     );
 
-    let abs_to_rel = "        ; mov rax, QWORD =>resume_label\n";
+    let abs_to_rel = "dynasm!(self.mc ; mov rax, QWORD =>resume_label);\n";
     assert_eq!(
         scan(abs_to_rel).len(),
         1,
         "an 8-byte label operand must be caught"
+    );
+
+    // A statement that wraps: the continuation line carries no `;` of its own,
+    // so a per-line scan would miss both of these, and the reported line is the
+    // statement's head rather than its tail.
+    let wrapped_abs_to_rel =
+        "dynasm!(self.mc\n    ; mov rax, QWORD\n          ->resume_label\n);\n";
+    assert_eq!(
+        scan(wrapped_abs_to_rel),
+        vec![(
+            2,
+            "absolutely encoded label operand emits an AbsToRel relocation"
+        )],
+        "a wrapped 8-byte label operand must be caught on its opening line"
+    );
+    let wrapped_extern = "dynasm!(self.mc\n    ; call\n          extern helper as _\n);\n";
+    assert_eq!(
+        scan(wrapped_extern),
+        vec![(2, "`extern` jump target emits a RelToAbs relocation")],
+        "a wrapped `extern` jump target must be caught on its opening line"
+    );
+
+    // Both forms are assembly syntax. Outside a `dynasm!` body the same spellings
+    // are ordinary Rust and mean something else entirely — these are the shapes
+    // that a whole-file scan reports as hits.
+    let host_extern = "unsafe extern \"C\" {\n    fn sys_icache_invalidate(p: *mut u8);\n}\n";
+    assert_eq!(
+        scan(host_extern),
+        Vec::new(),
+        "a Rust `extern` block is not a jump target"
+    );
+    let host_match_arm = "match placement {\n    Gpr(d) => emit(d, QWORD_MASK),\n}\n";
+    assert_eq!(
+        scan(host_match_arm),
+        Vec::new(),
+        "a `match` arm next to a QWORD operand is not a label reference"
+    );
+
+    // A nested `;` belongs to the interpolated Rust expression, not to dynasm,
+    // so it must not cut the statement it sits inside.
+    let nested_semicolon = "dynasm!(self.mc ; mov rax, QWORD { let x = 1; x } ->label);\n";
+    assert_eq!(
+        scan(nested_semicolon).len(),
+        1,
+        "a `;` inside an interpolated expression must not split the statement"
     );
 }
 
@@ -119,12 +290,26 @@ fn no_address_dependent_relocations() {
     );
 
     let mut violations = Vec::new();
+    let mut bodies = 0;
+    let mut statements = 0;
     for path in &sources {
         let text = fs::read_to_string(path).expect("source file is utf-8");
-        for (line_number, reason) in scan(&text) {
-            violations.push(format!("{}:{line_number}: {reason}", path.display()));
+        let (found, file_bodies) = dynasm_statements(&text);
+        bodies += file_bodies;
+        statements += found.len();
+        for statement in found {
+            if let Some(reason) = address_dependent_reason(&statement.text) {
+                violations.push(format!("{}:{}: {reason}", path.display(), statement.line));
+            }
         }
     }
+
+    // An empty result means nothing only if there was assembly to read.
+    assert!(
+        bodies > 1000 && statements > bodies,
+        "scan read {statements} statements from {bodies} `dynasm!` bodies, \
+         far below this backend's emitter — the parse, not the code, is what is empty"
+    );
 
     assert!(
         violations.is_empty(),

--- a/majit/majit-backend-dynasm/tests/relocation_guard.rs
+++ b/majit/majit-backend-dynasm/tests/relocation_guard.rs
@@ -1,0 +1,136 @@
+//! `codebuf::finalize_writable` copies finalized code to an arena address that
+//! differs from the one dynasm assembled it at. That is only sound while every
+//! relocation this backend emits is PC-relative, because the address-dependent
+//! ones live in dynasm's private `managed` list and no out-of-crate caller can
+//! re-apply them after the move.
+//!
+//! `PatchLoc::needs_adjustment` is true for exactly two relocation kinds, and
+//! the dynasm macro produces them from exactly two source forms:
+//!
+//! * `RelToAbs` — an `extern <addr>` jump target.
+//! * `AbsToRel` — a label operand encoded absolutely, which on x86 means an
+//!   8-byte jump-target immediate (`QWORD ->label` and friends). aarch64 emits
+//!   every jump target with `relative_encoding = true`, so it cannot reach this
+//!   kind at all.
+//!
+//! Neither form appears in this backend today. This test fails if one lands, so
+//! the copy in `finalize_writable` stays sound.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Data directives and operand size prefixes that encode a value absolutely.
+/// Paired with a label reference (`->name` / `=>expr`) each yields `AbsToRel`.
+const ABSOLUTE_ENCODINGS: [&str; 6] = ["QWORD", ".qword", ".u64", ".i64", "DQWORD", ".dword"];
+
+fn rust_sources(dir: &Path, out: &mut Vec<PathBuf>) {
+    for entry in fs::read_dir(dir).expect("backend src tree is readable") {
+        let path = entry.expect("readable dir entry").path();
+        if path.is_dir() {
+            rust_sources(&path, out);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            out.push(path);
+        }
+    }
+}
+
+/// The pieces of a source line that can be dynasm statements. Statements are
+/// `;`-separated inside `dynasm!`, so anything after a `;` is a candidate;
+/// ordinary Rust statements end with `;` and leave an empty tail.
+fn statement_fragments(line: &str) -> impl Iterator<Item = &str> {
+    line.split(';')
+        .skip(1)
+        .map(|fragment| fragment.split("//").next().unwrap_or("").trim())
+        .filter(|fragment| !fragment.is_empty())
+}
+
+/// Why `fragment` would emit a relocation that a buffer move invalidates.
+fn address_dependent_reason(fragment: &str) -> Option<&'static str> {
+    if fragment
+        .split_whitespace()
+        .any(|token| token.trim_matches(',') == "extern")
+    {
+        return Some("`extern` jump target emits a RelToAbs relocation");
+    }
+    let mentions_label = fragment.contains("->") || fragment.contains("=>");
+    if mentions_label
+        && ABSOLUTE_ENCODINGS
+            .iter()
+            .any(|encoding| fragment.contains(encoding))
+    {
+        return Some("absolutely encoded label operand emits an AbsToRel relocation");
+    }
+    None
+}
+
+fn scan(text: &str) -> Vec<(usize, &'static str)> {
+    let mut hits = Vec::new();
+    for (index, line) in text.lines().enumerate() {
+        // A `//`-led line is prose; dynasm statements never start there.
+        if line.trim_start().starts_with("//") {
+            continue;
+        }
+        for fragment in statement_fragments(line) {
+            if let Some(reason) = address_dependent_reason(fragment) {
+                hits.push((index + 1, reason));
+            }
+        }
+    }
+    hits
+}
+
+/// The scan above is what makes the corpus result below mean anything, so pin
+/// that it separates the two forms it names from the ones this backend does use.
+#[test]
+fn scan_separates_address_dependent_forms() {
+    let relative = "\
+        dynasm!(self.mc\n\
+            ; mov rax, QWORD helper as _\n\
+            ; jne =>skip_wb\n\
+            ; b ->slowpath\n\
+        );\n";
+    assert_eq!(scan(relative), Vec::new(), "PC-relative forms must pass");
+
+    let rel_to_abs = "        ; call extern helper as _\n";
+    assert_eq!(
+        scan(rel_to_abs).len(),
+        1,
+        "an `extern` jump target must be caught"
+    );
+
+    let abs_to_rel = "        ; mov rax, QWORD =>resume_label\n";
+    assert_eq!(
+        scan(abs_to_rel).len(),
+        1,
+        "an 8-byte label operand must be caught"
+    );
+}
+
+#[test]
+fn no_address_dependent_relocations() {
+    let mut sources = Vec::new();
+    rust_sources(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("src"),
+        &mut sources,
+    );
+    assert!(
+        sources.len() > 1,
+        "source scan found nothing to check: {sources:?}"
+    );
+
+    let mut violations = Vec::new();
+    for path in &sources {
+        let text = fs::read_to_string(path).expect("source file is utf-8");
+        for (line_number, reason) in scan(&text) {
+            violations.push(format!("{}:{line_number}: {reason}", path.display()));
+        }
+    }
+
+    assert!(
+        violations.is_empty(),
+        "address-dependent relocations would survive the copy in \
+         `codebuf::finalize_writable`, which moves finalized code to an arena \
+         address dynasm never sees:\n{}",
+        violations.join("\n")
+    );
+}

--- a/majit/majit-backend-dynasm/tests/relocation_guard.rs
+++ b/majit/majit-backend-dynasm/tests/relocation_guard.rs
@@ -48,14 +48,40 @@ struct Statement {
     text: String,
 }
 
-/// Advance `index` past a `//` line comment or a `"…"` literal starting there,
-/// returning the index just after it, or `None` if neither starts at `index`.
+/// Advance `index` past a comment or a `"…"` literal starting there, returning
+/// the index just after it, or `None` if none of those starts at `index`.
+///
+/// Both comment forms have to be recognised, and for the same reason: rustc
+/// strips them before `dynasm!` ever sees the tokens, so a `;` inside one is not
+/// a statement separator. Skipping only `//` would let
+/// `mov rax, QWORD /* ; */ ->resume_label` — a real `AbsToRel` — split into two
+/// fragments, neither of which carries both halves the scan looks for.
 fn skip_comment_or_string(chars: &[char], index: usize) -> Option<usize> {
     match (chars[index], chars.get(index + 1)) {
         ('/', Some('/')) => {
             let mut end = index;
             while end < chars.len() && chars[end] != '\n' {
                 end += 1;
+            }
+            Some(end)
+        }
+        // Rust block comments nest, so track depth rather than stopping at the
+        // first closing delimiter.
+        ('/', Some('*')) => {
+            let mut end = index + 2;
+            let mut depth = 1usize;
+            while end < chars.len() && depth > 0 {
+                match (chars[end], chars.get(end + 1)) {
+                    ('/', Some('*')) => {
+                        depth += 1;
+                        end += 2;
+                    }
+                    ('*', Some('/')) => {
+                        depth -= 1;
+                        end += 2;
+                    }
+                    _ => end += 1,
+                }
             }
             Some(end)
         }
@@ -274,6 +300,39 @@ fn scan_separates_address_dependent_forms() {
         scan(nested_semicolon).len(),
         1,
         "a `;` inside an interpolated expression must not split the statement"
+    );
+
+    // rustc strips comments before `dynasm!` sees the tokens, so a `;` inside
+    // one separates nothing. Both forms, and block comments nest.
+    let commented_semicolon = "dynasm!(self.mc ; mov rax, QWORD /* ; */ ->resume_label);\n";
+    assert_eq!(
+        scan(commented_semicolon).len(),
+        1,
+        "a `;` inside a block comment must not split the statement"
+    );
+    let nested_block_comment =
+        "dynasm!(self.mc ; mov rax, QWORD /* outer /* ; inner */ ; */ ->resume_label);\n";
+    assert_eq!(
+        scan(nested_block_comment).len(),
+        1,
+        "a nested block comment must be skipped whole"
+    );
+    let line_commented_semicolon =
+        "dynasm!(self.mc\n    ; mov rax, QWORD // ;\n      ->resume_label\n);\n";
+    assert_eq!(
+        scan(line_commented_semicolon).len(),
+        1,
+        "a `;` inside a line comment must not split the statement"
+    );
+
+    // A `dynasm!` spelled inside a comment is prose, not an invocation, so it
+    // must not register as a body the corpus scan then counts.
+    let commented_out_invocation = "/* dynasm!(self.mc ; call extern helper as _); */\n";
+    let (statements, bodies) = dynasm_statements(commented_out_invocation);
+    assert_eq!(
+        (statements.len(), bodies),
+        (0, 0),
+        "a commented-out invocation is not a dynasm body"
     );
 }
 

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2227,6 +2227,12 @@ impl majit_backend::Backend for WasmBackend {
                 || op.opcode == majit_ir::OpCode::Jump
                 || op.opcode.is_call_assembler()
         });
+        // The encoded module length, which is what this target can measure:
+        // the host runtime owns the compiled code, so there is no pyre-owned
+        // executable mapping and no retained capacity to report. It is read
+        // before any host compilation, and on native builds no host exists at
+        // all, so it is a submitted-bytes figure rather than
+        // `asmmemmgr.py:90`'s mapped arena.
         let code_size = wasm_bytes.len();
 
         // Instantiate via the host binding on wasm32, or store bytes for

--- a/majit/majit-backend/Cargo.toml
+++ b/majit/majit-backend/Cargo.toml
@@ -11,3 +11,6 @@ majit-ir = { workspace = true }
 majit-translate = { workspace = true }
 majit-gc = { workspace = true }
 parking_lot = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+region = { workspace = true }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -4,6 +4,10 @@
 /// The Backend trait is the contract between the JIT frontend (tracing + optimization)
 /// and the code generation backend (Cranelift, etc.).
 use std::cell::Cell;
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::BTreeMap;
+#[cfg(not(target_arch = "wasm32"))]
+use std::io;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -1710,32 +1714,9 @@ pub type CpuDescrHandle = Arc<std::sync::RwLock<CpuDescrAttachments>>;
 /// code bytes and is released with each compiled block, exactly like
 /// `AsmMemoryManager.free(start, stop)` (`asmmemmgr.py:47-50`).
 ///
-/// The counters are upstream's, but the allocator under them is not.
-/// `total_memory_allocated` is monotonic there because the arena it counts is
-/// *retained*: `free` puts the range back on a reuse list and the mapping
-/// stays, so the figure is the capacity the process still holds. Pyre has no
-/// such arena, and what `allocated` means differs per backend:
-///
-/// - dynasm gives every compiled block its own `ExecutableBuffer`, whose
-///   `memmap2` mapping really is unmapped on drop, so the monotonic figure
-///   *over*-reports once code is freed and grows across compile/invalidate
-///   cycles.
-/// - cranelift records the finalized machine-code length, while the provider
-///   inside `JITModule` page-rounds its mappings and never frees them, so the
-///   figure *under*-reports.
-/// - wasm has no pyre-owned executable mapping at all — the host compiler owns
-///   the code — so what it records is encoded module bytes, a different
-///   quantity from retained capacity.
-///
-/// The fix is the missing allocator — a real reusable `AsmMemoryManager` with
-/// the free list of `asmmemmgr.py:53-90` — not a subtraction here, which would
-/// make one number honest while leaving the semantics further from upstream.
-/// It is blocked on the emission APIs: `dynasmrt`'s `ExecutableBuffer` has no
-/// constructor over caller-owned memory (only `VecAssembler::new(baseaddr)`
-/// can target a chosen address, and copying a finalized buffer is unsound
-/// because `AbsToRel`/`RelToAbs` relocations bake the old base), and
-/// `cranelift-jit` exports `JITMemoryProvider` but not the `JITMemoryKind` its
-/// `allocate` takes, so the trait cannot be implemented outside that crate.
+/// Native backends allocate from [`AsmMemoryManager`], the retained free-list
+/// arena ported below. The wasm backend has no pyre-owned executable mapping;
+/// its existing accounting token measures encoded module bytes instead.
 #[derive(Default)]
 pub struct AsmMemoryManagerStats {
     total_memory_allocated: AtomicUsize,
@@ -1776,6 +1757,7 @@ impl AsmMemoryManagerStats {
         AsmMemoryBlock {
             owner: Arc::clone(self),
             used,
+            storage: AsmMemoryBlockStorage::AccountingOnly,
         }
     }
 
@@ -1787,24 +1769,385 @@ impl AsmMemoryManagerStats {
     }
 }
 
-/// Lifetime token stored beside the executable buffer it accounts for.
+#[cfg(not(target_arch = "wasm32"))]
+const ASM_LARGE_ALLOC_SIZE: usize = 1024 * 1024;
+#[cfg(not(target_arch = "wasm32"))]
+const ASM_MIN_FRAGMENT: usize = 64;
+#[cfg(not(target_arch = "wasm32"))]
+const ASM_NUM_INDICES: usize = 32;
+
+/// `rpython/jit/backend/llsupport/asmmemmgr.py:10-145`.
+///
+/// The two keyed maps and the size-bucket vectors deliberately preserve the
+/// upstream storage shape. `BTreeMap` is used only for exact-key lookups; the
+/// oldest-first policy lives in `blocks_by_size`, just as it does in RPython.
+/// Pyre creates one backend per mutator, so all manager handles share a
+/// process-owned inner arena: retained capacity remains mapped and reusable
+/// when a worker thread and its backend exit.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct AsmMemoryManager {
+    stats: Arc<AsmMemoryManagerStats>,
+    inner: Arc<parking_lot::Mutex<AsmMemoryManagerInner>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct AsmMemoryManagerInner {
+    allocations: Vec<region::Allocation>,
+    allocation_ranges: Vec<(usize, usize)>,
+    free_blocks: BTreeMap<usize, usize>,
+    free_blocks_end: BTreeMap<usize, usize>,
+    blocks_by_size: Vec<Vec<usize>>,
+}
+
+// `region::Allocation` is an owning handle to an OS mapping. Moving that
+// handle does not move the mapping or change its thread affinity; Cranelift's
+// upstream `ArenaMemoryProvider` makes the same `unsafe impl Send` assertion.
+#[cfg(not(target_arch = "wasm32"))]
+unsafe impl Send for AsmMemoryManagerInner {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AsmMemoryManagerInner {
+    fn new() -> Self {
+        Self {
+            allocations: Vec::new(),
+            allocation_ranges: Vec::new(),
+            free_blocks: BTreeMap::new(),
+            free_blocks_end: BTreeMap::new(),
+            blocks_by_size: (0..ASM_NUM_INDICES).map(|_| Vec::new()).collect(),
+        }
+    }
+
+    fn get_index(mut length: usize) -> usize {
+        let mut index = 0;
+        while length > ASM_MIN_FRAGMENT {
+            length = (length * 3) >> 2;
+            index += 1;
+            if index == ASM_NUM_INDICES - 1 {
+                break;
+            }
+        }
+        index
+    }
+
+    fn same_allocation(&self, left: usize, right: usize) -> bool {
+        self.allocation_ranges
+            .iter()
+            .any(|&(start, stop)| start <= left && right < stop)
+    }
+
+    fn del_free_block(&mut self, start: usize, stop: usize) {
+        assert_eq!(self.free_blocks.remove(&start), Some(stop));
+        assert_eq!(self.free_blocks_end.remove(&stop), Some(start));
+        let bucket = &mut self.blocks_by_size[Self::get_index(stop - start)];
+        let position = bucket
+            .iter()
+            .position(|candidate| *candidate == start)
+            .expect("free block missing from size bucket");
+        bucket.remove(position);
+    }
+
+    fn add_free_block(&mut self, mut start: usize, mut stop: usize) -> usize {
+        if let Some(&left_start) = self.free_blocks_end.get(&start)
+            && self.same_allocation(left_start, start)
+        {
+            self.del_free_block(left_start, start);
+            start = left_start;
+        }
+        if let Some(&right_stop) = self.free_blocks.get(&stop)
+            && self.same_allocation(stop, right_stop - 1)
+        {
+            self.del_free_block(stop, right_stop);
+            stop = right_stop;
+        }
+        assert!(self.free_blocks.insert(start, stop).is_none());
+        assert!(self.free_blocks_end.insert(stop, start).is_none());
+        self.blocks_by_size[Self::get_index(stop - start)].push(start);
+        start
+    }
+
+    fn allocate_large_block(
+        &mut self,
+        min_size: usize,
+        total_memory_allocated: usize,
+    ) -> io::Result<usize> {
+        let min_size = min_size.max(total_memory_allocated >> 4);
+        let size = min_size
+            .checked_add(ASM_LARGE_ALLOC_SIZE - 1)
+            .and_then(|value| value.checked_div(ASM_LARGE_ALLOC_SIZE))
+            .and_then(|value| value.checked_mul(ASM_LARGE_ALLOC_SIZE))
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "JIT arena size overflow")
+            })?;
+        let mut allocation =
+            region::alloc(size, region::Protection::READ_WRITE).map_err(io::Error::other)?;
+        let start = allocation.as_mut_ptr::<u8>() as usize;
+        let stop = start + size;
+        self.allocations.push(allocation);
+        self.allocation_ranges.push((start, stop));
+        Ok(self.add_free_block(start, stop))
+    }
+
+    fn allocate_block(
+        &mut self,
+        length: usize,
+        total_memory_allocated: usize,
+    ) -> io::Result<(usize, usize, Option<usize>)> {
+        let initial_index = Self::get_index(length);
+        let mut found = None;
+        for (position, &start) in self.blocks_by_size[initial_index].iter().enumerate() {
+            let stop = self.free_blocks[&start];
+            if start + length <= stop {
+                found = Some((initial_index, position, start, stop));
+                break;
+            }
+        }
+        if found.is_none() {
+            for index in initial_index + 1..ASM_NUM_INDICES {
+                if let Some(&start) = self.blocks_by_size[index].first() {
+                    found = Some((index, 0, start, self.free_blocks[&start]));
+                    break;
+                }
+            }
+        }
+        let newly_mapped = if found.is_none() {
+            let start = self.allocate_large_block(length, total_memory_allocated)?;
+            let stop = self.free_blocks[&start];
+            let index = Self::get_index(stop - start);
+            Some((index, self.blocks_by_size[index].len() - 1, start, stop))
+        } else {
+            None
+        };
+        let (index, position, start, stop) = found.or(newly_mapped).unwrap();
+        self.blocks_by_size[index].remove(position);
+        self.free_blocks.remove(&start);
+        self.free_blocks_end.remove(&stop);
+
+        let allocated_stop = start + length;
+        if stop - allocated_stop >= ASM_MIN_FRAGMENT {
+            self.add_free_block(allocated_stop, stop);
+        }
+        let mapped = (newly_mapped.is_some()).then_some(stop - start);
+        Ok((start, allocated_stop, mapped))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl AsmMemoryManager {
+    pub fn new(stats: Arc<AsmMemoryManagerStats>) -> Arc<Self> {
+        static PROCESS_ARENA: OnceLock<Arc<parking_lot::Mutex<AsmMemoryManagerInner>>> =
+            OnceLock::new();
+        let inner = Arc::clone(
+            PROCESS_ARENA
+                .get_or_init(|| Arc::new(parking_lot::Mutex::new(AsmMemoryManagerInner::new()))),
+        );
+        Arc::new(Self { stats, inner })
+    }
+
+    #[cfg(test)]
+    fn new_isolated(stats: Arc<AsmMemoryManagerStats>) -> Arc<Self> {
+        Arc::new(Self {
+            stats,
+            inner: Arc::new(parking_lot::Mutex::new(AsmMemoryManagerInner::new())),
+        })
+    }
+
+    pub fn stats(&self) -> &Arc<AsmMemoryManagerStats> {
+        &self.stats
+    }
+
+    /// Allocate one page-isolated range. Page isolation is the W^X adaptation
+    /// needed when compiled blocks with different lifetimes share an arena.
+    pub fn allocate(self: &Arc<Self>, size: usize, used: usize) -> io::Result<AsmMemoryBlock> {
+        if used > size {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "JIT used size exceeds requested allocation",
+            ));
+        }
+        let page_size = region::page::size();
+        let capacity = size
+            .max(1)
+            .checked_add(page_size - 1)
+            .map(|value| value / page_size * page_size)
+            .ok_or_else(|| {
+                io::Error::new(io::ErrorKind::InvalidInput, "JIT block size overflow")
+            })?;
+        let total = PROCESS_ASM_MEMORY_STATS
+            .total_memory_allocated
+            .load(Ordering::Relaxed);
+        let (start, stop, mapped) = self.inner.lock().allocate_block(capacity, total)?;
+        if let Some(mapped) = mapped {
+            self.stats
+                .total_memory_allocated
+                .fetch_add(mapped, Ordering::Relaxed);
+            PROCESS_ASM_MEMORY_STATS
+                .total_memory_allocated
+                .fetch_add(mapped, Ordering::Relaxed);
+        }
+        let protection_result = unsafe {
+            region::protect(
+                start as *const u8,
+                stop - start,
+                region::Protection::READ_WRITE,
+            )
+            .map_err(io::Error::other)
+        };
+        if let Err(error) = protection_result {
+            self.inner.lock().add_free_block(start, stop);
+            return Err(error);
+        }
+        self.stats.total_mallocs.fetch_add(used, Ordering::Relaxed);
+        PROCESS_ASM_MEMORY_STATS
+            .total_mallocs
+            .fetch_add(used, Ordering::Relaxed);
+        Ok(AsmMemoryBlock {
+            owner: Arc::clone(&self.stats),
+            used,
+            storage: AsmMemoryBlockStorage::Arena {
+                manager: Arc::clone(self),
+                start,
+                stop,
+            },
+        })
+    }
+
+    fn free(&self, start: usize, stop: usize) {
+        self.inner.lock().add_free_block(start, stop);
+    }
+}
+
+enum AsmMemoryBlockStorage {
+    AccountingOnly,
+    #[cfg(not(target_arch = "wasm32"))]
+    Arena {
+        manager: Arc<AsmMemoryManager>,
+        start: usize,
+        stop: usize,
+    },
+}
+
+/// Lifetime token stored beside executable code. Arena-backed tokens return
+/// their range to the upstream-style free list on drop.
 pub struct AsmMemoryBlock {
     owner: Arc<AsmMemoryManagerStats>,
     used: usize,
+    storage: AsmMemoryBlockStorage,
+}
+
+impl AsmMemoryBlock {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn ptr(&self) -> *const u8 {
+        match self.storage {
+            AsmMemoryBlockStorage::AccountingOnly => std::ptr::null(),
+            AsmMemoryBlockStorage::Arena { start, .. } => start as *const u8,
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.used
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.used == 0
+    }
+
+    pub fn capacity(&self) -> usize {
+        match self.storage {
+            AsmMemoryBlockStorage::AccountingOnly => self.used,
+            #[cfg(not(target_arch = "wasm32"))]
+            AsmMemoryBlockStorage::Arena { start, stop, .. } => stop - start,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn contains(&self, ptr: *const u8) -> bool {
+        let address = ptr as usize;
+        match self.storage {
+            AsmMemoryBlockStorage::AccountingOnly => false,
+            AsmMemoryBlockStorage::Arena { start, stop, .. } => start <= address && address < stop,
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        let AsmMemoryBlockStorage::Arena { start, stop, .. } = self.storage else {
+            panic!("accounting-only assembler block has no storage")
+        };
+        unsafe { std::slice::from_raw_parts_mut(start as *mut u8, stop - start) }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn make_read_only(&mut self) -> io::Result<()> {
+        self.protect(region::Protection::READ)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn make_writable(&mut self) -> io::Result<()> {
+        self.protect(region::Protection::READ_WRITE)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn make_executable(&mut self) -> io::Result<()> {
+        flush_instruction_cache(self.ptr(), self.capacity());
+        self.protect(region::Protection::READ_EXECUTE)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn protect(&mut self, protection: region::Protection) -> io::Result<()> {
+        let AsmMemoryBlockStorage::Arena { start, stop, .. } = self.storage else {
+            return Ok(());
+        };
+        unsafe { region::protect(start as *const u8, stop - start, protection) }
+            .map_err(io::Error::other)
+    }
 }
 
 impl Drop for AsmMemoryBlock {
     fn drop(&mut self) {
-        // `used` only, as `free` does at `asmmemmgr.py:47-50`. The capacity
-        // stays charged; see [`AsmMemoryManagerStats`] for what that costs
-        // without the arena upstream keeps it in.
         self.owner
             .total_mallocs
             .fetch_sub(self.used, Ordering::Relaxed);
         PROCESS_ASM_MEMORY_STATS
             .total_mallocs
             .fetch_sub(self.used, Ordering::Relaxed);
+        #[cfg(not(target_arch = "wasm32"))]
+        if let AsmMemoryBlockStorage::Arena {
+            ref manager,
+            start,
+            stop,
+        } = self.storage
+        {
+            manager.free(start, stop);
+        }
     }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn flush_instruction_cache(ptr: *const u8, len: usize) {
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    unsafe {
+        unsafe extern "C" {
+            fn sys_icache_invalidate(start: *mut u8, size: usize);
+        }
+        sys_icache_invalidate(ptr as *mut u8, len);
+    }
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    unsafe {
+        unsafe extern "C" {
+            fn __clear_cache(start: *mut u8, end: *mut u8);
+        }
+        __clear_cache(ptr as *mut u8, ptr.add(len) as *mut u8);
+    }
+    #[cfg(windows)]
+    unsafe {
+        unsafe extern "system" {
+            fn FlushInstructionCache(process: isize, addr: *const u8, size: usize) -> i32;
+            fn GetCurrentProcess() -> isize;
+        }
+        FlushInstructionCache(GetCurrentProcess(), ptr, len);
+    }
+    #[cfg(not(any(target_arch = "aarch64", windows)))]
+    let _ = (ptr, len);
 }
 
 /// The backend trait — implemented by Cranelift (or other code generators).
@@ -3482,5 +3825,40 @@ mod tests {
         assert_eq!(manager.get_stats(), (12_288, 300));
         drop(second);
         assert_eq!(manager.get_stats(), (12_288, 0));
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn asm_memory_manager_reuses_freed_arena_range() {
+        let stats = Arc::new(AsmMemoryManagerStats::default());
+        let manager = AsmMemoryManager::new_isolated(Arc::clone(&stats));
+
+        let first = manager.allocate(120, 120).unwrap();
+        let first_address = first.ptr();
+        assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 120));
+        drop(first);
+        assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 0));
+
+        let second = manager.allocate(300, 300).unwrap();
+        assert_eq!(second.ptr(), first_address);
+        assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 300));
+        drop(second);
+        assert_eq!(stats.get_stats(), (ASM_LARGE_ALLOC_SIZE, 0));
+    }
+
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn process_arena_reuses_range_after_backend_manager_drop() {
+        let first_stats = Arc::new(AsmMemoryManagerStats::default());
+        let first_manager = AsmMemoryManager::new(first_stats);
+        let first = first_manager.allocate(128, 128).unwrap();
+        let first_address = first.ptr();
+        drop(first);
+        drop(first_manager);
+
+        let second_stats = Arc::new(AsmMemoryManagerStats::default());
+        let second_manager = AsmMemoryManager::new(second_stats);
+        let second = second_manager.allocate(128, 128).unwrap();
+        assert_eq!(second.ptr(), first_address);
     }
 }

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1713,13 +1713,29 @@ pub type CpuDescrHandle = Arc<std::sync::RwLock<CpuDescrAttachments>>;
 /// The counters are upstream's, but the allocator under them is not.
 /// `total_memory_allocated` is monotonic there because the arena it counts is
 /// *retained*: `free` puts the range back on a reuse list and the mapping
-/// stays, so the figure is the capacity the process still holds. Here every
-/// compiled block instead carries its own executable mapping, unmapped when
-/// the block is reaped, so the same monotonic figure over-reports once code is
-/// freed and grows without bound across compile/invalidate cycles. The fix is
-/// the missing allocator — a real reusable `AsmMemoryManager` with the free
-/// list of `asmmemmgr.py:53-90` — not a subtraction here, which would make the
-/// number honest while leaving the semantics further from upstream.
+/// stays, so the figure is the capacity the process still holds. Pyre has no
+/// such arena, and what `allocated` means differs per backend:
+///
+/// - dynasm gives every compiled block its own `ExecutableBuffer`, whose
+///   `memmap2` mapping really is unmapped on drop, so the monotonic figure
+///   *over*-reports once code is freed and grows across compile/invalidate
+///   cycles.
+/// - cranelift records the finalized machine-code length, while the provider
+///   inside `JITModule` page-rounds its mappings and never frees them, so the
+///   figure *under*-reports.
+/// - wasm has no pyre-owned executable mapping at all — the host compiler owns
+///   the code — so what it records is encoded module bytes, a different
+///   quantity from retained capacity.
+///
+/// The fix is the missing allocator — a real reusable `AsmMemoryManager` with
+/// the free list of `asmmemmgr.py:53-90` — not a subtraction here, which would
+/// make one number honest while leaving the semantics further from upstream.
+/// It is blocked on the emission APIs: `dynasmrt`'s `ExecutableBuffer` has no
+/// constructor over caller-owned memory (only `VecAssembler::new(baseaddr)`
+/// can target a chosen address, and copying a finalized buffer is unsound
+/// because `AbsToRel`/`RelToAbs` relocations bake the old base), and
+/// `cranelift-jit` exports `JITMemoryProvider` but not the `JITMemoryKind` its
+/// `allocate` takes, so the trait cannot be implemented outside that crate.
 #[derive(Default)]
 pub struct AsmMemoryManagerStats {
     total_memory_allocated: AtomicUsize,

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3404,6 +3404,20 @@ impl MiniMarkGC {
     /// referents without changing collection state.
     fn visit_referents(&self, obj_addr: usize, visitor: &mut dyn FnMut(GcRef)) {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        self.visit_referents_with_type_id(obj_addr, type_id, visitor);
+    }
+
+    /// `visit_referents` for a caller that already resolved the type id,
+    /// because a prebuilt object carries no header to read it back out of.
+    /// The bounds check sits here rather than beside the header read so that
+    /// both callers get its diagnostic instead of `TypeTable::get`'s bare
+    /// index panic.
+    fn visit_referents_with_type_id(
+        &self,
+        obj_addr: usize,
+        type_id: u32,
+        visitor: &mut dyn FnMut(GcRef),
+    ) {
         self.validate_type_id(type_id, obj_addr, "visit_referents");
         let type_info = self.types.get(type_id);
         if let Some(trace_fn) = type_info.custom_trace {
@@ -3515,11 +3529,22 @@ impl MiniMarkGC {
     /// `inspector.py:51-72 get_rpy_referents`: trace only the direct raw
     /// fields of `obj`.  In contrast, `do_get_referents` below recursively
     /// looks through non-object implementation nodes.
+    ///
+    /// `inspector.py:56-61 _do_append_rpy_referents` traces every gcref
+    /// unconditionally, so heap membership cannot reject registered prebuilt
+    /// objects. `get_actual_typeid` instead rejects null, tagged immediates,
+    /// and unknown foreign pointers; the managed-only nursery check below is
+    /// the only remaining `header_of` on this path.
     pub fn do_get_rpy_referents(&mut self, obj: GcRef, visitor: &mut dyn FnMut(GcRef)) -> bool {
-        if obj.is_null() || !self.is_managed_heap_object(obj.0) {
+        if obj.is_null() {
             return true;
         }
-        if self.is_in_nursery(obj.0) && unsafe { (*header_of(obj.0)).is_forwarded() } {
+        let Some(type_id) = self.get_actual_typeid(obj) else {
+            return true;
+        };
+        let is_managed = self.is_managed_heap_object(obj.0);
+        if is_managed && self.is_in_nursery(obj.0) && unsafe { (*header_of(obj.0)).is_forwarded() }
+        {
             return true;
         }
         let _stw = if crate::gc_sync::stw_required() {
@@ -3527,7 +3552,7 @@ impl MiniMarkGC {
         } else {
             None
         };
-        self.visit_referents(obj.0, visitor);
+        self.visit_referents_with_type_id(obj.0, type_id, visitor);
         true
     }
 

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -430,6 +430,14 @@ pub struct TraceCtx {
     /// jump), consumed and reset by the following `jit_merge_point`
     /// (pyjitpl.py:1559-1562).  `-1` = not seen.
     pub seen_loop_header_for_jdindex: i32,
+    /// JitCode coordinate of the explicit `loop_header` that set
+    /// [`Self::seen_loop_header_for_jdindex`].  The codewriter emits that op in
+    /// the `JUMP_BACKWARD` block, so its containing Python coordinate is the
+    /// back-edge instruction rather than the target `jit_merge_point`.
+    /// Consumed together with the driver-index stamp.  `None` covers automatic
+    /// loop headers and resume-at-position pre-arming, which have no explicit
+    /// back-edge op at that crossing.
+    pub seen_loop_header_jit_pc: Option<usize>,
     /// pyjitpl.py:2941-2942 `if isinstance(key, compile.ResumeAtPositionDescr):
     /// self.seen_loop_header_for_jdindex = self.jitdriver_sd.index` — a bridge
     /// grown from a guard `inline_short_preamble` replayed (unroll.py:337 /
@@ -1608,6 +1616,7 @@ impl TraceCtx {
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,
+            seen_loop_header_jit_pc: None,
             bridge_resume_at_position: false,
             merge_point_resumed: false,
             callinfocollection: None,
@@ -1694,6 +1703,7 @@ impl TraceCtx {
             bridge_target_header_pc: None,
             portal_call_depth_fn: None,
             seen_loop_header_for_jdindex: -1,
+            seen_loop_header_jit_pc: None,
             bridge_resume_at_position: false,
             merge_point_resumed: false,
             callinfocollection: None,

--- a/pyre/bench/synth/gc_heap_dump.py
+++ b/pyre/bench/synth/gc_heap_dump.py
@@ -49,50 +49,37 @@ with tempfile.TemporaryDirectory(prefix="pyre-gc-dump-") as dump_dir:
 
     # The remaining two arms both take their descriptor from the builtin
     # `open`: `app_referents.py:23` for the filename arm and `:48` for the file
-    # object. The Windows builtin `open` hands back an in-memory wrapper that
-    # carries no descriptor, so `fileno()` raises there and neither arm can
-    # run. Ask the platform rather than name it, so a target that grows a
-    # descriptor picks the arms up without editing this file.
-    with open(os.path.join(dump_dir, "probe.bin"), "wb") as probe:
-        try:
-            probe.fileno()
-            open_is_descriptor_backed = True
-        except OSError:
-            open_is_descriptor_backed = False
-
+    # object.
     dump_path = os.path.join(dump_dir, "heap.bin")
-    if open_is_descriptor_backed:
-        with open(dump_path, "wb") as dump_file:
-            assert gc.dump_rpy_heap(dump_file) is None
-        with open(dump_path, "rb") as dump_file:
-            check_dump(dump_file.read())
+    with open(dump_path, "wb") as dump_file:
+        assert gc.dump_rpy_heap(dump_file) is None
+    with open(dump_path, "rb") as dump_file:
+        check_dump(dump_file.read())
 
     # app_referents.py:22-42 — the filename arm opens and truncates the dump
     # itself, then materializes typeids.txt/typeids.lst beside it when they are
     # absent. Neither sidecar is written for a file object or a descriptor, so
     # this is the only call shape that reaches them.
-    if open_is_descriptor_backed:
-        named_dir = os.path.join(dump_dir, "named")
-        os.mkdir(named_dir)
-        named_path = os.path.join(named_dir, "heap.bin")
-        assert gc.dump_rpy_heap(named_path) is None
-        with open(named_path, "rb") as dump_file:
-            check_dump(dump_file.read())
-        typeids_txt = os.path.join(named_dir, "typeids.txt")
-        typeids_lst = os.path.join(named_dir, "typeids.lst")
-        with open(typeids_txt, "rb") as sidecar:
-            assert len(sidecar.read()) > 2
-        with open(typeids_lst, "r") as sidecar:
-            lines = sidecar.read().splitlines()
-        assert len(lines) == len(typeids_list)
-        assert [int(line) for line in lines] == typeids_list
+    named_dir = os.path.join(dump_dir, "named")
+    os.mkdir(named_dir)
+    named_path = os.path.join(named_dir, "heap.bin")
+    assert gc.dump_rpy_heap(named_path) is None
+    with open(named_path, "rb") as dump_file:
+        check_dump(dump_file.read())
+    typeids_txt = os.path.join(named_dir, "typeids.txt")
+    typeids_lst = os.path.join(named_dir, "typeids.lst")
+    with open(typeids_txt, "rb") as sidecar:
+        assert len(sidecar.read()) > 2
+    with open(typeids_lst, "r") as sidecar:
+        lines = sidecar.read().splitlines()
+    assert len(lines) == len(typeids_list)
+    assert [int(line) for line in lines] == typeids_list
 
-        # The second call finds both sidecars in place and leaves them
-        # untouched.
-        with open(typeids_txt, "ab") as sidecar:
-            sidecar.write(b"sentinel\n")
-        assert gc.dump_rpy_heap(named_path) is None
-        with open(typeids_txt, "rb") as sidecar:
-            assert sidecar.read().endswith(b"sentinel\n")
+    # The second call finds both sidecars in place and leaves them untouched.
+    with open(typeids_txt, "ab") as sidecar:
+        sidecar.write(b"sentinel\n")
+    assert gc.dump_rpy_heap(named_path) is None
+    with open(typeids_txt, "rb") as sidecar:
+        assert sidecar.read().endswith(b"sentinel\n")
 
 print("OK")

--- a/pyre/bench/synth/gc_pypy_frontend.py
+++ b/pyre/bench/synth/gc_pypy_frontend.py
@@ -96,6 +96,16 @@ assert raw_roots
 # is its type, which is app-level and passes through unwrapped.
 raw_list_referents = gc.get_rpy_referents([object()])
 assert any(type(referent) is gc.GcRef for referent in raw_list_referents)
+
+# Bootstrap modules are immortal prebuilt objects outside the managed heap,
+# but their registered type still describes the GC fields they own.  The raw
+# inspector must trace those fields just as it traces a managed object's.
+assert not gc.is_tracked(gc)
+assert not any(obj is gc for obj in gc.get_objects())
+prebuilt_module_referents = gc.get_rpy_referents(gc)
+assert prebuilt_module_referents
+assert any(referent is gc.__dict__ for referent in prebuilt_module_referents)
+
 raw = raw_roots[0]
 memory_usage = gc.get_rpy_memory_usage(raw)
 type_index = gc.get_rpy_type_index(raw)

--- a/pyre/bench/synth/gc_pypy_frontend.py
+++ b/pyre/bench/synth/gc_pypy_frontend.py
@@ -100,8 +100,6 @@ assert any(type(referent) is gc.GcRef for referent in raw_list_referents)
 # Bootstrap modules are immortal prebuilt objects outside the managed heap,
 # but their registered type still describes the GC fields they own.  The raw
 # inspector must trace those fields just as it traces a managed object's.
-assert not gc.is_tracked(gc)
-assert not any(obj is gc for obj in gc.get_objects())
 prebuilt_module_referents = gc.get_rpy_referents(gc)
 assert prebuilt_module_referents
 assert any(referent is gc.__dict__ for referent in prebuilt_module_referents)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -16293,9 +16293,10 @@ fn file_method_flush(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
 /// builtins.open(file, mode='r', ...) — PyPy: io.open → FileIO + TextIOWrapper.
 /// Minimal implementation that loads the entire file into memory and
 /// returns a file wrapper instance.
-/// POSIX `open(2)` flags for a text/binary mode string, used when an
-/// `opener` is supplied (the opener receives `(file, flags)`).
-#[cfg(unix)]
+/// OS descriptor flags for a text/binary mode string, used when an `opener`
+/// is supplied (the opener receives `(file, flags)`). Windows forces binary
+/// descriptor I/O and requests a non-inheritable descriptor at open time.
+#[cfg(any(unix, windows))]
 fn open_flags_for_mode(mode: &str) -> i32 {
     let write = mode.contains('w');
     let append = mode.contains('a');
@@ -16317,13 +16318,21 @@ fn open_flags_for_mode(mode: &str) -> i32 {
     if exclusive {
         flags |= libc::O_CREAT | libc::O_EXCL;
     }
-    // PyPy `W_FileIO.descr_init`: every pathname/opener call receives
-    // `O_CLOEXEC` when the platform provides it.  The explicit fcntl below
-    // remains necessary for an opener that ignores the supplied flag.
-    flags |= libc::O_CLOEXEC;
+    // PyPy `W_FileIO.descr_init`: every pathname/opener call requests a
+    // non-inheritable descriptor. The explicit fcntl below remains necessary
+    // on Unix for an opener that ignores the supplied flag. Windows also uses
+    // binary descriptor I/O because the buffered/text layers own translation.
+    #[cfg(unix)]
+    {
+        flags |= libc::O_CLOEXEC;
+    }
+    #[cfg(windows)]
+    {
+        flags |= libc::O_BINARY | libc::O_NOINHERIT;
+    }
     flags
 }
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 fn open_flags_for_mode(_mode: &str) -> i32 {
     0
 }
@@ -16819,7 +16828,49 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
         Ok(wrapper)
     }
-    #[cfg(all(not(feature = "sandbox"), not(unix)))]
+    #[cfg(all(not(feature = "sandbox"), windows, feature = "host_env"))]
+    {
+        let _ = (reading, writing);
+        let flags = open_flags_for_mode(&mode);
+
+        // Match posix.open's Windows path boundary: `_wopen` receives the
+        // filesystem-decoded UTF-16 spelling, including unpaired surrogates.
+        let os_path = crate::gateway::os_string_from_fs_bytes(path_bytes);
+        let wide = widestring::WideCString::from_os_str(&os_path)
+            .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
+        let (opened, _errno) = crate::module::thread::call_external_function(|| {
+            rustpython_host_env::crt_fd::wopen(&wide, flags, 0o666)
+        });
+        let fd = opened
+            .map_err(|e| {
+                crate::PyError::os_error_syscall(
+                    io_error_posix_errno(&e, libc::EACCES),
+                    resolved_path.w_path(),
+                )
+            })?
+            .into_raw();
+
+        let wrapper = pyre_object::w_instance_new(file_wrapper_type());
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_mode__", w_str_new(&mode));
+        // Carry binary-ness so descriptor reads/readlines wrap their chunks as
+        // `bytes` for `rb`; tokenize.detect_encoding relies on that result.
+        let _ = crate::baseobjspace::setattr_str(wrapper, "__file_binary__", w_bool_from(binary));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "encoding", w_str_new(&encoding));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "errors", w_str_new(&errors));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "name", path_obj);
+        let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closefd", w_bool_from(true));
+        let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
+        Ok(wrapper)
+    }
+    // Preserve the existing non-Windows fallback (notably wasm) unchanged;
+    // the Windows host build above owns a real CRT descriptor instead.
+    #[cfg(all(
+        not(feature = "sandbox"),
+        not(unix),
+        any(not(windows), not(feature = "host_env"))
+    ))]
     {
         let data: Vec<u8> = if reading && !mode.contains('w') && !mode.contains('x') {
             #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -43,6 +43,24 @@ fn is_done_states(oldstate: u8, newstate: u8) -> bool {
 /// `interp_gc.py:91-130 StepCollector.finalizing`. `space.fromcache` owns one
 /// instance per object space upstream; pyre has one process-wide object space,
 /// so the corresponding state is shared rather than thread-local.
+///
+/// The atomic carries storage and visibility, not the state transition. The
+/// rgil is what serializes load -> collector step -> store: a mutator holds it
+/// across the whole builtin body (`rgil.rs:214` takes it with a single-owner
+/// CAS, and only an explicit release such as `call_external_function` gives it
+/// up), and nothing on this path releases it. So a second mutator cannot also
+/// observe `false` and start a major step.
+///
+/// The USERDEL drain is the deliberate exception, and matches
+/// `StepCollector.do`: the flag stays set until `run_finalizers_now` returns,
+/// so app-level `__del__` code can yield the GIL or re-enter `collect_step`.
+/// Both are safe because a queue entry is popped before its callback runs
+/// (`_run_finalizers` takes `next_dead()` first, and the collector's
+/// `finalizer_next_dead` is a `pop_front`), so an interleaved or nested drain
+/// cannot invoke the same entry twice. A lock held across the drain would not
+/// help and would invert against the GIL: its holder yields inside `__del__`,
+/// a second thread takes the GIL and blocks on the lock, and the holder can
+/// never reacquire the GIL.
 static STEP_FINALIZING: AtomicBool = AtomicBool::new(false);
 
 /// `referents.py:11-15 W_GcRef(W_Root)`: an app-level handle for a raw GC

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1797,6 +1797,12 @@ pub enum DispatchOutcome {
         /// Codewrite-time resume-marker twin at the merge point op's jitcode
         /// offset, carried into the loop-close guards' snapshot words.
         loop_header_marker_jit_pc: Option<usize>,
+        /// Python instruction containing the explicit `loop_header` op that
+        /// preceded this merge-point crossing.  The codewriter emits that op in
+        /// the `JUMP_BACKWARD` block, so this is the owning back-edge opcode.
+        back_edge_pc: Option<usize>,
+        /// Resume-marker twin for [`Self::CloseLoop::back_edge_pc`].
+        back_edge_marker_jit_pc: Option<usize>,
     },
     /// `jit_merge_point/cIRFIRF` reached a loop header that already has
     /// compiled targets, and the in-walk `compile_trace` attempt
@@ -1864,13 +1870,23 @@ impl PartialEq for DispatchOutcome {
                     jump_args: a_args,
                     loop_header_pc: a_pc,
                     loop_header_marker_jit_pc: a_marker,
+                    back_edge_pc: a_back_edge_pc,
+                    back_edge_marker_jit_pc: a_back_edge_marker,
                 },
                 Self::CloseLoop {
                     jump_args: b_args,
                     loop_header_pc: b_pc,
                     loop_header_marker_jit_pc: b_marker,
+                    back_edge_pc: b_back_edge_pc,
+                    back_edge_marker_jit_pc: b_back_edge_marker,
                 },
-            ) => a_args == b_args && a_pc == b_pc && a_marker == b_marker,
+            ) => {
+                a_args == b_args
+                    && a_pc == b_pc
+                    && a_marker == b_marker
+                    && a_back_edge_pc == b_back_edge_pc
+                    && a_back_edge_marker == b_back_edge_marker
+            }
             (
                 Self::CompileTracePending {
                     loop_header_pc: a_pc,
@@ -9991,6 +10007,7 @@ fn handle<Sym: WalkSym>(
                 _ => return Err(DispatchError::LoopHeaderJdIndexUnresolved { pc: op.pc }),
             };
             ctx.trace_ctx.seen_loop_header_for_jdindex = jdindex as i32;
+            ctx.trace_ctx.seen_loop_header_jit_pc = Some(op.pc);
             Ok((DispatchOutcome::Continue, op.next_pc))
         }
         // RPython parity: `pyjitpl.py _opimpl_inline_call*`
@@ -11542,6 +11559,7 @@ fn handle<Sym: WalkSym>(
                 && std::mem::take(&mut ctx.trace_ctx.bridge_resume_at_position)
             {
                 ctx.trace_ctx.seen_loop_header_for_jdindex = jdindex as i32;
+                ctx.trace_ctx.seen_loop_header_jit_pc = None;
             }
             if ctx.is_top_level
                 && ctx.trace_ctx.seen_loop_header_for_jdindex < 0
@@ -11590,6 +11608,7 @@ fn handle<Sym: WalkSym>(
                 }
                 // pyjitpl.py: automatically add a loop_header.
                 ctx.trace_ctx.seen_loop_header_for_jdindex = jdindex as i32;
+                ctx.trace_ctx.seen_loop_header_jit_pc = None;
             }
             // pyjitpl.py.
             assert!(
@@ -11598,6 +11617,7 @@ fn handle<Sym: WalkSym>(
                  the following jit_merge_point's"
             );
             ctx.trace_ctx.seen_loop_header_for_jdindex = -1;
+            let back_edge_jit_pc = ctx.trace_ctx.seen_loop_header_jit_pc.take();
 
             // pyjitpl.py self.heapcache.reset()
             ctx.trace_ctx.heap_cache_mut().reset();
@@ -11861,20 +11881,29 @@ fn handle<Sym: WalkSym>(
                 // point in reverse and closes at the first same_greenkey hit,
                 // whichever loop that is, and `compile_loop` re-derives the
                 // green key from the merge point it closed at.
-                let loop_header_marker_jit_pc = {
+                let (loop_header_marker_jit_pc, back_edge_pc, back_edge_marker_jit_pc) = {
                     let sym_ptr = ctx.fbw_mode.snapshot_sym;
                     if sym_ptr.is_null() {
-                        None
+                        (None, None, None)
                     } else {
                         let sym = unsafe { &*sym_ptr };
                         if sym.jitcode().is_null() {
-                            None
+                            (None, None, None)
                         } else {
-                            unsafe {
-                                (&*sym.jitcode())
-                                    .payload
-                                    .resume_marker_for_jitcode_pc(op.pc)
-                            }
+                            let payload = unsafe { &(&*sym.jitcode()).payload };
+                            let back_edge_pc = back_edge_jit_pc.map(|jit_pc| {
+                                crate::py_coord::containing_py_pc_for_jitcode_pc(
+                                    &payload.metadata,
+                                    jit_pc,
+                                ) as usize
+                            });
+                            (
+                                payload.resume_marker_for_jitcode_pc(op.pc),
+                                back_edge_pc,
+                                back_edge_jit_pc.and_then(|jit_pc| {
+                                    payload.resume_marker_for_jitcode_pc(jit_pc)
+                                }),
+                            )
                         }
                     }
                 };
@@ -11883,6 +11912,8 @@ fn handle<Sym: WalkSym>(
                         jump_args: live_args,
                         loop_header_pc: next_instr,
                         loop_header_marker_jit_pc,
+                        back_edge_pc,
+                        back_edge_marker_jit_pc,
                     },
                     op.next_pc,
                 ))

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -11671,6 +11671,7 @@ fn loop_header_stamps_seen_flag() {
     assert_eq!(outcome, DispatchOutcome::Continue);
     assert_eq!(next, code.len());
     assert_eq!(wc.trace_ctx.seen_loop_header_for_jdindex, 0);
+    assert_eq!(wc.trace_ctx.seen_loop_header_jit_pc, Some(0));
     assert_eq!(wc.trace_ctx.num_ops(), 0, "loop_header records nothing");
 }
 

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2898,6 +2898,8 @@ pub trait WalkSym {
         orgpc: usize,
         target_pc: Option<usize>,
         header_marker_jit_pc: Option<usize>,
+        poll_resume_pc: usize,
+        poll_resume_marker_jit_pc: Option<usize>,
     ) -> Vec<OpRef>;
 }
 
@@ -3120,9 +3122,17 @@ impl WalkSym for PyreSym {
         orgpc: usize,
         target_pc: Option<usize>,
         header_marker_jit_pc: Option<usize>,
+        poll_resume_pc: usize,
+        poll_resume_marker_jit_pc: Option<usize>,
     ) -> Vec<OpRef> {
         let mut frame = MIFrame::from_sym(ctx, self, concrete_frame, orgpc, orgpc);
-        frame.close_loop_args_at(ctx, target_pc, header_marker_jit_pc)
+        frame.close_loop_args_at(
+            ctx,
+            target_pc,
+            header_marker_jit_pc,
+            poll_resume_pc,
+            poll_resume_marker_jit_pc,
+        )
     }
 }
 
@@ -13819,7 +13829,8 @@ mod tests {
             pre_opcode_semantic_depth: None,
         };
 
-        let jump_args = state.with_ctx(|this, ctx| this.close_loop_args_at(ctx, None, None));
+        let jump_args =
+            state.with_ctx(|this, ctx| this.close_loop_args_at(ctx, None, None, 0, None));
 
         assert_eq!(jump_args.len(), 10);
         assert_eq!(jump_args[0], OpRef::input_arg_ref(0));
@@ -13930,7 +13941,8 @@ mod tests {
             pre_opcode_semantic_depth: None,
         };
 
-        let jump_args = state.with_ctx(|this, ctx| this.close_loop_args_at(ctx, None, None));
+        let jump_args =
+            state.with_ctx(|this, ctx| this.close_loop_args_at(ctx, None, None, 0, None));
 
         assert_eq!(
             jump_args.len(),

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3906,21 +3906,27 @@ fn run_perfn_walk<Sym: WalkSym>(
                 jump_args,
                 loop_header_pc,
                 loop_header_marker_jit_pc,
+                back_edge_pc,
+                back_edge_marker_jit_pc,
             },
             _end_pc,
         )) = &mut walk_result
         {
             let loop_header_pc = *loop_header_pc;
+            let poll_resume_pc = back_edge_pc.unwrap_or(loop_header_pc);
             let restart_pc = close_loop_restart_pc.expect("close loop has a restart pc");
             WALK_END_RESTART_PC.with(|c| c.set(Some(restart_pc)));
-            // `close_loop_args_at` reads the loop-header `orgpc` for the
-            // last_instr anchor, so pass that coordinate explicitly.
+            // The closing frame and GuardFutureCondition remain anchored at
+            // the loop header; the synthesized poll receives its owning
+            // back-edge coordinate separately.
             *jump_args = sym.close_loop_args_at(
                 ctx,
                 cf_addr,
                 loop_header_pc,
                 Some(loop_header_pc),
                 *loop_header_marker_jit_pc,
+                poll_resume_pc,
+                *back_edge_marker_jit_pc,
             );
         }
         // pyjitpl.py:3048-3091 raise_continue_running_normally parity: a

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -895,7 +895,16 @@ impl MIFrame {
         target_pc: Option<usize>,
         header_marker_jit_pc: Option<usize>,
     ) -> Vec<OpRef> {
-        self.with_ctx(|this, ctx| this.close_loop_args_at(ctx, target_pc, header_marker_jit_pc))
+        let poll_resume_pc = self.orgpc;
+        self.with_ctx(|this, ctx| {
+            this.close_loop_args_at(
+                ctx,
+                target_pc,
+                header_marker_jit_pc,
+                poll_resume_pc,
+                header_marker_jit_pc,
+            )
+        })
     }
 
     #[doc(hidden)]
@@ -1985,8 +1994,9 @@ impl MIFrame {
         ctx: &mut TraceCtx,
         target_pc: Option<usize>,
         header_marker_jit_pc: Option<usize>,
+        poll_resume_pc: usize,
+        poll_resume_marker_jit_pc: Option<usize>,
     ) -> Vec<OpRef> {
-        self.loop_close_marker_jit_pc = header_marker_jit_pc;
         // Mirror pypy/module/pypyjit/test_pypy_c/model.py's `--TICK--` shape:
         // load a process-global raw word through a baked constant address,
         // compare it, then guard the result. The folded eval-breaker word is a
@@ -2016,8 +2026,20 @@ impl MIFrame {
             let mask = ctx.const_int(majit_ir::eval_breaker_word::JIT_BREAKER_MASK as i64);
             let breaker_bits = ctx.record_op(OpCode::IntAnd, &[word, mask]);
             let armed = ctx.record_op(OpCode::IntIsTrue, &[breaker_bits]);
+            // The poll is synthesized while this MIFrame is anchored at the
+            // target merge point, but semantically it belongs to the
+            // JUMP_BACKWARD that reached that target.  Temporarily install the
+            // back-edge coordinates so guard flushing, liveness, last_instr,
+            // and the snapshot's JitCode/Python-PC pair all describe the same
+            // pre-opcode state.  Restore the header coordinates immediately:
+            // GuardFutureCondition below must retain its merge-point resume.
+            let header_orgpc = self.orgpc;
+            self.orgpc = poll_resume_pc;
+            self.loop_close_marker_jit_pc = poll_resume_marker_jit_pc;
             self.generate_guard(ctx, OpCode::GuardFalse, &[armed]);
+            self.orgpc = header_orgpc;
         }
+        self.loop_close_marker_jit_pc = header_marker_jit_pc;
         // pyjitpl.py:2954-2965 reached_loop_header: virtualizable_boxes
         // (read from locals_cells_stack_w[*] by virtualizable.py:86-98
         // read_boxes) are carried into the JUMP unchanged, including


### PR DESCRIPTION
Six commits on top of `origin/main`. The backend pair below is the reviewable
core; the gc/jit/builtins commits ride along on the same branch.

## Drop both vendored crates

The tree carried `vendor/cranelift-jit` and `vendor/dynasmrt` (~5,700 lines)
behind a `[patch.crates-io]` table so the arena work could reach two APIs. Both
patches turned out to be avoidable.

**cranelift-jit** — `JITMemoryProvider::allocate` names `JITMemoryKind`, which
0.132.3 left unreachable (`mod memory;` is private and the crate root does not
re-export it), so an out-of-crate provider could not be written. Upstream has
since fixed exactly this: 0.134.3 re-exports `JITMemoryKind`, and the trait
signature is unchanged. Bumping `cranelift-* 0.132 → 0.134` removes the patch.
`wasmtime 45 → 47` comes along because 47 is the release whose
`wasmtime-internal-*` crates ride on cranelift 0.134 — without it the tree would
build two cranelift copies. `pyre-wasm-runner` needed no source change.

The 0.132 → 0.134 delta over this backend is three API changes:

| change | sites |
| --- | --- |
| `MemFlags::{trusted,new}()` → `MemFlagsData::` | 130 |
| `stack_load` gained a leading `pointer_type` | 2 |
| `FunctionBuilder::finalize` gained `TargetFrontendConfig` | 2 |

`MemFlags` became a per-function interned handle in 0.134, but the instruction
builders take `impl Into<MemFlagsData>` and intern internally, so the 130 sites
are a rename rather than a restructuring.

**dynasmrt** — the local patch added `Assembler::finalize_into`, which resolved
relocations against dynasm's temporary mapping and then re-adjusted the
address-dependent ones for the arena base. Copying an `ExecutableBuffer` is
indeed unsound in general, because `RelToAbs`/`AbsToRel` retain the old base.
This backend emits neither: aarch64 encodes every jump target with
`relative_encoding = true`, and the x86 emitter uses no `extern` targets and no
8-byte label operands, which are the only two forms that produce one.

Measured rather than assumed — an instrumented `finalize_into` counting dynasm's
`managed` list over the whole `pyre/bench/synth` corpus (407 fixtures, 2,177
loops and 594 bridges compiled) reported **0** address-dependent relocations,
while a positive control (`mov rax, QWORD =>label`) reported 1. So the
adjustment loop never ran, and `finalize()` + `copy_from_slice` is byte-identical
in effect. `tests/relocation_guard.rs` fails if either form is ever introduced,
since the precondition can no longer be asserted at run time.

## Verification

`pyre/check.py --synthetic-only` on the pre-rebase tree:

- dynasm 407/407
- cranelift 407/407
- wasm 403/403 (under wasmtime 47)

Every `[jit-stats]` line of the dynasm corpus (2,849 lines) is byte-identical
between the vendored and un-vendored builds.

Those runs graded the branch before it was rebased onto current `origin/main`,
so CI here is what grades the pushed commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows support for opening files with correct encoding and descriptor handling.
  * Improved native executable-memory management with reusable, permission-safe storage.
  * Enhanced garbage-collector referent inspection for registered and immortal objects.
  * Improved JIT loop tracking, back-edge handling, and resume-point accuracy.

* **Bug Fixes**
  * Prevented unsafe speculative heap loads across runtime guards.
  * Improved executable code allocation and permission transitions across supported platforms.

* **Tests**
  * Expanded coverage for file-object heap dumps, referents, relocations, memory reuse, and loop tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->