### PR TITLE
cpyext follow-ups, constructor-argument GC roots, and NULL symbol rejection

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3494,6 +3494,15 @@ impl<'a> AssemblerARM64<'a> {
                     Some(Loc::Immed(i)) => i.value,
                     _ => 8,
                 };
+                // assembler.py:254 `_push_all_regs_to_jitframe` — the helper
+                // below can collect, and `emit_malloc_slowpath_helper_call`
+                // only saves the volatiles to the *stack*, where the
+                // collector can neither find nor rewrite them.  Spill every
+                // register into the jitframe first, so the gcmap pushed below
+                // describes the live references and the collector forwards
+                // them.  Must precede the argument setup, which clobbers
+                // x0/x1/x2.
+                self.push_all_regs_to_jitframe(&[], true);
                 // _build_malloc_slowpath(kind='var') parity:
                 // x0 = base_size, x1 = item_size, x2 = length
                 self.emit_mov_imm64(0, base_size);
@@ -3509,9 +3518,17 @@ impl<'a> AssemblerARM64<'a> {
                         self.emit_mov_imm64(2, 0);
                     }
                 }
-                // push_gcmap
+                // assembler.py:649-650 push_gcmap — a null gcmap tells the
+                // collector this frame holds no references, so every pointer
+                // spilled above would survive the collection unforwarded.
+                // `push_gcmap` marshals through x16, which is neither an
+                // argument register nor the helper register.
                 let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS as u32;
-                dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+                if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
+                    self.push_gcmap(gcmap as *mut usize);
+                } else {
+                    dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+                }
                 self.emit_mov_imm64(
                     3,
                     crate::runner::dynasm_nursery_slowpath_varsize as *const () as i64,
@@ -3520,6 +3537,12 @@ impl<'a> AssemblerARM64<'a> {
                 self.reload_frame_if_necessary();
                 // pop_gcmap
                 dynasm!(self.mc ; .arch aarch64 ; str xzr, [x29, gcmap_ofs]);
+                // assembler.py:283 `_pop_all_regs_from_jitframe` — the helper
+                // restored the volatiles from the stack, so they still name
+                // the pre-collection addresses; the jitframe slots are the
+                // ones the collector rewrote.  x0 is excluded because it
+                // carries the allocation result.
+                self.pop_all_regs_from_jitframe(&[crate::aarch64::registers::X0], true);
                 // `dynasm_nursery_slowpath_varsize` returns x0 = 0 on
                 // real host OOM (calloc failure preserved as NULL per
                 // runner.rs).  Route through the propagate path before

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -4528,6 +4528,13 @@ impl<'a> Assembler386<'a> {
                     Some(Loc::Immed(i)) => i.value,
                     _ => 8,
                 };
+                // x86/assembler.py:254 `_push_all_regs_to_jitframe` — the
+                // helper below can collect, and unlike the fixed-size path it
+                // is called directly rather than through the trampoline that
+                // spills for it, so nothing else puts the live references
+                // where the gcmap can name them.  Must precede the argument
+                // setup, which clobbers the ABI argument registers.
+                self.push_all_regs_to_jitframe(&[], true);
                 self.emit_abi_int_arg_from_imm(0, base_size);
                 self.emit_abi_int_arg_from_imm(1, itemsize);
                 match arglocs.first() {
@@ -4541,8 +4548,17 @@ impl<'a> Assembler386<'a> {
                         self.emit_abi_int_arg_from_imm(2, 0);
                     }
                 }
+                // assembler.py:649-650 push_gcmap — a null gcmap tells the
+                // collector this frame holds no references, so every pointer
+                // spilled above would survive the collection unforwarded.
+                // `push_gcmap` marshals through the scratch register, which
+                // is not an ABI argument register.
                 let gcmap_ofs = crate::jitframe::JF_GCMAP_OFS;
-                dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
+                if let Some(gcmap) = self.pending_malloc_nursery_gcmap {
+                    self.push_gcmap(gcmap as *mut usize);
+                } else {
+                    dynasm!(self.mc ; .arch x64 ; mov QWORD [rbp + gcmap_ofs], 0);
+                }
                 dynasm!(self.mc ; .arch x64
                     ; mov rax, QWORD crate::runner::dynasm_nursery_slowpath_varsize as *const () as i64
                 );
@@ -4552,6 +4568,12 @@ impl<'a> Assembler386<'a> {
                 // gcmap, otherwise the clear would target the freed
                 // nursery copy.
                 self.reload_frame_if_necessary();
+                // assembler.py:283 `_pop_all_regs_from_jitframe` — the
+                // jitframe slots are what the collector rewrote, so reload
+                // from them rather than trusting the callee-save/volatile
+                // state around the call.  EAX is excluded because it carries
+                // the allocation result the null check and result store read.
+                self.pop_all_regs_from_jitframe(&[crate::regloc::EAX], true);
                 // assembler.py:300-322 OOM propagate parity — the
                 // varsize helper now returns NULL on `libc::calloc`
                 // / `gc.alloc_varsize` failure; route that through

--- a/pyre/pyre-interpreter/include/pyre3.14/Python.h
+++ b/pyre/pyre-interpreter/include/pyre3.14/Python.h
@@ -10,7 +10,11 @@ extern "C" {
 
 #define PY_MAJOR_VERSION 3
 #define PY_MINOR_VERSION 14
-#define PY_VERSION_HEX 0x030E0000
+#define PY_MICRO_VERSION 6
+/* 3.14.6 final, matching sys.hexversion. The release-level nibble is 0xF for a
+   final release, so a value ending in 0x00 would put every `#if PY_VERSION_HEX
+   >= 0x030E00F0` extension on its pre-release branch. */
+#define PY_VERSION_HEX 0x030E06F0
 #define PYTHON_API_VERSION 1013
 
 #if defined(_WIN32)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -3703,10 +3703,24 @@ unsafe fn setitem_list(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef)
 
 #[inline(never)]
 unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
+    // `STORE_SUBSCR` pops all three operands off the value stack before
+    // dispatching here, so the frame no longer roots any of them and each is a
+    // bare address. Every step below can collect — `slice_unpack` honors
+    // `__index__`, `collect_iterable` runs the iterable's own Python code, and
+    // both list constructors allocate — so publish the operands on the shadow
+    // stack first and read each one back after any step that can collect.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(value);
+    let index_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(index);
     // CPython 3.14 `list_ass_subscript_lock_held`: unpack the slice first,
     // materialize the replacement next, and only then adjust the bounds
     // against the list's live length. Materializing an arbitrary iterable may
     // mutate `obj` (gh-120384), so using its earlier length is incorrect.
+    let index = pyre_object::gc_roots::shadow_stack_get(index_slot);
     let (raw_start, raw_stop, step) = crate::sliceobject::slice_unpack(
         w_slice_get_start(index),
         w_slice_get_stop(index),
@@ -3715,6 +3729,8 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     // PyPy listobject.py:709-714 wraps non-list iterables into a temporary
     // W_ListObject so the strategy-aware setslice path sees a list operand.
     // CPython additionally protects `a[::-1] = a` with a shallow copy.
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
     let w_other = if obj == value {
         pyre_object::listobject::w_list_new(pyre_object::listobject::w_list_items_copy_as_vec(
             value,
@@ -3725,6 +3741,9 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         let items = crate::builtins::collect_iterable(value)?;
         pyre_object::listobject::w_list_new(items)
     };
+    let other_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_other);
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let len = w_list_len(obj) as i64;
     let (start, stop, step, slicelength) =
         crate::sliceobject::slice_adjust_indices(raw_start, raw_stop, step, len);
@@ -3736,6 +3755,8 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
         // has zero length and inserts/deletes at 5, rather than forming the
         // invalid Rust range `5..2`.
         let s_hi = stop.max(start).max(0) as usize;
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let w_other = pyre_object::gc_roots::shadow_stack_get(other_slot);
         pyre_object::listobject::w_list_setslice(obj, s_lo, s_hi, w_other)
             .expect("w_other is always a valid list");
         return Ok(w_none());
@@ -3754,6 +3775,7 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
             i += step;
         }
     }
+    let w_other = pyre_object::gc_roots::shadow_stack_get(other_slot);
     let other_len = pyre_object::w_list_len(w_other);
     if other_len != indices.len() {
         return Err(PyError::new(
@@ -3772,8 +3794,19 @@ unsafe fn setitem_list_slice(obj: PyObjectRef, index: PyObjectRef, value: PyObje
     let mut k = 0usize;
     while k < indices.len() {
         let idx = indices[k];
+        // A store can switch the receiver's strategy, and that allocates, so
+        // both lists are re-read from their slots on every iteration and the
+        // item is published before the store that may collect. The item's slot
+        // is bracketed per iteration, or a long extended slice would push one
+        // root per element and never pop them.
+        let _item_roots = pyre_object::gc_roots::push_roots();
+        let w_other = pyre_object::gc_roots::shadow_stack_get(other_slot);
         let item =
             pyre_object::w_list_getitem(w_other, k as i64).expect("k < other_len by construction");
+        let item_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(item);
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let item = pyre_object::gc_roots::shadow_stack_get(item_slot);
         if !pyre_object::w_list_setitem(obj, idx, item) {
             return Err(PyError::new(
                 PyErrorKind::IndexError,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2438,6 +2438,23 @@ pub fn call_with_kwargs_in_ctx(
     let current_kwarg = |index: usize| {
         pyre_object::gc_roots::shadow_stack_get(call_root_base + 1 + pos_args.len() + index)
     };
+    // `Arguments` survives the whole dispatch upstream because its
+    // `arguments_w`/`keywords_w` lists are traced and updated in place. The
+    // builtin ABI passes a raw `&[PyObjectRef]` copy the collector cannot see,
+    // so every forward across an allocating call rebuilds the view from the
+    // roots pinned above rather than handing on the incoming slices.
+    let extend_current_args = |dst: &mut Vec<PyObjectRef>| {
+        for index in 0..pos_args.len() {
+            dst.push(current_pos_arg(index));
+        }
+    };
+    let current_kwargs = || -> Vec<(Wtf8Buf, PyObjectRef)> {
+        kwargs
+            .iter()
+            .enumerate()
+            .map(|(index, (name, _))| (name.clone(), current_kwarg(index)))
+            .collect()
+    };
 
     // function.py:712-713 StaticMethod.descr_call — the wrapper contributes
     // no implicit argument; forward the original positional and keyword
@@ -2995,10 +3012,10 @@ pub fn call_with_kwargs_in_ctx(
         // captured ordinary constructors such as
         // `_GenericAlias(origin, args, **kw)`.
         let w_metaclass = if pos_args.len() >= 3
-            && unsafe { pyre_object::is_str(pos_args[0]) }
-            && unsafe { pyre_object::is_tuple(pos_args[1]) }
+            && unsafe { pyre_object::is_str(current_pos_arg(0)) }
+            && unsafe { pyre_object::is_tuple(current_pos_arg(1)) }
         {
-            calculate_metaclass(current_type(), pos_args[1]).unwrap_or(current_type())
+            calculate_metaclass(current_type(), current_pos_arg(1)).unwrap_or(current_type())
         } else {
             current_type()
         };
@@ -3012,11 +3029,12 @@ pub fn call_with_kwargs_in_ctx(
             let new_fn = unsafe { unwrap_static_new(new_fn) };
             let mut new_args = Vec::with_capacity(1 + pos_args.len());
             // `lookup_in_type` interns its name and can collect; reload the
-            // winning metaclass rather than retaining its pre-lookup address.
+            // winning metaclass and the arguments rather than retaining their
+            // pre-lookup addresses.
             new_args.push(current_metaclass());
-            new_args.extend_from_slice(pos_args);
+            extend_current_args(&mut new_args);
             if unsafe { crate::is_function(new_fn) } && !kwargs.is_empty() {
-                call_with_kwargs_in_ctx(execution_context, new_fn, &new_args, kwargs)?
+                call_with_kwargs_in_ctx(execution_context, new_fn, &new_args, &current_kwargs())?
             } else {
                 call_callable_in_ctx(execution_context, new_fn, &new_args)?
             }
@@ -3045,13 +3063,19 @@ pub fn call_with_kwargs_in_ctx(
             // binds itself and receives only the original constructor args.
             let init_result = if unsafe { crate::is_function(init_descr) } {
                 let mut init_args = Vec::with_capacity(1 + pos_args.len());
-                // The `__new__` result is a movable nursery object. Reload
-                // the pointer rooted immediately above instead of retaining
-                // the pre-collection Rust local across argument binding and
-                // descriptor dispatch.
+                // The `__new__` result and the constructor arguments are
+                // movable nursery objects, and `__new__` has just run
+                // arbitrary allocating code. Reload every one of them from
+                // the roots instead of retaining the pre-collection locals
+                // across argument binding and descriptor dispatch.
                 init_args.push(pyre_object::gc_roots::shadow_stack_get(instance_slot));
-                init_args.extend_from_slice(pos_args);
-                call_with_kwargs_in_ctx(execution_context, init_descr, &init_args, kwargs)?
+                extend_current_args(&mut init_args);
+                call_with_kwargs_in_ctx(
+                    execution_context,
+                    init_descr,
+                    &init_args,
+                    &current_kwargs(),
+                )?
             } else {
                 let init_fn = unsafe {
                     crate::baseobjspace::get(
@@ -3061,7 +3085,11 @@ pub fn call_with_kwargs_in_ctx(
                     )?
                 }
                 .unwrap_or(init_descr);
-                call_with_kwargs_in_ctx(execution_context, init_fn, pos_args, kwargs)?
+                // Binding the descriptor allocates, so the arguments are
+                // reloaded after it rather than before.
+                let mut init_args = Vec::with_capacity(pos_args.len());
+                extend_current_args(&mut init_args);
+                call_with_kwargs_in_ctx(execution_context, init_fn, &init_args, &current_kwargs())?
             };
             check_init_returned_none(init_result)?;
         }
@@ -3084,33 +3112,24 @@ pub fn call_with_kwargs_in_ctx(
         // `user_call_slot` may run a descriptor and collect.  Rebuild the
         // Arguments view from the roots installed at function entry instead
         // of forwarding the stale incoming slices.
-        let current_pos_args: Vec<PyObjectRef> = (0..pos_args.len()).map(current_pos_arg).collect();
-        let current_kwargs: Vec<(Wtf8Buf, PyObjectRef)> = kwargs
-            .iter()
-            .enumerate()
-            .map(|(index, (name, _))| (name.clone(), current_kwarg(index)))
-            .collect();
         if prepend_receiver {
-            let mut call_args = Vec::with_capacity(1 + current_pos_args.len());
+            let mut call_args = Vec::with_capacity(1 + pos_args.len());
             call_args.push(current_callable());
-            call_args.extend_from_slice(&current_pos_args);
+            extend_current_args(&mut call_args);
             return call_with_kwargs_in_ctx(
                 execution_context,
                 call_fn,
                 &call_args,
-                &current_kwargs,
+                &current_kwargs(),
             );
         }
         // Depth guard: count this dispatch level and, dropping after the call,
         // keep it off the tail so a self-referential `A.__call__ = A()`
         // recurses natively for stack_check (see call_callable_with_mode).
         let _depth_guard = enter_native_dispatch();
-        return call_with_kwargs_in_ctx(
-            execution_context,
-            call_fn,
-            &current_pos_args,
-            &current_kwargs,
-        );
+        let mut call_args = Vec::with_capacity(pos_args.len());
+        extend_current_args(&mut call_args);
+        return call_with_kwargs_in_ctx(execution_context, call_fn, &call_args, &current_kwargs());
     }
 
     // GenericAlias.__call__ (`_pypy_generic_alias.py:41`) —
@@ -4932,18 +4951,39 @@ fn type_descr_call_with_mode(
     if let Some(result) = type_call_special_case(w_type, args, false) {
         return result;
     }
-    check_type_instantiable(w_type)?;
+    // `typeobject.py:731,738-739` threads one `__args__` through `__new__` and
+    // then `__init__`; it needs no reload because `Arguments.arguments_w` is a
+    // traced list the moving GC updates in place. This slice is a raw copy the
+    // collector cannot see, so pin the type and every argument here and read
+    // them back from the shadow stack after `__new__` has run Python code.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_type);
+    for &arg in args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let current_type = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let extend_current_args = |dst: &mut Vec<PyObjectRef>| {
+        for index in 0..args.len() {
+            dst.push(pyre_object::gc_roots::shadow_stack_get(
+                root_base + 1 + index,
+            ));
+        }
+    };
+
+    check_type_instantiable(current_type())?;
     // Step 1: Look up __new__ via type MRO → allocate instance.
     // PyPy: typeobject.py descr_call → `w_newtype, w_newdescr =
     // self.lookup_where('__new__')`; a missing descriptor (the pathological
     // mro-without-object case) raises, otherwise the descriptor is bound via
     // `space.get(w_newdescr, space.w_None, w_type=self)` and called with
     // w_type as the first arg.
-    let Some(new_descr) = (unsafe { crate::baseobjspace::lookup_in_type(w_type, "__new__") })
+    let Some(new_descr) =
+        (unsafe { crate::baseobjspace::lookup_in_type(current_type(), "__new__") })
     else {
         // typeobject.py:715 — `raise oefmt(space.w_TypeError,
         // "cannot create '%N' instances", self)`.
-        let name = unsafe { pyre_object::w_type_get_name(w_type) };
+        let name = unsafe { pyre_object::w_type_get_name(current_type()) };
         return Err(crate::PyError::type_error(format!(
             "cannot create '{name}' instances"
         )));
@@ -4951,12 +4991,13 @@ fn type_descr_call_with_mode(
     // typeobject.py:726 — `w_newfunc = space.get(w_newdescr, space.w_None,
     // w_type=self)`.  A descriptor with no __get__ (`get` → None) is its own
     // bound value, matching `space.get`'s `if w_get is None: return w_descr`.
-    let new_fn = unsafe { crate::baseobjspace::get(new_descr, pyre_object::PY_NULL, w_type)? }
-        .unwrap_or(new_descr);
+    let new_fn =
+        unsafe { crate::baseobjspace::get(new_descr, pyre_object::PY_NULL, current_type())? }
+            .unwrap_or(new_descr);
     // typeobject.py:731 — `space.call_obj_args(w_newfunc, self, __args__)`.
     let mut new_args = Vec::with_capacity(1 + args.len());
-    new_args.push(w_type);
-    new_args.extend_from_slice(args);
+    new_args.push(current_type());
+    extend_current_args(&mut new_args);
     let instance = call_callable_with_mode(execution_context, new_fn, &new_args, mode)?;
     let _instance_roots = pyre_object::gc_roots::push_roots();
     let instance_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -4965,20 +5006,24 @@ fn type_descr_call_with_mode(
 
     // Step 2: __init__ — only if __new__ returned an instance of w_type.
     // PyPy: descr_call — skips __init__ when __new__ returns a foreign type.
-    if let Some(w_insttype) = type_call_init_type(current_instance(), w_type)
+    if let Some(w_insttype) = type_call_init_type(current_instance(), current_type())
         && let Some(init_descr) =
             unsafe { crate::baseobjspace::lookup_in_type(w_insttype, "__init__") }
     {
         let init_result = if unsafe { crate::is_function(init_descr) } {
             let mut init_args = Vec::with_capacity(1 + args.len());
             init_args.push(current_instance());
-            init_args.extend_from_slice(args);
+            extend_current_args(&mut init_args);
             call_callable_with_mode(execution_context, init_descr, &init_args, mode)?
         } else {
             let init_fn =
                 unsafe { crate::baseobjspace::get(init_descr, current_instance(), w_insttype)? }
                     .unwrap_or(init_descr);
-            call_callable_with_mode(execution_context, init_fn, args, mode)?
+            // Binding the descriptor allocates, so the arguments are reloaded
+            // after it rather than before.
+            let mut init_args = Vec::with_capacity(args.len());
+            extend_current_args(&mut init_args);
+            call_callable_with_mode(execution_context, init_fn, &init_args, mode)?
         };
         check_init_returned_none(init_result)?;
     }

--- a/pyre/pyre-interpreter/src/cpyext.rs
+++ b/pyre/pyre-interpreter/src/cpyext.rs
@@ -16,9 +16,9 @@ use pyre_object::{PY_NULL, PyObjectRef};
 use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, c_char, c_int, c_void};
+use std::hash::BuildHasherDefault;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicIsize, Ordering};
-use std::sync::{LazyLock, Mutex};
 
 /// The large ownership contribution held by the linked pyre object.
 ///
@@ -89,23 +89,59 @@ struct ExtensionCacheEntry {
     _handle: usize,
 }
 
+/// A mutex whose lock word is rebuilt in the child of a `fork`, keeping the
+/// payload it guards.
+///
+/// The data-less `ForkExtensionLoadLock` below cannot serve these tables: the
+/// value lives *inside* the lock, so a fresh lock has to carry it over.  The
+/// payload is what the child must keep — `fork` copies the address space, so
+/// the loaded libraries, their static module definitions and every raw mirror
+/// are still mapped, and dropping the census would leave `ob_pyre_link` slots
+/// unvisited.  Only the lock word is stale, because the thread that held it
+/// does not exist in the child.
+///
+/// `ptr::read` moves the payload out without acquiring, and `ptr::write` does
+/// not drop the abandoned lock — the same reason the data-less wrappers write
+/// over theirs rather than replacing them by assignment.
+struct ForkMutex<T>(UnsafeCell<parking_lot::Mutex<T>>);
+unsafe impl<T: Send> Sync for ForkMutex<T> {}
+
+impl<T> ForkMutex<T> {
+    const fn new(value: T) -> Self {
+        Self(UnsafeCell::new(parking_lot::Mutex::new(value)))
+    }
+
+    fn lock(&self) -> parking_lot::MutexGuard<'_, T> {
+        unsafe { &*self.0.get() }.lock()
+    }
+
+    unsafe fn reinit_after_fork(&self) {
+        let value = unsafe { (*self.0.get()).data_ptr().read() };
+        unsafe { self.0.get().write(parking_lot::Mutex::new(value)) };
+    }
+}
+
+/// Keyed by path, so the hasher is never fed attacker-chosen keys; the default
+/// one is spelled out only because it is the const-constructible form.
+type ExtensionCache =
+    HashMap<PathBuf, ExtensionCacheEntry, BuildHasherDefault<std::hash::DefaultHasher>>;
+
 /// PyPy `State.extensions`: the upstream owner is a process/interpreter state
 /// dictionary, so a `HashMap` is intentional here rather than a side-table
 /// workaround.  The values are copied module dictionaries, not per-object
 /// optimization metadata.
-static EXTENSIONS: LazyLock<Mutex<HashMap<PathBuf, ExtensionCacheEntry>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
+static EXTENSIONS: ForkMutex<ExtensionCache> =
+    ForkMutex::new(HashMap::with_hasher(BuildHasherDefault::new()));
 
 /// PyPy/rawrefcount's P-list analogue.  The relationship itself lives on the
 /// raw object (`ob_pyre_link`); this Vec is only the collector's census of
 /// mirrors whose inline link must be visited.
-static RAW_OBJECTS: LazyLock<Mutex<Vec<usize>>> = LazyLock::new(|| Mutex::new(Vec::new()));
+static RAW_OBJECTS: ForkMutex<Vec<usize>> = ForkMutex::new(Vec::new());
 static CPYEXT_GC_ACTIVE: AtomicBool = AtomicBool::new(false);
 
 /// `State.package_context`, consumed by `PyModule_Create2` while `PyInit_*`
 /// runs. Imports are serialized by the import lock, as in PyPy.
-static PACKAGE_CONTEXT: LazyLock<Mutex<Option<(String, PathBuf)>>> =
-    LazyLock::new(|| Mutex::new(None));
+static PACKAGE_CONTEXT: ForkMutex<Option<(String, PathBuf)>> = ForkMutex::new(None);
 
 /// PyPy performs cpyext initialization under the GIL. Pyre currently has no
 /// process GIL, so this reentrant boundary preserves the same serialization
@@ -181,7 +217,17 @@ fn extension_load_lock() -> ExtensionLoadGuard {
 
 pub fn after_fork_child() {
     unsafe { EXTENSION_LOAD_LOCK.reinit_after_fork() };
-    *PACKAGE_CONTEXT.lock().unwrap() = None;
+    // Every one of these can be held by a thread the child does not have, so
+    // the lock word is replaced before anything acquires it — an import or a
+    // collection in the child would otherwise block forever.
+    unsafe {
+        EXTENSIONS.reinit_after_fork();
+        RAW_OBJECTS.reinit_after_fork();
+        PACKAGE_CONTEXT.reinit_after_fork();
+    }
+    // `PyInit_*` cannot have been mid-flight in the child, and the parent's
+    // half-finished import must not name the next module created here.
+    *PACKAGE_CONTEXT.lock() = None;
 }
 
 pub const fn soabi() -> &'static str {
@@ -215,7 +261,7 @@ fn attach_module(module: PyObjectRef) -> *mut CPyObject {
         ob_pyre_link: module,
         ob_type: (&raw mut CPY_MODULE_TYPE),
     }));
-    RAW_OBJECTS.lock().unwrap().push(raw as usize);
+    RAW_OBJECTS.lock().push(raw as usize);
     CPYEXT_GC_ACTIVE.store(true, Ordering::Release);
     raw
 }
@@ -228,10 +274,7 @@ unsafe fn detach_unowned_module_mirror(raw: *mut CPyObject) {
         return;
     }
     let address = raw as usize;
-    RAW_OBJECTS
-        .lock()
-        .unwrap()
-        .retain(|&candidate| candidate != address);
+    RAW_OBJECTS.lock().retain(|&candidate| candidate != address);
     unsafe {
         (*raw).ob_pyre_link = PY_NULL;
         (*raw).ob_refcnt -= REFCNT_FROM_PYRE;
@@ -248,7 +291,7 @@ pub fn walk_gc_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
     if !CPYEXT_GC_ACTIVE.load(Ordering::Acquire) {
         return;
     }
-    for &address in RAW_OBJECTS.lock().unwrap().iter() {
+    for &address in RAW_OBJECTS.lock().iter() {
         let raw = address as *mut CPyObject;
         unsafe {
             if (*raw).ob_refcnt > REFCNT_FROM_PYRE && !(*raw).ob_pyre_link.is_null() {
@@ -256,7 +299,7 @@ pub fn walk_gc_roots(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
             }
         }
     }
-    for entry in EXTENSIONS.lock().unwrap().values_mut() {
+    for entry in EXTENSIONS.lock().values_mut() {
         let mut dict = entry.dict as PyObjectRef;
         if !dict.is_null() {
             visitor(&mut dict);
@@ -285,7 +328,7 @@ fn module_from_cached_dict(name: &str, dict: PyObjectRef) -> PyObjectRef {
 fn cached_extension(name: &str, path: &Path) -> Option<PyObjectRef> {
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = {
-        let cache = EXTENSIONS.lock().unwrap();
+        let cache = EXTENSIONS.lock();
         let dict = cache.get(path)?.dict as PyObjectRef;
         let slot = pyre_object::gc_roots::shadow_stack_len();
         roots.pin_root(dict);
@@ -298,11 +341,7 @@ fn cached_extension(name: &str, path: &Path) -> Option<PyObjectRef> {
 }
 
 fn cached_extension_handle(path: &Path) -> Option<usize> {
-    EXTENSIONS
-        .lock()
-        .unwrap()
-        .get(path)
-        .map(|entry| entry._handle)
+    EXTENSIONS.lock().get(path).map(|entry| entry._handle)
 }
 
 fn fixup_extension(module: PyObjectRef, name: &str, path: &Path, handle: usize) {
@@ -313,7 +352,7 @@ fn fixup_extension(module: PyObjectRef, name: &str, path: &Path, handle: usize) 
     let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
     let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
     let dict_copy = unsafe { pyre_object::dictmultiobject::w_dict_copy(dict) };
-    EXTENSIONS.lock().unwrap().insert(
+    EXTENSIONS.lock().insert(
         path.to_path_buf(),
         ExtensionCacheEntry {
             dict: dict_copy as usize,
@@ -415,11 +454,10 @@ pub fn load_extension_module(name: &str, path: &Path) -> Result<PyObjectRef, cra
 
     let old_context = PACKAGE_CONTEXT
         .lock()
-        .unwrap()
         .replace((name.to_string(), path.to_path_buf()));
     let init: unsafe extern "C" fn() -> *mut CPyObject = unsafe { std::mem::transmute(address) };
     let result = unsafe { init() };
-    *PACKAGE_CONTEXT.lock().unwrap() = old_context;
+    *PACKAGE_CONTEXT.lock() = old_context;
 
     if result.is_null() {
         rustpython_host_env::ctypes::drop_library(handle);
@@ -515,9 +553,12 @@ pub unsafe extern "C" fn PyModule_Create2(
     if unsafe { !(*def).m_methods.is_null() && !(*(*def).m_methods).ml_name.is_null() } {
         return std::ptr::null_mut();
     }
+    // `m_size == 0` is a stateless single-phase module, `-1` keeps its state in
+    // C globals: neither needs `md_state`, so both are in this slice.  A
+    // positive size asks for per-module storage, which is not built yet.
     if unsafe {
         !(*def).m_slots.is_null()
-            || (*def).m_size != -1
+            || !matches!((*def).m_size, -1 | 0)
             || !(*def).m_traverse.is_null()
             || !(*def).m_clear.is_null()
             || !(*def).m_free.is_null()
@@ -528,7 +569,7 @@ pub unsafe extern "C" fn PyModule_Create2(
     let declared_name = unsafe { CStr::from_ptr((*def).m_name) }.to_string_lossy();
     // PyPy `PyModule_Create2` consumes package_context before allocating the
     // module. Releasing the mutex here also avoids holding it across GC.
-    let context = PACKAGE_CONTEXT.lock().unwrap().take();
+    let context = PACKAGE_CONTEXT.lock().take();
     let (name, path) = context
         .as_ref()
         .map(|(name, path)| (name.as_str(), Some(path.as_path())))

--- a/pyre/pyre-interpreter/src/cpyext.rs
+++ b/pyre/pyre-interpreter/src/cpyext.rs
@@ -386,6 +386,19 @@ fn extension_import_error(message: String, name: &str, path: &Path) -> crate::Py
     )
 }
 
+/// Resolve an extension's init entry point, or `None` if the library has none.
+///
+/// `dlsym` reports a miss by returning NULL, and a resolver that itself
+/// returns NULL leaves `dlerror` unset, so the lookup reports success with
+/// address 0. `rdynload.dlsym` rejects that, and it must be rejected here too:
+/// address 0 transmuted to the init signature is a call through a null pointer.
+fn lookup_init_address(handle: usize, symbol: &str) -> Option<usize> {
+    match rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol.as_bytes()) {
+        Ok(0) | Err(_) => None,
+        Ok(address) => Some(address),
+    }
+}
+
 /// PyPy `cpyext.api.create_extension_module`, single-phase branch.
 pub fn load_extension_module(name: &str, path: &Path) -> Result<PyObjectRef, crate::PyError> {
     let _load_guard = extension_load_lock();
@@ -396,17 +409,16 @@ pub fn load_extension_module(name: &str, path: &Path) -> Result<PyObjectRef, cra
     // opening on this host abstraction.
     if let Some(handle) = cached_extension_handle(path) {
         let symbol = init_symbol(name)?;
-        rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol.as_bytes())
-            .map_err(|_error| {
-                extension_import_error(
-                    format!(
-                        "function {symbol} not found in library '{}'",
-                        path.display()
-                    ),
-                    name,
-                    path,
-                )
-            })?;
+        if lookup_init_address(handle, &symbol).is_none() {
+            return Err(extension_import_error(
+                format!(
+                    "function {symbol} not found in library '{}'",
+                    path.display()
+                ),
+                name,
+                path,
+            ));
+        }
         if let Some(module) = cached_extension(name, path) {
             let roots = pyre_object::gc_roots::push_roots();
             let module_slot = pyre_object::gc_roots::shadow_stack_len();
@@ -438,19 +450,17 @@ pub fn load_extension_module(name: &str, path: &Path) -> Result<PyObjectRef, cra
             return Err(error);
         }
     };
-    let address =
-        rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol.as_bytes())
-            .map_err(|_error| {
-                rustpython_host_env::ctypes::drop_library(handle);
-                extension_import_error(
-                    format!(
-                        "function {symbol} not found in library '{}'",
-                        path.display()
-                    ),
-                    name,
-                    path,
-                )
-            })?;
+    let Some(address) = lookup_init_address(handle, &symbol) else {
+        rustpython_host_env::ctypes::drop_library(handle);
+        return Err(extension_import_error(
+            format!(
+                "function {symbol} not found in library '{}'",
+                path.display()
+            ),
+            name,
+            path,
+        ));
+    };
 
     let old_context = PACKAGE_CONTEXT
         .lock()

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1180,6 +1180,13 @@ fn walk_interpreter_global_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) 
         any(target_os = "macos", target_os = "linux")
     ))]
     {
+        // The cast reinterprets a mirror's link slot as a GC reference in
+        // place, so the two spellings of a machine word have to stay
+        // interchangeable for the forwarding write to land on the slot.
+        const _: () = assert!(
+            std::mem::size_of::<PyObjectRef>() == std::mem::size_of::<majit_ir::GcRef>()
+                && std::mem::align_of::<PyObjectRef>() == std::mem::align_of::<majit_ir::GcRef>()
+        );
         let mut forward = |slot: &mut PyObjectRef| {
             visitor(unsafe { &mut *(slot as *mut PyObjectRef as *mut majit_ir::GcRef) });
         };

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1214,6 +1214,86 @@ fn set_builtin_module_spec(_name: &str, _module: PyObjectRef) -> Result<(), crat
     Ok(())
 }
 
+/// Set an extension module's `__spec__`/`__loader__`/`__package__`/`__file__`
+/// from the app-level `_bootstrap_external.spec_from_file_location`, matching
+/// what `ExtensionFileLoader` installs when the same file is imported through
+/// importlib. `PyModule_Create2` supplies only the name, docstring and file, so
+/// without this a natively-resolved extension carries less metadata than the
+/// source module beside it — and the dict the extension cache snapshots is the
+/// incomplete one.
+///
+/// Best-effort throughout, like `set_builtin_module_spec`: an extension
+/// imported before the bootstrap is wired keeps what `PyModule_Create2` gave
+/// it rather than failing the import.
+#[cfg(all(
+    feature = "cpyext",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+fn set_extension_module_spec(
+    name: &str,
+    pathname: &Path,
+    module: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let (Some(bootstrap), Some(ext)) = (
+        get_sys_module("importlib._bootstrap"),
+        get_sys_module("importlib._bootstrap_external"),
+    ) else {
+        return Ok(());
+    };
+
+    let _roots = push_roots();
+    let mod_slot = shadow_stack_len();
+    pin_root(module);
+    let boot_slot = shadow_stack_len();
+    pin_root(bootstrap);
+    let ext_slot = shadow_stack_len();
+    pin_root(ext);
+
+    let Ok(from_location) =
+        crate::baseobjspace::getattr_str(shadow_stack_get(ext_slot), "spec_from_file_location")
+    else {
+        return Ok(());
+    };
+    let from_location_slot = shadow_stack_len();
+    pin_root(from_location);
+    let w_name = pyre_object::w_str_new(name);
+    let name_slot = shadow_stack_len();
+    pin_root(w_name);
+    let w_path = crate::gateway::fsdecode_os_str(pathname.as_os_str());
+    let path_slot = shadow_stack_len();
+    pin_root(w_path);
+
+    // A suffix `_get_supported_file_loaders` does not know yields `None`; that
+    // is the same "leave it alone" answer as a missing bootstrap.
+    let Ok(spec) = crate::call::call_function_impl_result(
+        shadow_stack_get(from_location_slot),
+        &[shadow_stack_get(name_slot), shadow_stack_get(path_slot)],
+    ) else {
+        return Ok(());
+    };
+    if unsafe { pyre_object::is_none(spec) } {
+        return Ok(());
+    }
+    let spec_slot = shadow_stack_len();
+    pin_root(spec);
+
+    let Ok(init) =
+        crate::baseobjspace::getattr_str(shadow_stack_get(boot_slot), "_init_module_attrs")
+    else {
+        return Ok(());
+    };
+    let init_slot = shadow_stack_len();
+    pin_root(init);
+    let _ = crate::call::call_function_impl_result(
+        shadow_stack_get(init_slot),
+        &[shadow_stack_get(spec_slot), shadow_stack_get(mod_slot)],
+    );
+    Ok(())
+}
+
 /// Set a source module's `__spec__`/`__loader__`/`__file__`/`__cached__` from
 /// the app-level `_bootstrap_external._fix_up_module` — the helper
 /// `PyImport_ExecCodeModuleObject` calls. Returns `false` when the importlib
@@ -3042,7 +3122,12 @@ fn load_part(
             any(target_os = "macos", target_os = "linux")
         ))]
         FindInfo::ExtensionFile { pathname } => {
-            crate::cpyext::load_extension_module(modulename, &pathname)?
+            let module = crate::cpyext::load_extension_module(modulename, &pathname)?;
+            let roots = pyre_object::gc_roots::push_roots();
+            let module_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(module);
+            set_extension_module_spec(modulename, &pathname, module)?;
+            pyre_object::gc_roots::shadow_stack_get(module_slot)
         }
         #[cfg(all(
             feature = "cpyext",
@@ -3054,16 +3139,28 @@ fn load_part(
             let roots = pyre_object::gc_roots::push_roots();
             let module_slot = pyre_object::gc_roots::shadow_stack_len();
             roots.pin_root(module);
+            set_extension_module_spec(
+                modulename,
+                &pathname,
+                pyre_object::gc_roots::shadow_stack_get(module_slot),
+            )?;
             let path = crate::gateway::fsdecode_os_str(dirpath.as_os_str());
             let path_slot = pyre_object::gc_roots::shadow_stack_len();
             roots.pin_root(path);
-            let path_list =
-                pyre_object::w_list_new(vec![pyre_object::gc_roots::shadow_stack_get(path_slot)]);
+            // `__path__` is re-stamped after the spec: the loader derives it
+            // from the file name, and the directory found here is the same
+            // answer spelled without that dependency.
+            // The store below allocates, so the fresh list is pinned rather
+            // than held in a local across it.
+            let list_slot = pyre_object::gc_roots::shadow_stack_len();
+            roots.pin_root(pyre_object::w_list_new(vec![
+                pyre_object::gc_roots::shadow_stack_get(path_slot),
+            ]));
             let module = pyre_object::gc_roots::shadow_stack_get(module_slot);
             crate::module_ns_store(
                 unsafe { pyre_object::w_module_get_w_dict(module) },
                 "__path__",
-                path_list,
+                pyre_object::gc_roots::shadow_stack_get(list_slot),
             );
             module
         }

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -157,17 +157,15 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
                     }
                     crate::baseobjspace::str_utf8_w(args[1])?.to_string()
                 };
-                let addr =
-                    rustpython_host_env::ctypes::lookup_function_symbol_addr(h, name.as_bytes())
-                        .map_err(|e| {
-                            use rustpython_host_env::ctypes::LookupSymbolError as L;
-                            let msg = match e {
-                                L::LibraryNotFound => "library not found".to_string(),
-                                L::LibraryClosed => "library closed".to_string(),
-                                L::Load(s) => s,
-                            };
-                            crate::PyError::os_error(format!("dlsym({name}): {msg}"))
-                        })?;
+                let addr = lookup_symbol(h, name.as_bytes()).map_err(|e| {
+                    use rustpython_host_env::ctypes::LookupSymbolError as L;
+                    let msg = match e {
+                        L::LibraryNotFound => "library not found".to_string(),
+                        L::LibraryClosed => "library closed".to_string(),
+                        L::Load(s) => s,
+                    };
+                    crate::PyError::os_error(format!("dlsym({name}): {msg}"))
+                })?;
                 Ok(pyre_object::w_int_new(addr as i64))
             },
             2,
@@ -431,7 +429,18 @@ pub(super) fn lookup_symbol(
     handle: usize,
     symbol: &[u8],
 ) -> Result<usize, rustpython_host_env::ctypes::LookupSymbolError> {
-    rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol)
+    use rustpython_host_env::ctypes::LookupSymbolError as Error;
+    let address = rustpython_host_env::ctypes::lookup_function_symbol_addr(handle, symbol)?;
+    // `dlsym` reports a miss by returning NULL, and a resolver that itself
+    // returns NULL — an IFUNC — leaves `dlerror` unset, so the load succeeds
+    // with address 0. `rdynload.dlsym` rejects that: address 0 is not a symbol.
+    if address == 0 {
+        return Err(Error::Load(format!(
+            "symbol '{}' not found",
+            String::from_utf8_lossy(symbol)
+        )));
+    }
+    Ok(address)
 }
 
 #[cfg(all(windows, feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -1116,14 +1116,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // `_imp_create_dynamic_impl`. Raising ImportError (rather than being
         // absent) matches the meta-path `hasattr` probe while still letting
         // `except ImportError` fall back to a pure-Python module.
-        crate::make_builtin_function_with_arity(
+        crate::make_builtin_function_with_signature(
             "create_dynamic",
             |args| {
-                let Some(&spec) = args.first() else {
+                // `file` is bound and dropped: the loader opens the library by
+                // path, so the already-open stream has no use here. Declaring
+                // it is what keeps a two-argument call from being rejected.
+                let spec = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                if spec.is_null() {
                     return Err(crate::PyError::type_error(
                         "create_dynamic() missing required argument 'spec'",
                     ));
-                };
+                }
                 #[cfg(all(
                     feature = "cpyext",
                     not(feature = "sandbox"),
@@ -1150,7 +1154,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ))
                 }
             },
-            1,
+            crate::Signature::new(vec!["spec", "file"], None, None, 0, 0),
         ),
     );
     crate::module_ns_store(

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -3916,7 +3916,17 @@ fn run_perfn_walk<Sym: WalkSym>(
             let loop_header_pc = *loop_header_pc;
             let poll_resume_pc = back_edge_pc.unwrap_or(loop_header_pc);
             let restart_pc = close_loop_restart_pc.expect("close loop has a restart pc");
-            WALK_END_RESTART_PC.with(|c| c.set(Some(restart_pc)));
+            // The handback only runs on the leg where the end-flush below
+            // declined, and a decline keeps the legacy replay, whose contract
+            // is that the frame still holds pre-walk state (the same statement
+            // the escape-flush undo leg makes).  Moving `last_instr` alone
+            // breaks it: the frame then carries the loop header's pc over the
+            // entry's locals.  Only the marker legs need the handback — a
+            // loop-header marker inside a super-instruction leaves the frame
+            // advanced past the header, so its resume pc differs from the
+            // header and the frame is already not at pre-walk state.
+            let handback_pc = (restart_pc != loop_header_pc).then_some(restart_pc);
+            WALK_END_RESTART_PC.with(|c| c.set(handback_pc));
             // The closing frame and GuardFutureCondition remain anchored at
             // the loop header; the synthesized poll receives its owning
             // back-edge coordinate separately.

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -720,15 +720,18 @@ unsafe fn ssl_socket_destructor(obj_addr: usize) {
 
 /// Custom trace for objects carrying the `MapdictStorageMixin` prefix
 /// (`W_ObjectObject` and native-layout Python subclasses such as
-/// `W_Random`; instance `map`+`storage`,
-/// `mapdict.py:907-910`).  The `storage` list is an off-GC
-/// `Box<Vec<PyObjectRef>>`, so — exactly as `dict_object_custom_trace`
-/// reaches the off-GC dict entries — this forwards each boxed
-/// attribute-value slot in place via `instance_walk_boxed_storage`,
-/// which consults the map to skip erased unboxed (`Vec<i64>`) slots
-/// (`mapdict.py:438/447` boxed `erase_item` vs `:601/612`
-/// `erase_unboxed`).  The off-GC `Vec` stays put; only its
-/// `PyObjectRef` contents are relocated.
+/// `W_Random`; instance `map`+`storage`, `mapdict.py:907-910`).
+///
+/// `storage` is a GC-managed leaf block (`W_MAPDICT_STORAGE_GC_TYPE_ID`,
+/// allocated stable and non-moving by `alloc_mapdict_storage_block`), so the
+/// collector reaches its slots only through this trace:
+/// `instance_walk_boxed_storage` forwards the `storage` reference itself and
+/// then every slot in `0..capacity` in place.  It consults no map — an
+/// unboxed longlong attribute stores the erased `GC_INT_ARRAY` block
+/// (`erase_unboxed`, `mapdict.py:601/612`), which is an ordinary GC reference
+/// like every boxed slot (`mapdict.py:438/447` `erase_item`), so no slot has
+/// to be skipped.  The block itself never moves; only the slot contents are
+/// relocated.
 ///
 /// `ob_header.w_class` is the instance's class reachability edge — the
 /// equivalent of PyPy reaching the class through the traced


### PR DESCRIPTION
Follow-up work on top of the merged cpyext slice (#1180), plus two defects the linux CPython-suite gate surfaced.

## Constructor arguments went stale across `__new__`

`type_descr_call_with_mode` pinned neither the type nor its arguments, and `call_with_kwargs_in_ctx` pinned them at entry but then forwarded the incoming slices raw. Both build the `__init__` argument list after `__new__` has run Python code, so a minor collection during `__new__` left the forwarded slice holding pre-move addresses. `__init__` stored one of those into an instance attribute, and the next collection tripped over it through the remembered set:

```
GC BUG: invalid type_id=... site=minor_varsize_item_target,
parent_site=minor_remembered_set   (majit-gc/src/collector.rs:2777)
```

`type_descr_call_impl` already had the correct shape; the other two now match it and read every argument back through `pyre_object::gc_roots`.

Measured on linux-aarch64 with `PYRE_NO_JIT=1 PYPY_GC_NURSERY=131072`:

| probe | before | after |
| --- | --- | --- |
| `__new__` churns, `__init__` does `sink.append(x)` | identity mismatch, then `GC BUG` | 0 |
| `__new__` churns, `__init__` does `self.got = x` | identity mismatch, then `GC BUG` | 0 |
| churn inside `__init__`, then `setattr` (control) | 0 | 0 |
| churn, then plain `setattr` (control) | 0 | 0 |

`test.test_unittest` under `PYRE_NO_JIT=1` goes from abort to `Ran 1090 tests ... OK`. A separate JIT-side defect with the same symptom remains — it is not addressed here.

## A symbol resolving to address 0 was reported as found

`dlsym` reports a miss by returning NULL, and a resolver that itself returns NULL leaves `dlerror` unset, so `lookup_function_symbol_addr` reported success with address 0. `rdynload.dlsym` rejects that.

- `_ctypes`: the unix `lookup_symbol` now rejects it, and `_ctypes.dlsym` goes through `lookup_symbol` instead of calling the host lookup directly. Fixes `test_ctypes.test_dlerror.test_null_dlsym` on the gate.
- `cpyext`: `load_extension_module` transmuted the looked-up address to the init signature unchecked, so address 0 became a call through a null pointer.

## Also here

- The cpyext review findings from #1180: fork-safe statics that preserve their payload, an `m_size`/slots guard in `PyModule_Create2`, a spec for extension modules and packages, a pinned `path_list`, and a layout assertion between `PyObjectRef` and `GcRef`.
- `module`: the module name is stored as WTF-8.
- `jit`: a walk-end resume pc the flush declined is no longer handed back.
- `pyrex`: the shutdown self-registration check converts the WTF-8 name before looking it up in the `&str`-keyed registry — a semantic conflict with #1187 that the rebase could not see.

## Verification

- `cargo fmt --check` clean
- `cargo test --all --no-default-features --features dynasm` — 7820 passed, 0 failed
- linux-aarch64 CPython suite: `test_ctypes` loses the `test_null_dlsym` failure; the remaining gate regressions (`test_dllist`, `test_fileio`, `test_dataclasses`, and the JIT-side `test_unittest` crash) are pre-existing on `main` and are follow-up work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKvxTiG1M3K7KuKxVVezaX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory safety during garbage collection, including nursery allocation, list slicing, and function or constructor calls.
  - Improved reliability when loading native extensions, including clearer handling of missing symbols and support for additional module types.
  - Preserved correct loop restart behavior in JIT execution.
- **Compatibility**
  - Updated the embedded Python runtime to version 3.14.6.
  - Improved native extension imports with standard module metadata and expanded dynamic-loader compatibility.
- **Documentation**
  - Clarified garbage-collection behavior for map-backed storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->