### PR TITLE
cpython_tests: refresh the darwin baseline and record the linux-aarch64 overlay

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -341,7 +341,7 @@
       "dynasm": "PASS"
     },
     "test.test_dictcomps": {
-      "dynasm": "FAIL"
+      "dynasm": "PASS"
     },
     "test.test_dictviews": {
       "dynasm": "PASS"
@@ -416,7 +416,7 @@
       "dynasm": "PASS"
     },
     "test.test_exceptions": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_extcall": {
       "dynasm": "IMPORTERROR"
@@ -531,7 +531,7 @@
       "dynasm": "PASS"
     },
     "test.test_getpass": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_getpath": {
       "dynasm": "IMPORTERROR"
@@ -594,7 +594,7 @@
       "reason": "needs display"
     },
     "test.test_imaplib": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_import": {
       "dynasm": "PASS"
@@ -671,7 +671,7 @@
       "dynasm": "PASS"
     },
     "test.test_listcomps": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_lltrace": {
       "cranelift": "PASS",
@@ -975,7 +975,7 @@
       "dynasm": "PASS"
     },
     "test.test_secrets": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_select": {
       "dynasm": "FAIL"
@@ -984,7 +984,7 @@
       "dynasm": "PASS"
     },
     "test.test_set": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_setcomps": {
       "dynasm": "PASS"
@@ -1012,7 +1012,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_smtpnet": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_socket": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/baseline.linux-aarch64.json
+++ b/pyre/cpython_tests/baseline.linux-aarch64.json
@@ -1,0 +1,18 @@
+{
+  "host": "linux-aarch64",
+  "modules": {
+    "test.test_ctypes": {
+      "dynasm": "FAIL",
+      "reason": "ctypes cannot hand a Python callback to C: a CFUNCTYPE instance carries no C-callable thunk, so ctypes.util.dllist's dl_iterate_phdr call fails. Also FAIL under PYRE_NO_JIT=1. test_dlerror wants dlsym returning NULL with a clear dlerror to raise"
+    },
+    "test.test_dataclasses": {
+      "dynasm": "FAIL",
+      "reason": "JIT wrong code, not a platform difference: _process_class raises a spurious 'dictionary changed size during iteration' over cls.__dict__ although the only delattr completes before the loop. PYRE_NO_JIT=1 passes and darwin-arm64 passes, so it is neither the arch nor the OS alone"
+    },
+    "test.test_unittest": {
+      "dynasm": "CRASH",
+      "reason": "GC bug, not a platform difference: invalid type_id at minor_custom_trace_target under minor_remembered_set, aborting through pyre_jit::call_jit::bh_call_fn mid-run. Passes when the driver is run directly, so it needs run.py's process shape to show up"
+    }
+  },
+  "stdlib_version": "3.14.6"
+}

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -753,7 +753,9 @@ def write_baseline(path: Path, baseline: dict, overlay: dict, results: dict,
             host_entry = overlay_modules.get(m)
             if host_entry is not None and host_entry.pop(backend, None) is not None:
                 overlay_dirty = True
-                if not host_entry:
+                # `reason` is prose about the divergence, so it cannot keep the
+                # entry alive once no backend still records one.
+                if not any(k != "reason" for k in host_entry):
                     del overlay_modules[m]
             continue
         if overlay_modules.setdefault(m, {}).get(backend) != status:


### PR DESCRIPTION
Follow-up to #1196, which added the per-host baseline overlay. This fills it
in: the darwin baseline is re-measured, and the Linux host that the overlay
mechanism was built for now has one.

## Eight modules promoted on darwin-arm64

The gate runs only the baseline-`PASS` subset, so a non-`PASS` entry is never
re-run and goes stale. Re-ran every non-`SKIP` module; the sweep ran under
load, so each candidate was then confirmed three times on its own:

    test_dictcomps    FAIL        -> PASS
    test_exceptions   IMPORTERROR -> PASS
    test_getpass      IMPORTERROR -> PASS
    test_imaplib      IMPORTERROR -> PASS
    test_listcomps    IMPORTERROR -> PASS
    test_secrets      IMPORTERROR -> PASS
    test_set          CRASH       -> PASS
    test_smtpnet      IMPORTERROR -> PASS

The gated set goes from 210 to 218 modules.

## linux-aarch64 overlay

Recorded by running `run.py --update-baseline` inside the `linux/arm64`
container, so the file is an observation rather than a hand-written guess and
the shared baseline stayed untouched. Three modules:

| module | verdict | what it is |
|---|---|---|
| `test_ctypes` | FAIL | a real platform difference |
| `test_dataclasses` | FAIL | **JIT wrong code** |
| `test_unittest` | CRASH | **GC abort** |

Only the first is a platform difference, and each entry's `reason` says so —
the two defects are recorded as what that host does today, not as expected
behaviour. Both were attributed before recording:

- **`test_dataclasses`** — `_process_class` raises a spurious
  `RuntimeError: dictionary changed size during iteration` while iterating
  `cls.__dict__`, although the only mutation (`delattr`, taken because the test
  declares `field(init=False)`) completes before the loop starts.
  `PYRE_NO_JIT=1` passes and darwin-arm64 passes 12/12, so it is neither the
  OS nor the arch alone. It is also a Heisenbug: hoisting the loop to
  `list(d.items())`, or wrapping the *unchanged* loop in `try/except`, both
  make it disappear — so it cannot be diagnosed by instrumenting
  `dataclasses.py`.
- **`test_unittest`** — `GC BUG: invalid type_id ... site=minor_custom_trace_target,
  parent_site=minor_remembered_set`, aborting through
  `pyre_jit::call_jit::bh_call_fn` mid-run, before the tests finish. Running
  the same driver directly does not reproduce it; it needs `run.py`'s process
  shape.

`test_fileio` is not in the overlay: it fails on the CI runner but passes in
the container, which has no `strace`, so `requires_strace()` skips the test
there and that host has nothing to record. On the runner the test asserts
CPython's exact syscall sequence for `FileIO`.

## Gates

- CPython suite, `linux/arm64` container: **213 PASS / 0 FAIL / 0 CRASH**, no
  regressions, header confirms `baseline.json + baseline.linux-aarch64.json
  (3 host entries)`
- CPython suite, darwin-arm64: 217 selected; the three rows it reported
  (`test_calendar`, `test_json`, `test_range`) each pass 3/3 when re-run on
  their own — they are load artifacts at load average 33-58, and `test_range`
  is now 30/30 serially

🤖 Generated with [Claude Code](https://claude.com/claude-code)