### PR TITLE
_sre, str: resolve string positions through the stored index storage; jit: pop-fold guard order and recorded-raise roots; typedef: __init_subclass__ keywords

### DIFF
--- a/.claude/skills/parity/SKILL.md
+++ b/.claude/skills/parity/SKILL.md
@@ -13,10 +13,11 @@ Apply these to every decision made while this skill is active, even if the user'
 
 2. **Upstream source is the spec.** The local PyPy tree at `rpython/` and `pypy/` is the authoritative reference. Before writing any non-trivial change, open the RPython counterpart and read it. Line-by-line porting usually has the answer; trust upstream over clever adaptations.
 
-3. **Every deviation must be classified and justified.** Three classes:
+3. **Every deviation must be classified and justified.** Four classes:
    - **NEW-DEVIATION** — introduced by us, in this diff or recent history, with no RPython backing. These must be removed. Replace with the correct RPython code, not with another adaptation.
    - **PRE-EXISTING-ADAPTATION** — a deviation documented with an RPython reference and an explanation of why the mechanical line-by-line port is blocked. **PRE-EXISTING-ADAPTATION is a temporary marker, not a permanent justification.** It is the label on a piece of technical debt: the code admits it diverges from RPython and commits to converging back. Its presence is not a reason to leave the code alone — it is a reason to fix it now if the blocker is no longer real, or to add a concrete "convergence path" comment if the blocker still holds. Every PRE-EXISTING-ADAPTATION encountered during a `/parity` pass must be re-evaluated: (a) is the blocker still real? (b) can it be ported right now, in this session? (c) if not, what specific dependency (helper, pass, data layout) would need to land first? Never use "it's marked PRE-EXISTING-ADAPTATION" as a reason to skip the fix. If the mechanical port is obvious and doesn't exceed session scope, do it now.
    - **PARITY** — matches RPython structure line-by-line. No action.
+   - **SPEC-DEVIATION** — a deviation from PyPy that makes pyre match the observable behaviour of the CPython pinned in `lib-python/stdlib-version.txt`, where PyPy and that CPython genuinely differ, adjudicated under AGENTS.md "Spec follows CPython 3.14; implementation follows PyPy". This is **not** a NEW-DEVIATION and is **not** auto-fixed under Principle 6 — reverting one to PyPy's shape re-introduces a known bug. Recognise it by the site comment citing both sides and the `§4 [3.14-spec]` entry in the review report. Audit it instead: does the comment carry an artefact (a `lib-python/3` `file:line`, a measured run at the pinned version, or C source read at that tag — never a pyre comment, never a PEP)? Does any PyPy-side hint govern the value it changes (`@jit.*`, `_immutable_*`, `_attrs_`, `make_sure_not_resized`, read across the whole definition including decorators, in `rpython/` too)? Does pyre now match PyPy on every adjacent observable that reads the state it changed? Any "no" makes it an ordinary NEW-DEVIATION again — report it, and restore PyPy's shape. Structure — names, control flow, data structures, storage owner — is never covered by this class and is audited as usual. The full six-test procedure is in "SPEC-DEVIATION: the six tests" at the end of this file.
 
 4. **Performance can temporarily regress.** If a benchmark slows down because parity-correct code replaced a clever local shortcut, accept it. Performance is recovered by further line-by-line porting of the upstream optimization, not by reintroducing the shortcut. Neither the user nor the benchmark suite overrides the parity principle.
 
@@ -233,3 +234,253 @@ Keep the tone direct and the citations concrete. No vague "I'll make sure this m
 - This skill is the strict enforced form of the "First principles" above: under `/parity`, there is no wiggle room for "Rust language adaptations" except where the RPython line is explicitly cited.
 - `/commit` (the commit skill) is compatible — parity auditing should happen before committing, not after.
 - If the user invokes `/parity` inside a larger plan document (e.g. `jtransform_optimize_goto_if_not_port.md`), the plan's existing PRE-EXISTING-ADAPTATION annotations are respected; the audit focuses only on changes introduced since the plan was written.
+
+## SPEC-DEVIATION: the six tests
+
+Standing ruling: **pyre's *implementation* is a port of PyPy; pyre's *spec* —
+what a Python program can observe — is CPython 3.14.** A behavioural difference
+from PyPy is a parity regression **unless** a CPython 3.14 artefact shows PyPy is
+wrong about what the caller observes. Then it is a spec fix, and PyPy's shape
+still governs every other line on the way there.
+
+**This is not a 3.11-vs-3.14 question, and reading it as one is why this cluster
+gets re-filed every cycle.** Of seven adjudicated cases, six have no version
+delta at all: `sched_setscheduler` has returned None since 3.3,
+`PyUnicode_FSConverter` has accepted bytes since 3.3, PEP 529 surrogatepass is
+3.6, `DirEntry` has cached its `stat_result` since PEP 471, audit hooks have
+suppressed everything under `Exception` since at least 3.9, and the `'%U'`
+attribute-error message is byte-identical in 3.13. These are standing
+PyPy-vs-CPython divergences, not PyPy lagging a release. "3.14" pins *which*
+CPython you read — `lib-python/stdlib-version.txt`, currently `v3.14.6` — it does
+not narrow the rule to version lag, and the absence of a delta is not grounds to
+refuse the exception. Conversely a real delta earns nothing on its own:
+`DirEntry.stat()` object caching predates 3.11 **and** still follows PyPy, for
+the reason in test 4.
+
+#### What the spec governs
+
+Only what a caller can observe: a return value, an exception's type / message /
+attributes, object identity, an encoding-and-errors contract, and which argument
+shapes are accepted or rejected.
+
+Everything else follows PyPy **unconditionally** — names, module paths,
+control-flow order, data structures, storage owner, JIT hints. See "Data
+structure parity with RPython/PyPy" above. A structural divergence does not
+become a spec fix by sitting next to one. If the only thing wrong is *how* pyre
+reaches an answer PyPy also reaches, restore PyPy's shape.
+
+#### The test — run in order, stop at the first leaf
+
+**1. Can you write a Python snippet whose printed output differs?**
+No → **STOP, this section does not apply.** Judge it as an ordinary parity
+finding.
+
+**2. Do you hold an admissible artefact for the 3.14 side?** One of three
+routes, and say which:
+
+  a. **In-tree pin** — a `lib-python/3/` test that asserts it, or stdlib code
+     that depends on it, at `file:line`, quoted. Strongest, no network.
+  b. **Measured** — a run on an interpreter whose version equals
+     `lib-python/stdlib-version.txt`, one fresh process per case, reading the
+     observable directly rather than inferring it from a return value.
+  c. **C source at the pinned tag in a named checkout**, quoted —
+     `git -C ~/Projects/cpython show v3.14.6:Modules/posixmodule.c`.
+     `Modules/`, `Objects/` and `Python/` are **not in this tree** (`Include/`
+     holds only a README); a claim about them names the checkout and the tag, or
+     it is memory.
+
+  **Prose is not admissible as evidence of the observable.** The docs and PEP 578
+  both say an audit hook's error must derive from `RuntimeError`; the
+  implementation has swallowed everything under `Exception` for many releases,
+  and `pypy/module/sys/vm.py:496-498` coded to the prose. (Prose *is* evidence of
+  PyPy's own intent — `interp_encoding.py:10`'s `# PEP 529` is what makes the
+  surrogatepass declaration PyPy's position. That belongs to test 3, not here.)
+
+  **A pyre in-tree comment is never the artefact.** Two of these deviations were
+  justified by comments a *later* PR wrote. §4 records the decision, not the
+  proof.
+
+  **Platform clause.** When the behaviour is `#[cfg(windows)]`- or Linux-gated
+  and neither oracle can execute it on this host, route (b) is unavailable — use
+  (a) or (c) and record the platform in the finding *and* the code comment. An
+  unqualified "measured on python3.14" on a Windows-only path names a run that
+  could not have happened.
+
+No artefact → **STOP. You may not invoke this section.**
+
+**3. Do the two upstreams actually disagree?** Read the PyPy side at the line
+that *decides*, and run `pypy3` when a fixture allows (see "The PyPy oracle").
+The binary is corroboration, not the authority: in-tree PyPy is
+`PYPY_VERSION = (7, 3, 24, "alpha", 0)` (`pypy/module/sys/version.py:18`) while
+the installed `pypy3` is 7.3.22, so an `AttributeError` from the binary is not
+evidence that the checkout lacks the function.
+
+  They agree → not a spec conflict. If pyre differs from both, that is a plain
+  **regression (§1/§2)** and no spec reasoning rescues it. The first question any
+  of these findings must survive is "is pyre wrong against *both*?"
+
+  **PyPy disagrees with itself → follow PyPy's own declaration, and this section
+  does not open.** On Windows `pypy/module/sys/interp_encoding.py:9-11` declares
+  `surrogatepass` per PEP 529 — and `getfilesystemencodeerrors` returns it, so
+  PyPy's own shipped `os.fsencode` (`lib-python/3/os.py:847-874 _fscodec`) uses
+  it — while `pypy/interpreter/unicodehelper.py:70-72` converts interpreter-level
+  paths with `surrogateescape`. Honouring the declaration against the conversion
+  path *increases* PyPy fidelity: file it under §4 with both lines cited, claim
+  no spec authority for it, and do not let it carry an unrelated restructure.
+
+**4. Is PyPy's shape load-bearing for a mechanism pyre also has?** Name the
+mechanism PyPy's shape serves, **whether or not PyPy states one**. A stated
+reason is sufficient evidence, not necessary — a shape with no English rationale
+is not a shape with no reason. Search, and record the search, over:
+
+  - the **whole definition** — decorator lines included — of the PyPy function
+    that produces the divergent value, and of every helper on the path that
+    produces it, in `rpython/` as well as `pypy/`;
+  - any class- or module-level binding those bodies read: `_immutable_`,
+    `_immutable_fields_`, `_attrs_`, `unrolling_iterable`, a module-level table;
+  - triggers: `@jit.elidable`, `@jit.unroll_safe`, `@jit.dont_look_inside`,
+    `@jit.look_inside_iff`, `@specialize`, `jit.promote`, `jit.hint(`,
+    `we_are_translated`, `rgc.`, `make_sure_not_resized`, or a per-call rebuild
+    that feeds one.
+
+  Cite the trigger's `file:line` **and name the value it protects**: a hint that
+  does not govern the value you are changing is not a trigger — `_immutable_ =
+  True` at `interp_bytesio.py:16`/`:54` sits on `BytesIOBuffer`/`BytesIOView` and
+  governs nothing `close_w` does. Found nothing? Record the negative search at
+  `file:line`, the same discipline the next section imposes on "PyPy has no
+  counterpart".
+
+  Trigger present and pyre has the mechanism — the tracing JIT and its virtuals,
+  the GC, the annotator, the RPython-level representation → **STOP. Follow
+  PyPy.** That is implementation, which this ruling assigns to PyPy. Overriding
+  it needs an explicit ruling from the repo owner: raise it and leave the finding
+  standing until they rule.
+
+  *Deliberateness decides nothing in either direction.* PyPy's own shipped copy
+  of `test_memoryio.py` gates the `BytesIO.close()` `BufferError` assertion
+  behind `check_impl_detail(pypy=False)` with "PyPy export buffers differently"
+  — knowing non-conformance that still loses, because that constraint is one
+  PyPy has and pyre does not. An accidental omission is no freer: it still has to
+  clear 1, 2, 3, 5 and 6. And an omission is distinguishable from a design — PyPy
+  already has `_check_exports` and calls it at `interp_bytesio.py:79`/`:120`/
+  `:131` while skipping `:194`. Machinery that exists and is wired at the
+  siblings is not a decision.
+
+**5. Per-site artefact, and a blast-radius census.** For **every** pyre
+`file:line` where you depart from PyPy, name the artefact that forces *that
+site*. "Consistency with a sibling" is not an artefact. Then `rg` pyre's own
+readers of the shape you are deleting — including `pyre-jit*` and `majit*` — and
+record what you found. If a reader keys on the shape, the shape is
+implementation: restore it there and bring it to the user.
+
+  This is the check reviewers already do by hand: `error_is_exception` has
+  exactly one caller (`vm.rs:2869`), so the audit-hook change cannot reach past
+  `addaudithook`. Contrast `is_w`: `pyre/pyre-jit-trace/src/jitcode_dispatch/
+  specialize.rs:5260 is_w_compares_by_value` lists exactly the seven types whose
+  `is_w` compares by value and makes `:5343` decline the `IS_OP` fold, so
+  "`is` is pointer identity in CPython" is not a spec fix — it is a JIT change
+  with an unmeasured blast radius.
+
+**6. Does pyre land on 3.14 across the whole decision, and on PyPy everywhere
+else?** Adjacency is defined by **what reads the state you changed**, not by "the
+same function". A change that lands pyre where **neither** upstream sits is a
+defect regardless of which axis matched 3.14 — strictly worse than following
+PyPy, and filed under §1. `DirEntry` again: the entry's stat cache is read by
+`check_mode`/`is_dir` at `interp_scandir.py:317`, and `posixmodule.c` also
+aliases lstat into the stat slot for a non-symlink and seeds the cache from
+`is_dir`/`is_file`; PyPy reproduces both. Caching the object while doing neither
+invents a third behaviour.
+
+Reaching here: **not a parity regression.** File under `## 4. Structural
+adaptations` as
+`[3.14-spec] our_file.rs:line ↔ pypy_file.py:line — <observable>; evidence: <route + cite>`
+so the next cycle sees it adjudicated instead of re-deriving it. That records the
+decision; it does not close it — per the codex-review skill, §4 is a
+classification, not a verdict.
+
+#### "PyPy has no counterpart" is a search, not a default
+
+If PyPy genuinely has no counterpart, tests 4 and 5 have nothing to evaluate and
+**this section is not what licenses the code** — write it in the shape of the
+nearest PyPy sibling, not in the shape of the C module, and say which sibling.
+Record the exact search and its scope (`rg -n 'if_nametoindex' pypy/ rpython/`),
+and re-run it at review time. `socket.if_nametoindex` shipped with the recorded
+belief "PyPy has no `if_nametoindex`, so there is no `unwrap_spec` to port" —
+false since PyPy `4faf5831374` (2023-12), registered at
+`pypy/module/_socket/interp_socket.py:1315-1321` and `moduledef.py:19`. The
+behaviour survived on other evidence; the reasoning had to be deleted (#1089). A
+counterpart found later **re-opens** the deviation: re-justify it against all six
+tests, or revert to PyPy's shape.
+
+#### What you actually do
+
+1. **Find the line in `pypy/` where the decision is made** — the converter in the
+   `unwrap_spec`, the `return`, the `raise`, the format string, the missing call.
+   Not the caller, not a wrapper, not a post-hoc fixup.
+2. **Change that, and only as far as the observable reaches.** Keep PyPy's helper
+   when PyPy has one; the check goes exactly where PyPy's sibling sites put
+   theirs.
+3. **If PyPy's shape genuinely cannot produce the observable, the computation
+   changes too — but state what PyPy's shape cannot produce.** PyPy's
+   `if_nametoindex` answers a miss by scanning `rsocket.if_nameindex()` and
+   raising a one-argument `OSError`, which has no `errno` to report and so cannot
+   satisfy `test_socket.py:1227`; calling libc `if_nametoindex(3)` is the minimum
+   that can. Say that in the comment.
+4. **Take the family the observable defines, and no more.** Every site in the
+   family needs its own artefact under test 5. `if_nameindex`/`if_indextoname`
+   came with `if_nametoindex` because the same converter contract governs them;
+   that is not licence to re-route every `path_or_fd_w` caller off one finding.
+   A one-site fix that leaves siblings inconsistent is a new mismatch; a
+   forty-site sweep off one artefact is a bigger one.
+5. **Comment at the site, citing both sides.** State the observable, the PyPy
+   `file:line` whose decision you replaced and what it produces there, the
+   evidence route with its cite, and the platform if the code is gated. A "do not
+   restore this" instruction carries its evidence or it is worthless. Naming the
+   other implementation is necessary here, which is rare: name the *symbol*
+   (`posixmodule.c path_converter`, `sysmodule.c sys_addaudithook_impl`), never
+   `CPython:` as a prefix and never "CPython's X" — the comment guideline holds.
+
+```rust
+// Both setters answer None. `interp_posix.py:3100`/`:3133` hand back the raw
+// `handle_posix_error` result instead, which is 0 on every success and which
+// `os.sched_setparam` does not publish. `posixmodule.c
+// os_sched_setscheduler_impl` ends `Py_RETURN_NONE` (read at v3.14.6 in
+// ~/Projects/cpython; identical at v3.11.0, clinic output=cde27faa55dc993e).
+```
+
+#### Why
+
+PyPy is an implementation of CPython, not a competing specification. In each of
+these cases a user program can tell the two apart: `os.sched_setparam` hands back
+`0` instead of None; `sys.addaudithook` lets a `ValueError` escape instead of
+swallowing it and dropping the hook; `BytesIO.close()` yanks the storage from
+under a live `getbuffer()` view instead of raising `BufferError`; `str(OSError)`
+says `Windows Error 3765269347` where `test_exceptions.py:432-438` demands
+`Windows Error 0xe06d7363`; a failed `getattr` reports `'\udcfe'` escaped to six
+characters instead of the code point. Shipping PyPy's answer there ships a bug —
+often one PyPy itself concedes. But the same rule read one step too wide deletes
+a JIT design, which is why tests 4 and 5 exist and why they are the ones that
+actually get skipped.
+
+Worked example (2026-08-13). `BytesIO.close()` with a live export.
+`lib-python/3/test/test_memoryio.py:458-461` asserts `BufferError` from `write`,
+`truncate` **and** `close`, then `assertFalse(memio.closed)`, and
+`CBytesIOTest(PyBytesIOTest)` at `:836` inherits it unmodified for the C class
+(route a). An A/B on two real interpreters (route b): CPython 3.14.6 raises and
+stays open under both `io.BytesIO` and `_pyio.BytesIO`; PyPy 3.11.15 closes
+successfully and the still-held memoryview degrades to `len(b) == 0`. PyPy's own
+shipped copy of that test wraps the whole block in
+`if support.check_impl_detail(pypy=False):` — it *skips* the assertion rather
+than claiming the spec changed, which is a concession of non-conformance, not a
+version gap. Test 4: `_immutable_` at `interp_bytesio.py:16`/`:54` governs
+`BytesIOBuffer`/`BytesIOView`, not what `close_w` does; no other hint in
+`close_w`, `close`, or `rStringIO.close`. Test 5: the check has one reader,
+`bytesio.rs` itself; `bytearray_check_exports` (`builtins.rs:148`) reads the real
+exporter counter fed by `getbuffer`, so it is neither vacuous nor JIT-visible.
+The fix is one line — PyPy already has `_check_exports`
+(`interp_bytesio.py:91-94`) with the exact `BufferError` text and already calls
+it from `descr_init`, `write_w` and `truncate_w` (`:79`, `:120`, `:131`); the
+only thing missing is the call in `close_w` (`:194-195`). `bytesio.rs:466` places
+that same check before the store, so the object stays open on failure. Nothing
+else moved. An op-by-op sweep confirms PyPy's own gate is now over-broad: `write`
+and `truncate` *do* raise on PyPy today; only `close` still does not.

--- a/.github/codex-review-prompt.md
+++ b/.github/codex-review-prompt.md
@@ -10,11 +10,33 @@ collecting all differences, organize the report into separate sections:
 3. Mismatches that already existed before this patch
 4. Structural adaptations
 
-Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
-3.14 differences, opcode mismatches caused by using a CPython-compatible
-compiler, GIL/free-threading differences, and fundamental implementation-
-language differences between RPython and Rust. Mark those separately under
-"Structural adaptations".
+Exceptions — mark these under "Structural adaptations", not under 1 or 2:
+opcode mismatches caused by using a CPython-compatible compiler,
+GIL/free-threading differences, and fundamental implementation-language
+differences between RPython and Rust.
+
+Also section 4: a deviation from PyPy that makes pyre match the observable
+behaviour of the CPython in `lib-python/3` (version pinned in
+`lib-python/stdlib-version.txt`), where PyPy and that CPython genuinely differ.
+This is usually NOT a 3.11-vs-3.14 delta but a standing PyPy-vs-CPython
+divergence; "CPython did not change in 3.14" is not grounds to refile it under
+1 or 2. It qualifies only when the finding carries all four of:
+(a) an observable difference — return value, exception type/message/attributes,
+    identity, encoding-and-errors contract, or accepted argument shapes;
+(b) a cited CPython artefact — a `lib-python/3/...:line` assertion, a measured
+    run at the pinned version, or C read at that tag in a named checkout. Not
+    docs, not a PEP, not a comment in pyre's own source;
+(c) the PyPy `file:line` that decides, showing the two upstreams actually
+    differ (if PyPy contradicts itself, pyre following PyPy's own declaration
+    is section 4 as ordinary parity);
+(d) no PyPy-side JIT/GC/annotator hint governing the value being changed —
+    `@jit.*`, `_immutable_*`, `_attrs_`, `make_sure_not_resized`,
+    `unrolling_iterable`, `rgc.*`, on the function, its helpers, or the class-
+    and module-level bindings they read.
+Missing any of (a)-(d), or leaving pyre matching NEITHER upstream on an
+adjacent observable of the same decision, keep it in section 1 or 2 and say
+which test it failed. Full rule: AGENTS.md "Spec follows CPython 3.14;
+implementation follows PyPy".
 
 Scope discipline: before writing the report, run
 `git diff upstream/main --name-only -- . ':(exclude)*.jitstats'` and treat that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -228,6 +228,63 @@ stood for weeks was overturned, and an unbounded "epic" turned into a named
 port, by one command. Note also `pypy3` is 3.11 — a fixture using newer syntax
 needs trimming to the subset that runs.
 
+## Spec follows CPython 3.14; implementation follows PyPy
+
+Standing ruling: **pyre's *implementation* is a port of PyPy; pyre's *spec* —
+what a Python program can observe — is CPython 3.14.** A behavioural difference
+from PyPy is a parity regression **unless** a CPython 3.14 artefact shows PyPy is
+wrong about what the caller observes. Then it is a spec fix, and PyPy's shape
+still governs every other line on the way there.
+
+**This is not a 3.11-vs-3.14 question, and reading it as one is why the same
+findings get re-filed every review cycle.** Of seven adjudicated cases, six have
+no version delta at all: `sched_setscheduler` has returned None since 3.3,
+`PyUnicode_FSConverter` has accepted bytes since 3.3, PEP 529 surrogatepass is
+3.6, `DirEntry` has cached its `stat_result` since PEP 471. These are standing
+PyPy-vs-CPython divergences, not PyPy lagging a release. "3.14" pins *which*
+CPython you read (`lib-python/stdlib-version.txt`); it does not narrow the rule
+to version lag, and the absence of a delta is not grounds to refuse the
+exception. Conversely a real delta earns nothing on its own.
+
+**What the spec governs** is only what a caller can observe: a return value, an
+exception's type / message / attributes, object identity, an
+encoding-and-errors contract, and which argument shapes are accepted or
+rejected. Everything else follows PyPy **unconditionally** — names, module
+paths, control-flow order, data structures, storage owner, JIT hints. A
+structural divergence does not become a spec fix by sitting next to one.
+
+**Six tests, in order; stop at the first leaf.** The full procedure, with the
+evidence rules and worked examples, is in the `/parity` skill under
+"SPEC-DEVIATION"; do not invoke this ruling without reading it.
+
+1. **Can a Python snippet print a difference?** No → ordinary parity finding.
+2. **Do you hold an admissible artefact for the 3.14 side?** An in-tree
+   `lib-python/3/…:line` assertion, a measured run at the pinned version, or C
+   source read at that tag in a named checkout. Prose (docs, PEPs) is not
+   admissible, and a comment in pyre's own source is never the artefact. No
+   artefact → you may not invoke this section.
+3. **Do the two upstreams actually disagree?** If they agree and pyre differs
+   from both, that is a plain regression and no spec reasoning rescues it.
+4. **Is PyPy's shape load-bearing for a mechanism pyre also has?** Search the
+   whole definition — decorators included — plus the class/module bindings it
+   reads, in `rpython/` as well as `pypy/`, for `@jit.*`, `_immutable_*`,
+   `_attrs_`, `unrolling_iterable`, `make_sure_not_resized`, `rgc.*`. A hint
+   that governs the value you are changing → **STOP, follow PyPy**; that is
+   implementation, which this ruling assigns to PyPy. Record the negative
+   search too.
+5. **Per-site artefact plus a blast-radius census.** Every departing
+   `file:line` needs the artefact that forces *that site*; "consistency with a
+   sibling" is not one. Then `rg` pyre's own readers of the shape you are
+   deleting, `pyre-jit*` and `majit*` included.
+6. **Does pyre land on 3.14 across the whole decision?** Adjacency is what
+   reads the state you changed, not "the same function". Landing where
+   **neither** upstream sits is a defect regardless of which axis matched.
+
+Reaching the end: file it under the review's `## 4. Structural adaptations` as
+`[3.14-spec] our_file.rs:line ↔ pypy_file.py:line — <observable>; evidence:
+<route + cite>`, and comment at the site citing both sides. That records the
+decision; it does not close it.
+
 ## RPython Parity Rules
 - When porting from RPython/PyPy, do STRICT line-by-line structural parity. Do NOT take shortcuts, reimplement from scratch, or declare phases 'complete' without the literal refactor.
 - If a parity fix causes regressions, investigate root cause before reverting. Do not declare success if structural alignment was skipped, even if benchmarks pass.

--- a/pyre/extra_tests/parity_tests/isinstance_class_property.py
+++ b/pyre/extra_tests/parity_tests/isinstance_class_property.py
@@ -113,3 +113,5 @@ for _ in range(N):
         other = other + 1
 print("dict hits", other)
 print("dict getter calls", len(calls) - before)
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/isinstance_class_property.py
+++ b/pyre/extra_tests/parity_tests/isinstance_class_property.py
@@ -1,0 +1,115 @@
+# CPython-suite gap: the suite never runs `isinstance` hot enough to trace over
+# an instance whose class binds its own `__class__`.
+# parity-tests reason: a traced `isinstance` must keep calling a `__class__`
+# property and keep returning what that property implies.
+
+# `isinstance(obj, cls)` falls back to reading `obj.__class__` whenever the MRO
+# test misses (`abstractinst.py:76`).  That read goes through the ordinary
+# getattr, so a class binding `__class__` as a property has its getter run — by
+# the *default* `object.__getattribute__`, which consults the type's data
+# descriptors before anything else.  The getter is user code, and it decides
+# the answer: `isinstance(Masked(), int)` is True below, not the plain False a
+# miss looks like.  Every count is printed rather than asserted, so a fold that
+# elided the call, cached its result, or answered False would show up as a diff
+# against CPython instead of a silent pass.
+#
+# Scope, measured rather than assumed: this pins the observable semantics only.
+# It does NOT exercise `observed_replay_safe_isinstance` in
+# `jitcode_dispatch/residual_call.rs`, whose sole consumer is the nested
+# residual abort inside an inline sub-walk; at this call depth the residual is
+# a plain `call_may_force` and that gate no-ops.  Swapping that predicate for
+# the weaker one it replaced leaves every line here byte-identical.
+#
+# The gate's own witness is `bench/synth/foriter_isinstance_class_property_replay.py`,
+# which needs three things this file has none of: the call admitted into a
+# FOR_ITER body, an opaque trailing call to make the first sub-walk abort, and
+# a replay to turn the missing effect record into an N+1 hit count.
+
+N = 300
+
+calls = []
+
+
+class Masked:
+    """`__class__` is a property, so the miss path runs Python."""
+
+    @property
+    def __class__(self):
+        calls.append(1)
+        return int
+
+
+class Plain:
+    """No override: the miss path reads the builtin getset and answers False."""
+
+
+class Counted:
+    """The getter mutates state the caller can observe afterwards."""
+
+    ticks = 0
+
+    @property
+    def __class__(self):
+        Counted.ticks += 1
+        return str
+
+
+def masked_loop(n):
+    hits = 0
+    i = 0
+    while i < n:
+        if isinstance(Masked(), int):
+            hits = hits + 1
+        i = i + 1
+    return hits
+
+
+def plain_loop(n):
+    misses = 0
+    i = 0
+    while i < n:
+        if not isinstance(Plain(), int):
+            misses = misses + 1
+        i = i + 1
+    return misses
+
+
+def counted_loop(n):
+    hits = 0
+    i = 0
+    while i < n:
+        if isinstance(Counted(), str):
+            hits = hits + 1
+        i = i + 1
+    return hits
+
+
+# ── a property-masked class answers True, and the getter runs every time ──
+print("masked hits", masked_loop(N))
+print("masked getter calls", len(calls))
+
+# ── the ordinary class still takes the builtin read and answers False ──
+print("plain misses", plain_loop(N))
+
+# ── the getter's side effect is observable after the loop ──
+print("counted hits", counted_loop(N))
+print("counted ticks", Counted.ticks)
+
+# ── the same instance re-tested keeps calling the getter ──
+one = Masked()
+before = len(calls)
+same = 0
+for _ in range(N):
+    if isinstance(one, int):
+        same = same + 1
+print("repeat hits", same)
+print("repeat getter calls", len(calls) - before)
+
+# ── isinstance against a non-matching type still consults the property ──
+before = len(calls)
+other = 0
+for _ in range(N):
+    if isinstance(one, dict):
+        other = other + 1
+print("dict hits", other)
+print("dict getter calls", len(calls) - before)

--- a/pyre/extra_tests/snippets/builtin_arity_kwargs.py
+++ b/pyre/extra_tests/snippets/builtin_arity_kwargs.py
@@ -41,6 +41,12 @@ try:
     raise AssertionError("expected TypeError")
 except TypeError as e:
     assert "__init_subclass__" in str(e), str(e)
+    # `parse_obj` collapses an unknown keyword to one message when the callee
+    # takes neither `**kwargs` nor a keyword-only argument (argument.py:377-380),
+    # so this does not name `flag`.  The qualname ahead of the `()` is not
+    # asserted: it is the one part pyre and CPython spell differently.
+    assert "takes no keyword arguments" in str(e), str(e)
+    assert "flag" not in str(e), str(e)
 
 # A user __init_subclass__ still receives the keywords.
 seen = {}

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -16,7 +16,7 @@ use pyre_object::interp_sre::{
 use pyre_object::*;
 use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use sre_engine::engine::{Request, SearchIter, State};
-use sre_engine::string::StrDrive;
+use sre_engine::string::{StrDrive, StringCursor};
 
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     // Must equal `re/_constants.py:MAGIC` (the bundled stdlib) — `_compiler.py`
@@ -660,15 +660,7 @@ enum Subject {
     AsciiStr(&'static [u8]),
     /// `Utf8MatchContext` carrying `ctx.w_unicode_obj` (interp_sre.py:248-250)
     /// — the object is kept rather than just its payload because the length
-    /// and the character-to-byte conversion are read off it.
-    ///
-    /// Positions here are code point indices, which the `Wtf8` driver still
-    /// resolves by walking from the start (`sre_engine` `string.rs:155-196`,
-    /// once for `count` and again for `create_cursor`).  Upstream avoids that
-    /// by driving the utf8 bytes for this context too — "'start' and 'end' are
-    /// byte positions" (interp_sre.py:58) — and converting the spans it
-    /// reports back with `_byte_to_index`.  Converting every reported span is
-    /// the step that would finish the port.
+    /// and the character-to-byte conversion are read off it, by [`Utf8Drive`].
     Str(PyObjectRef),
     Bytes(&'static [u8]),
 }
@@ -699,6 +691,100 @@ unsafe fn str_subject(string: PyObjectRef) -> Subject {
         Subject::AsciiStr(unsafe { w_str_get_wtf8(string) }.as_bytes())
     } else {
         Subject::Str(string)
+    }
+}
+
+/// The drive behind [`Subject::Str`]: a non-ASCII `str` whose positions are
+/// code point indices, resolved through the object's stored length and index
+/// storage — `_len()` and `_index_to_byte` (unicodeobject.py:1245-1251) —
+/// rather than by walking the payload.
+///
+/// This is the point of carrying `w_unicode_obj` on the context at all.
+/// `impl StrDrive for &Wtf8` (`sre_engine` `string.rs:153`) has only the
+/// payload, so it answers `count` by counting every code point and
+/// `create_cursor(n)` by stepping over the first `n` of them; both run once
+/// per match, which makes a scan that restarts at successive positions
+/// quadratic in the subject. The index storage answers the same two questions
+/// without touching the payload.
+///
+/// Stepping is left to that impl: it is pure cursor arithmetic, identical for
+/// either way of arriving at the cursor.
+#[derive(Clone, Copy)]
+struct Utf8Drive {
+    obj: PyObjectRef,
+    wtf8: &'static Wtf8,
+}
+
+/// # Safety
+/// `obj` must point to a valid `W_UnicodeObject`.
+unsafe fn utf8_drive(obj: PyObjectRef) -> Utf8Drive {
+    Utf8Drive {
+        obj,
+        wtf8: unsafe { w_str_get_wtf8(obj) },
+    }
+}
+
+impl StrDrive for Utf8Drive {
+    #[inline]
+    fn count(&self) -> usize {
+        unsafe { w_str_len(self.obj) }
+    }
+
+    #[inline]
+    fn create_cursor(&self, n: usize) -> StringCursor {
+        // `n == count()` is the end-of-subject cursor, which has no character
+        // to index; every other caller keeps `n` inside the subject.
+        let byte = if n >= unsafe { w_str_len(self.obj) } {
+            self.wtf8.as_bytes().len()
+        } else {
+            unsafe { w_str_index_to_byte(self.obj, n) }
+        };
+        // `StringCursor.ptr` is crate-private, so the cursor is minted at the
+        // head of the suffix — an O(1) reslice — and carries the code point
+        // index that the engine actually compares against.
+        let suffix: &Wtf8 = &self.wtf8[byte..];
+        let mut cursor = suffix.create_cursor(0);
+        cursor.position = n;
+        cursor
+    }
+
+    #[inline]
+    fn adjust_cursor(&self, cursor: &mut StringCursor, n: usize) {
+        // The `&Wtf8` impl only rebuilds when it has to move backwards,
+        // because seeking forward costs it a step per code point. Seeking is
+        // a lookup here, so a rebuild is never the slower branch, and it also
+        // avoids reading the crate-private `ptr` to test it for null.
+        *cursor = self.create_cursor(n);
+    }
+
+    #[inline]
+    fn advance(cursor: &mut StringCursor) -> u32 {
+        <&Wtf8 as StrDrive>::advance(cursor)
+    }
+
+    #[inline]
+    fn peek(cursor: &StringCursor) -> u32 {
+        <&Wtf8 as StrDrive>::peek(cursor)
+    }
+
+    #[inline]
+    fn skip(cursor: &mut StringCursor, n: usize) {
+        <&Wtf8 as StrDrive>::skip(cursor, n)
+    }
+
+    #[inline]
+    fn back_advance(cursor: &mut StringCursor) -> u32 {
+        <&Wtf8 as StrDrive>::back_advance(cursor)
+    }
+
+    #[inline]
+    fn back_peek(cursor: &StringCursor) -> u32 {
+        <&Wtf8 as StrDrive>::back_peek(cursor)
+    }
+
+    #[inline]
+    fn back_skip(cursor: &mut StringCursor, n: usize) {
+        <&Wtf8 as StrDrive>::back_skip(cursor, n)
     }
 }
 
@@ -1067,7 +1153,7 @@ fn do_match(
             drive_match(b, pos, endpos, code, search, match_all)
         }
         Subject::Str(obj) => {
-            let s = unsafe { w_str_get_wtf8(obj) };
+            let s = unsafe { utf8_drive(obj) };
             drive_match(s, pos, endpos, code, search, match_all)
         }
     };
@@ -1221,7 +1307,7 @@ fn sre_pattern_findall(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let matches = match subj {
         Subject::AsciiStr(b) | Subject::Bytes(b) => collect_matches(b, pos, endpos, code, pat),
         Subject::Str(obj) => {
-            let s = unsafe { w_str_get_wtf8(obj) };
+            let s = unsafe { utf8_drive(obj) };
             collect_matches(s, pos, endpos, code, pat)
         }
     };
@@ -1400,7 +1486,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
             stream_matches(b, 0, endpos, code, pat, count, on_match)?
         }
         Subject::Str(obj) => {
-            let s = unsafe { w_str_get_wtf8(obj) };
+            let s = unsafe { utf8_drive(obj) };
             stream_matches(s, 0, endpos, code, pat, count, on_match)?
         }
     };
@@ -1488,7 +1574,7 @@ fn sre_pattern_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             stream_matches(b, 0, endpos, code, pat, maxsplit, on_match)?
         }
         Subject::Str(obj) => {
-            let s = unsafe { w_str_get_wtf8(obj) };
+            let s = unsafe { utf8_drive(obj) };
             stream_matches(s, 0, endpos, code, pat, maxsplit, on_match)?
         }
     };
@@ -2012,7 +2098,7 @@ fn sre_scanner_step(
             drive_scanner_step(b, pos as usize, endpos, code, must_advance, anchored)
         }
         Subject::Str(obj) => {
-            let s = unsafe { w_str_get_wtf8(obj) };
+            let s = unsafe { utf8_drive(obj) };
             drive_scanner_step(s, pos as usize, endpos, code, must_advance, anchored)
         }
     };

--- a/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
+++ b/pyre/pyre-interpreter/src/module/_sre/interp_sre.rs
@@ -601,36 +601,17 @@ fn get_code(pat: PyObjectRef) -> Option<&'static [u32]> {
     }
 }
 
+/// `_index_to_byte` (`unicodeobject.py:1251`) — the byte offset of a character
+/// index, read through the object's cached index storage.  An index at or past
+/// the end is the end of the payload, which is the bound `make_ctx` applies to
+/// `endpos` (interp_sre.py:243-244).
 #[inline]
-fn char_len(s: &Wtf8) -> usize {
-    s.code_points().count()
-}
-
-#[inline]
-fn char_to_byte(s: &Wtf8, char_pos: usize) -> usize {
-    if char_pos == 0 {
-        return 0;
+fn char_to_byte(obj: PyObjectRef, char_pos: usize) -> usize {
+    let s = unsafe { w_str_get_wtf8(obj) };
+    if char_pos >= unsafe { w_str_len(obj) } {
+        return s.len();
     }
-    s.code_point_indices()
-        .nth(char_pos)
-        .map(|(byte_pos, _)| byte_pos)
-        .unwrap_or_else(|| s.len())
-}
-
-fn char_slice(s: &Wtf8, start: i64, end: i64) -> Option<&Wtf8> {
-    if start < 0 || end < start {
-        return None;
-    }
-    let start = start as usize;
-    let end = end as usize;
-    if end > char_len(s) {
-        return None;
-    }
-    Some(unsafe {
-        Wtf8::from_bytes_unchecked(
-            &s.as_bytes()[char_to_byte(s, start)..char_to_byte(s, end)],
-        )
-    })
+    unsafe { w_str_index_to_byte(obj, char_pos) }
 }
 
 fn byte_slice(b: &'static [u8], start: i64, end: i64) -> Option<&'static [u8]> {
@@ -669,16 +650,55 @@ fn normalize_bounds(len: usize, pos: i64, endpos: i64) -> (usize, usize) {
 /// same way it matches on any other character.
 #[derive(Clone, Copy)]
 enum Subject {
-    Str(&'static Wtf8),
+    /// `UnicodeAsciiMatchContext` (interp_sre.py:52), selected by `is_ascii()`
+    /// at interp_sre.py:246 — one byte per code point, so a character position
+    /// *is* a byte offset and the engine drives the payload as bytes.
+    /// `StrDrive` carries no semantics of its own (it is `count` and cursor
+    /// arithmetic; every unicode decision keys on the compiled pattern's
+    /// opcode), which is the same property that lets upstream spell this
+    /// context as a bare `StrMatchContext` subclass.
+    AsciiStr(&'static [u8]),
+    /// `Utf8MatchContext` carrying `ctx.w_unicode_obj` (interp_sre.py:248-250)
+    /// — the object is kept rather than just its payload because the length
+    /// and the character-to-byte conversion are read off it.
+    ///
+    /// Positions here are code point indices, which the `Wtf8` driver still
+    /// resolves by walking from the start (`sre_engine` `string.rs:155-196`,
+    /// once for `count` and again for `create_cursor`).  Upstream avoids that
+    /// by driving the utf8 bytes for this context too — "'start' and 'end' are
+    /// byte positions" (interp_sre.py:58) — and converting the spans it
+    /// reports back with `_byte_to_index`.  Converting every reported span is
+    /// the step that would finish the port.
+    Str(PyObjectRef),
     Bytes(&'static [u8]),
 }
 
 impl Subject {
+    /// Whether the subject slices back to `str` rather than to `bytes`.
+    fn is_unicode(self) -> bool {
+        !matches!(self, Subject::Bytes(_))
+    }
+
+    /// The subject's length in the engine's position units.
     fn len(self) -> usize {
         match self {
-            Subject::Str(s) => char_len(s),
-            Subject::Bytes(b) => b.len(),
+            Subject::AsciiStr(b) | Subject::Bytes(b) => b.len(),
+            // `_len()` (interp_sre.py:235) — the stored code point count.
+            Subject::Str(obj) => unsafe { w_str_len(obj) },
         }
+    }
+}
+
+/// The subject for a `str` (or `str` subclass) — `make_ctx`'s `is_ascii()`
+/// split (interp_sre.py:246-250).
+///
+/// # Safety
+/// `string` must point to a valid `W_UnicodeObject`.
+unsafe fn str_subject(string: PyObjectRef) -> Subject {
+    if unsafe { w_str_is_ascii(string) } {
+        Subject::AsciiStr(unsafe { w_str_get_wtf8(string) }.as_bytes())
+    } else {
+        Subject::Str(string)
     }
 }
 
@@ -766,7 +786,7 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
                 "cannot use a bytes pattern on a string-like object",
             ));
         }
-        Ok(Subject::Str(unsafe { w_str_get_wtf8(string) }))
+        Ok(unsafe { str_subject(string) })
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         if pattern_is_known_unicode(pat) {
             return Err(crate::PyError::type_error(
@@ -811,7 +831,7 @@ fn make_subject(pat: PyObjectRef, string: PyObjectRef) -> Result<Subject, crate:
 /// itself (`w_buffer` is `PY_NULL` and unused).
 unsafe fn subject_of(string: PyObjectRef, w_buffer: PyObjectRef) -> Subject {
     if unsafe { is_str(string) } {
-        Subject::Str(unsafe { w_str_get_wtf8(string) })
+        unsafe { str_subject(string) }
     } else if unsafe { pyre_object::bytesobject::is_bytes_like(string) } {
         Subject::Bytes(unsafe { pyre_object::bytesobject::bytes_like_data(string) })
     } else {
@@ -823,47 +843,59 @@ unsafe fn subject_of(string: PyObjectRef, w_buffer: PyObjectRef) -> Subject {
 /// (`str` → `str`, bytes-like → `bytes`), or `w_default` for an unmatched
 /// group (span `(-1, -1)` or otherwise out of range).
 fn slice_subject(subj: Subject, span: (i64, i64), w_default: PyObjectRef) -> PyObjectRef {
-    match subj {
-        Subject::Str(s) => char_slice(s, span.0, span.1)
-            // interp_sre.py:68/76 uses `space.newutf8`: a captured slice is
-            // an ordinary runtime string and must participate in the GC.
-            .map(|s| w_str_from_wtf8_managed(s.to_owned()))
-            .unwrap_or(w_default),
-        Subject::Bytes(b) => byte_slice(b, span.0, span.1)
-            .map(pyre_object::bytesobject::w_bytes_from_bytes)
-            .unwrap_or(w_default),
+    let Some(bytes) = subject_span_bytes(subj, span) else {
+        return w_default;
+    };
+    if subj.is_unicode() {
+        // interp_sre.py:68/76 uses `space.newutf8`: a captured slice is an
+        // ordinary runtime string and must participate in the GC.
+        w_str_from_wtf8_managed(unsafe { Wtf8::from_bytes_unchecked(bytes) }.to_owned())
+    } else {
+        pyre_object::bytesobject::w_bytes_from_bytes(bytes)
     }
 }
 
 /// The empty string of the subject's kind — `w_emptystr` for unmatched
 /// groups (findall, interp_sre.py:344-347) and empty replacement output.
 fn empty_subject(subj: Subject) -> PyObjectRef {
-    match subj {
-        Subject::Str(_) => w_str_new(""),
-        Subject::Bytes(_) => pyre_object::bytesobject::w_bytes_from_bytes(b""),
+    if subj.is_unicode() {
+        w_str_new("")
+    } else {
+        pyre_object::bytesobject::w_bytes_from_bytes(b"")
     }
 }
 
-/// The raw bytes of a span's slice (the UTF-8 encoding for a `str`
+/// The raw bytes of a span's slice (the WTF-8 encoding for a `str`
 /// subject), for building `sub`/`expand` replacement output.
 fn subject_span_bytes(subj: Subject, span: (i64, i64)) -> Option<&'static [u8]> {
-    match subj {
-        Subject::Str(s) => char_slice(s, span.0, span.1).map(Wtf8::as_bytes),
-        Subject::Bytes(b) => byte_slice(b, span.0, span.1),
+    let (start, end) = span;
+    let (payload, w_unicode_obj) = match subj {
+        Subject::Bytes(b) => return byte_slice(b, start, end),
+        // An ASCII span is a byte span already (interp_sre.py:66-68), so the
+        // conversion is the identity.
+        Subject::AsciiStr(b) => (b, None),
+        Subject::Str(obj) => (unsafe { w_str_get_wtf8(obj) }.as_bytes(), Some(obj)),
+    };
+    // A `str` span out of range is no slice at all, where a buffer span clamps
+    // (see [`byte_slice`]).
+    if start < 0 || end < start || end as usize > subj.len() {
+        return None;
     }
+    let to_byte =
+        |pos: i64| w_unicode_obj.map_or(pos as usize, |obj| char_to_byte(obj, pos as usize));
+    Some(&payload[to_byte(start)..to_byte(end)])
 }
 
 /// Wrap accumulated replacement bytes as the subject's kind — `str` from
 /// the (valid UTF-8) builder, or `bytes` (subx result, interp_sre.py:541-548).
 fn finish_output(subj: Subject, out: Vec<u8>) -> PyObjectRef {
-    match subj {
+    if subj.is_unicode() {
         // interp_sre.py:567 returns `space.newutf8(...)`: substitution and
         // expansion results are ordinary runtime strings, not bootstrap
         // structural strings that may live outside the managed heap.
-        Subject::Str(_) => {
-            w_str_from_wtf8_managed(Wtf8Buf::from_bytes(out).unwrap_or_default())
-        }
-        Subject::Bytes(_) => pyre_object::bytesobject::w_bytes_from_bytes(&out),
+        w_str_from_wtf8_managed(Wtf8Buf::from_bytes(out).unwrap_or_default())
+    } else {
+        pyre_object::bytesobject::w_bytes_from_bytes(&out)
     }
 }
 
@@ -1031,8 +1063,13 @@ fn do_match(
     );
 
     let (matched, state) = match subj {
-        Subject::Str(s) => drive_match(s, pos, endpos, code, search, match_all),
-        Subject::Bytes(b) => drive_match(b, pos, endpos, code, search, match_all),
+        Subject::AsciiStr(b) | Subject::Bytes(b) => {
+            drive_match(b, pos, endpos, code, search, match_all)
+        }
+        Subject::Str(obj) => {
+            let s = unsafe { w_str_get_wtf8(obj) };
+            drive_match(s, pos, endpos, code, search, match_all)
+        }
     };
 
     if matched {
@@ -1182,8 +1219,11 @@ fn sre_pattern_findall(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     let w_empty = empty_subject(subj);
 
     let matches = match subj {
-        Subject::Str(s) => collect_matches(s, pos, endpos, code, pat),
-        Subject::Bytes(b) => collect_matches(b, pos, endpos, code, pat),
+        Subject::AsciiStr(b) | Subject::Bytes(b) => collect_matches(b, pos, endpos, code, pat),
+        Subject::Str(obj) => {
+            let s = unsafe { w_str_get_wtf8(obj) };
+            collect_matches(s, pos, endpos, code, pat)
+        }
     };
     // `matchlist_w = []` in interp_sre.py:341 is a GC-managed list.  Build
     // that same shape here instead of retaining every result in an off-heap
@@ -1285,7 +1325,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
         None
     } else {
         let (repl_bytes, is_bytes) = match subj {
-            Subject::Str(_) => {
+            Subject::AsciiStr(_) | Subject::Str(_) => {
                 if !unsafe { is_str(w_repl) } {
                     return Err(crate::PyError::type_error(
                         "sub: replacement must be str or callable",
@@ -1332,7 +1372,7 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
             let w_piece = crate::call::call_function_impl_result(w_repl, &[m])?;
             if !unsafe { is_none(w_piece) } {
                 match subj {
-                    Subject::Str(_) => {
+                    Subject::AsciiStr(_) | Subject::Str(_) => {
                         if !unsafe { is_str(w_piece) } {
                             return Err(crate::PyError::type_error(
                                 "sub callable must return a string",
@@ -1356,8 +1396,13 @@ fn subx(args: &[PyObjectRef]) -> Result<(PyObjectRef, i64), crate::PyError> {
         Ok(())
     };
     let n = match subj {
-        Subject::Str(s) => stream_matches(s, 0, endpos, code, pat, count, on_match)?,
-        Subject::Bytes(b) => stream_matches(b, 0, endpos, code, pat, count, on_match)?,
+        Subject::AsciiStr(b) | Subject::Bytes(b) => {
+            stream_matches(b, 0, endpos, code, pat, count, on_match)?
+        }
+        Subject::Str(obj) => {
+            let s = unsafe { w_str_get_wtf8(obj) };
+            stream_matches(s, 0, endpos, code, pat, count, on_match)?
+        }
     };
     // interp_sre.py:478-484 — no substitution was made (no occurrence, or a
     // non-positive `count`): the result is the subject itself.  An exact
@@ -1439,8 +1484,13 @@ fn sre_pattern_split(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         Ok(())
     };
     match subj {
-        Subject::Str(s) => stream_matches(s, 0, endpos, code, pat, maxsplit, on_match)?,
-        Subject::Bytes(b) => stream_matches(b, 0, endpos, code, pat, maxsplit, on_match)?,
+        Subject::AsciiStr(b) | Subject::Bytes(b) => {
+            stream_matches(b, 0, endpos, code, pat, maxsplit, on_match)?
+        }
+        Subject::Str(obj) => {
+            let s = unsafe { w_str_get_wtf8(obj) };
+            stream_matches(s, 0, endpos, code, pat, maxsplit, on_match)?
+        }
     };
     // interp_sre.py:405 — the trailing remainder after the last match.
     append_slice((last, endpos as i64), w_empty);
@@ -1738,7 +1788,7 @@ fn sre_match_expand(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let w_template = args.get(1).copied().unwrap_or_else(w_none);
     let subj = unsafe { subject_of((*m).w_string, (*m).w_buffer) };
     let (template, is_bytes): (&[u8], bool) = match subj {
-        Subject::Str(_) => {
+        Subject::AsciiStr(_) | Subject::Str(_) => {
             if !unsafe { is_str(w_template) } {
                 return Err(crate::PyError::type_error("expand: template must be str"));
             }
@@ -1958,9 +2008,12 @@ fn sre_scanner_step(
     let must_advance = unsafe { (*sc).must_advance } != 0;
 
     let (found, state) = match subj {
-        Subject::Str(s) => drive_scanner_step(s, pos as usize, endpos, code, must_advance, anchored),
-        Subject::Bytes(b) => {
+        Subject::AsciiStr(b) | Subject::Bytes(b) => {
             drive_scanner_step(b, pos as usize, endpos, code, must_advance, anchored)
+        }
+        Subject::Str(obj) => {
+            let s = unsafe { w_str_get_wtf8(obj) };
+            drive_scanner_step(s, pos as usize, endpos, code, must_advance, anchored)
         }
     };
     if !found {

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -724,11 +724,15 @@ pub fn binary_slice_values(
         }
         if pyre_object::is_str(obj) {
             // Slice on code-point boundaries over the WTF-8 view, so a
-            // surrogate-bearing or multi-byte string slices correctly.
+            // surrogate-bearing or multi-byte string slices correctly.  The
+            // bounds convert through the object's own index storage
+            // (`_index_to_byte`, unicodeobject.py:1251) and the count is the
+            // stored `_length`: deriving either by walking the payload would
+            // make a one-character slice cost the whole string.  A bound equal
+            // to the count resolves to the end of the buffer, which is what
+            // the `stop` default asks for.
             let full = pyre_object::w_str_get_wtf8(obj);
-            let mut offsets: Vec<usize> = full.code_point_indices().map(|(i, _)| i).collect();
-            offsets.push(full.as_bytes().len());
-            let len = (offsets.len() - 1) as i64;
+            let len = pyre_object::w_str_len(obj) as i64;
             let s = if pyre_object::is_none(start) {
                 0
             } else {
@@ -741,8 +745,11 @@ pub fn binary_slice_values(
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = (if e < 0 { (len + e).max(0) } else { e.min(len) } as usize).max(s);
-            let part = rustpython_wtf8::Wtf8::from_bytes(&full.as_bytes()[offsets[s]..offsets[e]])
-                .expect("code-point-aligned slice is WTF-8");
+            let part = rustpython_wtf8::Wtf8::from_bytes(
+                &full.as_bytes()[pyre_object::w_str_index_to_byte(obj, s)
+                    ..pyre_object::w_str_index_to_byte(obj, e)],
+            )
+            .expect("code-point-aligned slice is WTF-8");
             // Substring slicing churns fresh dynamic strings; make it collectable.
             return Ok(pyre_object::w_str_from_wtf8_managed(part.to_wtf8_buf()));
         }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -20113,11 +20113,16 @@ fn init_object_type(ns: PyObjectRef) {
                     },
                     None => Vec::new(),
                 };
-                if let Some(first) = unknown.first() {
-                    return refuse(crate::argument::ArgErr::UnknownKwds {
-                        num_kwds: unknown.len(),
-                        kwd_name: first.clone(),
-                    });
+                if !unknown.is_empty() {
+                    // argument.py:377-380 — `parse_obj` does not report an
+                    // unknown keyword when the signature has neither `**kwargs`
+                    // nor a keyword-only argument; it collapses every such
+                    // refusal to one message.  This signature is `cls` alone,
+                    // so that branch always applies and naming the keyword
+                    // would be the shape a `**kwargs`-bearing callee gets.
+                    return Err(crate::PyError::type_error(
+                        "object.__init_subclass__() takes no keyword arguments".to_string(),
+                    ));
                 }
                 // `pos[0]` is the class the classmethod bound, so an argument
                 // of its own puts the count at two.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10375,9 +10375,11 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
 /// recording no guard) and returns before `run_sub_jitcode_walk`. Take that
 /// short-circuit away and the walk records the boxing body's own null and
 /// exception guards after the length is already shrunk, and a failure there
-/// pops twice. Nothing asserts this ordering; the pre-fold `GuardClass` /
-/// `GuardValue` and the strategy switch's guard are all ahead of the store by
-/// construction, not by check.
+/// pops twice. The pre-fold `GuardClass` / `GuardValue` and the strategy
+/// switch's guard are ahead of the store by construction; the body's own ops
+/// are checked instead of assumed —
+/// [`subwalk_guard_follows_store`] reads the window the sub-walk recorded and
+/// declines the fold if a guard landed past the first store.
 pub(crate) fn try_walker_orthodox_list_pop<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],
@@ -10502,6 +10504,42 @@ pub(crate) fn orthodox_list_pop_body_and_sym<Sym: WalkSym>(
     Some((sub_body, sym_ptr))
 }
 
+/// Whether the ops recorded since `start` put a guard after a store.
+///
+/// A sub-walk that gets no callee frame resumes its guards at the caller's CALL
+/// boundary, so a failure re-executes the whole call. That is sound only while
+/// every guard precedes the body's first store: past one, the resumed call
+/// re-applies an effect the body already recorded.
+///
+/// This reads the recorded IR only. A `setfield` here says the walk *recorded*
+/// a store, not that one reached the heap — `setfield_gc_via_heapcache` writes
+/// through only for boxes the walk itself allocated — so a caller that wants to
+/// decline on the answer still owes its own proof that nothing observable has
+/// been applied yet.
+///
+/// A `start` past the end means the trace was cut below the capture point, so
+/// the window this answers about is gone; report the guard rather than read an
+/// empty one as "sound".
+pub(crate) fn subwalk_guard_follows_store(
+    trace_ctx: &TraceCtx,
+    start: majit_metainterp::recorder::TracePosition,
+) -> bool {
+    let ops = trace_ctx.ops();
+    let Some(recorded) = ops.get(start._pos..) else {
+        return true;
+    };
+    let mut stored = false;
+    for op in recorded {
+        if op.opcode.is_guard() && stored {
+            return true;
+        }
+        stored |= op.opcode.is_setfield()
+            || op.opcode.is_setarrayitem()
+            || op.opcode.is_setinteriorfield();
+    }
+    false
+}
+
 /// Publish the pop call-site resume coordinate, descend the real helper body,
 /// write its Ref result, and journal/apply the concrete shrink exactly once.
 #[allow(clippy::too_many_arguments)]
@@ -10609,6 +10647,7 @@ pub(crate) fn orthodox_list_pop_commit<Sym: WalkSym>(
     ctx.raw_descrs = RawDescrPool::Global;
     ctx.sub_jitcode_lookup = &GLOBAL_SUB_JITCODE_LOOKUP_FN;
 
+    let walk_start = ctx.trace_ctx.get_trace_position();
     let saved_fbw_mode = ctx.fbw_mode;
     ctx.fbw_mode.inline_subwalk = true;
     let walk_result = run_sub_jitcode_walk(
@@ -10639,6 +10678,25 @@ pub(crate) fn orthodox_list_pop_commit<Sym: WalkSym>(
         }
         _ => return Err(DispatchError::UnexpectedVoidSubReturn { pc: op.pc }),
     };
+    // The Integer arm commits `ll_list_int_set_len` before it boxes, so a guard
+    // recorded after that store would resume at this CALL boundary and pop a
+    // second time. Today none is: the boxing call is short-circuited into
+    // `NewWithVtable` + `SetfieldGc`. Decline rather than inherit that as an
+    // assumption — the caller cuts back to the generic residual, which pops
+    // exactly once.
+    //
+    // Declining is only safe while the receiver is untouched, so it takes the
+    // same length re-read the commit below does: on a target whose
+    // `ll_list_int_set_len` keeps a runtime binding, the sub-walk executed it
+    // for real rather than recording it, and cutting back to a residual that
+    // pops again is the very double-pop this fold already had to fix on the
+    // append side. In that case the store is a `call`, not a `setfield`, so
+    // the ordering read has nothing to say about it either.
+    if unsafe { pyre_object::w_list_len(inner_self) } == len_before
+        && subwalk_guard_follows_store(ctx.trace_ctx, walk_start)
+    {
+        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op.pc });
+    }
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
 
     let w_item = pyre_object::w_int_new(raw_item);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10355,9 +10355,29 @@ pub(crate) fn orthodox_list_append_commit<Sym: WalkSym>(
     Ok(())
 }
 
-/// Descend the guard-free Integer-strategy `w_list_pop_end_inner` body for a
-/// bound `list.pop()` call, recording its length/item array operations instead
-/// of an opaque residual call.
+/// Descend the Integer-strategy `w_list_pop_end_inner` body for a bound
+/// `list.pop()` call, recording its length/item array operations instead of an
+/// opaque residual call.
+///
+/// "Guard-free" elsewhere about this body (`listobject.rs` `w_list_pop_end`,
+/// `jitcode_runtime.rs` `list_pop_end_jitcode`) names the *lock* guard: a
+/// `w_list_lock` pair inside the body would decline the sub-walk. It is not a
+/// claim about trace guards, and the two must not be conflated here, because
+/// what the fold's soundness rests on is a trace-guard ordering property:
+///
+/// The sub-walk gets no callee frame — `outer_*` and `snapshot_sym` below stay
+/// the caller's — so a guard recorded inside it resumes at this CALL boundary
+/// and re-executes the whole `pop()`. That is only sound while every guard
+/// lands *before* the body's first committed store. It does today: the Integer
+/// arm's `ll_list_int_set_len` is a native `setfield_gc_i`, and the sole op
+/// after it is the `w_int_new` call, which `dispatch_inline_call_dir_kind`
+/// short-circuits into `walker_box_int` (`NewWithVtable` + `SetfieldGc`,
+/// recording no guard) and returns before `run_sub_jitcode_walk`. Take that
+/// short-circuit away and the walk records the boxing body's own null and
+/// exception guards after the length is already shrunk, and a failure there
+/// pops twice. Nothing asserts this ordering; the pre-fold `GuardClass` /
+/// `GuardValue` and the strategy switch's guard are all ahead of the store by
+/// construction, not by check.
 pub(crate) fn try_walker_orthodox_list_pop<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     code: &[u8],

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -57,15 +57,37 @@ fn walker_emit_recorded_builtin_raise<Sym: WalkSym>(
         expected_kind
     ));
     let _roots = pyre_object::gc_roots::push_roots();
+    // Read every pinned value back out of its slot instead of reusing the
+    // local that was handed to `pin_root`.  `pin_root` normalizes the address
+    // it publishes once a second mutator has existed (`gc_roots.rs`
+    // `RootScope::pin_root`), so past that point the caller's copy can still
+    // name the pre-forwarding object while the slot names the live one — and
+    // these values are baked into the trace as `ConstPtr`s, which outlive the
+    // walk.  Same shape as the zip/tuple concrete-shadow build below.
+    let exc_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(exc);
-    let args_storage = unsafe { pyre_object::interp_exceptions::w_exception_get_args_storage(exc) };
-    let args_len = unsafe { pyre_object::w_list_len(args_storage) };
+    let args_storage = unsafe {
+        pyre_object::interp_exceptions::w_exception_get_args_storage(
+            pyre_object::gc_roots::shadow_stack_get(exc_slot),
+        )
+    };
+    let args_storage_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args_storage);
+    let args_len = unsafe {
+        pyre_object::w_list_len(pyre_object::gc_roots::shadow_stack_get(args_storage_slot))
+    };
     let mut concrete_args = Vec::with_capacity(args_len);
     for index in 0..args_len {
-        let arg = unsafe { pyre_object::w_list_getitem(args_storage, index as i64) }
-            .expect("recorded exception args were validated before trace emission");
+        let arg = unsafe {
+            pyre_object::w_list_getitem(
+                pyre_object::gc_roots::shadow_stack_get(args_storage_slot),
+                index as i64,
+            )
+        }
+        .expect("recorded exception args were validated before trace emission");
+        let arg_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(arg);
-        concrete_args.push(arg);
+        concrete_args.push(unsafe { pyre_object::gc_roots::shadow_stack_get(arg_slot) });
     }
     let args = concrete_args
         .iter()

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -12676,3 +12676,66 @@ fn foriter_body_identity_names_the_jitcode_its_op_pc_indexes() {
         other => panic!("expected the callee's Jit coordinate, got {other:?}"),
     }
 }
+
+#[test]
+fn a_guard_after_the_subwalks_store_is_what_declines_the_pop_fold() {
+    use super::specialize::subwalk_guard_follows_store;
+
+    let obj = OpRef::input_arg_ref(0);
+    let value = OpRef::ConstInt(7);
+
+    // The shape `w_list_pop_end_inner`'s Integer arm records today: every guard
+    // is ahead of `ll_list_int_set_len`, so a CALL-boundary resume re-executes
+    // a pop that has not happened.
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
+    let start = tc.get_trace_position();
+    tc.record_guard(majit_ir::OpCode::GuardNonnull, &[obj], 0);
+    tc.record_op(majit_ir::OpCode::SetfieldGc, &[obj, value]);
+    assert!(
+        !subwalk_guard_follows_store(&tc, start),
+        "guard-then-store is the sound order and must not decline"
+    );
+
+    // What removing the `w_int_new` short-circuit would produce: the boxing
+    // body's own guards land after the length is already shrunk, so the same
+    // resume pops a second time.
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
+    let start = tc.get_trace_position();
+    tc.record_op(majit_ir::OpCode::SetfieldGc, &[obj, value]);
+    tc.record_guard(majit_ir::OpCode::GuardNonnull, &[obj], 0);
+    assert!(
+        subwalk_guard_follows_store(&tc, start),
+        "a guard past the body's first store is the double-apply shape"
+    );
+
+    // The window starts at the recorded position: the caller's own pre-descent
+    // stores are not the body's, and a guard after them is not a finding.
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
+    tc.record_op(majit_ir::OpCode::SetfieldGc, &[obj, value]);
+    let start = tc.get_trace_position();
+    tc.record_guard(majit_ir::OpCode::GuardNonnull, &[obj], 0);
+    assert!(
+        !subwalk_guard_follows_store(&tc, start),
+        "ops recorded before the sub-walk are outside the window"
+    );
+
+    // Array stores commit just as much as field stores.
+    let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
+    let start = tc.get_trace_position();
+    tc.record_op(majit_ir::OpCode::SetarrayitemGc, &[obj, value, value]);
+    tc.record_guard(majit_ir::OpCode::GuardNonnull, &[obj], 0);
+    assert!(
+        subwalk_guard_follows_store(&tc, start),
+        "SetarrayitemGc is a committed store too"
+    );
+
+    // A start past the end is a window that no longer exists — an empty read
+    // there must not pass for "no guard after a store".
+    let tc = TraceCtx::for_test_types(&[Type::Ref]);
+    let mut past_end = tc.get_trace_position();
+    past_end._pos = tc.ops().len() + 1;
+    assert!(
+        subwalk_guard_follows_store(&tc, past_end),
+        "an unreadable window declines"
+    );
+}

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -365,8 +365,12 @@ pub fn list_append_jitcode() -> Option<Arc<JitCode>> {
     get_jitcode_by_index(idx)
 }
 
-/// The guard-free charon `w_list_pop_end_inner` body in `ALL_JITCODES`,
-/// resolved by name and cached per thread.
+/// The lock-guard-free charon `w_list_pop_end_inner` body in `ALL_JITCODES`,
+/// resolved by name and cached per thread. "Lock" is the whole of it: the body
+/// holds no `w_list_lock` pair, which is what would decline the fold's
+/// sub-walk (`listobject.rs` `w_list_pop_end`). It says nothing about trace
+/// guards — for those see `try_walker_orthodox_list_pop`, whose soundness
+/// turns on where they land relative to the body's first store.
 pub fn list_pop_end_jitcode() -> Option<Arc<JitCode>> {
     let idx = LIST_POP_END_JITCODE_INDEX
         .with(|cell| *cell.get_or_init(|| compute_named_jitcode_index("w_list_pop_end_inner")))?;

--- a/pyre/pyre-object/src/intobject.rs
+++ b/pyre/pyre-object/src/intobject.rs
@@ -199,10 +199,12 @@ pub fn w_int_new(value: i64) -> PyObjectRef {
 /// `SyntheticTransparentCtor` for the `PyObject` header survives lowering as
 /// a call to a `symbolic_fnaddr` hash, which a descending sub-jitcode walk
 /// cannot record and declines on. The boundary keeps both shapes out of the
-/// trace, and costs nothing where the arm is unreachable:
-/// `gc_interp::enabled()` is false on the native backends, whose
-/// `malloc_typed` arm is fused into a `NewWithVtable`. Drop it once the wasm
-/// backend lowers an offset-0 field store faithfully.
+/// trace. It is not free anywhere: `gc_interp::enabled()` reads
+/// `PYRE_GC_INTERP` and answers true for every value except exactly `0`
+/// (`gc_interp.rs` `enabled_from_env`), so it is on by default on every
+/// target and this arm — not the `malloc_typed` one `fuse_boxing_alloc`
+/// rewrites into a `NewWithVtable` — is the arm [`w_int_new`] takes. Drop the
+/// boundary once the wasm backend lowers an offset-0 field store faithfully.
 ///
 /// Spelled `*mut PyObject` rather than `PyObjectRef` so the attribute emits
 /// its `extern "C"` call trampoline: the macro recognises raw pointers


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [ ] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`
