### PR TITLE
wasm: gate execution time at 3x dynasm and fix every fixture over it

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2084,11 +2084,8 @@ fn build_function(
         .map(|op| op.getarglist().iter().map(|a| a.to_opref()).collect())
         .collect();
 
-    // x86/assembler.py:835-846 `write_pending_failure_recoveries` places the
-    // guard recovery stubs after the hot trace. Wasm uses one universal hot
-    // exit block and records only an exit ordinal at each guard site; the
-    // fail-argument spills are emitted in the cold dispatcher below. This is
-    // also the shape used by the dynasm sibling's pending guard tokens.
+    // The enclosing exit block gives each guard and Finish a direct path to
+    // the bridge-dispatch epilogue after it has spilled its fail arguments.
     sink.block(BlockType::Empty); // A $hot_exit
     if key_dispatch {
         // Per resumable label j (opened outermost = the loop header):
@@ -2136,7 +2133,7 @@ fn build_function(
     // Load inputs from frame into locals, and store Ref inputs to their homes.
     // The input value lives at the frame slot its producer wrote it to: the
     // caller fills slot `k` for the k-th input — `execute_token` for a loop
-    // entry, `emit_guard_exit`'s positional fail-arg spill for a bridge entry —
+    // entry, `emit_guard_spill`'s positional fail-arg spill for a bridge entry —
     // so read from the POSITIONAL slot `k`, not `ia.index` (a value number that
     // equals `k` for a loop but not for a bridge, whose live-in args carry their
     // trace value numbers). The local index stays `1 + ia.index` because the
@@ -2414,8 +2411,7 @@ fn build_function(
             }
 
             OpCode::Finish => {
-                sink.i32_const(guard_idx as i32);
-                sink.local_set(bridge_slot_local);
+                emit_guard_spill(&mut sink, constants, value_types, guard_idx, op);
                 sink.br(block_exit_depth);
                 guard_idx += 1;
             }
@@ -4785,45 +4781,11 @@ fn build_function(
         sink.end(); // end loop
     }
     // A well-formed trace exits through a guard or Finish. Preserve the old
-    // malformed/natural-fallthrough behavior without letting it enter the cold
-    // dispatcher with an uninitialized selector.
+    // malformed/natural-fallthrough behavior without reaching bridge dispatch
+    // with a stale frame fail index.
     sink.local_get(0);
     sink.return_();
     sink.end(); // end A $hot_exit
-
-    // Structured-Wasm equivalent of the native backends' out-of-line guard
-    // recovery stubs. Locals retain their fail-site SSA values across the
-    // branch, so each handler can perform the original positional spills here
-    // without adding hot-path frame traffic or GC roots.
-    let cold_exits: Vec<&Op> = ops
-        .iter()
-        .filter(|op| op.opcode.is_guard() || op.opcode == OpCode::Finish)
-        .collect();
-    if !cold_exits.is_empty() {
-        let exit_count = cold_exits.len() as u32;
-        sink.block(BlockType::Empty); // $cold_done
-        for _ in cold_exits.iter().rev() {
-            sink.block(BlockType::Empty);
-        }
-        sink.local_get(bridge_slot_local);
-        if fail_index_base != 0 {
-            sink.i32_const(fail_index_base as i32);
-            sink.i32_sub();
-        }
-        sink.br_table((0..exit_count).collect::<Vec<_>>(), exit_count);
-        for (ordinal, op) in cold_exits.into_iter().enumerate() {
-            sink.end();
-            emit_guard_exit(
-                &mut sink,
-                constants,
-                value_types,
-                fail_index_base + ordinal as u32,
-                op,
-            );
-            sink.br(exit_count - ordinal as u32 - 1);
-        }
-        sink.end(); // end $cold_done
-    }
 
     // Epilogue bridge dispatch. Control reaches here only
     // after a guard `br`'d out of the exit block, having written its
@@ -5317,33 +5279,40 @@ fn next_op_can_accept_cc<'a>(
     Some(next_op)
 }
 
-/// Common guard exit: condition is on stack (i32), emit a tiny hot failure arm.
+/// Common guard exit: condition is on stack (i32), spill and branch on failure.
+///
+/// The spill belongs in this arm rather than in one shared exit handler after
+/// the trace. x86/assembler.py:835-846 `write_pending_failure_recoveries` can
+/// place its recovery stubs after the hot code because `GuardToken.fail_locs`
+/// (llsupport/assembler.py:24) freezes the register or stack location the
+/// allocator gave each fail argument *at the guard*, so a stub reads a fixed
+/// home and nothing keeps the value live past its own guard. Wasm has no way
+/// to record such a location: the allocator is the engine's, and it derives
+/// liveness from where the emitted code reads a local. Routing every guard to
+/// one handler block therefore makes it a join point whose live-in set is the
+/// union of every guard's fail arguments, so each becomes live at every guard
+/// in the trace, and the resulting long ranges spill in the hot body. Reading
+/// them here ends each range at the guard that needs it.
 ///
 /// `block_exit_depth` is the statement-level depth of the enclosing exit
 /// `block` (preamble = 0, loop body = 1); the `+ 1` accounts for the `if`
-/// this opens. The actual fail-argument recovery is emitted out of line by
-/// `build_function`, matching x86's `write_pending_failure_recoveries`.
+/// this opens. The stores run only on the failing edge, so the fallthrough
+/// carries no frame traffic.
 fn emit_guard_if_exit(
     sink: &mut InstructionSink<'_>,
-    _constants: &indexmap::IndexMap<u32, i64>,
+    constants: &indexmap::IndexMap<u32, i64>,
     value_types: &[ValType],
     guard_idx: u32,
-    _op: &Op,
+    op: &Op,
     block_exit_depth: u32,
 ) {
     sink.if_(BlockType::Empty);
-    // The bridge-slot scratch is the first i32 local after the value locals,
-    // the UintMulHigh scratch locals, and the overflow flag. It is dead until
-    // the bridge epilogue overwrites it with `local.tee`, so it doubles as the
-    // cold-exit selector without growing the local or GC-root set.
-    let exit_selector_local = value_types.len() as u32 + UMULHI_SCRATCH + 2;
-    sink.i32_const(guard_idx as i32);
-    sink.local_set(exit_selector_local);
+    emit_guard_spill(sink, constants, value_types, guard_idx, op);
     sink.br(block_exit_depth + 1);
     sink.end();
 }
 
-fn emit_guard_exit(
+fn emit_guard_spill(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
     value_types: &[ValType],

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1186,13 +1186,11 @@ fn residual_call_float_sig(op: &Op) -> Option<Vec<ValType>> {
 /// void residual CALL whose descr records the dummy-word C ABI
 /// (`result_size == 8`, minted by `make_call_descr_void_word_abi`) — the
 /// callee is really `(i64×n) -> i64` with the result ignored, so it lowers
-/// through the same i64 type family with a trailing `drop`. A plain void
-/// descr (`result_size == 0`) may target a genuinely `()`-returning callee
-/// OR a word-returning one (the reflective host trampoline absorbs the
-/// difference), so it stays on `jit_call`. This includes `CallMayForceN`
-/// with the word ABI: the wasm virtualizable is always materialized, so
-/// `GuardNotForced` is a no-op and a direct call is sound. Float / release-GIL
-/// / cond / assembler calls and non-reflectable descrs remain on the trampoline.
+/// through the same i64 type family with a trailing `drop`. This includes
+/// `CallMayForceN` with the word ABI: the wasm virtualizable is always
+/// materialized, so `GuardNotForced` is a no-op and a direct call is sound.
+/// Float / release-GIL / cond / assembler calls and non-reflectable descrs
+/// remain on the trampoline.
 fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
     use OpCode::*;
     if !matches!(
@@ -1220,33 +1218,37 @@ fn residual_call_void_word_arity(op: &Op) -> Option<usize> {
     Some(nargs)
 }
 
-/// Whether `op` is the exact `() -> ()` helper that clears the caught-
-/// exception propagation root after `PUSH_EXC_INFO` publishes the exception
-/// on the execution context.
-///
-/// A plain void call descr (`result_size == 0`) is not enough to select this
-/// ABI: pyre also records word-returning helpers as void when their result is
-/// ignored, and only the reflective host trampoline can absorb that mismatch.
-/// `ClearInFlightException` is codewriter-stamped onto the one genuinely
-/// nullary, genuinely void target (`bh_clear_in_flight_exception`), so this
-/// exact tag + descr + operand shape is safe to call through a `() -> ()`
-/// table type. Keeping the allow-list singular also prevents an unrelated
-/// void helper from silently bypassing the signature audit.
-fn residual_call_true_void(op: &Op) -> bool {
-    if op.opcode != OpCode::CallN {
-        return false;
+/// True-void counterpart of [`residual_call_void_word_arity`]: an eligible
+/// void residual CALL whose descr records a `()` result (`result_size == 0`).
+/// Int/Ref-only arguments lower through the `(i64×n) -> ()` type family with
+/// no result to drop. Float / release-GIL / cond / assembler calls,
+/// non-reflectable descrs, and descr/operand arity mismatches remain on the
+/// trampoline.
+fn residual_call_void_true_arity(op: &Op) -> Option<usize> {
+    use OpCode::*;
+    if !matches!(
+        op.opcode,
+        CallN | CallPureN | CallLoopinvariantN | CallMayForceN
+    ) {
+        return None;
     }
-    let Some(descr) = op.getdescr() else {
-        return false;
-    };
-    let Some(cd) = descr.as_call_descr() else {
-        return false;
-    };
-    cd.result_type() == Type::Void
-        && cd.result_size() == 0
-        && cd.arg_types().is_empty()
-        && op.getarglist().len() == 1
-        && cd.get_extra_info().pyre_helper == majit_ir::PyreHelperKind::ClearInFlightException
+    let descr = op.getdescr()?;
+    let cd = descr.as_call_descr()?;
+    if cd.result_type() != Type::Void || cd.result_size() != 0 {
+        return None;
+    }
+    let arg_types = cd.arg_types();
+    if arg_types
+        .iter()
+        .any(|t| !matches!(t, Type::Int | Type::Ref))
+    {
+        return None;
+    }
+    let nargs = op.getarglist().len().saturating_sub(1);
+    if arg_types.len() != nargs {
+        return None;
+    }
+    Some(nargs)
 }
 
 /// Arity of `op`'s in-module `(i64×n) -> i64` lowering, if it has one: an
@@ -1254,7 +1256,8 @@ fn residual_call_true_void(op: &Op) -> bool {
 /// allocation (the `wasm_jit_alloc*` helper targets are plain
 /// `extern "C" fn(i64×n) -> i64` table entries), or a ref-storing store
 /// (its `wasm_jit_write_barrier` helper takes 1 arg). All of these share
-/// the residual-call type family, so one max covers them.
+/// the i64-result residual-call type family, so one max covers them. True-void
+/// residuals use a separate result family and arity census.
 fn direct_helper_i64_arity(op: &Op, ref_values: &RefValues) -> Option<usize> {
     if let Some(n) = residual_call_i64_arity(op) {
         return Some(n);
@@ -1295,10 +1298,10 @@ fn has_call_ops(ops: &[Op]) -> bool {
 /// invocation and therefore needs the corresponding function import.
 ///
 /// Keep this in lockstep with the individual emission arms below: the uniform
-/// i64 and typed float residual families, `New*`, and write barriers are direct
-/// under `WASM_DIRECT_RESIDUAL_CALL`; non-uniform CALLs and string allocation
-/// retain the trampoline. When the direct family is disabled, all of the
-/// existing call-area users return to the trampoline baseline.
+/// i64, typed float, and true-void residual families, `New*`, and write barriers
+/// are direct under `WASM_DIRECT_RESIDUAL_CALL`; non-uniform CALLs and string
+/// allocation retain the trampoline. When the direct family is disabled, all
+/// of the existing call-area users return to the trampoline baseline.
 fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -> bool {
     let ref_values = RefValues::collect(inputargs, ops);
     if !WASM_DIRECT_RESIDUAL_CALL {
@@ -1314,11 +1317,11 @@ fn has_trampoline_calls(inputargs: &[InputArg], ops: &[Op], emit_ca: bool) -> bo
         // carrying either is declined. Kept as a conservative superset.
         OpCode::Newstr | OpCode::Newunicode => true,
         // Every residual CALL uses the trampoline unless its exact lowering
-        // predicate supplies an i64 helper ABI or a typed float ABI.
+        // predicate supplies an i64, typed float, or true-void helper ABI.
         _ if op.opcode.is_call() => {
             direct_helper_i64_arity(op, &ref_values).is_none()
                 && residual_call_float_sig(op).is_none()
-                && !residual_call_true_void(op)
+                && residual_call_void_true_arity(op).is_none()
         }
         // `New*` and ref-store write barriers are covered by
         // `direct_helper_i64_arity`, so their direct-family arms do not touch
@@ -1752,18 +1755,21 @@ pub fn build_wasm_module(
             }
         }
     }
-    // `PUSH_EXC_INFO`'s propagation-root clear is the one signature-audited
-    // true-void residual helper. It gets a dedicated `() -> ()` type instead
-    // of being mixed into the `(i64×n) -> i64` family.
-    let has_true_void_residual =
-        WASM_DIRECT_RESIDUAL_CALL && ops.iter().any(residual_call_true_void);
+    // True-void residual calls use `(i64×n) -> ()`, a separate family from the
+    // i64- and f64-result types. As with the uniform i64 family, declaring
+    // `0..=max` makes each type index a base plus the call arity.
+    let true_void_residual_max_arity = if WASM_DIRECT_RESIDUAL_CALL {
+        ops.iter().filter_map(residual_call_void_true_arity).max()
+    } else {
+        None
+    };
     // The shared indirect-function table backs direct residual helpers as well
     // as host-trampoline dispatch, chained bridges, and CA recursion.
     let needs_table = needs_call
         || bridge_dispatch
         || residual_max_arity.is_some()
         || !float_residual_sigs.is_empty()
-        || has_true_void_residual
+        || true_void_residual_max_arity.is_some()
         || ca.emit_ca;
     // `ca.emit_ca` forces the direct helper family to include arities 0..=2,
     // so all CA frame-helper trampoline `else` arms below are baseline-only.
@@ -1816,10 +1822,12 @@ pub fn build_wasm_module(
     for sig in float_residual_type_indices.keys() {
         types.ty().function(sig.clone(), vec![ValType::F64]);
     }
-    let true_void_residual_type_idx =
+    let true_void_residual_type_base =
         float_residual_type_base + float_residual_type_indices.len() as u32;
-    if has_true_void_residual {
-        types.ty().function(vec![], vec![]);
+    if let Some(max) = true_void_residual_max_arity {
+        for n in 0..=max {
+            types.ty().function(vec![ValType::I64; n], vec![]);
+        }
     }
     module.section(&types);
 
@@ -1901,7 +1909,7 @@ pub fn build_wasm_module(
         frame,
         residual_max_arity.map(|_| residual_type_base),
         &float_residual_type_indices,
-        has_true_void_residual.then_some(true_void_residual_type_idx),
+        true_void_residual_max_arity.map(|_| true_void_residual_type_base),
         ca,
         bridge_finish_fi,
         ca_helper_type_idx,
@@ -1956,9 +1964,10 @@ fn build_function(
     // descr-derived parameter sequence. These types return `f64`; Float SSA
     // values are converted to/from their i64 bit carrier around the call.
     float_residual_type_indices: &indexmap::IndexMap<Vec<ValType>, u32>,
-    // Dedicated `() -> ()` type for the signature-audited
-    // ClearInFlightException residual, or `None` when absent.
-    true_void_residual_type_idx: Option<u32>,
+    // Base wasm type index of the `(i64×n) -> ()` true-void residual-call
+    // types (type `true_void_residual_type_base + n` for arity `n`), or
+    // `None` when the trace has no eligible true-void residual call.
+    true_void_residual_type_base: Option<u32>,
     // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`). `ca.emit_ca` off keeps
     // the body byte-identical.
     ca: CaParams,
@@ -4001,16 +4010,29 @@ fn build_function(
                         (!OpRef::raw_is_constant(vi)).then_some(vi),
                         frame,
                     );
-                } else if let Some(type_idx) =
-                    true_void_residual_type_idx.filter(|_| residual_call_true_void(op))
-                {
-                    // Exact `() -> ()` in-module helper. Unlike the generic
-                    // trampoline path, this cannot allocate, collect, force,
-                    // or replace the frame, so no frame/ref-home reload is
-                    // needed after the call.
+                } else if let (Some(base), Some(nargs)) = (
+                    true_void_residual_type_base,
+                    residual_call_void_true_arity(op),
+                ) {
+                    // Direct in-module true-void residual call: the callee is
+                    // `(i64×n)->()` (descr result_size == 0), so the call has no
+                    // result to drop.
+                    let call_args = &op.getarglist()[1..];
+                    for arg in call_args {
+                        emit_resolve(&mut sink, constants, value_types, arg.to_opref());
+                    }
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
-                    sink.call_indirect(0, type_idx);
+                    sink.call_indirect(0, base + nargs as u32);
+                    emit_reload_frame_if_necessary(
+                        &mut sink,
+                        residual_type_base,
+                        ca.ca_reload_fn_ptr,
+                        ca.jf_top_addr,
+                    );
+                    emit_reload_refs_from_homes(
+                        &mut sink, ref_homes, &liveness, op_idx, None, frame,
+                    );
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -727,6 +727,26 @@ fn write_barrier_base(op: &Op, ref_values: &RefValues) -> Option<OpRef> {
     ref_values.contains(val).then(|| op.arg(0).to_opref())
 }
 
+/// wasm emission's complete SETFIELD_GC write-barrier gate.  The import census
+/// deliberately keeps using [`write_barrier_base`]: it must remain an
+/// un-elided over-approximation so an arm that emits a barrier always has the
+/// `jit_call` import available.  Unlike SETARRAYITEM_GC, a SETFIELD_GC can
+/// carry a non-pointer field descriptor even when its value has a Ref home
+/// (the ForceToken layout is one such case).  rewrite.rs:1917-1923 rejects
+/// that store because the collector does not trace the field.
+fn emitted_write_barrier_base(op: &Op, ref_values: &RefValues) -> Option<OpRef> {
+    let base = write_barrier_base(op, ref_values)?;
+    if op.opcode == OpCode::SetfieldGc
+        && !op
+            .getdescr()
+            .and_then(|d| d.as_field_descr().map(|fd| fd.is_pointer_field()))
+            .unwrap_or(false)
+    {
+        return None;
+    }
+    Some(base)
+}
+
 /// Whether any op in the trace needs a write-barrier trampoline call, which
 /// requires the `jit_call` import to be present.
 fn has_ref_store_op(ops: &[Op], ref_values: &RefValues) -> bool {
@@ -2168,8 +2188,17 @@ fn build_function(
     let mut labels_passed = 0usize;
     let mut ovf_flag_live = false;
     let mut fused_guard_at: Option<usize> = None;
+    // rewrite.py:41-45 `_write_barrier_applied`, represented by
+    // RewriteState::wb_applied in rewrite.rs.  A base enters this set after
+    // its barrier is emitted or when a nursery allocation produces it; clear
+    // at every potentially-collecting op and LABEL so this describes every
+    // path reaching the next op, including entry through a LABEL loader.
+    let mut wb_applied = indexmap::IndexSet::<OpRef>::new();
 
     for (op_idx, op) in ops.iter().enumerate() {
+        if op.opcode == OpCode::Label || op.opcode.can_malloc() {
+            wb_applied.clear();
+        }
         if op.opcode == OpCode::Label && key_dispatch && labels_passed < num_labels {
             // End of the segment before label j (key-0 / earlier-label path).
             // Branch over the resume loader, then close C_j, emit the loader
@@ -2919,7 +2948,9 @@ fn build_function(
                 }
             }
             OpCode::SetfieldGc | OpCode::SetfieldRaw => {
-                if let Some(base) = write_barrier_base(op, ref_values) {
+                if let Some(base) = emitted_write_barrier_base(op, ref_values)
+                    && !wb_applied.contains(&base)
+                {
                     emit_write_barrier(
                         &mut sink,
                         constants,
@@ -2929,6 +2960,9 @@ fn build_function(
                         wb_fn_ptr,
                         base,
                     );
+                    // rewrite.rs:1941-1947 `gen_write_barrier`: remember
+                    // only after the barrier has been emitted.
+                    wb_applied.insert(base);
                 }
                 emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref()); // struct ptr
                 sink.i32_wrap_i64();
@@ -3013,7 +3047,9 @@ fn build_function(
                 }
             }
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
-                if let Some(base) = write_barrier_base(op, ref_values) {
+                if let Some(base) = emitted_write_barrier_base(op, ref_values)
+                    && !wb_applied.contains(&base)
+                {
                     emit_write_barrier(
                         &mut sink,
                         constants,
@@ -3023,6 +3059,9 @@ fn build_function(
                         wb_fn_ptr,
                         base,
                     );
+                    // rewrite.rs:1941-1947 `gen_write_barrier`: remember
+                    // only after the barrier has been emitted.
+                    wb_applied.insert(base);
                 }
                 emit_array_addr(&mut sink, constants, value_types, op);
                 if array_item_is_float_from_descr(op) {
@@ -4324,6 +4363,22 @@ fn build_function(
                         &mut sink, ref_homes, &liveness, op_idx, skip, frame,
                     );
                 }
+                // No `remember_wb` for the result. rewrite.rs:1130 and :2731
+                // seed it only on the branches that reached
+                // `can_use_nursery`; the `gen_malloc_fixedsize` decline does
+                // not, and :2720 spells out why — "the first result can come
+                // from an old-gen slow path whose TRACK_YOUNG_PTRS flag
+                // gen_initialize_tid intentionally preserves". Here the
+                // generation is not a codegen-time fact at all: a
+                // `non_moving` descr routes to `new_oldgen_fn_ptr`, whose
+                // `alloc_in_oldgen` stamps TRACK_YOUNG_PTRS, and the plain
+                // helper picks nursery or old-gen at runtime (the GC spells
+                // that out through `alloc_nursery_collecting_typed_rooted`'s
+                // `needs_write_barrier` out-parameter). Eliding here would
+                // drop the barrier on a fresh old object, losing an
+                // old-to-young edge. The inline flag test already makes the
+                // young case a load and a not-taken branch, so the elision
+                // this forgoes is the cheap one.
             }
             OpCode::NewArray | OpCode::NewArrayClear => {
                 let vi = op.pos.get().raw();
@@ -4685,6 +4740,9 @@ fn build_function(
                         &mut sink, ref_homes, &liveness, op_idx, skip, frame,
                     );
                 }
+                // No `remember_wb` for the result, for the reason the
+                // New/NewWithVtable arm above gives: a `non_moving` array
+                // descr routes to `new_array_oldgen_fn_ptr`.
             }
 
             // ── Misc ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -30,6 +30,99 @@ const SLOT_SIZE: u64 = 8;
 /// (al, ah, bl, bh, mid1).
 const UMULHI_SCRATCH: u32 = 5;
 
+/// Dense wasm-local assignment for the sparse value-id namespace.
+struct ValueLocals {
+    by_id: Vec<Option<u32>>,
+    types: Vec<ValType>,
+}
+
+impl ValueLocals {
+    fn mark(by_id: &mut [Option<u32>], id_types: &mut [ValType], id: u32, ty: ValType) {
+        let i = id as usize;
+        assert!(i < by_id.len(), "value id {id} exceeds pre-pass bounds");
+        by_id[i] = Some(0);
+        id_types[i] = ty;
+    }
+
+    fn collect(inputargs: &[InputArg], ops: &[Op], num_vars: u32) -> Self {
+        let mut by_id = vec![None; num_vars as usize];
+        let mut id_types = vec![ValType::I64; num_vars as usize];
+
+        for ia in inputargs {
+            Self::mark(
+                &mut by_id,
+                &mut id_types,
+                ia.index,
+                if ia.tp == Type::Float {
+                    ValType::F64
+                } else {
+                    ValType::I64
+                },
+            );
+        }
+        for op in ops {
+            let result = op.pos.get();
+            if result != OpRef::NONE && !result.is_constant() {
+                Self::mark(
+                    &mut by_id,
+                    &mut id_types,
+                    result.raw(),
+                    if op.result_type() == Type::Float {
+                        ValType::F64
+                    } else {
+                        ValType::I64
+                    },
+                );
+            }
+            for arg in op.getarglist() {
+                let arg = arg.to_opref();
+                if arg != OpRef::NONE && !arg.is_constant() {
+                    let ty = id_types[arg.raw() as usize];
+                    Self::mark(&mut by_id, &mut id_types, arg.raw(), ty);
+                }
+            }
+            if let Some(failargs) = op.getfailargs() {
+                for arg in failargs {
+                    let arg = arg.to_opref();
+                    if arg != OpRef::NONE && !arg.is_constant() {
+                        let ty = id_types[arg.raw() as usize];
+                        Self::mark(&mut by_id, &mut id_types, arg.raw(), ty);
+                    }
+                }
+            }
+        }
+
+        let mut types = Vec::new();
+        for (id, slot) in by_id.iter_mut().enumerate() {
+            if slot.is_some() {
+                *slot = Some(types.len() as u32 + 1);
+                types.push(id_types[id]);
+            }
+        }
+        Self { by_id, types }
+    }
+
+    fn local(&self, id: u32) -> u32 {
+        self.by_id
+            .get(id as usize)
+            .copied()
+            .flatten()
+            .unwrap_or_else(|| panic!("wasm value local is unmapped for id {id}"))
+    }
+
+    fn ty(&self, id: u32) -> ValType {
+        self.types[(self.local(id) - 1) as usize]
+    }
+
+    fn count(&self) -> u32 {
+        self.types.len() as u32
+    }
+
+    fn types(&self) -> &[ValType] {
+        &self.types
+    }
+}
+
 /// Call area layout in the historical fixed frame geometry.
 const CALL_RESULT_OFS: u64 = 2000;
 const CALL_FUNC_OFS: u64 = 2008;
@@ -361,8 +454,8 @@ impl RefValues {
 /// allocation inside the trace can forward it.
 ///
 /// Keyed by value id (`OpRef::raw()` / input `index`), which is the dense
-/// `[0, num_vars)` space the wasm value locals already use (`1 + raw`); a flat
-/// vector indexed by that id is the natural fit — no hashing, and iteration is
+/// `[0, num_vars)` value-id space; a flat vector indexed by that id is the
+/// natural fit — no hashing, and iteration is
 /// in id order, so the emitted module stays deterministic without sorting. The
 /// `is_constant` guard lives in one place (`home`): a constant `raw()` is a
 /// distinct namespace that must never alias a value's home.
@@ -768,7 +861,7 @@ fn has_ref_store_op(ops: &[Op], ref_values: &RefValues) -> bool {
 fn emit_write_barrier(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     jit_call_idx: Option<u32>,
     residual_type_base: Option<u32>,
     wb_fn_ptr: i64,
@@ -933,6 +1026,7 @@ fn collecting_call_positions(ops: &[Op], include_ca_collects: bool) -> Vec<usize
 /// native regalloc likewise reloads a spilled box only on its next use.
 fn emit_reload_refs_from_homes(
     sink: &mut InstructionSink<'_>,
+    value_types: &ValueLocals,
     ref_homes: &RefHomes,
     liveness: &HomeLiveness,
     at_op: usize,
@@ -947,7 +1041,7 @@ fn emit_reload_refs_from_homes(
         }
         sink.local_get(0);
         sink.i64_load(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
-        sink.local_set(1 + raw);
+        sink.local_set(value_types.local(raw));
     }
 }
 
@@ -1022,6 +1116,7 @@ fn emit_ca_reload_caller(sink: &mut InstructionSink<'_>, top_addr: u32) {
 /// *at* the CALL_ASSEMBLER op, not after it.
 fn emit_reload_ca_input_refs_from_homes(
     sink: &mut InstructionSink<'_>,
+    value_types: &ValueLocals,
     ref_homes: &RefHomes,
     ref_values: &RefValues,
     op: &Op,
@@ -1037,7 +1132,7 @@ fn emit_reload_ca_input_refs_from_homes(
         };
         sink.local_get(0);
         sink.i64_load(mem64(frame.home_slot_base + home as u64 * SLOT_SIZE));
-        sink.local_set(1 + arg.raw());
+        sink.local_set(value_types.local(arg.raw()));
     }
 }
 
@@ -1434,31 +1529,15 @@ fn collect_guards_and_vars(inputargs: &[InputArg], ops: &[Op]) -> (Vec<GuardExit
     (guards, max_var)
 }
 
-/// Wasm local type for each SSA value. Frame slots deliberately remain i64
-/// bit carriers, while Float values stay in f64 locals between operations.
-fn collect_value_types(inputargs: &[InputArg], ops: &[Op], num_vars: u32) -> Vec<ValType> {
-    let mut value_types = vec![ValType::I64; num_vars as usize];
-    for ia in inputargs {
-        if ia.tp == Type::Float && (ia.index as usize) < value_types.len() {
-            value_types[ia.index as usize] = ValType::F64;
-        }
-    }
-    for op in ops {
-        let result = op.pos.get();
-        if result != OpRef::NONE
-            && !result.is_constant()
-            && op.result_type() == Type::Float
-            && (result.raw() as usize) < value_types.len()
-        {
-            value_types[result.raw() as usize] = ValType::F64;
-        }
-    }
-    value_types
+/// Dense wasm-local assignment and type lookup for each addressed SSA value.
+fn collect_value_types(inputargs: &[InputArg], ops: &[Op], num_vars: u32) -> ValueLocals {
+    ValueLocals::collect(inputargs, ops, num_vars)
 }
 
 /// Assign each Ref-typed value (input arg or op result) a dense home-slot
 /// index, keyed by its value id (`raw()`), the same id its wasm local uses
-/// (`1 + raw`). Input args and op results share one value-id space (see
+/// (the dense wasm local is assigned separately). Input args and op results
+/// share one value-id space (see
 /// `collect_guards_and_vars`), so a single map covers both. Int / Float /
 /// Void values are skipped — only GC references need a forwarding home.
 /// Allocate the per-guard bridge-slot cell array for inter-trace chaining and
@@ -1952,7 +2031,7 @@ fn build_function(
     ops: &[Op],
     constants: &indexmap::IndexMap<u32, i64>,
     num_vars: u32,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     jit_call_idx: Option<u32>,
     vtable_offset: Option<usize>,
     classptr_to_typeid: &HashMap<i64, u32>,
@@ -2003,38 +2082,38 @@ fn build_function(
     // while `WASM_DIRECT_RESIDUAL_CALL` is enabled). Its `jit_call` fallback
     // branches are retained solely for the direct-family-disabled baseline.
     debug_assert!(!ca.emit_ca || residual_type_base.is_some());
-    // Value locals occupy `1 ..= num_vars`; reserve `UMULHI_SCRATCH` i64 locals
-    // past them (`num_vars+1 ..= num_vars+UMULHI_SCRATCH`) for the `UintMulHigh`
+    let num_value_locals = value_types.count();
+    // Value locals occupy the dense local range beginning at 1; reserve
+    // `UMULHI_SCRATCH` i64 locals past them for the `UintMulHigh`
     // 32-bit-split expansion, plus one i64 local for the pending overflow flag.
     // One i32 local past those holds the bridge table slot for the epilogue
     // `call_indirect` dispatch (unused when `!bridge_dispatch`).
-    let ovf_flag_local = num_vars + UMULHI_SCRATCH + 1;
-    let bridge_slot_local = num_vars + UMULHI_SCRATCH + 2;
+    let ovf_flag_local = num_value_locals + UMULHI_SCRATCH + 1;
+    let bridge_slot_local = num_value_locals + UMULHI_SCRATCH + 2;
     // The self-recursive CALL_ASSEMBLER arm needs two more i32 scratch locals:
     // `ca_cfp_local` (the current callee frame pointer) and `ca_fi_local` (the
     // returned frame[0] fail index). Reserve them only under `emit_ca` so a
     // flag-off module keeps exactly one i32 local (byte-identical).
-    let ca_cfp_local = num_vars + UMULHI_SCRATCH + 3;
-    let ca_fi_local = num_vars + UMULHI_SCRATCH + 4;
+    let ca_cfp_local = num_value_locals + UMULHI_SCRATCH + 3;
+    let ca_fi_local = num_value_locals + UMULHI_SCRATCH + 4;
     // Extra i32 scratches when the inline nursery-bump fast path is armed:
     // one holds the loaded `nursery_free` across the bump/commit sequence;
     // runtime varsize array allocation also needs one for the computed
     // total/new-free word.
     let base_i32_locals: u32 = if ca.emit_ca { 3 } else { 1 };
-    let alloc_scratch_local = num_vars + UMULHI_SCRATCH + 2 + base_i32_locals;
+    let alloc_scratch_local = num_value_locals + UMULHI_SCRATCH + 2 + base_i32_locals;
     let alloc_size_local = alloc_scratch_local + 1;
     debug_assert_eq!(bridge_slot_local, ovf_flag_local + 1);
     debug_assert_eq!(ca_cfp_local, bridge_slot_local + 1);
     debug_assert_eq!(ca_fi_local, ca_cfp_local + 1);
     debug_assert_eq!(alloc_scratch_local, bridge_slot_local + base_i32_locals);
     debug_assert_eq!(alloc_size_local, alloc_scratch_local + 1);
-    debug_assert_eq!(value_types.len(), num_vars as usize);
     let mut locals = Vec::new();
     let mut start = 0;
-    while start < value_types.len() {
-        let ty = value_types[start];
+    while start < value_types.types().len() {
+        let ty = value_types.types()[start];
         let mut end = start + 1;
-        while end < value_types.len() && value_types[end] == ty {
+        while end < value_types.types().len() && value_types.types()[end] == ty {
             end += 1;
         }
         locals.push(((end - start) as u32, ty));
@@ -2062,10 +2141,10 @@ fn build_function(
     // binding dominates the whole body, including a resume-at-LABEL entry.
     for (raw, bits) in unbound_pool_const_seeds(inputargs, ops, constants, num_vars)? {
         sink.i64_const(bits);
-        if value_types[raw as usize] == ValType::F64 {
+        if value_types.ty(raw) == ValType::F64 {
             sink.f64_reinterpret_i64();
         }
-        sink.local_set(1 + raw);
+        sink.local_set(value_types.local(raw));
     }
 
     // A peeled loop arrives as `[preamble..][LABEL][body..][JUMP]`: the
@@ -2156,17 +2235,17 @@ fn build_function(
     // entry, `emit_guard_spill`'s positional fail-arg spill for a bridge entry —
     // so read from the POSITIONAL slot `k`, not `ia.index` (a value number that
     // equals `k` for a loop but not for a bridge, whose live-in args carry their
-    // trace value numbers). The local index stays `1 + ia.index` because the
-    // body addresses each value by its number. For `key_dispatch` this runs on
+    // trace value numbers). `ValueLocals` maps each body value id to its dense
+    // local index. For `key_dispatch` this runs on
     // the key-0 (preamble) path only — past the `br_if` above — so a resuming
     // bridge never scatters its frame-passed label values into the function
     // inputargs' home slots; those stay null-initialized (GC-safe) and the
     // resume loader sets the live label-arg homes.
     for (k, ia) in inputargs.iter().enumerate() {
-        let local_idx = 1 + ia.index;
+        let local_idx = value_types.local(ia.index);
         let offset = FRAME_SLOT_BASE + k as u64 * SLOT_SIZE;
         sink.local_get(0).i64_load(mem64(offset));
-        if value_types[ia.index as usize] == ValType::F64 {
+        if value_types.ty(ia.index) == ValType::F64 {
             sink.f64_reinterpret_i64();
         }
         sink.local_set(local_idx);
@@ -2226,13 +2305,13 @@ fn build_function(
             for (i, la) in all_label_args[labels_passed].iter().enumerate() {
                 sink.local_get(0);
                 sink.i64_load(mem64(FRAME_SLOT_BASE + i as u64 * SLOT_SIZE));
-                if value_types[la.raw() as usize] == ValType::F64 {
+                if value_types.ty(la.raw()) == ValType::F64 {
                     sink.f64_reinterpret_i64();
                 }
-                sink.local_set(1 + la.raw());
+                sink.local_set(value_types.local(la.raw()));
                 if let Some(h) = ref_homes.home(*la) {
                     sink.local_get(0);
-                    sink.local_get(1 + la.raw());
+                    sink.local_get(value_types.local(la.raw()));
                     sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
                 }
             }
@@ -2245,13 +2324,13 @@ fn build_function(
                     .expect("LABEL live-in has assigned capture storage");
                 sink.local_get(0);
                 sink.i64_load(mem64(label_resume.frame_offset(storage, frame)));
-                if value_types[r.raw() as usize] == ValType::F64 {
+                if value_types.ty(r.raw()) == ValType::F64 {
                     sink.f64_reinterpret_i64();
                 }
-                sink.local_set(1 + r.raw());
+                sink.local_set(value_types.local(r.raw()));
                 if let Some(h) = ref_homes.home(r) {
                     sink.local_get(0);
-                    sink.local_get(1 + r.raw());
+                    sink.local_get(value_types.local(r.raw()));
                     sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
                 }
             }
@@ -2397,7 +2476,7 @@ fn build_function(
                 );
                 for &i in &moved {
                     let label_arg = label_args[i];
-                    if value_types[label_arg.raw() as usize] == ValType::F64 {
+                    if value_types.ty(label_arg.raw()) == ValType::F64 {
                         emit_resolve_f64(
                             &mut sink,
                             constants,
@@ -2409,7 +2488,7 @@ fn build_function(
                     }
                 }
                 for &i in moved.iter().rev() {
-                    sink.local_set(1 + label_args[i].raw());
+                    sink.local_set(value_types.local(label_args[i].raw()));
                 }
                 // The parallel move rebinds loop-carried locals without going
                 // through store-on-def, so a Ref label arg that is REBOUND to a
@@ -2432,7 +2511,7 @@ fn build_function(
                             continue;
                         }
                         sink.local_get(0);
-                        sink.local_get(1 + la.raw());
+                        sink.local_get(value_types.local(la.raw()));
                         sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
                     }
                 }
@@ -2691,7 +2770,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     sink.i32_const(exc_value_addr);
                     sink.i64_load(mem64(0));
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
                 sink.i32_const(exc_type_addr);
                 sink.i64_const(0);
@@ -2718,7 +2797,9 @@ fn build_function(
             // High 64 bits of the unsigned 64×64→128 product. The optimizer
             // emits this for division/modulo-by-constant strength reduction;
             // wasm has no mul-high instruction, so expand via 32-bit split.
-            OpCode::UintMulHigh => emit_umulhi(&mut sink, constants, value_types, op, num_vars),
+            OpCode::UintMulHigh => {
+                emit_umulhi(&mut sink, constants, value_types, op, value_types.count())
+            }
 
             // Overflow variants: compute result + overflow flag
             OpCode::IntAddOvf => {
@@ -2728,7 +2809,7 @@ fn build_function(
                     value_types,
                     op,
                     BinOp::I64Add,
-                    num_vars,
+                    value_types.count(),
                     ovf_flag_local,
                 );
             }
@@ -2739,7 +2820,7 @@ fn build_function(
                     value_types,
                     op,
                     BinOp::I64Sub,
-                    num_vars,
+                    value_types.count(),
                     ovf_flag_local,
                 );
             }
@@ -2750,7 +2831,7 @@ fn build_function(
                     value_types,
                     op,
                     BinOp::I64Mul,
-                    num_vars,
+                    value_types.count(),
                     ovf_flag_local,
                 );
             }
@@ -2806,7 +2887,7 @@ fn build_function(
                         sink.i64_const(shift);
                         sink.i64_shr_s();
                     }
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::IntForceGeZero => {
@@ -2816,14 +2897,14 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     // if val < 0, use 0; else use val
                     // Wasm: local.tee + i64.const 0 + local.get + i64.lt_s + select
-                    let tmp_local = 1 + vi; // reuse result local as temp
+                    let tmp_local = value_types.local(vi); // reuse result local as temp
                     sink.local_tee(tmp_local);
                     sink.i64_const(0);
                     sink.local_get(tmp_local);
                     sink.i64_const(0);
                     sink.i64_lt_s();
                     sink.select();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -2835,7 +2916,7 @@ fn build_function(
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.f64_div();
                     sink.f64_floor();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -2845,7 +2926,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i64_trunc_sat_f64_s();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::CastIntToFloat => {
@@ -2853,14 +2934,14 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_convert_i64_s();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::ConvertFloatBytesToLonglong => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::ConvertLonglongBytesToFloat => {
@@ -2868,7 +2949,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_reinterpret_i64();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -2892,14 +2973,14 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.i64_extend_i32_s();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::CastIntToPtr | OpCode::CastOpaquePtr => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -2908,14 +2989,14 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::SameAsF => {
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -2928,7 +3009,7 @@ fn build_function(
                     let field_offset = field_offset_from_descr(op);
                     let (size, signed) = field_size_sign_from_descr(op);
                     emit_sized_int_load(&mut sink, field_offset, size, signed);
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetfieldGcR | OpCode::GetfieldRawR => {
@@ -2944,7 +3025,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.i64_extend_i32_u();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::SetfieldGc | OpCode::SetfieldRaw => {
@@ -2993,7 +3074,7 @@ fn build_function(
                         align: 3,
                         memory_index: 0,
                     });
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -3008,7 +3089,7 @@ fn build_function(
                     // at its real width, like `bh_arraylen_gc`. A fixed i64_load
                     // would fold the next field into the high half on wasm32.
                     emit_sized_int_load(&mut sink, len_offset, len_size, false);
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetarrayitemGcI | OpCode::GetarrayitemGcPureI | OpCode::GetarrayitemRawI => {
@@ -3018,7 +3099,7 @@ fn build_function(
                     emit_array_addr(&mut sink, constants, value_types, op);
                     let (item_size, signed) = array_item_size_sign_from_descr(op);
                     emit_sized_int_load(&mut sink, 0, item_size, signed);
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetarrayitemGcR | OpCode::GetarrayitemGcPureR | OpCode::GetarrayitemRawR => {
@@ -3031,7 +3112,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.i64_extend_i32_u();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::GetarrayitemGcF | OpCode::GetarrayitemGcPureF | OpCode::GetarrayitemRawF => {
@@ -3043,7 +3124,7 @@ fn build_function(
                         align: 3,
                         memory_index: 0,
                     });
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::SetarrayitemGc | OpCode::SetarrayitemRaw => {
@@ -3160,7 +3241,7 @@ fn build_function(
                     sink.i32_add();
                     let (item_size, signed) = array_item_size_sign_from_descr(op);
                     emit_sized_int_load(&mut sink, 0, item_size, signed);
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::RawStore => {
@@ -3186,7 +3267,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     sink.i32_const(crate::jit_exc_value_addr() as i32);
                     sink.i64_load(mem64(0));
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
                 sink.i32_const(crate::jit_exc_type_addr() as i32);
                 sink.i64_const(0);
@@ -3202,7 +3283,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     sink.i32_const(crate::jit_exc_type_addr() as i32);
                     sink.i64_load(mem64(0));
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::RestoreException => {
@@ -3516,7 +3597,7 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     emit_resolve(&mut sink, constants, value_types, op.arg(1).to_opref());
                     sink.i64_add();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             // Emitted by `RawBufferPtrInfo::_force_elements` after a
@@ -3569,7 +3650,7 @@ fn build_function(
                         memory_index: 0,
                     });
                     sink.i64_extend_i32_u();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -3759,7 +3840,14 @@ fn build_function(
                     sink.i32_wrap_i64();
                     sink.local_set(0);
                 }
-                emit_reload_ca_input_refs_from_homes(&mut sink, ref_homes, ref_values, op, frame);
+                emit_reload_ca_input_refs_from_homes(
+                    &mut sink,
+                    value_types,
+                    ref_homes,
+                    ref_values,
+                    op,
+                    frame,
+                );
                 // dispatch key = 0: run the loop from its entry (preamble), not a
                 // LABEL resume — this is a fresh call.
                 sink.local_get(ca_cfp_local);
@@ -3865,7 +3953,7 @@ fn build_function(
                 }
                 // store-on-def homes the result Ref (from whichever branch).
                 if !OpRef::raw_is_constant(vi) {
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 } else {
                     sink.drop();
                 }
@@ -3913,7 +4001,15 @@ fn build_function(
                     ca.ca_reload_fn_ptr,
                     ca.inline,
                 );
-                emit_reload_refs_from_homes(&mut sink, ref_homes, &liveness, op_idx, skip, frame);
+                emit_reload_refs_from_homes(
+                    &mut sink,
+                    value_types,
+                    ref_homes,
+                    &liveness,
+                    op_idx,
+                    skip,
+                    frame,
+                );
             }
 
             // ── CALL operations (via trampoline) ──
@@ -3963,7 +4059,7 @@ fn build_function(
                     // call_indirect(table_index, type_index): table 0, type for arity n.
                     sink.call_indirect(0, base + nargs as u32);
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop(); // value-producing call whose result is unused
                     }
@@ -3975,6 +4071,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4004,7 +4101,13 @@ fn build_function(
                         ca.jf_top_addr,
                     );
                     emit_reload_refs_from_homes(
-                        &mut sink, ref_homes, &liveness, op_idx, None, frame,
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        None,
+                        frame,
                     );
                 } else if let Some((sig, &type_idx)) = residual_call_float_sig(op).and_then(|sig| {
                     float_residual_type_indices
@@ -4027,7 +4130,7 @@ fn build_function(
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, type_idx);
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop(); // value-producing call whose result is unused
                     }
@@ -4039,6 +4142,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4066,7 +4170,13 @@ fn build_function(
                         ca.jf_top_addr,
                     );
                     emit_reload_refs_from_homes(
-                        &mut sink, ref_homes, &liveness, op_idx, None, frame,
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        None,
+                        frame,
                     );
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
@@ -4108,10 +4218,10 @@ fn build_function(
                     if !OpRef::raw_is_constant(vi) && !is_void {
                         emit_call_area_addr(&mut sink);
                         sink.i64_load(mem64(STATIC_CALL_RESULT_OFS));
-                        if value_types[vi as usize] == ValType::F64 {
+                        if value_types.ty(vi) == ValType::F64 {
                             sink.f64_reinterpret_i64();
                         }
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     }
                     // Mirror the direct path: a trampoline residual call may force and collect.
                     emit_reload_frame_if_necessary(
@@ -4122,6 +4232,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4225,6 +4336,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4257,7 +4369,7 @@ fn build_function(
                     sink.i64_extend_i32_u();
                     sink.end();
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop();
                     }
@@ -4271,7 +4383,7 @@ fn build_function(
                     sink.i32_const(alloc_fn_ptr as i32);
                     sink.call_indirect(0, base + 2);
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop();
                     }
@@ -4300,7 +4412,7 @@ fn build_function(
                         // result pointer
                         emit_call_area_addr(&mut sink);
                         sink.i64_load(mem64(STATIC_CALL_RESULT_OFS));
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     }
                 }
 
@@ -4314,7 +4426,7 @@ fn build_function(
                         && vtable_offset.is_some();
                     if write_vtable {
                         let vt_off = vtable_offset.unwrap() as u64;
-                        sink.local_get(1 + vi);
+                        sink.local_get(value_types.local(vi));
                         sink.i32_wrap_i64();
                         sink.i32_const(vtable as i32);
                         sink.i32_store(MemArg {
@@ -4335,7 +4447,7 @@ fn build_function(
                         && let Some((w_class_offset, w_class)) = w_class_init
                         && w_class != 0
                     {
-                        sink.local_get(1 + vi);
+                        sink.local_get(value_types.local(vi));
                         sink.i32_wrap_i64();
                         sink.i32_const(w_class as i32);
                         sink.i32_store(MemArg {
@@ -4360,7 +4472,13 @@ fn build_function(
                         ca.jf_top_addr,
                     );
                     emit_reload_refs_from_homes(
-                        &mut sink, ref_homes, &liveness, op_idx, skip, frame,
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        skip,
+                        frame,
                     );
                 }
                 // No `remember_wb` for the result. rewrite.rs:1130 and :2731
@@ -4490,6 +4608,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4531,7 +4650,7 @@ fn build_function(
                     sink.i64_extend_i32_u();
                     sink.end();
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop();
                     }
@@ -4559,6 +4678,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4623,6 +4743,7 @@ fn build_function(
                     );
                     emit_reload_refs_from_homes(
                         &mut sink,
+                        value_types,
                         ref_homes,
                         &liveness,
                         op_idx,
@@ -4664,7 +4785,7 @@ fn build_function(
                     sink.end();
                     sink.end();
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop();
                     }
@@ -4680,7 +4801,7 @@ fn build_function(
                     sink.i32_const(alloc_array_fn_ptr as i32);
                     sink.call_indirect(0, base + 5);
                     if !OpRef::raw_is_constant(vi) {
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     } else {
                         sink.drop();
                     }
@@ -4721,7 +4842,7 @@ fn build_function(
                     if !OpRef::raw_is_constant(vi) {
                         emit_call_area_addr(&mut sink);
                         sink.i64_load(mem64(STATIC_CALL_RESULT_OFS));
-                        sink.local_set(1 + vi);
+                        sink.local_set(value_types.local(vi));
                     }
                 }
                 // `wasm_jit_alloc_array` collects; reload other live Refs. The
@@ -4737,7 +4858,13 @@ fn build_function(
                         ca.jf_top_addr,
                     );
                     emit_reload_refs_from_homes(
-                        &mut sink, ref_homes, &liveness, op_idx, skip, frame,
+                        &mut sink,
+                        value_types,
+                        ref_homes,
+                        &liveness,
+                        op_idx,
+                        skip,
+                        frame,
                     );
                 }
                 // No `remember_wb` for the result, for the reason the
@@ -4750,7 +4877,7 @@ fn build_function(
                 let vi = op.pos.get().raw();
                 if !OpRef::raw_is_constant(vi) {
                     sink.i64_const(0); // sentinel force token
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -4775,7 +4902,7 @@ fn build_function(
                         }
                         _ => unreachable!(),
                     }
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::FloatNeg => {
@@ -4783,7 +4910,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_neg();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
             OpCode::FloatAbs => {
@@ -4791,7 +4918,7 @@ fn build_function(
                 if !OpRef::raw_is_constant(vi) {
                     emit_resolve_f64(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.f64_abs();
-                    sink.local_set(1 + vi);
+                    sink.local_set(value_types.local(vi));
                 }
             }
 
@@ -4823,14 +4950,14 @@ fn build_function(
 
         // store-on-def: mirror a freshly-defined Ref result into its home slot
         // so a (future) collecting allocation can forward it. The local
-        // `1 + raw` holds the value the matched arm just set; `ref_homes` only
+        // The mapped value local holds the value the matched arm just set; `ref_homes` only
         // keys Ref-typed value ids, so non-Ref / void / constant ops are
         // skipped. Each value-producing arm is operand-stack-neutral, so this
         // appended store is balanced.
         let result = op.pos.get();
         if let Some(h) = ref_homes.home(result) {
             sink.local_get(0);
-            sink.local_get(1 + result.raw());
+            sink.local_get(value_types.local(result.raw()));
             sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
         }
     }
@@ -5068,7 +5195,7 @@ fn resolve_const_bits(constants: &indexmap::IndexMap<u32, i64>, opref: OpRef) ->
 fn emit_resolve(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     opref: OpRef,
 ) {
     if opref.is_constant() {
@@ -5083,8 +5210,8 @@ fn emit_resolve(
         // out of bounds (`raw() == u32::MAX`).
         sink.i64_const(0);
     } else {
-        sink.local_get(1 + opref.raw());
-        if value_types[opref.raw() as usize] == ValType::F64 {
+        sink.local_get(value_types.local(opref.raw()));
+        if value_types.ty(opref.raw()) == ValType::F64 {
             sink.i64_reinterpret_f64();
         }
     }
@@ -5095,7 +5222,7 @@ fn emit_resolve(
 fn emit_resolve_f64(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     opref: OpRef,
 ) {
     if opref.is_constant() {
@@ -5103,8 +5230,8 @@ fn emit_resolve_f64(
         sink.i64_const(val);
         sink.f64_reinterpret_i64();
     } else {
-        debug_assert_eq!(value_types[opref.raw() as usize], ValType::F64);
-        sink.local_get(1 + opref.raw());
+        debug_assert_eq!(value_types.ty(opref.raw()), ValType::F64);
+        sink.local_get(value_types.local(opref.raw()));
     }
 }
 
@@ -5216,7 +5343,7 @@ fn array_len_layout_from_descr(op: &Op) -> (u64, usize) {
 fn emit_array_addr(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
 ) {
     let (base_size, item_size) = op
@@ -5239,7 +5366,7 @@ fn emit_array_addr(
 fn emit_guard_true(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     guard_idx: u32,
     op: &Op,
     block_exit_depth: u32,
@@ -5259,7 +5386,7 @@ fn emit_guard_true(
 fn emit_guard_false(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     guard_idx: u32,
     op: &Op,
     block_exit_depth: u32,
@@ -5359,7 +5486,7 @@ fn next_op_can_accept_cc<'a>(
 fn emit_guard_if_exit(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     guard_idx: u32,
     op: &Op,
     block_exit_depth: u32,
@@ -5373,7 +5500,7 @@ fn emit_guard_if_exit(
 fn emit_guard_spill(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     guard_idx: u32,
     op: &Op,
 ) {
@@ -5452,7 +5579,7 @@ fn apply_binop(sink: &mut InstructionSink<'_>, op: BinOp) {
 fn emit_binop(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     binop: BinOp,
 ) {
@@ -5463,7 +5590,7 @@ fn emit_binop(
     emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
     emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
     apply_binop(sink, binop);
-    sink.local_set(1 + vi);
+    sink.local_set(value_types.local(vi));
 }
 
 /// `UintMulHigh`: high 64 bits of the unsigned 64×64→128 product. Wasm has
@@ -5471,35 +5598,42 @@ fn emit_binop(
 /// a = ah·2³²+al, b = bh·2³²+bl, with carry-safe intermediates
 ///   mid1 = ah·bl + (al·bl >> 32)
 ///   high = ah·bh + (mid1 >> 32) + ((al·bh + (mid1 & 0xFFFFFFFF)) >> 32)
-/// Uses the five scratch locals reserved at `num_vars+1 ..= num_vars+5`.
+/// Uses the five scratch locals reserved after the dense value-local range.
 fn emit_umulhi(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
-    num_vars: u32,
+    value_local_count: u32,
 ) {
     let vi = op.pos.get().raw();
     if OpRef::raw_is_constant(vi) {
         return;
     }
-    emit_umulhi_to_local(sink, constants, value_types, op, num_vars, 1 + vi);
+    emit_umulhi_to_local(
+        sink,
+        constants,
+        value_types,
+        op,
+        value_local_count,
+        value_types.local(vi),
+    );
 }
 
 fn emit_umulhi_to_local(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
-    num_vars: u32,
+    value_local_count: u32,
     output_local: u32,
 ) {
     const MASK32: i64 = 0xFFFF_FFFF;
-    let al = num_vars + 1;
-    let ah = num_vars + 2;
-    let bl = num_vars + 3;
-    let bh = num_vars + 4;
-    let mid1 = num_vars + 5;
+    let al = value_local_count + 1;
+    let ah = value_local_count + 2;
+    let bl = value_local_count + 3;
+    let bh = value_local_count + 4;
+    let mid1 = value_local_count + 5;
 
     // al = a & 0xFFFFFFFF
     emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
@@ -5561,26 +5695,26 @@ fn emit_umulhi_to_local(
 fn emit_ovf_binop(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     binop: BinOp,
-    num_vars: u32,
+    value_local_count: u32,
     ovf_flag_local: u32,
 ) -> bool {
     let vi = op.pos.get().raw();
     if OpRef::raw_is_constant(vi) {
         return false;
     }
-    let result_local = 1 + vi;
+    let result_local = value_types.local(vi);
 
     if matches!(binop, BinOp::I64Mul) {
         // Keep both factors in the umulhi scratch bank. The hot signed-32
         // overflow check below reuses them without resolving the SSA operands
         // again; the slow 64-bit path is free to overwrite the same bank.
         emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
-        sink.local_tee(num_vars + 1);
+        sink.local_tee(value_local_count + 1);
         emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
-        sink.local_tee(num_vars + 2);
+        sink.local_tee(value_local_count + 2);
     } else {
         emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
         emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
@@ -5622,13 +5756,13 @@ fn emit_ovf_binop(
             // every multiplication into a software 64x64->128 product. The
             // exact sign-extension checks preserve the full-width slow path
             // for every value outside that proven-safe domain.
-            sink.local_get(num_vars + 1);
+            sink.local_get(value_local_count + 1);
             sink.i64_extend32_s();
-            sink.local_get(num_vars + 1);
+            sink.local_get(value_local_count + 1);
             sink.i64_eq();
-            sink.local_get(num_vars + 2);
+            sink.local_get(value_local_count + 2);
             sink.i64_extend32_s();
-            sink.local_get(num_vars + 2);
+            sink.local_get(value_local_count + 2);
             sink.i64_eq();
             sink.i32_and();
             sink.if_(BlockType::Empty);
@@ -5638,8 +5772,15 @@ fn emit_ovf_binop(
 
             // Convert the unsigned high word to the signed high word:
             // smulhi = umulhi - ((a >>s 63) & b) - ((b >>s 63) & a).
-            let high_local = num_vars + 1;
-            emit_umulhi_to_local(sink, constants, value_types, op, num_vars, high_local);
+            let high_local = value_local_count + 1;
+            emit_umulhi_to_local(
+                sink,
+                constants,
+                value_types,
+                op,
+                value_local_count,
+                high_local,
+            );
             sink.local_get(high_local);
             emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
             sink.i64_const(63);
@@ -5775,7 +5916,7 @@ fn cond_kind_of(opcode: OpCode) -> Option<CondKind> {
 fn push_cond(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     kind: CondKind,
 ) {
@@ -5829,7 +5970,7 @@ fn push_cond(
 fn push_guard_failure_cond(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     kind: CondKind,
     guard_opcode: OpCode,
@@ -5867,7 +6008,7 @@ fn push_guard_failure_cond(
 fn emit_cond(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     kind: CondKind,
 ) {
@@ -5877,7 +6018,7 @@ fn emit_cond(
     }
     push_cond(sink, constants, value_types, op, kind);
     sink.i64_extend_i32_u();
-    sink.local_set(1 + vi);
+    sink.local_set(value_types.local(vi));
 }
 
 // ── Unary op helper ──
@@ -5885,7 +6026,7 @@ fn emit_cond(
 fn emit_unary_vi(
     sink: &mut InstructionSink<'_>,
     constants: &indexmap::IndexMap<u32, i64>,
-    value_types: &[ValType],
+    value_types: &ValueLocals,
     op: &Op,
     prefix: impl FnOnce(&mut InstructionSink<'_>),
     suffix: impl FnOnce(&mut InstructionSink<'_>),
@@ -5895,7 +6036,7 @@ fn emit_unary_vi(
         prefix(sink);
         emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
         suffix(sink);
-        sink.local_set(1 + vi);
+        sink.local_set(value_types.local(vi));
     }
 }
 

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -78,7 +78,7 @@ pub struct WasmFrameData {
     /// exited through a GuardNoException / GuardException (0 = none), surfaced
     /// via `grab_exc_value`.
     pub exc_value: i64,
-    /// Slots handed to [`crate::wasm_gc_add_root`] by [`WasmFrameData::boxed`],
+    /// Slots handed to [`crate::wasm_gc_add_roots`] by [`WasmFrameData::boxed`],
     /// released again in `Drop`.
     roots: Vec<usize>,
 }
@@ -108,28 +108,160 @@ impl WasmFrameData {
             exc_value,
             roots: Vec::new(),
         });
-        let mut roots: Vec<usize> = Vec::new();
-        for i in 0..data.raw_values.len() {
-            if data.fail_descr.fail_arg_types.get(i) == Some(&Type::Ref) {
-                roots.push(&mut data.raw_values[i] as *mut i64 as usize);
+        let ref_count = data
+            .fail_descr
+            .fail_arg_types
+            .iter()
+            .take(data.raw_values.len())
+            .filter(|ty| **ty == Type::Ref)
+            .count();
+        if ref_count != 0 || data.exc_value != 0 {
+            let mut roots = Vec::with_capacity(ref_count + usize::from(data.exc_value != 0));
+            for i in 0..data.raw_values.len() {
+                if data.fail_descr.fail_arg_types.get(i) == Some(&Type::Ref) {
+                    roots.push(&mut data.raw_values[i] as *mut i64 as usize);
+                }
             }
+            // `grab_exc_value` hands this out as a `GcRef` too, and the resume path
+            // reads it after it has already allocated. A null `GcRef` needs no root.
+            if data.exc_value != 0 {
+                roots.push(&mut data.exc_value as *mut i64 as usize);
+            }
+            unsafe { crate::wasm_gc_add_roots(&roots) };
+            data.roots = roots;
         }
-        // `grab_exc_value` hands this out as a `GcRef` too, and the resume path
-        // reads it after it has already allocated.
-        roots.push(&mut data.exc_value as *mut i64 as usize);
-        for slot in &roots {
-            unsafe { crate::wasm_gc_add_root(*slot as *mut majit_ir::GcRef) };
-        }
-        data.roots = roots;
         data
     }
 }
 
 impl Drop for WasmFrameData {
     fn drop(&mut self) {
-        for slot in self.roots.drain(..) {
-            crate::wasm_gc_remove_root(slot as *mut majit_ir::GcRef);
+        if self.roots.is_empty() {
+            return;
         }
+        // Remove in reverse push order so RootSet::remove stays on its
+        // O(1) stack-pop path.
+        crate::wasm_gc_remove_roots(self.roots.drain(..).rev());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use majit_gc::GcAllocator;
+    use majit_ir::GcRef;
+
+    use super::{Type, WasmFailDescr, WasmFrameData};
+
+    struct RootCountingGc(Arc<AtomicUsize>);
+
+    impl GcAllocator for RootCountingGc {
+        fn alloc_nursery(&mut self, _size: usize) -> GcRef {
+            GcRef(0)
+        }
+
+        fn alloc_nursery_no_collect(&mut self, _size: usize) -> GcRef {
+            GcRef(0)
+        }
+
+        fn alloc_varsize(&mut self, _base_size: usize, _item_size: usize, _length: usize) -> GcRef {
+            GcRef(0)
+        }
+
+        fn alloc_varsize_no_collect(
+            &mut self,
+            _base_size: usize,
+            _item_size: usize,
+            _length: usize,
+        ) -> GcRef {
+            GcRef(0)
+        }
+
+        fn write_barrier(&mut self, _obj: GcRef) {}
+
+        fn jit_remember_young_pointer_from_array(&mut self, _obj: GcRef) {}
+
+        fn remember_young_pointer_from_array2(
+            &mut self,
+            _obj: GcRef,
+            _index: usize,
+            _card_page_shift: u32,
+        ) {
+        }
+
+        fn collect_nursery(&mut self) {}
+
+        fn collect_full(&mut self) {}
+
+        fn nursery_free(&self) -> *mut u8 {
+            std::ptr::null_mut()
+        }
+
+        fn nursery_free_addr(&self) -> usize {
+            0
+        }
+
+        fn nursery_top(&self) -> *const u8 {
+            std::ptr::null()
+        }
+
+        fn nursery_top_addr(&self) -> usize {
+            0
+        }
+
+        fn max_nursery_object_size(&self) -> usize {
+            0
+        }
+
+        unsafe fn add_root(&mut self, _root: *mut GcRef) {
+            self.0.fetch_add(1, Ordering::SeqCst);
+        }
+
+        fn remove_root(&mut self, _root: *mut GcRef) {
+            self.0.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    fn install_root_counting_gc() -> Arc<AtomicUsize> {
+        let roots = Arc::new(AtomicUsize::new(0));
+        crate::install_gc_box(Box::new(RootCountingGc(Arc::clone(&roots))));
+        roots
+    }
+
+    fn fail_descr(fail_arg_types: Vec<Type>) -> Arc<WasmFailDescr> {
+        Arc::new(WasmFailDescr {
+            fail_index: 0,
+            trace_id: 0,
+            fail_arg_types,
+            is_finish: false,
+            meta_descr: None,
+        })
+    }
+
+    #[test]
+    fn boxed_roots_ref_slots_and_nonzero_exception_until_drop() {
+        let roots = install_root_counting_gc();
+        let before = roots.load(Ordering::SeqCst);
+        let frame = WasmFrameData::boxed(
+            vec![0x10, 42, 0, 0x20],
+            fail_descr(vec![Type::Ref, Type::Int, Type::Float, Type::Ref]),
+            0x30,
+        );
+        assert_eq!(roots.load(Ordering::SeqCst), before + 3);
+        drop(frame);
+        assert_eq!(roots.load(Ordering::SeqCst), before);
+    }
+
+    #[test]
+    fn boxed_without_refs_or_exception_does_not_bracket_roots() {
+        let roots = install_root_counting_gc();
+        let before = roots.load(Ordering::SeqCst);
+        let frame = WasmFrameData::boxed(vec![1, 2], fail_descr(vec![Type::Int, Type::Float]), 0);
+        assert_eq!(roots.load(Ordering::SeqCst), before);
+        drop(frame);
+        assert_eq!(roots.load(Ordering::SeqCst), before);
     }
 }
 

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1106,9 +1106,33 @@ pub(crate) unsafe fn wasm_gc_add_root(slot: *mut GcRef) {
     with_wasm_active_gc_mut(|gc| unsafe { gc.add_root(slot) });
 }
 
+/// Batched [`wasm_gc_add_root`] for one stack-shaped root bracket.
+///
+/// # Safety
+/// Every slot must remain valid until removed with [`wasm_gc_remove_roots`].
+pub(crate) unsafe fn wasm_gc_add_roots(slots: &[usize]) {
+    if slots.is_empty() {
+        return;
+    }
+    with_wasm_active_gc_mut(|gc| {
+        for &slot in slots {
+            unsafe { gc.add_root(slot as *mut GcRef) };
+        }
+    });
+}
+
 /// Companion to [`wasm_gc_add_root`].
 pub(crate) fn wasm_gc_remove_root(slot: *mut GcRef) {
     with_wasm_active_gc_mut(|gc| gc.remove_root(slot));
+}
+
+/// Batched [`wasm_gc_remove_root`] for one stack-shaped root bracket.
+pub(crate) fn wasm_gc_remove_roots(slots: impl Iterator<Item = usize>) {
+    with_wasm_active_gc_mut(|gc| {
+        for slot in slots {
+            gc.remove_root(slot as *mut GcRef);
+        }
+    });
 }
 
 /// Host-side write-barrier trampoline for the interpreter (mapdict / list /

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -9,7 +9,7 @@ use std::process::Command;
 
 use majit_backend_wasm::codegen;
 use majit_ir::operand::Operand;
-use majit_ir::{EffectInfo, ExtraEffect, InputArg, Op, OpCode, OpRef, PyreHelperKind, Type};
+use majit_ir::{EffectInfo, InputArg, Op, OpCode, OpRef, PyreHelperKind, Type};
 use smallvec::smallvec;
 use wasmi::{Engine, Linker, Memory, MemoryType, Module, Store};
 
@@ -968,13 +968,29 @@ fn test_call_generates_import() {
     assert!(has_jit_call, "module should import jit_call_compact");
 }
 
-fn true_void_call(helper: PyreHelperKind) -> Op {
+fn void_call(arg_types: Vec<Type>, args: &[OpRef], result_size: usize) -> Op {
+    void_call_with_helper(arg_types, args, result_size, PyreHelperKind::None)
+}
+
+fn void_call_with_helper(
+    arg_types: Vec<Type>,
+    args: &[OpRef],
+    result_size: usize,
+    helper: PyreHelperKind,
+) -> Op {
+    let mut operands = vec![rb(OpRef::const_int(42))];
+    operands.extend(args.iter().copied().map(rb));
+    let op = Op::new(OpCode::CallN, &operands);
     let mut effect = EffectInfo::default();
-    effect.extraeffect = ExtraEffect::CannotRaise;
-    effect.can_collect = false;
     effect.pyre_helper = helper;
-    let op = Op::new(OpCode::CallN, &[rb(OpRef::const_int(42))]);
-    op.setdescr(majit_ir::make_call_descr(vec![], Type::Void, effect));
+    op.setdescr(majit_ir::descr::make_call_descr_full(
+        0,
+        arg_types,
+        Type::Void,
+        false,
+        result_size,
+        effect,
+    ));
     op
 }
 
@@ -1028,11 +1044,28 @@ fn indirect_call_types_and_drop_count(bytes: &[u8]) -> (Vec<(u32, u32)>, usize) 
     (indirect_calls, drops)
 }
 
+fn function_type(
+    bytes: &[u8],
+    type_index: usize,
+) -> (Vec<wasmparser::ValType>, Vec<wasmparser::ValType>) {
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::TypeSection(types) = payload.unwrap() {
+            let ty = types
+                .into_iter_err_on_gc_types()
+                .nth(type_index)
+                .unwrap_or_else(|| panic!("missing function type {type_index}"))
+                .unwrap();
+            return (ty.params().to_vec(), ty.results().to_vec());
+        }
+    }
+    panic!("module has no type section");
+}
+
 #[test]
-fn test_clear_in_flight_exception_uses_true_void_indirect_call() {
+fn test_nullary_true_void_call_uses_indirect_call_without_drop() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
     let ops = vec![
-        true_void_call(PyreHelperKind::ClearInFlightException),
+        void_call(vec![], &[], 0),
         Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
     ];
     let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
@@ -1047,11 +1080,137 @@ fn test_clear_in_flight_exception_uses_true_void_indirect_call() {
 }
 
 #[test]
-fn test_untagged_size_zero_void_call_keeps_trampoline() {
-    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+fn test_true_void_int_ref_call_uses_void_result_type_without_drop() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Ref, 1),
+    ];
     let ops = vec![
-        true_void_call(PyreHelperKind::None),
+        void_call(
+            vec![Type::Int, Type::Ref],
+            &[OpRef::input_arg_int(0), OpRef::input_arg_ref(1)],
+            0,
+        ),
         Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    assert!(has_table_import(&bytes));
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), None);
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(3, 0)]);
+    assert_eq!(
+        function_type(&bytes, 3),
+        (
+            vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
+            vec![]
+        )
+    );
+    assert_eq!(drops, 0, "a genuine void call has no result to drop");
+}
+
+#[test]
+fn test_true_void_family_does_not_shift_new_call_type() {
+    use majit_ir::descr::SimpleSizeDescr;
+    use std::sync::Arc;
+
+    let inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Ref, 1),
+        InputArg::from_type(Type::Int, 2),
+    ];
+    let new_op = make_op(OpCode::New, &[], OpRef::ref_op(3));
+    new_op.setdescr(Arc::new(SimpleSizeDescr::new(0, 32, 53)));
+    let ops = vec![
+        void_call(
+            vec![Type::Ref, Type::Ref],
+            &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
+            0,
+        ),
+        new_op,
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(2))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(6, 0), (1, 0), (3, 0), (1, 0)]);
+    assert_eq!(
+        function_type(&bytes, 6),
+        (
+            vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
+            vec![]
+        )
+    );
+    assert_eq!(
+        function_type(&bytes, 3),
+        (
+            vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
+            vec![wasmparser::ValType::I64]
+        )
+    );
+    assert_eq!(drops, 0);
+}
+
+#[test]
+fn test_list_append_word_abi_and_new_type_indices_match_declared_i64_types() {
+    use majit_ir::descr::SimpleSizeDescr;
+    use std::sync::Arc;
+
+    let inputargs = vec![
+        InputArg::from_type(Type::Ref, 0),
+        InputArg::from_type(Type::Ref, 1),
+        InputArg::from_type(Type::Int, 2),
+    ];
+    let new_op = make_op(OpCode::New, &[], OpRef::ref_op(3));
+    new_op.setdescr(Arc::new(SimpleSizeDescr::new(0, 32, 53)));
+    let ops = vec![
+        void_call_with_helper(
+            vec![Type::Ref, Type::Ref],
+            &[OpRef::input_arg_ref(0), OpRef::input_arg_ref(1)],
+            8,
+            PyreHelperKind::ListAppendValue,
+        ),
+        new_op,
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(2))]),
+    ];
+    let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+
+    validate_wasm(&bytes);
+    assert_eq!(guards.len(), 1);
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(3, 0), (1, 0), (3, 0), (1, 0)]);
+    assert_eq!(
+        function_type(&bytes, indirect_calls[0].0 as usize),
+        (
+            vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
+            vec![wasmparser::ValType::I64]
+        ),
+        "jit_list_append returns an ignored machine word"
+    );
+    assert_eq!(
+        function_type(&bytes, indirect_calls[2].0 as usize),
+        (
+            vec![wasmparser::ValType::I64, wasmparser::ValType::I64],
+            vec![wasmparser::ValType::I64]
+        ),
+        "New must reference its declared (i64, i64) -> i64 type"
+    );
+    assert_eq!(drops, 1, "only jit_list_append's result is discarded");
+}
+
+#[test]
+fn test_true_void_float_arg_call_keeps_trampoline() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Float, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let ops = vec![
+        void_call(vec![Type::Float], &[OpRef::input_arg_float(0)], 0),
+        Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(1))]),
     ];
     let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
 
@@ -1063,32 +1222,28 @@ fn test_untagged_size_zero_void_call_keeps_trampoline() {
 }
 
 #[test]
-fn test_malformed_tagged_void_call_keeps_trampoline() {
+fn test_void_word_abi_call_uses_i64_result_type_and_drop() {
     let inputargs = vec![InputArg::from_type(Type::Int, 0)];
-    let mut effect = EffectInfo::default();
-    effect.extraeffect = ExtraEffect::CannotRaise;
-    effect.can_collect = false;
-    effect.pyre_helper = PyreHelperKind::ClearInFlightException;
-    let call = Op::new(
-        OpCode::CallN,
-        &[rb(OpRef::const_int(42)), rb(OpRef::input_arg_int(0))],
-    );
-    call.setdescr(majit_ir::make_call_descr(
-        vec![Type::Int],
-        Type::Void,
-        effect,
-    ));
     let ops = vec![
-        call,
+        void_call(vec![Type::Int], &[OpRef::input_arg_int(0)], 8),
         Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]),
     ];
     let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
 
     validate_wasm(&bytes);
     assert_eq!(guards.len(), 1);
-    assert_eq!(import_func_type(&bytes, "jit_call_compact"), Some(1));
-    let (indirect_calls, _) = indirect_call_types_and_drop_count(&bytes);
-    assert!(indirect_calls.is_empty());
+    assert!(has_table_import(&bytes));
+    assert_eq!(import_func_type(&bytes, "jit_call_compact"), None);
+    let (indirect_calls, drops) = indirect_call_types_and_drop_count(&bytes);
+    assert_eq!(indirect_calls, vec![(2, 0), (1, 0)]);
+    assert_eq!(
+        function_type(&bytes, 2),
+        (
+            vec![wasmparser::ValType::I64],
+            vec![wasmparser::ValType::I64]
+        )
+    );
+    assert_eq!(drops, 1, "the ignored word result must be dropped");
 }
 
 #[test]
@@ -1100,7 +1255,7 @@ fn test_true_void_type_index_accounts_for_trampoline_type() {
             &[OpRef::const_int(43), OpRef::input_arg_int(0)],
             OpRef::int_op(1),
         ),
-        true_void_call(PyreHelperKind::ClearInFlightException),
+        void_call(vec![], &[], 0),
         Op::new(OpCode::Finish, &[rb(OpRef::int_op(1))]),
     ];
     let (bytes, guards) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -628,50 +628,56 @@ fn test_int_mul_ovf_emits_signed32_fast_path_and_full_width_fallback() {
     );
 }
 
-/// PyPy's native backends append guard recovery stubs after the hot trace.
-/// Keep fail-argument stores out of the successful guard arm in Wasm too: a
-/// selector branch should reach one cold `br_table` dispatcher, where the
-/// original int/ref/float-bit spills are performed.
+/// Each guard spills its own fail arguments before it branches to the shared
+/// bridge-dispatch epilogue.
 #[test]
-fn test_guard_recovery_is_out_of_line() {
+fn test_guard_fail_args_spill_in_their_own_failure_arms() {
     let inputargs = vec![
         InputArg::from_type(Type::Int, 0),
-        InputArg::from_type(Type::Ref, 1),
-        InputArg::from_type(Type::Float, 2),
+        InputArg::from_type(Type::Int, 1),
     ];
-    let fail_args = smallvec![
+    let first_guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::input_arg_int(0))]);
+    first_guard.setfailargs(smallvec![
         rb(OpRef::input_arg_int(0)),
-        rb(OpRef::input_arg_ref(1)),
-        rb(OpRef::input_arg_float(2)),
-    ];
-    let guard = Op::new(OpCode::GuardTrue, &[rb(OpRef::input_arg_int(0))]);
-    guard.setfailargs(fail_args.clone());
-    let finish = Op::new(OpCode::Finish, &fail_args);
-    finish.setfailargs(fail_args);
-    let (bytes, guards) =
-        build_module_default(&inputargs, &[guard, finish], &indexmap::IndexMap::new());
+        rb(OpRef::input_arg_int(1)),
+    ]);
+    let second_guard = Op::new(OpCode::GuardFalse, &[rb(OpRef::input_arg_int(1))]);
+    second_guard.setfailargs(smallvec![
+        rb(OpRef::input_arg_int(1)),
+        rb(OpRef::input_arg_int(0)),
+    ]);
+    let finish = Op::new(OpCode::Finish, &[rb(OpRef::input_arg_int(0))]);
+    let (bytes, guards) = build_module_default(
+        &inputargs,
+        &[first_guard, second_guard, finish],
+        &indexmap::IndexMap::new(),
+    );
     validate_wasm(&bytes);
-    assert_eq!(guards.len(), 2);
+    assert_eq!(guards.len(), 3);
 
-    let mut control_is_if = Vec::new();
-    let mut stores_inside_if = 0;
+    let mut control_stack = Vec::new();
+    let mut stores_per_guard_arm = Vec::new();
     let mut br_tables = 0;
     for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
         if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
             let mut operators = body.get_operators_reader().unwrap();
             while !operators.eof() {
                 match operators.read().unwrap() {
-                    wasmparser::Operator::If { .. } => control_is_if.push(true),
+                    wasmparser::Operator::If { .. } => control_stack.push(Some(0usize)),
                     wasmparser::Operator::Block { .. } | wasmparser::Operator::Loop { .. } => {
-                        control_is_if.push(false);
+                        control_stack.push(None);
                     }
                     wasmparser::Operator::End => {
-                        control_is_if.pop();
+                        if let Some(Some(stores)) = control_stack.pop() {
+                            stores_per_guard_arm.push(stores);
+                        }
                     }
-                    wasmparser::Operator::I64Store { .. }
-                        if control_is_if.iter().any(|inside_if| *inside_if) =>
-                    {
-                        stores_inside_if += 1;
+                    wasmparser::Operator::I64Store { .. } => {
+                        if let Some(Some(stores)) =
+                            control_stack.iter_mut().rev().find(|frame| frame.is_some())
+                        {
+                            *stores += 1;
+                        }
                     }
                     wasmparser::Operator::BrTable { .. } => br_tables += 1,
                     _ => {}
@@ -679,8 +685,11 @@ fn test_guard_recovery_is_out_of_line() {
             }
         }
     }
-    assert_eq!(stores_inside_if, 0, "guard arms must not spill fail args");
-    assert_eq!(br_tables, 1, "all exits must share one cold dispatcher");
+    assert_eq!(stores_per_guard_arm, [3, 3]);
+    assert_eq!(
+        br_tables, 0,
+        "guard exits must not use a selector dispatcher"
+    );
 }
 
 #[test]

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -477,6 +477,52 @@ fn build_module_default(
     )
 }
 
+fn emitted_local_count(bytes: &[u8]) -> u32 {
+    wasmparser::Parser::new(0)
+        .parse_all(bytes)
+        .find_map(|payload| match payload.unwrap() {
+            wasmparser::Payload::CodeSectionEntry(body) => Some(
+                body.get_locals_reader()
+                    .unwrap()
+                    .into_iter()
+                    .map(|local| local.unwrap().0)
+                    .sum(),
+            ),
+            _ => None,
+        })
+        .expect("generated module must contain its trace function")
+}
+
+#[test]
+fn sparse_value_ids_declare_only_addressable_value_locals() {
+    let inputargs = vec![
+        InputArg::from_type(Type::Int, 0),
+        InputArg::from_type(Type::Int, 1),
+    ];
+    let ops = vec![
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), OpRef::input_arg_int(1)],
+            OpRef::int_op(2),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::int_op(2), OpRef::const_int(1)],
+            OpRef::int_op(40),
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::int_op(40), OpRef::const_int(1)],
+            OpRef::int_op(900),
+        ),
+        Op::new(OpCode::Finish, &[rb(OpRef::int_op(900))]),
+    ];
+
+    let (bytes, _) = build_module_default(&inputargs, &ops, &indexmap::IndexMap::new());
+    validate_wasm(&bytes);
+    assert_eq!(emitted_local_count(&bytes), 12);
+}
+
 /// Count the direct `wasm_jit_write_barrier` table calls by their unique table
 /// target immediate.  The direct lowering places that `i32.const` immediately
 /// before its `call_indirect`.

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -477,6 +477,125 @@ fn build_module_default(
     )
 }
 
+/// Count the direct `wasm_jit_write_barrier` table calls by their unique table
+/// target immediate.  The direct lowering places that `i32.const` immediately
+/// before its `call_indirect`.
+fn direct_write_barrier_call_count(bytes: &[u8], target: i32) -> usize {
+    let mut count = 0;
+    for payload in wasmparser::Parser::new(0).parse_all(bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            let mut target_on_stack = false;
+            while !operators.eof() {
+                match operators.read().unwrap() {
+                    wasmparser::Operator::I32Const { value } if value == target => {
+                        target_on_stack = true;
+                    }
+                    wasmparser::Operator::CallIndirect { .. } if target_on_stack => {
+                        count += 1;
+                        target_on_stack = false;
+                    }
+                    _ => target_on_stack = false,
+                }
+            }
+        }
+    }
+    count
+}
+
+fn build_module_with_write_barrier_target(
+    inputargs: &[InputArg],
+    ops: &[Op],
+    write_barrier_target: i64,
+) -> Vec<u8> {
+    let (bytes, _, _, _, _) = codegen::build_wasm_module(
+        inputargs,
+        ops,
+        &indexmap::IndexMap::new(),
+        Some(0),
+        &HashMap::new(),
+        &codegen::GuardGcTypeInfo::default(),
+        codegen::AllocHelpers::default(),
+        write_barrier_target,
+        None,
+        0,
+        0,
+        0,
+        0,
+        0,
+        // The allocated trace keeps both Ref inputs live across New; reserve
+        // their homes in the shared helper geometry.
+        codegen::FrameGeometry::compact(4, 2, 0),
+        codegen::CaParams::default(),
+    )
+    .expect("wasm codegen should succeed");
+    bytes
+}
+
+#[test]
+fn write_barrier_elision_keeps_one_barrier_per_base() {
+    use majit_ir::descr::{SimpleFieldDescr, SimpleSizeDescr};
+    use std::sync::Arc;
+
+    const WB_TARGET: i64 = 0x4a11;
+    let pointer_field = Arc::new(SimpleFieldDescr::new(0, 0, 8, Type::Ref, false));
+    let finish = Op::new(OpCode::Finish, &[]);
+
+    let new_obj = make_op(OpCode::New, &[], OpRef::ref_op(2));
+    new_obj.setdescr(Arc::new(SimpleSizeDescr::new(0, 16, 1)));
+    let new_store_a = Op::new(
+        OpCode::SetfieldGc,
+        &[rb(OpRef::ref_op(2)), rb(OpRef::input_arg_ref(0))],
+    );
+    new_store_a.setdescr(pointer_field.clone());
+    let new_store_b = Op::new(
+        OpCode::SetfieldGc,
+        &[rb(OpRef::ref_op(2)), rb(OpRef::input_arg_ref(1))],
+    );
+    new_store_b.setdescr(pointer_field.clone());
+    let allocated = build_module_with_write_barrier_target(
+        &[
+            InputArg::from_type(Type::Ref, 0),
+            InputArg::from_type(Type::Ref, 1),
+        ],
+        &[new_obj, new_store_a, new_store_b, finish.clone()],
+        WB_TARGET,
+    );
+    validate_wasm(&allocated);
+    assert_eq!(
+        direct_write_barrier_call_count(&allocated, WB_TARGET as i32),
+        1,
+        "an allocation result is not seeded into the applied set — its generation \
+         is a runtime choice — so the first store barriers and the second is elided"
+    );
+
+    let live_store_a = Op::new(
+        OpCode::SetfieldGc,
+        &[rb(OpRef::input_arg_ref(0)), rb(OpRef::input_arg_ref(1))],
+    );
+    live_store_a.setdescr(pointer_field.clone());
+    let live_store_b = Op::new(
+        OpCode::SetfieldGc,
+        &[rb(OpRef::input_arg_ref(0)), rb(OpRef::input_arg_ref(2))],
+    );
+    live_store_b.setdescr(pointer_field);
+    let repeated_livein = build_module_with_write_barrier_target(
+        &[
+            InputArg::from_type(Type::Ref, 0),
+            InputArg::from_type(Type::Ref, 1),
+            InputArg::from_type(Type::Ref, 2),
+        ],
+        &[live_store_a, live_store_b, finish],
+        WB_TARGET,
+    );
+    validate_wasm(&repeated_livein);
+    assert_eq!(
+        direct_write_barrier_call_count(&repeated_livein, WB_TARGET as i32),
+        1,
+        "repeated stores into one live-in base must emit one write-barrier call"
+    );
+}
+
 fn execute_ovf_trace_with_guard(
     opcode: OpCode,
     guard_opcode: OpCode,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -3355,6 +3355,27 @@ impl JitCodeBuilder {
         );
     }
 
+    pub fn residual_call_void_canonical_via_target_with_effect_info_and_word_abi(
+        &mut self,
+        fn_ptr_idx: u16,
+        arg_regs: &[JitCallArg],
+        effect_info: majit_ir::descr::EffectInfo,
+        void_word_abi: bool,
+    ) {
+        self.emit_canonical_call_void_via_target_with_word_abi(
+            (
+                jitcode::insns::BC_RESIDUAL_CALL_R_V,
+                jitcode::insns::BC_RESIDUAL_CALL_IR_V,
+                jitcode::insns::BC_RESIDUAL_CALL_IRF_V,
+            ),
+            fn_ptr_idx,
+            arg_regs,
+            effect_info,
+            void_word_abi,
+            "residual_call_void_canonical_via_target",
+        );
+    }
+
     /// Emit the canonical `residual_call_{r,ir,irf}_v` opname/argcodes byte
     /// layout.
     ///
@@ -3602,6 +3623,25 @@ impl JitCodeBuilder {
         effect_info: majit_ir::descr::EffectInfo,
         helper_name: &'static str,
     ) {
+        self.emit_canonical_call_void_via_target_with_word_abi(
+            opcodes,
+            fn_ptr_idx,
+            arg_regs,
+            effect_info,
+            false,
+            helper_name,
+        );
+    }
+
+    fn emit_canonical_call_void_via_target_with_word_abi(
+        &mut self,
+        opcodes: (u8, u8, u8),
+        fn_ptr_idx: u16,
+        arg_regs: &[JitCallArg],
+        effect_info: majit_ir::descr::EffectInfo,
+        void_word_abi: bool,
+        helper_name: &'static str,
+    ) {
         let target = match self.descrs.get(fn_ptr_idx as usize) {
             Some(RuntimeBhDescr::Call(target)) => *target.as_ref(),
             other => panic!(
@@ -3626,6 +3666,11 @@ impl JitCodeBuilder {
             majit_ir::value::Type::Void,
             effect_info,
         );
+        let calldescr = if void_word_abi {
+            calldescr.with_void_word_abi()
+        } else {
+            calldescr
+        };
         let calldescr_idx =
             self.emit_canonical_call_void(opcodes, concrete_ptr, arg_regs, calldescr);
         self.call_descr_to_call_target.insert(calldescr_idx, target);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5045,6 +5045,7 @@ enum AssemblerDescrKey {
         result_signed: bool,
         result_size: usize,
         result_erased: crate::jitcode::CallResultErasedKey,
+        void_word_abi: bool,
         effect: EffectInfoKey,
     },
     /// RPython uses the JitCode object itself as an AbstractDescr for
@@ -5059,6 +5060,7 @@ enum AssemblerDescrKey {
         result_signed: bool,
         result_size: usize,
         result_erased: crate::jitcode::CallResultErasedKey,
+        void_word_abi: bool,
         effect: EffectInfoKey,
     },
     Switch(Vec<(i64, usize)>),
@@ -5171,6 +5173,7 @@ impl AssemblerDescrKey {
                 result_signed: calldescr.result_signed,
                 result_size: calldescr.result_size,
                 result_erased: calldescr.result_erased,
+                void_word_abi: calldescr.void_word_abi,
                 effect: EffectInfoKey::from_effect_info(&calldescr.extra_info),
             },
             crate::jitcode::BhDescr::JitCode {
@@ -5185,6 +5188,7 @@ impl AssemblerDescrKey {
                 result_signed: calldescr.result_signed,
                 result_size: calldescr.result_size,
                 result_erased: calldescr.result_erased,
+                void_word_abi: calldescr.void_word_abi,
                 effect: EffectInfoKey::from_effect_info(&calldescr.extra_info),
             },
             crate::jitcode::BhDescr::Switch { dict, .. } => {
@@ -5920,6 +5924,7 @@ mod tests {
             result_signed: false,
             result_size: 8,
             result_erased: crate::jitcode::CallResultErasedKey::Unsigned,
+            void_word_abi: false,
             extra_info: effect.clone(),
         };
         let raw_address = crate::jitcode::BhCallDescr {
@@ -5928,6 +5933,7 @@ mod tests {
             result_signed: false,
             result_size: 8,
             result_erased: crate::jitcode::CallResultErasedKey::Address,
+            void_word_abi: false,
             extra_info: effect,
         };
 

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -263,6 +263,7 @@ impl CallDescriptor {
             result_signed: self.result_signed,
             result_size: self.result_size,
             result_erased: self.result_erased,
+            void_word_abi: self.result_type == 'v' && self.result_size == 8,
             extra_info: self.extra_info.clone(),
         }
     }

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -924,6 +924,11 @@ pub struct BhCallDescr {
     pub result_size: usize,
     /// RPython `descr.py:665` `RESULT_ERASED`.
     pub result_erased: CallResultErasedKey,
+    /// A void-recorded call whose C callee returns an ignored machine word.
+    /// `result_type` stays `'v'`; the runtime descriptor uses an eight-byte
+    /// result layout so signature-exact backends call the true ABI.
+    #[serde(default)]
+    pub void_word_abi: bool,
     /// RPython `CallDescr.extrainfo` (`descr.py:453`,
     /// `effectinfo.py:13-263`).
     pub extra_info: majit_ir::descr::EffectInfo,
@@ -999,6 +1004,7 @@ impl BhCallDescr {
                 // char-specific erased key.
                 result_erased
             },
+            void_word_abi: result_class == 'v' && result_size == 8,
             extra_info: cd.get_extra_info().clone(),
         }
     }
@@ -1016,6 +1022,7 @@ impl BhCallDescr {
             result_signed,
             result_size,
             result_erased,
+            void_word_abi: false,
             extra_info,
         }
     }
@@ -1042,8 +1049,19 @@ impl BhCallDescr {
                 result_type == majit_ir::value::Type::Int,
                 result_size,
             ),
+            void_word_abi: false,
             extra_info,
         }
+    }
+
+    pub fn with_void_word_abi(mut self) -> Self {
+        assert_eq!(
+            self.result_type, 'v',
+            "void-word ABI requires a void-recorded call descriptor",
+        );
+        self.result_size = 8;
+        self.void_word_abi = true;
+        self
     }
 }
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -136,6 +136,15 @@ WASM_ENGINE = "wasmtime"
 # slower still on loaded CI runners, so give it extra headroom by default to
 # avoid flaky timeouts. Overridable with --wasm-timeout-scale.
 WASM_TIMEOUT_SCALE = 4.0
+# Ceiling on wasm's execution-only user-CPU as a multiple of dynasm's on the
+# same fixture, both startup-subtracted. Unlike the vs-cpython / vs-pypy gates
+# this baseline is not a per-bench tuned constant: it is dynasm's own time from
+# the same invocation, so the pair sees one host under one load and there is no
+# recorded number that can age. Gated only when dynasm actually ran the fixture
+# in this run and its execution-only time clears FLOOR_GATE_MIN_BASELINE_S;
+# below that the denominator is startup noise, and the comparison table marks
+# the ratio `~` the way the pypy gates already do.
+WASM_MAX_DYNASM_RATIO = 3.0
 # Native Windows CI can spend substantially more wall time than reported
 # process user-CPU while antivirus and concurrent matrix jobs contend for the
 # runner.  Keep the timeout as a hang guard by granting native backends 2x
@@ -1351,6 +1360,15 @@ class Check:
         # interpreter/backend key -> measured empty-program user-CPU startup (s).
         # Populated by measure_startups(); missing key => 0.0 (no subtraction).
         self.startup = {}
+        # (backend, bench name) -> raw user-CPU of that backend's run in THIS
+        # invocation. Feeds the wasm-vs-dynasm gate, which needs a baseline
+        # measured on the same host under the same load; a recorded one would
+        # age out of the machine it was taken on.
+        self.bench_elapsed = {}
+        # Fixtures where the wasm run had no dynasm time to divide by, so
+        # WASM_MAX_DYNASM_RATIO was never applied. Reported in the summary: an
+        # unevaluated gate otherwise prints the same green as a satisfied one.
+        self.wasm_ratio_ungated = []
         self.snapshot_diffs = []
         self.snapshot_missing = []
         self.jitstats_diffs = []
@@ -2150,6 +2168,12 @@ class Check:
             self._append_comparison(backend, name, t_cpython, t_pypy, "WRONG")
             return
 
+        # Recorded before the gates so a later median retry cannot make one
+        # backend's stored time depend on which gates its own run happened to
+        # trip. dynasm runs before wasm in ALL_BACKENDS, so the wasm gate below
+        # finds this fixture's dynasm time already in place.
+        self.bench_elapsed[(backend, name)] = elapsed
+
         def _ratio(elapsed_val, pypy_val):
             num = self._exec_time(backend, elapsed_val)
             den = self._exec_time("pypy", pypy_val)
@@ -2226,6 +2250,37 @@ class Check:
                     f"({ratio} vs pypy)",
                 )
             )
+
+        # wasm carries no tuned per-fixture ratio, so it gates against dynasm's
+        # execution-only time from this same invocation instead. Placed after
+        # the other ratio gates so a fixture that is slow against several
+        # baselines still reports each one.
+        if backend == "wasm":
+            dynasm_elapsed = self.bench_elapsed.get(("dynasm", name))
+            if dynasm_elapsed is None:
+                self.wasm_ratio_ungated.append(name)
+            elif not self._baseline_exec_time_clamped("dynasm", dynasm_elapsed):
+                passed, bound, checked_elapsed, checked_baseline, retry_note = (
+                    self._performance_gate_passed(
+                        backend, script, timeout, elapsed,
+                        WASM_MAX_DYNASM_RATIO, dynasm_elapsed,
+                        [self._pyre("dynasm"), script], pypy_output, "dynasm",
+                    )
+                )
+                if not passed:
+                    detail = self._gate_fail_detail(
+                        backend, "dynasm", checked_elapsed, checked_baseline,
+                        WASM_MAX_DYNASM_RATIO, bound,
+                    )
+                    suffix = f" ({retry_note})" if retry_note else ""
+                    failures.append(
+                        (
+                            f"{red('SLOWER')}  pyre {detail}{suffix}",
+                            detail,
+                            fmt_time(f"{elapsed:.2f}"),
+                            f"({ratio} vs pypy)",
+                        )
+                    )
 
         snap_status, snap_reason = self._apply_snapshot_gate(
             backend, name, script, output, stderr, elapsed, timeout,
@@ -2615,6 +2670,17 @@ class Check:
                 dim(
                     f"cpython reference skipped (>{SYNTHETIC_CPYTHON_REFERENCE_TIMEOUT_S:g}s) "
                     f"for {len(self.cpython_reference_skips)}: {names}"
+                )
+            )
+        # A wasm run with no dynasm run beside it leaves WASM_MAX_DYNASM_RATIO
+        # with nothing to divide by. Said out loud because the per-fixture line
+        # for an unevaluated gate is the same green as a satisfied one.
+        if self.wasm_ratio_ungated:
+            print(
+                dim(
+                    f"wasm/dynasm {WASM_MAX_DYNASM_RATIO:g}x ratio not evaluated for "
+                    f"{len(self.wasm_ratio_ungated)} fixture(s): dynasm did not run "
+                    f"them in this invocation"
                 )
             )
         # The same weaker baseline, asked for rather than discovered. Listed

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -950,7 +950,7 @@ Polarity below follows this file's rule, with one correction it needed: an
 `PYRE_WASM_FORCE_CA_TERMINAL_DECLINE`, `PYRE_WASM_FUEL`,
 `PYRE_WASM_GUEST_PROFILE`, `PYRE_WASM_MODULE`.
 
-### §6c — Default-OFF diagnostics, censuses and probes (54): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (55): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
@@ -975,8 +975,8 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_PROBE_SUBSCR`, `PYRE_PROFILE_PIPELINE`, `PYRE_QMUT_MAPDICT_FORCE`,
 `PYRE_RERAISE_DIAG`, `PYRE_SIZE_SHELL_OWNERS`, `PYRE_SNAPSHOT_DIAG`,
 `PYRE_WASM_DUMP_BAD_TRACE`, `PYRE_WASM_EXEC_TRACE`, `PYRE_WASM_FBW_CENSUS`,
-`PYRE_WASM_GUARD_CENSUS`, `PYRE_WASM_JIT_STATS`, `PYRE_WASM_NO_CACHE`,
-`PYRE_WASM_STARTUP_TRACE`.
+`PYRE_WASM_GUARD_CENSUS`, `PYRE_WASM_JIT_STATS`, `PYRE_WASM_CALL_HIST`,
+`PYRE_WASM_NO_CACHE`, `PYRE_WASM_STARTUP_TRACE`.
 
 ## §7 — General MAJIT gates
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -6807,6 +6807,14 @@ pub fn make_call_descr_from_bh(bh: &majit_translate::jitcode::BhCallDescr) -> De
         'f' | 'L' => Type::Float,
         _ => Type::Void,
     };
+    if bh.void_word_abi {
+        assert_eq!(
+            result_type,
+            Type::Void,
+            "void-word ABI requires a void BhCallDescr result type",
+        );
+    }
+    let result_size = if bh.void_word_abi { 8 } else { bh.result_size };
     // call.py:320 effectinfo_from_writeanalyze parity: the descr consumed
     // by pyjitpl/residual-call recording must expose the same EffectInfo
     // that the codewriter classified for this call site.
@@ -6822,7 +6830,7 @@ pub fn make_call_descr_from_bh(bh: &majit_translate::jitcode::BhCallDescr) -> De
         result_type,
         bh.result_type,
         bh.result_signed,
-        bh.result_size,
+        result_size,
         bh.extra_info.clone(),
     )
 }

--- a/pyre/pyre-jit/src/jit/assembler.rs
+++ b/pyre/pyre-jit/src/jit/assembler.rs
@@ -1721,10 +1721,11 @@ fn dispatch_residual_call(
         }
         state
             .builder
-            .residual_call_void_canonical_via_target_with_effect_info(
+            .residual_call_void_canonical_via_target_with_effect_info_and_word_abi(
                 fn_idx,
                 &call_args,
                 stub.effect_info.clone(),
+                stub.void_word_abi,
             );
         return;
     }
@@ -2968,6 +2969,7 @@ mod tests {
                     ),
                     arg_kinds: vec![Kind::Int, Kind::Ref, Kind::Float],
                     result_kind: Some(Kind::Float),
+                    void_word_abi: false,
                 })),
             ],
             Register::new(Kind::Float, 1),
@@ -3009,6 +3011,7 @@ mod tests {
                         super::super::flatten::unresolved_release_gil_effect_info_for_via_target(),
                     arg_kinds: vec![Kind::Int, Kind::Ref],
                     result_kind: None,
+                    void_word_abi: false,
                 })),
             ],
         ));
@@ -3034,6 +3037,78 @@ mod tests {
             .unwrap()
             .as_calldescr();
         assert!(descr.extra_info.is_call_release_gil());
+    }
+
+    #[test]
+    fn residual_call_r_v_preserves_word_returning_and_genuine_void_abis() {
+        let mut word_builder = JitCodeBuilder::default();
+        let word_fn_idx = word_builder.add_fn_ptr(0x7777usize as *const ());
+        let word_insn = super::super::flatten::build_store_subscr_fn_residual_call_r_v_insn(
+            word_fn_idx,
+            0,
+            1,
+            2,
+        );
+        let mut word_ssarepr = SSARepr::new("residual_call_r_v_word_abi");
+        word_ssarepr.insns.push(word_insn);
+        let word_jitcode = assemble(
+            &mut word_ssarepr,
+            word_builder,
+            Some(NumRegs {
+                ref_: 3,
+                ..NumRegs::default()
+            }),
+        );
+        let word_bh = word_jitcode
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_bh_descr())
+            .find_map(|descr| match descr {
+                majit_translate::jitcode::BhDescr::Call { calldescr } => Some(calldescr),
+                _ => None,
+            })
+            .expect("word-returning residual_call_r_v must emit a BhCallDescr");
+        let word_descr = pyre_jit_trace::descr::make_call_descr_from_bh(word_bh);
+        let word_call = word_descr
+            .as_call_descr()
+            .expect("word-returning residual_call_r_v must yield a call descr");
+        assert_eq!(word_call.result_type(), majit_ir::Type::Void);
+        assert_eq!(word_call.result_size(), 8);
+
+        let mut void_builder = JitCodeBuilder::default();
+        let void_fn_idx = void_builder.add_fn_ptr(0x8888usize as *const ());
+        let void_insn =
+            super::super::flatten::build_set_current_exception_fn_residual_call_r_v_insn(
+                void_fn_idx,
+                0,
+            );
+        let mut void_ssarepr = SSARepr::new("residual_call_r_v_genuine_void");
+        void_ssarepr.insns.push(void_insn);
+        let void_jitcode = assemble(
+            &mut void_ssarepr,
+            void_builder,
+            Some(NumRegs {
+                ref_: 1,
+                ..NumRegs::default()
+            }),
+        );
+        let void_bh = void_jitcode
+            .exec
+            .descrs
+            .iter()
+            .filter_map(|descr| descr.as_bh_descr())
+            .find_map(|descr| match descr {
+                majit_translate::jitcode::BhDescr::Call { calldescr } => Some(calldescr),
+                _ => None,
+            })
+            .expect("set_current_exception residual_call_r_v must emit a BhCallDescr");
+        let void_descr = pyre_jit_trace::descr::make_call_descr_from_bh(void_bh);
+        let void_call = void_descr
+            .as_call_descr()
+            .expect("set_current_exception residual_call_r_v must yield a call descr");
+        assert_eq!(void_call.result_type(), majit_ir::Type::Void);
+        assert_eq!(void_call.result_size(), 0);
     }
 
     /// `assembler.py:197-206` parity: a `Descr` operand attached to an op

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -5682,13 +5682,20 @@ impl CodeWriter {
         // the opname-tail-derived `ResKind` at dispatch time
         // (`assembler.rs:1370`).
         let key = (effect_info, arg_kinds, result_kind);
+        // `jit_list_append` is recorded as a void LIST_APPEND operation, but
+        // its registered fallback has the uniform `(i64, i64) -> i64` helper
+        // ABI. Preserve that physical result exactly as the other ignored-word
+        // residual producers do; the tag is part of `EffectInfo` and therefore
+        // already separates this entry in the cache key.
+        let void_word_abi =
+            key.2.is_none() && key.0.pyre_helper == majit_ir::PyreHelperKind::ListAppendValue;
         let mut cache = self.call_descr_stub_cache.lock().unwrap();
         let arc = cache.entry(key.clone()).or_insert_with(|| {
             Arc::new(CallDescrStub {
                 effect_info: key.0.clone(),
                 arg_kinds: key.1.clone(),
                 result_kind: key.2,
-                void_word_abi: false,
+                void_word_abi,
             })
         });
         arc.clone() as Arc<dyn majit_ir::Descr>
@@ -15912,6 +15919,20 @@ mod tests {
     use pyre_interpreter::bytecode::{CodeObject, ConstantData};
     use pyre_interpreter::compile_exec;
     use std::sync::Arc;
+
+    #[test]
+    fn list_append_void_stub_records_ignored_word_abi() {
+        let writer = CodeWriter::new();
+        let mut effect_info = super::super::flatten::effect_info_for_call_flavor(CallFlavor::Plain);
+        effect_info.pyre_helper = majit_ir::PyreHelperKind::ListAppendValue;
+        let descr = writer.intern_call_descr_stub(effect_info, vec![Kind::Ref, Kind::Ref], None);
+        let stub = descr
+            .as_any()
+            .and_then(|descr| descr.downcast_ref::<CallDescrStub>())
+            .expect("interned call descr must remain a CallDescrStub");
+
+        assert!(stub.void_word_abi);
+    }
 
     #[test]
     fn frame_layout_slot_places_operand_stack_after_non_argument_deref_slots() {

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -5688,6 +5688,7 @@ impl CodeWriter {
                 effect_info: key.0.clone(),
                 arg_kinds: key.1.clone(),
                 result_kind: key.2,
+                void_word_abi: false,
             })
         });
         arc.clone() as Arc<dyn majit_ir::Descr>

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -477,6 +477,12 @@ pub struct CallDescrStub {
     /// that the two MUST agree per `descr.create_call_stub` /
     /// `descr.result_type` round-trip in `descr.py:670-674`.
     pub result_kind: Option<Kind>,
+    /// True when a void-recorded residual call targets an `extern "C"`
+    /// helper that returns an ignored machine word.  The opname tail and
+    /// `result_kind` remain void; this bit preserves the callee's low-level
+    /// ABI through `BhCallDescr` so signature-exact backends can select the
+    /// word-returning call type and discard its result.
+    pub void_word_abi: bool,
 }
 
 /// Make [`CallDescrStub`] addressable through `majit_ir::DescrRef` so the
@@ -493,8 +499,8 @@ impl Descr for CallDescrStub {
 
     fn repr(&self) -> String {
         format!(
-            "CallDescrStub(ei={:?}, kinds={:?}, result={:?})",
-            self.effect_info.extraeffect, self.arg_kinds, self.result_kind,
+            "CallDescrStub(ei={:?}, kinds={:?}, result={:?}, void_word_abi={})",
+            self.effect_info.extraeffect, self.arg_kinds, self.result_kind, self.void_word_abi,
         )
     }
 }
@@ -3849,6 +3855,7 @@ fn build_residual_call_ir_r_insn_from_operands(
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -3882,6 +3889,7 @@ fn build_residual_call_ir_r_insn_from_ref_list(
         effect_info,
         arg_kinds,
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -4106,6 +4114,7 @@ fn build_load_global_fn_insn_from_operands(
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -4140,6 +4149,7 @@ pub fn build_load_attr_fn_residual_call_ir_r_insn(
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -4181,6 +4191,7 @@ pub fn build_load_method_self_fn_residual_call_ir_r_insn(
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -4289,6 +4300,7 @@ where
         ctx.store_name_fn_idx,
         vec![frame_operand, name_operand, value_operand],
         CallFlavor::Plain,
+        true,
         // Tag so the full-body walker can try the module-scope IntMutableCell
         // in-place store fold (`try_walker_store_name_cell_fold`); the fold
         // falls through to this residual for non-module frames / non-int
@@ -4332,6 +4344,7 @@ where
         ctx.store_global_fn_idx,
         vec![frame_operand, name_operand, value_operand],
         CallFlavor::Plain,
+        true,
         // Tag for the same module-scope IntMutableCell in-place store fold as
         // `lower_store_name_hlop_to_insn` (`try_walker_store_name_cell_fold`).
         majit_ir::PyreHelperKind::StoreGlobal,
@@ -4358,6 +4371,7 @@ where
         ctx.delete_name_fn_idx,
         vec![frame_operand, name_operand],
         CallFlavor::Plain,
+        true,
         // Tagged so the walker can run the `jit_force_quasi_immutable` test
         // (`pyjitpl.py:1094-1118`) before executing the delete — `delitem_str`
         // calls `mutated()` on a successful removal.
@@ -4460,6 +4474,7 @@ where
         ctx.delete_global_fn_idx,
         vec![frame_operand, name_operand],
         CallFlavor::Plain,
+        true,
         // See [`lower_delete_name_hlop_to_insn`].
         majit_ir::PyreHelperKind::DeleteGlobal,
     ))
@@ -4843,6 +4858,7 @@ pub fn build_residual_call_r_r_insn_from_operands(
         effect_info,
         arg_kinds,
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_r_r",
@@ -4974,6 +4990,7 @@ fn build_residual_call_ir_r_insn_from_int_only_operands(
         effect_info,
         arg_kinds: vec![Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -5003,6 +5020,7 @@ pub fn build_one_int_one_ref_fn_residual_call_ir_r_insn(
         effect_info,
         arg_kinds: vec![Kind::Int, Kind::Ref],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -5052,6 +5070,7 @@ pub fn build_build_slice_fn_residual_call_ir_r_insn(
         effect_info,
         arg_kinds,
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",
@@ -5174,6 +5193,7 @@ fn build_residual_call_r_i_insn_from_operands(
         effect_info,
         arg_kinds: vec![Kind::Ref],
         result_kind: Some(Kind::Int),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_r_i",
@@ -5230,6 +5250,7 @@ where
         ctx.store_subscr_fn_idx,
         vec![obj_operand, key_operand, value_operand],
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::StoreSubscr,
     ))
 }
@@ -5271,6 +5292,7 @@ where
         ctx.store_slice_fn_idx,
         vec![obj_operand, start_operand, stop_operand, value_operand],
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::None,
     ))
 }
@@ -5589,6 +5611,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -5633,6 +5656,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -5683,6 +5707,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -5725,6 +5750,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -5778,6 +5804,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: None,
+        void_word_abi: true,
     }));
     Some(Insn::op(
         "residual_call_ir_v",
@@ -5869,6 +5896,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Int, Kind::Ref, Kind::Ref, Kind::Ref],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -5954,6 +5982,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6131,6 +6160,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6564,6 +6594,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6610,6 +6641,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6664,6 +6696,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6718,6 +6751,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6770,6 +6804,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6831,6 +6866,7 @@ where
             Kind::Int,
         ],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6882,6 +6918,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -6931,6 +6968,7 @@ where
         ctx.delete_subscr_fn_idx,
         vec![obj_operand, key_operand],
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::None,
     ))
 }
@@ -6970,6 +7008,7 @@ where
         ctx.list_extend_fn_idx,
         vec![list_operand, iterable_operand],
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::None,
     ))
 }
@@ -7014,6 +7053,7 @@ where
         fn_idx,
         operands,
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::None,
     ))
 }
@@ -7054,6 +7094,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: None,
+        void_word_abi: true,
     }));
     Some(Insn::op(
         "residual_call_ir_v",
@@ -7109,6 +7150,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -7154,6 +7196,7 @@ where
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Some(Insn::op_with_result(
         "residual_call_ir_r",
@@ -7264,6 +7307,7 @@ pub fn build_store_subscr_fn_residual_call_r_v_insn(
             Operand::Register(Register::new(Kind::Ref, value_reg)),
         ],
         CallFlavor::MayForce,
+        true,
         majit_ir::PyreHelperKind::StoreSubscr,
     )
 }
@@ -7290,6 +7334,7 @@ pub fn build_set_current_exception_fn_residual_call_r_v_insn(
         set_current_exception_fn_idx,
         vec![Operand::Register(Register::new(Kind::Ref, exc_reg))],
         CallFlavor::PlainCannotRaiseNoHeap,
+        false,
         majit_ir::PyreHelperKind::None,
     )
 }
@@ -7307,6 +7352,7 @@ fn build_residual_call_r_v_insn_from_operands(
     fn_idx: u16,
     ref_operands: Vec<Operand>,
     flavor: CallFlavor,
+    void_word_abi: bool,
     pyre_helper: majit_ir::PyreHelperKind,
 ) -> Insn {
     let arg_kinds = vec![Kind::Ref; ref_operands.len()];
@@ -7316,6 +7362,7 @@ fn build_residual_call_r_v_insn_from_operands(
         effect_info,
         arg_kinds,
         result_kind: None,
+        void_word_abi,
     }));
     Insn::op(
         "residual_call_r_v",
@@ -7421,6 +7468,7 @@ fn build_residual_call_ir_r_single_ref_plain_insn_from_operands(
         effect_info,
         arg_kinds: vec![Kind::Ref, Kind::Int],
         result_kind: Some(Kind::Ref),
+        void_word_abi: false,
     }));
     Insn::op_with_result(
         "residual_call_ir_r",

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -892,6 +892,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             }
         }
     }
+    probe_call_hist_dump();
     // Emit the sign-stable badness counters under MAJIT_STATS (the same env
     // check.py sets for every backend), so the regression floor gates wasm on
     // the same fields as the native backends. Kept separate from the verbose
@@ -1490,6 +1491,30 @@ fn jit_execute(caller: &mut Caller<'_, Host>, func_id: u32, frame_ptr: u32) -> R
 }
 
 /// Dispatch a residual call requested by a running trace.
+// PROBE(PYRE_WASM_CALL_HIST): temporary per-callee crossing histogram.
+static PROBE_CALL_HIST: std::sync::Mutex<Option<std::collections::BTreeMap<u32, u64>>> =
+    std::sync::Mutex::new(None);
+
+pub(crate) fn probe_call_hist_dump() {
+    if std::env::var_os("PYRE_WASM_CALL_HIST").is_none() {
+        return;
+    }
+    let g = PROBE_CALL_HIST.lock().unwrap();
+    let Some(m) = g.as_ref() else { return };
+    let total: u64 = m.values().sum();
+    let mut v: Vec<_> = m.iter().collect();
+    v.sort_by(|a, b| b.1.cmp(a.1));
+    eprintln!("[probe] call_hist total={total} distinct={}", v.len());
+    for (slot, n) in v.into_iter().take(15) {
+        let pct = if total > 0 {
+            *n as f64 * 100.0 / total as f64
+        } else {
+            0.0
+        };
+        eprintln!("[probe] call_hist slot={slot} n={n} pct={pct:.1}");
+    }
+}
+
 fn jit_call_trampoline(
     caller: &mut Caller<'_, Host>,
     frame_ptr: u32,
@@ -1501,6 +1526,12 @@ fn jit_call_trampoline(
     let call_area = frame_ptr as usize + call_area_ofs as usize;
 
     let func_ptr = read_u32(&memory, &*caller, call_area + 8);
+    if std::env::var_os("PYRE_WASM_CALL_HIST").is_some() {
+        let mut g = PROBE_CALL_HIST.lock().unwrap();
+        *g.get_or_insert_with(Default::default)
+            .entry(func_ptr)
+            .or_insert(0) += 1;
+    }
 
     // `func_ptr == 0` is the "newstr" sentinel; without a host string
     // allocator (matching the browser glue's null table slot) it yields 0.


### PR DESCRIPTION
Adds a wasm-vs-dynasm performance gate to `pyre/check.py` and fixes every
synthetic fixture that failed it.

## The gate

`WASM_MAX_DYNASM_RATIO = 3.0` caps wasm's execution-only user-CPU at three
times dynasm's on the same fixture. The baseline is dynasm's own time from the
same invocation rather than a recorded constant, so the pair sees one host under
one load and there is no number that can age. It runs through
`_performance_gate_passed` with `baseline_key="dynasm"`, inheriting the
startup-subtracted comparison, the noisy-denominator grace and the median
retry, and it is skipped when dynasm did not run the fixture or its
execution-only time is below `FLOOR_GATE_MIN_BASELINE_S`.

Six fixtures failed it when it landed.

## The four defects behind them

**Guard exits shared one dispatcher.** Every guard and `Finish` wrote an exit
ordinal and branched to a single `block`/`br_table` block after the trace body
that held all the fail-argument spills. That block is a join point: each handler
reachable from it reads its guard's fail-arg locals, so every one of them is
live-in there and therefore live along *every* guard-to-dispatcher edge — live
at every guard in the trace. On the first module emitted for
`short_circuit_value_kept_stack`, 35 of the 86 body-defined locals were read
only in that region, with a median live span of 235 lines against 2 for the
locals no handler reads. Spilling in each guard's own `if` ends each range at
its guard; the stores run only on the failing edge. The module got *smaller*
(4277 to 4015 bytes, one fewer `br_table`, the same 217 stores).

x86's `write_pending_failure_recoveries` can place stubs after the hot code
because `GuardToken.fail_locs` freezes each fail argument's location at the
guard. Wasm has no way to record such a location — the allocator is the
engine's, and it derives liveness from where the emitted code reads a local — so
copying the placement without that mechanism is what created the join.

**Every ref store took a write barrier.** The wasm backend runs only
`remove_ref_constants`, not the GC rewrite pass, so `write_barrier_base`
reproduced just rewrite.py:930-931's `v.type == 'r' and not ConstPtr` and
nothing of rewrite.py:714 `write_barrier_applied`. A base written N times in one
trace took N barriers where the native backends take one. `build_function` now
keeps the same set `rewrite.rs` models as `RewriteState::wb_applied`, cleared at
every `can_malloc()` op and every `Label` so it describes every path reaching
the next op, including entry through a label loader.

The allocation result is deliberately *not* seeded. rewrite.rs seeds only the
branches that reached `can_use_nursery`, and states why: the first result can
come from an old-gen slow path whose `TRACK_YOUNG_PTRS` is preserved. Here the
generation is not a codegen-time fact at all — a `non_moving` descr routes to
`new_oldgen_fn_ptr`, whose `alloc_in_oldgen` stamps the flag, and the plain
helper chooses at runtime. Eliding there would drop the barrier on a fresh old
object and lose an old-to-young edge.

**Locals were declared per value id, not per addressable value.** `num_vars` is
`max value id + 1` and ids are sparse, so most declared locals were never named:
23687 declared against 1156 referenced for `inline_chain_depth_typeflip`. A new
`ValueLocals` maps each addressable id to a dense index and is now the only way
a value local index is computed; `local()` panics on an unmapped id. `RefHomes`
keeps its id keying — its home slots are linear memory, a different space.


**The deopt root bracket defeated its own fast path.** `WasmFrameData` roots the
copied exit slots because wasm has no host-visible JITFRAME to hand back — that
adaptation stays. `RootSet::remove` pops in O(1) only when the root is the one
on top, and says so ("Host root brackets are stack-shaped"), but `Drop` drained
them in push order, so every removal took the `position()` scan fallback.
Each slot also went through its own `with_wasm_active_gc_mut`, re-acquiring the
`gc_sync` singleton per call, and a zero `exc_value` — written once at
construction, only read back by `grab_exc_value` — was rooted for nothing.
Drop now drains in reverse, add and remove batch into one acquisition, and a
bracket with no Ref slots and no exception does no work at all. Guest profile of
`loop_callee_shared_mutation`: `WasmFrameData::boxed` self share 12.2% to 4.83%.

## Measurements

Guest profile on `p2_local_result_bridge`: `do_write_barrier` 24.6% of samples
and `wasm_jit_write_barrier` 22.3% before, 0.0% each after. A `sample(1)` of the
dynasm run of the same fixture put the barrier below the 5-of-162 reporting
threshold, which is what made it an asymmetry rather than a platform cost.

Trace compilation for `inline_chain_depth_typeflip`: 200.5ms before, 33.6ms
after the guard-spill change, 29.4ms after the dense locals. Declared locals over
its emitted modules: 23687 to 1895.

Fixtures over the gate: 6 at the start, 4 after the guard-spill change, 0 after
the barrier change. Across the 192 fixtures whose dynasm time clears the floor,
wasm/dynasm now has a median of 1.28x and a maximum of 2.78x, with 15 fixtures
faster on wasm.

`pyre/check.py --synthetic-only --backend dynasm,wasm`: dynasm 408/408, wasm
404/404, nothing over the gate.

## Not addressed

Two fixtures still sit near 2.7x with no wasm-specific defect visible.
`short_circuit_value_kept_stack` spends 71% of its samples in `execute_token`'s
own frame — the trace body — with no barrier, allocation or host crossing left
to point at. `pickle_terminal_raise_resume` spends 12.8% in dlmalloc and the
rest of its head in the jitcode assembly path (`insns_snapshot`'s
`IndexMap<String, u8>` clone, `decode_op_at`, `publish_state`), which lives in
`pyre/pyre-jit` and is paid by dynasm too, so it is not the asymmetry.

Ratios for that group cannot be read to better than a few tenths: their
execution-only dynasm times are 0.04-0.19s, and the startup median subtracted
from both sides moved 0.052s to 0.042s between two runs on a loaded machine,
which alone shifts the quotient. The gate's own median-3 measurement reports
nothing over 3x.

Densifying removes the gaps between ids but still declares a local for an op
result that is never read — `pickle_terminal_raise_resume` sits at 5142 declared
against 2250 referenced. The compile-time return on the densification was ~12%,
far less than the 12x reduction in declared locals, so cranelift's per-local
cost is small and further trimming looks low-value.
