### PR TITLE
majit: retarget bare assertion-raise blocks instead of widening the pass

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2567,6 +2567,9 @@ fn lower_unstructured_with_static_addrs_and_attrs(
 ///   raise block between a discriminant switch's `else
 ///   unreachable!()` exit and `exceptblock`, exposing the
 ///   `[Constant(AssertionError), …]` link to the next pass.
+/// - `retarget_assert_raise_blocks` points an edge into a bare
+///   implicit-raise block at `exceptblock` instead, which is where
+///   upstream's flow space puts it and what the next pass matches.
 /// - `remove_assertion_errors` (simplify.py:321-346) prunes the
 ///   shouldn't-occur branch and promotes the surviving exit to an
 ///   unconditional link.
@@ -2643,6 +2646,10 @@ fn simplify_lowered_graph(
     // keeps them because a `FieldWrite` is side-effecting, so its `base`
     // pins the aggregate (`remove_simple_mallocs`, malloc.py).
     dirty |= crate::model::remove_dead_aggregates(graph) > 0;
+    // Bring the raise into the shape `remove_assertion_errors` matches: the
+    // MIR front builds the exception in a block of its own, where upstream's
+    // flow space links straight to `exceptblock`.
+    dirty |= crate::model::retarget_assert_raise_blocks(graph) > 0;
     dirty |= crate::model::remove_assertion_errors(graph) > 0;
     // Constant-condition arms (`if WITHPREBUILTINT { … }` with the
     // config const folded by `const_eval_global`) collapse to the

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2418,6 +2418,87 @@ pub fn eliminate_empty_blocks(graph: &mut FunctionGraph) {
     }
 }
 
+/// Retarget each edge into a block that exists only to raise the implicit
+/// `AssertionError` so it names `exceptblock` directly, giving
+/// [`remove_assertion_errors`] the `exit.target is graph.exceptblock` shape
+/// its upstream counterpart is written against.
+///
+/// Upstream's flow space raises `assert` as a link straight to `exceptblock`
+/// (`flowcontext.py` `_implicit_`), so `simplify.remove_assertion_errors`
+/// never has a block in between and its predicate can be literal.
+/// `set_raise` / `set_raise_implicit` always install one, and the MIR front
+/// fills it with the operations that build the exception, so the same raise
+/// arrives here one block further out.
+///
+/// A block qualifies when it has a single exit, that exit is the
+/// `AssertionError` raise, and every operation it holds satisfies
+/// `can_remove_op` — `CanRemove` (`simplify.py:411-423`), the predicate the
+/// dead-op pass would apply to those operations once the raise is gone.  An
+/// operation outside it — anything that can raise or write — leaves the edge
+/// pointing at its block.
+///
+/// The bypassed block keeps its own exits and falls out as unreachable, the
+/// same way `eliminate_empty_blocks` (`simplify.py:52-69`) leaves the blocks
+/// it rewires past.
+///
+/// Returns the number of retargeted edges.
+pub fn retarget_assert_raise_blocks(graph: &mut FunctionGraph) -> usize {
+    use crate::flowspace::model::HOST_ENV;
+
+    let assert_err_class = HOST_ENV
+        .lookup_builtin("AssertionError")
+        .expect("HOST_ENV missing AssertionError");
+    let exceptblock = graph.exceptblock;
+    let mut raise_args: std::collections::HashMap<BlockId, Vec<LinkArg>> =
+        std::collections::HashMap::new();
+    for block in &graph.blocks {
+        if block.id == exceptblock || block.exits.len() != 1 {
+            continue;
+        }
+        let exit = &block.exits[0];
+        let raises = exit.target == exceptblock
+            && matches!(
+                exit.args.first(),
+                Some(LinkArg::Const(c))
+                    if matches!(
+                        &c.value,
+                        ConstValue::HostObject(h) if *h == assert_err_class
+                    )
+            );
+        if !raises {
+            continue;
+        }
+        if !block
+            .operations
+            .iter()
+            .all(|op| crate::inline::can_remove_op(&op.kind))
+        {
+            continue;
+        }
+        raise_args.insert(block.id, exit.args.clone());
+    }
+    if raise_args.is_empty() {
+        return 0;
+    }
+    let mut retargeted = 0usize;
+    for block_idx in 0..graph.blocks.len() {
+        if raise_args.contains_key(&graph.blocks[block_idx].id) {
+            continue;
+        }
+        for exit_idx in 0..graph.blocks[block_idx].exits.len() {
+            let target = graph.blocks[block_idx].exits[exit_idx].target;
+            let Some(args) = raise_args.get(&target).cloned() else {
+                continue;
+            };
+            let exit = &mut graph.blocks[block_idx].exits[exit_idx];
+            exit.target = exceptblock;
+            exit.args = args;
+            retargeted += 1;
+        }
+    }
+    retargeted
+}
+
 /// RPython `remove_assertion_errors(graph)` (simplify.py:321-346) over
 /// the front model graph.
 ///
@@ -2463,56 +2544,28 @@ pub fn eliminate_empty_blocks(graph: &mut FunctionGraph) {
 /// Returns the number of removed exits so the caller can gate the
 /// follow-up dead-condition sweep (`removeassert.py:35-37` — "now melt
 /// away the (hopefully) dead operation that compute the condition").
-/// The front model does not run `join_blocks` over this graph type, so
-/// the assertion raise can remain behind a single-entry, single-exit block
-/// that upstream `simplify.py:271-319` would have collapsed.
+///
+/// The predicate here is upstream's literal `exit.target is
+/// graph.exceptblock`.  Graphs whose raise sits one block further out are
+/// brought into that shape by [`retarget_assert_raise_blocks`], which the
+/// caller runs first.
 pub fn remove_assertion_errors(graph: &mut FunctionGraph) -> usize {
     use crate::flowspace::model::{HOST_ENV, HostObject};
 
     fn targets_assertion_error(
-        graph: &FunctionGraph,
         exit: &Link,
         exceptblock: BlockId,
         assert_err_class: &HostObject,
     ) -> bool {
-        let indirect = exit.target != exceptblock;
-        let assertion_exit = if indirect {
-            let target = graph.block(exit.target);
-            if target.exits.len() != 1 {
-                return false;
-            }
-            &target.exits[0]
-        } else {
-            exit
-        };
-
-        let raises_assertion_error = assertion_exit.target == exceptblock
+        exit.target == exceptblock
             && matches!(
-                assertion_exit.args.first(),
+                exit.args.first(),
                 Some(LinkArg::Const(c))
                     if matches!(
                         &c.value,
                         ConstValue::HostObject(h) if h == assert_err_class
                     )
-            );
-        if !raises_assertion_error {
-            return false;
-        }
-        if !indirect {
-            return true;
-        }
-        // Only `join_blocks` would collapse the intermediate block into this
-        // one, and only when this exit is its sole entry — otherwise removing
-        // the exit strands the other predecessors.  Counted last: it is the
-        // one whole-graph scan here, and the cheap shape tests above already
-        // reject every exit that is not a raise-block edge.
-        graph
-            .blocks
-            .iter()
-            .flat_map(|block| block.exits.iter())
-            .filter(|candidate| candidate.target == exit.target)
-            .count()
-            == 1
+            )
     }
 
     let assert_err_class = HOST_ENV
@@ -2531,7 +2584,7 @@ pub fn remove_assertion_errors(graph: &mut FunctionGraph) -> usize {
             };
             // upstream: `if not (exit.target is graph.exceptblock and
             // exit.args[0] == Constant(AssertionError)): continue`.
-            if !targets_assertion_error(graph, exit, exceptblock, &assert_err_class) {
+            if !targets_assertion_error(exit, exceptblock, &assert_err_class) {
                 continue;
             }
             // upstream: `if len(block.exits) < 2: break`.
@@ -6510,67 +6563,59 @@ mod tests {
         assert!(entry_block.exits[0].llexitcase.is_none());
     }
 
+    /// The MIR front raises through a block of its own, so the edge only
+    /// reaches the shape `remove_assertion_errors` matches after the
+    /// retarget.  A block holding operations the dead-op pass would reclaim
+    /// qualifies; one holding a `getslice` — outside `CanRemove` — does not.
     #[test]
-    fn remove_assertion_errors_prunes_through_single_entry_raise_block() {
-        let mut graph = FunctionGraph::new("indirect_assertion_error");
-        let entry = graph.startblock;
-        let live = graph.create_block();
-        let raise = graph.create_block();
-        let cond = graph
-            .push_op_var(
-                entry,
-                OpKind::Input {
-                    name: "cond".into(),
-                    ty: ValueType::Bool,
-                    class_root: None,
-                },
-                true,
-            )
-            .unwrap();
-        graph.set_branch(entry, cond, raise, vec![], live, vec![]);
-        graph.set_raise_implicit(raise, "ValueError");
+    fn retarget_assert_raise_blocks_judges_the_block_by_can_remove() {
+        let build = |unremovable: bool| {
+            let mut graph = FunctionGraph::new("indirect_assertion_error");
+            let entry = graph.startblock;
+            let live = graph.create_block();
+            let raise = graph.create_block();
+            let cond = graph
+                .push_op_var(
+                    entry,
+                    OpKind::Input {
+                        name: "cond".into(),
+                        ty: ValueType::Bool,
+                        class_root: None,
+                    },
+                    true,
+                )
+                .unwrap();
+            graph.set_branch(entry, cond, raise, vec![], live, vec![]);
+            let base = graph
+                .push_op_var(raise, OpKind::ConstInt(42), true)
+                .unwrap();
+            if unremovable {
+                graph
+                    .push_op_var(raise, OpKind::GetSlice { args: vec![base] }, true)
+                    .unwrap();
+            }
+            graph.set_raise_implicit(raise, "ValueError");
+            (graph, entry, live, raise)
+        };
 
-        assert_eq!(remove_assertion_errors(&mut graph), 1);
-        let entry_block = graph.block(entry);
+        let (mut removable, entry, live, _) = build(false);
+        assert_eq!(retarget_assert_raise_blocks(&mut removable), 1);
+        assert_eq!(remove_assertion_errors(&mut removable), 1);
+        let entry_block = removable.block(entry);
         assert_eq!(entry_block.exits.len(), 1);
         assert_eq!(entry_block.exits[0].target, live);
         assert!(entry_block.exitswitch.is_none());
         assert!(entry_block.exits[0].exitcase.is_none());
-        assert!(entry_block.exits[0].llexitcase.is_none());
-    }
 
-    #[test]
-    fn remove_assertion_errors_keeps_raise_block_with_multiple_entries() {
-        let mut graph = FunctionGraph::new("shared_assertion_error");
-        let entry = graph.startblock;
-        let other_predecessor = graph.create_block();
-        let live = graph.create_block();
-        let raise = graph.create_block();
-        let cond = graph
-            .push_op_var(
-                entry,
-                OpKind::Input {
-                    name: "cond".into(),
-                    ty: ValueType::Bool,
-                    class_root: None,
-                },
-                true,
-            )
-            .unwrap();
-        graph.set_branch(entry, cond, raise, vec![], live, vec![]);
-        graph.set_goto(other_predecessor, raise, vec![]);
-        graph.set_raise_implicit(raise, "ValueError");
-
-        assert_eq!(remove_assertion_errors(&mut graph), 0);
-        assert_eq!(graph.block(entry).exits.len(), 2);
+        let (mut kept, entry, _, raise) = build(true);
+        assert_eq!(retarget_assert_raise_blocks(&mut kept), 0);
+        assert_eq!(remove_assertion_errors(&mut kept), 0);
         assert!(
-            graph
-                .block(entry)
+            kept.block(entry)
                 .exits
                 .iter()
                 .any(|exit| exit.target == raise)
         );
-        assert_eq!(graph.block(other_predecessor).exits[0].target, raise);
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1206, addressing the Codex parity review's §1 finding on that PR and the P1 on the first revision of this one.

## The finding

#1206 taught `remove_assertion_errors` to follow a one-block indirection. Codex objected twice, and both times correctly:

> "accept a single-entry intermediate block" is broader than PyPy's direct-only condition (`exit.target is graph.exceptblock`). It can remove a conditional edge whose target block contains operations before raising `AssertionError`. `join_blocks` cannot justify this: it requires the predecessor to be unconditional with one exit (`simplify.py:283-286`), which a branch block is not.

> Collapse or retarget the raise block in the corresponding simplification phase, then keep this pass's predicate literal, rather than retaining a second implementation with different eligibility rules.

## The fix

`remove_assertion_errors` goes back to upstream's literal predicate. A new `retarget_assert_raise_blocks` runs immediately before it in `simplify_lowered_graph` and points an edge whose target exists only to raise the implicit `AssertionError` straight at `exceptblock` — where the flow space puts it upstream (`flowcontext.py` `_implicit_`), which is why the upstream predicate can be literal in the first place. The bypassed block keeps its exits and falls out as unreachable, the way `eliminate_empty_blocks` (`simplify.py:52-69`) leaves the blocks it rewires past.

A block qualifies when it has a single exit carrying that raise and every operation it holds satisfies `can_remove_op` — `CanRemove` (`simplify.py:411-423`), the predicate the dead-op pass would apply to those operations once the raise is gone. `can_remove_op` rather than `is_pure_op`: the question is what may be *deleted*, and `inline.rs:1130-1135` already records that upstream keeps `LLOp.is_pure()` and `CanRemove` distinct for that reason.

## Two other placements were tried and rejected by measurement

- **Require the intermediate block to be empty.** Disarms the change entirely — the raise blocks in this corpus build the exception. Back to three unrepairable `constants_r` entries and the in-process determinism failure.
- **Widen the front's `panic_block_is_pure_message` so `collapse_panic_message_chains` normalises these raises** — the phase whose own doc says it collapses panic chains "to the bare raise so `remove_assertion_errors` prunes the branch as it does for a direct implicit raise". Also disarms the change. Instrumenting the rejection path showed why: that phase runs *after* `simplify_lowered_graph`, and neither `do_warn_explicit` nor `w_member_get_direct_kind` ever presents an assert-raising block to it. Its 24 rejections across the corpus are all genuine side-effecting calls (`handle_alloc_error`, `os::exit`, `core::intrinsics::unreachable`), so widening its predicate buys nothing here.

The normalisation therefore belongs in the pass sequence that runs before `remove_assertion_errors`, which is where it now sits.

## Generated code is unchanged

Against #1206's guard at the same base and corpus (`af392b9a`):

| | #1206 guard | this |
|---|---|---|
| `all_jitcodes` | 2645 | 2645 |
| `jitcodes_index.bin` | identical | |
| jitcode name list | identical | |
| jitcodes differing in bytecode, register counts, constant-pool sizes, result types, start points | **0** | |
| unrepairable `constants_r` | 1 (`_unpackiterable_unknown_length` `0x8`) | 1 (same) |
| in-process determinism | 13/13 identical | 13/13 identical |

`jitcodes.bin` and `descrs.bin` are in `HOST_ADDRESSED_OUTPUTS` and are not comparable across processes, so the comparison is on the address-free fields.

## Tests

`majit-translate` lib suite green (3193 passed). One new test pins both directions of the retarget predicate: a raise block holding only a `ConstInt` is retargeted and then pruned; one holding a `getslice` — outside `CanRemove` — keeps its edge and survives the pass.

## Note on main's current CI

`pyre/check.py` is red on ubuntu and windows and the CPython gate is red, all of which predate #1206: main at `b0f34c0af3e` failed the same three jobs with byte-identical rows — `wasm synth/exception_traceback_loop_forms` `guard_failures 810 -> 811` and `cranelift synth/str_fstring` `659 -> 658`, cranelift 1 failed/424 passed, wasm 1 failed/417 passed. `b0f34c0af3e` re-recorded `exception_traceback_loop_forms` for dynasm and cranelift (811) and left wasm at 810. Not touched here.

— *authored by Claude*