### PR TITLE
jit: fold the bare-class raise of every kind whose zero-argument instance is reproducible

### DIFF
--- a/pyre/bench/synth/raise_bare_class_slot_kinds.cranelift.jitstats
+++ b/pyre/bench/synth/raise_bare_class_slot_kinds.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/raise_bare_class_slot_kinds.dynasm.jitstats
+++ b/pyre/bench/synth/raise_bare_class_slot_kinds.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/raise_bare_class_slot_kinds.py
+++ b/pyre/bench/synth/raise_bare_class_slot_kinds.py
@@ -1,0 +1,56 @@
+# pyre-check: max-pypy-ratio=25
+# A bare `raise X` of an exception kind whose `descr_init` writes flattened
+# slots beyond `args_w` — `interp_exceptions.py:496-499 W_StopIteration`
+# (`value`), `:810-812 W_NameError` and `:1134-1137 W_AttributeError` (`name` /
+# `obj`), `:363-377 W_ImportError` (`name` / `path` / `msg`). `do_raise`
+# instantiates the class with no arguments, so every one of those slots takes a
+# trace-time constant and the construction can be traced instead of residualised.
+# Each raise site stays monomorphic so the class operand is a single value.
+#
+# N is large because the residual shape this replaces degrades super-linearly:
+# 30k iterations hide it inside compile time, while 3M separate the two shapes
+# by two orders of magnitude.
+N = 3000000
+
+
+def stop_iteration():
+    raise StopIteration
+
+
+def name_error():
+    raise NameError
+
+
+def attribute_error():
+    raise AttributeError
+
+
+def import_error():
+    raise ImportError
+
+
+def main():
+    acc = 0
+    i = 0
+    while i < N:
+        try:
+            stop_iteration()
+        except StopIteration:
+            acc = acc + 1
+        try:
+            name_error()
+        except NameError:
+            acc = acc + 2
+        try:
+            attribute_error()
+        except AttributeError:
+            acc = acc + 4
+        try:
+            import_error()
+        except ImportError:
+            acc = acc + 8
+        i = i + 1
+    print(acc)
+
+
+main()

--- a/pyre/bench/synth/raise_bare_class_slot_kinds.wasm.jitstats
+++ b/pyre/bench/synth/raise_bare_class_slot_kinds.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/extra_tests/parity_tests/raise_bare_class_slot_defaults.py
+++ b/pyre/extra_tests/parity_tests/raise_bare_class_slot_defaults.py
@@ -1,0 +1,107 @@
+# CPython-suite gap: the exception tests read `StopIteration.value` /
+# `NameError.name` / `ImportError.path` once, never from a `raise` site hot
+# enough for a JIT construction fold to take over.
+# parity-tests reason: pyre builds the zero-argument instance of a bare
+# `raise X` in traced code, so those slots are written by trace IR rather than
+# by the runtime `__init__`.
+
+# `do_raise` instantiates a raised class with no arguments, so every flattened
+# slot the initializer touches takes its no-argument value:
+# `interp_exceptions.py:496-499 W_StopIteration` leaves `value` at None,
+# `:810-812 W_NameError` and `:1134-1137 W_AttributeError` take `name` / `obj`
+# from keywords only, and `:363-377 W_ImportError` fills `name` / `path` /
+# `msg` from keywords and a lone positional. A fold that emits those stores
+# itself has to reproduce all of them, and leave `args`, `__context__`,
+# `__cause__` and `__suppress_context__` exactly as the interpreter does.
+
+N = 3000
+
+
+def raise_stop_iteration():
+    raise StopIteration
+
+
+def raise_name_error():
+    raise NameError
+
+
+def raise_attribute_error():
+    raise AttributeError
+
+
+def raise_import_error():
+    raise ImportError
+
+
+def raise_module_not_found():
+    raise ModuleNotFoundError
+
+
+def raise_value_error():
+    raise ValueError
+
+
+def caught(fn):
+    """The instance a bare `raise` built, over a loop the JIT compiles."""
+    seen = None
+    for _ in range(N):
+        try:
+            fn()
+        except BaseException as exc:
+            seen = exc
+            assert exc.args == ()
+            assert exc.__cause__ is None
+            assert exc.__context__ is None
+            assert exc.__suppress_context__ is False
+            assert exc.__traceback__ is not None
+    return seen
+
+
+exc = caught(raise_stop_iteration)
+assert type(exc) is StopIteration, type(exc)
+assert exc.value is None, exc.value
+
+exc = caught(raise_name_error)
+assert type(exc) is NameError, type(exc)
+assert exc.name is None, exc.name
+
+exc = caught(raise_attribute_error)
+assert type(exc) is AttributeError, type(exc)
+assert exc.name is None, exc.name
+assert exc.obj is None, exc.obj
+
+for fn, cls in ((raise_import_error, ImportError),
+                (raise_module_not_found, ModuleNotFoundError)):
+    exc = caught(fn)
+    assert type(exc) is cls, type(exc)
+    assert exc.name is None, exc.name
+    assert exc.path is None, exc.path
+    assert exc.msg is None, exc.msg
+
+exc = caught(raise_value_error)
+assert type(exc) is ValueError, type(exc)
+
+# `raise X from Y` keeps `__cause__` and flips `__suppress_context__`, which the
+# no-cause fold must decline rather than reproduce.
+cause = ValueError("cause")
+for _ in range(N):
+    try:
+        raise StopIteration from cause
+    except StopIteration as exc:
+        assert exc.__cause__ is cause
+        assert exc.__suppress_context__ is True
+        assert exc.value is None
+
+# A raise nested inside an active handler chains `__context__` onto the new
+# instance, so the fold's inline `__context__` store has to see the same value.
+for _ in range(N):
+    try:
+        raise ValueError("outer")
+    except ValueError as outer:
+        try:
+            raise StopIteration
+        except StopIteration as inner:
+            assert inner.__context__ is outer
+            assert inner.value is None
+
+print("OK")

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4179,7 +4179,7 @@ pub fn pytraceback_lineno_descr() -> DescrRef {
 /// exception attribute fold.  The field is located by its `W_BaseException`
 /// offset, so a slot added to `build_w_exception_group` cannot silently
 /// renumber the ones after it; no parallel descriptor is constructed.
-pub fn w_exception_slot_descr(
+pub fn w_exception_attr_slot_descr(
     kind: ExcKind,
     slot: pyre_interpreter::baseobjspace::ExceptionAttrSlot,
 ) -> DescrRef {
@@ -4214,6 +4214,23 @@ pub fn w_exception_slot_descr(
         .position(|d| d.offset() == offset)
         .expect("W_BaseException descr group has no field at the selected slot offset");
     field_descr_from_group(group, field_index)
+}
+
+/// Cached field descriptor for a flattened `W_BaseException` slot selected
+/// by byte offset.  Returns `None` when the per-kind group does not carry the
+/// requested offset.
+pub fn w_exception_slot_descr(kind: ExcKind, offset: usize) -> Option<DescrRef> {
+    let idx = kind as u8 as usize;
+    let mut cache = W_BASE_EXCEPTION_DESCR_CACHE.lock().unwrap();
+    if cache[idx].is_none() {
+        cache[idx] = Some(build_w_exception_group(kind));
+    }
+    let group = cache[idx].as_ref().unwrap();
+    group
+        .field_descrs
+        .iter()
+        .position(|d| d.offset() == offset)
+        .map(|field| field_descr_from_group(group, field))
 }
 
 /// Field descr for `ExecutionContext::sys_exc_value`, used by the JIT

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3090,7 +3090,7 @@ pub(crate) fn try_walker_specialize_load_attr<Sym: WalkSym>(
         let raw_value = crate::state::opimpl_getfield_gc_r(
             ctx.trace_ctx,
             obj,
-            crate::descr::w_exception_slot_descr(kind, slot),
+            crate::descr::w_exception_attr_slot_descr(kind, slot),
         );
         walker_emit_fold_guard_with_snapshot(ctx, op_pc, OpCode::GuardNonnull, &[raw_value])?;
         ctx.trace_ctx.set_opref_concrete(
@@ -4161,7 +4161,7 @@ pub(crate) fn try_walker_specialize_store_attr<Sym: WalkSym>(
             } else {
                 (value, concrete_value)
             };
-        let field_descr = crate::descr::w_exception_slot_descr(kind, slot);
+        let field_descr = crate::descr::w_exception_attr_slot_descr(kind, slot);
         let field_index = field_descr.index();
         ctx.trace_ctx
             .record_op_with_descr(OpCode::SetfieldGc, &[obj, stored_value], field_descr);
@@ -11168,7 +11168,7 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
         } else {
             direct_code.expect("SystemExit code has neither direct nor tuple value")
         };
-        let descr = crate::descr::w_exception_slot_descr(
+        let descr = crate::descr::w_exception_attr_slot_descr(
             kind,
             pyre_interpreter::baseobjspace::ExceptionAttrSlot::Code,
         );
@@ -11194,7 +11194,7 @@ pub(crate) fn try_walker_trace_exception_new<Sym: WalkSym>(
             }
         }
         for (slot, value) in stores {
-            let descr = crate::descr::w_exception_slot_descr(kind, slot);
+            let descr = crate::descr::w_exception_attr_slot_descr(kind, slot);
             let descr_index = descr.index();
             ctx.trace_ctx
                 .record_op_with_descr(OpCode::SetfieldGc, &[new_op, value], descr);
@@ -11365,12 +11365,12 @@ pub(crate) fn try_walker_trace_raise_builtin<Sym: WalkSym>(
 ///
 /// `do_raise` instantiates a raised class with no arguments, so a bare
 /// `raise ValueError` is `raise ValueError()`.  When the operand is a
-/// canonical builtin exception class with a trivial-args constructor and no
-/// explicit `from` cause, build the zero-argument instance inline (the
-/// `try_walker_trace_exception_new` Empty-args shape) and chain
+/// canonical builtin exception class whose concrete zero-argument instance
+/// can be reproduced exactly and with no explicit `from` cause, build it
+/// inline using the `try_walker_trace_exception_new` Empty-args shape and chain
 /// `__context__` (the `try_walker_trace_raise_builtin` tail), so the whole
-/// exception virtualizes and DCEs when it never escapes.  A subclass or a
-/// non-trivial-args kind (OSError / Unicode) declines to the residual.
+/// exception virtualizes and DCEs when it never escapes.  A subclass or an
+/// instance carrying any other pointer-slot value declines to the residual.
 ///
 /// Returns `None` (fall through to the generic residual) for any
 /// non-matching shape.
@@ -11439,9 +11439,6 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
     if pyre_object::interp_exceptions::lookup_exc_class_for_kind(kind) != concrete_class {
         return Ok(None);
     }
-    if !kind.has_trivial_args_constructor() {
-        return Ok(None);
-    }
     let exc_type_ptr = unsafe {
         (*(exc as *const pyre_object::interp_exceptions::W_BaseException))
             .ob_header
@@ -11452,6 +11449,23 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
         pyre_object::interp_exceptions::exc_kind_to_pytype(kind),
     ) {
         return Ok(None);
+    }
+
+    let w_none = pyre_object::w_none();
+    let mut w_none_slot_descrs = Vec::new();
+    for (offset, value) in
+        unsafe { pyre_object::interp_exceptions::w_exception_traced_construction_slots(exc) }
+    {
+        if value.is_null() {
+            continue;
+        }
+        if !std::ptr::eq(value, w_none) {
+            return Ok(None);
+        }
+        let Some(descr) = crate::descr::w_exception_slot_descr(kind, offset) else {
+            return Ok(None);
+        };
+        w_none_slot_descrs.push(descr);
     }
 
     // Resolve the EC while declining is still free.  `walker_ensure_execution_
@@ -11495,6 +11509,14 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
 
     let new_op =
         crate::helpers::emit_exception_new_inline(ctx.trace_ctx, kind, class_op, args_list);
+    let w_none_const = ctx.trace_ctx.const_ref(w_none as i64);
+    for descr in w_none_slot_descrs {
+        let descr_index = descr.index();
+        ctx.trace_ctx
+            .record_op_with_descr(OpCode::SetfieldGc, &[new_op, w_none_const], descr);
+        ctx.trace_ctx
+            .heapcache_setfield_cached(new_op, descr_index, w_none_const);
+    }
     ctx.trace_ctx
         .heap_cache_mut()
         .class_now_known(new_op, exc_type_ptr as usize as i64);

--- a/pyre/pyre-object/src/interp_exceptions.rs
+++ b/pyre/pyre-object/src/interp_exceptions.rs
@@ -521,6 +521,55 @@ pub const EXC_W_GROUP_EXCEPTIONS_REPR_OFFSET: usize =
 pub const EXC_W_DICT_OFFSET: usize = std::mem::offset_of!(W_BaseException, w_dict);
 pub const EXC_W_WEAKREF_OFFSET: usize = std::mem::offset_of!(W_BaseException, w_weakreflifeline);
 
+/// The pointer slots a traced construction emit must reproduce itself.
+///
+/// Values are read through their exported byte offsets so this census cannot
+/// drift from the flattened `W_BaseException` layout.
+pub unsafe fn w_exception_traced_construction_slots(
+    obj: PyObjectRef,
+) -> [(usize, PyObjectRef); 33] {
+    const OFFSETS: [usize; 33] = [
+        EXC_W_CAUSE_OFFSET,
+        EXC_W_TRACEBACK_OFFSET,
+        EXC_W_OBJECT_OFFSET,
+        EXC_W_START_OFFSET,
+        EXC_W_END_OFFSET,
+        EXC_W_REASON_OFFSET,
+        EXC_W_ENCODING_OFFSET,
+        EXC_W_ERRNO_OFFSET,
+        EXC_W_WINERROR_OFFSET,
+        EXC_W_STRERROR_OFFSET,
+        EXC_W_FILENAME_OFFSET,
+        EXC_W_FILENAME2_OFFSET,
+        EXC_W_CODE_OFFSET,
+        EXC_W_VALUE_OFFSET,
+        EXC_W_NAME_OFFSET,
+        EXC_W_ATTR_OBJ_OFFSET,
+        EXC_W_IMPORT_PATH_OFFSET,
+        EXC_W_IMPORT_NAME_FROM_OFFSET,
+        EXC_W_IMPORT_MSG_OFFSET,
+        EXC_W_SYNTAX_MSG_OFFSET,
+        EXC_W_SYNTAX_FILENAME_OFFSET,
+        EXC_W_SYNTAX_LINENO_OFFSET,
+        EXC_W_SYNTAX_OFFSET_OFFSET,
+        EXC_W_SYNTAX_TEXT_OFFSET,
+        EXC_W_SYNTAX_END_LINENO_OFFSET,
+        EXC_W_SYNTAX_END_OFFSET_OFFSET,
+        EXC_W_SYNTAX_PRINT_FILE_AND_LINE_OFFSET,
+        EXC_W_SYNTAX_METADATA_OFFSET,
+        EXC_W_GROUP_MESSAGE_OFFSET,
+        EXC_W_GROUP_EXCEPTIONS_OFFSET,
+        EXC_W_GROUP_EXCEPTIONS_REPR_OFFSET,
+        EXC_W_DICT_OFFSET,
+        EXC_W_WEAKREF_OFFSET,
+    ];
+    let base = obj.cast::<u8>();
+    OFFSETS.map(|offset| {
+        let value = unsafe { base.add(offset).cast::<PyObjectRef>().read() };
+        (offset, value)
+    })
+}
+
 /// GC trace offsets for `W_BaseException` — `args_w` plus the three
 /// `PyObjectRef`-shaped chained-exception slots per
 /// `interp_exceptions.py:113-117 W_BaseException` class defaults,


### PR DESCRIPTION
## What

`try_walker_trace_raise_bare_class` — the walker fold that turns a bare `raise SomeExceptionClass` into a traced `NewWithVtable` + `SetfieldGc` construction so the exception stays virtual and a locally caught raise DCEs — gated on `ExcKind::has_trivial_args_constructor`. That is a per-kind allowlist, and it rejected StopIteration, AttributeError, NameError, ImportError, ModuleNotFoundError, SystemExit, SyntaxError and the OSError and Unicode families outright.

The fold only ever constructs with **zero arguments**, and with zero arguments those initializers write nothing argument-derived:

- `interp_exceptions.py:496-499 W_StopIteration` leaves `w_value` at None unless `len(args_w) > 0`
- `:810-812 W_NameError` and `:1134-1137 W_AttributeError` take `w_name` / `w_obj` from keywords only
- `:363-377 W_ImportError` fills `w_name` / `w_path` from keywords and `w_msg` from a lone positional

So `raise StopIteration` fell out to the opaque `bh_normalize_raise_varargs_with_frame` `CallMayForce`, which takes the callee frame and therefore materialises the frame, its locals array, its vref and every `PyTraceback` node on every compiled iteration.

## How

The allowlist is replaced by an exact check against the instance the fold already builds concretely, before its commit point. Every flattened pointer slot that `emit_exception_new_inline` does not write is read from that instance:

- `PY_NULL` — the `NewWithVtable` zero fill already matches, emit nothing
- the `w_none()` singleton — emit a `SetfieldGc` beside the construction stores
- anything else — decline to the residual

Kind-agnostic and self-checking: if an interpreter-side `descr_init` ever writes something else into a slot, the fold declines instead of emitting a wrong object. A zero-argument Unicode-error construction raises, so those kinds still decline on the `Err`.

`w_exception_traced_construction_slots` reads the slots through their exported offsets so the census cannot drift from the layout; `w_exception_slot_descr` gains an offset-keyed form and the existing `ExceptionAttrSlot`-keyed lookup becomes `w_exception_attr_slot_descr`. `try_walker_trace_exception_new` (the argument-bearing call form) is unchanged.

## Measured

Discriminator — same program, only the exception class changed (`def f(): raise X` called inside a `try` in a hot `while` loop), dynasm compiled loop:

| raise | ops | SetfieldGc | NewWithVtable | may-force |
|---|---|---|---|---|
| `raise ValueError` (already folded) | 46 | 2 | 0 | 0 |
| `raise StopIteration` before | 150 | 62 | 8 | 2 `CallMayForceR` + 2 `CondCallN` |
| `raise StopIteration` after | 46 | 2 | 0 | 0 |

New bench `synth/raise_bare_class_slot_kinds`, compiled loop: 1008 ops / 496 SetfieldGc / 64 NewWithVtable / 16 may-force → **164 / 16 / 0 / 0**. Wall clock at N=3000000 on dynasm: **23.87s → 0.25s**, pypy3 0.03s. The old shape degrades super-linearly (64 allocations per iteration), which is why N is 3M — 30k hides it inside compile time. Ratios read dynasm 11.5x / cranelift 11.1x / wasm 4.7x; ceiling 25.

No pre-existing bench moves. The `raise StopIteration` in the iterator benches sits inside a `__next__` that `FOR_ITER` residualises wholesale as `CallMayForceR(runtime_ops::jit_next, …)`, so it never reaches the walker — a separate defect.

## Gates

- `pyre/check.py --backend dynasm` 425/425, `--backend cranelift` green, `--backend wasm` 418 passed / 1 failed
- `pyre/extra_tests/parity_tests/run.py` all pass
- `cargo fmt --all -- --check` clean, `cargo test --all --no-default-features --features dynasm` green

The one wasm row is **not this change**: `synth/exception_traceback_loop_forms` reads `guard_failures 810 -> 811`. That bench contains no bare-class raise (every raise is a call form), and its dynasm jit-stats are byte-identical between a control binary with the gate restored and this branch (`loops_compiled=8 bridges_compiled=4 guard_failures=814` on both). Its committed wasm baseline was recorded on this same machine at #1182; the same machine now reads 811 at a newer base, so the move belongs to a base commit — `#1188` touched the bridge path and the bench compiles 4 bridges. Left untouched rather than folded into this PR.

## Separately found, not fixed here

A pre-existing wrong-code bug, reproduced on both backends:

```python
for cls in (ValueError, UserErr, RuntimeError):   # UserErr is a plain user subclass
    probe(cls)   # hot while loop doing `raise cls` inside a try
# TypeError: exception must derive from BaseException
```

It needs a folded first trace, a declining second one, and a third unseen class. The bridge taken from `GuardNotInvalidated` restores the frame fields and then `Finish(v41)` where `v41` is the failed **class** object, which is then raised as if it were the normalized exception. It reproduces identically on the control binary with the fold gate restored, so it predates this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when raising bare exception classes, including `StopIteration`, `NameError`, `AttributeError`, `ImportError`, and related exception types.
  * Ensured raised exceptions correctly preserve default arguments, chaining information, traceback details, and active exception-handler context.
  * Improved handling of exceptions with additional internal fields during optimized execution.

* **Tests**
  * Added parity coverage for bare-class exception behavior across multiple exception types.

* **Benchmarks**
  * Added performance coverage and runtime statistics for repeated bare-class exception raising.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->