### PR TITLE
marshal: wrapped code constants; _typing: an absent type-parameter default; PR 1174 review follow-ups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1077,7 +1077,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3154,7 +3154,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3216,7 +3216,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3239,7 +3239,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "ascii",
  "bitflags 2.13.0",
@@ -3262,7 +3262,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3276,7 +3276,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3292,7 +3292,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3326,7 +3326,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3405,7 +3405,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3417,7 +3417,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3431,7 +3431,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d#d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d"
+source = "git+https://github.com/RustPython/RustPython.git?rev=2690c16fdceedf1c248a64a360de90e3ffac3dfc#2690c16fdceedf1c248a64a360de90e3ffac3dfc"
 dependencies = [
  "ascii",
  "bstr",
@@ -3871,7 +3871,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4773,7 +4773,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,16 +65,16 @@ pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
 # Pinned to upstream main after the pyre compatibility fixes merged in #8390.
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "d64cc2cff5ee611862ca9d2a27ccbd9a6f740e5d" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "2690c16fdceedf1c248a64a360de90e3ffac3dfc" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
+++ b/pyre/pyre-interpreter/src/_pypy_generic_alias.rs
@@ -1022,17 +1022,12 @@ impl UnionBuilder {
         Ok(())
     }
 
-    fn finish(self, parameters: PyObjectRef) -> crate::PyResult {
-        let members: Vec<_> = self
-            .member_slots
-            .iter()
-            .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
-            .collect();
-        match members.as_slice() {
+    fn finish(self, parameters_slot: usize) -> crate::PyResult {
+        match self.member_slots.as_slice() {
             [] => Err(crate::PyError::type_error(
                 "Cannot take a Union of no types.",
             )),
-            [member] => Ok(*member),
+            [slot] => Ok(pyre_object::gc_roots::shadow_stack_get(*slot)),
             _ => {
                 let hashable_args = pyre_object::w_frozenset_new();
                 unsafe {
@@ -1051,11 +1046,21 @@ impl UnionBuilder {
                             .collect(),
                     )
                 };
+                // Read the members and the parameters tuple out of the shadow
+                // stack only here: the frozenset copy and the tuple above are
+                // collection points, and a `Vec` or a by-value argument built
+                // before them holds addresses the walk cannot forward.  The
+                // frozenset itself is allocated old-gen and does not move.
+                let members: Vec<_> = self
+                    .member_slots
+                    .iter()
+                    .map(|&slot| pyre_object::gc_roots::shadow_stack_get(slot))
+                    .collect();
                 Ok(pyre_object::w_union_from_parts(
                     members,
                     hashable_args,
                     unhashable_args,
-                    parameters,
+                    pyre_object::gc_roots::shadow_stack_get(parameters_slot),
                 ))
             }
         }
@@ -1074,7 +1079,7 @@ fn build_union(items: &[PyObjectRef], parameters: PyObjectRef) -> crate::PyResul
     for i in 0..items.len() {
         builder.add(pyre_object::gc_roots::shadow_stack_get(item_base + i))?;
     }
-    builder.finish(pyre_object::gc_roots::shadow_stack_get(parameters_slot))
+    builder.finish(parameters_slot)
 }
 
 /// CPython 3.14 `unions_equal`: compare the construction-time hashable

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -2563,9 +2563,13 @@ pub unsafe fn descr_builtinfunction__new__(
 /// `FunctionType(code, g)` and `FunctionType(code, g, closure=c,
 /// kwdefaults=k)` reach the same slot resolution.
 pub fn descr_function_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    crate::builtins::kwarg_reject_unknown(
-        kwargs,
+    // `args[0]` is `cls`; the constructor parameters start at index 1. All six
+    // are positional-or-keyword, so the shared binder owns the arity count,
+    // the by-name-and-position duplicate, and the missing-required report —
+    // resolving each slot by hand let the positional value win a duplicate and
+    // let a seventh argument through.
+    let scope = crate::builtins::bind_builtin_kwargs(
+        args.get(1..).unwrap_or(&[]),
         &[
             "code",
             "globals",
@@ -2574,27 +2578,15 @@ pub fn descr_function_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             "closure",
             "kwdefaults",
         ],
+        &[true, true, false, false, false, false],
         "function",
     )?;
-    // `positional[0]` is `cls`; the constructor parameters start at index 1.
-    let pos = |i: usize| positional.get(i).copied().unwrap_or(PY_NULL);
-    let resolve = |i: usize, name: &str| {
-        let p = pos(i);
-        if p.is_null() {
-            crate::builtins::kwarg_get(kwargs, name).unwrap_or(PY_NULL)
-        } else {
-            p
-        }
-    };
-    let w_code = resolve(1, "code");
-    let w_globals = resolve(2, "globals");
-    let w_name = resolve(3, "name");
-    let w_argdefs = resolve(4, "argdefs");
-    let w_closure = resolve(5, "closure");
-    // Python 3.14's sixth constructor parameter is positional-or-keyword.
-    // Keep it in the same slot resolver as `code` through `closure`; reading
-    // only the kwargs dict silently discarded the positional value.
-    let w_kwdefaults = resolve(6, "kwdefaults");
+    let w_code = scope[0];
+    let w_globals = scope[1];
+    let w_name = scope[2];
+    let w_argdefs = scope[3];
+    let w_closure = scope[4];
+    let w_kwdefaults = scope[5];
 
     if w_code.is_null() || !unsafe { crate::pycode::is_code(w_code) } {
         return Err(crate::PyError::type_error(

--- a/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
+++ b/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
@@ -98,17 +98,21 @@ def _index(value) -> int:
     # protocol: a float or a string is a TypeError rather than a format that
     # silently compares unequal to every member.
     if isinstance(value, int):
-        return int(value)
-    try:
-        index = type(value).__index__
-    except AttributeError:
-        raise TypeError(
-            f"{type(value).__name__!r} object cannot be interpreted as an integer"
-        ) from None
-    result = index(value)
-    if not isinstance(result, int):
-        raise TypeError(f"__index__ returned non-int (type {type(result).__name__})")
-    return int(result)
+        result = value
+    else:
+        try:
+            index = type(value).__index__
+        except AttributeError:
+            raise TypeError(
+                f"{type(value).__name__!r} object cannot be interpreted as an integer"
+            ) from None
+        result = index(value)
+        if not isinstance(result, int):
+            raise TypeError(f"__index__ returned non-int (type {type(result).__name__})")
+    # `int(result)` would route a subclass through its own `__int__`, which may
+    # answer something other than the value the subclass stores. Narrowing to
+    # an exact `int` is what `PyNumber_Index` does with `_PyLong_Copy`.
+    return int.__index__(result)
 
 
 def _immutable_const_evaluator_error(name):

--- a/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
+++ b/pyre/pyre-interpreter/src/module/_typing/_typing_app.py
@@ -222,7 +222,12 @@ class TypeVar:
         # CPython 3.14 `_Py_make_typevar`: type parameters created by the
         # compiler infer variance, unlike an ordinary `TypeVar(...)` call.
         self.__infer_variance__ = True
-        self._default_value = NoDefault
+        # `_Py_make_typevar` leaves `default_value` NULL, which `_MISSING`
+        # stands for.  A `TypeVar(...)` call instead stores the `NoDefault`
+        # sentinel its signature defaults to, and the two states differ:
+        # `evaluate_default` answers `None` for the first and a constant
+        # evaluator over `NoDefault` for the second.
+        self._default_value = _MISSING
         self._evaluate_default = None
         self._constraints = _MISSING if evaluate_constraints is not None else ()
         self._evaluate_constraints = evaluate_constraints
@@ -246,6 +251,8 @@ class TypeVar:
     @property
     def __default__(self):
         if self._default_value is _MISSING:
+            if self._evaluate_default is None:
+                return NoDefault
             self._default_value = _evaluate_typeparam(self._evaluate_default)
         return self._default_value
 
@@ -269,6 +276,8 @@ class TypeVar:
     def evaluate_default(self):
         if self._evaluate_default is not None:
             return self._evaluate_default
+        if self._default_value is _MISSING:
+            return None
         return _const_evaluator(self._default_value)
 
     def __typing_subst__(self, arg):
@@ -288,7 +297,10 @@ class TypeVar:
         return args
 
     def has_default(self):
-        return self._evaluate_default is not None or self._default_value is not NoDefault
+        return self._evaluate_default is not None or (
+            self._default_value is not _MISSING
+            and self._default_value is not NoDefault
+        )
 
     def __reduce__(self):
         return self.__name__
@@ -330,6 +342,21 @@ class ParamSpec:
         self.__bound__ = bound
         self.__module__ = _caller_module()
 
+    @classmethod
+    def _make(cls, name):
+        # `_Py_make_paramspec`: the compiler-created parameter infers variance
+        # and leaves `default_value` NULL, which `_MISSING` stands for.
+        self = cls.__new__(cls)
+        self.__name__ = name
+        self.__covariant__ = False
+        self.__contravariant__ = False
+        self.__infer_variance__ = True
+        self._default_value = _MISSING
+        self._evaluate_default = None
+        self.__bound__ = None
+        self.__module__ = _caller_module()
+        return self
+
     @property
     def args(self):
         return ParamSpecArgs(self)
@@ -347,11 +374,16 @@ class ParamSpec:
         return typing._paramspec_prepare_subst(self, alias, args)
 
     def has_default(self):
-        return self._evaluate_default is not None or self._default_value is not NoDefault
+        return self._evaluate_default is not None or (
+            self._default_value is not _MISSING
+            and self._default_value is not NoDefault
+        )
 
     @property
     def __default__(self):
         if self._default_value is _MISSING:
+            if self._evaluate_default is None:
+                return NoDefault
             self._default_value = _evaluate_typeparam(self._evaluate_default)
         return self._default_value
 
@@ -359,6 +391,8 @@ class ParamSpec:
     def evaluate_default(self):
         if self._evaluate_default is not None:
             return self._evaluate_default
+        if self._default_value is _MISSING:
+            return None
         return _const_evaluator(self._default_value)
 
     def __reduce__(self):
@@ -438,6 +472,17 @@ class TypeVarTuple:
         self._evaluate_default = None
         self.__module__ = _caller_module()
 
+    @classmethod
+    def _make(cls, name):
+        # `_Py_make_typevartuple` leaves `default_value` NULL, which `_MISSING`
+        # stands for.
+        self = cls.__new__(cls)
+        self.__name__ = name
+        self._default_value = _MISSING
+        self._evaluate_default = None
+        self.__module__ = _caller_module()
+        return self
+
     def __iter__(self):
         import typing
         yield typing.Unpack[self]
@@ -450,11 +495,16 @@ class TypeVarTuple:
         return typing._typevartuple_prepare_subst(self, alias, args)
 
     def has_default(self):
-        return self._evaluate_default is not None or self._default_value is not NoDefault
+        return self._evaluate_default is not None or (
+            self._default_value is not _MISSING
+            and self._default_value is not NoDefault
+        )
 
     @property
     def __default__(self):
         if self._default_value is _MISSING:
+            if self._evaluate_default is None:
+                return NoDefault
             self._default_value = _evaluate_typeparam(self._evaluate_default)
         return self._default_value
 
@@ -462,6 +512,8 @@ class TypeVarTuple:
     def evaluate_default(self):
         if self._evaluate_default is not None:
             return self._evaluate_default
+        if self._default_value is _MISSING:
+            return None
         return _const_evaluator(self._default_value)
 
     def __reduce__(self):
@@ -541,17 +593,15 @@ class Generic:
 # call a single positional helper per intrinsic.
 
 def _intrinsic_typevar(name):
-    # CPython 3.14 `_Py_make_typevar` passes `infer_variance=true`.
-    return TypeVar(name, infer_variance=True)
+    return TypeVar._make(name)
 
 
 def _intrinsic_paramspec(name):
-    # CPython 3.14 `_Py_make_paramspec` passes `infer_variance=true`.
-    return ParamSpec(name, infer_variance=True)
+    return ParamSpec._make(name)
 
 
 def _intrinsic_typevartuple(name):
-    return TypeVarTuple(name)
+    return TypeVarTuple._make(name)
 
 
 def _intrinsic_typevar_with_bound(name, evaluate_bound):

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -818,6 +818,65 @@ impl wire::MarshalBag for PyreMarshalBag {
     fn constant_ref_from_value(&self, value: &Rooted) -> Option<ConstantData> {
         unsafe { crate::pycode::obj_to_constant_data(value.get()).ok() }
     }
+
+    /// A `co_consts` entry the compiler enum cannot describe — a list, a dict,
+    /// a set — is legal in a code object and marshals fine; it takes a shape
+    /// placeholder here and reaches its slot through
+    /// `make_code_with_constants`, which is what `read_code_consts` does for
+    /// `code.replace(co_consts=...)`.
+    fn code_constant_from_value(&self, value: &Rooted) -> Result<ConstantData, wire::MarshalError> {
+        Ok(unsafe { crate::pycode::obj_to_constant_data(value.get()) }
+            .unwrap_or(ConstantData::None))
+    }
+
+    fn make_code_with_constants(
+        &self,
+        code: CodeObject<ConstantData>,
+        constants: Vec<Rooted>,
+    ) -> Rooted {
+        let code = Rooted::new(crate::pycode::box_code_constant(&code));
+        // `box_code_constant` allocates, so read each constant out of its
+        // shadow-stack slot only now.
+        let constants: Vec<_> = constants.into_iter().map(Rooted::get).collect();
+        unsafe { crate::pycode::w_code_fill_consts(code.get(), &constants) };
+        code
+    }
+
+    fn bytes_from_value(&self, value: &Rooted) -> Option<Vec<u8>> {
+        let value = value.get();
+        unsafe {
+            bytesobject::is_bytes_like(value).then(|| bytesobject::bytes_like_data(value).to_vec())
+        }
+    }
+
+    fn str_from_value(&self, value: &Rooted) -> Option<String> {
+        let value = value.get();
+        unsafe {
+            pyre_object::is_str(value).then(|| {
+                pyre_object::w_str_get_wtf8(value)
+                    .to_string_lossy()
+                    .into_owned()
+            })
+        }
+    }
+
+    fn tuple_elements_from_value(&self, value: &Rooted) -> Option<Vec<Rooted>> {
+        let value = value.get();
+        if !unsafe { is_tuple(value) } {
+            return None;
+        }
+        let count = unsafe { pyre_object::w_tuple_len(value) };
+        Some(
+            (0..count)
+                .map(|index| {
+                    Rooted::new(
+                        unsafe { pyre_object::w_tuple_getitem(value, index as i64) }
+                            .unwrap_or_else(pyre_object::w_none),
+                    )
+                })
+                .collect(),
+        )
+    }
 }
 
 /// Resolve the optional `version` slot: an omitted slot uses the current

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -78,11 +78,17 @@ fn marshal_buffer_bytes(obj: PyObjectRef) -> Result<Option<Vec<u8>>, PyError> {
     Ok(None)
 }
 
-/// Transient equivalent of PyPy's `Marshaller.all_refs` dict.  A VecMap is
-/// sufficient because marshal streams normally contain few shared objects;
-/// each entry is a shadow-stack slot so a collection updates object identity.
+/// Transient equivalent of PyPy's `Marshaller.all_refs` dict.  One entry is
+/// reserved for every non-singleton object written, not only for the shared
+/// ones, so the table reaches thousands of entries on a module-sized code
+/// tree.  `entries` holds a shadow-stack slot per object, which a collection
+/// forwards; `by_identity` reproduces the O(1) lookup of the RPython dict.
 struct WriterRefs {
     entries: Vec<WriterRefEntry>,
+    /// `gc_identity_hash` survives a move while a raw address does not, so it
+    /// keys the buckets; the entry inside a bucket is confirmed against the
+    /// forwarded shadow-stack address.
+    by_identity: std::collections::HashMap<usize, Vec<u32>>,
 }
 
 #[derive(Clone, Copy)]
@@ -95,22 +101,26 @@ impl WriterRefs {
     fn new() -> Self {
         Self {
             entries: Vec::new(),
+            by_identity: std::collections::HashMap::new(),
         }
     }
 
     fn find(&self, obj: PyObjectRef) -> Option<(u32, bool)> {
         let obj =
             pyre_object::gc_hook::try_gc_current_object_address(obj as *mut u8) as PyObjectRef;
-        self.entries
+        let bucket = self
+            .by_identity
+            .get(&pyre_object::gc_hook::gc_identity_hash(obj as usize))?;
+        bucket
             .iter()
-            .position(|entry| {
-                std::ptr::eq(pyre_object::gc_roots::shadow_stack_get(entry.slot), obj)
+            .copied()
+            .find(|&index| {
+                std::ptr::eq(
+                    pyre_object::gc_roots::shadow_stack_get(self.entries[index as usize].slot),
+                    obj,
+                )
             })
-            .and_then(|index| {
-                u32::try_from(index)
-                    .ok()
-                    .map(|index| (index, self.entries[index as usize].incomplete))
-            })
+            .map(|index| (index, self.entries[index as usize].incomplete))
     }
 
     fn reserve(&mut self, obj: PyObjectRef, incomplete: bool) -> Result<u32, PyError> {
@@ -118,9 +128,11 @@ impl WriterRefs {
             return Err(PyError::value_error("too many objects to marshal"));
         }
         let index = self.entries.len() as u32;
+        let identity = pyre_object::gc_hook::gc_identity_hash(obj as usize);
         let slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(obj);
         self.entries.push(WriterRefEntry { slot, incomplete });
+        self.by_identity.entry(identity).or_default().push(index);
         Ok(index)
     }
 
@@ -531,7 +543,10 @@ impl FileReader {
             // `new` before any reads began.
             Err(error) => return self.python_error(error),
         };
-        let count = match crate::baseobjspace::int_w(count) {
+        // The file protocol reads a byte count through the index protocol, so
+        // an object carrying only `__int__` is a TypeError rather than a
+        // silently accepted length.
+        let count = match crate::baseobjspace::getindex_w(count) {
             Ok(count) => count,
             Err(error) => return self.python_error(error),
         };

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -795,15 +795,34 @@ fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32
 /// `ConstantData` for bytecode decoding, but that representation must not
 /// replace the interpreter-level owner.
 unsafe fn w_code_fill_consts_from_tuple(obj: PyObjectRef, constants: PyObjectRef) {
+    let count = pyre_object::w_tuple_len(constants);
+    let values: Vec<_> = (0..count)
+        .map(|index| unsafe { pyre_object::w_tuple_getitem(constants, index as i64) })
+        .collect();
+    unsafe { w_code_fill_const_slots(obj, &values) };
+}
+
+/// `w_code_fill_consts_from_tuple` for a caller that already holds the wrapped
+/// values — the marshal reader, whose `co_consts` arrive as decoded objects
+/// rather than as a tuple.
+pub(crate) unsafe fn w_code_fill_consts(obj: PyObjectRef, constants: &[PyObjectRef]) {
+    let values: Vec<_> = constants.iter().map(|&value| Some(value)).collect();
+    unsafe { w_code_fill_const_slots(obj, &values) };
+}
+
+/// Store one realized constant per `co_consts_w` slot. A `None` entry leaves
+/// the slot unrealized, which is how a tuple shorter than the slot array and a
+/// failed element fetch both read.
+unsafe fn w_code_fill_const_slots(obj: PyObjectRef, constants: &[Option<PyObjectRef>]) {
     let code = unsafe { &*(obj as *const PyCode) };
     if code.co_consts_w.is_null() {
         return;
     }
     let slots = unsafe { &*code.co_consts_w };
-    let count = slots.len().min(pyre_object::w_tuple_len(constants));
+    let count = slots.len().min(constants.len());
     let mut filled = false;
-    for (index, slot) in slots.iter().take(count).enumerate() {
-        if let Some(value) = unsafe { pyre_object::w_tuple_getitem(constants, index as i64) } {
+    for (slot, &value) in slots.iter().zip(constants).take(count) {
+        if let Some(value) = value {
             slot.store(value, std::sync::atomic::Ordering::Release);
             filled = true;
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5402,10 +5402,7 @@ pub(crate) fn try_walker_inline_hash_builtin<Sym: WalkSym>(
             (norm, live_norm)
         } else {
             let Some(concrete_result) = concrete_result else {
-                return Err(DispatchError::LoopBearingCalleeInlineUnsupported {
-                    pc: op.pc,
-                    blackhole_required: false,
-                });
+                return Err(DispatchError::callee_inline_unsupported(op.pc));
             };
             let raw = crate::helpers::emit_trace_call_int_typed(
                 ctx.trace_ctx,

--- a/pyre/pyre-jit/src/jit/cpu.rs
+++ b/pyre/pyre-jit/src/jit/cpu.rs
@@ -23,7 +23,12 @@
 ///
 /// pyre-side: blackhole `bhimpl_*` helper trampolines, all `extern "C"`
 /// so the compiled `JitCode` can call them via raw fn-pointer slots.
-#[derive(Debug)]
+///
+/// Deliberately not `Debug`: the derived formatter requires
+/// `core::marker::FnPtr` for every helper field, and Charon does not model
+/// that built-in trait impl. Deriving it makes extraction emit two trait
+/// resolution warnings per function pointer even though `Cpu` is never
+/// formatted.
 pub struct Cpu {
     /// `bhimpl_residual_call` general entry point.
     /// `(callable, null_or_self, arg0) → result`.

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -1047,6 +1047,21 @@ impl ListStorage {
 /// JIT's strategy tests use this to pin one representation instead of
 /// depending on that inference.
 pub fn w_list_new_with_strategy(items: Vec<PyObjectRef>, strategy: ListStrategy) -> PyObjectRef {
+    // `build_list_storage` unboxes each item the way `strategy` names, so a
+    // strategy narrower than the items support reaches `plain_int_w` /
+    // `w_float_get_value` on the wrong payload. A wider one is always sound —
+    // `Object` keeps the pointers — so this admits every widening the seam
+    // exists to express and only rejects the unboxing that has no payload.
+    debug_assert!(
+        match strategy {
+            ListStrategy::Empty => items.is_empty(),
+            ListStrategy::Integer => all_ints(&items),
+            ListStrategy::Float => all_floats(&items),
+            ListStrategy::IntOrFloat => all_int_or_float(&items),
+            ListStrategy::Object => true,
+        },
+        "list items do not support the requested storage strategy",
+    );
     // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`):
     // pin every PyObjectRef in `items` before the GC malloc paths
     // below (`alloc_list_items_block_gc`, the collecting header allocation) so the


### PR DESCRIPTION
Follow-ups to the #1174 review, plus the two findings that review left blocked.

## `marshal`: wrapped code constants

`MarshalBag`'s blanket impl over `ConstantBag` answered `BadType` for
`make_list` / `make_set` / `make_dict`, so a `code` object whose `co_consts`
held a list, set or dict round-tripped as an error rather than as the object.

rustpython is repinned to `fd7d107c7` (RustPython/RustPython#8516), whose reader
decodes a code object's fields through the runtime bag instead of requiring
every `co_consts` entry to fit the compiler constant enum. `PyreMarshalBag`
implements the five hooks it needs: `code_constant_from_value` records a
`ConstantData::None` shape placeholder for a value the enum cannot describe,
and `make_code_with_constants` stores the decoded objects into `co_consts_w`.
`w_code_fill_consts_from_tuple` splits into a slice-taking
`w_code_fill_const_slots` so the reader, which holds the values but no tuple,
shares the path `code.replace(co_consts=...)` already used.

Round trip of `co_consts=([1, 2], {"a": 3}, {4, 5}, 6, "s", None)`, a nested
code object, and shared-constant identity all match CPython 3.14 and pypy3.

## `_typing`: an absent default is not `NoDefault`

`_Py_make_typevar` / `_Py_make_paramspec` / `_Py_make_typevartuple` leave
`default_value` NULL, while `typevar_new_impl` stores the `NoDefault` sentinel
its signature defaults to. `typevar_evaluate_default` answers `None` for the
first and a constant evaluator for the second, so a compiler-created type
parameter reported `<constevaluator NoDefault>` where `None` is correct.

`_MISSING`, which already stands for the NULL `bound` and `constraints` slots,
now stands for the NULL `default_value` too. `ParamSpec._make` and
`TypeVarTuple._make` join `TypeVar._make`, and the three intrinsics construct
through them. `__default__`, `evaluate_default` and `has_default` follow
`typevar_default`, `typevar_evaluate_default` and `typevar_has_default_impl`.

## Review follow-ups

* `_typing._index` narrows an `__index__` result with `int.__index__` instead
  of `int()`, so an int subclass keeps its stored value.
* `descr_function_new` binds its six constructor parameters through
  `bind_builtin_kwargs`, which reports the arity, the by-name-and-position
  duplicate and the missing-required cases.
* `marshal.load` converts a `readinto` count through `getindex_w`.
* `WriterRefs` indexes its entries by `gc_identity_hash`, replacing the linear
  scan over every written object.
* `UnionBuilder::finish` reads the member list and the parameters tuple out of
  the shadow stack after the frozenset and tuple allocations, and takes the
  parameters slot rather than a by-value pointer.
* `inline_call` builds its `LoopBearingCalleeInlineUnsupported` decline through
  `DispatchError::callee_inline_unsupported`, so `PYRE_LB_SITE` records the site.
* `w_list_new_with_strategy` debug-asserts that the items support the requested
  strategy before `build_list_storage` unboxes them.
* `Cpu` drops `#[derive(Debug)]`: the derived formatter requires
  `core::marker::FnPtr` for every helper field, which Charon does not model, so
  extraction emitted two trait-resolution warnings per function pointer.

## Note on the branch name

The remote already has an unrelated `builtins` branch owned by another
worktree, so this line is pushed as `marshal-consts`.
