### PR TITLE
majit: array element write-sets for residual calls, per-jitdriver enable_opts, and resume-path fixes

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -3387,9 +3387,11 @@ impl<'a> AssemblerARM64<'a> {
                     let rv = r.value;
                     dynasm!(self.mc ; .arch aarch64 ; mov X(rv), x0);
                 }
-                if !op.pos.get().is_none() {
-                    self.store_rax_to_result(op.pos.get());
-                }
+                // aarch64/regalloc.py:964-966 keeps malloc's result in the
+                // selected result register (x0); it does not eagerly mirror
+                // every result into its jitframe slot.  Regalloc emits the
+                // eventual spill when a guard or register-pressure boundary
+                // actually needs one.
             }
             // aarch64/assembler.py:715 malloc_cond_varsize_frame
             OpCode::CallMallocNurseryVarsizeFrame => {
@@ -6546,9 +6548,11 @@ impl<'a> AssemblerARM64<'a> {
             return;
         }
 
-        // x0 = nursery_free, x1 = new_free, x2 = scratch, x3 = nursery_top
-        self.emit_mov_imm64(2, nf_addr as i64);
-        dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x2]);
+        // aarch64/assembler.py:682-708 uses only x0/x1 plus the reserved IP
+        // scratch registers.  Keep x2..x13 available to regalloc on the fast
+        // path; the collecting slow path spills/restores them below.
+        self.emit_mov_imm64(16, nf_addr as i64);
+        dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x16]);
 
         if total_size < 4096 {
             let ts = total_size as u32;
@@ -6558,18 +6562,18 @@ impl<'a> AssemblerARM64<'a> {
             dynasm!(self.mc ; .arch aarch64 ; add x1, x0, x1);
         }
 
-        self.emit_mov_imm64(3, nt_addr as i64);
-        dynasm!(self.mc ; .arch aarch64 ; ldr x3, [x3]);
-        dynasm!(self.mc ; .arch aarch64 ; cmp x1, x3);
+        self.emit_mov_imm64(17, nt_addr as i64);
+        dynasm!(self.mc ; .arch aarch64 ; ldr x17, [x17]);
+        dynasm!(self.mc ; .arch aarch64 ; cmp x1, x17);
 
         let slow_path = self.mc.new_dynamic_label();
         let done = self.mc.new_dynamic_label();
         dynasm!(self.mc ; .arch aarch64 ; b.hi =>slow_path);
 
-        // Fast path: bump nursery_free, zero header, return payload ptr
-        self.emit_mov_imm64(2, nf_addr as i64);
+        // Fast path: x16 still holds &nursery_free; bump it, zero the header,
+        // and return the payload pointer.
         dynasm!(self.mc ; .arch aarch64
-            ; str x1, [x2]       // *nursery_free = new_free
+            ; str x1, [x16]      // *nursery_free = new_free
             ; str xzr, [x0]      // zero GcHeader
         );
         let hs = gc_hdr as u32;
@@ -6685,8 +6689,11 @@ impl<'a> AssemblerARM64<'a> {
             return;
         }
 
-        self.emit_mov_imm64(2, nf_addr as i64);
-        dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x2]);
+        // As in upstream malloc_cond, x0/x1 are the only managed registers
+        // clobbered by the fast path; nursery addresses live in reserved IP
+        // scratch registers.
+        self.emit_mov_imm64(16, nf_addr as i64);
+        dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x16]);
 
         if size < 4096 {
             let sz = size as u32;
@@ -6696,17 +6703,29 @@ impl<'a> AssemblerARM64<'a> {
             dynasm!(self.mc ; .arch aarch64 ; add x1, x0, x1);
         }
 
-        self.emit_mov_imm64(3, nt_addr as i64);
-        dynasm!(self.mc ; .arch aarch64 ; ldr x3, [x3]);
-        dynasm!(self.mc ; .arch aarch64 ; cmp x1, x3);
+        // Aheui's live nursery places the top slot immediately after the free
+        // slot. Reuse x16 as the address base when the allocator reports that
+        // layout; custom allocators with independent slots retain the general
+        // path.
+        if nt_addr == nf_addr.wrapping_add(std::mem::size_of::<usize>()) {
+            dynasm!(self.mc ; .arch aarch64 ; ldr x17, [x16, 8]);
+        } else {
+            self.emit_mov_imm64(17, nt_addr as i64);
+            dynasm!(self.mc ; .arch aarch64 ; ldr x17, [x17]);
+        }
+        dynasm!(self.mc ; .arch aarch64 ; cmp x1, x17);
 
         let slow_path = self.mc.new_dynamic_label();
         let done = self.mc.new_dynamic_label();
         dynasm!(self.mc ; .arch aarch64 ; b.hi =>slow_path);
 
-        self.emit_mov_imm64(2, nf_addr as i64);
+        // x16 still holds nf_addr from the load above: the intervening add,
+        // top load, compare, and branch only write x0, x1, x17, and flags.
+        // Keep that address live on the fast arm instead of materializing the
+        // same 64-bit constant a second time.  The slow arm has its own call
+        // sequence and does not join at this store.
         dynasm!(self.mc ; .arch aarch64
-            ; str x1, [x2]       // *nursery_free = new_free
+            ; str x1, [x16]      // *nursery_free = new_free
             ; b =>done
         );
 

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -303,7 +303,8 @@ pub struct AssemblerARM64<'a> {
     /// Vec-backed `IndexMap`: `resolve_opref` reads this per emitted op during
     /// codegen and the sync loop inserts one entry per live var, so a Vec-`get`
     /// is O(n) and makes `_assemble` O(n^2) on large traces — `get_index_of`
-    /// inlines into `_assemble` and dominated aheui's logo compile. The box→
+    /// inlines into `_assemble` and dominated compile time on a trace of tens
+    /// of thousands of ops. The box→
     /// location map is a dict in the reference assembler; insertion order is
     /// preserved (no semantic change, only the lookup cost).
     opref_to_slot: indexmap::IndexMap<OpRef, usize>,
@@ -6012,18 +6013,24 @@ impl<'a> AssemblerARM64<'a> {
         }
     }
 
-    /// Inline aheui's headerless `jit_alloc_node(value, next)` nursery bump.
+    /// Inline nursery bump for a call tagged
+    /// [`majit_ir::PyreHelperKind::NurseryAlloc`].
     ///
-    /// The fast path only advances `nursery_free` and initializes the
-    /// 16-byte Node payload, so it cannot collect and emits no gcmap. The
-    /// slow path is the ordinary residual call wrapper, which may collect
-    /// inside `jit_alloc_node` / `Nursery::alloc` and passes `next` (the old
-    /// head) as the keep-root. This is sound because the op is still a call:
-    /// the optimizer's residual-call emission fences pending head/size
-    /// setfields before this allocation, matching the storage collector's
-    /// root-currentness requirement.
+    /// The tag declares a two-word headerless node taken from the
+    /// interpreter's own nursery, whose payload is the call's two arguments:
+    /// the value at offset 0 and the successor link at offset 8.
+    ///
+    /// The fast path only advances `nursery_free` and stores those two words,
+    /// so it cannot collect and emits no gcmap. The slow path is the ordinary
+    /// residual call wrapper, which may collect inside the callee; the callee
+    /// is free to treat the second argument as a keep-root, since that is the
+    /// object the new node links to. This is sound because the op is still a
+    /// call: the optimizer's residual-call emission fences pending setfields
+    /// before the allocation, so a collector that walks the interpreter's own
+    /// structures finds roots that are current.
     fn genop_nursery_alloc_inline(&mut self, op: &Op, arglocs: &[Loc]) {
-        const NURSERY_ALLOC_NODE_SIZE: u32 = 16; // aheui headerless Node = 16B (value@0,next@8)
+        // Two-word headerless node: value@0, link@8.
+        const NURSERY_ALLOC_NODE_SIZE: u32 = 16;
 
         let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
         if nf_addr == 0 || nt_addr == 0 {
@@ -6662,9 +6669,9 @@ impl<'a> AssemblerARM64<'a> {
     ///
     /// The fast path raw-bumps `dynasm_nursery_addrs()`, so it is correct only
     /// when the active dynasm GC is headerless-aware — its nursery must yield a
-    /// raw base carrying no `GcHeader` (aheui's `NurseryGcAllocator`, whose
-    /// nursery is the aheui node arena collected by aheui's own copying node
-    /// GC).  A headered collector such as MiniMarkGC must never back this op:
+    /// raw base carrying no `GcHeader` — what an interpreter that runs its own
+    /// collector over its own object arena supplies.  A headered collector such
+    /// as MiniMarkGC must never back this op:
     /// its nursery walk reads a `GcHeader` at `base - GcHeader::SIZE`, which a
     /// raw base lacks.  The overflow slowpath enforces this via
     /// `alloc_nursery_headerless`'s panicking default; the fast path relies on
@@ -6703,10 +6710,9 @@ impl<'a> AssemblerARM64<'a> {
             dynasm!(self.mc ; .arch aarch64 ; add x1, x0, x1);
         }
 
-        // Aheui's live nursery places the top slot immediately after the free
-        // slot. Reuse x16 as the address base when the allocator reports that
-        // layout; custom allocators with independent slots retain the general
-        // path.
+        // When the allocator reports the top slot immediately after the free
+        // slot, reuse x16 as the address base; allocators that keep the two
+        // slots independent retain the general path.
         if nt_addr == nf_addr.wrapping_add(std::mem::size_of::<usize>()) {
             dynasm!(self.mc ; .arch aarch64 ; ldr x17, [x16, 8]);
         } else {

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -257,7 +257,7 @@ pub struct LifetimeManager {
     // (`RegisterManager::loc`/`_sync_var_to_stack`/`spill_*`,
     // `FrameManager::get`/`bind`/`get_new_loc`) resolves a variable through
     // `lifetimes.get(v)`, and a Vec-backed `get` is O(n) — making regalloc
-    // O(n^2) on very large traces (aheui's logo whole-program loop spends
+    // O(n^2) on very large traces (a whole-program loop spends
     // ~all its backend time in `IndexMap::get_index_of` here). regalloc.py:1054
     // keys longevity by a dict (O(1)); `IndexMap` restores that O(1) lookup
     // while keeping the insertion-ordered iteration `IndexMap` provided.

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -5379,10 +5379,11 @@ impl<'a> RegAlloc<'a> {
         self.perform(i, arglocs, result_loc, output);
     }
 
-    /// aarch64/regalloc.py:958 prepare_op_call_malloc_nursery parity.
-    /// Spill ALL registers: the nursery bump path clobbers x0-x3 (aarch64)
-    /// or ecx/edx/rax (x86). The slow path may trigger GC.
-    /// aarch64/regalloc.py:958 prepare_op_call_malloc_nursery parity.
+    /// aarch64/regalloc.py:958 / x86/regalloc.py:1013
+    /// prepare/consider_call_malloc_nursery parity. Move or spill only the
+    /// nursery bump registers. The AArch64 emitter uses x0/x1 plus reserved IP
+    /// scratch registers; collecting slow paths save/restore the other
+    /// managed registers on both native architectures.
     fn consider_call_malloc_nursery(&mut self, op: &Op, i: usize, output: &mut Vec<RegAllocOp>) {
         let type_index = OpTypeIndex::from_parts(
             self.inputargs,
@@ -5394,7 +5395,7 @@ impl<'a> RegAlloc<'a> {
         self.rm.spill_or_move_registers_before_call(
             &MALLOC_NURSERY_CLOBBER,
             &[],
-            SAVE_ALL_REGS,
+            SAVE_DEFAULT_REGS,
             &mut self.longevity,
             &mut self.fm,
             &mut self.pending_moves,
@@ -5453,7 +5454,7 @@ impl<'a> RegAlloc<'a> {
         self.rm.spill_or_move_registers_before_call(
             &MALLOC_NURSERY_CLOBBER,
             &[],
-            SAVE_ALL_REGS,
+            SAVE_DEFAULT_REGS,
             &mut self.longevity,
             &mut self.fm,
             &mut self.pending_moves,
@@ -6312,6 +6313,58 @@ mod tests {
         assert!(reg2 == reg0 || reg2 == reg1);
         // The spilled variable should now be in the frame
         assert!(fm.get_frame_depth() >= 1);
+    }
+
+    #[test]
+    fn test_fixed_nursery_malloc_keeps_unrelated_live_register_bound() {
+        // aarch64/regalloc.py:958-970 and x86/regalloc.py:1013-1034 move
+        // values away from the two malloc-cond registers only.  In
+        // particular, a live Ref in any other managed register stays there;
+        // the collecting slow path saves and restores it through the
+        // jitframe.  SAVE_ALL_REGS at this call site used to turn every such
+        // binding into an eager spill in the allocation fast path.
+        let live_ref = OpRef::input_arg_ref(0);
+        let malloc_result = OpRef::ref_op(0);
+        let size = OpRef::const_int(16);
+        let inputargs = vec![InputArg::from_type(Type::Ref, live_ref.raw())];
+
+        let malloc = Op::new(OpCode::CallMallocNursery, &[rb(size)]);
+        malloc.pos.set(malloc_result);
+        let finish = Op::new(OpCode::Finish, &[rb(live_ref), rb(malloc_result)]);
+        finish.pos.set(OpRef::int_op(1));
+        finish.setfailargs(vec![].into());
+        finish.set_fail_arg_types(vec![Type::Ref, Type::Ref]);
+        let ops = vec![malloc, finish];
+
+        let mut ra = RegAlloc::new(indexmap::IndexMap::new(), &inputargs, &ops);
+        ra.prepare_loop();
+        let unrelated = all_core_regs()
+            .into_iter()
+            .find(|reg| !MALLOC_NURSERY_CLOBBER.contains(reg))
+            .expect("architecture must expose a managed register outside malloc clobbers");
+        ra.rm.force_allocate_reg(
+            live_ref,
+            &[],
+            Some(unrelated),
+            false,
+            &mut ra.longevity,
+            &mut ra.fm,
+        );
+        ra.pending_moves.clear();
+        ra.rm.spill_moves.clear();
+
+        let mut output = Vec::new();
+        ra.consider_call_malloc_nursery(&ops[0], 0, &mut output);
+
+        assert_eq!(
+            ra.rm.reg_bindings_get(live_ref, &ra.longevity),
+            Some(unrelated),
+            "fixed nursery allocation must preserve unrelated live bindings"
+        );
+        assert!(
+            !has_move_from(&output, &Loc::Reg(unrelated)),
+            "fixed nursery allocation must not spill an unrelated live register"
+        );
     }
 
     #[test]

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1843,8 +1843,8 @@ impl DynasmBackend {
             // `next_const_idx` seeding in `with_constants`), never overwriting
             // a pre-existing key, so a move-replace is equivalent to re-merging
             // every key. The old `entry`/`or_insert` merge rescanned the whole
-            // Vec-backed pool per fresh key (O(n^2), quadratic on large traces
-            // like aheui's logo).
+            // Vec-backed pool per fresh key (O(n^2), quadratic on large
+            // traces).
             self.constants = new_constants;
             (result, gcrefs)
         }
@@ -1867,7 +1867,7 @@ impl DynasmBackend {
     /// cranelift backend already routes `New` through the active GC when
     /// one is installed (`cranelift_gc_active`), but dynasm has always used
     /// a `malloc` stub. A consumer whose `New` objects belong to the GC's
-    /// own pool (e.g. aheui's nursery-backed linked-list nodes) sets this so
+    /// own pool (nursery-backed nodes, say) sets this so
     /// compiled allocations share the same pool as the interpreter path.
     pub fn set_new_via_gc(&mut self, enabled: bool) {
         NEW_VIA_GC.store(enabled, std::sync::atomic::Ordering::Relaxed);

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -7337,18 +7337,24 @@ impl<'a> Assembler386<'a> {
         }
     }
 
-    /// Inline aheui's headerless `jit_alloc_node(value, next)` nursery bump.
+    /// Inline nursery bump for a call tagged
+    /// [`majit_ir::PyreHelperKind::NurseryAlloc`].
     ///
-    /// The fast path only advances `nursery_free` and initializes the
-    /// 16-byte Node payload, so it cannot collect and emits no gcmap. The
-    /// slow path is the ordinary residual call wrapper, which may collect
-    /// inside `jit_alloc_node` / `Nursery::alloc` and passes `next` (the old
-    /// head) as the keep-root. This is sound because the op is still a call:
-    /// the optimizer's residual-call emission fences pending head/size
-    /// setfields before this allocation, matching the storage collector's
-    /// root-currentness requirement.
+    /// The tag declares a two-word headerless node taken from the
+    /// interpreter's own nursery, whose payload is the call's two arguments:
+    /// the value at offset 0 and the successor link at offset 8.
+    ///
+    /// The fast path only advances `nursery_free` and stores those two words,
+    /// so it cannot collect and emits no gcmap. The slow path is the ordinary
+    /// residual call wrapper, which may collect inside the callee; the callee
+    /// is free to treat the second argument as a keep-root, since that is the
+    /// object the new node links to. This is sound because the op is still a
+    /// call: the optimizer's residual-call emission fences pending setfields
+    /// before the allocation, so a collector that walks the interpreter's own
+    /// structures finds roots that are current.
     fn genop_nursery_alloc_inline_x86(&mut self, op: &Op, arglocs: &[Loc]) {
-        const NURSERY_ALLOC_NODE_SIZE: i32 = 16; // aheui headerless Node = 16B (value@0,next@8)
+        // Two-word headerless node: value@0, link@8.
+        const NURSERY_ALLOC_NODE_SIZE: i32 = 16;
 
         let (nf_addr, nt_addr) = crate::runner::dynasm_nursery_addrs();
         if nf_addr == 0 || nt_addr == 0 {
@@ -7969,9 +7975,9 @@ impl<'a> Assembler386<'a> {
     ///
     /// The fast path raw-bumps `dynasm_nursery_addrs()`, so it is correct only
     /// when the active dynasm GC is headerless-aware — its nursery must yield a
-    /// raw base carrying no `GcHeader` (aheui's `NurseryGcAllocator`, whose
-    /// nursery is the aheui node arena collected by aheui's own copying node
-    /// GC).  A headered collector such as MiniMarkGC must never back this op:
+    /// raw base carrying no `GcHeader` — what an interpreter that runs its own
+    /// collector over its own object arena supplies.  A headered collector such
+    /// as MiniMarkGC must never back this op:
     /// its nursery walk reads a `GcHeader` at `base - GcHeader::SIZE`, which a
     /// raw base lacks.  The overflow slowpath enforces this via
     /// `alloc_nursery_headerless`'s panicking default; the fast path relies on

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -1174,6 +1174,25 @@ impl EffectInfo {
         )
     }
 
+    /// Array twin of [`Self::writes_field_descr_by_identity`], for the same
+    /// macro / `JitDriver` path where `compute_bitstrings` never runs.
+    ///
+    /// Without it a `residual_writes` array declaration is inert: the raw set
+    /// names the descr, but every array descr's `ei_index` is still the
+    /// `u32::MAX` sentinel so `check_write_descr_array` always misses, and the
+    /// trace keeps serving a `getarrayitem_gc_i` cached from before the call.
+    /// The field side has been recovering exactly this case since the write-set
+    /// table was introduced; the array side had no counterpart.
+    pub fn writes_array_descr_by_identity(&self, descr: &DescrRef) -> bool {
+        match self._write_descrs_arrays.as_deref() {
+            Some(arrays) => {
+                let target = descr_ptr_id(descr);
+                arrays.iter().any(|d| descr_ptr_id(d) == target)
+            }
+            None => false,
+        }
+    }
+
     /// effectinfo.py:223-226: check_readonly_descr_interiorfield (NOTE: not used so far)
     pub fn check_readonly_descr_interiorfield(&self, descr_idx: u32) -> bool {
         crate::bitstring::bitcheck(

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -1183,14 +1183,43 @@ impl EffectInfo {
     /// trace keeps serving a `getarrayitem_gc_i` cached from before the call.
     /// The field side has been recovering exactly this case since the write-set
     /// table was introduced; the array side had no counterpart.
-    pub fn writes_array_descr_by_identity(&self, descr: &DescrRef) -> bool {
-        match self._write_descrs_arrays.as_deref() {
-            Some(arrays) => {
-                let target = descr_ptr_id(descr);
-                arrays.iter().any(|d| descr_ptr_id(d) == target)
-            }
-            None => false,
-        }
+    ///
+    /// This matches on the array's STRUCTURAL shape where the field twin uses
+    /// pointer identity, and the asymmetry is deliberate.  A field descr has a
+    /// single producer — `gc_cache()._cache_field`, which both the getfield
+    /// lowering and the write-EI builder mint through — so two references to
+    /// one field are always the same `Arc`.  An array descr on this path is
+    /// minted per-`MetaInterpStaticData` in `dispatch_array_descr_cache` at
+    /// trace time, while the write-EI is built during jitcode assembly, so the
+    /// two are never the same `Arc`.  Structure is the right key regardless:
+    /// `Assembler::add_gc_int_array_descr` already dedups on exactly this
+    /// tuple, so for these arrays the shape IS the identity.
+    ///
+    /// Conflating two arrays that share a shape can only over-invalidate,
+    /// which costs a reload and can never miscompile — the same asymmetry the
+    /// `residual_writes` table is built on.  And the caller gates this on
+    /// `!compute_bitstrings_has_run()`, so the translated interpreter's
+    /// registered array descrs never reach it.
+    pub fn writes_array_descr_by_shape(&self, descr: &DescrRef) -> bool {
+        let Some(arrays) = self._write_descrs_arrays.as_deref() else {
+            return false;
+        };
+        let shape = |d: &DescrRef| {
+            d.as_array_descr().map(|a| {
+                (
+                    a.base_size(),
+                    a.item_size(),
+                    a.item_type(),
+                    a.is_item_signed(),
+                )
+            })
+        };
+        // A non-array descr in either position has no shape to compare, so it
+        // matches nothing rather than matching everything.
+        let Some(target) = shape(descr) else {
+            return false;
+        };
+        arrays.iter().any(|d| shape(d) == Some(target))
     }
 
     /// effectinfo.py:223-226: check_readonly_descr_interiorfield (NOTE: not used so far)

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -908,11 +908,11 @@ pub enum PyreHelperKind {
     /// storage write.  Every unsupported shape keeps the original generic
     /// setattr residual.
     StoreAttr,
-    /// aheui headerless-Node nursery allocation (`jit_alloc_node(value,next)`).
-    /// The dynasm backend recognises this tag on the CallR descr to emit an
-    /// inline nursery bump (RPython malloc_cond shape) instead of a full
-    /// residual `blr`; the node stays a real escaping alloc result (NOT a
-    /// virtualized New), so the following `selected_ref.head = new_node`
+    /// Headerless two-word node allocation, `(value, link)`, from the
+    /// interpreter's own nursery.  The dynasm backend recognises this tag on
+    /// the CallR descr to emit an inline nursery bump (RPython malloc_cond
+    /// shape) instead of a full residual call; the node stays a real escaping
+    /// alloc result (NOT a virtualized New), so the setfield that links it in
     /// remains a normal committed setfield. has_oopspec stays false.
     NurseryAlloc,
     /// `bh_load_method_self_fn(obj, attr, code, name_idx)` — the LOAD_METHOD

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1043,8 +1043,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     // `initialize_sym_scalar_parts`. `values[idx]` is the scalar at
     // state-field index `idx` (the order `collect_scalar_values_parts`
     // produced). recover runs afterwards and overwrites the storage-derived
-    // caches, so only scalars recover cannot re-derive (e.g. aheui `selected`)
-    // meaningfully carry through.
+    // caches, so only scalars recover cannot re-derive (a `selected`-style
+    // storage index, say) meaningfully carry through.
     let writeback_from_values_parts: Vec<TokenStream> = scalars
         .iter()
         .enumerate()
@@ -1780,7 +1780,7 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         quote! {}
     };
     // Emit the virt-array write-back override only for consumers that declare a
-    // `[.. ; virt]` array; 0-array interps (aheui, tlr, tinyframe, i64env) keep
+    // `[.. ; virt]` array; 0-array interps (tlr, tinyframe, i64env) keep
     // the trait default no-op, leaving their generated impl byte-identical.
     let writeback_virt_array_override: TokenStream = if num_virt_arrays > 0 {
         quote! {
@@ -2652,14 +2652,13 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             // bridge ever forms — a failing loop guard re-enters via
             // ContinueRunningNormally instead of forming a bridge.  Adding it
             // flips `start_bridge_tracing` ok=false→ok=true and bridges form;
-            // aheui hello/99bottles/fib stay byte-identical.
+            // existing consumers stay byte-identical.
             //
             // NOTE: this is general guard-exit bridge-formation infrastructure.
-            // It does NOT address the logo `--jit` hang: that was root-caused
-            // to a separate optimizer issue (a sel=4 peeled loop constant-folds
-            // the stacksize red and drops the stack-size exit guard, looping on
-            // a stack-mutating residual) — not a missing or unseeded bridge.
-            // See `aheui-logo-spin-observer-replay-rootcause.md`.
+            // A trace that spins is not by itself evidence of a missing or
+            // unseeded bridge: one such spin was instead a peeled loop that
+            // constant-folded a red and dropped the matching exit guard,
+            // leaving a state-mutating residual to loop forever.
             fn rebuild_from_resumedata(
                 _meta: &mut #meta_ty,
                 fail_arg_types: &[majit_ir::Type],
@@ -2727,10 +2726,10 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             //    loop state (without this a guard-exit bridge re-traces
             //    un-seeded). ──
             //
-            // STATUS: this seeds int/ref SCALAR slots only.  No available aheui
+            // STATUS: this seeds int/ref SCALAR slots only.  No available
             // workload has been observed to reach this path (setup_bridge_sym
-            // emits no MAJIT_BRIDGE_DEBUG lines for 99bottles/fibonacci/
-            // factorial), so part B is present-but-unexercised; treat the
+            // emits no MAJIT_BRIDGE_DEBUG lines for any of them), so part B is
+            // present-but-unexercised; treat the
             // seeding as unverified on real traces.  Latent gaps once it IS
             // exercised by a consumer:
             //   * flattened `[int]` arrays + virt-array ptr/len slots are NOT
@@ -2741,7 +2740,8 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             //   * a multi-frame resume (inlined sub-frames) is decoded as a
             //     single frame by `rebuild_from_resumedata` (None
             //     frame_value_count) — later frame headers would be read as
-            //     values.  Both bite only for non-aheui macro states.
+            //     values.  Both bite only for macro states that declare
+            //     arrays or inline sub-frames.
             //
             // `frame.values` is laid out by liveness bank: [int-bank, then
             // ref-bank, then float], greens/loop-invariants decoded as `Const`,

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -157,6 +157,16 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     // not a per-array count.
     let has_vable_identity = num_virt_arrays > 0;
     let num_vable_identity_slots = usize::from(has_vable_identity);
+    // Int-bank slots a sub-JitCode actually reserves, i.e. the ones the
+    // inline-frame snapshot trim may blank. Only `split_dispatch` pushes a
+    // sub-JitCode's register allocation past the identity range
+    // (`split_identity_floor`), so the reservation — and the trim — is empty
+    // without it. See `int_identity_reserved_end` below.
+    let num_reserved_identity_slots = if config.split_dispatch {
+        num_scalars + num_vable_identity_slots
+    } else {
+        0
+    };
     let num_ref_scalars = ref_scalars.len();
     let num_float_scalars = float_scalars.len();
     // First ref-bank register available for ref-scalar identity slots.
@@ -2410,8 +2420,18 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             // `jitcode_lower/mod.rs` exactly: the working-register floor stops
             // after the scalars plus the single vable-identity slot, because a
             // virt array's element count is only known from the live object.
+            //
+            // It must also mirror the CONDITION under which that end is
+            // applied. `split_identity_floor` (`jitcode_lower/api.rs`) raises a
+            // sub-JitCode's `alloc_reg()` floor past the range only when
+            // `split_dispatch` is on; with it off, no sub-JitCode reserves
+            // anything and `[base, end)` holds ordinary working registers. The
+            // inline-frame snapshot trim keyed on this end blanks the range
+            // unconditionally, so reporting a non-empty range here would drop
+            // live data from a sub-frame's snapshot. Report an empty range
+            // instead, so the trim is inert exactly where the reservation is.
             fn int_identity_reserved_end(&self) -> usize {
-                #int_identity_base + #num_scalars + #num_vable_identity_slots
+                #int_identity_base + #num_reserved_identity_slots
             }
 
             fn loop_header_pc(&self) -> usize {

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -40,6 +40,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.residual_writes,
         &config.pool_arrays,
         &config.ref_fields,
+        &config.array_fields,
         &config.int_fields,
         &config.call_returns,
         &config.headerless_structs,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -395,6 +395,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     calls: &[crate::jit_interp::CallEntry],
     ref_params: &[(Ident, syn::Path)],
     ref_fields: &[crate::jit_interp::RefFieldEntry],
+    array_fields: &[crate::jit_interp::ArrayFieldEntry],
     int_fields: &[crate::jit_interp::IntFieldEntry],
     native_int_binops: &[(Path, Ident)],
     native_tag_small: &[Path],
@@ -433,6 +434,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         .collect();
     let inline_config = if ref_param_structs.is_empty()
         && ref_fields.is_empty()
+        && array_fields.is_empty()
         && int_fields.is_empty()
         && native_int_binops.is_empty()
         && native_tag_small.is_empty()
@@ -442,6 +444,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     } else {
         Some(LowererConfig::inline_helper(
             ref_fields,
+            array_fields,
             int_fields,
             native_int_binops,
             native_tag_small,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -641,8 +641,8 @@ fn try_generate_jitcode_body_inner(
 /// A.3.6.1 (jtransform.py:1693-1714): bind body-local `let` stmts that
 /// appear in the dispatch while-body BEFORE the `jit_merge_point!()`
 /// macro stmt, so that consumer-declared
-/// `#[jit_interp(greens = [<body-local>])]` (e.g. aheui-jit's
-/// `greens = [stackok]` with `let stackok = program.get_req_size(pc) <= ...`)
+/// `#[jit_interp(greens = [<body-local>])]` (say `greens = [ok]` with
+/// `let ok = program.get_req_size(pc) <= ...`)
 /// flow through `resolve_greens` / `emit_promote_greens` without panic.
 ///
 /// TODO: RPython has no equivalent two-pass walker.

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -57,8 +57,8 @@ mod find_dispatch_loop_body_tests {
 /// jitcode sees them via its portal-input bindings.  Pyre's dispatch
 /// arm lowerer emits `__builder.inline_call(__sub_idx)` with no args,
 /// leaving the sub-frame without `pc` / `program` / `op` etc. — any
-/// arm body that references these (e.g. `program.get_operand(pc - 1)`
-/// in aheui-jit) lowers to raw Rust that fails to compile inside
+/// arm body that references these (`program.get_operand(pc - 1)`, say)
+/// lowers to raw Rust that fails to compile inside
 /// `__dispatch_jitcode_<fn>` where the names are out of scope.
 ///
 /// This collector is the first slice (of three) closing that gap:
@@ -1455,8 +1455,7 @@ fn try_lower_opcode_fetch_stmt(lowerer: &mut Lowerer, stmt: &Stmt) -> bool {
                 // opcode-result name so `lower_dispatch_chain`
                 // can find the binding regardless of whether the
                 // consumer named it `opcode` (PyPy convention,
-                // `pyopcode.py:171`) or `op` (aheui-jit
-                // `aheui.py:255`) or anything else.
+                // `pyopcode.py:171`) or `op` or anything else.
                 lowerer.opcode_var_name = Some(name);
             }
             return true;
@@ -1629,8 +1628,8 @@ fn expr_int_literal_value(expr: &Expr) -> Option<i64> {
 /// Find the body block of the unique top-level loop in `func_block` whose
 /// body contains `target_match`.
 ///
-/// Recognises both `while cond { ... }` (e.g. `aheui.py:251 while pc <
-/// program.size`) and `loop { ... }` (e.g. `rpython/jit/tl/tinyframe/tinyframe.py` and
+/// Recognises both `while cond { ... }` (e.g. `while pc < program.size`)
+/// and `loop { ... }` (e.g. `rpython/jit/tl/tinyframe/tinyframe.py` and
 /// other tinyframe-family interpreters whose dispatch loop is unconditional
 /// with a `break`-driven exit).  Mirrors `codegen_trace.rs:520
 /// expr_inner_match_block`'s recognition set.
@@ -3657,8 +3656,8 @@ pub(crate) fn lower_dispatch_body(
 
     // A.3.6.1 (jtransform.py:1693): bind body-local `let` stmts that
     // appear BEFORE `jit_merge_point!()` in the dispatch while-body, so
-    // that consumer-declared `greens = [<body-local>]` (e.g. aheui-jit's
-    // `greens = [stackok]`) resolve via `lowerer.bindings` when
+    // that consumer-declared `greens = [<body-local>]` (say
+    // `greens = [ok]`) resolve via `lowerer.bindings` when
     // `emit_promote_greens` and `resolve_greens` consult it below.
     let _ = bind_pre_merge_point_stmts(&mut lowerer, func_block);
     if lowerer.dispatch_tainted_reason.is_some() {
@@ -3774,8 +3773,7 @@ pub(crate) fn lower_dispatch_body(
     // then iterate stmts before the match-containing stmt.
     //
     // Pin pc-writes to i0 for the whole pre-dispatch walk. The branch-op
-    // match that precedes the dispatch match (aheui-jit lib.rs:520-545
-    // OP_BRPOP/OP_JMP/OP_BRZ, rpaheui aheui.py:294-311) carries
+    // match that precedes the dispatch match (the branch opcodes) carries
     // `pc = program.get_label(pc - 1); ...; continue;` arms. Without the
     // pin, the assignment SSA-rebinds `pc` to a fresh register that dies
     // at the `continue` back-edge, so the next merge point reads the

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -19,13 +19,19 @@ pub(super) const REFUSAL_SEPARATOR: &str = " || ";
 
 impl<'c> Lowerer<'c> {
     /// If `func` is a registered `residual_writes` mutator, return the
-    /// `struct_field_write_effect_info(...)` expression naming the written
-    /// fields, so the residual call records a write-set `EffectInfo` that
-    /// invalidates cached getfields on those fields.  `None` for a
+    /// `residual_write_effect_info(...)` expression naming the written fields
+    /// and arrays, so the residual call records a write-set `EffectInfo` that
+    /// invalidates cached getfields and cached array elements.  `None` for a
     /// plain residual call (empty write-set).  `can_raise` carries the
     /// call policy's extra-effect into the write-set `EffectInfo` so a
     /// `ResidualVoidCannotRaise` mutator keeps `CannotRaise` instead of
     /// silently widening to `CanRaise`.
+    ///
+    /// A `field` declaration names the field itself; a `field[]` declaration
+    /// names the ELEMENTS of the array `field` points at.  The two are separate
+    /// caches in `OptHeap` — invalidating the base field hands the next element
+    /// load a fresh base, which only helps when the base actually changes — so a
+    /// residual that mutates a buffer in place has to say `field[]`.
     pub(super) fn residual_write_effect_info_tokens(
         &self,
         func: &Expr,
@@ -36,22 +42,46 @@ impl<'c> Lowerer<'c> {
         let writes: Vec<_> = config
             .residual_writes
             .iter()
-            .filter(|(segments, _, _)| *segments == func_segments)
+            .filter(|(segments, _, _, _)| *segments == func_segments)
             .collect();
         let mut layouts: Vec<(&syn::Path, Vec<TokenStream>)> = Vec::new();
-        for (_, path, field) in writes {
-            let fields = if let Some((_, fields)) = layouts.iter_mut().find(|(p, _)| *p == path) {
-                fields
-            } else {
-                layouts.push((path, Vec::new()));
-                &mut layouts.last_mut().unwrap().1
-            };
+        // `(key, element_path)` for the `field[]` declarations, deduplicated by
+        // key: naming one array from two helpers of the same residual would
+        // otherwise repeat its descr in the write set.
+        let mut arrays: Vec<(String, &syn::Path)> = Vec::new();
+        for (_, path, field, writes_elements) in writes {
             let struct_last = path
                 .segments
                 .last()
                 .map(|segment| segment.ident.to_string())
                 .unwrap_or_default();
             let key = format!("{}::{}", struct_last, field);
+            if *writes_elements {
+                let Some((_, _, element_path)) = config.array_fields.get(&key) else {
+                    return Some(
+                        syn::Error::new(
+                            field.span(),
+                            format!(
+                                "jit_interp: residual_writes `{key}[]` declares a write to the \
+                                 elements of an array field, but `{key}` is not declared in \
+                                 `array_fields`, so there is no element type to mint the written \
+                                 array descr from"
+                            ),
+                        )
+                        .to_compile_error(),
+                    );
+                };
+                if !arrays.iter().any(|(seen, _)| *seen == key) {
+                    arrays.push((key, element_path));
+                }
+                continue;
+            }
+            let fields = if let Some((_, fields)) = layouts.iter_mut().find(|(p, _)| *p == path) {
+                fields
+            } else {
+                layouts.push((path, Vec::new()));
+                &mut layouts.last_mut().unwrap().1
+            };
             let is_ref = config.ref_fields.contains_key(&key);
             // Same declared width the getfield/setfield lowering registers, so
             // this write-EI rebuild mints the field descr the reads resolve to
@@ -90,13 +120,26 @@ impl<'c> Lowerer<'c> {
                 }
             })
             .collect();
+        let arrays: Vec<_> = arrays
+            .iter()
+            .map(|(_, element_path)| {
+                // `is_item_signed = true` mirrors the literal the READ side
+                // passes (`add_gc_int_array_descr(size_of::<Elem>(), true)` in
+                // `lower_ref_binding_array_read`).  It is not derived from the
+                // element type on purpose: the write descr has to match what
+                // the reads intern, and deriving it here would make an unsigned
+                // element type produce a shape no read ever mints.
+                quote! { (::core::mem::size_of::<#element_path>(), true) }
+            })
+            .collect();
         Some(quote! {
             // The residual mutates a host-owned native struct field (no
             // GC header) → `is_gc_managed = false`, matching the
             // getfield/setfield lowering so the write-EI rebuilds the
             // SAME parent SizeDescr identity the getfield reads back.
-            majit_metainterp::struct_fields_write_effect_info(
+            majit_metainterp::residual_write_effect_info(
                 &[#(#layouts),*],
+                &[#(#arrays),*],
                 #can_raise,
             )
         })

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1253,6 +1253,12 @@ impl<'c> Lowerer<'c> {
         if let Some(()) = self.lower_state_ref_field_setfield(expr) {
             return Some(());
         }
+        // Array element write on a local ref binding whose field is declared
+        // in `array_fields`: `<binding>.<field>[<idx>] = <expr>` →
+        // getfield_gc_r for the buffer base, then setarrayitem_gc_i.
+        if let Some(()) = self.lower_ref_binding_array_write(expr) {
+            return Some(());
+        }
         // Field write on a local ref binding with known struct type:
         // `<binding>.<field> = <expr>` → setfield_gc_i/setfield_gc_r.
         if let Some(()) = self.lower_ref_binding_setfield(expr) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -593,8 +593,8 @@ impl<'c> Lowerer<'c> {
         // arm-pattern bound names) which are not in scope at the
         // surrounding Rust scope.  Without this guard, dispatch arm
         // sub-JitCode bodies that contain unrecognised method calls on
-        // a parent binding (e.g. aheui-jit's `program.get_operand(pc - 1)`
-        // when no `Program::get_operand` call policy is registered) would
+        // a parent binding (`program.get_operand(pc - 1)` with no
+        // `Program::get_operand` call policy registered, say) would
         // emit verbatim Rust referencing `program`/`pc` in the
         // `__sub_builder` block — failing to compile.  Returning `None`
         // here triggers the dispatch arm's `None` branch which substitutes
@@ -1564,9 +1564,9 @@ impl<'c> Lowerer<'c> {
                 }
                 // Stmt-form variants of result-returning policies discard
                 // the value but still need the IR call op recorded so the
-                // compiled trace runs the side effect (e.g. aheui OP_POP's
-                // `lj::stack_pop(state.selected_ref);` discards the popped
-                // value but the pop side effect must reach compiled code).
+                // compiled trace runs the side effect (a `stack_pop(...)`
+                // whose result is discarded still has to pop in compiled
+                // code).
                 // Allocate a throwaway destination register; never read it.
                 //
                 // RPython jtransform.py:456 `handle_residual_call` lowers
@@ -2212,7 +2212,7 @@ impl<'c> Lowerer<'c> {
         Some(())
     }
 
-    /// Lower I/O call: aheui_io::write_number(r, writer) → residual_call_void(shim, r)
+    /// Lower I/O call: `<io>::write_number(r, writer)` → `residual_call_void(shim, r)`
     fn lower_io_call_stmt(&mut self, expr: &Expr) -> Option<()> {
         let Expr::Call(call) = expr else {
             return None;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -123,13 +123,20 @@ impl<'c> Lowerer<'c> {
         let arrays: Vec<_> = arrays
             .iter()
             .map(|(_, element_path)| {
-                // `is_item_signed = true` mirrors the literal the READ side
-                // passes (`add_gc_int_array_descr(size_of::<Elem>(), true)` in
-                // `lower_ref_binding_array_read`).  It is not derived from the
-                // element type on purpose: the write descr has to match what
-                // the reads intern, and deriving it here would make an unsigned
-                // element type produce a shape no read ever mints.
-                quote! { (::core::mem::size_of::<#element_path>(), true) }
+                // `writes_array_descr_by_shape` keys on `is_item_signed`, so
+                // this has to derive it exactly as the element read and write
+                // do (`add_raw_int_array_descr_signed` in
+                // `lower_ref_binding_array_read` / `_write`).  A literal here
+                // mints a shape no unsigned-element read ever produces, and
+                // the declaration then silently stops invalidating the load it
+                // names — the optimizer keeps serving the element it cached
+                // from before the mutating call.
+                quote! {
+                    (
+                        ::core::mem::size_of::<#element_path>(),
+                        (<#element_path>::MIN as i128) < 0,
+                    )
+                }
             })
             .collect();
         Some(quote! {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -34,6 +34,15 @@ pub(super) fn field_scalar_tokens(
     }
 }
 
+/// A `<local ref binding>.<field>` access that `array_fields` declares, resolved
+/// but not yet emitted.  See [`JitCodeLowerer::match_array_field_base`].
+struct ArrayFieldBase {
+    base_reg: u16,
+    struct_path: syn::Path,
+    member: syn::Member,
+    element_type: syn::Path,
+}
+
 impl<'c> Lowerer<'c> {
     /// Read an immediate operand byte from the green bytecode array:
     /// `program[<index>]`.  Mirrors the dispatch-top opcode fetch
@@ -1126,15 +1135,16 @@ impl<'c> Lowerer<'c> {
         }
     }
 
-    /// Resolve `<local ref binding>.<field>` where `<field>` is declared in
-    /// `array_fields`, emitting the `getfield_gc_r` that loads the array's
-    /// base pointer and returning `(base_reg, element_type)`.
+    /// Match `<local ref binding>.<field>` against `array_fields` WITHOUT
+    /// emitting anything, so a caller can finish rejecting before it commits
+    /// any op to the trace.
     ///
-    /// Shared by the element read and the element write so both take the
-    /// buffer pointer through the SAME interned field descr — a store to the
-    /// base (a realloc on growth) then invalidates the load the heapcache
-    /// served, instead of leaving a stale buffer pointer live in the trace.
-    fn lower_array_field_base(&mut self, field: &syn::ExprField) -> Option<(u16, syn::Path)> {
+    /// Split from [`Self::emit_array_field_base`] because the element write
+    /// has to emit its right-hand side first: Rust evaluates the assigned
+    /// value before the assignee place, and a lowering that emitted the base
+    /// load first would run the two in the opposite order from the
+    /// interpreter.
+    fn match_array_field_base(&self, field: &syn::ExprField) -> Option<ArrayFieldBase> {
         let config = self.config?;
         let Expr::Path(path) = &*field.base else {
             return None;
@@ -1154,8 +1164,30 @@ impl<'c> Lowerer<'c> {
             .unwrap_or_default();
         let key = format!("{}::{}", struct_last, member_name);
         let element_type = config.array_fields.get(&key)?.2.clone();
+        Some(ArrayFieldBase {
+            base_reg: binding.reg,
+            struct_path,
+            member,
+            element_type,
+        })
+    }
+
+    /// Emit the `getfield_gc_r` that loads the array's base pointer for a
+    /// shape [`Self::match_array_field_base`] already accepted.
+    ///
+    /// Shared by the element read and the element write so both take the
+    /// buffer pointer through the SAME interned field descr — a store to the
+    /// base (a realloc on growth) then invalidates the load the heapcache
+    /// served, instead of leaving a stale buffer pointer live in the trace.
+    fn emit_array_field_base(&mut self, shape: &ArrayFieldBase) -> u16 {
+        let ArrayFieldBase {
+            base_reg,
+            struct_path,
+            member,
+            ..
+        } = shape;
+        let (base_reg, struct_path, member) = (*base_reg, struct_path.clone(), member.clone());
         let tid = struct_type_id_tokens(&struct_path, false);
-        let base_reg = binding.reg;
         let buffer_reg = self.alloc_reg();
         self.emit_op(
             OpMeta::linear(
@@ -1186,7 +1218,7 @@ impl<'c> Lowerer<'c> {
                 );
             },
         );
-        Some((buffer_reg, element_type))
+        buffer_reg
     }
 
     /// Recognizes an array element READ on a local ref binding:
@@ -1208,10 +1240,12 @@ impl<'c> Lowerer<'c> {
         let Expr::Field(field) = &*index_expr.expr else {
             return None;
         };
-        // Lower the index BEFORE the base load would be wasted work only if
-        // the shape does not match; `lower_array_field_base` is the last
-        // rejecting step, so run it first and emit nothing until it accepts.
-        let (buffer_reg, element_type) = self.lower_array_field_base(field)?;
+        // Match before emitting anything, so a shape this does not handle
+        // leaves the trace untouched.  A place expression evaluates its base
+        // before its index, which is the order emitted here.
+        let shape = self.match_array_field_base(field)?;
+        let element_type = shape.element_type.clone();
+        let buffer_reg = self.emit_array_field_base(&shape);
         let index = self.lower_value_expr(&index_expr.index)?;
         if !matches!(index.kind, BindingKind::Int) {
             return None;
@@ -1227,7 +1261,13 @@ impl<'c> Lowerer<'c> {
             quote! {
                 let __descr_idx = __builder.add_gc_int_array_descr(
                     ::core::mem::size_of::<#element_type>(),
-                    true,
+                    // descr.py:240-254 get_type_flag reads signedness off the
+                    // declared element type.  Hard-coding signed would
+                    // sign-extend a `u8` element of 0x80 to -128 where the
+                    // concrete Rust read yields 128.  `MIN` resolves through a
+                    // type alias, and a non-integer element type fails to
+                    // compile here rather than loading as a signed word.
+                    (<#element_type>::MIN as i128) < 0,
                 );
                 __builder.getarrayitem_gc_i(
                     #result_reg as u16,
@@ -1262,13 +1302,19 @@ impl<'c> Lowerer<'c> {
         let Expr::Field(field) = &*index_expr.expr else {
             return None;
         };
-        let (buffer_reg, element_type) = self.lower_array_field_base(field)?;
-        let index = self.lower_value_expr(&index_expr.index)?;
-        if !matches!(index.kind, BindingKind::Int) {
-            return None;
-        }
+        // Match before emitting, then emit in Rust's evaluation order for an
+        // assignment: the assigned value first, then the assignee place (base,
+        // then index).  Emitting the base load first would run the array's
+        // side effects ahead of the right-hand side's.
+        let shape = self.match_array_field_base(field)?;
+        let element_type = shape.element_type.clone();
         let value = self.lower_value_expr(&assign.right)?;
         if !matches!(value.kind, BindingKind::Int) {
+            return None;
+        }
+        let buffer_reg = self.emit_array_field_base(&shape);
+        let index = self.lower_value_expr(&index_expr.index)?;
+        if !matches!(index.kind, BindingKind::Int) {
             return None;
         }
         let index_reg = index.reg;
@@ -1286,7 +1332,13 @@ impl<'c> Lowerer<'c> {
             quote! {
                 let __descr_idx = __builder.add_gc_int_array_descr(
                     ::core::mem::size_of::<#element_type>(),
-                    true,
+                    // descr.py:240-254 get_type_flag reads signedness off the
+                    // declared element type.  Hard-coding signed would
+                    // sign-extend a `u8` element of 0x80 to -128 where the
+                    // concrete Rust read yields 128.  `MIN` resolves through a
+                    // type alias, and a non-integer element type fails to
+                    // compile here rather than loading as a signed word.
+                    (<#element_type>::MIN as i128) < 0,
                 );
                 __builder.setarrayitem_gc_i(
                     #buffer_reg as u16,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -893,7 +893,7 @@ impl<'c> Lowerer<'c> {
     /// `setfield_gc` on the same `(struct_type_id, field)` — mirroring an
     /// RPython `len(obj)`/`obj.field` getfield_gc_i on a mutable field.
     ///
-    /// Only int fields are lowered here (the aheui length read); a ref field
+    /// Only int fields are lowered here (the length read); a ref field
     /// read would route through `getfield_gc_r` and is left unimplemented
     /// until a caller needs it.
     pub(super) fn lower_state_ref_field_getfield(&mut self, expr: &Expr) -> Option<Binding> {
@@ -1302,7 +1302,7 @@ impl<'c> Lowerer<'c> {
     /// Recognizes a pool-array element read through the registered getter call
     /// `<getter>(state.<pool_base_ref>, <int index>)` → `getarrayitem_gc_r` on
     /// the raw-pointer array (`[*mut U; N]` at offset 0) the ref-scalar points
-    /// at — the aheui `pools[selected]` read.  Unlike the residual-call form (an
+    /// at — the `pools[selected]` read.  Unlike the residual-call form (an
     /// opaque CALL_R the optimizer can neither re-produce in the short preamble
     /// nor invalidate), the getarrayitem on the immutable `pools` array
     /// re-derives the element each loop entry from the consistent `selected`

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1126,6 +1126,179 @@ impl<'c> Lowerer<'c> {
         }
     }
 
+    /// Resolve `<local ref binding>.<field>` where `<field>` is declared in
+    /// `array_fields`, emitting the `getfield_gc_r` that loads the array's
+    /// base pointer and returning `(base_reg, element_type)`.
+    ///
+    /// Shared by the element read and the element write so both take the
+    /// buffer pointer through the SAME interned field descr — a store to the
+    /// base (a realloc on growth) then invalidates the load the heapcache
+    /// served, instead of leaving a stale buffer pointer live in the trace.
+    fn lower_array_field_base(&mut self, field: &syn::ExprField) -> Option<(u16, syn::Path)> {
+        let config = self.config?;
+        let Expr::Path(path) = &*field.base else {
+            return None;
+        };
+        let ident = path.path.get_ident()?;
+        let binding = self.bindings.get(&ident.to_string())?.clone();
+        if !matches!(binding.kind, BindingKind::Ref) {
+            return None;
+        }
+        let struct_path = binding.struct_type.as_ref()?.clone();
+        let member = field.member.clone();
+        let member_name = named_member(&field.member)?;
+        let struct_last = struct_path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        let key = format!("{}::{}", struct_last, member_name);
+        let element_type = config.array_fields.get(&key)?.2.clone();
+        let tid = struct_type_id_tokens(&struct_path, false);
+        let base_reg = binding.reg;
+        let buffer_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::Vable,
+                vec![Register::ref_(base_reg)],
+                vec![Register::ref_(buffer_reg)],
+            ),
+            quote! {
+                __builder.register_struct_layout(
+                    ::core::mem::size_of::<#struct_path>(),
+                    #tid,
+                    false,
+                    false,
+                    &[(
+                        ::core::mem::offset_of!(#struct_path, #member),
+                        true,
+                        stringify!(#member),
+                        ::core::mem::size_of::<usize>(),
+                        false,
+                    )],
+                );
+                __builder.getfield_gc_r(
+                    #buffer_reg,
+                    #base_reg,
+                    ::core::mem::offset_of!(#struct_path, #member),
+                    #tid,
+                    stringify!(#member),
+                );
+            },
+        );
+        Some((buffer_reg, element_type))
+    }
+
+    /// Recognizes an array element READ on a local ref binding:
+    /// `<binding>.<array_field>[<int expr>]` → `getfield_gc_r` for the buffer
+    /// base followed by `getarrayitem_gc_i`.
+    ///
+    /// This is the non-virtualizable counterpart of the `[..; virt]` element
+    /// read: the loaded value is an ordinary trace value, so it does NOT ride
+    /// the guard's `vable_array` resume section and the snapshot stays O(1) in
+    /// the array's length.
+    ///
+    /// No `arraylen_gc` is emitted anywhere on this path — the buffer has no
+    /// object header to read a length from. A bound belongs on a sibling
+    /// `int_fields` length field.
+    pub(super) fn lower_ref_binding_array_read(&mut self, expr: &Expr) -> Option<Binding> {
+        let Expr::Index(index_expr) = expr else {
+            return None;
+        };
+        let Expr::Field(field) = &*index_expr.expr else {
+            return None;
+        };
+        // Lower the index BEFORE the base load would be wasted work only if
+        // the shape does not match; `lower_array_field_base` is the last
+        // rejecting step, so run it first and emit nothing until it accepts.
+        let (buffer_reg, element_type) = self.lower_array_field_base(field)?;
+        let index = self.lower_value_expr(&index_expr.index)?;
+        if !matches!(index.kind, BindingKind::Int) {
+            return None;
+        }
+        let index_reg = index.reg;
+        let result_reg = self.alloc_reg();
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::Vable,
+                vec![Register::ref_(buffer_reg), Register::int(index_reg)],
+                vec![Register::int(result_reg)],
+            ),
+            quote! {
+                let __descr_idx = __builder.add_gc_int_array_descr(
+                    ::core::mem::size_of::<#element_type>(),
+                    true,
+                );
+                __builder.getarrayitem_gc_i(
+                    #result_reg as u16,
+                    #buffer_reg as u16,
+                    #index_reg as u16,
+                    __descr_idx,
+                );
+            },
+        );
+        Some(Binding {
+            reg: result_reg,
+            kind: BindingKind::Int,
+            depends_on_stack: index.depends_on_stack,
+            struct_type: None,
+        })
+    }
+
+    /// Recognizes an array element WRITE on a local ref binding:
+    /// `<binding>.<array_field>[<int expr>] = <int expr>` → `getfield_gc_r`
+    /// for the buffer base followed by `setarrayitem_gc_i`.
+    ///
+    /// Store counterpart of [`Self::lower_ref_binding_array_read`]; both take
+    /// the element descr from `add_gc_int_array_descr`, so the store
+    /// invalidates the heapcache entry the matching load populated.
+    pub(super) fn lower_ref_binding_array_write(&mut self, expr: &Expr) -> Option<()> {
+        let Expr::Assign(assign) = expr else {
+            return None;
+        };
+        let Expr::Index(index_expr) = &*assign.left else {
+            return None;
+        };
+        let Expr::Field(field) = &*index_expr.expr else {
+            return None;
+        };
+        let (buffer_reg, element_type) = self.lower_array_field_base(field)?;
+        let index = self.lower_value_expr(&index_expr.index)?;
+        if !matches!(index.kind, BindingKind::Int) {
+            return None;
+        }
+        let value = self.lower_value_expr(&assign.right)?;
+        if !matches!(value.kind, BindingKind::Int) {
+            return None;
+        }
+        let index_reg = index.reg;
+        let value_reg = value.reg;
+        self.emit_op(
+            OpMeta::linear(
+                OpKind::Vable,
+                vec![
+                    Register::ref_(buffer_reg),
+                    Register::int(index_reg),
+                    Register::int(value_reg),
+                ],
+                vec![],
+            ),
+            quote! {
+                let __descr_idx = __builder.add_gc_int_array_descr(
+                    ::core::mem::size_of::<#element_type>(),
+                    true,
+                );
+                __builder.setarrayitem_gc_i(
+                    #buffer_reg as u16,
+                    #index_reg as u16,
+                    #value_reg as u16,
+                    __descr_idx,
+                );
+            },
+        );
+        Some(())
+    }
+
     /// Recognizes a pool-array element read through the registered getter call
     /// `<getter>(state.<pool_base_ref>, <int index>)` → `getarrayitem_gc_r` on
     /// the raw-pointer array (`[*mut U; N]` at offset 0) the ref-scalar points

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1184,9 +1184,14 @@ impl<'c> Lowerer<'c> {
             base_reg,
             struct_path,
             member,
-            ..
+            element_type,
         } = shape;
-        let (base_reg, struct_path, member) = (*base_reg, struct_path.clone(), member.clone());
+        let (base_reg, struct_path, member, element_type) = (
+            *base_reg,
+            struct_path.clone(),
+            member.clone(),
+            element_type.clone(),
+        );
         let tid = struct_type_id_tokens(&struct_path, false);
         let buffer_reg = self.alloc_reg();
         self.emit_op(
@@ -1196,6 +1201,18 @@ impl<'c> Lowerer<'c> {
                 vec![Register::ref_(buffer_reg)],
             ),
             quote! {
+                // The `int_fields` twin of this check lives in
+                // `field_scalar_tokens`.  Nothing else ties the declared
+                // element type to the field: the concrete rewrite indexes the
+                // real pointer while the emitted descr takes its stride and
+                // signedness from the declaration, so a declaration that
+                // drifted from the struct (`Stack::data => u16` over a
+                // `*mut u8`) would compile and read past the buffer.  Naming
+                // the pointee rather than the pointer accepts `*const T` as
+                // well as `*mut T`; the closure body is type-checked but never
+                // evaluated.
+                const _: fn(&#struct_path) -> #element_type =
+                    |__s| unsafe { *__s.#member };
                 __builder.register_struct_layout(
                     ::core::mem::size_of::<#struct_path>(),
                     #tid,
@@ -1259,7 +1276,7 @@ impl<'c> Lowerer<'c> {
                 vec![Register::int(result_reg)],
             ),
             quote! {
-                let __descr_idx = __builder.add_gc_int_array_descr(
+                let __descr_idx = __builder.add_raw_int_array_descr_signed(
                     ::core::mem::size_of::<#element_type>(),
                     // descr.py:240-254 get_type_flag reads signedness off the
                     // declared element type.  Hard-coding signed would
@@ -1290,7 +1307,7 @@ impl<'c> Lowerer<'c> {
     /// for the buffer base followed by `setarrayitem_gc_i`.
     ///
     /// Store counterpart of [`Self::lower_ref_binding_array_read`]; both take
-    /// the element descr from `add_gc_int_array_descr`, so the store
+    /// the element descr from `add_raw_int_array_descr_signed`, so the store
     /// invalidates the heapcache entry the matching load populated.
     pub(super) fn lower_ref_binding_array_write(&mut self, expr: &Expr) -> Option<()> {
         let Expr::Assign(assign) = expr else {
@@ -1330,7 +1347,7 @@ impl<'c> Lowerer<'c> {
                 vec![],
             ),
             quote! {
-                let __descr_idx = __builder.add_gc_int_array_descr(
+                let __descr_idx = __builder.add_raw_int_array_descr_signed(
                     ::core::mem::size_of::<#element_type>(),
                     // descr.py:240-254 get_type_flag reads signedness off the
                     // declared element type.  Hard-coding signed would

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -70,6 +70,14 @@ impl<'c> Lowerer<'c> {
         if let Some(binding) = self.lower_state_ref_field_getfield(expr) {
             return Some(binding);
         }
+        // Array element read on a local ref binding whose field is declared
+        // in `array_fields`: `<binding>.<field>[<idx>]` → getfield_gc_r for
+        // the buffer base, then getarrayitem_gc_i. Before the plain field
+        // read, which cannot match an `Index` shape anyway, and before
+        // `lower_state_array_read`, which is the `state.<array>` form.
+        if let Some(binding) = self.lower_ref_binding_array_read(expr) {
+            return Some(binding);
+        }
         // Field read on a local ref binding with known struct type:
         // `<binding>.<field>` → getfield_gc_i/getfield_gc_r.
         if let Some(binding) = self.lower_ref_binding_getfield(expr) {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -187,7 +187,7 @@ impl<'c> Lowerer<'c> {
                     return Some(binding.clone());
                 }
                 // Otherwise a path whose final segment is a SCREAMING_CASE
-                // symbolic constant (`VAL_QUEUE`, `aheui::VAL_PORT`) lowers to
+                // symbolic constant (`VAL_QUEUE`, `consts::VAL_PORT`) lowers to
                 // a runtime int const — the same `#path as i64` form match-arm
                 // patterns use (`extract_pat_value_tokens`); the Rust compiler
                 // resolves the const value while building the JitCode, and a

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -183,7 +183,9 @@ pub struct LowererConfig {
     /// naming the field so the optimizer invalidates the cached
     /// `getfield_gc_i`.  Source: `JitInterpConfig.residual_writes`, the struct
     /// `Path` recovered from `state_ref_scalars[ref_scalar]`.
-    pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident)>,
+    /// The trailing `bool` is the `[]` suffix: the helper writes the ELEMENTS
+    /// of the array the field points at, rather than the field itself.
+    pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident, bool)>,
     /// `(pool-base ref-scalar name, getter function path segments, element type)`.
     /// A call `<getter>(state.<base>, <int>)` whose function path matches
     /// `getter` AND whose arg0 is the `base` lowers to `getarrayitem_gc_r`
@@ -1165,9 +1167,14 @@ impl LowererConfig {
                         .map(|(_, p)| p.clone())
                 });
                 entry.helpers.iter().filter_map(move |helper| {
-                    struct_path
-                        .clone()
-                        .map(|p| (canonical_path_segments(helper), p, entry.field.clone()))
+                    struct_path.clone().map(|p| {
+                        (
+                            canonical_path_segments(helper),
+                            p,
+                            entry.field.clone(),
+                            entry.writes_elements,
+                        )
+                    })
                 })
             })
             .collect();
@@ -2610,6 +2617,11 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            // ref_params, ref_fields, array_fields, int_fields,
+            // native_int_binops, native_tag_small, headerless_structs — the
+            // surface these tests assert is the call encoding, which none of
+            // them participate in.
+            &[],
             &[],
             &[],
             &[],
@@ -2635,6 +2647,11 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            // ref_params, ref_fields, array_fields, int_fields,
+            // native_int_binops, native_tag_small, headerless_structs — the
+            // surface these tests assert is the call encoding, which none of
+            // them participate in.
+            &[],
             &[],
             &[],
             &[],
@@ -2660,6 +2677,11 @@ mod tests {
                 "#,
             ),
             &[inline_policy("callee")],
+            // ref_params, ref_fields, array_fields, int_fields,
+            // native_int_binops, native_tag_small, headerless_structs — the
+            // surface these tests assert is the call encoding, which none of
+            // them participate in.
+            &[],
             &[],
             &[],
             &[],

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -194,6 +194,13 @@ pub struct LowererConfig {
     /// encounters a field access and the `(struct, field)` pair matches, it
     /// emits `getfield_gc_r` / `setfield_gc_r` (ref-kind) instead of `_gc_i`.
     pub(super) ref_fields: HashMap<String, (syn::Path, Ident, syn::Path)>,
+    /// `array_fields = { Struct::field => ElementType }`, keyed
+    /// `"StructLastSegment::field"` → (struct_path, field_ident,
+    /// element_path). The field holds an array BASE POINTER, so
+    /// `base.field[i]` is a `getfield_gc_r` followed by
+    /// `get/setarrayitem_gc_i` — never `arraylen_gc`, since the buffer
+    /// carries no header length.
+    pub(super) array_fields: HashMap<String, (syn::Path, Ident, syn::Path)>,
     /// Sub-word integer struct field declarations.  Key = `"StructType::field"`,
     /// value = `(rust_int_type, is_signed)`.  Source:
     /// `JitInterpConfig.int_fields`.  A field listed here registers its real
@@ -880,14 +887,45 @@ fn int_fields_map(
         .collect()
 }
 
+/// Key `array_fields` entries the same way `ref_fields` are keyed —
+/// `"StructLastSegment::field"` -> `(struct_path, field_ident, element_path)` —
+/// so the lowerer resolves an array field off a binding's `struct_type`
+/// exactly as it resolves a ref field.
+fn build_array_fields_map(
+    array_fields: &[crate::jit_interp::ArrayFieldEntry],
+) -> HashMap<String, (syn::Path, Ident, syn::Path)> {
+    array_fields
+        .iter()
+        .map(|entry| {
+            let struct_name = entry
+                .struct_type
+                .segments
+                .last()
+                .map(|s| s.ident.to_string())
+                .unwrap_or_default();
+            let key = format!("{}::{}", struct_name, entry.field);
+            (
+                key,
+                (
+                    entry.struct_type.clone(),
+                    entry.field.clone(),
+                    entry.element_type.clone(),
+                ),
+            )
+        })
+        .collect()
+}
+
 impl LowererConfig {
     pub fn inline_helper(
         ref_fields: &[crate::jit_interp::RefFieldEntry],
+        array_fields: &[crate::jit_interp::ArrayFieldEntry],
         int_fields: &[crate::jit_interp::IntFieldEntry],
         native_int_binops: &[(syn::Path, syn::Ident)],
         native_tag_small: &[syn::Path],
         headerless_structs: &[syn::Path],
     ) -> Self {
+        let array_fields_map = build_array_fields_map(array_fields);
         let ref_fields_map: HashMap<String, (syn::Path, Ident, syn::Path)> = ref_fields
             .iter()
             .map(|entry| {
@@ -929,6 +967,7 @@ impl LowererConfig {
             residual_writes: Vec::new(),
             pool_arrays: Vec::new(),
             ref_fields: ref_fields_map,
+            array_fields: array_fields_map,
             int_fields: int_fields_map(int_fields),
             call_returns: HashMap::new(),
             headerless_structs: headerless_structs
@@ -966,6 +1005,7 @@ impl LowererConfig {
         residual_writes: &[crate::jit_interp::ResidualWriteEntry],
         pool_arrays: &[crate::jit_interp::PoolArrayEntry],
         ref_fields: &[crate::jit_interp::RefFieldEntry],
+        array_fields: &[crate::jit_interp::ArrayFieldEntry],
         int_fields: &[crate::jit_interp::IntFieldEntry],
         call_returns: &[(Path, Path)],
         headerless_structs: &[Path],
@@ -1131,6 +1171,7 @@ impl LowererConfig {
                 })
             })
             .collect();
+        let array_fields_map = build_array_fields_map(array_fields);
         // Build the ref_fields lookup: key = "StructLastSegment::field",
         // value = (struct_path, field_ident, pointee_path).
         let ref_fields_map: HashMap<String, (syn::Path, Ident, syn::Path)> = ref_fields
@@ -1173,6 +1214,7 @@ impl LowererConfig {
             env_type_name: env_type.to_string(),
             residual_writes,
             ref_fields: ref_fields_map,
+            array_fields: array_fields_map,
             int_fields: int_fields_map(int_fields),
             call_returns: call_returns
                 .iter()

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -147,6 +147,9 @@ pub struct JitInterpConfig {
     /// The `PointeeType` is recorded so subsequent field access on the
     /// returned ref can resolve its struct layout.
     pub ref_fields: Vec<RefFieldEntry>,
+    /// Array base-pointer field declarations, `array_fields = { Struct::field
+    /// => ElementType, ... }`.  See [`ArrayFieldEntry`].
+    pub array_fields: Vec<ArrayFieldEntry>,
     /// Sub-word integer field declarations, `int_fields = { Struct::field =>
     /// u32, ... }`.  A field access lowers to `getfield_gc_i` /
     /// `setfield_gc_i` either way; what this adds is the field's real width
@@ -405,6 +408,30 @@ pub struct RefFieldEntry {
     pub pointee_type: Path,
 }
 
+/// One entry in `array_fields = { Struct::field => ElementType, ... }`.
+///
+/// Declares that `Struct.field` holds the base pointer of a contiguous
+/// array of `ElementType`, so `base.field[i]` lowers to a `getfield_gc_r`
+/// for the buffer pointer followed by `get/setarrayitem_gc_i` on it.
+///
+/// This is the non-virtualizable array vocabulary: the elements do NOT ride
+/// a guard's `vable_array` resume section, so the snapshot stays O(1) in the
+/// array's length. A `[..; virt]` state field is the other choice and is only
+/// correct for per-frame state whose length is bounded by the green key.
+///
+/// The buffer carries no object header, so its length is NOT readable with
+/// `arraylen_gc`; bound an index against a sibling `int_fields` length/offset
+/// field instead.
+#[derive(Clone)]
+pub struct ArrayFieldEntry {
+    /// The struct that owns the field (e.g. `Stack`).
+    pub struct_type: Path,
+    /// The field holding the array base pointer (e.g. `data`).
+    pub field: Ident,
+    /// The element type (e.g. `i64`).
+    pub element_type: Path,
+}
+
 /// One entry in `int_fields = { Struct::field => u32, ... }`.
 #[derive(Clone)]
 pub struct IntFieldEntry {
@@ -607,6 +634,7 @@ impl Parse for JitInterpConfig {
         let mut residual_writes: Vec<ResidualWriteEntry> = Vec::new();
         let mut pool_arrays: Vec<PoolArrayEntry> = Vec::new();
         let mut ref_fields: Vec<RefFieldEntry> = Vec::new();
+        let mut array_fields: Vec<ArrayFieldEntry> = Vec::new();
         let mut int_fields: Vec<IntFieldEntry> = Vec::new();
         let mut call_returns: Vec<(Path, Path)> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
@@ -669,6 +697,9 @@ impl Parse for JitInterpConfig {
                 }
                 "ref_fields" => {
                     ref_fields = parse_ref_fields_map(input)?;
+                }
+                "array_fields" => {
+                    array_fields = parse_array_fields_map(input)?;
                 }
                 "int_fields" => {
                     int_fields = parse_int_fields_map(input)?;
@@ -746,6 +777,7 @@ impl Parse for JitInterpConfig {
             residual_writes,
             pool_arrays,
             ref_fields,
+            array_fields,
             int_fields,
             call_returns,
             struct_allocs,
@@ -927,6 +959,27 @@ pub(crate) fn parse_ref_fields_map(input: ParseStream) -> syn::Result<Vec<RefFie
             struct_type,
             field,
             pointee_type,
+        });
+        let _ = content.parse::<Token![,]>();
+    }
+    Ok(entries)
+}
+
+/// Parse `array_fields = { Struct::field => ElementType, ... }`.
+/// Each entry declares that `Struct.field` is the base pointer of a
+/// contiguous `ElementType` array; see [`ArrayFieldEntry`].
+pub(crate) fn parse_array_fields_map(input: ParseStream) -> syn::Result<Vec<ArrayFieldEntry>> {
+    let content;
+    braced!(content in input);
+    let mut entries = Vec::new();
+    while !content.is_empty() {
+        let (struct_type, field) = split_struct_field_path(content.parse::<Path>()?)?;
+        content.parse::<Token![=>]>()?;
+        let element_type: Path = content.parse()?;
+        entries.push(ArrayFieldEntry {
+            struct_type,
+            field,
+            element_type,
         });
         let _ = content.parse::<Token![,]>();
     }

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -52,7 +52,7 @@ use syn::{
 /// `__MAJIT_HELPER_POLICIES`). Alternatively, use `helpers` or `calls`
 /// to explicitly list the functions that need JIT integration.
 pub struct JitInterpConfig {
-    /// The interpreter state type (e.g., `AheuiState`).
+    /// The interpreter state type (e.g., `InterpState`).
     pub state_type: Ident,
     /// The environment type (e.g., `Program`).
     pub env_type: Ident,
@@ -313,7 +313,7 @@ pub enum StateFieldKind {
     /// but the user-visible struct field carries the declared type. The
     /// macro emits `as i64` / `as <type>` casts at the JIT boundary so
     /// IR sees a uniform i64 while the interpreter keeps natural Rust
-    /// types (e.g. aheui's `selected: usize`, `stacksize: i32`).
+    /// types (e.g. `selected: usize`, `stacksize: i32`).
     Scalar {
         ir_type: Ident,
         /// `None` ⇒ Rust storage type matches `ir_type` (default i64
@@ -511,7 +511,8 @@ pub(crate) enum CallPolicyKind {
     ElidableIntOrMemerrorWrapped,
     ResidualRef,
     /// Like `ResidualRef` but stamps the descr EffectInfo with
-    /// `PyreHelperKind::NurseryAlloc` (aheui inline nursery bump). Result is a
+    /// `PyreHelperKind::NurseryAlloc`, which the backend lowers to an inline
+    /// nursery bump. Result is a
     /// real escaping Ref — no virtualization.
     NurseryAllocRef,
     ResidualRefWrapped,

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -372,6 +372,12 @@ pub struct ResidualWriteEntry {
     /// pointer carried by `ref_scalar` type-puns several repr(C) layouts whose
     /// shared field offsets nevertheless have distinct field-descr identities.
     pub struct_type: Option<Path>,
+    /// Set by the `[]` suffix (`selected_ref.data[] => [...]`): the helpers
+    /// mutate the ELEMENTS of the array `<field>` points at, not the field
+    /// itself.  The two are independent claims — a residual that reallocates a
+    /// buffer writes both, and one that only stores through it writes only the
+    /// elements — so a declaration of each is written separately.
+    pub writes_elements: bool,
     pub helpers: Vec<Path>,
 }
 
@@ -802,6 +808,18 @@ fn parse_residual_writes_map(input: ParseStream) -> syn::Result<Vec<ResidualWrit
         let ref_scalar: Ident = content.parse()?;
         content.parse::<Token![.]>()?;
         let field: Ident = content.parse()?;
+        // `<field>[]` — the elements behind the pointer, not the pointer field.
+        let writes_elements = content.peek(syn::token::Bracket);
+        if writes_elements {
+            let brackets;
+            bracketed!(brackets in content);
+            if !brackets.is_empty() {
+                return Err(brackets.error(
+                    "residual_writes element syntax takes no index: write `field[]`, \
+                     which declares a write to some element of the array",
+                ));
+            }
+        }
         let struct_type = if content.peek(Token![@]) {
             content.parse::<Token![@]>()?;
             Some(content.parse::<Path>()?)
@@ -817,6 +835,7 @@ fn parse_residual_writes_map(input: ParseStream) -> syn::Result<Vec<ResidualWrit
             ref_scalar,
             field,
             struct_type,
+            writes_elements,
             helpers: helpers.into_iter().collect(),
         });
         let _ = content.parse::<Token![,]>();

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1515,22 +1515,38 @@ fn generate_merge_wrapper(config: &JitInterpConfig, func: &ItemFn) -> TokenStrea
                 __driver.dispatch_jitcode().cloned();
             __driver.merge_point(|__meta, __sym| {
                 use majit_metainterp::JitCodeSym;
-                // pyjitpl.py:1577 `self.pc = saved_pc`: a merge point whose
+                // pyjitpl.py:1574 `self.pc = saved_pc`: a merge point whose
                 // `reached_loop_header` returned without closing (the
                 // `current_merge_points.append` path, :3058-3060) resumes the
-                // walk at the SAME guest pc. This closure is re-run for that,
-                // so the header-revisit fast path below — which exists to close
-                // a trace that came back round to its header — must not fire on
-                // the resumption: it would return CloseLoop before the walk ran
-                // a single step, and the retrace would compile an empty body.
+                // walk at the merge point's own guest pc. This closure is
+                // re-run for that, so the header-revisit fast path below —
+                // which exists to close a trace that came back round to its
+                // header — must not fire on the resumption: it would return
+                // CloseLoop before the walk ran a single step, and the retrace
+                // would compile an empty body.
                 //
-                // PEEK only. The dispatch merge-point arm is the consumer
-                // (`take_merge_point_resumed`); taking it here would let the
-                // resumed walk's own first merge-point visit close instantly.
-                let __resumed = __meta
-                    .trace_ctx()
-                    .map(|__ctx| __ctx.merge_point_resumed)
-                    .unwrap_or(false);
+                // The flag is a PEEK. The dispatch merge-point arm is its
+                // consumer (`take_merge_point_resumed`); taking it here would
+                // let the resumed walk's own first merge-point visit close
+                // instantly. The pc beside it is consumed here, because the pc
+                // is what this closure hands to the walk.
+                let (__resumed, __resume_pc) = match __meta.trace_ctx() {
+                    ::core::option::Option::Some(__ctx) => {
+                        (__ctx.merge_point_resumed, __ctx.walk_resume_pc.take())
+                    }
+                    ::core::option::Option::None => (false, ::core::option::Option::None),
+                };
+                // The position half of `self.pc = saved_pc`. `__pc` is the
+                // native interpreter's `pc` captured by this closure, so it
+                // names where the walk STARTED; the driver re-enters without
+                // advancing it, and a walk that closed deeper in its own
+                // segment would restart before the state it is carrying.
+                // Re-seed at the pc the close published; `None` — every
+                // re-entry that publishes none — keeps `__pc`.
+                let __pc: usize = match __resume_pc {
+                    ::core::option::Option::Some(__p) if __resumed => __p,
+                    _ => __pc,
+                };
                 if !__resumed && __sym.trace_started && __pc == __sym.loop_header_pc() {
                     if let Some(__ctx) = __meta.trace_ctx() {
                         __ctx.walk_final_pc = Some(__pc);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -2638,7 +2638,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// This is the Rust equivalent of RPython's meta-tracing: the proc macro analyzes
 /// the interpreter's opcode dispatch match and generates the tracing code automatically.
 ///
-/// The interpreter author writes ONLY the dispatch loop (like RPython's rpaheui).
+/// The interpreter author writes ONLY the dispatch loop.
 /// The macro generates:
 /// - `trace_instruction()` function (IR recording for each opcode)
 /// - `JitState` impl with Meta/Sym types
@@ -2648,7 +2648,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///
 /// ```ignore
 /// #[jit_interp(
-///     state = AheuiState,
+///     state = InterpState,
 ///     env = Program,
 ///     storage = {
 ///         pool: state.storage,
@@ -2657,8 +2657,8 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///         scan: find_used_storages,
 ///     },
 ///     io_shims = {
-///         aheui_io::write_number => jit_write_number,
-///         aheui_io::write_utf8 => jit_write_utf8,
+///         interp_io::write_number => jit_write_number,
+///         interp_io::write_utf8 => jit_write_utf8,
 ///     },
 ///     // optional: infer direct helper calls from sidecar metadata
 ///     // non-int result helpers still need explicit `calls = { ... => ... }`

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -181,11 +181,7 @@ fn rewrite_jit_inline_ref_param_fields(
             self.field_pointees.get(&key).cloned()
         }
 
-        fn array_field_elem(
-            &self,
-            struct_path: &syn::Path,
-            field_name: &str,
-        ) -> Option<syn::Path> {
+        fn array_field_elem(&self, struct_path: &syn::Path, field_name: &str) -> Option<syn::Path> {
             let struct_last = struct_path.segments.last()?.ident.to_string();
             let key = format!("{}::{}", struct_last, field_name);
             self.array_field_elems.get(&key).cloned()

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -34,6 +34,7 @@ struct JitInlineArgs {
     calls: Vec<jit_interp::CallEntry>,
     ref_params: Vec<(Ident, Path)>,
     ref_fields: Vec<jit_interp::RefFieldEntry>,
+    array_fields: Vec<jit_interp::ArrayFieldEntry>,
     int_fields: Vec<jit_interp::IntFieldEntry>,
     native_int_binops: Vec<(Path, Ident)>,
     native_tag_small: Vec<Path>,
@@ -51,6 +52,7 @@ impl Parse for JitInlineArgs {
         let mut native_tag_small: Vec<Path> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
         let mut headerless_structs: Vec<Path> = Vec::new();
+        let mut array_fields: Vec<jit_interp::ArrayFieldEntry> = Vec::new();
         while !input.is_empty() {
             let key: Ident = input.parse()?;
             input.parse::<Token![=]>()?;
@@ -93,6 +95,9 @@ impl Parse for JitInlineArgs {
                 "ref_fields" => {
                     ref_fields = jit_interp::parse_ref_fields_map(input)?;
                 }
+                "array_fields" => {
+                    array_fields = jit_interp::parse_array_fields_map(input)?;
+                }
                 "int_fields" => {
                     int_fields = jit_interp::parse_int_fields_map(input)?;
                 }
@@ -131,6 +136,7 @@ impl Parse for JitInlineArgs {
             calls,
             ref_params,
             ref_fields,
+            array_fields,
             int_fields,
             native_int_binops,
             native_tag_small,
@@ -144,6 +150,7 @@ fn rewrite_jit_inline_ref_param_fields(
     block: &syn::Block,
     ref_params: &[(Ident, Path)],
     ref_fields: &[jit_interp::RefFieldEntry],
+    array_fields: &[jit_interp::ArrayFieldEntry],
     struct_allocs: &[(Path, Path)],
 ) -> syn::Block {
     use std::collections::HashMap;
@@ -152,6 +159,10 @@ fn rewrite_jit_inline_ref_param_fields(
     struct InlineRefFieldRewriter {
         local_ref_types: HashMap<String, syn::Path>,
         field_pointees: HashMap<String, syn::Path>,
+        // `array_fields` entries: "StructLast::field" -> element type. The
+        // field holds the buffer BASE POINTER, so an indexed access derefs
+        // through it rather than reading the field itself.
+        array_field_elems: HashMap<String, syn::Path>,
         struct_allocs: HashMap<Vec<String>, syn::Path>,
     }
 
@@ -168,6 +179,16 @@ fn rewrite_jit_inline_ref_param_fields(
             let struct_last = struct_path.segments.last()?.ident.to_string();
             let key = format!("{}::{}", struct_last, field_name);
             self.field_pointees.get(&key).cloned()
+        }
+
+        fn array_field_elem(
+            &self,
+            struct_path: &syn::Path,
+            field_name: &str,
+        ) -> Option<syn::Path> {
+            let struct_last = struct_path.segments.last()?.ident.to_string();
+            let key = format!("{}::{}", struct_last, field_name);
+            self.array_field_elems.get(&key).cloned()
         }
 
         fn record_ref_field_local(&mut self, local: &syn::Local) {
@@ -226,6 +247,68 @@ fn rewrite_jit_inline_ref_param_fields(
         }
 
         fn visit_expr_mut(&mut self, expr: &mut syn::Expr) {
+            // Array element WRITE: `<base>.<array_field>[<idx>] = <rhs>`.
+            // Must precede the plain-field arms: the field itself holds the
+            // buffer BASE POINTER, so letting the default visitor rewrite
+            // `<base>.<array_field>` on its own would leave a raw pointer
+            // being indexed with `[]`, which does not compile.
+            if let syn::Expr::Assign(assign) = expr
+                && let syn::Expr::Index(index_expr) = &*assign.left
+                && let syn::Expr::Field(field) = &*index_expr.expr
+                && let Some(struct_path) = self.local_ref_struct_of_base(&field.base)
+                && let syn::Member::Named(member_id) = &field.member
+                && self
+                    .array_field_elem(&struct_path, &member_id.to_string())
+                    .is_some()
+            {
+                let base = (*field.base).clone();
+                let member = field.member.clone();
+                let mut idx = (*index_expr.index).clone();
+                let mut rhs = (*assign.right).clone();
+                self.visit_expr_mut(&mut idx);
+                self.visit_expr_mut(&mut rhs);
+                *expr = syn::parse_quote! {
+                    {
+                        let __majit_arr_obj = #base;
+                        let __majit_arr_idx = #idx;
+                        let __majit_arr_val = #rhs;
+                        unsafe {
+                            *((*(__majit_arr_obj as *mut #struct_path))
+                                .#member
+                                .add(__majit_arr_idx as usize)) = __majit_arr_val;
+                        }
+                    }
+                };
+                return;
+            }
+
+            // Array element READ: `<base>.<array_field>[<idx>]`.
+            if let syn::Expr::Index(index_expr) = expr
+                && let syn::Expr::Field(field) = &*index_expr.expr
+                && let Some(struct_path) = self.local_ref_struct_of_base(&field.base)
+                && let syn::Member::Named(member_id) = &field.member
+                && self
+                    .array_field_elem(&struct_path, &member_id.to_string())
+                    .is_some()
+            {
+                let base = (*field.base).clone();
+                let member = field.member.clone();
+                let mut idx = (*index_expr.index).clone();
+                self.visit_expr_mut(&mut idx);
+                *expr = syn::parse_quote! {
+                    {
+                        let __majit_arr_obj = #base;
+                        let __majit_arr_idx = #idx;
+                        unsafe {
+                            *((*(__majit_arr_obj as *const #struct_path))
+                                .#member
+                                .add(__majit_arr_idx as usize))
+                        }
+                    }
+                };
+                return;
+            }
+
             if let syn::Expr::Assign(assign) = expr
                 && let syn::Expr::Field(lhs) = &*assign.left
                 && let Some(struct_path) = self.local_ref_struct_of_base(&lhs.base)
@@ -317,6 +400,21 @@ fn rewrite_jit_inline_ref_param_fields(
             .map(|(name, struct_type)| (name.to_string(), struct_type.clone()))
             .collect(),
         field_pointees,
+        array_field_elems: array_fields
+            .iter()
+            .map(|entry| {
+                let struct_last = entry
+                    .struct_type
+                    .segments
+                    .last()
+                    .map(|seg| seg.ident.to_string())
+                    .unwrap_or_default();
+                (
+                    format!("{}::{}", struct_last, entry.field),
+                    entry.element_type.clone(),
+                )
+            })
+            .collect(),
         struct_allocs: struct_allocs_map,
     };
     let mut block = block.clone();
@@ -2399,6 +2497,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.calls,
         &args.ref_params,
         &args.ref_fields,
+        &args.array_fields,
         &args.int_fields,
         &args.native_int_binops,
         &args.native_tag_small,
@@ -2423,6 +2522,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &func.block,
         &args.ref_params,
         &args.ref_fields,
+        &args.array_fields,
         &args.struct_allocs,
     );
     let helper_with_asm_name = format_ident!("__majit_inline_jitcode_{}_with_asm", sig.ident);

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -263,11 +263,15 @@ fn rewrite_jit_inline_ref_param_fields(
                 let mut rhs = (*assign.right).clone();
                 self.visit_expr_mut(&mut idx);
                 self.visit_expr_mut(&mut rhs);
+                // The assigned value is evaluated before the assignee place,
+                // so an index or RHS with side effects must not be reordered:
+                // `base.data[next_index()] = compute_value()` runs
+                // `compute_value()` first.
                 *expr = syn::parse_quote! {
                     {
+                        let __majit_arr_val = #rhs;
                         let __majit_arr_obj = #base;
                         let __majit_arr_idx = #idx;
-                        let __majit_arr_val = #rhs;
                         unsafe {
                             *((*(__majit_arr_obj as *mut #struct_path))
                                 .#member

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2883,8 +2883,8 @@ mod tests {
 
     #[test]
     fn state_field_layout_total_live_values_includes_ref_scalars() {
-        // aheui: selected/stacksize/pool_ptr (3 int scalars) + selected_ref
-        // (1 ref scalar past the `program` ref arg at r0 → base 1).
+        // Three int scalars plus one ref scalar, the latter past a ref arg
+        // at r0 → base 1.
         // total_slots() counts only int-bank slots; the ref scalar lives in
         // the ref bank and is appended by extract_live, so
         // total_live_values() = total_slots() + num_ref_scalars. The
@@ -8349,10 +8349,10 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // in `wire_bhimpl_handlers` and the canonical bytes exist in
     // `wellknown_bh_insns`, but the whole family was absent from this
     // builder's insns map — so a deopt replaying a struct field access
-    // (e.g. an aheui Stack/Queue `size` store, `setfield_gc_i/rid` =
-    // BC_SETFIELD_GC_I 0xac) landed on the unwired-opcode placeholder.
-    // Canonical `rd`/`r{i,r,f}d` argcodes only (aheui accesses fields off
-    // a ref base); intbase (`id`/`iid`/`ird`) forms have no canonical byte
+    // (an int field store, `setfield_gc_i/rid` = BC_SETFIELD_GC_I 0xac)
+    // landed on the unwired-opcode placeholder.
+    // Canonical `rd`/`r{i,r,f}d` argcodes only (these access fields off a
+    // ref base); intbase (`id`/`iid`/`ird`) forms have no canonical byte
     // and are not emitted here.  Additive: every byte is currently unwired.
     for (key, byte) in [
         (

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -201,7 +201,7 @@ pub fn can_raise_effect_info() -> EffectInfo {
     EffectInfo::const_new(ExtraEffect::CanRaise, OopSpecIndex::None)
 }
 
-/// aheui nursery-alloc residual: `EF_CAN_RAISE` with empty write sets —
+/// Nursery-alloc residual: `EF_CAN_RAISE` with empty write sets —
 /// an allocation publishes a fresh object and writes no field of any
 /// object the trace already cached, so `graphanalyze.py:60
 /// analyze_external_call`'s `bottom_result()` is the honest answer.

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -5295,6 +5295,24 @@ impl TraceCtx {
         std::mem::take(&mut self.merge_point_resumed)
     }
 
+    /// Both halves of pyjitpl.py:1571/1574 `saved_pc`, for a close that did
+    /// NOT end the trace and so has to hand the walk back.
+    ///
+    /// The two are one operation upstream and must stay one here: a re-entry
+    /// that latches the skip without handing over the pc rewinds the walk to
+    /// wherever its segment began while its state stands at the merge point
+    /// just reached, and the instructions in between are re-executed against
+    /// state belonging to neither. Both driver re-entries call this so neither
+    /// can acquire one half without the other.
+    ///
+    /// `close_green_pc` is `None` for a close that named no merge-point pc, in
+    /// which case there is nothing to correct and the walk keeps the pc it was
+    /// called with.
+    pub fn resume_walk_after_close(&mut self) {
+        self.walk_resume_pc = self.close_green_pc.and_then(|p| usize::try_from(p).ok());
+        self.merge_point_resumed = true;
+    }
+
     pub fn has_merge_point_at(&self, key: u64, header_pc: usize) -> bool {
         self.current_merge_points
             .iter()

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -465,8 +465,8 @@ pub trait JitState: Sized {
     /// values (captured at close time by `collect_scalar_state_field_values`)
     /// into native state. `values[idx]` is the scalar at state-field index
     /// `idx`, written in the same order the sym read them. A scalar the walk
-    /// mutates but `recover` cannot re-derive from shared storage (e.g. aheui's
-    /// `selected` storage index, set by SEL from a program operand) would
+    /// mutates but `recover` cannot re-derive from shared storage (a
+    /// `selected` storage index set from a program operand, say) would
     /// otherwise stay frozen at its trace-start value. Applied before
     /// `recover_after_compiled_run` so recover then refines the storage-derived
     /// caches (stacksize / list refs) from the now-current scalars. Default

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1604,8 +1604,8 @@ impl JitCodeBuilder {
     /// Ref-result array read: `dst = array[index]` where the element is a
     /// GC pointer (8 bytes). Mirrors [`Self::getarrayitem_gc_i`] but routes
     /// `dst` through the ref register bank and uses the `/rid>r` mnemonic.
-    /// Used to re-derive a pointer-array element (aheui `pools[selected]`)
-    /// as a re-producible heap read instead of an opaque residual call.
+    /// Used to re-derive a pointer-array element (a `pools[selected]`-shaped
+    /// read) as a re-producible heap read instead of an opaque residual call.
     pub fn getarrayitem_gc_r(&mut self, dst: u16, array_reg: u16, index_reg: u16, descr_idx: u16) {
         self.touch_ref_reg(array_reg);
         self.touch_reg(index_reg);
@@ -1797,8 +1797,9 @@ impl JitCodeBuilder {
     /// getlenbound().make_gt_const(index)`) and the short preamble re-emits
     /// `ARRAYLEN_GC` to re-establish the `len > index` guard each loop entry
     /// — without a lendescr the GC rewrite of that `ARRAYLEN_GC` panics.
-    /// The aheui `Storage` carries this header as `pools_len` (offset 0,
-    /// `pools` at offset 8).  Deduped structurally by `add_bh_descr`.
+    /// An interpreter supplies that header itself — a length word at offset
+    /// 0 with the pointer array at offset 8.  Deduped structurally by
+    /// `add_bh_descr`.
     pub fn add_ptr_array_descr(&mut self) -> u16 {
         self.add_array_descr(CanonicalBhDescr::Array {
             base_size: std::mem::size_of::<usize>(),

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1961,6 +1961,65 @@ impl JitCodeBuilder {
         self.push_reg_u8(dest, "newlist_clear dst");
     }
 
+    /// Store an integer element into a GC-managed array.
+    ///
+    /// blackhole.py:1351 `bhimpl_setarrayitem_gc_i @arguments("cpu","r","i",
+    /// "i","d")`: reads `registers_r[array_reg]` as the array pointer,
+    /// `registers_i[index_reg]` (or a const-pool slot) as the element index,
+    /// `registers_i[value_reg]` (or a const-pool slot) as the new value, and
+    /// `descrs[descr_idx]` as the array descriptor.
+    ///
+    /// Encoding: `[BC_SETARRAYITEM_GC_I][array_reg u8][index_reg u8]
+    ///             [value_reg u8][descr_idx lo u8][descr_idx hi u8]`.
+    ///
+    /// Store counterpart of [`Self::getarrayitem_gc_i`]. Both take the
+    /// element descr from [`Self::add_gc_int_array_descr`], so a store
+    /// invalidates the heapcache entry the matching load populated.
+    pub fn setarrayitem_gc_i(
+        &mut self,
+        array_reg: u16,
+        index_reg: u16,
+        value_reg: u16,
+        descr_idx: u16,
+    ) {
+        self.touch_ref_reg(array_reg);
+        self.touch_int_reg_or_pool_slot(index_reg);
+        self.touch_int_reg_or_pool_slot(value_reg);
+        self.write_insn("setarrayitem_gc_i/riid");
+        self.push_reg_u8(array_reg, "setarrayitem_gc_i array");
+        self.push_reg_u8(index_reg, "setarrayitem_gc_i index");
+        self.push_reg_u8(value_reg, "setarrayitem_gc_i value");
+        self.push_u16(descr_idx);
+    }
+
+    /// `c`-argcode form of [`Self::setarrayitem_gc_i`] —
+    /// `assembler.py:99-107 emit_const(allow_short=True)` writes a small
+    /// ConstInt VALUE (-128..127) inline as one signed byte
+    /// (`setarrayitem_gc_i` is in `USE_C_FORM`, `assembler.py:339`).
+    ///
+    /// Note the constant operand differs from
+    /// [`Self::setarrayitem_gc_r_c`], where it is the INDEX: here the index
+    /// stays a register and the stored value is inline, matching the
+    /// `/ricd` argcode string the blackhole registers.
+    ///
+    /// Encoding: `[BC_SETARRAYITEM_GC_I_C][array_reg u8][index_reg u8]
+    ///             [value i8][descr_idx lo u8][descr_idx hi u8]`.
+    pub fn setarrayitem_gc_i_c(
+        &mut self,
+        array_reg: u16,
+        index_reg: u16,
+        value: i8,
+        descr_idx: u16,
+    ) {
+        self.touch_ref_reg(array_reg);
+        self.touch_int_reg_or_pool_slot(index_reg);
+        self.write_insn("setarrayitem_gc_i/ricd");
+        self.push_reg_u8(array_reg, "setarrayitem_gc_i array");
+        self.push_reg_u8(index_reg, "setarrayitem_gc_i index");
+        self.push_u8(value as u8);
+        self.push_u16(descr_idx);
+    }
+
     /// Store a Ref element into a GC-managed array.
     ///
     /// blackhole.py `bhimpl_setarrayitem_gc_r @arguments("cpu","r","i",
@@ -7085,6 +7144,63 @@ mod tests {
         let jitcode = builder.finish();
         let opcode = jitcode::insn_byte("raise/r");
         assert_eq!(jitcode.code, vec![opcode, 0]);
+    }
+
+    #[test]
+    fn setarrayitem_gc_i_encodes_the_riid_operand_order() {
+        // `handler_setarrayitem_gc_i` (blackhole.rs) reads
+        // `code[position]` as the array ref reg, `+1` as the index int
+        // reg, `+2` as the value int reg, then the descr — the `riid`
+        // argcode string it is registered under. Pin that order here so
+        // the emit side cannot drift from the handler that decodes it.
+        let mut builder = JitCodeBuilder::new();
+        let descr_idx = builder.add_gc_int_array_descr(8, true);
+        builder.setarrayitem_gc_i(1, 2, 3, descr_idx);
+        let jitcode = builder.finish();
+        let opcode = jitcode::insn_byte("setarrayitem_gc_i/riid");
+        assert_eq!(
+            jitcode.code,
+            vec![
+                opcode,
+                1,
+                2,
+                3,
+                (descr_idx & 0xff) as u8,
+                (descr_idx >> 8) as u8
+            ]
+        );
+        // The array operand is a REF reg and the other two are INT regs,
+        // so the banks must be sized independently.
+        assert_eq!(jitcode.c_num_regs_r, 2);
+        assert_eq!(jitcode.c_num_regs_i, 4);
+    }
+
+    #[test]
+    fn setarrayitem_gc_i_c_encodes_the_value_inline_not_the_index() {
+        // The `_c` form's constant operand is the stored VALUE, not the
+        // index — `setarrayitem_gc_i/ricd`, unlike `setarrayitem_gc_r`'s
+        // `/rcrd` where it is the index. `handler_setarrayitem_gc_i_c`
+        // reads `code[position + 1]` as an index REGISTER and
+        // `code[position + 2]` as a signed inline byte.
+        let mut builder = JitCodeBuilder::new();
+        let descr_idx = builder.add_gc_int_array_descr(8, true);
+        builder.setarrayitem_gc_i_c(1, 2, -5, descr_idx);
+        let jitcode = builder.finish();
+        let opcode = jitcode::insn_byte("setarrayitem_gc_i/ricd");
+        assert_eq!(
+            jitcode.code,
+            vec![
+                opcode,
+                1,
+                2,
+                (-5i8) as u8,
+                (descr_idx & 0xff) as u8,
+                (descr_idx >> 8) as u8
+            ]
+        );
+        // Only the index is an int reg here; the value never touches the
+        // int bank.
+        assert_eq!(jitcode.c_num_regs_i, 3);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1654,6 +1654,18 @@ impl JitCodeBuilder {
 
     /// Add a descriptor for a raw native integer array, selecting sign- vs
     /// zero-extension for sub-word `raw_load_i` results.
+    ///
+    /// Also the descr for a header-less buffer reached through a bare `*mut T`
+    /// field, even though those elements are read with `getarrayitem_gc_i`
+    /// rather than `raw_load_i`: what the flag governs is the object header,
+    /// and such a buffer has none.  `ArrayPtrInfo::make_guards`
+    /// (`optimizeopt/info.rs:668`, mirroring `info.py:632-639`) emits
+    /// `GUARD_GC_TYPE` for a GC-managed array descr, reading a type-id word at
+    /// `ptr - GcHeader::SIZE`; ahead of such a buffer that word belongs to
+    /// whatever precedes the allocation, so once the base is red the guard
+    /// fails or faults on short-preamble re-entry.  The `&[u8]` `env` array
+    /// keeps `add_gc_int_array_descr` because its base is a green constant and
+    /// the optimizer therefore gives it `PtrInfo::Constant`, never this arm.
     pub fn add_raw_int_array_descr_signed(
         &mut self,
         item_size: usize,
@@ -1782,7 +1794,9 @@ impl JitCodeBuilder {
             interior_fields: Vec::new(),
             // Preserve existing GUARD_GC_TYPE behavior for the `&[u8]`
             // program-array path (only the `pool_arrays` base flips to
-            // raw via `add_ptr_array_descr`).
+            // raw via `add_ptr_array_descr`).  A header-less buffer reached
+            // through a `*mut T` field takes `add_raw_int_array_descr_signed`
+            // instead — see the note there.
             is_gc_managed: true,
         })
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3092,6 +3092,18 @@ impl<S: JitState> JitDriver<S> {
                                         // `close_bridge` directly and have no such path.
                                         crate::mc_diag_bump(67); // bridge_unattempted_close
                                     }
+                                    // pyjitpl.py:1574 `self.pc = saved_pc` resumes at the
+                                    // merge point that was CONSULTED — the one whose greens
+                                    // `get_procedure_token` read (pyjitpl.py:3005), which is
+                                    // this one. The `continue` below re-runs the walk with
+                                    // the native interpreter's `pc` untouched, i.e. at the
+                                    // position the walk STARTED from, while the symbolic
+                                    // state stands here. Publish the position half before
+                                    // dropping the only record of it, or the re-entered walk
+                                    // replays the instructions between the two against state
+                                    // that belongs to neither.
+                                    ctx.walk_resume_pc =
+                                        ctx.close_green_pc.and_then(|p| usize::try_from(p).ok());
                                     ctx.close_greens = None;
                                     ctx.close_green_pc = None;
                                     ctx.merge_point_resumed = true;
@@ -8967,6 +8979,108 @@ mod cross_loop_cut_close_tests {
         assert!(
             driver.is_tracing(),
             "the walk keeps recording, as on the declined-attempt path",
+        );
+    }
+
+    /// `close_jumping_into` with the walk-entry bookkeeping the
+    /// `jit_merge_point!` expansion performs, and with a `close_green_pc` the
+    /// caller chooses.  Returns the `walk_resume_pc` observed at the top of
+    /// each walk — one entry per invocation of the closure, which is what the
+    /// macro reads to decide where to seed the walk.
+    fn close_jumping_into_observing_resume(
+        driver: &mut JitDriver<CutCloseState>,
+        target: u64,
+        close_pc: Option<i64>,
+    ) -> Vec<Option<usize>> {
+        let mut observed = Vec::new();
+        driver.merge_point(|meta, _sym| {
+            let Some(ctx) = meta.trace_ctx() else {
+                return TraceAction::Continue;
+            };
+            observed.push(ctx.walk_resume_pc.take());
+            if std::mem::take(&mut ctx.merge_point_resumed) {
+                return TraceAction::Continue;
+            }
+            ctx.close_greens = Some(inner_greens());
+            ctx.close_green_pc = close_pc;
+            ctx.close_jump_into_key = Some(target);
+            TraceAction::CloseLoop
+        });
+        observed
+    }
+
+    /// Where a declined close re-enters the walk.
+    ///
+    /// pyjitpl.py:1571/1574 `saved_pc`: upstream consults one merge point per
+    /// `opimpl_jit_merge_point` call, so the position that entered the call and
+    /// the position that declined cannot differ.  A pyre walk covers a whole
+    /// segment, so they can — and only the second one names the state the walk
+    /// is carrying.  The driver hands that pc over; the walk is re-seeded from
+    /// it rather than from wherever the segment began.
+    ///
+    /// `close_jumping_into`, which the rest of this module drives, publishes no
+    /// `close_green_pc` at all, so none of those tests can tell the two pcs
+    /// apart.
+    #[test]
+    fn a_declined_close_hands_over_the_pc_that_declined() {
+        let mut driver = JitDriver::<CutCloseState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let inner_key = 7081u64;
+        compile_inner_loop(&mut driver, inner_key, /* cut */ true);
+
+        // Deliberately unrelated to the trace's own header, which is what a
+        // close reached deeper in the walk than its entry looks like.
+        let declining_pc = 385i64;
+        start_outer_trace(&mut driver, 7082);
+        let seen = close_jumping_into_observing_resume(&mut driver, inner_key, Some(declining_pc));
+
+        assert!(
+            driver.is_tracing(),
+            "premise: the decline keeps tracing, so there is a re-entry to check",
+        );
+        assert_eq!(
+            seen.len(),
+            2,
+            "the declined close re-runs the walk exactly once",
+        );
+        assert_eq!(
+            seen[0], None,
+            "the first walk is seeded by its caller; nothing has declined yet",
+        );
+        assert_eq!(
+            seen[1],
+            Some(declining_pc as usize),
+            "the re-entered walk must be seeded at the merge point that \
+             declined. Seeded at the pc that entered the walk instead, it \
+             re-executes everything between the two against the state it \
+             already advanced past, and closes a loop whose registered green \
+             key contradicts the state its own JUMP carries",
+        );
+    }
+
+    /// …and a close that names no pc leaves the seed alone, rather than
+    /// pointing the walk at 0.  The pc is the merge point's green
+    /// (pyjitpl.py:3005), so a driver whose merge point yields none has
+    /// nothing to correct and keeps the pc it was called with.
+    #[test]
+    fn a_declined_close_without_a_pc_hands_over_nothing() {
+        let mut driver = JitDriver::<CutCloseState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let inner_key = 7091u64;
+        compile_inner_loop(&mut driver, inner_key, /* cut */ true);
+
+        start_outer_trace(&mut driver, 7092);
+        let seen = close_jumping_into_observing_resume(&mut driver, inner_key, None);
+
+        assert_eq!(
+            seen.len(),
+            2,
+            "the declined close re-runs the walk exactly once"
+        );
+        assert!(
+            seen.iter().all(Option::is_none),
+            "with no pc published there is nothing to re-seed from, and the \
+             walk keeps the pc its caller passed",
         );
     }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1276,7 +1276,7 @@ pub struct JitDriver<S: JitState> {
     ///
     /// The Mutex serialises factory invocations from blackhole resume
     /// callers; in practice tracing/resume run single-threaded for the
-    /// state-field JIT consumer (aheui), so contention is negligible.
+    /// state-field JIT consumer, so contention is negligible.
     ///
     /// Snapshot contract: factory calls that can append distinct
     /// liveness entries must run before tracing starts, followed by
@@ -1285,7 +1285,8 @@ pub struct JitDriver<S: JitState> {
     /// `MetaInterpStaticData.liveness_info` immutable during tracing.
     shared_asm: std::sync::Arc<std::sync::Mutex<majit_translate::codewriter::assembler::Assembler>>,
     /// resume.py:1367 — CPU allocation backend for virtual materialization
-    /// during blackhole resume. Registered by pyre/aheui at startup.
+    /// during blackhole resume. Registered by the embedding interpreter at
+    /// startup.
     blackhole_allocator: Option<Box<dyn crate::resume::BlackholeAllocator + Send>>,
     /// warmspot.py:961 handle_jitexception parity: portal runner callback.
     /// Called when ContinueRunningNormally is raised at a recursive portal
@@ -3013,7 +3014,7 @@ impl<S: JitState> JitDriver<S> {
                                 //
                                 // What the widened arm produces, at the op level: the
                                 // declined close returns here, the walk runs on and closes a
-                                // second time one aheui instruction later, and the bridge it
+                                // second time one interpreter instruction later, and the bridge it
                                 // compiles carries that instruction's pop (`IntAdd -1`, two
                                 // `GcLoadR`, two `GcStore`) ahead of a `Jump` into a
                                 // four-input label, where the close that was declined jumped
@@ -3444,7 +3445,7 @@ impl<S: JitState> JitDriver<S> {
                         //
                         // The slot is here because nothing available reaches
                         // this branch: it fires on no test in this crate, no
-                        // majit example, and no aheui corpus program at
+                        // majit example, and no downstream corpus program at
                         // thresholds 2/8/32/128. A zero says "still unreached";
                         // the first non-zero is the first evidence this
                         // resumption is exercised at all.
@@ -7905,7 +7906,7 @@ mod tests {
     }
 
     /// State whose walk advances a scalar state field the recover hook cannot
-    /// re-derive (an aheui `selected`-style storage index). The Sym carries the
+    /// re-derive (a `selected`-style storage index). The Sym carries the
     /// scalar; `collect_scalar_state_field_values` reads it (at close time,
     /// while the sym is live) and `writeback_scalar_state_fields_from_values`
     /// pushes the captured value into native `state`.
@@ -7980,9 +7981,9 @@ mod tests {
     /// `writeback_scalar_state_fields` applies that stash to native `state`
     /// afterward. Previously the write-back read `self.sym` directly, but the
     /// CloseLoop arm had already set `self.sym = None`, so the write-back was
-    /// always a silent no-op — a program whose walk advanced a scalar (e.g. an
-    /// aheui SEL changing `selected`) would seed native state from the stale
-    /// trace-start value.
+    /// always a silent no-op — a program whose walk advanced a scalar (an
+    /// instruction switching the selected storage, say) would seed native
+    /// state from the stale trace-start value.
     #[test]
     fn single_pass_close_writes_back_walk_final_scalar() {
         let mut driver = JitDriver::<ScalarWalkState>::new(1);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3102,11 +3102,9 @@ impl<S: JitState> JitDriver<S> {
                                     // dropping the only record of it, or the re-entered walk
                                     // replays the instructions between the two against state
                                     // that belongs to neither.
-                                    ctx.walk_resume_pc =
-                                        ctx.close_green_pc.and_then(|p| usize::try_from(p).ok());
+                                    ctx.resume_walk_after_close();
                                     ctx.close_greens = None;
                                     ctx.close_green_pc = None;
-                                    ctx.merge_point_resumed = true;
                                 }
                                 // The walk-final handoff staged at the top of this arm describes a trace
                                 // that ENDED; discard it, same as the `take_keep_tracing_after_close` path
@@ -3434,12 +3432,25 @@ impl<S: JitState> JitDriver<S> {
                         self.meta.single_pass_outcome = None;
                         self.meta.single_pass_scalar_values = None;
                         self.meta.single_pass_virt_array_values = None;
-                        // pyjitpl.py:1577 `self.pc = saved_pc` — the resumed walk
+                        // pyjitpl.py:1571/1574 `saved_pc` — the resumed walk
                         // re-enters at the merge point's own guest pc, so the
                         // merge-point op must fall through once instead of
-                        // closing again with nothing recorded in between.
+                        // closing again with nothing recorded in between, and
+                        // the walk must be seeded THERE rather than wherever
+                        // its segment began. `register_retrace_merge_point`
+                        // registered this merge point under `close_header_pc`,
+                        // the same pc `close_green_pc` names, so resuming
+                        // anywhere else also disagrees with that registration.
+                        //
+                        // The slot is here because nothing available reaches
+                        // this branch: it fires on no test in this crate, no
+                        // majit example, and no aheui corpus program at
+                        // thresholds 2/8/32/128. A zero says "still unreached";
+                        // the first non-zero is the first evidence this
+                        // resumption is exercised at all.
+                        crate::mc_diag_bump(78); // retrace_close_resumed
                         if let Some(ctx) = self.meta.trace_ctx() {
-                            ctx.merge_point_resumed = true;
+                            ctx.resume_walk_after_close();
                         }
                         continue;
                     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1877,6 +1877,17 @@ impl<S: JitState> JitDriver<S> {
         self.set_max_unroll_recursion(value);
     }
 
+    /// warmspot.py:73 `jd.warmstate.set_param_enable_opts(enable_opts)`.
+    ///
+    /// Takes the `':'`-separated pass names of `ALL_OPTS`; `"all"` restores the
+    /// full set. Dropping `"unroll"` selects the simple-loop compilation path
+    /// for this driver alone, which is why this is per-driver rather than a
+    /// process-wide switch. `set_param` cannot carry it — that surface is
+    /// `i64`-valued, and this parameter is a string upstream too.
+    pub fn set_param_enable_opts(&mut self, value: &str) {
+        self.meta.warm_state_mut().set_param_enable_opts(value);
+    }
+
     /// Whether this driver was declared recursive.
     pub fn is_recursive(&self) -> bool {
         self.is_recursive

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -156,9 +156,9 @@ pub use pyjitpl::{
     record_application_traceback_for_recording, record_application_traceback_hook_address,
     record_discarded_level_traceback_for_recording, record_discarded_level_traceback_hook_address,
     record_inline_application_traceback_for_recording,
-    record_inline_application_traceback_hook_address, set_record_application_traceback_hook,
-    set_record_discarded_level_traceback_hook, set_record_inline_application_traceback_hook,
-    struct_fields_write_effect_info, trace_jitcode, trace_jitcode_from_merge_point,
+    record_inline_application_traceback_hook_address, residual_write_effect_info,
+    set_record_application_traceback_hook, set_record_discarded_level_traceback_hook,
+    set_record_inline_application_traceback_hook, trace_jitcode, trace_jitcode_from_merge_point,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };
 pub use resume_box_reader::{

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -874,7 +874,7 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 
 /// Number of `MC_DIAG` slots. Declared once so the counter array and
 /// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
-pub const MC_DIAG_SLOTS: usize = 78;
+pub const MC_DIAG_SLOTS: usize = 79;
 
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
@@ -1213,6 +1213,12 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     "qmut_deps_simple_loop",
     "qmut_deps_entry_bridge",
     "qmut_deps_blackhole_arm",
+    // The second of the driver's two "close kept the trace alive, hand the
+    // walk back" re-entries (`take_keep_tracing_after_close`). Its sibling has
+    // no slot because the corpus reaches it; this one is reached by nothing
+    // runnable today, so a zero here is the difference between "the resumption
+    // is correct" and "the resumption has never run".
+    "retrace_close_resumed",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2012,7 +2012,22 @@ impl OptHeap {
             let read = ei.check_readonly_descr_array(effect_idx);
             // heap.py:556 — no sentinel special case, for the reason given
             // in the field loop above.
-            let write = ei.check_write_descr_array(effect_idx);
+            //
+            // Raw-set fallback, the array twin of the field loop's: on the
+            // macro / `JitDriver` path `compute_bitstrings` never runs, so
+            // `effect_idx` is the unset sentinel and the bitstring lookup
+            // always misses. Invalidate when the call's concrete
+            // `_write_descrs_arrays` names this exact array descr by pointer
+            // identity. Gated on `!compute_bitstrings_has_run()` so the
+            // translated interpreter's bitstring path is unchanged.
+            //
+            // The soundness argument is the field loop's verbatim: a call
+            // whose write set was never computed is `EF_RANDOM_EFFECTS` and
+            // is routed to `clean_caches` before reaching this function, so a
+            // sentinel descr bitchecking false here is correct.
+            let write = ei.check_write_descr_array(effect_idx)
+                || (!majit_ir::effectinfo::compute_bitstrings_has_run()
+                    && ei.writes_array_descr_by_identity(&descr));
             if !read && !write {
                 continue;
             }

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -2027,7 +2027,7 @@ impl OptHeap {
             // sentinel descr bitchecking false here is correct.
             let write = ei.check_write_descr_array(effect_idx)
                 || (!majit_ir::effectinfo::compute_bitstrings_has_run()
-                    && ei.writes_array_descr_by_identity(&descr));
+                    && ei.writes_array_descr_by_shape(&descr));
             if !read && !write {
                 continue;
             }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -532,7 +532,8 @@ pub struct OptContext {
     /// op's result position. `find_producer_op`'s highest-priority lookup
     /// otherwise scans `new_operations` with `iter().rfind(...)`, which is
     /// O(n) per call and O(n²) over a whole trace — the dominant cost when
-    /// optimizing a large loop (e.g. aheui's ~64k-op whole-program trace).
+    /// optimizing a large loop — a whole-program trace can reach tens of
+    /// thousands of ops.
     /// Maintained incrementally by `push_new_operation` (insert overwrites,
     /// so the last push at a position wins, matching the `rfind`
     /// last-occurrence semantics); rebuilt by `rebuild_new_operations_index`
@@ -796,7 +797,7 @@ pub struct OptContext {
     // `IndexMap`: `find_producer_op` does `resop_refs.get(&opref)` once per
     // live box of every guard inside `store_final_boxes_in_guard`, and a
     // Vec-backed `get` is O(n), making the box-numbering O(n^2) on very
-    // large traces (aheui's logo loop spends ~all its compile time there).
+    // large traces, where it can dominate the whole compile time.
     // `IndexMap` keeps the same insertion-ordered `values()` semantics the
     // earlier container guaranteed but resolves `get` in O(1).  Same O(1)
     // acceleration rationale as `input_ops_index`; no PyPy counterpart
@@ -820,7 +821,8 @@ pub struct OptContext {
     /// exists per position (the emit invariant asserted throughout this file),
     /// so the map is unambiguous. Maintained via `live_synthetics_push` /
     /// `live_synthetics_swap_remove_pos`; without it the scan is O(n^2) over a
-    /// vector that grows to the whole trace length (~44k on aheui's logo loop),
+    /// vector that grows to the whole trace length (tens of thousands of ops
+    /// on a whole-program loop),
     /// the same producer-resolution cost `phase1_emit_ops_index` removes.
     pub(crate) live_synthetics_index: FxHashMap<OpRef, usize>,
     /// Phase 1 emit ops carried into Phase 2's lookup surface.
@@ -840,7 +842,8 @@ pub struct OptContext {
     /// (`ctx.phase1_emit_ops = mem::take(...)` in `optimizer.rs`) — and never
     /// mutated afterwards, so the index is rebuilt in lockstep there via
     /// `rebuild_phase1_emit_ops_index`. Without it, `find_producer_op` scans
-    /// the full cross-phase carry (~60k ops on aheui's logo loop) per live
+    /// the full cross-phase carry (tens of thousands of ops on a
+    /// whole-program loop) per live
     /// box of every Phase 2 guard, the dominant O(n^2) compile cost. Same
     /// derived-index rationale as `input_ops_index` (no PyPy counterpart:
     /// upstream keys producers on `box._forwarded`, not a positional map).
@@ -862,7 +865,7 @@ pub struct OptContext {
     /// `rebuild_input_ops_index`. Eliminates the O(n) scan of the full
     /// recorder trace that `find_producer_op` otherwise performs on every
     /// miss of the higher-priority stores (the dominant O(n^2) cost on very
-    /// large traces, e.g. aheui's logo loop).
+    /// large traces).
     ///
     /// No PyPy counterpart: upstream keys producer information on the box
     /// itself (`box._forwarded` / `PtrInfo`, `optimizer.py`), so a

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3278,8 +3278,8 @@ impl Optimizer {
                         // with five virtual-carrying fixtures (escaping tuple,
                         // escaping instance, aliased list, varying-length
                         // array, nested virtual), two of which do compile
-                        // bridges — zero hits, as with the aheui corpus and
-                        // pyre/bench + pyre/extra_tests. Upstream matches
+                        // bridges — zero hits, as with pyre/bench and
+                        // pyre/extra_tests. Upstream matches
                         // against a *different* loop's stored state in
                         // `jump_to_existing_trace` (unroll.py:207);
                         // `export_state_re_matched_against_its_own_args_cannot_fail`

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6225,12 +6225,14 @@ impl<M: Clone> MetaInterp<M> {
         let trace_ops_snapshot = trace_ops.clone();
         let constants_snapshot = constants.clone();
 
-        // PyPy: pyjitpl.py:3016-3017 `can_use_unroll = cpu.supports_guard_gc_type
-        // and 'unroll' in warmstate.enable_opts`. PYRE_NO_UNROLL forces the
-        // simple-loop compilation path (compile.py:251 compile_simple_loop)
-        // without preamble peeling, useful for diagnostics and to isolate
-        // unroller-related regressions.
-        let no_unroll = crate::no_unroll_enabled();
+        // PyPy: pyjitpl.py:3016-3017 gates unrolling on `unroll` in
+        // warmstate.enable_opts. PYRE_NO_UNROLL remains a diagnostic override.
+        let no_unroll = crate::no_unroll_enabled()
+            || !self
+                .warm_state
+                .get_enable_opts()
+                .iter()
+                .any(|opt| opt == "unroll");
 
         // Use UnrollOptimizer for preamble peeling when available.
         // compile.py: compile_loop → PreambleCompileData + LoopCompileData.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4,7 +4,7 @@ mod frame;
 pub use dispatch::build_state_field_snapshot;
 pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
-    StandaloneFrameStack, struct_fields_write_effect_info, trace_jitcode,
+    StandaloneFrameStack, residual_write_effect_info, trace_jitcode,
     trace_jitcode_from_merge_point, trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -22181,7 +22181,7 @@ mod tests {
 
     /// The LABEL's argument order is its own, not the frontend's state-field
     /// order, and the two can agree in length while disagreeing in position.
-    /// `aheui`'s `pi/pi.jinseo` under the cranelift backend hit exactly that:
+    /// A downstream interpreter under the cranelift backend hit exactly that:
     /// four state values `(Int, Int, Ref, Ref)` entered a four-argument
     /// `(Int, Ref, Ref, Ref)` LABEL, and compiled code dereferenced the second
     /// `Int` as a pointer.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -476,8 +476,8 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
 /// Build a `CanRaise` [`majit_ir::effectinfo::EffectInfo`] whose field write-set names `write_field`
 /// of struct `type_id`, sharing the exact keyed `Arc<SimpleFieldDescr>` that a
 /// `getfield_gc_i` on the same `(type_id, write_field)` resolves to.  A
-/// residual helper that mutates a struct field through opaque host code — e.g.
-/// aheui's `jit_storage_*` changing selected `Stack` fields — declares them so
+/// residual helper that mutates a struct field through opaque host code —
+/// changing a field of the currently selected struct, say — declares them so
 /// `OptHeap::force_from_effectinfo` invalidates cached getfields after the
 /// call.  Without it the residual call carries an empty write-set and the
 /// optimizer can CSE-fold a mutable field load across the call.  This is the
@@ -4348,8 +4348,8 @@ where
             }
             // ── BC_GETARRAYITEM_GC_R ──
             //
-            // Ref-result element read for a raw-pointer array (aheui
-            // `pools[selected]` → `*mut Stack`).  Mirrors BC_GETARRAYITEM_GC_I
+            // Ref-result element read for a raw-pointer array (a
+            // `pools[selected]`-shaped read).  Mirrors BC_GETARRAYITEM_GC_I
             // but loads an 8-byte GC pointer and writes the ref bank.  Unlike
             // the int arm there is NO all-constant fold: the array base is a
             // live state pointer and the result must stay a `GetarrayitemGcR`
@@ -5267,7 +5267,7 @@ where
                 // trace time (verify_green_args, asserted below).
                 let mut mp_green_pc: Option<i64> = None;
                 // MAJIT_PCSEQ diagnostic: all int-green constants at this merge
-                // point (pc plus any scalar greens like aheui's stackok/is_queue).
+                // point (pc plus any scalar greens the consumer declares).
                 let mut mp_green_ints: Vec<i64> = Vec::new();
                 // pyjitpl.py:3912 same_greenkey compares EVERY green, not just
                 // the int slot.  Capture the ref (slot 1) and float (slot 2)
@@ -5804,8 +5804,8 @@ where
                     };
                     let pc_matches = mp_green_pc.is_none_or(|pc| pc == close_target_pc as i64);
                     // pyjitpl.py:3021/3912 same_greenkey: beyond the pc, close
-                    // only when EVERY green (aheui's stackok / is_queue, the
-                    // `program` ref, …) equals the trace-start header's.  Compare
+                    // only when EVERY green — the scalars and the ref the
+                    // consumer declares — equals the trace-start header's.  Compare
                     // element-wise against the header greens captured on the first
                     // visit (`header_greens`) — the SAME merge-point green
                     // vocabulary — which is `Box.same_constant` per Const type

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -748,8 +748,14 @@ pub trait JitCodeSym {
     ///
     /// The inline-frame snapshot trim must use THIS end: it blanks the range
     /// unconditionally, and blanking a working register would drop live data.
+    ///
+    /// The default is the EMPTY range, not `int_identity_slots_end()`. A
+    /// symbol reserves identity slots in its sub-JitCodes only by opting in
+    /// (`split_dispatch`, which is what raises `split_identity_floor`); a
+    /// symbol that has not opted in has ordinary working registers there, and
+    /// an over-wide default would silently blank them out of the snapshot.
     fn int_identity_reserved_end(&self) -> usize {
-        self.int_identity_slots_end()
+        self.int_identity_slots_base()
     }
 
     /// First int-bank register used as a canonical identity slot

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -492,12 +492,27 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
 /// getfield — pointer identity, which `compute_bitstrings` keys on.  Must run
 /// before `finish_setup_descrs` (jitcode assembly does), matching the
 /// non-trivial-raw-set construction-timing `call_descr` asserts.
+///
+/// `arrays` is the element-write half: `(item_size, is_item_signed)` per array
+/// the residual mutates through its base pointer.  It cannot use the field
+/// half's pointer-identity trick — a read's array descr comes from
+/// `MetaInterpStaticData::dispatch_array_descr_cache` at trace time while this
+/// one is minted during jitcode assembly, so the two are never the same `Arc`.
+/// The array descrs built here therefore only have to carry the right SHAPE;
+/// `EffectInfo::writes_array_descr_by_shape` is what reads them back, and the
+/// remaining fields are pinned to the `Assembler::add_gc_int_array_descr` shape
+/// the reads intern (`base_size = 0`, no length header, `Type::Int`).
+///
+/// An empty `arrays` leaves the affirmative "writes no arrays" that
+/// `EffectInfo::const_new` already installs, so a fields-only caller is
+/// unaffected by the array half existing.
 #[expect(
     clippy::type_complexity,
     reason = "This is the literal nested tuple/list/dict/callable shape at an RPython parity boundary; a wrapper would change structural ownership, while a one-use alias would conceal the audited upstream shape"
 )]
-pub fn struct_fields_write_effect_info(
+pub fn residual_write_effect_info(
     layouts: &[(usize, u64, bool, &[(usize, bool, &str, usize, bool)])],
+    arrays: &[(usize, bool)],
     can_raise: bool,
 ) -> majit_ir::EffectInfo {
     // Mirror `JitCodeBuilder::field_specs_from_layout`: sort by offset so
@@ -563,11 +578,35 @@ pub fn struct_fields_write_effect_info(
                 .cloned()
                 .unwrap_or_else(|| {
                     panic!(
-                        "struct_fields_write_effect_info: field `{write_field}` not registered for type {type_id}"
+                        "residual_write_effect_info: field `{write_field}` not registered for type {type_id}"
                     )
                 }) as majit_ir::DescrRef
         }));
     }
+    let ads: Vec<majit_ir::DescrRef> = arrays
+        .iter()
+        .map(|&(item_size, is_item_signed)| {
+            majit_ir::descr::make_array_descr_from_lltype_shape(
+                /* type_id */ 0,
+                // A raw slice data pointer: the base points straight at
+                // `items[0]`, so there is no header to skip and no length word
+                // to read.
+                /* base_size */
+                0,
+                item_size,
+                /* len_offset */ None,
+                majit_ir::value::Type::Int,
+                /* is_array_of_pointers */ false,
+                /* is_array_of_structs */ false,
+                is_item_signed,
+                /* is_gc_managed */ true,
+                /* lendescr */ None,
+                /* is_pure */ false,
+                /* ei_index */ u32::MAX,
+                /* interior_field_descrs */ Vec::new(),
+            ) as majit_ir::DescrRef
+        })
+        .collect();
     let extra_effect = if can_raise {
         majit_ir::ExtraEffect::CanRaise
     } else {
@@ -575,6 +614,7 @@ pub fn struct_fields_write_effect_info(
     };
     let mut ei = majit_ir::EffectInfo::const_new(extra_effect, majit_ir::OopSpecIndex::None);
     ei._write_descrs_fields = Some(fds);
+    ei._write_descrs_arrays = Some(ads);
     ei
 }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -599,7 +599,14 @@ pub fn residual_write_effect_info(
                 /* is_array_of_pointers */ false,
                 /* is_array_of_structs */ false,
                 is_item_signed,
-                /* is_gc_managed */ true,
+                // The only arrays reachable here are the header-less buffers
+                // an `array_fields` declaration names, which the reads intern
+                // through `Assembler::add_raw_int_array_descr_signed`.  The shape
+                // predicate ignores this flag, but a descr that disagreed with
+                // the read it is meant to match would be a trap for the next
+                // reader of either side.
+                /* is_gc_managed */
+                false,
                 /* lendescr */ None,
                 /* is_pure */ false,
                 /* ei_index */ u32::MAX,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -315,8 +315,8 @@ pub struct TraceCtx {
     /// header's concrete green constants, grouped by IR register slot
     /// (`(ints, refs, floats)`).  Captured on the first merge-point visit of a
     /// primary trace (the header), then compared element-wise against every
-    /// later visit's greens to decline closing when a scalar green (aheui's
-    /// `stackok` / `is_queue`) differs from the header.  `None` until captured;
+    /// later visit's greens to decline closing when a scalar green differs
+    /// from the header.  `None` until captured;
     /// bridges never populate it (they close through the compiled-loop
     /// registry).  This is the merge-point green vocabulary — distinct from
     /// `green_key_values`, the back-edge/can_enter_jit key, which carries a

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -450,16 +450,38 @@ pub struct TraceCtx {
     /// merge point asserts the flag equals its own `jdindex`. Consumed
     /// (`take`) by the first merge point, which then stamps that `jdindex`.
     pub bridge_resume_at_position: bool,
-    /// pyjitpl.py:1570/1577 `saved_pc = self.pc` / `self.pc = saved_pc`.
+    /// pyjitpl.py:1571/1574 `saved_pc = self.pc` / `self.pc = saved_pc`, the
+    /// "do not re-consult the merge point" half. [`Self::walk_resume_pc`] is
+    /// the position half.
     ///
     /// Upstream consults a merge point once per visit and then resumes the
     /// frame just after it, so the loop body runs before the next consult.
     /// Pyre fuses the merge point onto the guest instruction hosting it, so a
-    /// walk re-entered at the same guest pc — the `current_merge_points.append`
-    /// path, which keeps tracing instead of ending the trace — would re-consult
-    /// it with nothing recorded in between. Set on that re-entry and consumed
-    /// by the next `BC_JIT_MERGE_POINT`, which then falls straight through.
+    /// walk re-entered at the merge point's own guest pc — the
+    /// `current_merge_points.append` path, which keeps tracing instead of
+    /// ending the trace — would re-consult it with nothing recorded in
+    /// between. Set on that re-entry and consumed by the next
+    /// `BC_JIT_MERGE_POINT`, which then falls straight through.
     pub merge_point_resumed: bool,
+    /// The guest pc a re-entered walk must be seeded at — the position half of
+    /// `self.pc = saved_pc`.
+    ///
+    /// Upstream consults exactly one merge point per `opimpl_jit_merge_point`
+    /// call, so `saved_pc` is a function of that visit's own `orgpc` and the
+    /// position that entered the call cannot differ from the position that
+    /// declined. Pyre runs a whole walk segment — many merge-point visits —
+    /// per `JitDriver::merge_point` call, and a walk re-entered from inside
+    /// that call is re-seeded from the closure-captured `__pc`, which is where
+    /// the walk STARTED and which the native loop has not advanced. Left
+    /// unset that rewinds the position while the symbolic state stays at the
+    /// merge point the walk reached, and the instructions between the two are
+    /// re-executed against state they do not belong to.
+    ///
+    /// Set to the declining merge point's own guest pc; consumed (`take`) by
+    /// the `jit_merge_point!` expansion before it hands the pc to the walk.
+    /// `None` for a re-entry that publishes no resume pc, which keeps the
+    /// closure-captured `__pc`.
+    pub walk_resume_pc: Option<usize>,
     /// pyjitpl.py: `metainterp.staticdata.callinfocollection`. Needed by
     /// `ResumeDataBoxReader.concat_strings` / `slice_string` / `concat_unicodes`
     /// / `slice_unicode` (resume.py:1143-1188) which look up the
@@ -1619,6 +1641,7 @@ impl TraceCtx {
             seen_loop_header_jit_pc: None,
             bridge_resume_at_position: false,
             merge_point_resumed: false,
+            walk_resume_pc: None,
             callinfocollection: None,
             call_pure_results: indexmap::IndexMap::new(),
             trace_limit: DEFAULT_TRACE_LIMIT,
@@ -1706,6 +1729,7 @@ impl TraceCtx {
             seen_loop_header_jit_pc: None,
             bridge_resume_at_position: false,
             merge_point_resumed: false,
+            walk_resume_pc: None,
             callinfocollection: None,
             call_pure_results: indexmap::IndexMap::new(),
             trace_limit: DEFAULT_TRACE_LIMIT,

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1915,7 +1915,12 @@ impl WarmEnterState {
     /// Value is a colon-separated string like "intbounds:rewrite:virtualize:string:pure:earlyforce:heap:unroll".
     /// "all" enables all passes.
     pub fn set_param_enable_opts(&mut self, value: &str) {
-        self.enable_opts = if value == "all" || value.is_empty() {
+        // warmstate.py:284 substitutes the full list for `'all'` (and for
+        // `None`, which this `&str` surface cannot express) and for nothing
+        // else.  `''` therefore splits into no names and disables every pass;
+        // treating it as `'all'` would silently keep unrolling on for a caller
+        // that asked for the empty set.
+        self.enable_opts = if value == "all" {
             default_enable_opts()
         } else {
             value
@@ -2307,6 +2312,31 @@ impl WarmEnterState {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `warmstate.py:284` substitutes the full pass list for `'all'` alone.
+    /// The empty string splits into no names, so it selects nothing — the one
+    /// spelling a caller uses to turn every optimization off. Reading it as
+    /// `'all'` inverts that request completely and silently, since the driver
+    /// then keeps unrolling and every other pass.
+    #[test]
+    fn an_empty_enable_opts_selects_no_passes() {
+        let mut ws = WarmEnterState::new(1);
+        let all = default_enable_opts();
+        assert_eq!(ws.get_enable_opts(), all.as_slice(), "default is the full set");
+
+        ws.set_param_enable_opts("");
+        assert!(
+            ws.get_enable_opts().is_empty(),
+            "`\"\"` names no pass, so no pass is enabled; got {:?}",
+            ws.get_enable_opts()
+        );
+
+        ws.set_param_enable_opts("all");
+        assert_eq!(ws.get_enable_opts(), all.as_slice(), "`all` restores them");
+
+        ws.set_param_enable_opts("intbounds:heap");
+        assert_eq!(ws.get_enable_opts(), ["intbounds", "heap"]);
+    }
 
     #[test]
     fn test_not_hot_initially() {

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -2322,7 +2322,11 @@ mod tests {
     fn an_empty_enable_opts_selects_no_passes() {
         let mut ws = WarmEnterState::new(1);
         let all = default_enable_opts();
-        assert_eq!(ws.get_enable_opts(), all.as_slice(), "default is the full set");
+        assert_eq!(
+            ws.get_enable_opts(),
+            all.as_slice(),
+            "default is the full set"
+        );
 
         ws.set_param_enable_opts("");
         assert!(

--- a/majit/majit-metainterp/tests/array_write_set_invalidation.rs
+++ b/majit/majit-metainterp/tests/array_write_set_invalidation.rs
@@ -99,7 +99,7 @@ fn array_write_set_is_visible_to_force_from_effectinfo() {
     // Exactly what `OptHeap::force_from_effectinfo`'s array loop evaluates.
     let visible_to_optimizer = ei.check_write_descr_array(descr.get_ei_index())
         || (!majit_ir::effectinfo::compute_bitstrings_has_run()
-            && ei.writes_array_descr_by_identity(&descr));
+            && ei.writes_array_descr_by_shape(&descr));
 
     assert_eq!(
         named_by_identity, visible_to_optimizer,
@@ -109,6 +109,61 @@ fn array_write_set_is_visible_to_force_from_effectinfo() {
          run; the array loop has no such fallback, so the declared write is \
          silently dropped and the trace keeps serving a stale \
          `getarrayitem_gc_i` from before the call"
+    );
+}
+
+/// The shape the opcode-fetch path interns: `program: &[u8]`, one-byte
+/// unsigned items. Signedness matters — a signed byte descr makes the backend
+/// emit `movsx` and corrupt dispatch — so this is a genuinely distinct array.
+fn mint_program_byte_array_descr() -> DescrRef {
+    make_array_descr_from_lltype_shape(
+        0,
+        0,
+        1,
+        None,
+        Type::Int,
+        false,
+        false,
+        /* is_item_signed */ false,
+        true,
+        None,
+        false,
+        u32::MAX,
+        Vec::new(),
+    )
+}
+
+/// The write set is built during jitcode assembly and the cached read descr is
+/// minted at trace time from a different cache, so the two are NEVER the same
+/// `Arc`. Matching has to survive that, which is why the array predicate keys
+/// on shape rather than pointer identity.
+#[test]
+fn a_distinct_arc_of_the_same_shape_still_matches() {
+    let cached = mint_element_array_descr();
+    let declared = mint_element_array_descr();
+    assert!(
+        !std::sync::Arc::ptr_eq(&cached, &declared),
+        "test setup: these must be distinct Arcs, or this proves nothing"
+    );
+
+    let ei = ei_writing_array(&declared);
+    assert!(
+        ei.writes_array_descr_by_shape(&cached),
+        "a residual's declared array write must reach the cached read even \
+         though the two descrs were minted separately"
+    );
+}
+
+/// …and it must not match everything, or the predicate is vacuous and the test
+/// above passes for the wrong reason. A write to the `Val` element array must
+/// not invalidate the opcode-fetch byte array.
+#[test]
+fn a_different_element_shape_does_not_match() {
+    let ei = ei_writing_array(&mint_element_array_descr());
+    assert!(
+        !ei.writes_array_descr_by_shape(&mint_program_byte_array_descr()),
+        "declaring a write to the 8-byte signed element array must not \
+         invalidate the 1-byte unsigned opcode array"
     );
 }
 

--- a/majit/majit-metainterp/tests/array_write_set_invalidation.rs
+++ b/majit/majit-metainterp/tests/array_write_set_invalidation.rs
@@ -1,0 +1,129 @@
+//! Array-element write-sets must be visible on the macro / `JitDriver` path.
+//!
+//! `residual_writes` restores the heapcache invalidation an inline
+//! `setfield_gc` would have performed, for residuals that mutate a host struct
+//! through opaque code.  These tests pin the array-element half of that
+//! contract, which the node-chain storage layout never exercised: an element
+//! used to live at `Node.value`, reached through a base that was a different
+//! node ref on every iteration, so invalidating the `head` field handed the
+//! next load a fresh base and a guaranteed cache miss.  With a buffer the base
+//! is the SAME pointer across the residual, so a missing array invalidation is
+//! a stale read on the common path rather than a latent one.
+//!
+//! `OptHeap::force_from_effectinfo` resolves a cached container's bitstring
+//! slot through `descr.get_ei_index()`.  On the `#[jit_interp]` path
+//! `compute_bitstrings` never runs, so that slot is the unset `u32::MAX`
+//! sentinel and every bitstring lookup misses.  The FIELD loop already covers
+//! this with a raw-set identity fallback gated on `!compute_bitstrings_has_run()`
+//! (`optimizeopt/heap.rs`, `writes_field_descr_by_identity`).  The ARRAY loop
+//! has no counterpart, which is what these tests hold it to.
+
+use majit_ir::Type;
+use majit_ir::descr::make_array_descr_from_lltype_shape;
+use majit_ir::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
+
+/// The shape `Assembler::add_gc_int_array_descr(8, true)` interns for an
+/// `array_fields` element access: a raw slice data pointer (`base_size = 0`,
+/// no length header) over signed 8-byte items.
+fn mint_element_array_descr() -> DescrRef {
+    make_array_descr_from_lltype_shape(
+        /* type_id */ 0,
+        /* base_size */ 0,
+        /* item_size */ 8,
+        /* len_offset */ None,
+        Type::Int,
+        /* is_array_of_pointers */ false,
+        /* is_array_of_structs */ false,
+        /* is_item_signed */ true,
+        /* is_gc_managed */ true,
+        /* lendescr */ None,
+        /* is_pure */ false,
+        /* ei_index */ u32::MAX,
+        /* interior_field_descrs */ Vec::new(),
+    )
+}
+
+/// An `EffectInfo` shaped the way a `residual_writes`-declared residual's would
+/// be once the array vocabulary exists: it names `descr` in its raw array write
+/// set and nothing else.
+fn ei_writing_array(descr: &DescrRef) -> EffectInfo {
+    let mut ei = EffectInfo::const_new(ExtraEffect::CannotRaise, OopSpecIndex::None);
+    ei._write_descrs_arrays = Some(vec![descr.clone()]);
+    ei
+}
+
+/// Precondition for the test below, asserted separately so a failure there is
+/// not misread as the defect under test: on this path `compute_bitstrings` has
+/// not run, so no descr carries a real bitstring slot.
+#[test]
+fn macro_path_leaves_the_array_descr_at_the_unset_sentinel() {
+    let descr = mint_element_array_descr();
+    assert!(
+        !majit_ir::effectinfo::compute_bitstrings_has_run(),
+        "these tests characterise the `#[jit_interp]` path, on which \
+         `compute_bitstrings` never runs"
+    );
+    assert_eq!(
+        descr.get_ei_index(),
+        u32::MAX,
+        "an element array descr should carry the unset slot on this path"
+    );
+}
+
+/// The defect: an EI that names an array descr in its raw write set is
+/// invisible to `force_from_effectinfo`, because the array loop consults only
+/// the bitstring and the bitstring slot is the sentinel.
+///
+/// The two sides of the `assert_eq!` are deliberate — `named_by_identity` is
+/// what the EI actually declares, `visible_to_optimizer` is what the array loop
+/// in `force_from_effectinfo` can currently see. They must agree.
+///
+/// When the array-side identity fallback lands, `visible_to_optimizer` becomes
+/// a call to the real predicate (the array twin of
+/// `EffectInfo::writes_field_descr_by_identity`) rather than the bitstring
+/// check alone, and this test turns green without its subject changing.
+#[test]
+fn array_write_set_is_visible_to_force_from_effectinfo() {
+    let descr = mint_element_array_descr();
+    let ei = ei_writing_array(&descr);
+
+    let named_by_identity = ei
+        ._write_descrs_arrays
+        .as_deref()
+        .is_some_and(|set| set.iter().any(|d| std::sync::Arc::ptr_eq(d, &descr)));
+    assert!(
+        named_by_identity,
+        "test setup: the EI must name the descr in its raw array write set"
+    );
+
+    // Exactly what `OptHeap::force_from_effectinfo`'s array loop evaluates.
+    let visible_to_optimizer = ei.check_write_descr_array(descr.get_ei_index())
+        || (!majit_ir::effectinfo::compute_bitstrings_has_run()
+            && ei.writes_array_descr_by_identity(&descr));
+
+    assert_eq!(
+        named_by_identity, visible_to_optimizer,
+        "a residual that declares it writes this array must invalidate the \
+         cached element load. The field loop recovers exactly this case via \
+         `writes_field_descr_by_identity` when `compute_bitstrings` has not \
+         run; the array loop has no such fallback, so the declared write is \
+         silently dropped and the trace keeps serving a stale \
+         `getarrayitem_gc_i` from before the call"
+    );
+}
+
+/// The field half of the same contract, as the control: it must already pass.
+/// If this ever goes red the fallback mechanism itself moved, and the array
+/// test above is measuring something other than the missing array twin.
+#[test]
+fn field_write_set_identity_fallback_is_the_working_control() {
+    let descr = mint_element_array_descr();
+    let mut ei = EffectInfo::const_new(ExtraEffect::CannotRaise, OopSpecIndex::None);
+    ei._write_descrs_fields = Some(vec![descr.clone()]);
+
+    assert!(
+        ei.writes_field_descr_by_identity(&descr),
+        "the field raw-set identity probe is the precedent the array side must \
+         mirror; if this fails the precedent is gone"
+    );
+}

--- a/majit/majit-metainterp/tests/array_write_set_invalidation.rs
+++ b/majit/majit-metainterp/tests/array_write_set_invalidation.rs
@@ -167,6 +167,49 @@ fn a_different_element_shape_does_not_match() {
     );
 }
 
+/// The macro's emitted expression, evaluated directly: a `field[]` declaration
+/// lowers to one `(size_of::<Elem>(), true)` array spec, and the descr
+/// `residual_write_effect_info` mints from it must carry the shape the reads
+/// intern.  This is the join between the two halves — the macro picks the
+/// numbers, this function turns them into a descr, and the shape predicate
+/// reads it back.
+#[test]
+fn the_emitted_array_spec_mints_the_shape_the_reads_intern() {
+    let ei = majit_metainterp::residual_write_effect_info(
+        &[],
+        // What `residual_write_effect_info_tokens` emits for a `Val` element
+        // array: `(::core::mem::size_of::<Val>(), true)`.
+        &[(8, true)],
+        true,
+    );
+    assert!(
+        ei.writes_array_descr_by_shape(&mint_element_array_descr()),
+        "the descr minted from the emitted spec must match the one \
+         `add_gc_int_array_descr(8, true)` interns for the read"
+    );
+    assert!(
+        !ei.writes_array_descr_by_shape(&mint_program_byte_array_descr()),
+        "and must not reach an array of a different element shape"
+    );
+}
+
+/// A fields-only caller must be unaffected by the array half existing: an empty
+/// `arrays` has to leave the same affirmative "writes no arrays" that
+/// `EffectInfo::const_new` installs, not an unknown-writes `None`.
+#[test]
+fn an_empty_array_spec_list_still_declares_that_nothing_is_written() {
+    let ei = majit_metainterp::residual_write_effect_info(&[], &[], true);
+    assert_eq!(
+        ei._write_descrs_arrays.as_deref().map(<[_]>::len),
+        Some(0),
+        "an empty array spec list must stay an affirmative empty write set"
+    );
+    assert!(
+        !ei.writes_array_descr_by_shape(&mint_element_array_descr()),
+        "a residual that declares no array writes must not invalidate one"
+    );
+}
+
 /// The field half of the same contract, as the control: it must already pass.
 /// If this ever goes red the fallback mechanism itself moved, and the array
 /// test above is measuring something other than the missing array twin.

--- a/majit/majit-metainterp/tests/array_write_set_invalidation.rs
+++ b/majit/majit-metainterp/tests/array_write_set_invalidation.rs
@@ -22,25 +22,30 @@ use majit_ir::Type;
 use majit_ir::descr::make_array_descr_from_lltype_shape;
 use majit_ir::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
 
-/// The shape `Assembler::add_gc_int_array_descr(8, true)` interns for an
-/// `array_fields` element access: a raw slice data pointer (`base_size = 0`,
-/// no length header) over signed 8-byte items.
-fn mint_element_array_descr() -> DescrRef {
+/// The shape `Assembler::add_raw_int_array_descr(item_size, is_item_signed)`
+/// interns for an `array_fields` element access: a header-less buffer pointer
+/// (`base_size = 0`, no length word, not GC-managed) over `item_size` items.
+fn mint_element_array_descr_of(item_size: usize, is_item_signed: bool) -> DescrRef {
     make_array_descr_from_lltype_shape(
         /* type_id */ 0,
         /* base_size */ 0,
-        /* item_size */ 8,
+        item_size,
         /* len_offset */ None,
         Type::Int,
         /* is_array_of_pointers */ false,
         /* is_array_of_structs */ false,
-        /* is_item_signed */ true,
-        /* is_gc_managed */ true,
+        is_item_signed,
+        /* is_gc_managed */ false,
         /* lendescr */ None,
         /* is_pure */ false,
         /* ei_index */ u32::MAX,
         /* interior_field_descrs */ Vec::new(),
     )
+}
+
+/// The signed 8-byte element array the node-chain storage reads.
+fn mint_element_array_descr() -> DescrRef {
+    mint_element_array_descr_of(8, true)
 }
 
 /// An `EffectInfo` shaped the way a `residual_writes`-declared residual's would
@@ -190,6 +195,33 @@ fn the_emitted_array_spec_mints_the_shape_the_reads_intern() {
     assert!(
         !ei.writes_array_descr_by_shape(&mint_program_byte_array_descr()),
         "and must not reach an array of a different element shape"
+    );
+}
+
+/// Signedness is part of the shape key, so a `u8` element declaration has to
+/// mint an UNSIGNED write descr — the same value the read derives from
+/// `(<u8>::MIN as i128) < 0`. The write spec used to be a hard-coded `true`,
+/// which matched only because the read hard-coded `true` as well; deriving the
+/// read alone leaves the two halves disagreeing and the declaration inert.
+///
+/// The second assertion is what makes this test able to fail: it evaluates the
+/// old spelling on the same input and requires it to miss.
+#[test]
+fn an_unsigned_element_declaration_mints_an_unsigned_write_descr() {
+    let unsigned_read = mint_element_array_descr_of(1, false);
+
+    let derived = majit_metainterp::residual_write_effect_info(&[], &[(1, false)], true);
+    assert!(
+        derived.writes_array_descr_by_shape(&unsigned_read),
+        "a `u8` element write declaration must invalidate the `u8` element \
+         load the same declaration's reads intern"
+    );
+
+    let hard_coded_signed = majit_metainterp::residual_write_effect_info(&[], &[(1, true)], true);
+    assert!(
+        !hard_coded_signed.writes_array_descr_by_shape(&unsigned_read),
+        "control: a signed write spec must NOT reach the unsigned read, or \
+         this test could not have caught the mismatch it exists for"
     );
 }
 

--- a/majit/majit-metainterp/tests/jit_interp_array_element_signedness.rs
+++ b/majit/majit-metainterp/tests/jit_interp_array_element_signedness.rs
@@ -1,0 +1,113 @@
+//! `array_fields = { Struct::field => ElementType }` — the element descr's
+//! sign flag.
+//!
+//! `descr.py:240-254 get_type_flag(FIELDTYPE)` reads signedness off the
+//! declared element type, and a load honours it: a signed descr sign-extends
+//! the sub-word it read.  So an element declared `u8` whose byte is `0x80`
+//! must reach the trace as `128` — the value the concrete Rust read produces —
+//! not as `-128`.
+//!
+//! Nothing downstream can recover from getting this wrong.  The sign extension
+//! happens inside the traced load and again in the backend, so the wrong value
+//! simply *is* the value; there is no later point that could tell it from a
+//! genuine negative element.
+
+use majit_macros::jit_inline;
+use majit_metainterp::jitcode::{CanonicalBhDescr, RuntimeBhDescr};
+
+/// Unsigned elements.
+#[repr(C)]
+struct ByteStack {
+    data: *mut u8,
+    sp: usize,
+}
+
+/// Signed elements, so the unsigned assertion has a counterpart: without it a
+/// change that hard-coded *unsigned* would pass just as the hard-coded
+/// *signed* one did.
+#[repr(C)]
+struct WordStack {
+    data: *mut i64,
+    sp: usize,
+}
+
+#[jit_inline(
+    ref_params = { stack: ref(ByteStack) },
+    array_fields = { ByteStack::data => u8 },
+)]
+fn byte_elem_read(stack: usize) -> i64 {
+    let sp = stack.sp;
+    let value = stack.data[sp];
+    value as i64
+}
+
+#[jit_inline(
+    ref_params = { stack: ref(WordStack) },
+    array_fields = { WordStack::data => i64 },
+)]
+fn word_elem_read(stack: usize) -> i64 {
+    let sp = stack.sp;
+    let value = stack.data[sp];
+    value
+}
+
+/// Every array element descr the jitcode interns, as
+/// `(itemsize, is_item_signed)`.
+fn array_element_descrs(jc: &majit_metainterp::JitCode) -> Vec<(usize, bool)> {
+    let mut out = Vec::new();
+    let mut index = 0usize;
+    while let Some(entry) = jc.descr_at(index) {
+        if let RuntimeBhDescr::Descr(descr) = entry
+            && let CanonicalBhDescr::Array {
+                itemsize,
+                is_item_signed,
+                ..
+            } = &**descr
+        {
+            out.push((*itemsize, *is_item_signed));
+        }
+        index += 1;
+    }
+    out
+}
+
+#[test]
+fn an_unsigned_element_type_interns_an_unsigned_element_descr() {
+    let mut asm = majit_metainterp::Assembler::new();
+    let jitcode = __majit_inline_jitcode_byte_elem_read_with_asm(&mut asm);
+    let descrs = array_element_descrs(&jitcode);
+    let byte_signs: Vec<bool> = descrs
+        .iter()
+        .filter(|(size, _)| *size == 1)
+        .map(|(_, signed)| *signed)
+        .collect();
+    assert!(
+        !byte_signs.is_empty(),
+        "the fixture must intern a 1-byte element descr; interned {descrs:?}"
+    );
+    assert!(
+        byte_signs.iter().all(|signed| !signed),
+        "`u8` elements must intern an UNSIGNED descr, or a 0x80 byte loads as \
+         -128 where the interpreter reads 128; interned {descrs:?}"
+    );
+}
+
+#[test]
+fn a_signed_element_type_still_interns_a_signed_element_descr() {
+    let mut asm = majit_metainterp::Assembler::new();
+    let jitcode = __majit_inline_jitcode_word_elem_read_with_asm(&mut asm);
+    let descrs = array_element_descrs(&jitcode);
+    let word_signs: Vec<bool> = descrs
+        .iter()
+        .filter(|(size, _)| *size == std::mem::size_of::<i64>())
+        .map(|(_, signed)| *signed)
+        .collect();
+    assert!(
+        !word_signs.is_empty(),
+        "the fixture must intern an 8-byte element descr; interned {descrs:?}"
+    );
+    assert!(
+        word_signs.iter().all(|signed| *signed),
+        "`i64` elements must stay SIGNED; interned {descrs:?}"
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_array_element_signedness.rs
+++ b/majit/majit-metainterp/tests/jit_interp_array_element_signedness.rs
@@ -52,8 +52,8 @@ fn word_elem_read(stack: usize) -> i64 {
 }
 
 /// Every array element descr the jitcode interns, as
-/// `(itemsize, is_item_signed)`.
-fn array_element_descrs(jc: &majit_metainterp::JitCode) -> Vec<(usize, bool)> {
+/// `(itemsize, is_item_signed, is_gc_managed)`.
+fn array_element_descrs(jc: &majit_metainterp::JitCode) -> Vec<(usize, bool, bool)> {
     let mut out = Vec::new();
     let mut index = 0usize;
     while let Some(entry) = jc.descr_at(index) {
@@ -61,10 +61,11 @@ fn array_element_descrs(jc: &majit_metainterp::JitCode) -> Vec<(usize, bool)> {
             && let CanonicalBhDescr::Array {
                 itemsize,
                 is_item_signed,
+                is_gc_managed,
                 ..
             } = &**descr
         {
-            out.push((*itemsize, *is_item_signed));
+            out.push((*itemsize, *is_item_signed, *is_gc_managed));
         }
         index += 1;
     }
@@ -78,8 +79,8 @@ fn an_unsigned_element_type_interns_an_unsigned_element_descr() {
     let descrs = array_element_descrs(&jitcode);
     let byte_signs: Vec<bool> = descrs
         .iter()
-        .filter(|(size, _)| *size == 1)
-        .map(|(_, signed)| *signed)
+        .filter(|(size, _, _)| *size == 1)
+        .map(|(_, signed, _)| *signed)
         .collect();
     assert!(
         !byte_signs.is_empty(),
@@ -99,8 +100,8 @@ fn a_signed_element_type_still_interns_a_signed_element_descr() {
     let descrs = array_element_descrs(&jitcode);
     let word_signs: Vec<bool> = descrs
         .iter()
-        .filter(|(size, _)| *size == std::mem::size_of::<i64>())
-        .map(|(_, signed)| *signed)
+        .filter(|(size, _, _)| *size == std::mem::size_of::<i64>())
+        .map(|(_, signed, _)| *signed)
         .collect();
     assert!(
         !word_signs.is_empty(),
@@ -109,5 +110,32 @@ fn a_signed_element_type_still_interns_a_signed_element_descr() {
     assert!(
         word_signs.iter().all(|signed| *signed),
         "`i64` elements must stay SIGNED; interned {descrs:?}"
+    );
+}
+
+/// An `array_fields` buffer is a bare `*mut T` with no object header, so its
+/// element descr must NOT be GC-managed.
+///
+/// `ArrayPtrInfo::make_guards` (`info.py:632-639`) emits `GUARD_GC_TYPE` for a
+/// GC-managed array descr, and that guard reads a type-id word at
+/// `ptr - GcHeader::SIZE`. Ahead of a header-less buffer that word belongs to
+/// whatever precedes the allocation, so once the base is red and the loop
+/// unrolls, short-preamble re-entry either fails the guard against unrelated
+/// memory or reads an unmapped page. Nothing downstream can tell that apart
+/// from a genuine type mismatch.
+#[test]
+fn an_array_field_element_descr_is_not_gc_managed() {
+    let mut asm = majit_metainterp::Assembler::new();
+    let jitcode = __majit_inline_jitcode_byte_elem_read_with_asm(&mut asm);
+    let descrs = array_element_descrs(&jitcode);
+    let element_descrs: Vec<_> = descrs.iter().filter(|(size, _, _)| *size == 1).collect();
+    assert!(
+        !element_descrs.is_empty(),
+        "the fixture must intern a 1-byte element descr; interned {descrs:?}"
+    );
+    assert!(
+        element_descrs.iter().all(|(_, _, gc_managed)| !gc_managed),
+        "an `array_fields` element descr must be raw, or the short preamble \
+         guards a type header the buffer does not have; interned {descrs:?}"
     );
 }

--- a/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
+++ b/majit/majit-metainterp/tests/jit_interp_dispatch_ir_shape.rs
@@ -2090,14 +2090,12 @@ mod oparg_with_body_local_state_le_green {
     }
 }
 
-/// A.3.6.3: pin the method-call body-local lowering shape against
-/// aheui-jit's `let mut stackok = program.get_req_size(pc) as i32 <=
-/// state.stacksize;` chain. The fixture exercises:
+/// A.3.6.3: pin the method-call body-local lowering shape for a green
+/// derived as `let g = program.get_req_size(pc) as i32 <= state.f1 as i32;`.
+/// The fixture exercises:
 ///   - body-local `let g = program.get_req_size(pc) as i32 <= state.f1
 ///     as i32;` placed before `jit_merge_point!()`,
-///   - `MockProgram::get_req_size => elidable_int` policy registration
-///     (the same canonical path used by aheui-jit at `aheui-jit/src/lib.
-///     rs:302`),
+///   - `MockProgram::get_req_size => elidable_int` policy registration,
 ///   - `greens = [g]` so the merge-point's `greens_i` payload + the
 ///     A.3.5 promote-greens pair both reference `g`'s int register.
 ///
@@ -2105,9 +2103,8 @@ mod oparg_with_body_local_state_le_green {
 /// emission (`BC_RESIDUAL_CALL_IR_I` because receiver=Ref + pc=Int) to
 /// land BEFORE `BC_JIT_MERGE_POINT(_C)` and threads its result reg
 /// forward through `BC_INT_LE` and finally A.3.5's `BC_INT_GUARD_VALUE`
-/// + greens_i payload byte. Locks aheui-jit's `stackok` lowering chain
-///   so future refactors of `lower_method_call_value` (A.3.6.2) cannot
-///   silently regress it.
+/// + greens_i payload byte, so future refactors of
+///   `lower_method_call_value` (A.3.6.2) cannot silently regress the chain.
 ///
 /// RPython parity: `jtransform.py:456 handle_residual_call`
 /// (graph-identity-keyed; pyre keys on canonical path so
@@ -2165,10 +2162,10 @@ mod oparg_with_body_local_method_call_green {
         state = MethodCallGreenState,
         env = MockProgram,
         state_fields = { f1: int, a: int },
-        // `program.get_req_size(pc) as i32 <= state.f1 as i32` is the
-        // body-local computation aheui-jit's main loop uses to derive
-        // `stackok`; lower_method_call_value (A.3.6.2) routes the
-        // method-call RHS through the call-policy table.
+        // `program.get_req_size(pc) as i32 <= state.f1 as i32` is a
+        // body-local computation a dispatch loop derives a green from;
+        // lower_method_call_value (A.3.6.2) routes the method-call RHS
+        // through the call-policy table.
         calls = {
             MockProgram::get_req_size => elidable_int,
         },
@@ -2186,9 +2183,8 @@ mod oparg_with_body_local_method_call_green {
                 .install_canonical_liveness(&mut driver);
         }
         while pc < program.len() {
-            // Mirrors `aheui-jit/src/lib.rs:456`:
-            //   let mut stackok = program.get_req_size(pc) as i32
-            //                       <= state.stacksize;
+            // A body-local green computed from a method call on the env
+            // and a state field.
             let g = program.get_req_size(pc) as i32 <= state.f1 as i32;
             jit_merge_point!();
             let opcode = program[pc];
@@ -2399,16 +2395,14 @@ mod oparg_with_body_local_method_call_green {
     }
 }
 
-/// A.3.7: pin the full rpaheui 4-green parity merge-point shape.
-/// rpaheui aheui.py:29 declares `greens=['pc', 'stackok', 'is_queue',
-/// 'program']`; aheui-jit/src/lib.rs:354 mirrors it as
-/// `greens=[pc, stackok, is_queue, program]` after A.3.6.1's body-local
-/// walker landed and accepted the `let stackok = ...; let is_queue = ...;`
-/// pre-merge-point chain.
+/// A.3.7: pin the merge-point shape for a 4-green declaration whose two
+/// middle greens are body-locals — `greens = [pc, a, b, program]`, with
+/// `let a = ...; let b = ...;` ahead of the merge point, which A.3.6.1's
+/// body-local walker accepts.
 ///
 /// Layout pinned here:
-///   - greens_i_len = 3 (pc=Int/i0, stackok=Int from BinOp::Le,
-///     is_queue=Int from BinOp::Eq).
+///   - greens_i_len = 3 (pc=Int/i0, one Int from BinOp::Le, one Int from
+///     BinOp::Eq).
 ///   - greens_r_len = 1 (program=Ref/r0).
 ///   - greens_f_len = 0.
 ///   - reds_i_len = reds_r_len = reds_f_len = 0 (both portal-input
@@ -2416,7 +2410,7 @@ mod oparg_with_body_local_method_call_green {
 ///
 /// Locks the byte order so a future macro change that re-buckets greens
 /// or shifts the merge-point payload trips this fixture rather than
-/// silently regressing rpaheui parity.
+/// silently regressing the shape.
 mod oparg_with_full_4_green_parity {
 
     use majit_metainterp::{Assembler, JitDriver};
@@ -2454,10 +2448,8 @@ mod oparg_with_full_4_green_parity {
                 .install_canonical_liveness(&mut driver);
         }
         while pc < program.len() {
-            // rpaheui aheui.py:252 stackok recompute.
+            // Two body-local greens recomputed before the merge point.
             let stackok = state.f1 <= state.f2;
-            // rpaheui aheui.py:284 is_queue (recomputed pre-merge-point
-            // here from `state.sel == 21` per A.3.7's pyre adaptation).
             let is_queue = state.sel == 21i64;
             jit_merge_point!();
             let opcode = program[pc];

--- a/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
@@ -683,3 +683,117 @@ fn jit_inline_mixed_identity_uses_dense_kind_banks_at_runtime() {
 
     assert_eq!(bh.registers_i[1], 21);
 }
+
+// ── Array-backed storage: `array_fields` element read/write ─────────
+//
+// The non-virtualizable array vocabulary. `data` holds the buffer BASE
+// POINTER, so `stack.data[i]` is a `getfield_gc_r` for the base followed by
+// `get/setarrayitem_gc_i` — the elements do not ride a guard's `vable_array`
+// resume section, so a guard's snapshot stays O(1) in the buffer length.
+
+#[repr(C)]
+struct InlineArrayStack {
+    data: *mut i64,
+    sp: usize,
+}
+
+#[jit_inline(
+    ref_params = {
+        stack: ref(InlineArrayStack),
+    },
+    array_fields = {
+        InlineArrayStack::data => i64,
+    },
+)]
+fn inline_array_stack_push(stack: usize, value: i64) {
+    let sp = stack.sp;
+    stack.data[sp] = value;
+    stack.sp = sp + 1usize;
+}
+
+#[jit_inline(
+    ref_params = {
+        stack: ref(InlineArrayStack),
+    },
+    array_fields = {
+        InlineArrayStack::data => i64,
+    },
+)]
+fn inline_array_stack_pop(stack: usize) -> i64 {
+    let sp = stack.sp - 1usize;
+    let value = stack.data[sp];
+    stack.sp = sp;
+    value
+}
+
+/// Whether `key`'s opcode byte appears anywhere in the jitcode body.
+///
+/// Locating instruction boundaries would need a full argcode-driven walk, so
+/// this is containment only: an operand byte could alias the opcode. That is
+/// enough for what these tests claim — that the emitter selected the array
+/// opcode at all rather than falling back to a residual call — and each
+/// caller corroborates it with a register-bank assertion that only the
+/// getfield_gc_r + array-op pair produces.
+fn jitcode_contains_opcode(jitcode: &majit_metainterp::JitCode, key: &str) -> bool {
+    let opcode = *majit_metainterp::jitcode::wellknown_bh_insns()
+        .get(key)
+        .unwrap_or_else(|| panic!("missing wellknown opcode for {key}"));
+    jitcode.code.contains(&opcode)
+}
+
+#[test]
+fn jit_inline_array_field_write_emits_setarrayitem_gc_i() {
+    let mut asm = majit_metainterp::Assembler::new();
+    let jitcode = __majit_inline_jitcode_inline_array_stack_push_with_asm(&mut asm);
+    assert!(
+        jitcode_contains_opcode(&jitcode, "setarrayitem_gc_i/riid"),
+        "`stack.data[sp] = value` should lower to setarrayitem_gc_i, not a residual call"
+    );
+    // The buffer base is loaded through a getfield_gc_r, so the ref bank
+    // holds both the struct pointer and the buffer pointer.
+    assert!(
+        jitcode.c_num_regs_r >= 2,
+        "struct ref + loaded buffer base both need ref registers, got {}",
+        jitcode.c_num_regs_r
+    );
+}
+
+#[test]
+fn jit_inline_array_field_read_emits_getarrayitem_gc_i() {
+    let mut asm = majit_metainterp::Assembler::new();
+    let jitcode = __majit_inline_jitcode_inline_array_stack_pop_with_asm(&mut asm);
+    assert!(
+        jitcode_contains_opcode(&jitcode, "getarrayitem_gc_i/rid>i"),
+        "`stack.data[sp]` should lower to getarrayitem_gc_i, not a residual call"
+    );
+    assert!(
+        jitcode.c_num_regs_r >= 2,
+        "struct ref + loaded buffer base both need ref registers, got {}",
+        jitcode.c_num_regs_r
+    );
+}
+
+#[test]
+fn jit_inline_array_field_keeps_interpreter_behavior() {
+    // The concrete (non-JIT) path must compute the same thing the jitcode
+    // does: the macro rewrites `stack.data[i]` into a deref through the
+    // base pointer, since the helper receives the struct as raw `usize`.
+    let mut buffer = vec![0i64; 4];
+    let mut stack = InlineArrayStack {
+        data: buffer.as_mut_ptr(),
+        sp: 0,
+    };
+    let stack_ptr = &mut stack as *mut InlineArrayStack as usize;
+
+    inline_array_stack_push(stack_ptr, 10);
+    inline_array_stack_push(stack_ptr, 20);
+    inline_array_stack_push(stack_ptr, 30);
+    assert_eq!(stack.sp, 3);
+    assert_eq!(buffer[..3], [10, 20, 30]);
+
+    assert_eq!(inline_array_stack_pop(stack_ptr), 30);
+    assert_eq!(inline_array_stack_pop(stack_ptr), 20);
+    assert_eq!(stack.sp, 1);
+    assert_eq!(inline_array_stack_pop(stack_ptr), 10);
+    assert_eq!(stack.sp, 0);
+}

--- a/majit/majit-metainterp/tests/jit_interp_residual_array_write.rs
+++ b/majit/majit-metainterp/tests/jit_interp_residual_array_write.rs
@@ -1,0 +1,225 @@
+//! `residual_writes = { <ref>.<field>[] => [...] }` — the element half.
+//!
+//! A plain `residual_writes` entry names the FIELD, which invalidates a cached
+//! `getfield_gc_r` of the array base.  That is the wrong invalidation for a
+//! buffer mutated in place: the base does not change, so the next element load
+//! is served from `OptHeap`'s separate array cache and reads a value from
+//! before the call.  The `[]` suffix declares the ELEMENTS instead.
+//!
+//! This fixture holds the declaration to the descr it must produce.  The shape
+//! it has to carry is pinned by `array_write_set_invalidation.rs`; what is
+//! tested here is that the declaration reaches the emitted call at all.
+
+use majit_metainterp::jitcode::CanonicalBhDescr;
+use majit_metainterp::{Assembler, JitDriver};
+
+/// The array-backed pool the residual mutates.  `data` holds the buffer BASE
+/// POINTER — `size` is the sibling length field, since a headerless buffer has
+/// no length word to read.
+#[repr(C)]
+struct ArrStack {
+    data: *mut i64,
+    size: usize,
+}
+
+/// An opaque in-place mutator of `stack.data`'s elements.  The body is
+/// irrelevant to what this fixture asserts — the JIT never looks inside a
+/// residual — but it must exist for the concrete interpreter path.
+extern "C" fn jit_scramble(stack: usize) {
+    let stack = stack as *mut ArrStack;
+    if stack.is_null() {
+        return;
+    }
+    // SAFETY: the fixture never runs the interpreter, so this is only reached
+    // through the null guard above.
+    unsafe {
+        let n = (*stack).size;
+        for i in 0..n {
+            *(*stack).data.add(i) = 0;
+        }
+    }
+}
+
+struct ArrTestState {
+    a: i64,
+    sel: usize,
+}
+
+const OP_NOP: u8 = 0;
+const OP_SCRAMBLE: u8 = 1;
+
+pub type Bytecode = [u8];
+
+#[majit_macros::jit_interp(
+    state = ArrTestState,
+    env = Bytecode,
+    state_fields = { a: int, sel: ref(ArrStack) },
+    greens = [],
+    array_fields = { ArrStack::data => i64 },
+    calls = { jit_scramble => residual_void },
+    residual_writes = {
+        sel.data[] => [jit_scramble],
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn arr_minimal(program: &Bytecode, threshold: u32) -> i64 {
+    let mut driver: JitDriver<ArrTestState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let state = ArrTestState { a: 0, sel: 0 };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_NOP => {}
+            OP_SCRAMBLE => jit_scramble(state.sel),
+            _ => break,
+        }
+    }
+    state.a
+}
+
+fn build_dispatch_jitcode(asm: &mut Assembler) -> majit_metainterp::JitCode {
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_arr_minimal(asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    __dispatch_jitcode_arr_minimal(asm, 0i64)
+        .expect("dispatch lower must succeed for the array-write fixture")
+}
+
+/// Every emitted call's `EffectInfo`, across the dispatch jitcode and each
+/// per-arm sub-jitcode — the residual lives in an arm, not the portal.
+fn all_call_effect_infos(dispatch_jc: &majit_metainterp::JitCode) -> Vec<majit_ir::EffectInfo> {
+    fn collect(jc: &majit_metainterp::JitCode, out: &mut Vec<majit_ir::EffectInfo>) {
+        for descr in &jc.exec.descrs {
+            if let Some(CanonicalBhDescr::Call { calldescr }) = descr.as_bh_descr() {
+                out.push(calldescr.extra_info.clone());
+            }
+            if let Some(sub) = descr.as_jitcode() {
+                collect(sub, out);
+            }
+        }
+    }
+    let mut out = Vec::new();
+    collect(dispatch_jc, &mut out);
+    out
+}
+
+/// The shape `Assembler::add_gc_int_array_descr(size_of::<i64>(), true)` interns
+/// for a `stack.data[i]` read — what the declared write has to reach.
+fn element_read_descr() -> majit_ir::DescrRef {
+    majit_ir::descr::make_array_descr_from_lltype_shape(
+        0,
+        /* base_size */ 0,
+        /* item_size */ std::mem::size_of::<i64>(),
+        None,
+        majit_ir::Type::Int,
+        false,
+        false,
+        /* is_item_signed */ true,
+        true,
+        None,
+        false,
+        u32::MAX,
+        Vec::new(),
+    )
+}
+
+#[test]
+fn the_bracket_suffix_reaches_the_emitted_calls_effect_info() {
+    let mut asm = Assembler::new();
+    let dispatch_jc = build_dispatch_jitcode(&mut asm);
+    let eis = all_call_effect_infos(&dispatch_jc);
+    assert!(
+        !eis.is_empty(),
+        "the fixture must emit at least one residual call, or this test \
+         cannot observe anything"
+    );
+    let read = element_read_descr();
+    assert!(
+        eis.iter().any(|ei| ei.writes_array_descr_by_shape(&read)),
+        "`sel.data[] => [jit_scramble]` must give the emitted call a write set \
+         reaching the element descr the read interns; without it the trace \
+         keeps serving a `getarrayitem_gc_i` from before the call"
+    );
+}
+
+/// The negative half: the flag has to be what selects the array write set, not
+/// something every residual gets.  A `residual_writes` declaration WITHOUT the
+/// `[]` suffix is a field write, and must leave the element cache alone.
+///
+/// This fixture is the same shape as the one above minus the brackets, so a
+/// change that made every residual write every array would fail here while the
+/// test above still passed.
+mod without_the_bracket_suffix {
+    use super::{ArrStack, Bytecode, JitDriver, OP_NOP, OP_SCRAMBLE, jit_scramble};
+    use majit_metainterp::Assembler;
+
+    struct FieldOnlyState {
+        a: i64,
+        sel: usize,
+    }
+
+    #[majit_macros::jit_interp(
+        state = FieldOnlyState,
+        env = Bytecode,
+        state_fields = { a: int, sel: ref(ArrStack) },
+        greens = [],
+        array_fields = { ArrStack::data => i64 },
+        calls = { jit_scramble => residual_void },
+        residual_writes = {
+            sel.data => [jit_scramble],
+        },
+    )]
+    #[allow(unused_assignments, unused_variables)]
+    fn field_only(program: &Bytecode, threshold: u32) -> i64 {
+        let mut driver: JitDriver<FieldOnlyState> = JitDriver::new(threshold);
+        let mut pc: usize = 0;
+        let state = FieldOnlyState { a: 0, sel: 0 };
+        {
+            use majit_metainterp::JitState as _;
+            state
+                .build_meta(0, program)
+                .install_canonical_liveness(&mut driver);
+        }
+        while pc < program.len() {
+            jit_merge_point!();
+            let opcode = program[pc];
+            pc += 1;
+            match opcode {
+                OP_NOP => {}
+                OP_SCRAMBLE => jit_scramble(state.sel),
+                _ => break,
+            }
+        }
+        state.a
+    }
+
+    #[test]
+    fn a_field_declaration_leaves_the_element_cache_alone() {
+        let mut asm = Assembler::new();
+        asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+        __prebuild_jitcode_liveness_field_only(&mut asm);
+        let _ = asm.ensure_canonical_liveness_offset();
+        let dispatch_jc = __dispatch_jitcode_field_only(&mut asm, 0i64)
+            .expect("dispatch lower must succeed for the field-only fixture");
+        let eis = super::all_call_effect_infos(&dispatch_jc);
+        assert!(
+            !eis.is_empty(),
+            "the fixture must emit at least one residual call"
+        );
+        let read = super::element_read_descr();
+        assert!(
+            eis.iter().all(|ei| !ei.writes_array_descr_by_shape(&read)),
+            "`sel.data` without the `[]` suffix declares a write to the base \
+             field, not to the elements; declaring it must not invalidate the \
+             element cache"
+        );
+    }
+}

--- a/majit/majit-metainterp/tests/jit_interp_residual_array_write.rs
+++ b/majit/majit-metainterp/tests/jit_interp_residual_array_write.rs
@@ -111,24 +111,29 @@ fn all_call_effect_infos(dispatch_jc: &majit_metainterp::JitCode) -> Vec<majit_i
     out
 }
 
-/// The shape `Assembler::add_gc_int_array_descr(size_of::<i64>(), true)` interns
-/// for a `stack.data[i]` read — what the declared write has to reach.
-fn element_read_descr() -> majit_ir::DescrRef {
+/// The shape `Assembler::add_raw_int_array_descr_signed(item_size, signed)`
+/// interns for a `stack.data[i]` read — what the declared write has to reach.
+fn element_read_descr_of(item_size: usize, is_item_signed: bool) -> majit_ir::DescrRef {
     majit_ir::descr::make_array_descr_from_lltype_shape(
         0,
         /* base_size */ 0,
-        /* item_size */ std::mem::size_of::<i64>(),
+        item_size,
         None,
         majit_ir::Type::Int,
         false,
         false,
-        /* is_item_signed */ true,
-        true,
+        is_item_signed,
+        /* is_gc_managed */ false,
         None,
         false,
         u32::MAX,
         Vec::new(),
     )
+}
+
+/// The `i64` element array both fixtures below declare.
+fn element_read_descr() -> majit_ir::DescrRef {
+    element_read_descr_of(std::mem::size_of::<i64>(), true)
 }
 
 #[test]
@@ -220,6 +225,111 @@ mod without_the_bracket_suffix {
             "`sel.data` without the `[]` suffix declares a write to the base \
              field, not to the elements; declaring it must not invalidate the \
              element cache"
+        );
+    }
+}
+
+/// Signedness is part of the shape key, so the declaration and the reads must
+/// derive it from the SAME element type.  The fixtures above are all `i64`,
+/// where a hard-coded "signed" write spec agrees with the read by accident;
+/// this one is `u8`, where it does not.
+mod unsigned_elements {
+    use super::{Bytecode, JitDriver, OP_NOP, OP_SCRAMBLE};
+    use majit_metainterp::Assembler;
+
+    #[repr(C)]
+    struct ByteStack {
+        data: *mut u8,
+        size: usize,
+    }
+
+    extern "C" fn jit_scramble_bytes(stack: usize) {
+        let stack = stack as *mut ByteStack;
+        if stack.is_null() {
+            return;
+        }
+        // SAFETY: the fixture never runs the interpreter, so this is only
+        // reached through the null guard above.
+        unsafe {
+            let n = (*stack).size;
+            for i in 0..n {
+                *(*stack).data.add(i) = 0;
+            }
+        }
+    }
+
+    struct ByteState {
+        a: i64,
+        sel: usize,
+    }
+
+    #[majit_macros::jit_interp(
+        state = ByteState,
+        env = Bytecode,
+        state_fields = { a: int, sel: ref(ByteStack) },
+        greens = [],
+        array_fields = { ByteStack::data => u8 },
+        calls = { jit_scramble_bytes => residual_void },
+        residual_writes = {
+            sel.data[] => [jit_scramble_bytes],
+        },
+    )]
+    #[allow(unused_assignments, unused_variables)]
+    fn byte_elements(program: &Bytecode, threshold: u32) -> i64 {
+        let mut driver: JitDriver<ByteState> = JitDriver::new(threshold);
+        let mut pc: usize = 0;
+        let state = ByteState { a: 0, sel: 0 };
+        {
+            use majit_metainterp::JitState as _;
+            state
+                .build_meta(0, program)
+                .install_canonical_liveness(&mut driver);
+        }
+        while pc < program.len() {
+            jit_merge_point!();
+            let opcode = program[pc];
+            pc += 1;
+            match opcode {
+                OP_NOP => {}
+                OP_SCRAMBLE => jit_scramble_bytes(state.sel),
+                _ => break,
+            }
+        }
+        state.a
+    }
+
+    #[test]
+    fn a_u8_declaration_reaches_the_unsigned_read_and_not_a_signed_one() {
+        let mut asm = Assembler::new();
+        asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+        __prebuild_jitcode_liveness_byte_elements(&mut asm);
+        let _ = asm.ensure_canonical_liveness_offset();
+        let dispatch_jc = __dispatch_jitcode_byte_elements(&mut asm, 0i64)
+            .expect("dispatch lower must succeed for the u8-element fixture");
+        let eis = super::all_call_effect_infos(&dispatch_jc);
+        assert!(
+            !eis.is_empty(),
+            "the fixture must emit at least one residual call"
+        );
+
+        let unsigned_read = super::element_read_descr_of(1, false);
+        assert!(
+            eis.iter()
+                .any(|ei| ei.writes_array_descr_by_shape(&unsigned_read)),
+            "a `u8` element declaration must reach the UNSIGNED element descr \
+             its own reads intern; a hard-coded signed write spec misses it \
+             entirely and the trace keeps serving the pre-call element"
+        );
+
+        // The control that makes the assertion above non-vacuous: the write set
+        // is not matching everything. A signed byte array is the shape the old
+        // hard-coded spelling produced, and it is a different array.
+        let signed_read = super::element_read_descr_of(1, true);
+        assert!(
+            eis.iter()
+                .all(|ei| !ei.writes_array_descr_by_shape(&signed_read)),
+            "the declaration must not reach a signed byte array — if it does, \
+             the shape predicate is too loose to have detected the mismatch"
         );
     }
 }

--- a/majit/majit-trace/src/logger.rs
+++ b/majit/majit-trace/src/logger.rs
@@ -37,7 +37,7 @@ pub struct TraceRecord {
     pub ops_before_opt: usize,
     /// Number of operations after optimization.
     pub ops_after_opt: usize,
-    /// Time spent recording + optimization.
+    /// Time spent in the unroll and optimization pipeline, excluding trace recording.
     pub opt_time: Duration,
     /// Time spent in backend compilation.
     pub compile_time: Duration,

--- a/majit/majit-translate/src/annotator/bookkeeper.rs
+++ b/majit/majit-translate/src/annotator/bookkeeper.rs
@@ -6559,7 +6559,7 @@ mod tests {
     }
 
     /// Fixture for the methods-on-classdef capability that `dyn Trait`
-    /// receiver-driven dispatch (receiver-dispatch configuration, aheui LinkedList) needs.
+    /// receiver-driven dispatch (receiver-dispatch configuration) needs.
     ///
     /// A ≥2-impl trait family registered through `register_trait_family`
     /// must (a) link a base ClassDef to its impl subclasses, (b) carry the

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -1329,8 +1329,8 @@ pub struct CallControl {
     /// Opt-in receiver-driven method-dispatch families (see
     /// [`TraitFamilyRegistration`]).  Empty for pyre production — its
     /// multi-impl traits keep their classdef-less / fail-loud
-    /// disposition; a consumer (e.g. the aheui census) opts specific
-    /// traits in through [`Self::set_trait_family_registrations`].
+    /// disposition; a consumer opts specific traits in through
+    /// [`Self::set_trait_family_registrations`].
     trait_family_registrations: Vec<TraitFamilyRegistration>,
 
     /// RPython: `symbolic.get_array_token(ARRAY, tsc)[0]` — array base size.

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -240,8 +240,8 @@ fn build_semantic_program_via_active_frontend(
             // Seed the local-crate alias roots from the loaded set so
             // `free_function_alias_paths` and the registry's canonical
             // dedup treat every extracted crate name as an alias root
-            // (`local_crates.rs`); non-pyre consumers (aheui) resolve
-            // their crate-qualified cross-crate callsites through this.
+            // (`local_crates.rs`); a non-pyre consumer resolves its
+            // crate-qualified cross-crate callsites through this.
             crate::local_crates::register_local_crate_roots(
                 llbcs.iter().map(|l| l.crate_name().to_string()),
             );
@@ -1668,7 +1668,7 @@ fn analyze_pipeline_from_module_paths(
         }
     }
     // Opt-in receiver-driven dispatch families (receiver-dispatch configuration): a consumer
-    // (e.g. the aheui census) names `>=2`-impl trait qualified paths
+    // names `>=2`-impl trait qualified paths
     // whose `dyn Trait` receivers should annotate to a base ClassDef
     // linking the impl subclasses, so a method getattr on the receiver
     // resolves the impl MethodDesc family.  Built from `trait_impl_owners`
@@ -1737,8 +1737,8 @@ fn analyze_pipeline_from_module_paths(
     // Auto-population (receiver-dispatch configuration): register EVERY `>=2`-impl trait so its
     // inline `dyn Trait` receiver (lowered to `CallTarget::Indirect`) narrows
     // to the family base ClassDef.  Union with the config list (dedup by
-    // base_root), never replacing it, to stay forward-safe with the aheui
-    // census. Minting base/impl subclass classdefs and lowering the indirect
+    // base_root), never replacing it, so an existing configuration stays
+    // valid. Minting base/impl subclass classdefs and lowering the indirect
     // call are one decision. Applies the same within-family
     // `dup_leaf` guard as the config path plus the cross-registry
     // `struct_leaf_counts` bail: an impl leaf that also names a DIFFERENT
@@ -2407,8 +2407,7 @@ pub fn generate_trace_code_from_pipeline(result: &pipeline::ProgramPipelineResul
 /// Like [`generate_trace_code_from_pipeline`] but takes a
 /// [`codegen::CodegenFlavor`]. The flavor is currently a no-op (the
 /// pyre-specific helpers it used to gate now live in
-/// `pyre-jit-trace/src/trace_helpers.rs`); retained for external callers
-/// such as `aheui-jit`.
+/// `pyre-jit-trace/src/trace_helpers.rs`); retained for external callers.
 pub fn generate_trace_code_from_pipeline_with_flavor(
     result: &pipeline::ProgramPipelineResult,
     flavor: codegen::CodegenFlavor,

--- a/majit/majit-translate/src/local_crates.rs
+++ b/majit/majit-translate/src/local_crates.rs
@@ -5,7 +5,7 @@
 //! identity, so a callable has one identity regardless of the import
 //! spelling. pyre resolves symbolic paths extracted from LLBC, where a
 //! cross-crate callsite spells the callee with its crate name
-//! (`aheui_runtime::io::output_flush`) while the graph registers under
+//! (`somecrate::io::output_flush`) while the graph registers under
 //! module-relative spellings — so every *local* (LLBC-extracted) crate
 //! name must be an alias root on both the registration side
 //! (`free_function_alias_paths`) and the canonical-dedup side

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -64,7 +64,7 @@ pub struct PipelineConfig {
     /// subclasses (so a method getattr resolves the impl `MethodDesc`
     /// family via the attrfamily merge).  Empty for pyre production — its
     /// multi-impl traits keep their classdef-less / fail-loud
-    /// disposition; the aheui census opts `LinkedList` in.
+    /// disposition; a consumer opts its own traits in by name.
     #[serde(default)]
     pub register_trait_families: Vec<String>,
 }

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -808,6 +808,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "qmut_deps_simple_loop",
                 "qmut_deps_entry_bridge",
                 "qmut_deps_blackhole_arm",
+                "retrace_close_resumed",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {


### PR DESCRIPTION
Twelve commits on top of `main`, in three groups.

## Array element write-sets for residual calls

`residual_writes` could not express a write to an array element, so a helper
that stores into one had no way to declare it. This adds the vocabulary and
the emit side, then closes two gaps in how the write-set is recovered:

- `8ac021ff56f` emit-side `setarrayitem_gc_i` builders
- `4e58ff3f623` the `array_fields` vocabulary for non-virtualizable element access
- `a07f9e58deb` recover array write-sets by raw-set identity when `compute_bitstrings` has not run
- `c008f77bdb7` key the fallback on shape rather than pointer identity
- `acd5157e74d` the `field[]` element write-set in `residual_writes`

New tests: `array_write_set_invalidation.rs`, `jit_interp_residual_array_write.rs`.

## Per-jitdriver `enable_opts`

`unroll` was on for every driver. `warmspot.py:73` makes it per-driver
upstream, so the knob is exposed and unrolling reads it:

- `3a525f5f6b3` gate unrolling on the jitdriver's `enable_opts`
- `4b075433008` expose `set_param_enable_opts` on `JitDriver`

## Resume-path fixes

- `a33c8b8e3d8` scope the inline-frame identity-slot snapshot trim to `split_dispatch`
- `948e34df157` seed a walk re-entered after a declined close at the pc that declined
- `54e723c8383` route both close re-entries through one resume publisher
- `ab5199cb1ee` align nursery allocation with upstream regalloc
- `dd927e894bb` describe what `opt_time` measures

## Verification

`pyre/check.py` was still running when this PR was opened; its result is
reported in a follow-up comment rather than asserted here.

The aheui consumer of the `enable_opts` change lives in a separate repository
(`youknowone/aheui-rust`) and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLDxh1mE6nALnJFaCZNoJ
