### PR TITLE
jit: fold census + kill switch, symbolic-fnaddr naming, fat-pointer publication removal, and two crashes it exposed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2056,6 +2056,7 @@ dependencies = [
  "quote",
  "rustpython-compiler",
  "rustpython-compiler-core",
+ "rustpython-wtf8",
  "serde",
  "serde_json",
  "syn",

--- a/majit/majit-translate/Cargo.toml
+++ b/majit/majit-translate/Cargo.toml
@@ -42,6 +42,7 @@ libc = { workspace = true }
 # Critically this is NOT a dependency on pyre: rustpython-compiler-core is
 # external to both majit and pyre. The `rpython/` ⊥ `pypy/` boundary holds.
 rustpython-compiler-core = { workspace = true }
+rustpython-wtf8 = { workspace = true }
 # `md-5` mirrors upstream `hashlib.md5(...).hexdigest()` used by
 # `rpython/translator/backendopt/stat.py:48` to fingerprint each
 # graph's `co_code` when `print_statistics(save_per_graph_details=...)`

--- a/majit/majit-translate/src/codegen.rs
+++ b/majit/majit-translate/src/codegen.rs
@@ -171,6 +171,7 @@ mod tests {
                 main_jitcode_index: 0,
             }],
             jitcodes: vec![main_jitcode],
+            symbolic_fnaddr_paths: Vec::new(),
             jitcodes_by_path: indexmap::IndexMap::new(),
             indirectcalltarget_indices: Vec::new(),
             insns: indexmap::IndexMap::new(),

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1495,6 +1495,23 @@ impl Assembler {
                 let opnum = self.get_opnum(&key);
                 state.code[startposition] = opnum;
             }
+            OpKind::ConstStr(bytes) => {
+                let p = crate::translator::rtyper::lltypesystem::rstr::const_str_cache_llstr(bytes)
+                    .expect("prebuilt STR constant must materialize");
+                let const_value = crate::flowspace::model::ConstValue::LLPtr(Box::new(p));
+                let idx = self.emit_const_r(&const_value, state);
+                state.code.push(idx);
+                argcodes.push('r');
+                if let Some(result) = op.result.as_ref() {
+                    argcodes.push('>');
+                    let (reg, kc) = self.lookup_reg_with_kind_var(result, regallocs);
+                    argcodes.push(kc);
+                    state.code.push(reg);
+                }
+                let key = format!("ref_copy/{argcodes}");
+                let opnum = self.get_opnum(&key);
+                state.code[startposition] = opnum;
+            }
             OpKind::ConstRefNull => {
                 let const_value = crate::flowspace::model::ConstValue::LLAddress(
                     crate::translator::rtyper::lltypesystem::lltype::_address::Null,
@@ -2731,6 +2748,7 @@ impl Assembler {
                 OpKind::ConstBool(_) => "ConstBool",
                 OpKind::ConstSymbolic { .. } => "ConstSymbolic",
                 OpKind::ConstFloat(_) => "ConstFloat",
+                OpKind::ConstStr(_) => "ConstStr",
                 OpKind::ConstRef(_) => "ConstRef",
                 OpKind::ConstRefNull => "ConstRefNull",
                 OpKind::ConstNone => "ConstNone",
@@ -4418,7 +4436,10 @@ fn op_kind_to_opname(kind: &crate::model::OpKind) -> String {
         // `identity_id()` enters the shared `constants_r` pool via
         // `emit_const_r`, then a `ref_copy/r>r` op moves it into the
         // SSA destination register.
-        OpKind::ConstRef(_) | OpKind::ConstRefNull | OpKind::ConstRefAddr(_) => "ref_copy".into(),
+        OpKind::ConstStr(_)
+        | OpKind::ConstRef(_)
+        | OpKind::ConstRefNull
+        | OpKind::ConstRefAddr(_) => "ref_copy".into(),
         // `ConstNone` (Void `None`) is const-inlined by
         // `legacy_const_define_hlvalue`, and `decompose_slice_args` DROPS
         // the getslice `stop` operand for a `[start:]` slice

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -10,7 +10,11 @@
 //! subset. Descriptor operands are deduplicated through the RPython
 //! `_descr_dict` shape before bytecode emission.
 
-use std::{collections::HashMap, fmt};
+use std::{
+    collections::{BTreeSet, HashMap},
+    fmt,
+    sync::Mutex,
+};
 
 use vecset::VecSet;
 
@@ -3560,6 +3564,33 @@ fn bh_size_spec_from_callcontrol(
         for (index, field) in all_fielddescrs.iter_mut().enumerate() {
             field.index = index as u32;
             field.index_in_parent = index;
+        }
+    }
+    let violating_fields = all_fielddescrs
+        .iter()
+        .filter(|field| field.offset + field.field_size > size)
+        .collect::<Vec<_>>();
+    if !violating_fields.is_empty() {
+        static WARNED_LAYOUT_OWNERS: Mutex<BTreeSet<String>> = Mutex::new(BTreeSet::new());
+        let mut warned = WARNED_LAYOUT_OWNERS
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if warned.insert(layout_owner.to_string()) {
+            let count = warned.len();
+            let rows = violating_fields
+                .iter()
+                .map(|field| {
+                    format!(
+                        "{:?} (offset {}, field_size {})",
+                        field.name, field.offset, field.field_size
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            eprintln!(
+                "[majit-translate] struct layout warning #{count}: owner {layout_owner:?} has \
+                 parent size {size}; out-of-bounds field rows: {rows}"
+            );
         }
     }
     Some(crate::jitcode::BhSizeSpec {

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -4700,6 +4700,30 @@ impl CallControl {
     /// `CallPath`; otherwise it falls back to the stable symbolic address
     /// shim for source-only analysis.
     pub fn fnaddr_for_target(&self, target: &CallTarget) -> i64 {
+        // A `__pyre_wrap_*` wrapper takes `&[PyObjectRef]` (two words) and
+        // returns `Result<PyObjectRef, PyError>` (sret), neither of which the
+        // one-register-per-slot residual-call ABI can carry. The codewriter
+        // gives every wrapper its own jitcode and inlines it, so refusing the
+        // address here costs nothing and prevents a wrong-ABI call if inlining
+        // is ever declined. This guard precedes every resolution arm because a
+        // wrapper otherwise resolves through `target_to_path` and never reaches
+        // the symbolic tail. Both resolution arms below return
+        // `symbolic_fnaddr_for_path(&path)` when `function_fnaddrs` misses, so
+        // deriving the refusal from the same path makes a fire on a path that
+        // would have missed byte-identical to the unguarded result. Only a fire
+        // that refuses a resolved address changes the constant, keeping that
+        // change attributable to a real refusal.
+        let wrapper_path = crate::model::fn_const_segments(target)
+            .map(|segments| CallPath::from_segments(segments.iter().map(String::as_str)))
+            .or_else(|| self.target_to_path(target));
+        if let Some(path) = &wrapper_path
+            && path
+                .last_segment()
+                .is_some_and(|leaf| leaf.starts_with("__pyre_wrap_"))
+        {
+            return symbolic_fnaddr_for_path(path);
+        }
+
         if let Some(segments) = crate::model::fn_const_segments(target) {
             let path = CallPath::from_segments(segments.iter().map(String::as_str));
             return self

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8354,6 +8354,7 @@ fn op_can_raise(op: &OpKind) -> RaiseClass {
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
         | OpKind::ConstNone

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8347,8 +8347,11 @@ pub(crate) fn get_type_flag(
         "u16" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 2),
         "u8" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 1),
         "bool" => (ArrayFlag::Unsigned, majit_ir::value::Type::Int, 1),
-        // RPython: Void fields are skipped
-        "()" => (ArrayFlag::Void, majit_ir::value::Type::Void, 0),
+        // Zero-sized types occupy no storage and contribute no field slot
+        // (heaptracker.py:60-62; lltype.py:334 `_names_without_voids()`).
+        s if s == "()" || s == "PhantomData" || s.starts_with("PhantomData<") => {
+            (ArrayFlag::Void, majit_ir::value::Type::Void, 0)
+        }
         // Unknown type — treat as GC pointer (conservative)
         _ => (
             ArrayFlag::Pointer,

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -7,6 +7,7 @@
 //! (oopspec) and recursive (portal) call classification.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
+use std::sync::{Mutex, OnceLock};
 
 use majit_ir::descr::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
 use majit_ir::value::Type;
@@ -6676,17 +6677,52 @@ fn stable_symbolic_fnaddr<T: std::hash::Hash>(value: &T) -> i64 {
     ((hasher.finish() & !SYMBOLIC_FNADDR_HIGH_MASK) | SYMBOLIC_FNADDR_BASE) as i64
 }
 
+static SYMBOLIC_FNADDR_PATHS: OnceLock<Mutex<HashMap<i64, String>>> = OnceLock::new();
+
+fn record_symbolic_fnaddr(value: i64, description: String) {
+    let registry = SYMBOLIC_FNADDR_PATHS.get_or_init(|| Mutex::new(HashMap::new()));
+    let mut paths = registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    paths
+        .entry(value)
+        .and_modify(|existing| {
+            if description < *existing {
+                existing.clone_from(&description);
+            }
+        })
+        .or_insert(description);
+}
+
+pub(crate) fn symbolic_fnaddr_paths_snapshot() -> Vec<(i64, String)> {
+    let registry = SYMBOLIC_FNADDR_PATHS.get_or_init(|| Mutex::new(HashMap::new()));
+    let paths = registry
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let mut snapshot: Vec<_> = paths
+        .iter()
+        .map(|(&value, description)| (value, description.clone()))
+        .collect();
+    snapshot.sort_by(|left, right| left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0)));
+    snapshot
+}
+
 pub(crate) fn symbolic_fnaddr_for_path(path: &CallPath) -> i64 {
-    stable_symbolic_fnaddr(path)
+    let symbolic = stable_symbolic_fnaddr(path);
+    record_symbolic_fnaddr(symbolic, path.canonical_key());
+    symbolic
 }
 
 pub(crate) fn symbolic_fnaddr_for_target(target: &CallTarget) -> i64 {
     if let Some(segments) = crate::model::fn_const_segments(target) {
-        return stable_symbolic_fnaddr(&CallPath::from_segments(
-            segments.iter().map(String::as_str),
-        ));
+        let path = CallPath::from_segments(segments.iter().map(String::as_str));
+        let symbolic = stable_symbolic_fnaddr(&path);
+        record_symbolic_fnaddr(symbolic, path.canonical_key());
+        return symbolic;
     }
-    stable_symbolic_fnaddr(target)
+    let symbolic = stable_symbolic_fnaddr(target);
+    record_symbolic_fnaddr(symbolic, format!("target:{target}"));
+    symbolic
 }
 
 impl Default for CallControl {
@@ -9034,6 +9070,23 @@ mod tests {
         let jitcode = cc.get_jitcode(&path);
 
         assert_eq!(jitcode.fnaddr, symbolic_fnaddr_for_path(&path));
+    }
+
+    #[test]
+    fn symbolic_fnaddr_minters_record_descriptions() {
+        let path = CallPath::from_segments(["symbolic_registry", "path_callee"]);
+        let path_symbolic = symbolic_fnaddr_for_path(&path);
+        let target = CallTarget::synthetic_transparent_ctor_with_owner(
+            vec!["symbolic_registry".to_string()],
+            "TargetCallee",
+        );
+        let target_symbolic = symbolic_fnaddr_for_target(&target);
+        let target_description = format!("target:{target}");
+
+        let paths = symbolic_fnaddr_paths_snapshot();
+        assert!(paths.contains(&(path_symbolic, path.canonical_key())));
+        assert!(target_description.starts_with("target:"));
+        assert!(paths.contains(&(target_symbolic, target_description)));
     }
 
     #[test]

--- a/majit/majit-translate/src/codewriter/format.rs
+++ b/majit/majit-translate/src/codewriter/format.rs
@@ -488,6 +488,7 @@ fn op_name(op: &crate::model::SpaceOperation) -> String {
         OpKind::Call { .. } => "call".to_string(),
         OpKind::ConstInt(_) => "const_int".to_string(),
         OpKind::ConstFloat(_) => "const_float".to_string(),
+        OpKind::ConstStr(_) => "const_str".to_string(),
         OpKind::CallElidable {
             result_kind,
             args_i,
@@ -602,6 +603,9 @@ fn op_args_repr(op: &crate::model::SpaceOperation) -> String {
         }
         OpKind::ConstFloat(bits) => {
             let _ = write!(out, "${}", f64::from_bits(*bits));
+        }
+        OpKind::ConstStr(bytes) => {
+            let _ = write!(out, "${bytes:?}");
         }
         // jtransform.py:414-435 `rewrite_call`:
         //   sublists = [lst_i?, lst_r?, lst_f?, calldescr?]   # only kinds present
@@ -790,6 +794,7 @@ fn op_result_kind(kind: &crate::model::OpKind) -> RegKind {
         },
         OpKind::ConstInt(_) => RegKind::Int,
         OpKind::ConstFloat(_) => RegKind::Float,
+        OpKind::ConstStr(_) => RegKind::Ref,
         OpKind::ConstBool(_) => RegKind::Int,
         OpKind::BinOp { result_ty, .. }
         | OpKind::UnaryOp { result_ty, .. }

--- a/majit/majit-translate/src/codewriter/jtransform.rs
+++ b/majit/majit-translate/src/codewriter/jtransform.rs
@@ -530,6 +530,7 @@ fn is_source_constant_variable(
                 OpKind::ConstInt(_)
                 | OpKind::ConstBool(_)
                 | OpKind::ConstFloat(_)
+                | OpKind::ConstStr(_)
                 | OpKind::ConstRef(_)
                 | OpKind::ConstRefNull
                 | OpKind::ConstNone
@@ -6451,6 +6452,7 @@ fn remap_op(
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
         | OpKind::ConstNone

--- a/majit/majit-translate/src/codewriter/type_state.rs
+++ b/majit/majit-translate/src/codewriter/type_state.rs
@@ -122,6 +122,7 @@ pub(crate) fn authoritative_result_type_from_op(kind: &OpKind) -> Option<Concret
         // kind; folded to `ConstBool(true)` by `jtransform` before emit.
         OpKind::ConstSymbolic { .. } => Some(ConcreteType::Signed),
         OpKind::ConstFloat(_) => Some(ConcreteType::Float),
+        OpKind::ConstStr(_) => Some(ConcreteType::GcRef),
         OpKind::Input { ty, .. } => concrete_if_known(valuetype_to_concrete(ty)),
         OpKind::FieldRead { ty, .. } | OpKind::VableFieldRead { ty, .. } => {
             concrete_if_known(valuetype_to_concrete(ty))

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4804,16 +4804,16 @@ impl<'a> Lowering<'a> {
                 for op in operands {
                     arg_vars.push(self.resolve_operand(mir_bb, op)?);
                 }
-                // Resolve the user-defined owner + field names from the
+                // Resolve the user-defined owner + field names and types from the
                 // Adt kind's `type_id` when possible.  Charon encodes
                 // `AggregateKind::Adt(type_id, variant_idx, ..)` as
                 // `{"Adt": [type_id, variant_idx, ..]}`; struct variants
                 // use `variant_idx = null`, enum variants index into the
                 // `TypeDeclKind::Enum` variant list.
                 let resolved = self.resolve_aggregate_adt(&kind);
-                let (owner_path, ctor_name, field_names, aggregate_owner_id) = match resolved {
-                    Some((owner_path, ctor_name, field_names, owner_id)) => {
-                        (owner_path, ctor_name, field_names, Some(owner_id))
+                let (owner_path, ctor_name, field_rows, aggregate_owner_id) = match resolved {
+                    Some((owner_path, ctor_name, field_rows, owner_id)) => {
+                        (owner_path, ctor_name, field_rows, Some(owner_id))
                     }
                     None => {
                         // Synthetic placeholders for non-Adt aggregates
@@ -4837,8 +4837,9 @@ impl<'a> Lowering<'a> {
                             aggregate_ctor_name(&kind),
                             tyref_tuple_suffix(dest_ty, self.llbc)
                         );
-                        let positional =
-                            (0..arg_vars.len()).map(|i| format!("__pos_{i}")).collect();
+                        let positional = (0..arg_vars.len())
+                            .map(|i| (format!("__pos_{i}"), String::new()))
+                            .collect();
                         (Vec::new(), leaf, positional, None)
                     }
                 };
@@ -4916,10 +4917,18 @@ impl<'a> Lowering<'a> {
                 // schema entry (tuple aggregates, deduplicated types
                 // not in the LLBC's local table).
                 for (i, value) in arg_vars.into_iter().enumerate() {
-                    let name = field_names
+                    let (name, field_ty) = field_rows
                         .get(i)
                         .cloned()
-                        .unwrap_or_else(|| format!("__pos_{i}"));
+                        .unwrap_or_else(|| (format!("__pos_{i}"), String::new()));
+                    // `_names_without_voids()` / `heaptracker.py:104-105`: a
+                    // zero-sized field occupies no storage and gets no slot,
+                    // so no write is generated for it.
+                    if crate::codewriter::call::get_type_flag(&field_ty).1
+                        == majit_ir::value::Type::Void
+                    {
+                        continue;
+                    }
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: None,
                         kind: OpKind::FieldWrite {
@@ -5844,14 +5853,18 @@ impl<'a> Lowering<'a> {
     /// - the field index is out of range for the resolved variant.
     ///
     /// Resolve a Charon `AggregateKind::Adt` payload to the
-    /// `(owner_path, ctor_leaf, field_names)` triple suitable for a
-    /// transparent-ctor + FieldWrite chain emission.
+    /// `(owner_path, ctor_leaf, field_rows)` triple suitable for a
+    /// transparent-ctor + FieldWrite chain emission.  Each row carries the
+    /// field's name and its rendered type, so the emission site can tell a
+    /// zero-sized field (which gets no slot and therefore no write) from a
+    /// stored one.
     ///
     /// Charon encodes `Aggregate(AggregateKind::Adt(type_id,
     /// variant_idx, ..), operands)` as `{"Adt": [type_id, variant_idx,
     /// ..]}`.  Struct aggregates use `variant_idx = null` and pull
-    /// field names straight from the `TypeDeclKind::Struct(fields)`
-    /// list; enum aggregates use a non-null `variant_idx` to select
+    /// field names and types straight from the
+    /// `TypeDeclKind::Struct(fields)` list; enum aggregates use a
+    /// non-null `variant_idx` to select
     /// the right `VariantDecl` and emit the qualified ctor leaf
     /// (`Variant`) under the enum's `owner_path` (everything up to but
     /// not including the leaf in the resolved `name_path()`).
@@ -5953,7 +5966,12 @@ impl<'a> Lowering<'a> {
     fn resolve_aggregate_adt(
         &self,
         kind: &serde_json::Value,
-    ) -> Option<(Vec<String>, String, Vec<String>, majit_ir::descr::StructId)> {
+    ) -> Option<(
+        Vec<String>,
+        String,
+        Vec<(String, String)>,
+        majit_ir::descr::StructId,
+    )> {
         let adt = kind.as_object()?.get("Adt")?.as_array()?;
         // `AggregateKind::Adt` head: either a bare `type_id` u64 or a
         // full `TypeDeclRef` object `{"generics": …, "id": {"Adt":
@@ -5979,17 +5997,22 @@ impl<'a> Lowering<'a> {
         let owner_path = segments;
         match (&td.kind, variant_idx) {
             (TypeDeclKind::Struct(fields), None) | (TypeDeclKind::Struct(fields), Some(_)) => {
-                let field_names: Vec<String> = fields
+                let field_rows: Vec<(String, String)> = fields
                     .iter()
                     .enumerate()
-                    .map(|(i, f)| f.name.clone().unwrap_or_else(|| format!("__pos_{i}")))
+                    .map(|(i, f)| {
+                        (
+                            f.name.clone().unwrap_or_else(|| format!("__pos_{i}")),
+                            tyref_to_ast_string(&f.ty, self.llbc),
+                        )
+                    })
                     .collect();
                 let template =
                     majit_ir::descr::StructId::from_canonical(&strip_crate_prefix(&name_path));
                 Some((
                     owner_path,
                     type_leaf,
-                    field_names,
+                    field_rows,
                     concrete_adt_struct_id(template, head_adt, self.llbc),
                 ))
             }
@@ -6011,11 +6034,16 @@ impl<'a> Lowering<'a> {
                     None => type_leaf,
                 };
                 variant_owner.push(leaf);
-                let field_names: Vec<String> = v
+                let field_rows: Vec<(String, String)> = v
                     .fields
                     .iter()
                     .enumerate()
-                    .map(|(i, f)| f.name.clone().unwrap_or_else(|| format!("__pos_{i}")))
+                    .map(|(i, f)| {
+                        (
+                            f.name.clone().unwrap_or_else(|| format!("__pos_{i}")),
+                            tyref_to_ast_string(&f.ty, self.llbc),
+                        )
+                    })
                     .collect();
                 let template = majit_ir::descr::StructId::from_canonical(&format!(
                     "{}::{}",
@@ -6025,7 +6053,7 @@ impl<'a> Lowering<'a> {
                 Some((
                     variant_owner,
                     v.name.clone(),
-                    field_names,
+                    field_rows,
                     concrete_adt_struct_id(template, head_adt, self.llbc),
                 ))
             }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -11926,10 +11926,9 @@ impl<'a> Lowering<'a> {
         // the metadata word. A def-id alone does NOT imply thin: a DST newtype
         // is a nominal ADT with a def-id. Gate on the pointee's RESOLVED layout
         // size being concrete (`Some`) — `None` is the DST/unsized signature.
-        // Read-only `#[pyre_class]` accessors reach here via
-        // `from_obj(...).map(|m| &*m) -> Option<&Self>` and
-        // `getdebug_data() -> Option<&FrameDebugData>`; every such `W_*` /
-        // `FrameDebugData` pointee is Sized (carries a concrete layout size).
+        // `getdebug_data() -> Option<&FrameDebugData>` is a live shared-ref
+        // producer reaching here; its `FrameDebugData` pointee is Sized
+        // (carries a concrete layout size).
         if let Some(shared_pointee) = type_node_shared_ref_pointee(payload, self.llbc)
             && let Some(stripped) = strip_ty_wrappers(shared_pointee, self.llbc)
             && let Some(def_id) = adt_node_def_id(stripped)

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -493,11 +493,16 @@ pub(crate) fn lower_result_exc_returns(
         // Require the strict pure-forwarder property (empty, unconditional
         // intervening blocks only) for `Err` shells; decline to a residual
         // call otherwise.
-        let forwards_ok = if is_err {
+        let forward_err: Option<String> = if is_err {
             forwards_to_returnblock(graph, bi, &ctor_var)
+                .err()
+                .map(|e| format!("Err shell: {e}"))
         } else {
-            verify_forwards_to_returnblock_general(graph, bi, &ctor_var).is_ok()
+            verify_forwards_to_returnblock_general(graph, bi, &ctor_var)
+                .err()
+                .map(|e| format!("Ok shell: {e}"))
         };
+        let forwards_ok = forward_err.is_none();
         if !well_formed_return || !forwards_ok {
             // Leaving the ctor materialised is sound only when it is a
             // consumed intermediate that never returns — its value must NOT
@@ -511,10 +516,23 @@ pub(crate) fn lower_result_exc_returns(
             // object.  Decline the whole callee (fail-safe → residual call)
             // rather than emit that partial, unsound rewrite.
             if shell_reaches_returnblock(graph, bi, &ctor_var) {
+                // Name the condition(s) that actually fired.  The guard is a
+                // disjunction, so both can hold; join whichever did.
+                let shell_use = (!well_formed_return).then(|| {
+                    format!(
+                        "extra shell use (op_uses={}, link_uses={})",
+                        consumers.op_uses, consumers.link_uses
+                    )
+                });
+                let cause = [shell_use.as_deref(), forward_err.as_deref()]
+                    .into_iter()
+                    .flatten()
+                    .collect::<Vec<_>>()
+                    .join("; ");
                 return Err(format!(
                     "{}: Result return shell in block {bi} reaches returnblock \
-                     but cannot be lowered cleanly (non-pure forward / extra \
-                     shell use) — declining the callee to avoid a partial rewrite",
+                     but cannot be lowered cleanly ({cause}) — declining the \
+                     callee to avoid a partial rewrite",
                     graph.name
                 ));
             }
@@ -599,7 +617,7 @@ fn has_tail_forwarded_call_result(graph: &FunctionGraph) -> bool {
         for op in &graph.blocks[bi].operations {
             if matches!(op.kind, OpKind::Call { .. })
                 && let Some(r) = &op.result
-                && forwards_to_returnblock(graph, bi, r)
+                && forwards_to_returnblock(graph, bi, r).is_ok()
             {
                 return true;
             }
@@ -882,8 +900,10 @@ fn verify_forwards_to_returnblock_general(
                 if op_operand_vars(&op.kind).iter().any(|o| o == &v) {
                     return Err(format!(
                         "{}: Result shell alias is read by an operation in \
-                         block {cur} on the forwarding path — not a pure forward",
-                        graph.name
+                         block {cur} on the forwarding path — not a pure \
+                         forward (op: {})",
+                        graph.name,
+                        truncated_kind(&op.kind),
                     ));
                 }
             }
@@ -1073,7 +1093,7 @@ fn rewire_one_call_site(
         .position(|b| b.operations.iter().any(|op| op.result.as_ref() == Some(r)))
         .ok_or_else(|| format!("{name}: scoped call result var has no producer block"))?;
     // Tail forward: the callee's Result flows straight to returnblock.
-    if forwards_to_returnblock(graph, a, r) {
+    if forwards_to_returnblock(graph, a, r).is_ok() {
         if !enclosing_scoped {
             return Err(format!(
                 "{name}: tail-forwards a scoped callee's Result out of a \
@@ -1526,7 +1546,7 @@ fn verify_drain_reraise_returns_err_payload(
     // exit, no exitswitch, only empty alias-hop blocks en route.  The tolerant
     // forwarder would license a conditional tail (`if flag { return Err(e) }
     // else { … }`) whose non-reraise branch the substitution silently drops.
-    if forwards_to_returnblock(graph, reraise_target, &outer) {
+    if forwards_to_returnblock(graph, reraise_target, &outer).is_ok() {
         Ok(())
     } else {
         Err(format!(
@@ -2301,11 +2321,17 @@ fn build_shell(
 }
 
 /// Probe: does `var` flow from `block`'s exit through pure positional
-/// forwarding into `returnblock`?  The non-erroring twin of
-/// [`verify_forwards_to_returnblock`] — any non-conforming hop means
-/// "not a tail forward" rather than a build failure (the site is then
-/// matched as a diamond, whose own checks fail loud).
-fn forwards_to_returnblock(graph: &FunctionGraph, block: usize, var: &Variable) -> bool {
+/// forwarding into `returnblock`?  Any non-conforming hop means "not a
+/// tail forward" rather than a build failure (the site is then matched as
+/// a diamond, whose own checks fail loud).  The `Err` describes which hop
+/// disqualified the chain; callers that only need the yes/no answer use
+/// `.is_ok()`.  Six distinct shapes disqualify a chain, and the
+/// `[mir-coverage]` report is only actionable if it names which one.
+fn forwards_to_returnblock(
+    graph: &FunctionGraph,
+    block: usize,
+    var: &Variable,
+) -> Result<(), String> {
     let mut current = block;
     let mut tracked = var.clone();
     for _ in 0..graph.blocks.len() {
@@ -2315,31 +2341,57 @@ fn forwards_to_returnblock(graph: &FunctionGraph, block: usize, var: &Variable) 
         // a tail forward.
         if current != block {
             let b = &graph.blocks[current];
-            if !b.operations.is_empty() || b.exitswitch.is_some() {
-                return false;
+            if !b.operations.is_empty() {
+                return Err(format!(
+                    "forwarding block {current} carries {} operation(s), \
+                     first {:?}",
+                    b.operations.len(),
+                    truncated_kind(&b.operations[0].kind),
+                ));
+            }
+            if b.exitswitch.is_some() {
+                return Err(format!("forwarding block {current} has a conditional exit"));
             }
         }
         let [link] = graph.blocks[current].exits.as_slice() else {
-            return false;
+            return Err(format!(
+                "block {current} has {} exits, not exactly one",
+                graph.blocks[current].exits.len()
+            ));
         };
         let Some(pos) = link
             .args
             .iter()
             .position(|a| matches!(a, LinkArg::Value(v) if *v == tracked))
         else {
-            return false;
+            return Err(format!(
+                "block {current}'s single exit does not carry the tracked value"
+            ));
         };
         if link.target == graph.returnblock {
-            return true;
+            return Ok(());
         }
         let target = link.target.0;
         let Some(next_var) = graph.blocks[target].inputargs.get(pos) else {
-            return false;
+            return Err(format!(
+                "forwarding target block {target} has no inputarg at position {pos}"
+            ));
         };
         tracked = next_var.clone();
         current = target;
     }
-    false
+    Err("forwarding chain is longer than the block count".to_string())
+}
+
+/// A bounded `Debug` rendering of an op kind, for diagnostics that name
+/// the operation that disqualified a rewrite.  Truncates on a `char`
+/// boundary so a non-ASCII name cannot panic the build.
+fn truncated_kind(kind: &OpKind) -> String {
+    let text = format!("{kind:?}");
+    if text.chars().count() <= 100 {
+        return text;
+    }
+    text.chars().take(100).collect::<String>() + "…"
 }
 
 /// Map a continue-arm link variable back to its A-scope origin

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -2383,11 +2383,28 @@ fn forwards_to_returnblock(
     Err("forwarding chain is longer than the block count".to_string())
 }
 
-/// A bounded `Debug` rendering of an op kind, for diagnostics that name
-/// the operation that disqualified a rewrite.  Truncates on a `char`
-/// boundary so a non-ASCII name cannot panic the build.
+/// A bounded rendering of an op kind, for diagnostics that name the
+/// operation that disqualified a rewrite.
+///
+/// Field accesses render as `owner::field` rather than through `Debug`:
+/// which field a `Result` shell is read through is the whole content of
+/// the diagnostic (`__pos_0` is the payload the rewrite would substitute,
+/// `__discriminant` is a match on the shell), and the `Debug` form buries
+/// it behind the base `Variable`'s interior-mutability wrappers.
+/// Truncates on a `char` boundary so a non-ASCII name cannot panic.
 fn truncated_kind(kind: &OpKind) -> String {
-    let text = format!("{kind:?}");
+    let field_access = |verb, field: &crate::model::FieldDescriptor| {
+        format!(
+            "{verb} {}::{}",
+            field.owner_root.as_deref().unwrap_or("<unknown-owner>"),
+            field.name,
+        )
+    };
+    let text = match kind {
+        OpKind::FieldRead { field, .. } => field_access("FieldRead", field),
+        OpKind::FieldWrite { field, .. } => field_access("FieldWrite", field),
+        _ => format!("{kind:?}"),
+    };
     if text.chars().count() <= 100 {
         return text;
     }

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -659,6 +659,7 @@ pub(crate) fn op_operand_vars(kind: &OpKind) -> Vec<Variable> {
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
         | OpKind::ConstNone

--- a/majit/majit-translate/src/front/result_exc.rs
+++ b/majit/majit-translate/src/front/result_exc.rs
@@ -73,7 +73,7 @@ use majit_charon_reader::ullbc::TyRef;
 
 use crate::flowspace::model::Variable;
 use crate::model::{
-    CallFuncPtr, CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
+    BlockId, CallFuncPtr, CallTarget, ExitSwitch, FunctionGraph, Link, LinkArg, OpKind, ValueType,
 };
 
 /// Resolve the JSON body behind a generics slot — `{"Deduplicated":
@@ -2344,9 +2344,12 @@ fn forwards_to_returnblock(
             if !b.operations.is_empty() {
                 return Err(format!(
                     "forwarding block {current} carries {} operation(s), \
-                     first {:?}",
+                     first {:?}, {} exit(s), exitswitch {}, {} predecessor(s)",
                     b.operations.len(),
                     truncated_kind(&b.operations[0].kind),
+                    b.exits.len(),
+                    b.exitswitch.is_some(),
+                    graph.predecessors(BlockId(current)).len(),
                 ));
             }
             if b.exitswitch.is_some() {

--- a/majit/majit-translate/src/inline.rs
+++ b/majit/majit-translate/src/inline.rs
@@ -439,6 +439,7 @@ pub(crate) fn remap_op_kind(
             ty: ty.clone(),
         },
         OpKind::ConstFloat(bits) => OpKind::ConstFloat(*bits),
+        OpKind::ConstStr(bytes) => OpKind::ConstStr(bytes.clone()),
         OpKind::ConstRef(obj) => OpKind::ConstRef(obj.clone()),
         OpKind::ConstRefNull => OpKind::ConstRefNull,
         OpKind::ConstNone => OpKind::ConstNone,
@@ -905,6 +906,7 @@ pub fn op_variable_refs(kind: &OpKind) -> Vec<crate::flowspace::model::Variable>
         | OpKind::ConstBool(_)
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
         | OpKind::ConstNone
@@ -1180,6 +1182,7 @@ pub fn is_pure_op(kind: &OpKind) -> bool {
         // `jtransform` before assembly).
         | OpKind::ConstSymbolic { .. }
         | OpKind::ConstFloat(_)
+        | OpKind::ConstStr(_)
         | OpKind::ConstRef(_)
         | OpKind::ConstRefNull
         | OpKind::ConstNone

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -2054,6 +2054,7 @@ fn analyze_pipeline_from_module_paths(
         functions: Vec::new(),
         jit_drivers: Vec::new(),
         jitcodes: Vec::new(),
+        symbolic_fnaddr_paths: Vec::new(),
         indirectcalltarget_indices: Vec::new(),
         jitcodes_by_path: indexmap::IndexMap::new(),
         insns: indexmap::IndexMap::new(),
@@ -2099,6 +2100,7 @@ fn analyze_pipeline_from_module_paths(
         })
         .collect();
     pipeline.jitcodes = jitcodes;
+    pipeline.symbolic_fnaddr_paths = call::symbolic_fnaddr_paths_snapshot();
     pipeline.indirectcalltarget_indices = indirectcalltarget_indices;
     // Mirror of `CallControl::jitcodes` (RPython `call.py:87 self.jitcodes`)
     // captured before `call_control` is dropped. Needed because consumers

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -648,6 +648,12 @@ pub enum OpKind {
     /// existing `constants_f` pool with a `float_copy` op, mirroring
     /// the `ConstInt` → `int_copy` lowering.
     ConstFloat(u64),
+    /// RPython `flowmodel.py:Constant(str_value)` after
+    /// `StringRepr.convert_const` resolves the host string to a
+    /// prebuilt `Ptr(STR)`. The pre-jtransform string-constant fold
+    /// carries bytes here; the assembler mints the lltype pointer and
+    /// materialises it through the ref constant pool.
+    ConstStr(Vec<u8>),
     /// RPython `flowmodel.py:Constant(host_object)` resolved by the
     /// rtyper to a singleton instance pointer
     /// (`rtyper/rpbc.py::SingleFrozenPBCRepr`).  Stored as a thin

--- a/majit/majit-translate/src/pipeline.rs
+++ b/majit/majit-translate/src/pipeline.rs
@@ -111,6 +111,10 @@ pub struct ProgramPipelineResult {
     /// `JitDriverStaticData.mainjitcode` or `IndirectCallTargets`) share
     /// identity with the values appearing here.
     pub jitcodes: Vec<std::sync::Arc<crate::jitcode::JitCode>>,
+    /// Every symbolic fnaddr placeholder minted while codewriting, paired with
+    /// a description of the callee it stands for.  Lets a consumer resolve a
+    /// symbolic funcbox constant back to the function it replaced.
+    pub symbolic_fnaddr_paths: Vec<(i64, String)>,
     /// RPython `Assembler.indirectcalltargets`, encoded by identity as dense
     /// indices into `jitcodes`.
     #[serde(default)]
@@ -212,6 +216,7 @@ mod tests {
                 main_jitcode_index: 0,
             }],
             jitcodes: vec![Arc::new(JitCode::new("consts"))],
+            symbolic_fnaddr_paths: Vec::new(),
             indirectcalltarget_indices: Vec::new(),
             jitcodes_by_path: indexmap::IndexMap::new(),
             insns: indexmap::IndexMap::new(),

--- a/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
+++ b/majit/majit-translate/src/translator/rtyper/legacy_annotator.rs
@@ -275,7 +275,10 @@ fn infer_op_type(kind: &OpKind) -> ValueType {
         // Singleton instance pointer (unit-variant PBC).  The legacy
         // annotator sees this as a plain ref-typed value; concrete
         // class identity stays in the `HostObject` carrier itself.
-        OpKind::ConstRef(_) | OpKind::ConstRefNull | OpKind::ConstRefAddr(_) => {
+        OpKind::ConstStr(_)
+        | OpKind::ConstRef(_)
+        | OpKind::ConstRefNull
+        | OpKind::ConstRefAddr(_) => {
             ValueType::Ref(None)
         }
         // The annotator `None` constant is `Void`-typed (`concretetype =

--- a/majit/majit-translate/src/translator/rtyper/mod.rs
+++ b/majit/majit-translate/src/translator/rtyper/mod.rs
@@ -19,6 +19,8 @@
 //! * `unit_variant_fold` pre-folds Rust unit-variant constructors into
 //!   prebuilt PBC-like constants, matching the effect of upstream
 //!   frozen-PBC/instance-repr lowering before `jtransform`.
+//! * `str_const_fold` resolves synthetic string-literal calls to the
+//!   prebuilt-string constant shape produced by `StringRepr.convert_const`.
 //!
 //! `lltypesystem::ll2ctypes`, `lltypesystem::llarena`, and
 //! `tool::rffi_platform` are intentionally absent; their module roots
@@ -68,5 +70,6 @@ pub mod rtuple;
 pub mod rtyper;
 pub mod rvirtualizable;
 pub mod rweakref;
+pub(crate) mod str_const_fold;
 pub mod tool;
 pub(crate) mod unit_variant_fold;

--- a/majit/majit-translate/src/translator/rtyper/str_const_fold.rs
+++ b/majit/majit-translate/src/translator/rtyper/str_const_fold.rs
@@ -1,0 +1,94 @@
+//! Pre-jtransform fold of synthetic `__str_const` calls.
+//!
+//! `rtyper/rstr.py::StringRepr.convert_const` resolves a host string into a
+//! prebuilt `Ptr(STR)` constant before `codewriter/jtransform` sees the graph.
+//!
+//! Pyre's frontend (`front::mir`) lowers string, char, and byte-string
+//! literals to `OpKind::Call { target: FunctionPath(["__str_const",
+//! payload]), args: [] }`. The companion fold inside
+//! `translator/rtyper/flowspace_adapter.rs::legacy_const_define_hlvalue`
+//! covers graphs that traverse the Match arm of the dual gate, but graphs
+//! registered directly through `register_function_graph` can take the Skip
+//! arm and bypass that fold.
+//!
+//! This pass operates directly on `model::FunctionGraph` before
+//! `Transformer::transform`, so it catches both gate arms. The assembler
+//! performs the lltype materialization, keeping low-level pointers out of
+//! the model graph.
+//!
+//! # Deliberately dormant
+//!
+//! This pass is deliberately not wired into the translation pipeline yet.
+//! Wiring it without the consumer half turns a string constant into a real
+//! traced value that no string-taking consumer can read correctly; this has
+//! been observed as a silent wrong answer in `pickle._dumps`. Before the pass
+//! can be enabled, the JIT must have both a one-word string representation it
+//! can carry and `jit_*` shims that let string-taking helpers be published or
+//! looked inside. RPython strings are `Ptr(STR)`, a single word carrying its
+//! own length, so upstream has no fat-pointer gap here.
+
+use crate::model::{CallTarget, FunctionGraph, OpKind};
+
+/// Rewrite zero-argument `__str_const` calls with valid WTF-8 payloads into
+/// `OpKind::ConstStr`, mirroring `rtyper/rstr.py::StringRepr.convert_const`.
+/// Invalid payloads remain calls because runtime string materialization uses
+/// the same WTF-8 validity requirement.
+///
+/// The payload currently arrives as a JSON string through `Value::as_str` in
+/// `front/mir.rs:18091`, so it is always valid UTF-8 and this guard cannot fire.
+/// The guard stays so that a future byte-carrying representation leaves the
+/// call symbolic and aborts the descent instead of reaching the runtime panic.
+#[allow(dead_code)]
+pub fn fold_str_consts(graph: &mut FunctionGraph) {
+    for block in graph.blocks.iter_mut() {
+        for op in block.operations.iter_mut() {
+            let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            if !args.is_empty()
+                || segments.len() != 2
+                || segments[0] != "__str_const"
+                || rustpython_wtf8::Wtf8::from_bytes(segments[1].as_bytes()).is_none()
+            {
+                continue;
+            }
+            op.kind = OpKind::ConstStr(segments[1].as_bytes().to_vec());
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ValueType;
+
+    fn str_const_call(payload: String) -> OpKind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath {
+                segments: vec!["__str_const".to_string(), payload],
+            },
+            args: vec![],
+            result_ty: ValueType::Ref(None),
+        }
+    }
+
+    #[test]
+    fn folds_valid_wtf8_and_preserves_result_variable() {
+        let mut graph = FunctionGraph::new("valid_str_const");
+        let entry = graph.startblock;
+        let result = graph
+            .push_op_var(entry, str_const_call("hello".to_string()), true)
+            .expect("string constant call must produce a result");
+
+        fold_str_consts(&mut graph);
+
+        let op = &graph.block(entry).operations[0];
+        assert_eq!(op.result.as_ref(), Some(&result));
+        assert_eq!(op.kind, OpKind::ConstStr(b"hello".to_vec()));
+    }
+}

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -872,7 +872,16 @@ The hand audits above enumerated what they were looking at. Measured against the
 tree instead, **66 of the 105 live gates had no entry anywhere in this file** —
 the table was 63% empty, because nothing failed when a new gate skipped it.
 `pyre/pyrex/tests/gate_triage_complete.rs` is now that failure: a `PYRE_*` read
-with no entry here fails `cargo test`. The counts to quote, distinguished:
+with no entry here fails `cargo test`.
+
+⚠ That reader is line-based, and one rule bites anyone adding prose: a line
+whose text contains the past participle of "retire" marks **its first** `PYRE_*`
+token as a closed subject, wherever in the file the line sits — so a sentence
+that names a live gate and that word together silently un-documents the gate,
+and the test then reports it as missing rather than as mis-parsed. Keep the
+word and the name on separate lines.
+
+The counts to quote, distinguished:
 
 | count | value |
 |---|---|
@@ -941,16 +950,25 @@ Polarity below follows this file's rule, with one correction it needed: an
 | PYRE_WALKABORT_OFF | the non-carrier walk-abort leg (`trace.rs walk_abort_leg_enabled`) | kept deliberately: the leg commits irrevocably once the blackhole runs, so it is the one-binary A/B for the bug class it sits in |
 | PYRE_WASM_FULL_TEARDOWN | skipping the ~0.2s wasm engine teardown at exit; setting it restores the drops for leak diagnostics | when teardown stops being the dominant fixed startup tax |
 
-### §6b — VALUE knobs (11): config, not gates
+### §6b — VALUE knobs (12): config, not gates
 
-`PYRE_FBW_MULTIFRAME_DEPTH`, `PYRE_JD1_THRESHOLD`,
+`PYRE_FBW_MULTIFRAME_DEPTH`, `PYRE_FBW_NO_SPECIALIZE`, `PYRE_JD1_THRESHOLD`,
 `PYRE_PCMAP_RECIPE_RESULTCOLOR_AUDIT_PROBE`,
 `PYRE_DTRACE_CONST_FROM`, `PYRE_DTRACE_CONST_TO`,
 `PYRE_TRACE_CALL_DIAG`, `PYRE_TRACE_OPS_DIAG`,
 `PYRE_WASM_FORCE_CA_TERMINAL_DECLINE`, `PYRE_WASM_FUEL`,
 `PYRE_WASM_GUEST_PROFILE`, `PYRE_WASM_MODULE`.
 
-### §6c — Default-OFF diagnostics, censuses and probes (55): keep, cost nothing
+`PYRE_FBW_NO_SPECIALIZE` is the one entry here that changes behaviour rather
+than reporting it: its comma-separated selectors (or the reserved `all`) turn
+off that many of the 56 hand-written trace-time specialization rows, and an
+unset variable suppresses none. It is a measurement instrument — suppressing a
+fold is how the descent wall behind it is made to print — so it retires with
+the folds it selects, not before them.
+`PYRE_FBW_SPEC_CENSUS` in §6c is its read-only half: the per-fold
+consulted/fired tallies.
+
+### §6c — Default-OFF diagnostics, censuses and probes (58): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
@@ -961,7 +979,8 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_DETERMINISM_TRACE`, `PYRE_DTRACE_CONST_BT`,
 `PYRE_DYNASM_EXEC_DIAG`, `PYRE_FBW_CENSUS`, `PYRE_FBW_INLINE_DIAG`,
 `PYRE_FBW_LOOPBODY_SCAN_FULL`, `PYRE_FBW_LOOPBODY_SCAN_LOOP_ONLY`,
-`PYRE_FBW_MF_DIAG`, `PYRE_FBW_STRICT_DIAG`, `PYRE_FIELD_IDENTITY_CENSUS`,
+`PYRE_FBW_MF_DIAG`, `PYRE_FBW_SPEC_CENSUS`, `PYRE_FBW_STRICT_DIAG`,
+`PYRE_FIELD_IDENTITY_CENSUS`,
 `PYRE_FORITER_INFLIGHT_CENSUS`, `PYRE_FOR_ITER_GATE_DIAG`,
 `PYRE_GC_DIAG`, `PYRE_GC_FREELIST_DIAG`, `PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
 `PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LLBC_STRICT`,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4596,6 +4596,7 @@ pub(crate) fn split_builtin_kwargs(args: &[PyObjectRef]) -> (&[PyObjectRef], Opt
 /// iterator-adapter graph: a `take_while` closure inlined per wrapper gives
 /// every `__pyre_wrap_*` shim its own closure type, and merging those
 /// distinct types on one `TakeWhile` graph's input has no common base class.
+#[majit_macros::unroll_safe]
 pub(crate) fn leading_non_null_count(args: &[PyObjectRef]) -> usize {
     let mut count = 0;
     while count < args.len() && !args[count].is_null() {

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5985,12 +5985,28 @@ macro_rules! exc_constructor {
             // `self.args_w = args_w`.  The string form of the exception
             // is derived from `args_w` on demand (`descr_str`), so the
             // constructor only captures the args — no eager message copy.
-            let exc = pyre_object::interp_exceptions::w_exception_new_empty($kind);
-            let args_list = pyre_object::interp_exceptions::w_exception_args_new(args.to_vec());
-            unsafe {
-                pyre_object::interp_exceptions::w_exception_set_args(exc, args_list);
+            let _roots = pyre_object::gc_roots::push_roots();
+            let args_base = pyre_object::gc_roots::shadow_stack_len();
+            for &arg in args {
+                pyre_object::gc_roots::pin_root(arg);
             }
-            Ok(exc)
+            let exc = pyre_object::interp_exceptions::w_exception_new_empty($kind);
+            let exc_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(exc);
+            // The allocation above may collect and move the arguments without
+            // updating the raw slice, so rebuild them from their rooted slots.
+            let mut rooted_args = Vec::with_capacity(args.len());
+            for i in 0..args.len() {
+                rooted_args.push(pyre_object::gc_roots::shadow_stack_get(args_base + i));
+            }
+            let args_list = pyre_object::interp_exceptions::w_exception_args_new(rooted_args);
+            unsafe {
+                pyre_object::interp_exceptions::w_exception_set_args(
+                    pyre_object::gc_roots::shadow_stack_get(exc_slot),
+                    args_list,
+                );
+            }
+            Ok(pyre_object::gc_roots::shadow_stack_get(exc_slot))
         }
     };
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2833,7 +2833,7 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         // keyword is rejected with "takes no keyword arguments".
         crate::gateway::make_module_builtin_function_with_arity_and_sig(
             "abs",
-            builtin_abs,
+            __pyre_wrap_builtin_abs,
             1,
             crate::gateway::Signature::new(vec!["val"], None, None, 0, 1),
         )
@@ -4510,6 +4510,10 @@ pub fn builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         [val] => *val,
         _ => parse_single_required(args, "val", "abs")?,
     };
+    builtin_abs_obj(obj)
+}
+
+fn builtin_abs_obj(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     unsafe {
         if is_bool(obj) {
             return Ok(w_int_new(w_bool_get_value(obj) as i64));
@@ -4556,6 +4560,23 @@ pub fn builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         crate::baseobjspace::object_functionstr_type_name(obj)
     )))
 }
+
+pub fn __pyre_wrap_builtin_abs(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() != 1 {
+        return builtin_abs(args);
+    }
+    let obj = args[0];
+    builtin_abs_obj(obj)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[linkme::distributed_slice(crate::gateway::BUILTIN_WRAPPER_DESCRIPTORS)]
+#[allow(non_upper_case_globals)]
+static __pyre_wrap_builtin_abs_target: crate::gateway::BuiltinWrapperDescriptor =
+    crate::gateway::BuiltinWrapperDescriptor {
+        path: concat!(module_path!(), "::", "__pyre_wrap_builtin_abs"),
+        func: __pyre_wrap_builtin_abs,
+    };
 
 /// Strip the trailing `__pyre_kw__` dict that `call_with_kwargs`
 /// (`call.rs`) appends for builtin callees and return the positional

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -623,6 +623,22 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::shadow_stack_cell",
         pyre_object::gc_roots::shadow_stack_cell as *const (),
     );
+    // The other two thirds of the `push_roots` bracket.  Both take the cell
+    // pointer `shadow_stack_cell` returns, so a descent that gets past the
+    // resolution lands on these next; all three are one-word scalars in and
+    // out, with no fat pointer, `Option`, or sret.
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_roots::shadow_stack_cell_len",
+        "pyre_object::shadow_stack_cell_len",
+        pyre_object::gc_roots::shadow_stack_cell_len as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::gc_roots::shadow_stack_cell_truncate",
+        "pyre_object::shadow_stack_cell_truncate",
+        pyre_object::gc_roots::shadow_stack_cell_truncate as *const (),
+    );
     push_alias_pair(
         &mut entries,
         "pyre_object::typeobject::w_type_set_uses_object_setattr",

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -619,6 +619,12 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     );
     push_alias_pair(
         &mut entries,
+        "pyre_object::gc_roots::shadow_stack_cell",
+        "pyre_object::shadow_stack_cell",
+        pyre_object::gc_roots::shadow_stack_cell as *const (),
+    );
+    push_alias_pair(
+        &mut entries,
         "pyre_object::typeobject::w_type_set_uses_object_setattr",
         "pyre_object::w_type_set_uses_object_setattr",
         crate::opcode_ops::bh_w_type_set_uses_object_setattr as *const (),

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -344,24 +344,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
 
     push_alias_pair(
         &mut entries,
-        "pyre_interpreter::gateway::method_arity_failure",
-        "gateway::method_arity_failure",
-        crate::gateway::method_arity_failure as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::gateway::method_noarg_failure",
-        "gateway::method_noarg_failure",
-        crate::gateway::method_noarg_failure as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::gateway::method_min_arity_failure",
-        "gateway::method_min_arity_failure",
-        crate::gateway::method_min_arity_failure as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
         "pyre_interpreter::builtins::builtin_kwargs_marker_dict",
         "builtins::builtin_kwargs_marker_dict",
         crate::builtins::builtin_kwargs_marker_dict as *const (),
@@ -704,30 +686,16 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::pin_root",
         pyre_object::gc_roots::pin_root as *const (),
     );
-    // `mark_prebuilt_roots_dirty` sets the static `PREBUILT_ROOTS_DIRTY`
-    // bit, `box_str_constant` reads the TLS `STRING_CONSTANT_CACHE`, and
-    // `try_gc_add_root` dispatches the TLS `GC_ADD_ROOT_HOOK` — all through
+    // `mark_prebuilt_roots_dirty` sets the static `PREBUILT_ROOTS_DIRTY` bit,
+    // and `try_gc_add_root` dispatches the TLS `GC_ADD_ROOT_HOOK` — both through
     // state the tracer cannot model (the `pin_root` / `try_gc_write_barrier`
-    // twins).  Their `#[dont_look_inside]` calls bind the Rust `fn` directly
-    // by qualified path (`-> ()` / pointer / `-> bool` signatures are
-    // JIT-representable).
+    // twins). Their `#[dont_look_inside]` calls bind the Rust `fn` directly by
+    // qualified path (`-> ()` / `-> bool` signatures are JIT-representable).
     push_alias_pair(
         &mut entries,
         "pyre_object::gc_roots::mark_prebuilt_roots_dirty",
         "pyre_object::mark_prebuilt_roots_dirty",
         pyre_object::gc_roots::mark_prebuilt_roots_dirty as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::unicodeobject::box_str_constant",
-        "pyre_object::box_str_constant",
-        pyre_object::unicodeobject::box_str_constant as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::unicodeobject::w_str_new",
-        "pyre_object::w_str_new",
-        pyre_object::unicodeobject::w_str_new as *const (),
     );
     push_alias_pair(
         &mut entries,
@@ -792,15 +760,9 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // #346: direct allocation roots residualised via `#[dont_look_inside]`;
     // each binds both the qualified module path and the glob-re-exported root
     // alias. `function_new_impl` lives in this crate so it binds through
-    // `crate::`. The bytes/bytearray constructors allocate a GC-managed storage
-    // box (off-GC storage) that is not phaseA-liftable, so they
+    // `crate::`. The bytearray constructors allocate a GC-managed storage box
+    // (off-GC storage) that is not phaseA-liftable, so they
     // residualise like the `malloc_typed` (`NewWithVtable`) roots below.
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::bytesobject::w_bytes_from_bytes",
-        "pyre_object::w_bytes_from_bytes",
-        pyre_object::bytesobject::w_bytes_from_bytes as *const (),
-    );
     push_alias_pair(
         &mut entries,
         "pyre_object::bytearrayobject::w_bytearray_new",
@@ -846,24 +808,8 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "bool_invert_deprecation_text",
         bool_invert_deprecation_text as *const (),
     );
-    // `lookup_exc_class` is `#[dont_look_inside]` (it hides the
-    // `EXC_CLASS_REGISTRY` static); bind it so the residual call from
-    // `warn::warn_category_w` and the `_warnings` category helpers resolves.
-    let lookup_exc_class: fn(&str) -> Option<pyre_object::PyObjectRef> =
-        crate::builtins::lookup_exc_class;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::builtins::lookup_exc_class",
-        "pyre_interpreter::lookup_exc_class",
-        lookup_exc_class as *const (),
-    );
-    push_fnaddr(
-        &mut entries,
-        "lookup_exc_class",
-        lookup_exc_class as *const (),
-    );
-    // `emit_stdout` / `emit_stderr` are `#[dont_look_inside]` (host stdio
-    // handles); bind them so the residual calls resolve.
+    // `emit_stdout` is `#[dont_look_inside]` (host stdio handle); bind it so
+    // the residual call resolves.
     let emit_stdout: fn(&[u8]) = crate::host_seam::emit_stdout;
     push_alias_pair(
         &mut entries,
@@ -872,14 +818,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         emit_stdout as *const (),
     );
     push_fnaddr(&mut entries, "emit_stdout", emit_stdout as *const ());
-    let emit_stderr: fn(&[u8]) = crate::host_seam::emit_stderr;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::host_seam::emit_stderr",
-        "pyre_interpreter::emit_stderr",
-        emit_stderr as *const (),
-    );
-    push_fnaddr(&mut entries, "emit_stderr", emit_stderr as *const ());
     // `w_set_new` / `w_frozenset_new` are `#[dont_look_inside]` for the same
     // host `IndexMap::new` storage-box reason; bind their zero-arg
     // `fn() -> PyObjectRef` so the residual calls resolve.
@@ -919,12 +857,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dictmultiobject::w_dict_len",
         "pyre_object::w_dict_len",
         pyre_object::dictmultiobject::w_dict_len as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::dictmultiobject::w_dict_setitem_str",
-        "pyre_object::w_dict_setitem_str",
-        pyre_object::dictmultiobject::w_dict_setitem_str as *const (),
     );
     // The wtf8-keyed dict adapters residualise their fallible `Wtf8::as_str`
     // dispatch: `wtf8_key_is_utf8` is the `bool` validity probe, and
@@ -1082,47 +1014,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::memoryview_gather_bytes",
         memoryview_gather_bytes as *const (),
     );
-    // #346: `lookup_in_type_where_uncached` is the scalar-`Option` residual
-    // boundary over the cold uncached MRO walk. With `compute_mro` opaque,
-    // `lookup_where`'s `mro` phi-merges the cached slice against the opaque
-    // `Vec` borrow (`<other> ∪ _ptr`), a union the annotator cannot model, so
-    // this projection carries `#[dont_look_inside]`. No build-time constant, so
-    // bind its `fn` directly by qualified path.
-    let lookup_in_type_where_uncached: unsafe fn(
-        pyre_object::PyObjectRef,
-        &str,
-    ) -> Option<pyre_object::PyObjectRef> = crate::baseobjspace::lookup_in_type_where_uncached;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::baseobjspace::lookup_in_type_where_uncached",
-        "pyre_interpreter::lookup_in_type_where_uncached",
-        lookup_in_type_where_uncached as *const (),
-    );
-    // #346: the WTF-8 twin of the projection above. `lookup_in_type_wtf8_uncached`
-    // maps the tuple-payload `Option<(PyObjectRef, PyObjectRef)>` of the already
-    // opaque `lookup_where_pair_wtf8_uncached` to the value; tracing that `.map`
-    // walls the annotator on the tuple's classdef-less payload, so it is
-    // `#[dont_look_inside]` and residualises to the single-word `Option`.
-    let lookup_in_type_wtf8_uncached: unsafe fn(
-        pyre_object::PyObjectRef,
-        &rustpython_wtf8::Wtf8,
-    ) -> Option<pyre_object::PyObjectRef> = crate::baseobjspace::lookup_in_type_wtf8_uncached;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::baseobjspace::lookup_in_type_wtf8_uncached",
-        "pyre_interpreter::lookup_in_type_wtf8_uncached",
-        lookup_in_type_wtf8_uncached as *const (),
-    );
-    // #346: the getattribute attribute-miss / special-attribute path.  Its cold
-    // `[Option; 2].iter().flatten()` metaclass walks and array indexing are
-    // opaque to the annotator, so it is `#[dont_look_inside]` and residualises
-    // over the blessed `PyResult` carrier; bind its `fn` by qualified path.
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::baseobjspace::object_getattr_miss",
-        "pyre_interpreter::object_getattr_miss",
-        crate::baseobjspace::object_getattr_miss as *const (),
-    );
     // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic, and
     // `longobject::bigint_gc_type_id` /
     // `dictmultiobject::dict_view_iterator_gc_type_id` read the
@@ -1164,9 +1055,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
     // `set_sys_modules_dict` stamps, `sys_modules_registry_get` the
     // `SYS_MODULES` name→module registry those stamps mirror,
     // `set_in_flight_exception` writes the
-    // `IN_FLIGHT_EXCEPTION` thread-local, `lookup_exc_class` reads the
-    // `EXC_CLASS_REGISTRY` `OnceLock`, `check_sys_modules` the process-owned
-    // `SYS_MODULES` registry, `mmap_type` the lazily-installed
+    // `IN_FLIGHT_EXCEPTION` thread-local, `mmap_type` the lazily-installed
     // `mmap` type object, and the two `note_eval_activation_*` twins move the
     // `EVAL_NESTING` thread-local `at_outermost_activation` already reads.
     // None is a build-time constant, so each carries `#[dont_look_inside]`
@@ -1239,21 +1128,14 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::state_ns",
         warnings_state_ns as *const (),
     );
-    // The host-boundary seams beside them: the two fd writers every
-    // diagnostic path funnels through, and the thread-identity read.
+    // The host-boundary seams beside them: the stdout fd writer and the
+    // thread-identity read.
     let emit_stdout: fn(&[u8]) = crate::host_seam::emit_stdout;
     push_alias_pair(
         &mut entries,
         "pyre_interpreter::host_seam::emit_stdout",
         "pyre_interpreter::emit_stdout",
         emit_stdout as *const (),
-    );
-    let emit_stderr: fn(&[u8]) = crate::host_seam::emit_stderr;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::host_seam::emit_stderr",
-        "pyre_interpreter::emit_stderr",
-        emit_stderr as *const (),
     );
     let current_ident: fn() -> i64 = crate::module::thread::current_ident;
     push_alias_pair(
@@ -1269,22 +1151,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::eval::set_in_flight_exception",
         "pyre_interpreter::set_in_flight_exception",
         set_in_flight_exception as *const (),
-    );
-    let lookup_exc_class: fn(&str) -> Option<pyre_object::PyObjectRef> =
-        crate::builtins::lookup_exc_class;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::builtins::lookup_exc_class",
-        "pyre_interpreter::lookup_exc_class",
-        lookup_exc_class as *const (),
-    );
-    let check_sys_modules: fn(&str) -> Option<pyre_object::PyObjectRef> =
-        crate::importing::check_sys_modules;
-    push_alias_pair(
-        &mut entries,
-        "pyre_interpreter::importing::check_sys_modules",
-        "pyre_interpreter::check_sys_modules",
-        check_sys_modules as *const (),
     );
     // `mmap_type` is `#[cfg(unix)]` inside `interp_mmap`, and the `mmap`
     // module itself is gated at `module/mod.rs:80`; the row has to carry
@@ -2044,18 +1910,11 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::hash_str_hooked",
         pyre_object::dict_eq_hook::hash_str_hooked as *const (),
     );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::dict_eq_hook::hash_str_hooked_bytes",
-        "pyre_object::hash_str_hooked_bytes",
-        pyre_object::dict_eq_hook::hash_str_hooked_bytes as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::dictmultiobject::dict_entries_probe_str",
-        "pyre_object::dict_entries_probe_str",
-        pyre_object::dictmultiobject::dict_entries_probe_str as *const (),
-    );
+    /*
+     * Fat-pointer arguments (`&str`, `&[u8]`, `&Wtf8`) are two words, but the
+     * residual-call ABI passes one register per argument slot; publishing these
+     * addresses would pass one word where the callee reads two.
+     */
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::dict_entries_probe_object",
@@ -2132,14 +1991,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dict_entries_insert_object",
         pyre_object::dictmultiobject::dict_entries_insert_object as *const (),
     );
-    // The index-returning twins of the `dict_entries_probe_*` pair, for
-    // `setitem_str`'s borrow-key membership test.
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::dictmultiobject::dict_entries_index_of_str_hashed",
-        "pyre_object::dict_entries_index_of_str_hashed",
-        pyre_object::dictmultiobject::dict_entries_index_of_str_hashed as *const (),
-    );
+    // The index-returning twin of the object-key probe.
     push_alias_pair(
         &mut entries,
         "pyre_object::dictmultiobject::dict_entries_index_of_object",
@@ -2170,19 +2022,6 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::dictmultiobject::w_dict_unicode_key_hash",
         "pyre_object::w_dict_unicode_key_hash",
         w_dict_unicode_key_hash as *const (),
-    );
-    // The module-dict storage's own `String`-keyed probe / store pair.
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::celldict::module_dict_entries_get",
-        "pyre_object::module_dict_entries_get",
-        pyre_object::celldict::module_dict_entries_get as *const (),
-    );
-    push_alias_pair(
-        &mut entries,
-        "pyre_object::celldict::module_dict_entries_insert",
-        "pyre_object::module_dict_entries_insert",
-        pyre_object::celldict::module_dict_entries_insert as *const (),
     );
     // A runtime-mutable global counter, not a build-time constant: bind the
     // read seam by address so the JIT calls it instead of folding whatever

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -478,6 +478,13 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "w_list_new_empty",
         w_list_new_empty as *const (),
     );
+    let w_none: fn() -> pyre_object::PyObjectRef = pyre_object::noneobject::w_none;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::noneobject::w_none",
+        "pyre_object::w_none",
+        w_none as *const (),
+    );
     let w_list_new_object: fn(Vec<pyre_object::PyObjectRef>) -> pyre_object::PyObjectRef =
         pyre_object::listobject::w_list_new_object;
     push_alias_pair(

--- a/pyre/pyre-interpreter/src/module/_io/buffered.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered.rs
@@ -601,7 +601,7 @@ impl W_BufferedReader {
         &mut self,
         #[default(pyre_object::w_none())] w_size: PyObjectRef,
     ) -> Result<PyObjectRef, crate::PyError> {
-        let size = super::iobase_convert_size(Some(w_size))?;
+        let size = super::iobase_convert_size(w_size)?;
         self.read_size(size)
     }
 
@@ -632,7 +632,7 @@ impl W_BufferedReader {
         #[default(pyre_object::w_none())] w_limit: PyObjectRef,
     ) -> Result<PyObjectRef, crate::PyError> {
         self.check_closed("readline of closed file")?;
-        let mut limit = super::iobase_convert_size(Some(w_limit))?;
+        let mut limit = super::iobase_convert_size(w_limit)?;
         let mut have = self.readahead();
         if limit >= 0 {
             have = have.min(limit as usize);

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -723,7 +723,7 @@ impl W_BufferedRandom {
         &mut self,
         #[default(pyre_object::w_none())] w_size: PyObjectRef,
     ) -> Result<PyObjectRef, crate::PyError> {
-        let size = super::iobase_convert_size(Some(w_size))?;
+        let size = super::iobase_convert_size(w_size)?;
         self.read_size(size)
     }
 
@@ -757,7 +757,7 @@ impl W_BufferedRandom {
         #[default(pyre_object::w_none())] w_limit: PyObjectRef,
     ) -> Result<PyObjectRef, crate::PyError> {
         self.check_closed("readline of closed file")?;
-        let mut limit = super::iobase_convert_size(Some(w_limit))?;
+        let mut limit = super::iobase_convert_size(w_limit)?;
         let mut have = self.readahead();
         if limit >= 0 {
             have = have.min(limit as usize);

--- a/pyre/pyre-interpreter/src/module/_io/bytesio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/bytesio.rs
@@ -287,7 +287,7 @@ impl W_BytesIO {
     ) -> Result<PyObjectRef, crate::PyError> {
         // interp_bytesio.py:96-100 plus interp_iobase.py `convert_size`.
         self.check_closed()?;
-        let size = super::iobase_convert_size(Some(w_size))?;
+        let size = super::iobase_convert_size(w_size)?;
         Ok(pyre_object::bytesobject::w_bytes_from_bytes(
             &self.read_bytes(size),
         ))
@@ -307,7 +307,7 @@ impl W_BytesIO {
     ) -> Result<PyObjectRef, crate::PyError> {
         // interp_bytesio.py:105-108 plus interp_iobase.py `convert_size`.
         self.check_closed()?;
-        let limit = super::iobase_convert_size(Some(w_limit))?;
+        let limit = super::iobase_convert_size(w_limit)?;
         Ok(pyre_object::bytesobject::w_bytes_from_bytes(
             &self.readline_bytes(limit),
         ))

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -550,11 +550,13 @@ pub(crate) fn iobase_writelines(args: &[PyObjectRef]) -> crate::PyResult {
     Ok(w_none())
 }
 
-fn iobase_convert_size(value: Option<PyObjectRef>) -> Result<i64, crate::PyError> {
-    match value {
-        None => Ok(-1),
-        Some(value) if unsafe { pyre_object::is_none(value) } => Ok(-1),
-        Some(value) => crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?),
+/// A null value means the argument was not supplied and produces the same
+/// `-1` result as `None`.
+fn iobase_convert_size(value: PyObjectRef) -> Result<i64, crate::PyError> {
+    if value.is_null() || unsafe { pyre_object::is_none(value) } {
+        Ok(-1)
+    } else {
+        crate::baseobjspace::int_w(crate::baseobjspace::space_index(value)?)
     }
 }
 
@@ -571,7 +573,7 @@ fn iobase_readline(args: &[PyObjectRef]) -> crate::PyResult {
             args.len().saturating_sub(1)
         )));
     }
-    let limit = iobase_convert_size(args.get(1).copied())?;
+    let limit = iobase_convert_size(args.get(1).copied().unwrap_or(PY_NULL))?;
     let peek = match crate::baseobjspace::getattr_str(self_obj, "peek") {
         Ok(method) => Some(method),
         Err(error) if error.kind == crate::PyErrorKind::AttributeError => None,
@@ -644,7 +646,7 @@ pub(super) fn iobase_readlines(args: &[PyObjectRef]) -> crate::PyResult {
             args.len().saturating_sub(1)
         )));
     }
-    let hint = iobase_convert_size(args.get(1).copied())?;
+    let hint = iobase_convert_size(args.get(1).copied().unwrap_or(PY_NULL))?;
     let iterator = crate::baseobjspace::iter(self_obj)?;
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();

--- a/pyre/pyre-interpreter/src/module/_io/stringio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/stringio.rs
@@ -303,7 +303,7 @@ impl W_StringIO {
         self.check_closed()?;
         let _roots = pyre_object::gc_roots::push_roots();
         let slot = self.pin_self();
-        let size = super::iobase_convert_size(Some(w_size))?;
+        let size = super::iobase_convert_size(w_size)?;
         let this = Self::from_slot(slot);
         this.check_closed()?;
         if this.pos >= this.len() as i64 {
@@ -330,7 +330,7 @@ impl W_StringIO {
         self.check_closed()?;
         let _roots = pyre_object::gc_roots::push_roots();
         let slot = self.pin_self();
-        let limit = super::iobase_convert_size(Some(w_limit))?;
+        let limit = super::iobase_convert_size(w_limit)?;
         let this = Self::from_slot(slot);
         this.check_closed()?;
         if this.pos >= this.len() as i64 {
@@ -433,7 +433,7 @@ impl W_StringIO {
         let size = if unsafe { pyre_object::is_none(w_size) } {
             current
         } else {
-            super::iobase_convert_size(Some(w_size))?
+            super::iobase_convert_size(w_size)?
         };
         let this = Self::from_slot(slot);
         this.check_closed()?;

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -425,12 +425,15 @@ pub fn classify_callable(callable: PyObjectRef) -> Result<CallableKind, PyError>
                 Ok(CallableKind::User)
             }
         } else {
-            let type_name = crate::typedef::r#type(callable)
-                .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
-                .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
-            Err(PyError::type_error(format!(
-                "'{type_name}' object is not callable"
-            )))
+            let message = if callable.is_null() {
+                "<NULL> object is not callable (interpreter received a null callable)".to_string()
+            } else {
+                let type_name = crate::typedef::r#type(callable)
+                    .map(|tp| unsafe { pyre_object::w_type_get_name(tp.as_ptr()) })
+                    .unwrap_or_else(|| unsafe { (*(*callable).ob_type).name });
+                format!("'{type_name}' object is not callable")
+            };
+            Err(PyError::type_error(message))
         }
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/diag.rs
@@ -218,3 +218,306 @@ pub fn skip_python_trivia_forward(code: &pyre_interpreter::CodeObject, mut py_pc
         }
     }
 }
+
+/// Every hand-written trace-time specialization, its call-site file, and — for
+/// a fold reached only from another fold — the outer fold whose `fired` count
+/// already contains it.
+///
+/// Declared beside the counters so a fold cannot be added to the tree and go
+/// unnamed here.  `site` is `"none"` for a fold with no call site at all.
+///
+/// `store_attr` occupies two rows because its single call site has two firing
+/// outcomes that must not be summed: `Direct` folds the store away, while
+/// `Residual` only replaces the generic setattr residual's descr, arguments and
+/// effect and lets the rewritten call continue through the ordinary record
+/// path.  Both are `Ok(Some(_))`, so a single row would read as fully foldable
+/// when part of it is a descr swap.  The two rows share one call, so they carry
+/// identical `consulted` and `suppressed` counts and only `fired` is split;
+/// `parent` marks the second row as a split of the first so the reader does not
+/// sum them.
+#[rustfmt::skip]
+pub const SPEC_FOLD_ROWS: [(&str, &str, &str); 56] = [
+    // (label, site, parent)
+    ("truth_int",                 "residual_call", "-"),
+    ("truth_bool",                "residual_call", "-"),
+    ("unary_positive_int",        "residual_call", "-"),
+    ("unary_negative_int",        "residual_call", "-"),
+    ("unary_invert_int",          "residual_call", "-"),
+    ("store_subscr",              "residual_call", "-"),
+    ("setslice",                  "residual_call", "-"),
+    ("get_iter",                  "residual_call", "-"),
+    ("for_iter_next",             "residual_call", "-"),
+    ("make_function",             "residual_call", "-"),
+    ("newtuple",                  "residual_call", "-"),
+    ("newtuple_object",           "residual_call", "-"),
+    ("newlist",                   "residual_call", "-"),
+    ("builtin_len",               "residual_call", "-"),
+    ("builtin_type",              "residual_call", "-"),
+    ("builtin_dict_get",          "residual_call", "-"),
+    ("builtin_type_getattr",      "residual_call", "-"),
+    ("builtin_range",             "residual_call", "-"),
+    ("builtin_zip",               "residual_call", "-"),
+    ("builtin_locals",            "residual_call", "-"),
+    ("sys_getframe",              "residual_call", "-"),
+    ("math_sqrt",                 "residual_call", "-"),
+    ("math_log_trig",             "residual_call", "-"),
+    ("math_frexp",                "residual_call", "-"),
+    ("math_ldexp",                "residual_call", "-"),
+    ("math_isqrt",                "residual_call", "-"),
+    ("int_call",                  "residual_call", "-"),
+    ("float_call",                "residual_call", "-"),
+    ("builtin_divmod",            "residual_call", "-"),
+    ("store_attr_direct",         "residual_call", "-"),
+    ("store_attr_residual",       "residual_call", "store_attr_direct"),
+    ("load_attr",                 "residual_call", "-"),
+    ("load_type_name_attr",       "residual_call", "-"),
+    ("load_type_attr",            "residual_call", "-"),
+    ("load_method_attr",          "residual_call", "-"),
+    ("load_classmethod_attr",     "residual_call", "-"),
+    ("load_bound_method_attr",    "residual_call", "-"),
+    ("subscr",                    "residual_call", "-"),
+    ("binary_op_int",             "residual_call", "-"),
+    ("binary_op_long_int",        "residual_call", "-"),
+    ("binary_op_long_int_shift",  "residual_call", "-"),
+    ("binary_op_long_int_div",    "residual_call", "-"),
+    ("binary_op_long_int_pow",    "residual_call", "-"),
+    ("binary_op_long",            "residual_call", "-"),
+    ("truediv_op_long",           "residual_call", "-"),
+    ("binary_op_float",           "residual_call", "-"),
+    ("compare_op_int",            "residual_call", "-"),
+    ("compare_op_long_int",       "residual_call", "-"),
+    ("compare_op_long",           "residual_call", "-"),
+    ("compare_op_float",          "residual_call", "-"),
+    ("unpack",                    "residual_call", "-"),
+    ("subscr_tuple",              "specialize",    "subscr"),
+    ("subscr_specialised_pair",   "specialize",    "subscr"),
+    ("builtin_divmod_long_int",   "specialize",    "builtin_divmod"),
+    ("zip_two_tuple_iters",       "specialize",    "for_iter_next"),
+    ("seqiter_getitem_next",      "none",          "-"),
+];
+
+const SPEC_FOLD_COUNT: usize = SPEC_FOLD_ROWS.len();
+
+static SPEC_CONSULTED: [std::sync::atomic::AtomicU64; SPEC_FOLD_COUNT] = {
+    const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    [Z; SPEC_FOLD_COUNT]
+};
+static SPEC_FIRED: [std::sync::atomic::AtomicU64; SPEC_FOLD_COUNT] = {
+    const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    [Z; SPEC_FOLD_COUNT]
+};
+/// How many times the kill switch skipped the call.  Reported per fold so a
+/// suppression run states what it actually suppressed rather than what it was
+/// asked to suppress.
+static SPEC_SUPPRESSED: [std::sync::atomic::AtomicU64; SPEC_FOLD_COUNT] = {
+    const Z: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    [Z; SPEC_FOLD_COUNT]
+};
+/// A label passed to a gate that `SPEC_FOLD_ROWS` does not carry.  A nonzero
+/// value means a typo at a call site; the summary reports it rather than
+/// silently dropping the row.
+static SPEC_UNKNOWN: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// `PYRE_FBW_SPEC_CENSUS`: per-fold consulted/fired tallies for the
+/// hand-written trace-time specializations.  Off by default; the gated branch
+/// is the only added work on the dispatch path.
+pub(crate) fn fbw_spec_census_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_FBW_SPEC_CENSUS").is_some())
+}
+
+/// Parse `PYRE_FBW_NO_SPECIALIZE` once into table-index bits and unknown
+/// selector tokens.  The reserved `all` token turns off these 56 rows and
+/// nothing else: the `try_walker_fold_*` trio, the 11 `try_walker_inline_*`
+/// descent entry points, and `try_walker_store_subscr_specialization` all stay
+/// live.
+fn spec_suppression() -> &'static (u64, Vec<String>) {
+    static SUPPRESSION: std::sync::OnceLock<(u64, Vec<String>)> = std::sync::OnceLock::new();
+    SUPPRESSION.get_or_init(|| {
+        let mut mask = 0u64;
+        let mut unknown = Vec::new();
+        if let Some(selectors) = std::env::var_os("PYRE_FBW_NO_SPECIALIZE") {
+            for selector in selectors.to_string_lossy().split(',') {
+                let selector = selector.trim();
+                if selector.is_empty() {
+                    continue;
+                }
+                if selector == "all" {
+                    mask = (1u64 << SPEC_FOLD_COUNT) - 1;
+                } else if let Some(idx) = spec_row_index(selector) {
+                    mask |= 1u64 << idx;
+                } else {
+                    unknown.push(selector.to_owned());
+                }
+            }
+        }
+        (mask, unknown)
+    })
+}
+
+fn spec_suppressed_mask() -> u64 {
+    spec_suppression().0
+}
+
+fn spec_suppress_unknown() -> &'static [String] {
+    &spec_suppression().1
+}
+
+/// Either axis armed.  A gate's fast path reads only this, so a default run
+/// pays one cached load and one predictable branch per consult.
+fn spec_instrumented() -> bool {
+    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ON.get_or_init(|| fbw_spec_census_enabled() || spec_suppressed_mask() != 0)
+}
+
+fn spec_row_index(name: &str) -> Option<usize> {
+    SPEC_FOLD_ROWS
+        .iter()
+        .position(|(label, _, _)| *label == name)
+}
+
+/// Gate and observe one hand-written specialization.
+///
+/// When `name` is suppressed the fold is NOT CALLED and the site sees
+/// `Ok(None)` — the decline every one of these folds already produces for a
+/// shape it cannot handle, and the decline path is uniformly the generic
+/// residual.  Otherwise the call runs and its outcome is passed back unchanged,
+/// including `Err`, so `?` at the call site behaves exactly as it did before
+/// the wrap.
+///
+/// `consulted` counts calls that were made — in an `&&` chain that means every
+/// preceding guard held, so `consulted == 0` says the site's guards never held.
+/// `fired` counts `Ok(Some(_))`.  `consulted - fired` covers both `Ok(None)`
+/// declines and `Err` propagations; an `Err` aborts the walk, so it is rare, and
+/// it is counted as consulted and never as fired.
+#[inline]
+pub(crate) fn spec_gate<T, E>(
+    name: &'static str,
+    call: impl FnOnce() -> Result<Option<T>, E>,
+) -> Result<Option<T>, E> {
+    // Neither axis armed: one cached load, one predictable branch, then the
+    // original call.  This is what every default run executes.
+    if !spec_instrumented() {
+        return call();
+    }
+    let Some(idx) = spec_row_index(name) else {
+        SPEC_UNKNOWN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return call();
+    };
+    if spec_suppressed_mask() & (1u64 << idx) != 0 {
+        SPEC_SUPPRESSED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return Ok(None);
+    }
+    let outcome = call();
+    if fbw_spec_census_enabled() {
+        SPEC_CONSULTED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        if matches!(&outcome, Ok(Some(_))) {
+            SPEC_FIRED[idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+    }
+    outcome
+}
+
+/// The STORE_ATTR gate.  One call, two firing outcomes: `Direct` folded the
+/// store away, `Residual` only rewrote the generic setattr residual's descr,
+/// arguments and effect.  Both are `Ok(Some(_))`, so they are recorded on
+/// separate rows; the shared call means `consulted` and `suppressed` land on
+/// both.
+///
+/// The two rows cannot be suppressed independently — naming either one, or
+/// `all`, suppresses the single call.
+#[inline]
+pub(super) fn spec_gate_store_attr<E>(
+    call: impl FnOnce() -> Result<Option<WalkerStoreAttrSpecialization>, E>,
+) -> Result<Option<WalkerStoreAttrSpecialization>, E> {
+    // Neither axis armed: one cached load, one predictable branch, then the
+    // original call.  This is what every default run executes.
+    if !spec_instrumented() {
+        return call();
+    }
+    let (Some(direct_idx), Some(residual_idx)) = (
+        spec_row_index("store_attr_direct"),
+        spec_row_index("store_attr_residual"),
+    ) else {
+        SPEC_UNKNOWN.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return call();
+    };
+    let mask = spec_suppressed_mask();
+    if mask & ((1u64 << direct_idx) | (1u64 << residual_idx)) != 0 {
+        SPEC_SUPPRESSED[direct_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        SPEC_SUPPRESSED[residual_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return Ok(None);
+    }
+    let outcome = call();
+    if fbw_spec_census_enabled() {
+        SPEC_CONSULTED[direct_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        SPEC_CONSULTED[residual_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        match &outcome {
+            Ok(Some(WalkerStoreAttrSpecialization::Direct)) => {
+                SPEC_FIRED[direct_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            Ok(Some(WalkerStoreAttrSpecialization::Residual(..))) => {
+                SPEC_FIRED[residual_idx].fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+            Ok(None) | Err(_) => {}
+        }
+    }
+    outcome
+}
+
+/// One line per fold, sorted heaviest first, INCLUDING every fold with zero
+/// firings — a zero is the answer this census exists to produce, so it is
+/// printed, never omitted.
+///
+/// Deliberately not under the `[jit-stats]` prefix: `check.py`'s
+/// `_jit_stats_snapshot` merges every such line, so this census uses its own
+/// prefix.
+pub fn spec_census_summary() -> String {
+    let ordering = std::sync::atomic::Ordering::Relaxed;
+    let mask = spec_suppressed_mask();
+    let mut rows: Vec<_> = SPEC_FOLD_ROWS
+        .iter()
+        .enumerate()
+        .map(|(idx, &(label, site, parent))| {
+            (
+                label,
+                site,
+                parent,
+                SPEC_CONSULTED[idx].load(ordering),
+                SPEC_FIRED[idx].load(ordering),
+                SPEC_SUPPRESSED[idx].load(ordering),
+            )
+        })
+        .collect();
+    rows.sort_by(|a, b| b.4.cmp(&a.4).then(b.3.cmp(&a.3)).then(a.0.cmp(b.0)));
+
+    let consulted_total: u64 = rows.iter().map(|row| row.3).sum();
+    let fired_total: u64 = rows.iter().map(|row| row.4).sum();
+    let suppressed_total: u64 = rows.iter().map(|row| row.5).sum();
+    let suppressed_names = if mask == 0 {
+        "-".to_owned()
+    } else {
+        SPEC_FOLD_ROWS
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, (label, _, _))| (mask & (1u64 << idx) != 0).then_some(*label))
+            .collect::<Vec<_>>()
+            .join(",")
+    };
+    let suppress_unknown = if spec_suppress_unknown().is_empty() {
+        "-".to_owned()
+    } else {
+        spec_suppress_unknown().join(",")
+    };
+    let mut summary = format!(
+        "[spec-census] folds={} consulted_total={consulted_total} fired_total={fired_total} unknown_labels={} suppressed_total={suppressed_total} suppressed_names={suppressed_names} suppress_unknown={suppress_unknown}\n",
+        rows.len(),
+        SPEC_UNKNOWN.load(ordering),
+    );
+    for (label, site, parent, consulted, fired, suppressed) in rows {
+        summary.push_str(&format!(
+            "[spec-census] fold={label} consulted={consulted} fired={fired} suppressed={suppressed} site={site} parent={parent}\n"
+        ));
+    }
+    summary
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2144,13 +2144,19 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     macro_rules! builtin_inline_decline {
         ($why:expr, $addr:expr) => {
             if fbw_inline_diag_enabled() {
+                let name = if unsafe { pyre_interpreter::is_function(callable) } {
+                    unsafe { pyre_interpreter::function_get_name(callable) }
+                } else {
+                    ""
+                };
                 eprintln!(
-                    "[builtin-inline-decline] pc={} why={} callable={} operand={} fnaddr={:#x}",
+                    "[builtin-inline-decline] pc={} why={} callable={} operand={} fnaddr={:#x} name={}",
                     op.pc,
                     $why,
                     unsafe { pyre_object::type_name_of(callable) },
                     unsafe { pyre_object::type_name_of(callable_operand) },
                     $addr,
+                    name,
                 );
             }
         };
@@ -2455,16 +2461,38 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
         // descent back and let the ordinary residual call run, the same way
         // the orthodox `w_list_append` descent does.  A descent that already
         // applied an effect cannot be rewound this way, so it keeps the abort.
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { .. })
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, symbolic })
             if fbw_store_journal_len() == journal_before
                 && fbw_has_unjournaled_effect() == unjournaled_before =>
         {
+            if fbw_inline_diag_enabled() {
+                eprintln!(
+                    "[subwalk-abort] name={} pc={} abort_pc={} symbolic={:#x} disp=rollback",
+                    unsafe { pyre_interpreter::function_get_name(callable) },
+                    op.pc,
+                    pc,
+                    symbolic as u64,
+                );
+            }
             ctx.trace_ctx.cut_trace(pre_fold_pos);
             ctx.trace_ctx.heap_cache_mut().reset();
             bool_box_truth_reset();
             return Ok(None);
         }
-        Err(error) => return Err(error),
+        Err(error) => {
+            if let DispatchError::OrthodoxSubWalkTraceUnsupported { pc, symbolic } = &error {
+                if fbw_inline_diag_enabled() {
+                    eprintln!(
+                        "[subwalk-abort] name={} pc={} abort_pc={} symbolic={:#x} disp=propagate",
+                        unsafe { pyre_interpreter::function_get_name(callable) },
+                        op.pc,
+                        pc,
+                        *symbolic as u64,
+                    );
+                }
+            }
+            return Err(error);
+        }
     };
     match walk_result {
         DispatchOutcome::SubReturn {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1677,7 +1677,7 @@ pub struct WalkContext<'frame, 'static_a: 'frame, Sym: WalkSym> {
     /// `MIFrame.run_one_step` steps a live frame whose `registers_r` survive
     /// the step.  This mirror is instead reconstructed from source pcs, and
     /// that reconstruction is exactly what an excursion can lose.
-    pub vstack_reorder_saved: Option<(u32, usize, Vec<OpRef>)>,
+    pub vstack_reorder_saved: Option<(u32, usize, Vec<OpRef>, Vec<bool>)>,
     /// The py_pc the walk's floor lookup reports while it is inside an
     /// out-of-line exception LANDING block — the unwind bookkeeping the
     /// codewriter emits per catch site, after the whole body, which then jumps

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2102,7 +2102,7 @@ pub enum DispatchError {
     /// `walker_capture_snapshot_for_last_guard` snapshots.  Surfaced here to
     /// abort the trace gracefully (interpreter fallback) instead of committing
     /// a trace that SIGSEGVs on its first side exit.  Default OFF.
-    OrthodoxSubWalkTraceUnsupported { pc: usize },
+    OrthodoxSubWalkTraceUnsupported { pc: usize, symbolic: i64 },
     /// The LIST_APPEND opcode's void `jit_list_append` residual
     /// (`ListAppendValue`) reached the authoritative full-body walker but the
     /// orthodox `w_list_append` fold declined (the list needs a resize, or the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4895,7 +4895,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_len", || {
+            try_walker_specialize_builtin_len(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5171,14 +5174,18 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // `int_is_true`, eliding the may-force call whose force/exc guards
         // mis-resume the kept short-circuit stack.
         if ei.pyre_helper == majit_ir::PyreHelperKind::Truth {
-            if let Some(truth) = try_walker_specialize_truth_int(ctx, op.pc, r_args[0])? {
+            if let Some(truth) = spec_gate("truth_int", || {
+                try_walker_specialize_truth_int(ctx, op.pc, r_args[0])
+            })? {
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
                 return Ok((DispatchOutcome::Continue, op.next_pc));
             }
             // The boxed bool a residual `COMPARE_OP` leaves behind — the int
             // arm above guards `INT_TYPE` and declines it, so without this the
             // test on every `if a == b:` stays a second may-force call.
-            if let Some(truth) = try_walker_specialize_truth_bool(ctx, op.pc, r_args[0])? {
+            if let Some(truth) = spec_gate("truth_bool", || {
+                try_walker_specialize_truth_bool(ctx, op.pc, r_args[0])
+            })? {
                 write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, truth)?;
                 return Ok((DispatchOutcome::Continue, op.next_pc));
             }
@@ -5195,7 +5202,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryPositive
-        && try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)?.is_some()
+        && spec_gate("unary_positive_int", || {
+            try_walker_specialize_unary_positive_int(ctx, op.pc, r_args[0], dst, dst_bank)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5209,9 +5219,11 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryNegative
-        && try_walker_specialize_unary_negative_int(
-            ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
-        )?
+        && spec_gate("unary_negative_int", || {
+            try_walker_specialize_unary_negative_int(
+                ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
+            )
+        })?
         .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -5225,9 +5237,11 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && r_args.len() == 1
         && ei.pyre_helper == majit_ir::PyreHelperKind::UnaryInvert
-        && try_walker_specialize_unary_invert_int(
-            ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
-        )?
+        && spec_gate("unary_invert_int", || {
+            try_walker_specialize_unary_invert_int(
+                ctx, op.pc, r_args[0], &allboxes, call_descr, dst, dst_bank,
+            )
+        })?
         .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -5243,7 +5257,11 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'v'
         && ei.pyre_helper == majit_ir::PyreHelperKind::StoreSubscr
     {
-        if try_walker_specialize_store_subscr(ctx, op.pc, &r_args)?.is_some() {
+        if spec_gate("store_subscr", || {
+            try_walker_specialize_store_subscr(ctx, op.pc, &r_args)
+        })?
+        .is_some()
+        {
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
         // #171 setslice inline: `target[const_slice] = source` for a
@@ -5252,7 +5270,11 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         // a virtualizable BUILD_LIST source temp is consumed without forcing.
         // Declines to the opaque residual for any shape it cannot reproduce
         // faithfully (SAFE — always byte-correct).
-        if try_walker_specialize_setslice(ctx, op.pc, &r_args)?.is_some() {
+        if spec_gate("setslice", || {
+            try_walker_specialize_setslice(ctx, op.pc, &r_args)
+        })?
+        .is_some()
+        {
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
         if ctx.trace_ctx.is_bridge_trace && fbw_debug_abort_enabled() {
@@ -5267,7 +5289,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // Range GET_ITER: virtualize exact machine-word `range` into the same
     // `W_IntRangeIterator` shape PyPy's inlined `descr_iter` would trace.
     if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::GetIter {
-        if let Some(iter_op) = try_walker_specialize_get_iter(ctx, op.pc, &r_args, dst, dst_bank)? {
+        if let Some(iter_op) = spec_gate("get_iter", || {
+            try_walker_specialize_get_iter(ctx, op.pc, &r_args, dst, dst_bank)
+        })? {
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, iter_op)?;
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
@@ -5284,9 +5308,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     // including NULL for exhaustion, so the codewriter's trailing
     // GuardNonnull remains the only loop-exit guard.
     if ctx.is_authoritative_executor && ei.pyre_helper == majit_ir::PyreHelperKind::ForIterNext {
-        if let Some(item_op) =
-            try_walker_specialize_for_iter_next(ctx, op.pc, &r_args, dst, dst_bank)?
-        {
+        if let Some(item_op) = spec_gate("for_iter_next", || {
+            try_walker_specialize_for_iter_next(ctx, op.pc, &r_args, dst, dst_bank)
+        })? {
             write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, item_op)?;
             return Ok((DispatchOutcome::Continue, op.next_pc));
         }
@@ -5299,7 +5323,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::MakeFunction
-        && try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+        && spec_gate("make_function", || {
+            try_walker_specialize_make_function(ctx, op.pc, &r_args, dst, dst_bank)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5312,7 +5339,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::NewtupleFromArray
-        && try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+        && spec_gate("newtuple", || {
+            try_walker_specialize_newtuple(ctx, op.pc, &r_args, dst, dst_bank)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5326,7 +5356,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::NewtupleFromArray
-        && try_walker_specialize_newtuple_object(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+        && spec_gate("newtuple_object", || {
+            try_walker_specialize_newtuple_object(ctx, op.pc, &r_args, dst, dst_bank)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5343,7 +5376,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::NewlistFromArray
-        && try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)?.is_some()
+        && spec_gate("newlist", || {
+            try_walker_specialize_newlist(ctx, op.pc, &r_args, dst, dst_bank)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5428,7 +5464,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_type(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_type", || {
+            try_walker_specialize_builtin_type(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5439,7 +5478,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_dict_get", || {
+            try_walker_specialize_builtin_dict_get(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5450,7 +5492,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_type_getattr(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_type_getattr", || {
+            try_walker_specialize_builtin_type_getattr(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5462,7 +5507,9 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
     {
-        if let Some(outcome) = try_walker_specialize_builtin_range(ctx, code, op, &r_args, dst)? {
+        if let Some(outcome) = spec_gate("builtin_range", || {
+            try_walker_specialize_builtin_range(ctx, code, op, &r_args, dst)
+        })? {
             return Ok((outcome, op.next_pc));
         }
     }
@@ -5471,7 +5518,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallKw
-        && try_walker_specialize_builtin_zip(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_zip", || {
+            try_walker_specialize_builtin_zip(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5488,7 +5538,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_locals(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_locals", || {
+            try_walker_specialize_builtin_locals(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5504,7 +5557,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_sys_getframe(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("sys_getframe", || {
+            try_walker_specialize_sys_getframe(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5518,49 +5574,70 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("math_sqrt", || {
+            try_walker_specialize_math_sqrt(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("math_log_trig", || {
+            try_walker_specialize_math_log_trig(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("math_frexp", || {
+            try_walker_specialize_math_frexp(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_math_ldexp(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("math_ldexp", || {
+            try_walker_specialize_math_ldexp(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_math_isqrt(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("math_isqrt", || {
+            try_walker_specialize_math_isqrt(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_int_call(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("int_call", || {
+            try_walker_specialize_int_call(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_float_call(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("float_call", || {
+            try_walker_specialize_float_call(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -5574,7 +5651,10 @@ pub(crate) fn dispatch_residual_call_iRd_kind<Sym: WalkSym>(
     if ctx.is_authoritative_executor
         && dst_bank == 'r'
         && ei.pyre_helper == majit_ir::PyreHelperKind::CallFn
-        && try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)?.is_some()
+        && spec_gate("builtin_divmod", || {
+            try_walker_specialize_builtin_divmod(ctx, code, op, &r_args, dst)
+        })?
+        .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));
     }
@@ -6040,15 +6120,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 )? {
                     return Ok(outcome);
                 }
-                if let Some(specialization) = try_walker_specialize_store_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    value_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    original_call_descr.get_extra_info(),
-                )? {
+                if let Some(specialization) = spec_gate_store_attr(|| {
+                    try_walker_specialize_store_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        value_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        original_call_descr.get_extra_info(),
+                    )
+                })? {
                     match specialization {
                         WalkerStoreAttrSpecialization::Residual(
                             specialized_descr,
@@ -6374,15 +6456,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(code_opref),
                 ctx.trace_ctx.box_value(namei_opref),
             ) {
-                if try_walker_specialize_load_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_attr", || {
+                    try_walker_specialize_load_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6390,15 +6474,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // The plain-slot fold wants a mapdict instance and declines a
                 // class; `Cls.__name__` reads the slot the metatype getset
                 // returns instead.
-                if try_walker_specialize_load_type_name_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_type_name_attr", || {
+                    try_walker_specialize_load_type_name_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6421,15 +6507,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 }
                 // A type receiver whose class-MRO value needs no descriptor
                 // binding folds to that value under receiver + version pins.
-                if try_walker_specialize_load_type_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_type_attr", || {
+                    try_walker_specialize_load_type_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6483,15 +6571,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 ctx.trace_ctx.box_value(code_opref),
                 ctx.trace_ctx.box_value(namei_opref),
             ) {
-                if try_walker_specialize_load_method_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_method_attr", || {
+                    try_walker_specialize_load_method_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6501,15 +6591,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // declines (non-instance receiver, non-method descriptor).
                 // Write the classmethod's `__func__` so the paired
                 // `load_method_self` binds the class and the CALL inlines it.
-                if try_walker_specialize_load_classmethod_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_classmethod_attr", || {
+                    try_walker_specialize_load_classmethod_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6519,15 +6611,17 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 // builtin receiver (`lst.append`) leaves `getattr` to build a
                 // `Method`.  Emit that construction instead of the opaque
                 // residual so it virtualizes into the following CALL.
-                if try_walker_specialize_load_bound_method_attr(
-                    ctx,
-                    op.pc,
-                    obj_opref,
-                    w_code_ptr,
-                    namei as usize,
-                    dst,
-                    dst_bank,
-                )?
+                if spec_gate("load_bound_method_attr", || {
+                    try_walker_specialize_load_bound_method_attr(
+                        ctx,
+                        op.pc,
+                        obj_opref,
+                        w_code_ptr,
+                        namei as usize,
+                        dst,
+                        dst_bank,
+                    )
+                })?
                 .is_some()
                 {
                     return Ok((DispatchOutcome::Continue, op.next_pc));
@@ -6637,30 +6731,39 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         }
                         // BINARY_SUBSCR list[int] getitem (int/float storage);
                         // falls through to the generic may-force leg otherwise.
-                        try_walker_specialize_subscr(
-                            ctx, op.pc, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )?
+                        spec_gate("subscr", || {
+                            try_walker_specialize_subscr(
+                                ctx, op.pc, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )
+                        })?
                     } else {
                         // int specialization first; float (incl. mixed int/float)
                         // as a fallback so two-int operands keep int arithmetic.
-                        if let Some(outcome) = try_walker_specialize_binary_op_int(
-                            ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )? {
+                        if let Some(outcome) = spec_gate("binary_op_int", || {
+                            try_walker_specialize_binary_op_int(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )
+                        })? {
                             return Ok((outcome, op.next_pc));
                         }
                         // longobject.py `_make_generic_descr_binop` and
                         // `descr_sub` use the rbigint.int_* family for
                         // mixed Long/Int operands.
-                        let mut specialized = try_walker_specialize_binary_op_long_int(
-                            ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )?;
+                        let mut specialized = spec_gate("binary_op_long_int", || {
+                            try_walker_specialize_binary_op_long_int(
+                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
+                            )
+                        })?;
                         if specialized.is_none() {
                             // `_make_descr_binop` gives shifts with an Int
                             // count their own `_int_lshift` / `_int_rshift`
                             // path before Long/Long.
-                            if let Some(outcome) = try_walker_specialize_binary_op_long_int_shift(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )? {
+                            if let Some(outcome) = spec_gate("binary_op_long_int_shift", || {
+                                try_walker_specialize_binary_op_long_int_shift(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })? {
                                 return Ok((outcome, op.next_pc));
                             }
                         }
@@ -6669,9 +6772,12 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // an Int divisor keeps its machine word instead of
                             // being widened to a bigint, and `_int_mod`'s
                             // result is a machine int rather than a long.
-                            if let Some(outcome) = try_walker_specialize_binary_op_long_int_div(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )? {
+                            if let Some(outcome) = spec_gate("binary_op_long_int_div", || {
+                                try_walker_specialize_binary_op_long_int_div(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })? {
                                 return Ok((outcome, op.next_pc));
                             }
                         }
@@ -6679,29 +6785,41 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                             // `descr_pow` keeps a `W_IntObject` exponent
                             // unwrapped and calls `rbigint.int_pow`; only a
                             // long exponent reaches `rbigint.pow`.
-                            specialized = try_walker_specialize_binary_op_long_int_pow(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )?;
+                            specialized = spec_gate("binary_op_long_int_pow", || {
+                                try_walker_specialize_binary_op_long_int_pow(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })?;
                         }
                         if specialized.is_none() {
                             // W_LongObject operands take the long fast path
                             // before float so bigint arithmetic retains its
                             // payload representation.
-                            specialized = try_walker_specialize_binary_op_long(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )?;
+                            specialized = spec_gate("binary_op_long", || {
+                                try_walker_specialize_binary_op_long(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })?;
                         }
                         if specialized.is_none() {
                             // Two-long true-divide → float fast path
                             // (CallPureF + wrapfloat).
-                            specialized = try_walker_specialize_truediv_op_long(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )?;
+                            specialized = spec_gate("truediv_op_long", || {
+                                try_walker_specialize_truediv_op_long(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })?;
                         }
                         if specialized.is_none() {
-                            if let Some(outcome) = try_walker_specialize_binary_op_float(
-                                ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )? {
+                            if let Some(outcome) = spec_gate("binary_op_float", || {
+                                try_walker_specialize_binary_op_float(
+                                    ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                    dst_bank,
+                                )
+                            })? {
                                 return Ok((outcome, op.next_pc));
                             }
                         }
@@ -6740,22 +6858,31 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                 } else {
                     // int compare first; then long (two-bigint operands keep
                     // bigint comparison); float (incl. mixed int/float) last.
-                    match try_walker_specialize_compare_op_int(
-                        ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                    )? {
-                        Some(()) => Some(()),
-                        None => match try_walker_specialize_compare_op_long_int(
+                    match spec_gate("compare_op_int", || {
+                        try_walker_specialize_compare_op_int(
                             ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                        )? {
-                            Some(()) => Some(()),
-                            None => match try_walker_specialize_compare_op_long(
+                        )
+                    })? {
+                        Some(()) => Some(()),
+                        None => match spec_gate("compare_op_long_int", || {
+                            try_walker_specialize_compare_op_long_int(
                                 ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst, dst_bank,
-                            )? {
-                                Some(()) => Some(()),
-                                None => try_walker_specialize_compare_op_float(
+                            )
+                        })? {
+                            Some(()) => Some(()),
+                            None => match spec_gate("compare_op_long", || {
+                                try_walker_specialize_compare_op_long(
                                     ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
                                     dst_bank,
-                                )?,
+                                )
+                            })? {
+                                Some(()) => Some(()),
+                                None => spec_gate("compare_op_float", || {
+                                    try_walker_specialize_compare_op_float(
+                                        ctx, op.pc, op_tag, &r_args, &allboxes, call_descr, dst,
+                                        dst_bank,
+                                    )
+                                })?,
                             },
                         },
                     }
@@ -6788,17 +6915,19 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
     if matches!(
         ei.pyre_helper,
         majit_ir::PyreHelperKind::UnpackSequence | majit_ir::PyreHelperKind::UnpackItem
-    ) && try_walker_specialize_unpack(
-        ctx,
-        op.pc,
-        ei.pyre_helper,
-        &i_args,
-        &r_args,
-        &allboxes,
-        call_descr,
-        dst,
-        dst_bank,
-    )?
+    ) && spec_gate("unpack", || {
+        try_walker_specialize_unpack(
+            ctx,
+            op.pc,
+            ei.pyre_helper,
+            &i_args,
+            &r_args,
+            &allboxes,
+            call_descr,
+            dst,
+            dst_bank,
+        )
+    })?
     .is_some()
     {
         return Ok((DispatchOutcome::Continue, op.next_pc));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -2402,7 +2402,10 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
         && let Some(majit_ir::Value::Int(addr)) = ctx.trace_ctx.box_value(allboxes[0])
         && majit_translate::codewriter::call::is_symbolic_fnaddr(addr)
     {
-        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op_pc });
+        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported {
+            pc: op_pc,
+            symbolic: addr,
+        });
     }
     // Authoritative-executor gate: fire ONLY when the walk is the sole
     // concrete-execution leg (the production full-body walk and its

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -9897,7 +9897,7 @@ pub(crate) fn try_walker_orthodox_list_append<Sym: WalkSym>(
     );
     match commit_result {
         Ok(()) => {}
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LIST-APPEND-SUBWALK pc={pc}");
             }
@@ -10459,7 +10459,7 @@ pub(crate) fn try_walker_orthodox_list_pop<Sym: WalkSym>(
         ctx, op, sym, &sub_body, self_ref, inner_self, len_before, raw_item, dst,
     ) {
         Ok(()) => Ok(Some(())),
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LIST-POP-SUBWALK pc={pc}");
             }
@@ -10768,7 +10768,7 @@ pub(crate) fn try_walker_orthodox_list_append_opcode<Sym: WalkSym>(
     );
     match commit_result {
         Ok(()) => {}
-        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc }) => {
+        Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, .. }) => {
             if fbw_debug_abort_enabled() {
                 eprintln!("[decline-why] LIST-APPEND-SUBWALK pc={pc}");
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -10701,7 +10701,14 @@ pub(crate) fn orthodox_list_pop_commit<Sym: WalkSym>(
     if unsafe { pyre_object::w_list_len(inner_self) } == len_before
         && subwalk_guard_follows_store(ctx.trace_ctx, walk_start)
     {
-        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc: op.pc });
+        // This decline is an ordering verdict on the receiver, not a descent
+        // that reached an unlowered helper, so there is no symbolic address to
+        // carry.  Zero is unambiguous: a real symbolic hash always carries the
+        // `SYMBOLIC_FNADDR_BASE` tag.
+        return Err(DispatchError::OrthodoxSubWalkTraceUnsupported {
+            pc: op.pc,
+            symbolic: 0,
+        });
     }
     write_residual_call_result_to_dst(ctx, op.pc, dst, 'r', result)?;
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6090,9 +6090,11 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
             )
     };
     if tuple_canonical {
-        return try_walker_specialize_subscr_tuple(
-            ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
-        );
+        return spec_gate("subscr_tuple", || {
+            try_walker_specialize_subscr_tuple(
+                ctx, op_pc, list_op, key_op, list_obj, key_obj, allboxes, call_descr, dst, dst_bank,
+            )
+        });
     }
 
     // The arity-2 specialisations reach the same `getitem`, but their items
@@ -6102,10 +6104,12 @@ pub(crate) fn try_walker_specialize_subscr<Sym: WalkSym>(
     // `ob_type`, so a tuple subclass (which keeps `&TUPLE_TYPE`) can never
     // pass the class guard below.
     if let Some(pair_kind) = specialised_pair_kind(unsafe { (*list_obj).ob_type }) {
-        return try_walker_specialize_subscr_specialised_pair(
-            ctx, op_pc, list_op, key_op, list_obj, key_obj, pair_kind, allboxes, call_descr, dst,
-            dst_bank,
-        );
+        return spec_gate("subscr_specialised_pair", || {
+            try_walker_specialize_subscr_specialised_pair(
+                ctx, op_pc, list_op, key_op, list_obj, key_obj, pair_kind, allboxes, call_descr,
+                dst, dst_bank,
+            )
+        });
     }
 
     // The `dict.lookup` gate.  Both `w_class` checks are load-bearing: a dict
@@ -9490,15 +9494,17 @@ pub(crate) fn try_walker_specialize_builtin_divmod<Sym: WalkSym>(
     if !is_exact_int(lhs_obj) || !is_exact_int(rhs_obj) {
         // `_make_descr_binop(_divmod, _int_divmod)` (longobject.py:459) keeps a
         // dedicated long/int arm; every other operand shape stays generic.
-        return try_walker_specialize_builtin_divmod_long_int(
-            ctx,
-            op,
-            r_args,
-            dst,
-            concrete_callable,
-            lhs_obj,
-            rhs_obj,
-        );
+        return spec_gate("builtin_divmod_long_int", || {
+            try_walker_specialize_builtin_divmod_long_int(
+                ctx,
+                op,
+                r_args,
+                dst,
+                concrete_callable,
+                lhs_obj,
+                rhs_obj,
+            )
+        });
     }
     let (la, rb) = unsafe {
         (
@@ -12717,7 +12723,9 @@ pub(crate) fn try_walker_specialize_for_iter_next<Sym: WalkSym>(
         return Ok(None);
     };
     if unsafe { pyre_object::functional::is_zip(iter_obj) } {
-        return try_walker_specialize_zip_two_tuple_iters(ctx, op_pc, iter_op, iter_obj);
+        return spec_gate("zip_two_tuple_iters", || {
+            try_walker_specialize_zip_two_tuple_iters(ctx, op_pc, iter_op, iter_obj)
+        });
     }
     let (concrete_current, concrete_remaining, concrete_step) = unsafe {
         if !pyre_object::functional::is_range_iter(iter_obj) {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -151,12 +151,20 @@ fn signature_bound_wrapper_reads_argument_slice_with_distinct_item_descr() {
         .expect("wrapper first op");
     // `getrandbits` registers with a `Signature`, so the call path resolves
     // keywords into positional PY_NULL-padded slots before the wrapper runs.
-    // There is no `split_builtin_kwargs(args)` peel at the entry, so the
-    // wrapper does not open with the splitter's `inline_call_*`; it reads its
-    // argument array directly.
-    assert!(
-        !first.opname.starts_with("inline_call_"),
-        "signature-bound wrapper does not open with a keyword-split call, got {}",
+    // The entry counts the leading non-null slots of the wrapper's own
+    // argument array; it does not peel a `split_builtin_kwargs(args)` result
+    // and read that instead.
+    //
+    // Spelled as the entry callee rather than as "op 0 is not an
+    // `inline_call_*`": no `__pyre_wrap_*` jitcode inline-calls the splitter
+    // anywhere, so the negative form holds of every wrapper and separates
+    // nothing, while the opcode form of op 0 only tracks which helpers the
+    // codewriter is currently allowed to descend into.
+    assert_eq!(
+        inline_call_callee_name(&wrapper.code, &first),
+        Some("leading_non_null_count"),
+        "signature-bound wrapper opens by counting its leading non-null \
+         argument slots, got {}",
         first.key
     );
 
@@ -199,6 +207,27 @@ fn signature_bound_wrapper_reads_argument_slice_with_distinct_item_descr() {
 fn item_pool_descr_index(code: &[u8], at: usize) -> u32 {
     let pool_index = code[at] as usize | ((code[at + 1] as usize) << 8);
     crate::jitcode_runtime::all_descr_refs()[pool_index].index()
+}
+
+/// Name of the jitcode an `inline_call_*` enters, `None` for any other op.
+/// Every `inline_call_*` key opens with its `d` operand, so the descr-pool
+/// index is the two bytes after the opcode.
+fn inline_call_callee_name(
+    code: &[u8],
+    op: &crate::jitcode_runtime::DecodedOp,
+) -> Option<&'static str> {
+    if !op.opname.starts_with("inline_call_") {
+        return None;
+    }
+    let pool_index = code[op.pc + 1] as usize | ((code[op.pc + 2] as usize) << 8);
+    match crate::jitcode_runtime::all_descrs().get(pool_index)? {
+        majit_translate::codewriter::jitcode::BhDescr::JitCode { jitcode_index, .. } => {
+            crate::jitcode_runtime::all_jitcodes()
+                .get(*jitcode_index)
+                .map(|jitcode| jitcode.name.as_str())
+        }
+        _ => None,
+    }
 }
 
 #[test]

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -876,6 +876,16 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
                     ctx.vstack_boxes.resize(stack_slot + 1, OpRef::NONE);
                 }
                 ctx.vstack_boxes[stack_slot] = value;
+                // Mark the slot as execution-derived while an out-of-order
+                // region is armed, so the boundary restore does not put its
+                // pc-derived snapshot back over it.  Outside a region the
+                // mask does not exist and this costs one `Option` test.
+                if let Some((_, _, _, mask)) = ctx.vstack_reorder_saved.as_mut() {
+                    if mask.len() <= stack_slot {
+                        mask.resize(stack_slot + 1, false);
+                    }
+                    mask[stack_slot] = true;
+                }
             }
             ctx.vstack_last_ref = value;
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -445,8 +445,12 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     }
     if !cfg_successor && ctx.vstack_reorder_ceiling == u32::MAX {
         ctx.vstack_reorder_ceiling = (new_pypc as usize).max(prev_pypc) as u32;
-        ctx.vstack_reorder_saved =
-            Some((prev_pypc as u32, ctx.vstack_depth, ctx.vstack_boxes.clone()));
+        ctx.vstack_reorder_saved = Some((
+            prev_pypc as u32,
+            ctx.vstack_depth,
+            ctx.vstack_boxes.clone(),
+            Vec::new(),
+        ));
     }
     let in_reorder_region = ctx.vstack_reorder_ceiling != u32::MAX;
     let (fallthrough_depth, branch_depth) =
@@ -502,15 +506,52 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     // and nothing here to mirror.
     let returned_to_arm_point = matches!(
         &ctx.vstack_reorder_saved,
-        Some((pc, depth, _)) if *pc == new_pypc && *depth == new_depth
+        Some((pc, depth, _, _)) if *pc == new_pypc && *depth == new_depth
     );
     let restored = in_reorder_region && returned_to_arm_point;
     if restored {
-        let (_, _, boxes) = ctx
+        let (_, _, saved, mask) = ctx
             .vstack_reorder_saved
             .take()
             .expect("checked by returned_to_arm_point");
-        ctx.vstack_boxes = boxes;
+        // `vstack_boxes` has two producers: the executed
+        // `setarrayitem_vable_r` store, and this pc-derived reconstruction.
+        // `_opimpl_setarrayitem_vable` (`pyjitpl.py:1245`) is the only writer
+        // of `virtualizable_boxes` upstream and takes its index from the
+        // descr, never from a pc, so no precedence rule was ever needed there.
+        // Here one is: a slot the walk actually executed a store into is
+        // authoritative, and the snapshot — taken at a boundary that can be
+        // reported mid-opcode, so it can hold a state no opcode ever left
+        // behind — must not overwrite it.  Same-pc-and-same-depth cannot tell
+        // the two apart: `obj.m()` with the method-load fold suppressed saves
+        // `[NULL, method]` mid-`LOAD_ATTR` and returns to the same coordinate
+        // once the stores have produced `[method, NULL]`, so restoring the
+        // snapshot wholesale hands `CALL` a null callable.
+        //
+        // With no executed store in the window the mask is empty and the
+        // restore is unchanged, which keeps the slots it legitimately
+        // recovers: `ShadowReseed` clears the mirror at the arming boundary
+        // and the shadow-backed hole-fill declines any slot the virtualizable
+        // does not carry, and those holes are exactly what the snapshot
+        // restores.
+        if mask.iter().all(|&w| !w) {
+            ctx.vstack_boxes = saved;
+        } else {
+            // Merge per slot rather than keeping either side whole: one window
+            // can hold both an executed store and a slot the reseed dropped.
+            let cur = std::mem::replace(&mut ctx.vstack_boxes, saved);
+            if ctx.vstack_boxes.len() < new_depth {
+                ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
+            }
+            for s in 0..new_depth {
+                if mask.get(s).copied().unwrap_or(false)
+                    && let Some(&v) = cur.get(s)
+                {
+                    ctx.vstack_boxes[s] = v;
+                }
+            }
+            ctx.vstack_boxes.truncate(new_depth);
+        }
         ctx.vstack_reorder_ceiling = u32::MAX;
     }
 

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -98,6 +98,10 @@ pub fn fbw_diag_counter(i: usize) -> u64 {
     pyre_jit_trace::trace::fbw_diag::get(i)
 }
 
+pub fn spec_census_summary() -> String {
+    pyre_jit_trace::jitcode_dispatch::spec_census_summary()
+}
+
 /// The `PYPY_GC_*` variables the collector sizes itself from, and the setter
 /// for an embedder whose platform hands the process no environment to read them
 /// out of. Re-exported so such a host reaches them through the crate it already

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -1847,14 +1847,16 @@ fn expand_pyre_methods(
                     MethodKind::Getter(..) | MethodKind::Setter(..) | MethodKind::Deleter(..) => 1,
                     _ => 0,
                 };
-                let from_obj_call = if recv.mutability.is_some() {
-                    quote! { <#self_ty>::from_obj(args[#self_idx]) }
+                let bind_self = if recv.mutability.is_some() {
+                    quote! { s }
                 } else {
                     // `from_obj` returns `Option<&mut Self>` even for
                     // `&self` callers — reborrow as `&Self` so the
                     // method's signature matches without a separate
-                    // `from_obj_ref` API.
-                    quote! { <#self_ty>::from_obj(args[#self_idx]).map(|m| &*m) }
+                    // `from_obj_ref` API. Bind the reborrow in the `Some`
+                    // arm: routing it through `Option::map` would add a
+                    // closure aggregate and `call_once` to every wrapper.
+                    quote! { &*s }
                 };
                 let needed = self_idx + 1;
                 let preamble = quote! {
@@ -1865,8 +1867,8 @@ fn expand_pyre_methods(
                             ),
                         );
                     }
-                    let __pyre_self = match #from_obj_call {
-                        ::std::option::Option::Some(s) => s,
+                    let __pyre_self = match <#self_ty>::from_obj(args[#self_idx]) {
+                        ::std::option::Option::Some(s) => #bind_self,
                         ::std::option::Option::None => {
                             return ::std::result::Result::Err(
                                 crate::PyError::type_error(

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -71,7 +71,7 @@ const DEFAULT_ROOT_STACK_DEPTH: usize = 163840;
 /// any/all rooting probes with a pure-integer control at exactly `1.0000`.
 /// The buffer is raw-allocated once instead, as `_prepare_unused_stack` does
 /// (`shadowstack.py:344-349`), and released by [`RootStackOwner`].
-struct RootStack {
+pub struct RootStack {
     base: Cell<*mut PyObjectRef>,
     top: Cell<*mut PyObjectRef>,
     limit: Cell<*mut PyObjectRef>,
@@ -596,7 +596,7 @@ pub fn shadow_stack_len() -> usize {
 /// of tracing into it (`@dont_look_inside`, `rlib/jit.py:139`), the
 /// `shadow_stack_len` twin.
 #[majit_macros::dont_look_inside]
-fn shadow_stack_cell() -> *const RootStack {
+pub fn shadow_stack_cell() -> *const RootStack {
     with_shadow_stack(|stack| stack as *const RootStack)
 }
 

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -601,14 +601,14 @@ pub fn shadow_stack_cell() -> *const RootStack {
 }
 
 #[majit_macros::dont_look_inside]
-fn shadow_stack_cell_len(cell: *const RootStack) -> usize {
+pub fn shadow_stack_cell_len(cell: *const RootStack) -> usize {
     // SAFETY: `cell` is this thread's root-stack cell, and `_not_send` keeps
     // the bracket on the thread that resolved it.
     unsafe { (*cell).len() }
 }
 
 #[majit_macros::dont_look_inside]
-fn shadow_stack_cell_truncate(cell: *const RootStack, len: usize) {
+pub fn shadow_stack_cell_truncate(cell: *const RootStack, len: usize) {
     // SAFETY: `cell` is this thread's root-stack cell, and `_not_send` keeps
     // the bracket on the thread that resolved it.
     unsafe { (*cell).truncate(len) };

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -769,6 +769,7 @@ fn maybe_print_jit_stats() {
     }
     maybe_print_mc_diag();
     maybe_print_gc_diag();
+    maybe_print_spec_census();
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }
@@ -904,6 +905,17 @@ fn maybe_print_gc_diag() {
         "[jit-gc-diag] minor={minor} major={major} heap_bytes={heap_bytes} \
          nursery_bytes={nursery_bytes}"
     );
+}
+
+/// Deliberately not under the `[jit-stats]` prefix, following
+/// [`maybe_print_mc_diag`] and [`maybe_print_gc_diag`]: `check.py`'s
+/// `_jit_stats_snapshot` merges every such line, so the specialization census
+/// uses its own prefix.
+fn maybe_print_spec_census() {
+    if std::env::var_os("PYRE_FBW_SPEC_CENSUS").is_none() {
+        return;
+    }
+    eprint!("{}", pyre_jit::spec_census_summary());
 }
 
 fn maybe_print_mc_diag() {


### PR DESCRIPTION
Nineteen commits on the walker-descent line: diagnostics that made the
remaining blockers measurable, the fnaddr-table corrections that came out of
that, and two crash fixes the new instrumentation exposed.

## The two crashes

Both were found by suppressing a hand-written trace fold, which routes the case
to the generic residual. A crash there is not the suppression's bug — it is a
pre-existing unsoundness the fold was hiding.

**`interpreter: root the args and the exception in exc_constructor!`** — the
macro-generated public exception constructors held two live values across two
allocations with no shadow-stack roots. `args` is the caller's raw slice and
`args.to_vec()` ran *after* `w_exception_new_empty`; a collection there
relocates the young arguments and updates the caller's rooted slots but not the
slice, so the copy carried pre-move addresses into the fresh args list. That
produces a capacity-1 items block whose `items[0]` points at a forwarded
object, which the collector later reads as a header. `exc` was separately
unrooted across the arg-list build — a distinct hazard, since `exc` is
non-moving oldgen and can be swept rather than moved. `w_exception_new` and
`w_exception_new_wtf8` already root the value they hold; the macro did not.

Measured with both binaries built at the same base and differing only by this
file: `PYRE_FBW_NO_SPECIALIZE=binary_op_int` on
`pyre/bench/synth/subscr_user_getitem_inline.py` gives **20/20 SIGABRT before,
0/20 after**, and the control's panic names the object the diagnosis pointed at
(`holder_type_id=9` = `ItemsBlock`, `holder_offset=8` = `items[0]`).

**`interpreter: guard the null callable in classify_callable's TypeError
path`** — the not-callable arm read `(*(*callable).ob_type).name` through
`unwrap_or_else`, dereferencing a null `callable`. `typedef::type` returns
`None` both for a null pointer and for a non-null unregistered type, so the
`None` arm cannot tell them apart. Branching on `is_null()` turns an
empty-stderr segfault into a traceback that names the failing expression. The
operand-window defect behind it is diagnosed but not fixed here.

## Diagnostics

`jit: count and optionally suppress the walker specializations` adds
`PYRE_FBW_SPEC_CENSUS` and `PYRE_FBW_NO_SPECIALIZE=<labels|all>` over the 56
fold rows. Silent when unset. With all folds suppressed the corpus still runs
402/408, so the folds are not load-bearing for the overwhelming majority — but
suppression *raises* the abort count (79 → 152) because a fold blocks the
descent from being attempted rather than replacing it.

`jit: record what each symbolic fnaddr stands for and carry it to the abort`
makes the abort name its blocker instead of a raw hash, which is what turned
the blocker census from hashes into a work list.

## fnaddr table

`jit: stop publishing fat-pointer-argument helpers in the trace fnaddr table` —
a published helper whose argument is a two-word fat pointer is uncallable
through the one-register-per-slot residual ABI; one word is passed and two are
read. The symbolic abort was the only thing preventing those calls, so any
change that widens descent arms them.

The `w_none` / `shadow_stack_cell` / shadow-stack-bracket publications and the
`abs` gateway go the other way, adding addresses that are ABI-clean.

## Not wired

`jit: add a ConstStr op kind and an unwired str_const_fold pass` lands the fold
for synthetic `__str_const` calls with no caller. Wiring it without a one-word
string representation turns a string constant into a traced value no
string-taking consumer can read; that was observed as a silent wrong answer in
`pickle._dumps`. It stays dormant deliberately.

## Verification

408/408 `pyre/bench/synth` fixtures exit 0; executed descent aborts 79
occurrences / 14 builtins, unchanged from the base. The corpus gate was last
run before this branch was rebased onto the current `main`; it is being re-run
at the new base and I will post the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling and preservation of string constants during translation.
  * Added optional JIT specialization census reporting and diagnostics.
  * Expanded diagnostics for unsupported calls and translation failures.
  * Added symbolic function-address reporting for pipeline analysis.

* **Bug Fixes**
  * Improved `abs()` compatibility and error handling.
  * Corrected optional size handling across I/O operations.
  * Fixed zero-sized structure field emission.
  * Improved callable error messages and runtime memory safety.
  * Preserved updated values when restoring JIT execution state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->