### PR TITLE
majit: harden generic tracing and diagnostics

### DIFF
--- a/majit/examples/i64env/src/main.rs
+++ b/majit/examples/i64env/src/main.rs
@@ -244,7 +244,7 @@ mod tests {
 
     /// How many unroll-free fallback compiles `jit_tier_is_alive` currently
     /// sees — see the block at its assertion. `MC_DIAG` slot 73.
-    const EXPECT_UNPEELED: u64 = 1;
+    const EXPECT_UNPEELED: u64 = 0;
 
     /// Like [`probe`], but also reports `LAST_OPS_AFTER`, read *inside* the
     /// lock.
@@ -361,6 +361,22 @@ mod tests {
     fn jit_tier_is_alive() {
         let (got, compiles, ops_after, unpeeled, shape) =
             probe_with_ops("jit_tier_is_alive", &count_program(1000, 1), 3, 3);
+        // `unpeeled` counts loops this run compiled through the unroll-free
+        // fallback: the unrolled compile raised `InvalidLoop`, and the retry
+        // WITHOUT the peel succeeded. The retry succeeding is what makes a
+        // relapse silent — measured on this crate with the `identity_input_ref`
+        // repair present and absent, one variable:
+        //
+        //   INVARIANT:     `compiles`, `closes_a_loop()` and the result read
+        //                  the same in both arms, so not one of them notices.
+        //   DISCRIMINATING: `unpeeled` 0 vs 1, and `ops_after` 9 vs 4.
+        //
+        // So the `ops_after` pin below is the other half of this one: they are
+        // two arms of one defect, not two independent measurements.
+        //
+        // Not a target value in either direction. A rise means a subject lost
+        // its peel and the unroll-free fallback is live on it again; the
+        // response is to find the subject, not to raise the pin.
         assert_eq!(
             unpeeled, EXPECT_UNPEELED,
             "expected {EXPECT_UNPEELED} unroll-free fallback compile(s) out of \
@@ -402,11 +418,14 @@ mod tests {
              file would still pass"
         );
 
+        // 9 is the peeled body: `Label`/`IntAdd`/`IntGt`/`GuardTrue` twice plus
+        // the closing `Jump`. A drop to 4 is the unpeeled fallback body — read
+        // it together with the `unpeeled` pin above, which moves with it.
         assert_eq!(
-            ops_after, 4,
-            "compiled body is {ops_after} ops, not the pinned 4 — 1 is a bare \
-             `Finish()`, i.e. a dispatch that lowered nothing at all, and 9 is \
-             the peeled shape the legacy bare merge point produced"
+            ops_after, 9,
+            "compiled body is {ops_after} ops, not the pinned 9 — 4 is the \
+             unpeeled fallback body and 1 is a bare `Finish()`, i.e. a dispatch \
+             that lowered nothing at all"
         );
         println!(
             "[tier-alive] count_program(1000, 1) = {got}, compiled {compiles} loop(s) of {ops_after} ops, 0 degraded arms"

--- a/majit/examples/tinyframe/src/jit_interp.rs
+++ b/majit/examples/tinyframe/src/jit_interp.rs
@@ -223,7 +223,7 @@ mod tests {
 
     /// How many unroll-free fallback compiles the tier gate currently sees —
     /// see the block at its assertion. `MC_DIAG` slot 73.
-    const EXPECT_UNPEELED: u64 = 1;
+    const EXPECT_UNPEELED: u64 = 0;
 
     /// Run with both counters reset, returning `(result, compiles, ops_after)`.
     ///
@@ -307,6 +307,22 @@ mod tests {
         ",
         );
         let (got, compiles, ops_after, unpeeled, shape) = compile_probe(&code, &[(2, N)]);
+        // `unpeeled` counts loops this run compiled through the unroll-free
+        // fallback: the unrolled compile raised `InvalidLoop`, and the retry
+        // WITHOUT the peel succeeded. The retry succeeding is what makes a
+        // relapse silent — measured on this crate with the `identity_input_ref`
+        // repair present and absent, one variable:
+        //
+        //   INVARIANT:     `compiles`, `closes_a_loop()` and the result read
+        //                  the same in both arms, so not one of them notices.
+        //   DISCRIMINATING: `unpeeled` 0 vs 1, and `ops_after` 9 vs 4.
+        //
+        // So the `ops_after` pin below is the other half of this one: they are
+        // two arms of one defect, not two independent measurements.
+        //
+        // Not a target value in either direction. A rise means a subject lost
+        // its peel and the unroll-free fallback is live on it again; the
+        // response is to find the subject, not to raise the pin.
         assert_eq!(
             unpeeled, EXPECT_UNPEELED,
             "expected {EXPECT_UNPEELED} unroll-free fallback compile(s) out of \
@@ -347,11 +363,14 @@ mod tests {
              the interpreter is answering alone, which every other assertion in \
              this file would still pass"
         );
+        // 9 is the peeled body: `Label`/`IntAdd`/`IntGt`/`GuardTrue` twice plus
+        // the closing `Jump`. A drop to 4 is the unpeeled fallback body — read
+        // it together with the `unpeeled` pin above, which moves with it.
         assert_eq!(
-            ops_after, 4,
-            "compiled loop body is {ops_after} ops, not the pinned 4 — a value \
-             of 1 means the body is a bare `Finish()`, i.e. a dispatch that \
-             lowered nothing at all"
+            ops_after, 9,
+            "compiled loop body is {ops_after} ops, not the pinned 9 — 4 is the \
+             unpeeled fallback body and a value of 1 means the body is a bare \
+             `Finish()`, i.e. a dispatch that lowered nothing at all"
         );
         println!(
             "[tier-alive] count_to({N}) = {got}, compiled {compiles} loop(s) of {ops_after} ops, 0 degraded arms"

--- a/majit/gate-triage.md
+++ b/majit/gate-triage.md
@@ -1,0 +1,386 @@
+# majit environment gate triage
+
+This catalog must contain exactly the live `MAJIT_*` environment gates read by workspace Rust and Python sources. `pyre/pyrex/tests/gate_triage_complete.rs` checks both directions.
+
+Each entry records its reader, purpose, and retirement condition. `UNRECORDED` marks information that must not be guessed.
+
+## Live gates
+
+### `MAJIT_BH_DEBUG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `bh_debug_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_BH_NULL_ARG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/blackhole.rs`
+- Accessor: `bh_null_arg_report()`
+- What it does: `MAJIT_BH_NULL_ARG`: report a null ref argument about to be handed to a residual call, with the jitcode coordinate, before the callee can dereference it.  Some ABIs pass a legitimate null sentinel (e.g. the CallFn `null_or_self` slot), so this reports rather than aborts.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_BRIDGE_DEBUG`
+
+- Read sites: 5 — `majit/majit-macros/src/jit_interp/codegen_state.rs`, `majit/majit-metainterp/src/lib.rs`
+- Accessor: `ref_identity_slots_end()`; also read inline in `setup_bridge_sym()` and `bridge_debug_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_BRIDGE_DIAG`
+
+- Read sites: 2 — `majit/majit-macros/src/jit_interp/codegen_state.rs`, `majit/majit-metainterp/src/resume_box_reader.rs`
+- Accessor: `setup_bridge_sym()`; also read inline in `replay_pending_fields()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_BRIDGE_FUEL_LOG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: read inline in `bridge_fuel_take()`
+- What it does: Prints the sequence number of each bridge compilation that consumes bridge fuel.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_CLOSEDBG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `closedbg_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_CL_GCSTORE_LOG`
+
+- Read sites: 1 — `majit/majit-backend-cranelift/src/compiler.rs`
+- Accessor: read inline in `do_compile()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_COVERAGE_AUDIT`
+
+- Read sites: 1 — `majit/majit-translate/src/codewriter/assembler.rs`
+- Accessor: `assemble_with_callcontrol()`
+- What it does: Lists every SSA variable without a register-allocation color, grouped by graph. This complements the panic-on-first-gap mode.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_COVERAGE_PANIC`
+
+- Read sites: 1 — `majit/majit-translate/src/codewriter/assembler.rs`
+- Accessor: read inline in `assemble_with_callcontrol()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DEBUG_DECLARES`
+
+- Read sites: 1 — `majit/majit-backend-cranelift/src/compiler.rs`
+- Accessor: read inline in `do_compile()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DIAG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `diag_enabled()`
+- What it does: Enables the metainterpreter's diagnostic counters. Bridge-close counters distinguish declined compilation attempts from closes for which compilation was not attempted.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DUMP`
+
+- Read sites: 1 — `majit/majit-backend-dynasm/src/lib.rs`
+- Accessor: `majit_dump_enabled()`
+- What it does: Whether `MAJIT_DUMP` is set, cached at first access.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DUMP_BYTECODE`
+
+- Read sites: 1 — `pyre/pyre-jit/src/eval.rs`
+- Accessor: `dump_bytecode_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DUMP_CLIF`
+
+- Read sites: 2 — `majit/majit-backend-cranelift/src/compiler.rs`
+- Accessor: read inline in `do_compile()`, at both sites
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DUMP_LIVENESS`
+
+- Read sites: 1 — `majit/majit-macros/src/jit_interp/jitcode_lower/liveness.rs`
+- Accessor: `maybe_dump_liveness()`
+- What it does: Print per-marker live sets to stderr when `MAJIT_DUMP_LIVENESS` is set in the proc-macro build environment. `label` is the lowerer scope being dumped (e.g. helper name) so concurrent expansions are distinguishable.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_DUMP_SSAREPR`
+
+- Read sites: 1 — `pyre/pyre-jit/src/jit/assembler.rs`
+- Accessor: `dump_assembled_ssarepr()`
+- What it does: Print the assembled instruction stream, byte position first, for graphs whose name matches `MAJIT_DUMP_SSAREPR`. A blackhole failure reports a raw `(jitcode, position)` pair; without the stream there is no way back from that byte offset to the op that wrote it or to the register operands it reads.  The env lookup is cached because `try_assemble` runs per graph on the tracing path.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_FAILVALS`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `failvals_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_FIELD_MINT_TRACE`
+
+- Read sites: 2 — `majit/majit-ir/src/descr.rs`, `pyre/pyre-jit-trace/build.rs`
+- Accessor: `field_mint_trace_enabled()`; the build script also declares it as a rerun input and bypasses its code-generation cache while enabled
+- What it does: Setting it to `1` prints descriptor-mint disagreements and keeps the analyzer live so those diagnostics cannot be hidden by a restored artifact cache. Unset is inert.
+- Retirement condition: Remove when field and size descriptor identity no longer has fallback or disagreement paths to diagnose.
+
+### `MAJIT_FIELD_POS_UNRESOLVED`
+
+- Read sites: 1 — `majit/majit-ir/src/descr.rs`
+- Accessor: `field_position_unresolved_limit()`
+- What it does: Dumps unresolved field-position rows. A positive integer limits the number of rows; `1` or a non-numeric value dumps the whole table; unset disables the dump.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GC_BH_PROBE`
+
+- Read sites: 1 — `majit/majit-gc/src/lib.rs`
+- Accessor: `bh_probe_enabled()`
+- What it does: Whether the blackhole-object probe is enabled.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GC_DRAIN_CENSUS`
+
+- Read sites: 1 — `majit/majit-gc/src/lib.rs`
+- Accessor: `drain_census_dump_interval()`
+- What it does: Set `MAJIT_GC_DRAIN_CENSUS` to a positive integer to also dump the running summary every that many collections. The end-of-run summary is unreachable for the runs this census is most needed on — a collection storm that has to be killed rather than waited out — so those need the periodic line.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GC_LIFETIME_LOG`
+
+- Read sites: 1 — `majit/majit-gc/src/lib.rs`
+- Accessor: `gc_lifetime_log_enabled()`
+- What it does: `MAJIT_GC_LIFETIME_LOG` — trace remembered-set adds and old-gen frees. Read once.  The gate sits in the write barrier and the old-gen sweep, and `std::env::var_os` takes the environment lock and scans it linearly on every call, so asking per event costs whether or not the variable is set.  Same shape as `majit_metainterp::majit_log_enabled`.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GC_NURSERY_POISON`
+
+- Read sites: 2 — `majit/majit-gc/src/nursery.rs`, `majit/majit-gc/src/oldgen.rs`
+- Accessor: `new()`
+- What it does: **UNRECORDED** — no doc comment describes the gate. Read off the sites, not quoted: the two reads initialise `poison_on_reset` (`nursery.rs`) and `poison_on_alloc` (`oldgen.rs`).
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GC_STRESS`
+
+- Read sites: 1 — `majit/majit-gc/src/collector.rs`
+- Accessor: read inline in `with_config()`, behind `#[cfg(feature = "gc_stress")]`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GUARDLOG`
+
+- Read sites: 2 — `majit/majit-metainterp/src/jitdriver.rs`, `majit/majit-metainterp/src/pyjitpl.rs`
+- Accessor: `guardlog_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_GUARD_CENSUS`
+
+- Read sites: 2 — `majit/majit-metainterp/src/lib.rs`, `pyre/pyrex/src/lib.rs`
+- Accessor: `guard_census_enabled()`; also read inline in `maybe_print_jit_stats()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_HEAPDBG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `heapdbg_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_J2PLAN_LOG`
+
+- Read sites: 2 — `majit/majit-backend-dynasm/src/aarch64/assembler.rs`, `majit/majit-backend-dynasm/src/lib.rs`
+- Accessor: `majit_j2plan_log_enabled()`; also read inline in `_assemble()`
+- What it does: Whether `MAJIT_J2PLAN_LOG` is set, cached at first access.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_LEAF3_PROV`
+
+- Read sites: 1 — `majit/majit-metainterp/src/resume.rs`
+- Accessor: `leaf3_prov_enabled()`
+- What it does: Emits the resume tag, value, and null status of the virtualizable identity slot consumed by `consume_vable_info()`.
+- Retirement condition: Remove after the unseeded-snapshot route into `_number_boxes()` is rejected or proven unreachable.
+
+### `MAJIT_LLBC_EXTRACTION`
+
+- Read sites: 2 — `pyre/pyre-jit-trace/build.rs`
+- Accessor: `main()` — one `cargo::rerun-if-env-changed=` declaration and one `env::var_os` read, on adjacent lines
+- What it does: **UNRECORDED** — no doc comment describes the gate; the one above `main()` describes the build script. Read off the site, not quoted: `=1` calls `emit_llbc_extraction_placeholders()` and returns early, so the extraction does not run.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_LOG`
+
+- Read sites: 19 — `majit/majit-backend-cranelift/src/compiler.rs`, `majit/majit-backend-dynasm/src/lib.rs`, `majit/majit-gc/src/lib.rs`, `majit/majit-gc/src/rewrite.rs`, `majit/majit-ir/src/debug.rs`, `majit/majit-metainterp/src/lib.rs`, `majit/majit-trace/src/logger.rs`
+- Accessor: no single accessor — `majit_log_enabled()` is defined once per crate and several sites read the environment inline; relocate with `rg -w MAJIT_LOG <file>`.
+- What it does: Whether `MAJIT_LOG` is set, cached at first access.  Mirrors PyPy's `PYPYLOG` env-var check (`rpython/rlib/debug.py:31-38`).
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_LOG_JTET`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `log_jtet_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_LOG_OPT`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `log_opt_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_MACRO_DEBUG`
+
+- Read sites: 8 — `majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs`, `majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs`
+- Accessor: `try_inline_dispatch_arm()`; also read inline in `lower_dispatch_chain()`, `lower_return_stmt()` and `lower_stmt_fallback()`
+- What it does: **UNRECORDED** — no doc comment describes the gate. Read off the sites, not quoted: every read guards an `eprintln!` and nothing else. The prose around them documents the lowering decisions being printed, not what the gate is for.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_MAX_BRIDGES`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `bridge_fuel_take()`
+- What it does: Allows the first N bridge compilations, then suppresses further bridges. Fuel is consumed only after the other `should_bridge` conditions pass.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_MINT_INDEX_CENSUS`
+
+- Read sites: 1 — `pyre/pyre-jit-trace/build.rs`
+- Accessor: read inline in `real_main()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_MPTRACE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `mptrace_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_NO_BRIDGE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `no_bridge_enabled()`
+- What it does: `MAJIT_NO_BRIDGE`: suppress bridge recording so every guard failure resumes through the blackhole.  Public because a frontend that owns its own guard-failure entry point has to honour it there too — gating only the jitdriver-internal paths leaves the variable set but inert, which reads as "bridges are off" while they keep recording.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_OPREF_VARIANT_AUDIT`
+
+- Read sites: 1 — `majit/majit-ir/src/opref_audit.rs`
+- Accessor: read inline in `resolve_mode()`
+- What it does: available only in a `jit-audits` build; `=1` reports and `=abort` panics on the first collision of two `OpRef` variants on one `raw()` key. The ordinary build contains neither the state nor its call sites. In an audit build with the environment gate off, each site performs one thread-local read and returns. State and mode are thread-local so two tests in parallel cannot read each other's collisions or silence one another.
+- Retirement condition: Remove when the two `OpRef` namespaces are structurally unable to collide.
+
+### `MAJIT_OPTRACE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `optrace_enabled()`
+- What it does: Per-op trace of `run_to_end`'s dispatch loop (frame depth, pc, raw opcode). Diagnostic for pinpointing the op that faults a hardware-signal crash (SIGBUS/SIGSEGV) which `catch_unwind` cannot capture.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_PCSEQ`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `pcseq_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_PORTAL_INLINE`
+
+- Read sites: 1 — `majit/majit-metainterp/src/pyjitpl/dispatch.rs`
+- Accessor: `portal_inline_experiment_enabled()`
+- What it does: Enables the experimental recursive-portal inline re-entry path. Unset keeps the clean-abort fallback when `portal_jitcode` is absent.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_PROBE_LIVENESS`
+
+- Read sites: 1 — `pyre/pyre-jit/src/call_jit.rs`
+- Accessor: `majit_probe_liveness_enabled()`
+- What it does: Whether `MAJIT_PROBE_LIVENESS` is set, cached at first access.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_REG_WRITE_AUDIT`
+
+- Read sites: 1 — `majit/majit-ir/src/reg_write_audit.rs`
+- Accessor: read inline in `resolve()`, cached per thread by `enabled()`
+- What it does: available only in a `jit-audits` build; records the source location of the latest write to each integer register, so a later read can report its writer. The ordinary build contains neither the state nor its call sites. Diagnostic state is thread-local to keep parallel traces independent.
+- Default polarity: **OFF**; unset, empty, and `0` disable it.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_SMALLIR`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `smallir_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_SPDIAG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/jitdriver.rs`
+- Accessor: `spdiag_enabled()`
+- What it does: Enables stack-position diagnostics on hot back-edge and guard-failure paths. The value is cached to avoid repeated environment reads.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_STALL_WINDOW`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `stall_window()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_STATS`
+
+- Read sites: 3 — `majit/majit-trace/src/logger.rs`, `pyre/pyre-wasm-runner/src/main.rs`, `pyre/pyrex/src/lib.rs`
+- Accessor: `stats_enabled()`; also read inline in `run()` and `maybe_print_jit_stats()`
+- What it does: Whether JIT statistics collection is enabled. Checks MAJIT_STATS=1 or MAJIT_LOG=1.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_STEP_LIMIT`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `step_limit()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_STRICT`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `jit_strict_mode()`
+- What it does: Strict JIT mode: a non-`InvalidLoop` panic during compilation is a bug and must fail loudly rather than silently degrade to the interpreter and mask the bug behind correct output. Enabled in debug builds (`cargo test`) and whenever `MAJIT_STRICT` is set (release benches / CI); off in plain release so production keeps graceful degradation. Cached like `majit_log_enabled`.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_STRUCT_LAYOUT_CENSUS`
+
+- Read sites: 2 — `majit/majit-translate/src/lib.rs`, `pyre/pyre-jit-trace/build.rs`
+- Accessor: `struct_layout_census_enabled()`; the build script also declares it as a rerun input and bypasses its code-generation cache while enabled
+- What it does: Setting it to `1` reports structure IDs that resolve to multiple spellings or conflicting concrete layouts during translation. Unset is inert.
+- Retirement condition: Remove when one structure ID cannot collect conflicting layouts by construction.
+
+### `MAJIT_TLDBG`
+
+- Read sites: 1 — `majit/majit-metainterp/src/lib.rs`
+- Accessor: `tldbg_enabled()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_VERIFY`
+
+- Read sites: 1 — `majit/majit-backend-cranelift/src/compiler.rs`
+- Accessor: `majit_verify_enabled()`
+- What it does: Whether `MAJIT_VERIFY` is set, cached at first access.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.
+
+### `MAJIT_X2_PROBE`
+
+- Read sites: 1 — `majit/majit-backend-cranelift/src/compiler.rs`
+- Accessor: `drop()`
+- What it does: **UNRECORDED** — no doc comment at the read site.
+- Retirement condition: **UNRECORDED** — owed by this gate's owner.

--- a/majit/majit-ir/Cargo.toml
+++ b/majit/majit-ir/Cargo.toml
@@ -7,6 +7,10 @@ repository.workspace = true
 description = "Intermediate representation for majit JIT compiler"
 
 [features]
+# Compile the heavyweight JIT audit state. Production callers also gate every
+# instrumentation site, so leaving this feature off removes both the state and
+# the calls that would reach it.
+jit-audits = []
 # Exposes `forwarding::test_support` cross-crate so downstream test suites
 # (backends / gc / jit-trace) can build bound Operands from a single helper
 # instead of duplicating it. Enabled only from `[dev-dependencies]`, so it

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -12,9 +12,13 @@ pub mod op_descr;
 pub mod op_info;
 pub mod op_type_index;
 pub mod operand;
+#[cfg(any(test, feature = "jit-audits"))]
+pub mod opref_audit;
 pub mod optimize;
 pub mod ptr_info;
 pub mod rawbuffer;
+#[cfg(any(test, feature = "jit-audits"))]
+pub mod reg_write_audit;
 pub mod resoperation;
 pub mod resumecode;
 pub mod resumedata;

--- a/majit/majit-ir/src/opref_audit.rs
+++ b/majit/majit-ir/src/opref_audit.rs
@@ -1,0 +1,470 @@
+//! Debug-gated detector for distinct `OpRef` variants sharing one `raw()` key.
+//!
+//! `OpRef::raw()` omits the enum tag, so values from different input, operation,
+//! or constant namespaces can map to the same integer. A collision matters when
+//! two numbering scopes feed one raw-keyed table; payload changes within the
+//! same variant are valid rewrites and are not collisions.
+//!
+//! Constants are skipped because they have no raw key. Callers must therefore
+//! instrument before any transformation that replaces a register with a
+//! constant. This audit reports contested lookup keys; the bank check in
+//! `translate_trace_iter_opref` separately validates the resolved value.
+//!
+//! Build with `jit-audits` to compile the instrumentation sites. In that
+//! build, `MAJIT_OPREF_VARIANT_AUDIT=1` reports and `=abort` panics on the
+//! first collision; with the environment gate off, `note` is one thread-local
+//! read and a return. Without the Cargo feature, the module and its call sites
+//! are absent.
+//!
+//! State and mode are thread-local because each trace is processed on one
+//! thread and parallel tests must not share diagnostic observations.
+//!
+//! Retires when the two namespaces are made structurally uncollidable: at that
+//! point a collision is unrepresentable rather than merely unobserved, and
+//! this instrument has nothing left to detect.
+
+use crate::resoperation::OpRef;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::mem::{Discriminant, discriminant};
+
+const OFF: u8 = 1;
+const REPORT: u8 = 2;
+const ABORT: u8 = 3;
+
+/// `(label, scope, key)` — one slot of one table.
+type Key = (&'static str, usize, u32);
+
+/// One distinct collision, plus how often it recurred.
+struct Collision {
+    label: &'static str,
+    scope: usize,
+    key: u32,
+    first: OpRef,
+    now: OpRef,
+    occurrences: usize,
+}
+
+#[derive(Default)]
+struct Audit {
+    /// `None` until this thread has read the environment.
+    mode: Option<u8>,
+    /// The OpRef that first claimed each key.
+    ///
+    /// `scope` is caller-supplied and identifies the *table*, not the process:
+    /// two different caches may legitimately assign different variants to the
+    /// same raw, and only a collision *within one table* is a defect. Callers
+    /// pass something stable for the table's lifetime, e.g. `slice.as_ptr()`.
+    seen: HashMap<Key, OpRef>,
+    /// Keyed by slot *and* by the ordered pair of variants, so one slot that
+    /// collides two different ways stays two findings.
+    collisions: HashMap<(Key, Discriminant<OpRef>, Discriminant<OpRef>), Collision>,
+    collision_occurrences: usize,
+    /// Every non-const note this thread accepted while enabled. This separates
+    /// a clean result from an instrumented path that never ran.
+    notes: usize,
+    /// Notes whose key was already claimed and whose OpRef has the SAME
+    /// variant as the stored entry — payload ignored, so a legitimate rewrite
+    /// (`InputArgRef(0)` answered by `InputArgRef(4824)`) counts here, and so
+    /// does re-noting a byte-identical box.
+    ///
+    revisits_same_variant: usize,
+}
+
+thread_local! {
+    static AUDIT: RefCell<Audit> = RefCell::new(Audit::default());
+}
+
+fn resolve_mode() -> u8 {
+    match std::env::var("MAJIT_OPREF_VARIANT_AUDIT") {
+        Ok(v) if v == "abort" => ABORT,
+        Ok(v) if v != "0" && !v.is_empty() => REPORT,
+        _ => OFF,
+    }
+}
+
+/// Whether the audit is collecting on this thread. Callers may use this to
+/// skip computing a scope value; `note` re-checks, so it is an optimization.
+#[inline]
+pub fn enabled() -> bool {
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        *audit.mode.get_or_insert_with(resolve_mode) >= REPORT
+    })
+}
+
+/// Collision *occurrences* on this thread since start or since [`reset`] —
+/// every firing, including repeats of one already reported.
+///
+/// Pair this with [`notes`], because zero also results when the instrumented
+/// path never ran.
+pub fn collisions() -> usize {
+    AUDIT.with(|a| a.borrow().collision_occurrences)
+}
+
+/// Distinct `(slot, variant-pair)` collisions — how many places are affected,
+/// as opposed to how often they fire ([`collisions`]).
+pub fn distinct_collisions() -> usize {
+    AUDIT.with(|a| a.borrow().collisions.len())
+}
+
+/// Notes that landed on an already-claimed key carrying the SAME variant.
+///
+/// See the field's doc for the exact definition. In short: a revisit, payload
+/// ignored — the healthy translation-cache answer and the byte-identical
+/// re-note both count here, and neither is a collision.
+pub fn revisits_same_variant() -> usize {
+    AUDIT.with(|a| a.borrow().revisits_same_variant)
+}
+
+/// Notes accepted on this thread while enabled, collisions included.
+///
+/// This is the reached-ness half of any verdict: `collisions() == 0` means
+/// "no collision" only when `notes() > 0`. Zero here means the instrumented
+/// code did not run — a dead instrument, not a clean one.
+pub fn notes() -> usize {
+    AUDIT.with(|a| a.borrow().notes)
+}
+
+/// Distinct `(label, scope, key)` triples seen on this thread.
+pub fn keys_seen() -> usize {
+    AUDIT.with(|a| a.borrow().seen.len())
+}
+
+/// Forget every key and zero this thread's counters.
+pub fn reset() {
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        audit.seen.clear();
+        audit.collisions.clear();
+        audit.collision_occurrences = 0;
+        audit.notes = 0;
+        audit.revisits_same_variant = 0;
+    });
+}
+
+/// Print this thread's totals and one line per distinct collision.
+///
+/// Also runs from `Audit`'s destructor at thread exit, so a gated run gets a
+/// total without the subject having to call anything. That is best-effort —
+/// a thread-local destructor is not guaranteed to run on the main thread — so
+/// a caller that needs the summary should call this itself rather than assume
+/// teardown produced it.
+pub fn report_summary() {
+    AUDIT.with(|a| print_summary(&a.borrow()));
+}
+
+fn print_summary(audit: &Audit) {
+    if audit.mode.unwrap_or(OFF) < REPORT {
+        return;
+    }
+    eprintln!(
+        "[opref-audit] SUMMARY notes={} keys={} revisits_same_variant={} \
+         distinct_collisions={} collision_occurrences={}",
+        audit.notes,
+        audit.seen.len(),
+        audit.revisits_same_variant,
+        audit.collisions.len(),
+        audit.collision_occurrences,
+    );
+    let mut rows: Vec<&Collision> = audit.collisions.values().collect();
+    rows.sort_by(|l, r| r.occurrences.cmp(&l.occurrences));
+    for row in rows {
+        eprintln!(
+            "[opref-audit]   x{} {}: key={} (scope={:#x}) first {:?}, now {:?}",
+            row.occurrences, row.label, row.key, row.scope, row.first, row.now,
+        );
+    }
+}
+
+impl Drop for Audit {
+    fn drop(&mut self) {
+        print_summary(self);
+    }
+}
+
+/// Force this thread's mode, bypassing the environment, so a test can exercise
+/// the detector regardless of how the run was invoked.
+pub fn set_mode_for_test(on: bool) {
+    AUDIT.with(|a| a.borrow_mut().mode = Some(if on { REPORT } else { OFF }));
+}
+
+/// Record that `opref` was used as a `raw()` key in `label`'s table `scope`.
+///
+/// Fires when an `OpRef` of a different variant already claimed that key in
+/// the same table.
+///
+/// Inline-`Const` variants are skipped: they carry their value inline and have
+/// no `raw()` encoding at all (`raw()` panics on them by design).
+#[inline]
+pub fn note(label: &'static str, scope: usize, opref: OpRef) {
+    if opref.is_none() || opref.is_constant() {
+        return;
+    }
+    note_key(label, scope, opref.raw(), opref);
+}
+
+/// Record that `opref` claims the key `key` in `label`'s table `scope`, where
+/// `key` is supplied rather than taken from `opref.raw()`.
+///
+/// Use this for a lookup and the entry it resolves to: both must be recorded
+/// under the table slot even when their own raw payloads differ. Only the enum
+/// variant is compared.
+#[inline]
+pub fn note_key(label: &'static str, scope: usize, key: u32, opref: OpRef) {
+    if opref.is_none() || opref.is_constant() {
+        return;
+    }
+    let report = AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        if *audit.mode.get_or_insert_with(resolve_mode) < REPORT {
+            return None;
+        }
+        audit.notes += 1;
+        let abort = audit.mode == Some(ABORT);
+        let slot = (label, scope, key);
+        let Some(&first) = audit.seen.get(&slot) else {
+            audit.seen.insert(slot, opref);
+            return None;
+        };
+        if discriminant(&first) == discriminant(&opref) {
+            audit.revisits_same_variant += 1;
+            return None;
+        }
+        audit.collision_occurrences += 1;
+        let occurrences = {
+            let row = audit
+                .collisions
+                .entry((slot, discriminant(&first), discriminant(&opref)))
+                .or_insert(Collision {
+                    label,
+                    scope,
+                    key,
+                    first,
+                    now: opref,
+                    occurrences: 0,
+                });
+            row.occurrences += 1;
+            row.occurrences
+        };
+        // Print once per distinct collision. A hot slot would otherwise emit
+        // one line per firing and bury every other finding in the run.
+        if occurrences > 1 {
+            return None;
+        }
+        Some((
+            first,
+            abort,
+            audit.collisions.len(),
+            audit.collision_occurrences,
+        ))
+    });
+    let Some((first, abort, distinct, total)) = report else {
+        return;
+    };
+    let message = format!(
+        "[opref-audit] {label}: key={key} claimed by two OpRef variants in one table \
+         (scope={scope:#x}): first {first:?}, now {opref:?} \
+         [distinct #{distinct}, occurrences so far {total}]"
+    );
+    eprintln!("{message}");
+    assert!(!abort, "{message}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// POSITIVE CONTROL. Two variants sharing a payload must fire.
+    ///
+    /// Without this the detector's silence is worthless: an assertion that
+    /// only ever sees singletons reads exactly like one that never runs.
+    #[test]
+    fn two_variants_on_one_key_fire() {
+        set_mode_for_test(true);
+        reset();
+        note("t", 0, OpRef::input_arg_int(7));
+        assert_eq!(
+            collisions(),
+            0,
+            "the first claim on a key is never a collision"
+        );
+        note("t", 0, OpRef::int_op(7));
+        assert_eq!(
+            collisions(),
+            1,
+            "InputArgInt(7) and IntOp(7) share raw=7 and must be reported"
+        );
+    }
+
+    /// The collision is between a lookup and the entry it lands on,
+    /// not between two lookups: the query `InputArgInt(0)` reaches slot 0,
+    /// which the recorder filled for `InputArgRef(4824)`. The two carry
+    /// different raws, so noting each under its own `raw()` files them under
+    /// different keys and nothing is compared — the detector reads zero and is
+    /// blind, not clean. Both must be noted under the SLOT.
+    #[test]
+    fn a_lookup_colliding_with_its_stored_entry_fires() {
+        set_mode_for_test(true);
+        reset();
+        let slot = 0;
+        note_key("cache", 0, slot, OpRef::input_arg_int(0));
+        note_key("cache", 0, slot, OpRef::input_arg_ref(4824));
+        assert_eq!(
+            collisions(),
+            1,
+            "the query's bank and the stored entry's bank differ at slot 0"
+        );
+
+        // And the wiring that would have missed it: keying each by its own
+        // raw() puts them in different buckets and reports nothing.
+        reset();
+        note("cache", 0, OpRef::input_arg_int(0));
+        note("cache", 0, OpRef::input_arg_ref(4824));
+        assert_eq!(
+            collisions(),
+            0,
+            "documents the blind wiring — raw 0 and raw 4824 are different keys"
+        );
+    }
+
+    /// A translation-cache rewrite may change the payload while retaining the
+    /// same variant; that is not a namespace collision.
+    #[test]
+    fn a_rewrite_that_keeps_the_variant_is_silent() {
+        set_mode_for_test(true);
+        reset();
+        let slot = 0;
+        note_key("cache", 0, slot, OpRef::input_arg_ref(0));
+        note_key("cache", 0, slot, OpRef::input_arg_ref(4824));
+        assert_eq!(
+            collisions(),
+            0,
+            "same bank, new position is what a translation cache is FOR"
+        );
+        assert_eq!(
+            revisits_same_variant(),
+            1,
+            "and it must be counted, not merely ignored"
+        );
+    }
+
+    /// The counters must partition the notes, so no note can be silently
+    /// dropped into a category nobody reads. Any future early return that
+    /// forgets to classify its note breaks this identity.
+    #[test]
+    fn every_note_lands_in_exactly_one_category() {
+        set_mode_for_test(true);
+        reset();
+        note_key("t", 0, 3, OpRef::input_arg_int(3)); // new key
+        note_key("t", 0, 3, OpRef::input_arg_int(99)); // revisit, same variant
+        note_key("t", 0, 3, OpRef::int_op(3)); // collision
+        note_key("t", 0, 4, OpRef::int_op(4)); // new key
+        assert_eq!(notes(), 4);
+        assert_eq!(
+            keys_seen() + revisits_same_variant() + collisions(),
+            notes(),
+            "first claims + same-variant revisits + collisions must be every note"
+        );
+    }
+
+    /// Dedupe and count are separate facts and the detector owes both: one
+    /// line per distinct collision, and a tally of how hot each one is.
+    #[test]
+    fn a_recurring_collision_is_one_finding_with_many_occurrences() {
+        set_mode_for_test(true);
+        reset();
+        note_key("t", 0, 5, OpRef::input_arg_int(5));
+        for _ in 0..7 {
+            note_key("t", 0, 5, OpRef::int_op(5));
+        }
+        assert_eq!(distinct_collisions(), 1, "one slot, one variant pair");
+        assert_eq!(collisions(), 7, "and the firing rate is not thrown away");
+    }
+
+    /// CONTROL FOR THE LIVENESS COUNTER ITSELF.
+    ///
+    /// `notes()` exists so a reported `collisions() == 0` can be told apart
+    /// from an instrument that never ran. A counter that is itself never
+    /// incremented would reintroduce the same defect one level down, so it is
+    /// asserted to move — and to move on the *silent* path, which is exactly
+    /// the case a zero-collision verdict rests on.
+    #[test]
+    fn notes_counts_every_accepted_note() {
+        set_mode_for_test(true);
+        reset();
+        assert_eq!(notes(), 0, "reset must zero the liveness counter");
+        note("t", 0, OpRef::int_op(1));
+        note("t", 0, OpRef::int_op(2));
+        note("t", 0, OpRef::int_op(1));
+        assert_eq!(notes(), 3, "every accepted note counts, repeats included");
+        assert_eq!(keys_seen(), 2, "two distinct keys");
+        assert_eq!(
+            collisions(),
+            0,
+            "the reached-ness proof must hold on the silent path"
+        );
+
+        // Constants carry their value inline and have no raw() encoding, so
+        // they are skipped entirely and must not inflate the reached count.
+        note("t", 0, OpRef::const_int(9));
+        assert_eq!(notes(), 3);
+    }
+
+    /// Gated off, the liveness counter must stay at zero too — otherwise a
+    /// disabled run would look reached.
+    #[test]
+    fn disabled_records_no_notes() {
+        set_mode_for_test(false);
+        reset();
+        note("t", 0, OpRef::int_op(1));
+        assert_eq!(notes(), 0);
+        assert_eq!(collisions(), 0);
+    }
+
+    /// NEGATIVE CONTROL. The same box seen repeatedly is the common case and
+    /// must stay silent, or the detector drowns its own signal.
+    #[test]
+    fn one_variant_seen_repeatedly_is_silent() {
+        set_mode_for_test(true);
+        reset();
+        for _ in 0..8 {
+            note("t", 0, OpRef::int_op(7));
+        }
+        assert_eq!(collisions(), 0);
+    }
+
+    /// The same raw in two different tables is legal — a per-table numbering
+    /// may assign the same position to different variants. Scoping is what
+    /// keeps the detector from reporting correct behaviour as a defect.
+    #[test]
+    fn same_raw_in_two_scopes_is_silent() {
+        set_mode_for_test(true);
+        reset();
+        note("t", 0x1000, OpRef::input_arg_int(7));
+        note("t", 0x2000, OpRef::int_op(7));
+        assert_eq!(collisions(), 0);
+    }
+
+    /// Distinct raws never collide however many variants are involved.
+    #[test]
+    fn distinct_raws_are_silent() {
+        set_mode_for_test(true);
+        reset();
+        note("t", 0, OpRef::input_arg_int(0));
+        note("t", 0, OpRef::int_op(1));
+        note("t", 0, OpRef::input_arg_ref(2));
+        assert_eq!(collisions(), 0);
+    }
+
+    /// Gated off, the detector must not report — otherwise every host pays for
+    /// an instrument they did not ask for.
+    #[test]
+    fn disabled_records_nothing() {
+        set_mode_for_test(false);
+        reset();
+        note("t", 0, OpRef::input_arg_int(7));
+        note("t", 0, OpRef::int_op(7));
+        assert_eq!(collisions(), 0);
+    }
+}

--- a/majit/majit-ir/src/reg_write_audit.rs
+++ b/majit/majit-ir/src/reg_write_audit.rs
@@ -1,0 +1,392 @@
+//! Debug-gated attribution for writes into a frame's `int_regs`.
+//!
+//! Each write records its `#[track_caller]` location, allowing a later register
+//! read to identify the code that produced its value. Frames are keyed by the
+//! address of the live `int_regs` buffer because callees may be populated before
+//! they have a stack depth. The key is suitable for latest-writer attribution,
+//! not for counting frames across buffer reuse.
+//!
+//! Reads, writes, and reads diverted before indexing the register file are
+//! counted separately so a zero can be distinguished from an unexecuted path.
+//! Reports also name the caller-declared configuration arm; see [`declare_arm`].
+//!
+//! Build with `jit-audits` to compile the instrumentation sites. In that
+//! build, `MAJIT_REG_WRITE_AUDIT=1` enables collection; with the environment
+//! gate off, every entry point is one thread-local read and a return. Without
+//! the Cargo feature, the module and its call sites are absent. State is
+//! thread-local because each trace is processed on one thread and parallel
+//! tests must not share diagnostic observations.
+
+use crate::resoperation::OpRef;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::panic::Location;
+
+/// `(file, line)` of a writer. `Location` is not used as a key directly so the
+/// key stays a plain comparable pair.
+type Site = (&'static str, u32);
+
+/// One distinct thing a reader observed: a slot, the variant it held, and the
+/// site that last wrote it.
+#[derive(PartialEq, Eq, Hash)]
+struct Observation {
+    slot: usize,
+    /// `Debug` of the `OpRef`, e.g. `InputArgInt(0)`. Kept as text because the
+    /// point of the report is to be read, and the payload is part of the
+    /// witness being attributed.
+    value: String,
+    writer: Option<Site>,
+}
+
+#[derive(Default)]
+struct Audit {
+    /// `None` until this thread has read the environment.
+    on: Option<bool>,
+    /// `(int_regs buffer address, slot) -> site that last wrote it`.
+    last_writer: HashMap<(usize, usize), Site>,
+    /// Per-site write tally. A site with no entry here never wrote.
+    writes: HashMap<Site, usize>,
+    /// Slots each site wrote, so "ran but never touched slot 4" is a statement
+    /// the report can make rather than one the reader has to infer.
+    slots: HashMap<Site, Vec<usize>>,
+    /// Distinct observations, with how often each recurred.
+    observations: HashMap<Observation, usize>,
+    reads: usize,
+    /// The macro-time configuration declared by the consumer. It cannot be
+    /// recovered from generated register writes at this layer.
+    arm: Option<&'static str>,
+    /// Slots the reader visited but resolved WITHOUT indexing `int_regs` —
+    /// keyed by `(slot, which branch took it)`.
+    ///
+    /// Together with [`Audit::reads`], these partition the slots visited by the
+    /// liveness iterator.
+    diverted: HashMap<(usize, &'static str), usize>,
+}
+
+thread_local! {
+    static AUDIT: RefCell<Audit> = RefCell::new(Audit::default());
+}
+
+fn resolve() -> bool {
+    matches!(std::env::var("MAJIT_REG_WRITE_AUDIT"), Ok(v) if v != "0" && !v.is_empty())
+}
+
+#[inline]
+fn enabled(audit: &mut Audit) -> bool {
+    *audit.on.get_or_insert_with(resolve)
+}
+
+/// Record that the caller wrote `slot` of the `int_regs` buffer at `regs`.
+///
+/// `regs` is the buffer address (`self.int_regs.as_ptr() as usize`), not the
+/// frame — see the module doc for why depth is unavailable at three of the
+/// writers.
+#[track_caller]
+#[inline]
+pub fn note_int_write(regs: usize, slot: usize, _opref: Option<OpRef>) {
+    // Resolve before entering the closure: `#[track_caller]` does not propagate
+    // through it, and resolving inside would attribute every write to this file.
+    let loc = Location::caller();
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        if !enabled(&mut audit) {
+            return;
+        }
+        let site: Site = (loc.file(), loc.line());
+        audit.last_writer.insert((regs, slot), site);
+        *audit.writes.entry(site).or_insert(0) += 1;
+        let seen = audit.slots.entry(site).or_default();
+        if !seen.contains(&slot) {
+            seen.push(slot);
+        }
+    });
+}
+
+/// Record that a reader took `opref` out of `slot` of the buffer at `regs`, and
+/// attribute it to whichever site last wrote that slot.
+///
+/// A read whose slot has no recorded writer is kept with `writer: None` rather
+/// than dropped: an unattributed read is the finding, not a gap to hide.
+pub fn note_int_read(regs: usize, slot: usize, opref: OpRef) {
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        if !enabled(&mut audit) {
+            return;
+        }
+        audit.reads += 1;
+        let writer = audit.last_writer.get(&(regs, slot)).copied();
+        let obs = Observation {
+            slot,
+            value: format!("{opref:?}"),
+            writer,
+        };
+        *audit.observations.entry(obs).or_insert(0) += 1;
+    });
+}
+
+/// Record that the reader visited `slot` but was answered by `which` instead of
+/// by the register file, so no read of `int_regs[slot]` took place.
+pub fn note_int_read_diverted(slot: usize, which: &'static str) {
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        if !enabled(&mut audit) {
+            return;
+        }
+        *audit.diverted.entry((slot, which)).or_insert(0) += 1;
+    });
+}
+
+/// Slots the reader visited without indexing the register file, as
+/// `(slot, branch, count)`.
+pub fn diverted_reads() -> Vec<(usize, &'static str, usize)> {
+    AUDIT.with(|a| {
+        let mut rows: Vec<(usize, &'static str, usize)> = a
+            .borrow()
+            .diverted
+            .iter()
+            .map(|(&(slot, which), &n)| (slot, which, n))
+            .collect();
+        rows.sort_unstable();
+        rows
+    })
+}
+
+/// Print every distinct observation and every writer's tally.
+pub fn report(subject: &str) {
+    AUDIT.with(|a| print_table(&a.borrow(), subject));
+}
+
+fn print_table(audit: &Audit, header: &str) {
+    if audit.on != Some(true) {
+        return;
+    }
+    let diverted_total: usize = audit.diverted.values().sum();
+    eprintln!(
+        "[reg-write] ===== {header}: arm={} reads={} diverted={} \
+         distinct_observations={} writer_sites={} =====",
+        audit.arm.unwrap_or("UNDECLARED"),
+        audit.reads,
+        diverted_total,
+        audit.observations.len(),
+        audit.writes.len(),
+    );
+    if audit.arm.is_none() {
+        // Loud, and on the same line-prefix as the data, so a grep that
+        // collects the table also collects the caveat. A quiet default would
+        // let an arm-A zero be quoted as a property of the mechanism.
+        eprintln!(
+            "[reg-write]   WARNING: NO ARM DECLARED — this table describes ONE configuration and \
+             does not say which. Call declare_arm() from the subject. A zero here is not a \
+             statement about majit; it is a statement about the arm that was built."
+        );
+    }
+    let mut rows: Vec<(&Observation, &usize)> = audit.observations.iter().collect();
+    rows.sort_by(|l, r| l.0.slot.cmp(&r.0.slot).then(r.1.cmp(l.1)));
+    for (obs, count) in rows {
+        let writer = match obs.writer {
+            Some((file, line)) => format!("{file}:{line}"),
+            None => "UNATTRIBUTED (no recorded write to this slot)".to_string(),
+        };
+        eprintln!(
+            "[reg-write]   int_regs[{}] = {} <- {} (x{count})",
+            obs.slot, obs.value, writer
+        );
+    }
+    let mut diverted: Vec<(&(usize, &'static str), &usize)> = audit.diverted.iter().collect();
+    diverted.sort_unstable();
+    for ((slot, which), count) in diverted {
+        eprintln!("[reg-write]   DIVERTED slot {slot} answered by {which} (x{count})");
+    }
+    let mut sites: Vec<(&Site, &usize)> = audit.writes.iter().collect();
+    sites.sort_by(|l, r| r.1.cmp(l.1));
+    for ((file, line), count) in sites {
+        let mut slots = audit.slots[&(*file, *line)].clone();
+        slots.sort_unstable();
+        eprintln!("[reg-write]   WRITER {file}:{line} wrote {count}x, slots {slots:?}");
+    }
+}
+
+/// Printed at thread exit so a gated run produces its table without the
+/// subject having to call anything. Best-effort, exactly as in `opref_audit`:
+/// a thread-local destructor is not guaranteed to run on the main thread, so a
+/// caller that needs the table should call [`report`] itself.
+impl Drop for Audit {
+    fn drop(&mut self) {
+        print_table(self, "thread exit");
+    }
+}
+
+/// Declare the caller-known configuration this run was built in.
+///
+/// This records rather than verifies the configuration; the caller owns the
+/// value because this crate cannot recover macro-time consumer settings.
+pub fn declare_arm(arm: &'static str) {
+    AUDIT.with(|a| a.borrow_mut().arm = Some(arm));
+}
+
+/// The declared arm, or `None` if the subject never declared one.
+pub fn arm() -> Option<&'static str> {
+    AUDIT.with(|a| a.borrow().arm)
+}
+
+/// Forget every attribution and zero the counters.
+///
+/// The declared arm is retained because resetting counters does not change the
+/// binary's configuration.
+pub fn reset() {
+    AUDIT.with(|a| {
+        let mut audit = a.borrow_mut();
+        audit.last_writer.clear();
+        audit.writes.clear();
+        audit.slots.clear();
+        audit.observations.clear();
+        audit.reads = 0;
+    });
+}
+
+/// Force this thread's mode, so a test can exercise the instrument regardless
+/// of how the run was invoked.
+pub fn set_mode_for_test(on: bool) {
+    AUDIT.with(|a| a.borrow_mut().on = Some(on));
+}
+
+/// Every writer site recorded on this thread, as `("file", line, writes)`.
+pub fn writer_sites() -> Vec<(&'static str, u32, usize)> {
+    AUDIT.with(|a| {
+        let audit = a.borrow();
+        let mut rows: Vec<(&'static str, u32, usize)> =
+            audit.writes.iter().map(|(&(f, l), &n)| (f, l, n)).collect();
+        rows.sort_unstable();
+        rows
+    })
+}
+
+/// The site that last wrote `slot` of the buffer at `regs`, if any.
+pub fn writer_of(regs: usize, slot: usize) -> Option<(&'static str, u32)> {
+    AUDIT.with(|a| a.borrow().last_writer.get(&(regs, slot)).copied())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// POSITIVE CONTROL. A write then a read of the same slot must attribute
+    /// the read to the writing line, and the line must be this test's own.
+    #[test]
+    fn a_read_is_attributed_to_the_line_that_wrote_the_slot() {
+        set_mode_for_test(true);
+        reset();
+        let regs = 0x1000;
+        let write_line = line() + 1;
+        note_int_write(regs, 4, Some(OpRef::input_arg_int(0)));
+        assert_eq!(
+            writer_of(regs, 4),
+            Some((file!(), write_line)),
+            "#[track_caller] must report the CALL site, not this module"
+        );
+    }
+
+    /// Two different lines writing the same slot: the LAST one owns the read.
+    /// Without this the instrument could report a stale attribution and read
+    /// exactly like a correct one.
+    #[test]
+    fn the_last_writer_wins() {
+        set_mode_for_test(true);
+        reset();
+        let regs = 0x2000;
+        note_int_write(regs, 4, Some(OpRef::input_arg_int(0)));
+        let second = line() + 1;
+        note_int_write(regs, 4, Some(OpRef::int_op(9)));
+        assert_eq!(writer_of(regs, 4), Some((file!(), second)));
+    }
+
+    /// Two buffers are two frames. A write to one must not attribute a read of
+    /// the other — that collapse is what makes a slot-keyed table say "the
+    /// root frame's slot 4" when it means some callee's.
+    #[test]
+    fn two_buffers_do_not_share_attributions() {
+        set_mode_for_test(true);
+        reset();
+        note_int_write(0x3000, 4, Some(OpRef::input_arg_int(0)));
+        assert!(
+            writer_of(0x4000, 4).is_none(),
+            "a different register file must not inherit an attribution"
+        );
+    }
+
+    /// NEGATIVE CONTROL for the third value. A slot nobody wrote must stay
+    /// UNATTRIBUTED rather than borrow the nearest writer, because "nobody
+    /// wrote this" is a finding.
+    #[test]
+    fn an_unwritten_slot_stays_unattributed() {
+        set_mode_for_test(true);
+        reset();
+        let regs = 0x5000;
+        note_int_write(regs, 1, Some(OpRef::input_arg_int(0)));
+        note_int_read(regs, 4, OpRef::input_arg_int(0));
+        assert!(writer_of(regs, 4).is_none());
+        AUDIT.with(|a| {
+            let audit = a.borrow();
+            let obs = audit.observations.keys().next().expect("one observation");
+            assert_eq!(obs.slot, 4);
+            assert!(obs.writer.is_none(), "must not be attributed to slot 1");
+        });
+    }
+
+    /// A site that ran and wrote only other slots is distinguishable from a
+    /// site that never ran. This is the distinction the whole instrument turns
+    /// on: excluding a candidate needs the first, and only the first.
+    #[test]
+    fn a_site_that_wrote_elsewhere_is_not_a_site_that_never_ran() {
+        set_mode_for_test(true);
+        reset();
+        let regs = 0x6000;
+        let ran = line() + 1;
+        note_int_write(regs, 7, Some(OpRef::int_op(1)));
+        let sites = writer_sites();
+        assert_eq!(sites, vec![(file!(), ran, 1)], "the site that ran reports");
+        assert!(
+            writer_of(regs, 4).is_none(),
+            "and it is still not the writer of slot 4"
+        );
+    }
+
+    /// The arm is never guessed, and `reset` must not silently drop it.
+    ///
+    /// Both halves matter. Defaulting an undeclared arm to a plausible string
+    /// would make an arm-A zero readable as a claim about majit; clearing it on
+    /// `reset` would downgrade the second of two measurements in one process to
+    /// UNDECLARED without anyone touching the declaration.
+    #[test]
+    fn the_arm_is_declared_never_defaulted_and_survives_reset() {
+        set_mode_for_test(true);
+        reset();
+        assert_eq!(arm(), None, "an undeclared arm must stay unknown");
+        declare_arm("dualtape split_dispatch=false");
+        reset();
+        assert_eq!(
+            arm(),
+            Some("dualtape split_dispatch=false"),
+            "reset clears measurements, not the configuration they were taken in"
+        );
+    }
+
+    /// Gated off, nothing is recorded — otherwise every host pays for an
+    /// instrument they did not ask for, and a disabled run looks reached.
+    #[test]
+    fn disabled_records_nothing() {
+        set_mode_for_test(false);
+        reset();
+        note_int_write(0x7000, 4, Some(OpRef::input_arg_int(0)));
+        note_int_read(0x7000, 4, OpRef::input_arg_int(0));
+        assert!(writer_of(0x7000, 4).is_none());
+        assert!(writer_sites().is_empty());
+    }
+
+    /// `line!()` at the call site, so the controls above compute the expected
+    /// line rather than hard-coding one that rots on the next edit.
+    #[track_caller]
+    fn line() -> u32 {
+        Location::caller().line()
+    }
+}

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_control.rs
@@ -889,6 +889,7 @@ fn parse_checked_ovf_match(
 #[cfg(test)]
 mod unroll_binding_tests {
     use super::*;
+    use crate::jit_interp::jitcode_lower::dispatch::InlineArmOutcome;
 
     fn int_binding(reg: u16) -> Binding {
         Binding {
@@ -940,5 +941,76 @@ mod unroll_binding_tests {
             !lowerer.bindings.contains_key("y"),
             "a body-local let must not escape the loop"
         );
+    }
+
+    #[test]
+    fn unlowerable_while_condition_restores_the_label_snapshot() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.next_label = 17;
+        let expr: syn::ExprWhile = syn::parse_quote! {
+            while unsupported_condition() {}
+        };
+
+        assert!(lowerer.lower_while_loop(&expr).is_none());
+        assert_eq!(lowerer.next_label, 17);
+        assert!(lowerer.statements.is_empty());
+        assert!(lowerer.op_metadata.is_empty());
+    }
+
+    #[test]
+    fn failed_if_and_match_classification_do_not_consume_forward_labels() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.next_label = 23;
+
+        let expr_if: syn::ExprIf = syn::parse_quote! {
+            if 1 { unsupported_body() }
+        };
+        assert!(lowerer.lower_if_stmt(&expr_if).is_none());
+        assert_eq!(lowerer.next_label, 23);
+
+        let expr_match: syn::ExprMatch = syn::parse_quote! {
+            match 0 {
+                (1, 2) => {},
+                _ => {},
+            }
+        };
+        assert!(lowerer.lower_match_stmt(&expr_match).is_none());
+        assert_eq!(lowerer.next_label, 23);
+    }
+
+    #[test]
+    fn failed_inline_dispatch_arm_restores_allocated_labels() {
+        let mut lowerer = Lowerer::new(None);
+        lowerer.next_label = 31;
+        let body: Expr = syn::parse_quote! {{
+            match 0 {
+                0 => unsupported_body(),
+                _ => 1,
+            };
+        }};
+
+        assert_eq!(
+            lowerer.try_inline_dispatch_arm(&body),
+            InlineArmOutcome::Rejected,
+        );
+        assert_eq!(lowerer.next_label, 31);
+        assert!(lowerer.statements.is_empty());
+        assert!(lowerer.op_metadata.is_empty());
+    }
+
+    #[test]
+    fn typed_local_binds_like_the_unannotated_spelling() {
+        let mut lowerer = Lowerer::new(None);
+        let stmt: Stmt = syn::parse_quote! { let value: i64 = 7; };
+        let Stmt::Local(local) = stmt else {
+            unreachable!("parse_quote produced the requested let statement")
+        };
+
+        assert!(lowerer.lower_local(&local).is_some());
+        let binding = lowerer
+            .bindings
+            .get("value")
+            .expect("the typed local must create its identifier binding");
+        assert!(matches!(binding.kind, BindingKind::Int));
     }
 }

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -10,6 +10,7 @@ description = "Meta-interpreter and optimizer for majit JIT compiler"
 # Backend selection is mandatory and intentionally has no default.
 dynasm = ["dep:majit-backend-dynasm"]
 cranelift = ["dep:majit-backend-cranelift"]
+jit-audits = ["majit-ir/jit-audits"]
 
 [dependencies]
 majit-ir = { workspace = true }

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -688,6 +688,16 @@ pub struct OptContext {
     /// RPython unroll.py relies on this distinction so virtualize can keep
     /// body-side allocations concrete when guard recovery cannot rebuild them.
     pub skip_flush_mode: bool,
+    /// Bridge mode from `optimizer.building_bridge` (unroll.py:183-236
+    /// `optimize_bridge`).
+    ///
+    /// A bridge's inputargs are rebuilt from the deadframe frame-first, so the
+    /// virtualizable identity sits at slot 0 whatever the front end's own
+    /// layout says. `inputarg_base` cannot carry that distinction: Phase 2
+    /// shifts the base as well (`unroll.rs` `phase2_inputarg_base`), so a
+    /// consumer keying on `inputarg_base != 0` treats an unrolled loop body as
+    /// a bridge. This flag is the discriminator; the base is the namespace.
+    pub building_bridge: bool,
     /// Index of the pass currently executing propagate_forward.
     /// Used by passes to call send_extra_operation_after(self_idx, ..)
     /// matching RPython's emit_extra(op, emit=False) which routes to
@@ -1691,6 +1701,7 @@ impl OptContext {
             patchguardop: None,
             preamble_end_args: None,
             skip_flush_mode: false,
+            building_bridge: false,
             current_pass_idx: 0,
             optearlyforce_idx: 0,
 
@@ -2313,6 +2324,7 @@ impl OptContext {
             patchguardop: None,
             preamble_end_args: None,
             skip_flush_mode: false,
+            building_bridge: false,
             current_pass_idx: 0,
             optearlyforce_idx: 0,
 
@@ -6299,6 +6311,44 @@ impl OptContext {
         // separate section after vable_array. opencoder.py:767
         // create_top_snapshot writes both arrays into the snapshot.
         snapshot.vref_array = vref_oprefs;
+
+        // Compare every snapshot cell's carried type with the type encoded by
+        // its `OpRef` variant. `None` is an unclassified producer rather than
+        // agreement. This complements the variant audit because `OpRef::ty()`
+        // deliberately collapses variants within one type bank.
+        #[cfg(feature = "jit-audits")]
+        if majit_ir::opref_audit::enabled() {
+            let mut agree = 0usize;
+            let mut disagree = 0usize;
+            let mut untyped = 0usize;
+            let cells = snapshot
+                .framestack
+                .iter()
+                .flat_map(|frame| frame.boxes.iter())
+                .chain(snapshot.vable_array.iter())
+                .chain(snapshot.vref_array.iter());
+            for cell in cells {
+                let encoded = cell.opref.ty();
+                match cell.tp {
+                    None => untyped += 1,
+                    Some(tp) if Some(tp) == encoded => agree += 1,
+                    Some(tp) => {
+                        disagree += 1;
+                        eprintln!(
+                            "[snapbox-tp] DISAGREE opref={:?} tp={:?} ty={:?}",
+                            cell.opref, tp, encoded
+                        );
+                    }
+                }
+            }
+            eprintln!(
+                "[snapbox-tp] cells={} agree={} disagree={} untyped={}",
+                agree + disagree + untyped,
+                agree,
+                disagree,
+                untyped
+            );
+        }
 
         if crate::callee_rca_enabled() {
             let env = OptBoxEnv { ctx: self };

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2452,6 +2452,7 @@ impl Optimizer {
             start_next_pos,
         );
         ctx.skip_flush_mode = self.skip_flush;
+        ctx.building_bridge = self.building_bridge;
         ctx.constant_fold_alloc = self.constant_fold_alloc.take();
         // Seed the canonical `find_producer_op` surface (`input_ops`) with
         // the input ops' producers so they resolve directly; `find_producer_op`

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -94,10 +94,10 @@ pub(crate) struct VirtualizableConfig {
     /// returns true there and no vable array access is ever resolved for
     /// mirroring.
     ///
-    /// The decline is not total. `identity_input_ref` returns
-    /// `Some(input_arg_ref(base))` whenever `ctx.inputarg_base != 0` — a bridge —
-    /// before it consults this field at all, so a tracker is still installed on
-    /// that path with this set to `None`.
+    /// The decline is not total. On the bridge path (`ctx.building_bridge`)
+    /// `identity_input_ref` returns `Some(input_arg_ref(ctx.inputarg_base))`
+    /// before it consults this field at all, so a tracker is still installed
+    /// there with this set to `None`.
     pub identity_input_index: Option<usize>,
     /// Whether the tracker seeds array-element state from the trace-entry
     /// input args (`init`'s array loop).
@@ -164,18 +164,31 @@ impl VirtualizableTracker {
     /// The input-arg slot the virtualizable identity occupies, or `None` when
     /// no sound slot is known and the tracker must decline.
     ///
-    /// A bridge keeps the identity at its own base: its input args are rebuilt
-    /// from the deadframe frame-first, which is also what `init`'s `base == 0`
-    /// gate and `is_standard_ref` assume, so the resolved offset applies to the
-    /// loop entry only — and so does the decline, since the bridge's base is
-    /// established by the deadframe rather than by the host's layout.
+    /// The answer is always expressed in this run's own OpRef namespace:
+    /// inputarg `#i` is raw OpRef `inputarg_base + i`. Phase 1 runs at base 0;
+    /// Phase 2 and bridges are shifted above the parent trace's high water
+    /// mark.
+    ///
+    /// A bridge keeps the identity at slot 0: its input args are rebuilt from
+    /// the deadframe frame-first, which is also what `init`'s seeding gate and
+    /// `is_standard_ref` assume, so the front end's resolved offset does not
+    /// describe them — the bridge's layout is established by the deadframe.
+    /// Every other run — loop, preamble, unrolled Phase 2 body — carries the
+    /// front end's own layout, so it consults `identity_input_index` and
+    /// declines with it.
+    ///
+    /// The discriminator is `ctx.building_bridge`, not
+    /// `inputarg_base != 0`. Phase 2 shifts the base as well, so keying on the
+    /// base sends an unrolled loop body down the bridge path and installs
+    /// `PtrInfo::Virtualizable` on whatever inputarg 0 happens to be. On the
+    /// banked layout that is an Int scalar, and the loop-close Jump then fails
+    /// to match the Ref-typed preview (`VirtualStatesCantMatch`).
     fn identity_input_ref(&self, ctx: &OptContext) -> Option<OpRef> {
-        let base = ctx.inputarg_base;
-        if base != 0 {
-            return Some(OpRef::input_arg_ref(base));
+        if ctx.building_bridge {
+            return Some(OpRef::input_arg_ref(ctx.inputarg_base));
         }
         Some(OpRef::input_arg_ref(
-            self.config.identity_input_index? as u32,
+            ctx.inputarg_base + self.config.identity_input_index? as u32,
         ))
     }
 
@@ -339,14 +352,12 @@ impl VirtualizableTracker {
 
     fn is_standard_ref(&self, b: &Operand, ctx: &OptContext) -> bool {
         // pyjitpl.py:1131 `standard_box is box` — box identity against the
-        // standard virtualizable frame, then virtualizable check. The frame
-        // is the trace's first inputarg, at `inputarg_base`: `0` for
-        // loops/preambles, `bridge_inputarg_base` for bridges (whose parent
-        // loop owns the low OpRef range, so the bridge's own inputargs — frame
-        // first — start at the shifted base). A loop whose front end does not
-        // lead with the identity declares where it does sit
-        // (`identity_input_index`), and a loop with no known identity slot
-        // declines: nothing is the standard ref.
+        // standard virtualizable frame, then virtualizable check. The slot is
+        // resolved by `identity_input_ref`, so this reads the same answer
+        // `ensure_setup` installed on: a bridge's frame-first slot 0, or the
+        // front end's declared `identity_input_index`, both in this run's own
+        // OpRef namespace. A run with no known identity slot declines:
+        // nothing is the standard ref.
         match self
             .identity_input_ref(ctx)
             .and_then(|r| ctx.get_box_replacement_operand_opt(r))

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -646,9 +646,58 @@ fn clone_bridge_ops_preserving_value(bridge_ops: &[majit_ir::Op]) -> Vec<majit_i
         .collect()
 }
 
+#[cfg(feature = "jit-audits")]
+thread_local! {
+    /// Scope key for the `translate_trace_iter` OpRef-variant audit: one value
+    /// per `prepare_bridge_trace_for_optimizer` call, never reused.
+    ///
+    /// A generation counter keeps separate bridge preparations apart without
+    /// depending on allocation addresses that may be reused.
+    static AUDIT_PREPARE_GENERATION: std::cell::Cell<usize> = const { std::cell::Cell::new(0) };
+}
+
+/// Open a new audit scope, one per bridge preparation.
+///
+/// Bump once per preparation, not per operand; otherwise every note would have
+/// a unique scope and collisions would become unrepresentable.
+///
+/// Wrapping is unreachable at one increment per compiled bridge and is spelled
+/// explicitly so the counter can never abort a debug build from an audit path.
+#[cfg(feature = "jit-audits")]
+fn next_audit_prepare_generation() {
+    AUDIT_PREPARE_GENERATION.with(|c| c.set(c.get().wrapping_add(1)));
+}
+
+/// The scope opened by the most recent `prepare_bridge_trace_for_optimizer` on
+/// this thread; 0 before any has run.
+///
+/// Private translation helpers call this only within
+/// `prepare_bridge_trace_for_optimizer`, after opening a generation.
+#[cfg(feature = "jit-audits")]
+fn audit_prepare_generation() -> usize {
+    AUDIT_PREPARE_GENERATION.with(std::cell::Cell::get)
+}
+
 fn translate_trace_iter_opref(opref: OpRef, cache: &[Option<majit_ir::operand::Operand>]) -> OpRef {
     if opref.is_none() || opref.is_constant() {
         return opref;
+    }
+    // Record which variants claim each SLOT of this cache — the query below
+    // and, once resolved, the operand the slot actually holds. Both are noted
+    // under `opref.raw()`, the slot, not under their own raws: they carry
+    // different raws by construction (`InputArgInt(0)` lands on a slot filled
+    // for `InputArgRef(4824)`), so keying each by its own raw files them
+    // apart and compares nothing.
+    //
+    // This is wider than the bank compare below, which fires only when the
+    // two banks disagree on `ty()`; `InputArgInt(n)` against `IntOp(n)` is the
+    // same `ty()` and passes it silently. The per-preparation generation
+    // scopes the keys to one bridge, so two bridges reusing a position are not
+    // a collision.
+    #[cfg(feature = "jit-audits")]
+    {
+        let audit_scope = audit_prepare_generation();
+        majit_ir::opref_audit::note_key("translate_trace_iter", audit_scope, opref.raw(), opref);
     }
     // opencoder.py:286-289 `_get(self, i)` parity — `assert _cache[i] is
     // not None`. The bridge fresh-iterator
@@ -732,6 +781,12 @@ fn prepare_bridge_trace_for_optimizer(
     runtime_boxes: Vec<OpRef>,
     bridge_inputarg_base: u32,
 ) -> PreparedBridgeTrace {
+    // Open this bridge's audit scope before anything reads it. Every caller of
+    // `translate_trace_iter_opref` and `translate_trace_iter_box_map` is below
+    // this line, so the keys they file all carry this call's generation and no
+    // two preparations share one.
+    #[cfg(feature = "jit-audits")]
+    next_audit_prepare_generation();
     // unroll.py:187 `trace = trace.get_iter()` parity for bridge traces.
     // RPython allocates fresh InputArg / ResOperation objects before
     // optimize_bridge() consumes the trace; majit's analogue is a fresh
@@ -6580,8 +6635,8 @@ impl<M: Clone> MetaInterp<M> {
         // cpu.vector_ext and cpu.vector_ext.is_enabled()`. No pyre jitdriver
         // declares vectorize=True, so `jitdriver_sd.vec` is false and the
         // gate reduces to `warmstate.vec_all`; `vector_register_size()` is
-        // `cpu.vector_ext` collapsed to a byte width (0 ⇒ absent/disabled,
-        // non-zero ⇒ is_enabled()). The unroll-free retry is the simple-loop
+        // `cpu.vector_ext` collapsed to a byte width (0 means absent/disabled,
+        // non-zero means is_enabled()). The unroll-free retry is the simple-loop
         // path (compile.py:233 compile_simple_loop), which is not vectorized.
         let optimized_ops = {
             let driver_vec = false; // jitdriver_sd.vec

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1774,6 +1774,12 @@ where
             // Preserve that mutation instead of restoring the pre-snapshot
             // state-field materialization save.
             if Some(idx) != root_inflight_int_result {
+                #[cfg(feature = "jit-audits")]
+                majit_ir::reg_write_audit::note_int_write(
+                    self.frames.frames[0].int_regs.as_ptr() as usize,
+                    idx,
+                    saved_int_regs[idx],
+                );
                 self.frames.frames[0].int_regs[idx] = saved_int_regs[idx];
                 self.frames.frames[0].int_values[idx] = saved_int_values[idx];
             }
@@ -3036,6 +3042,12 @@ where
                 match kind {
                     JitArgKind::Int => {
                         let (value, concrete) = self.read_int_reg(caller_src);
+                        #[cfg(feature = "jit-audits")]
+                        majit_ir::reg_write_audit::note_int_write(
+                            portal_frame.int_regs.as_ptr() as usize,
+                            callee_dst,
+                            Some(value),
+                        );
                         portal_frame.int_regs[callee_dst] = Some(value);
                         portal_frame.int_values[callee_dst] = Some(concrete);
                     }
@@ -6307,6 +6319,12 @@ where
                     match kind {
                         JitArgKind::Int => {
                             let (value, concrete) = self.read_int_reg(caller_src);
+                            #[cfg(feature = "jit-audits")]
+                            majit_ir::reg_write_audit::note_int_write(
+                                sub_frame.int_regs.as_ptr() as usize,
+                                callee_dst,
+                                Some(value),
+                            );
                             sub_frame.int_regs[callee_dst] = Some(value);
                             sub_frame.int_values[callee_dst] = Some(concrete);
                         }
@@ -8562,6 +8580,12 @@ where
 
         for (callee_dst, caller_src) in args_i.into_iter().enumerate() {
             let (value, concrete) = self.read_int_reg(caller_src);
+            #[cfg(feature = "jit-audits")]
+            majit_ir::reg_write_audit::note_int_write(
+                sub_frame.int_regs.as_ptr() as usize,
+                callee_dst,
+                Some(value),
+            );
             sub_frame.int_regs[callee_dst] = Some(value);
             sub_frame.int_values[callee_dst] = Some(concrete);
         }
@@ -8600,6 +8624,8 @@ where
 
     fn set_int_reg(&mut self, reg: usize, opref: Option<OpRef>, value: Option<i64>) {
         let frame = self.frames.current_mut();
+        #[cfg(feature = "jit-audits")]
+        majit_ir::reg_write_audit::note_int_write(frame.int_regs.as_ptr() as usize, reg, opref);
         frame.int_regs[reg] = opref;
         frame.int_values[reg] = value;
     }

--- a/majit/majit-metainterp/src/pyjitpl/frame.rs
+++ b/majit/majit-metainterp/src/pyjitpl/frame.rs
@@ -479,6 +479,8 @@ impl MIFrame {
         let num_regs_i = self.jitcode.c_num_regs_i as usize;
         for (i, &value) in self.jitcode.constants_i.iter().enumerate() {
             let slot = num_regs_i + i;
+            #[cfg(feature = "jit-audits")]
+            majit_ir::reg_write_audit::note_int_write(self.int_regs.as_ptr() as usize, slot, None);
             self.int_regs[slot] = Some(ctx.const_int(value));
             self.int_values[slot] = Some(value);
         }
@@ -576,6 +578,12 @@ impl MIFrame {
         }
         match kind {
             JitArgKind::Int => {
+                #[cfg(feature = "jit-audits")]
+                majit_ir::reg_write_audit::note_int_write(
+                    self.int_regs.as_ptr() as usize,
+                    target_index,
+                    Some(opref),
+                );
                 self.int_regs[target_index] = Some(opref);
                 self.int_values[target_index] = Some(concrete);
             }
@@ -670,6 +678,12 @@ impl MIFrame {
                 match argcode {
                     b'i' => {
                         let opref = OpRef::const_int(0);
+                        #[cfg(feature = "jit-audits")]
+                        majit_ir::reg_write_audit::note_int_write(
+                            self.int_regs.as_ptr() as usize,
+                            index,
+                            Some(opref),
+                        );
                         self.int_regs[index] = Some(opref);
                         self.int_values[index] = Some(0);
                         (None, None, None)
@@ -846,6 +860,12 @@ impl MIFrame {
                 match argcode {
                     b'i' => {
                         let opref = OpRef::const_int(0);
+                        #[cfg(feature = "jit-audits")]
+                        majit_ir::reg_write_audit::note_int_write(
+                            self.int_regs.as_ptr() as usize,
+                            index,
+                            Some(opref),
+                        );
                         self.int_regs[index] = Some(opref);
                         self.int_values[index] = Some(0);
                     }
@@ -899,6 +919,8 @@ impl MIFrame {
             for index in it.by_ref() {
                 let idx = index as usize;
                 let tagged = if Some(idx) == clear_int_idx {
+                    #[cfg(feature = "jit-audits")]
+                    majit_ir::reg_write_audit::note_int_read_diverted(idx, "clear_int_idx");
                     SnapshotTagged::Const(0, Type::Int)
                 } else if skip_int_identity.is_some_and(|(b, e)| idx >= b && idx < e)
                     && idx < num_regs_i
@@ -931,6 +953,12 @@ impl MIFrame {
                 } else if idx < num_regs_i {
                     let opref = self.int_regs[idx]
                         .expect("get_list_of_active_snapshot_boxes: int register uninitialized");
+                    #[cfg(feature = "jit-audits")]
+                    majit_ir::reg_write_audit::note_int_read(
+                        self.int_regs.as_ptr() as usize,
+                        idx,
+                        opref,
+                    );
                     let value = self.int_values[idx]
                         .expect("get_list_of_active_snapshot_boxes: int value uninitialized");
                     if opref.is_constant() {
@@ -939,6 +967,8 @@ impl MIFrame {
                         SnapshotTagged::Box(opref, Type::Int)
                     }
                 } else {
+                    #[cfg(feature = "jit-audits")]
+                    majit_ir::reg_write_audit::note_int_read_diverted(idx, "constants-pool");
                     SnapshotTagged::Const(self.jitcode.constants_i[idx - num_regs_i], Type::Int)
                 };
                 boxes.push(tagged);
@@ -1070,6 +1100,12 @@ impl MIFrame {
         for (kind, value, concrete) in argboxes {
             match kind {
                 JitArgKind::Int => {
+                    #[cfg(feature = "jit-audits")]
+                    majit_ir::reg_write_audit::note_int_write(
+                        self.int_regs.as_ptr() as usize,
+                        count_i,
+                        Some(*value),
+                    );
                     self.int_regs[count_i] = Some(*value);
                     self.int_values[count_i] = Some(*concrete);
                     count_i += 1;

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -8874,6 +8874,43 @@ mod tests {
     use super::*;
     use crate::model::{ExitSwitch, FunctionGraph, Link, LinkArg, ValueType, exception_exitcase};
 
+    #[test]
+    fn serialized_descr_set_keys_ignore_descriptor_address_order() {
+        use majit_ir::effectinfo::DescrSetMember;
+        use std::sync::Arc;
+
+        #[derive(Debug)]
+        struct StubDescr(u32);
+        impl majit_ir::Descr for StubDescr {
+            fn index(&self) -> u32 {
+                self.0
+            }
+        }
+
+        let a: DescrRef = Arc::new(StubDescr(1));
+        let b: DescrRef = Arc::new(StubDescr(2));
+        let (first, second) =
+            if majit_ir::effectinfo::descr_ptr_id(&a) < majit_ir::effectinfo::descr_ptr_id(&b) {
+                (a, b)
+            } else {
+                (b, a)
+            };
+        let pairs = vec![
+            (first, Some(DescrSetMember::Array { array_id: 2 })),
+            (second, Some(DescrSetMember::Array { array_id: 1 })),
+        ];
+
+        let (_, keys) = canonicalize_keyed_descrs(pairs, None).unwrap();
+        assert_eq!(
+            keys,
+            vec![
+                DescrSetMember::Array { array_id: 1 },
+                DescrSetMember::Array { array_id: 2 },
+            ],
+            "serialized keys must follow structural member order, not Arc address order",
+        );
+    }
+
     /// A `TypedItemsBlock` puts its items at the length word rounded up to the
     /// element's alignment. Only a target whose word is narrower than an
     /// element can tell the two apart: with a 4-byte word, an `i64` item sits

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -20770,13 +20770,10 @@ mod tests {
             .find(|fd| fd.item_meta.name_path().ends_with("::__pyre_wrap_random"))
             .expect("_random::__pyre_wrap_random");
         let graph = super::lower_fun_decl(&llbc, fd).expect("lower wrapper");
-        let ops: Vec<_> = graph
+        let receiver = graph
             .blocks
             .iter()
             .flat_map(|block| &block.operations)
-            .collect();
-        let receiver = ops
-            .iter()
             .find_map(|op| match &op.kind {
                 OpKind::Call {
                     target: CallTarget::Method { name, .. },
@@ -20786,10 +20783,19 @@ mod tests {
                 _ => None,
             })
             .expect("random receiver");
-        let producer = ops
+        // The receiver reaches the `random` call across a block link, which
+        // renames the value: `Variable` equality is object identity, so a flat
+        // scan for an op whose `result` is this variable finds nothing.
+        // `resolve_to_producer_op` walks the links back to the producing op —
+        // the same resolver `extract_fmt_chain` opens with.
+        let (block_id, idx) =
+            super::resolve_to_producer_op(&graph, &receiver).expect("random receiver producer");
+        let producer = &graph
+            .blocks
             .iter()
-            .find(|op| op.result.as_ref().is_some_and(|result| result == &receiver))
-            .expect("random receiver producer");
+            .find(|block| block.id == block_id)
+            .expect("producer block")
+            .operations[idx];
         assert!(matches!(
             &producer.kind,
             OpKind::Call {
@@ -22416,15 +22422,30 @@ mod tests {
         assert_eq!(result.id(), result_id(6));
     }
 
-    /// Anchor [`extract_fmt_chain`] to the real lowered IR of
+    /// Anchor the `format!` collapse to the real lowered IR of
     /// `stack_underflow_error` (= `type_error(format!("stack underflow
-    /// during {context}"))`). Ignored by default (loads the 242MB real
-    /// LLBC); run with `cargo test -p majit-translate --lib
-    /// extract_fmt_chain_matches_real -- --ignored --nocapture`.
+    /// during {context}"))`). Ignored by default (loads the real LLBC); run
+    /// with `cargo test -p majit-translate --lib
+    /// real_stack_underflow_fmt_chain -- --ignored --nocapture`.
+    ///
+    /// This grades the collapse's OUTPUT rather than calling
+    /// [`extract_fmt_chain`] on the returned graph, because that call is not
+    /// reachable here: `collapse_fmt_chains` runs unconditionally inside the
+    /// lowering pipeline and consumes the `alloc::fmt::format` call, so no
+    /// entry point hands back a graph still carrying one. The two facts the
+    /// recognizer's `FmtChain` stated — the literal piece, and one argument
+    /// rendered by `Display` — survive as ops, so they are asserted on the
+    /// ops. [`extract_fmt_chain`] itself is graded on synthetic graphs by
+    /// `extract_fmt_chain_recovers_pieces_and_args_cross_block`.
+    ///
+    /// The expected shape is read from the artefact:
+    /// `stack_underflow_error` lowers to five ops — the `context: Str` input,
+    /// `__str_const("stack underflow during ")`, `str(context)`, their `add`,
+    /// and the `error::PyError::type_error` call. Re-take it from a dump if
+    /// the message text or the template changes.
     #[test]
     #[ignore]
-    fn extract_fmt_chain_matches_real_stack_underflow() {
-        use super::{FmtArgKind, extract_fmt_chain};
+    fn real_stack_underflow_fmt_chain_collapses_to_str_concat() {
         use crate::model::{CallTarget, OpKind};
 
         let path = concat!(
@@ -22434,31 +22455,56 @@ mod tests {
         let llbc = Llbc::load(path).expect("load real LLBC");
         let graph = super::lower_function(&llbc, "stack_underflow_error")
             .expect("lower stack_underflow_error");
-
-        // Find the `alloc::fmt::format(args)` call and extract its arg.
-        let fmt_args = graph
+        let ops: Vec<_> = graph
             .blocks
             .iter()
             .flat_map(|b| b.operations.iter())
-            .find_map(|op| match &op.kind {
+            .collect();
+
+        // The chain is consumed: no `alloc::fmt::format` call survives.
+        assert!(
+            !ops.iter().any(|op| matches!(
+                &op.kind,
                 OpKind::Call {
                     target: CallTarget::FunctionPath { segments },
-                    args,
                     ..
-                } if super::fmt_path_ends_with(segments, &["fmt", "format"]) => {
-                    args.first().cloned()
-                }
+                } if super::fmt_path_ends_with(segments, &["fmt", "format"])
+            )),
+            "the fmt chain must not residualize as an alloc::fmt::format call"
+        );
+
+        // The template's literal piece became a `__str_const`.
+        assert!(
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::Call {
+                    target: CallTarget::FunctionPath { segments },
+                    ..
+                } if segments
+                    == &[
+                        "__str_const".to_string(),
+                        "stack underflow during ".to_string(),
+                    ]
+            )),
+            "expected a __str_const carrying the template's literal piece"
+        );
+
+        // The one Display argument became a native `str` render, concatenated
+        // onto that literal.
+        let render = ops
+            .iter()
+            .find_map(|op| match &op.kind {
+                OpKind::UnaryOp { op: name, .. } if name == "str" => op.result.clone(),
                 _ => None,
             })
-            .expect("alloc::fmt::format call present");
-
-        let chain = extract_fmt_chain(&graph, &fmt_args).expect("recognized real fmt chain");
-        assert_eq!(
-            chain.pieces,
-            vec!["stack underflow during ".to_string(), String::new()]
+            .expect("expected a `str` render of the Display argument");
+        assert!(
+            ops.iter().any(|op| matches!(
+                &op.kind,
+                OpKind::BinOp { op: name, rhs, .. } if name == "add" && rhs == &render
+            )),
+            "the rendered argument must be concatenated onto the literal piece"
         );
-        assert_eq!(chain.args.len(), 1);
-        assert_eq!(chain.args[0].kind, FmtArgKind::Display);
     }
 
     /// Anchor the `Arguments::from_str_nonconst` alias to the real lowered IR
@@ -22838,10 +22884,23 @@ mod tests {
     /// Anchor [`Lowering::fold_size_const_global`] to the real lowered
     /// IR of `function_new_impl` (= reads `FUNCTION_OBJECT_SIZE`, a
     /// `const usize = size_of::<Function>()`).  The global read must fold
-    /// to `Function`'s concrete byte size (144) rather than residualize
-    /// as an unregisterable `FunctionPath` accessor call.  Ignored by
-    /// default (loads the 249MB real LLBC); run with `cargo test -p
-    /// majit-translate --lib fold_size_const_real -- --ignored`.
+    /// to `Function`'s concrete byte size rather than residualize as an
+    /// unregisterable `FunctionPath` accessor call.  Ignored by default
+    /// (loads the real LLBC); run with `cargo test -p majit-translate
+    /// --lib fold_size_const_real -- --ignored`.
+    ///
+    /// The literal is READ from the artefact this fold consumes, not
+    /// computed: `pyre-interpreter.ullbc` carries exactly one layout
+    /// entry for `Function`, `"size":176`, `"align":8`, `"repr_algo":"C"`,
+    /// with 21 `field_offsets` running `[0,16,24,…,168]`.  A source census
+    /// of `struct Function` reads the same 21 fields, and `168 + 8` is the
+    /// same 176.  Because there is a single entry, `select_target_layout`
+    /// resolves it through its sole-entry fallback even when `TARGET` is
+    /// unset, so a declining fold cannot be the reason this reds — the
+    /// second assertion below is what catches that case.
+    ///
+    /// Re-take the literal from the artefact's `layout` entry whenever
+    /// `Function` changes.
     #[test]
     #[ignore]
     fn fold_size_const_real_function_object_size() {
@@ -22864,8 +22923,8 @@ mod tests {
 
         // The `size_of::<Function>()` const read folded to its byte size.
         assert!(
-            ops.iter().any(|k| matches!(k, OpKind::ConstInt(144))),
-            "expected a ConstInt(144) for the folded FUNCTION_OBJECT_SIZE"
+            ops.iter().any(|k| matches!(k, OpKind::ConstInt(176))),
+            "expected a ConstInt(176) for the folded FUNCTION_OBJECT_SIZE"
         );
         // No residual accessor call to the const remains.
         let residual = ops.iter().any(|k| {

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -715,6 +715,31 @@ def _jit_panic_reason(stderr):
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
+def _jit_stats_merged(stderr):
+    """Every `[jit-stats]` line merged into one `key -> value` map, UNFILTERED.
+
+    `None` when the run printed no such line at all, which is a different
+    condition from printing one with no keys.
+
+    Split out from `_jit_stats_snapshot` because the two callers want opposite
+    things. A committed baseline may only contain the host-stable surface, so
+    the snapshot narrows to `JITSTATS_SNAPSHOT_FIELDS`; a *non-vacuity* check
+    has to read a counter precisely because it is NOT recorded — see
+    `JITSTATS_DENOMINATOR_FIELDS`. Narrowing first would hide it.
+    """
+    fields = {}
+    seen = False
+    for line in stderr.splitlines():
+        if not line.startswith("[jit-stats]"):
+            continue
+        seen = True
+        for token in line[len("[jit-stats]") :].split():
+            if "=" in token:
+                key, value = token.split("=", 1)
+                fields[key] = value
+    return fields if seen else None
+
+
 def _jit_stats_snapshot(stderr):
     """Return every jit-stats line merged into normalized key/value text.
 
@@ -738,17 +763,8 @@ def _jit_stats_snapshot(stderr):
     questions: merging arms the floor, the filter keeps the recorded surface
     host-stable.
     """
-    fields = {}
-    seen = False
-    for line in stderr.splitlines():
-        if not line.startswith("[jit-stats]"):
-            continue
-        seen = True
-        for token in line[len("[jit-stats]") :].split():
-            if "=" in token:
-                key, value = token.split("=", 1)
-                fields[key] = value
-    if not seen:
+    fields = _jit_stats_merged(stderr)
+    if fields is None:
         return None
     fields = {k: v for k, v in fields.items() if k in JITSTATS_SNAPSHOT_FIELDS}
     # This watches what the JIT compiles, never how well. A regression that
@@ -868,6 +884,16 @@ JITSTATS_BADNESS_FIELDS = (
     "fbw_store_journal_rollback_failed",
 )
 
+# A zero-valued badness counter is meaningful only if its source census ran.
+# Pair counters whose census has a reliable denominator and reject runs where
+# that denominator is absent or zero. The denominator is not baselined because
+# it describes a host-dependent descriptor population; only non-vacuity is
+# stable across hosts. `field_pos_attached_misplaced` is intentionally absent:
+# its checked population can legitimately be empty for compiled fixtures.
+JITSTATS_DENOMINATOR_FIELDS = {
+    "field_pos_spec_misplaced": "field_pos_spec_checked",
+}
+
 # The count-valued counters, and what a move in either direction means:
 #
 # * `guard_failures` counts every guard failure that re-enters the metainterp,
@@ -882,8 +908,11 @@ JITSTATS_BADNESS_FIELDS = (
 #   makes the tracer stop admitting a frame at all — a widened
 #   `unsupported_jit_shape` predicate, a pre-trace decline — aborts nothing
 #   (`loops_aborted` holds) and *lowers* `guard_failures` (the compiled guards
-#   that used to fail are gone), so a fall here is the only signal that a hot
-#   loop went back to running interpreted.
+#   that used to fail are gone), so a fall here is the signal that a hot loop
+#   went back to running interpreted.
+#   This counts all compilations, including straight-line traces, so it cannot
+#   distinguish a loop-shaped trace from a flat trace. Inspect `Label` and
+#   `Jump` operations when that distinction matters.
 # * `bridges_compiled` is that same signal one level down: guards that stop
 #   earning a bridge keep re-entering the metainterp forever. It was left
 #   ungated for a long time on the grounds that it "moves in both directions
@@ -911,10 +940,9 @@ JITSTATS_BADNESS_FIELDS = (
 # reshuffling them, but the merged set also carries keys that are not comparable
 # against a file checked into the repo:
 #
-# * `all_descrs` and `descr_set_resolved` are HOST-DEPENDENT — the Charon/LLBC
-#   extraction runs per host, so the same commit reads `all_descrs` 1168 on
-#   macOS, 1396 on ubuntu and 1365 on windows. Committing either makes every
-#   host but one disagree.
+# * `all_descrs` and `descr_set_resolved` are host-dependent because Charon/LLBC
+#   extraction runs per host. Committing either count would make otherwise
+#   equivalent hosts disagree.
 # * the `mc_diag` tallies include contention counters (`busy_skip`,
 #   `stfe_cell_busy`, `stfe_tick`) that move with machine load.
 # * `PYRE_WASM_JIT_STATS=1` adds wall-clock (`compile_ms`) and repeated
@@ -953,7 +981,8 @@ JITSTATS_SNAPSHOT_FIELDS = JITSTATS_BADNESS_FIELDS + (
 # `loops_compiled` is inverted against the badness fields: it is the counter
 # that falls when the tracer stops admitting a frame at all, which aborts
 # nothing and *lowers* `guard_failures`, so a fall is the regression and a rise
-# is the gain. `retraces_compiled` has the same polarity: a fall means an
+# is the gain — within the limit recorded above, that it counts compiles and not
+# loop-shaped ones. `retraces_compiled` has the same polarity: a fall means an
 # assembled retrace stopped being attached. The blackhole adoption counters are
 # inverted the same way: a fall means the interpreter stopped receiving an
 # image and went back to replay.
@@ -1030,6 +1059,30 @@ def _jit_stats_change(saved, current):
         else:
             regressions.append(f"{field} {old} -> {new}")
     return regressions, improvements
+
+
+def _jit_stats_vacuous(stderr):
+    """Return why a gated badness counter is vacuous this run, or "".
+
+    A badness counter's zero means "clean" only when its source census ran.
+    Require a nonzero denominator without baselining its host-dependent value.
+    This detects total loss of a census, not a producer that merely omits some
+    census updates.
+    """
+    fields = _jit_stats_merged(stderr)
+    if fields is None:
+        return ""  # the caller already failed this run for the missing line
+    for numerator, denominator in JITSTATS_DENOMINATOR_FIELDS.items():
+        raw = fields.get(denominator)
+        if raw is not None and raw.isdigit() and int(raw) > 0:
+            continue
+        return (
+            f"{denominator}={raw if raw is not None else '<absent>'} — "
+            f"the census behind `{numerator}` did not run, so that counter's 0 "
+            f"means 'nothing was checked', not 'nothing is misplaced', and its "
+            f"gate passed without inspecting anything"
+        )
+    return ""
 
 
 def _jit_stats_context(current):
@@ -1410,6 +1463,12 @@ class Check:
         # baseline is a bench nobody recorded, an absent line is a bench that
         # stopped reporting.
         self.jitstats_absent = []
+        # Benches whose run printed the line, but with a badness counter's
+        # census denominator at zero — the counter's gate passed on an
+        # instrument that inspected nothing. Tracked apart from
+        # `jitstats_absent` because the line IS there and every other gate on it
+        # is still meaningful; only the paired counters are void.
+        self.jitstats_vacuous = []
 
     # ── backend helpers ──
 
@@ -1650,6 +1709,11 @@ class Check:
         #   "recorded and clean" — which is how the floor came to cover 3 of 340
         #   synthetic fixtures without anyone noticing.
         # * A counter that moved, in either direction.
+        # * A badness counter reading 0 because its census never ran, rather
+        #   than because nothing is wrong — `JITSTATS_DENOMINATOR_FIELDS`. The
+        #   other three disarms are visible as an absence (no line, no file, no
+        #   move); this one is invisible, because a disarmed census and a clean
+        #   one print the same digit.
         if self.args.snapshot_mode != "record":
             if jitstats is None:
                 self.jitstats_absent.append(f"{backend}/{name}")
@@ -1664,6 +1728,10 @@ class Check:
                     f"no committed jit-stats baseline ({jitstats_path.name}) — record it with "
                     f"`pyre/check.py --snapshot --backend {backend}`"
                 )
+            vacuous = _jit_stats_vacuous(stderr)
+            if vacuous:
+                self.jitstats_vacuous.append(f"{backend}/{name}")
+                return "fail", vacuous
             regressions, improvements = _jit_stats_change(
                 jitstats_path.read_text(encoding="utf-8"), jitstats
             )
@@ -2015,6 +2083,21 @@ class Check:
             and float(exec_b) <= EXEC_TIME_FLOOR_S
         )
 
+    def _baseline_exec_time_thin(self, baseline, baseline_time):
+        """Whether a baseline clears the floor but not the floor gate's bar.
+
+        Reporting only: the ceiling accepts any value above
+        `EXEC_TIME_FLOOR_S`, while the floor gate requires
+        `FLOOR_GATE_MIN_BASELINE_S`. Mark ratios in the intervening band so
+        they are not mistaken for values accepted by both directions.
+        """
+        exec_b = self._exec_time(baseline, baseline_time)
+        return (
+            not self.args.no_startup_subtract
+            and exec_b not in (None, "-")
+            and EXEC_TIME_FLOOR_S < float(exec_b) < FLOOR_GATE_MIN_BASELINE_S
+        )
+
     def _performance_gate_passed(
         self, backend, script, timeout, elapsed, limit, baseline_time,
         baseline_cmd, expected_output, baseline_key, minimum=None,
@@ -2206,7 +2289,17 @@ class Check:
             den = self._exec_time("pypy", pypy_val)
             if den in (None, "-") or float(den) <= 0 or num in (None, "-"):
                 return "-"
-            marker = "~" if self._baseline_exec_time_clamped("pypy", pypy_val) else ""
+            # Display only: neither marker reaches a verdict. `~` says no gate
+            # was applied; `?` says one was, against a baseline under the bar
+            # the floor gate uses. An unmarked ratio now means both directions
+            # of the gate accepted the denominator, which is what a reader has
+            # been entitled to assume all along.
+            if self._baseline_exec_time_clamped("pypy", pypy_val):
+                marker = "~"
+            elif self._baseline_exec_time_thin("pypy", pypy_val):
+                marker = "?"
+            else:
+                marker = ""
             return f"{marker}{float(num) / float(den):.1f}x"
 
         ratio = _ratio(elapsed, t_pypy) if elapsed > 0 else "-"
@@ -2542,7 +2635,15 @@ class Check:
         # `N to run,` rather than the runner's own "no regressions": a
         # selection that came out empty prints every counter as zero and
         # still exits 0, which reads as a pass and tests nothing.
-        selected = re.search(r"^(\d+) to run,", output, re.M)
+        #
+        # The default runner gates only modules whose recorded baseline passes.
+        # Report skipped and non-gated counts so this subset is not mistaken
+        # for the full suite.
+        selected = re.search(
+            r"^(\d+) to run, (\d+) skipped(?:, (\d+) not gated \(non-PASS\))?,",
+            output,
+            re.M,
+        )
         if code == 124:
             detail = f"timeout (>{CPYTHON_SUITE_TIMEOUT_S}s)"
         elif selected is None:
@@ -2561,7 +2662,13 @@ class Check:
             self._append_comparison(backend, name, "-", "-", "FAIL")
             return
         self._record(backend, True, name, "")
-        print(f"{green('PASS')}  {selected.group(1)} modules, {elapsed:.0f}s")
+        ran, not_run, degated = (
+            selected.group(1), selected.group(2), selected.group(3) or "0",
+        )
+        print(
+            f"{green('PASS')}  {ran} gated, {degated} not gated, "
+            f"{not_run} skipped, {elapsed:.0f}s"
+        )
         self._append_comparison(backend, name, "-", "-", f"{elapsed:.0f}s")
 
     # ── synthetic parity suite ──
@@ -2750,6 +2857,14 @@ class Check:
                 "  ~ pypy exec clamped to floor; ratio is not a measurement, "
                 "and no ratio gate is applied to it"
             )
+        # Sniffing the rendered cell, like the line above: no other cell value
+        # contains a `?` (they are times, ratios, FAIL/WRONG/UNSTABLE/skip/-).
+        if any("?" in c[b] for c in self.comparisons for b in cols):
+            print(
+                "  ? pypy exec is above the floor but under "
+                "FLOOR_GATE_MIN_BASELINE_S; the ceiling is applied, the floor "
+                "gate declines the same baseline as too small to judge"
+            )
         print("  " + "─" * (54 + 19 * len(cols)))
         for c in self.comparisons:
             row = f"  {c['name']:<35s} {c['cpython']:>8s} {c['pypy']:>8s}"
@@ -2786,6 +2901,7 @@ class Check:
                 (yellow, "jit-stats unstable (not gated)", self.jitstats_unstable),
                 (red, "jit-stats baseline missing", self.jitstats_missing),
                 (red, "jit-stats line absent", self.jitstats_absent),
+                (red, "jit-stats census vacuous", self.jitstats_vacuous),
             ):
                 if benches:
                     print(

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -968,14 +968,15 @@ the folds it selects, not before them.
 `PYRE_FBW_SPEC_CENSUS` in §6c is its read-only half: the per-fold
 consulted/fired tallies.
 
-### §6c — Default-OFF diagnostics, censuses and probes (58): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (61): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
 
-`PYRE_BH_NULL_ARG`, `PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
+`PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
+`PYRE_CELL_CENSUS`,
 `PYRE_DESCR_SPELLING_GATE`,
-`PYRE_DIAG_51C`, `PYRE_DIAG_GIN`, `PYRE_DIAG_INLINE_RECOG`,
+`PYRE_DEOPT_PROBE`, `PYRE_DIAG_51C`, `PYRE_DIAG_GIN`, `PYRE_DIAG_INLINE_RECOG`,
 `PYRE_DETERMINISM_TRACE`, `PYRE_DTRACE_CONST_BT`,
 `PYRE_DYNASM_EXEC_DIAG`, `PYRE_FBW_CENSUS`, `PYRE_FBW_INLINE_DIAG`,
 `PYRE_FBW_LOOPBODY_SCAN_FULL`, `PYRE_FBW_LOOPBODY_SCAN_LOOP_ONLY`,
@@ -996,6 +997,12 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_WASM_DUMP_BAD_TRACE`, `PYRE_WASM_EXEC_TRACE`, `PYRE_WASM_FBW_CENSUS`,
 `PYRE_WASM_GUARD_CENSUS`, `PYRE_WASM_JIT_STATS`, `PYRE_WASM_CALL_HIST`,
 `PYRE_WASM_NO_CACHE`, `PYRE_WASM_STARTUP_TRACE`.
+
+`PYRE_ALLOCSITES` enables stack attribution in the standalone `allocsites`
+example; it is unset by default. Its `AFTER`, `BUDGET`, `EVERY`, and `ROWS`
+value knobs bound the capture window, sampling rate, and report size. This is a
+diagnostic tool rather than a temporary runtime experiment, so it retires only
+if the example itself is removed.
 
 ## §7 — General MAJIT gates
 

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -444,7 +444,6 @@ crate::py_module! {
                 ("GetModuleFileName", 1, process::get_module_file_name),
                 ("TerminateProcess", 2, process::terminate_process),
                 ("CreatePipe", 2, process::create_pipe),
-                ("CreateProcess", 9, process::create_process),
             ] {
                 crate::module_ns_store(
                     ns,
@@ -455,6 +454,24 @@ crate::py_module! {
                     ),
                 );
             }
+            // Fixed-arity builtin fast paths only cover zero through four
+            // arguments. CreateProcess still needs an exact-arity check, so
+            // register it through the general call path with a checked body.
+            crate::module_ns_store(
+                ns,
+                "CreateProcess",
+                crate::gateway::with_module(
+                    "_winapi",
+                    crate::make_module_builtin_function(
+                        "CreateProcess",
+                        crate::py_checked_arity_fn!(
+                            "CreateProcess",
+                            9,
+                            process::create_process
+                        ),
+                    ),
+                ),
+            );
             // `options` is the one argument with a default (`0`), so the
             // count is not fixed.
             crate::module_ns_store(

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -1037,6 +1037,25 @@ fn real_main() {
         let descrs_bin = bincode::serialize(&pipeline.descrs).unwrap();
         std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
 
+        // `MAJIT_MINT_INDEX_CENSUS=1`: how many `fielddescrof` mints resolved a
+        // slot for `index_in_parent`, and how many carried out the `0` they were
+        // initialised with. The split the emitted descr cannot record — an
+        // unwritten initialiser and a real slot-0 claim are the same bytes once
+        // this function returns.
+        //
+        // Read in the minting build process: runtime statistics run in another
+        // process and would see fresh zeroed atomics. A cached build emits no
+        // warning, so force the build script to rerun when collecting this
+        // census.
+        if std::env::var_os("MAJIT_MINT_INDEX_CENSUS").is_some() {
+            let [claimed, placeholder] = majit_ir::descr::GcCache::mint_index_census();
+            println!(
+                "cargo::warning=mint_index_census: claimed={claimed} placeholder={placeholder} \
+                 (fielddescrof mints; placeholder=0 means no descr in this build carries an \
+                 unresolved index_in_parent)"
+            );
+        }
+
         // The table above is RPython's `opcode_descrs` (`pyjitpl.py:2261
         // setup_descrs(asm.descrs)`), not its `all_descrs` (`pyjitpl.py:2289
         // self.cpu.setup_descrs()` = the full gccache walk at `descr.py:25-47`).

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/resume_snapshot.rs
@@ -109,7 +109,7 @@ pub(crate) fn walker_capture_snapshot_for_last_guard_scoped<Sym: WalkSym>(
 /// and panic.  A callee frame is non-standard whether reached by an
 /// inline sub-walk or compiled as its own Finish portal (via
 /// call_user_function_with_eval); the production main frame IS the
-/// standard virtualizable, so the check short-circuits at Step 1 and
+/// standard virtualizable, so *that* check short-circuits at Step 1 and
 /// emits nothing — gate on a full-body walk being active so this is a
 /// no-op (one cheap `num_guards` read) outside it.  The non-standard
 /// fact is cached per box
@@ -138,20 +138,21 @@ pub(crate) fn walker_capture_inline_nonstandard_vable_guard<Sym: WalkSym>(
     guards_before: usize,
     write: Option<majit_metainterp::VableEntryWrite>,
 ) -> Result<(), DispatchError> {
-    // The non-standard virtualizable's internal promote GuardValue is
-    // emitted only inside a full-body walk against a callee frame that is
-    // not the production standard virtualizable: either an inline sub-walk's
-    // callee heap frame, or a callee compiled as its own Finish portal
-    // (reached via call_user_function_with_eval). Outside a full-body walk
-    // the frame is always the standard virtualizable and emits no such
-    // guard.
+    // The non-standard virtualizable's `_nonstandard_virtualizable` promote
+    // GuardValue is emitted inside a full-body walk against a callee frame
+    // that is not the production standard virtualizable: either an inline
+    // sub-walk's callee heap frame, or a callee compiled as its own Finish
+    // portal (reached via call_user_function_with_eval).
     if ctx.fbw_mode.snapshot_sym.is_null() {
         return Ok(());
     }
     if ctx.trace_ctx.num_guards() <= guards_before {
-        // Standard virtualizable (the production main frame): the
-        // `_nonstandard_virtualizable` check short-circuited and emitted no
-        // guard, so there is nothing to capture.
+        // No guard was recorded by the call this wraps, so there is nothing
+        // to capture.
+        //
+        // Test the observed count rather than the virtualizable kind: the
+        // standard path may also emit a guard when promoting a non-constant
+        // array index.
         return Ok(());
     }
     let restored = write.and_then(|w| {

--- a/pyre/pyre-jit/Cargo.toml
+++ b/pyre/pyre-jit/Cargo.toml
@@ -11,6 +11,9 @@ default = ["dynasm"]
 jit = []  # meta feature: enabled by cranelift or dynasm
 cranelift = ["jit", "majit-backend-cranelift", "majit-metainterp/cranelift", "pyre-jit-trace/cranelift"]
 dynasm = ["jit", "majit-backend-dynasm", "majit-metainterp/dynasm", "pyre-jit-trace/dynasm"]
+# Build opt-in majit audit instrumentation. Individual audits remain selected
+# at runtime by their environment gates.
+jit-audits = ["majit-metainterp/jit-audits", "majit-ir/jit-audits"]
 # Forward the majit-translate `mir-frontend` feature so pyre-jit builds
 # can select the MIR front-end from the top level
 # (`cargo build --features pyre-jit/mir-frontend`).  Production

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -7098,7 +7098,15 @@ pub fn cranelift_resumedata_deopt(
     _bridge_num_inputs: usize,
 ) -> bool {
     use majit_backend::Backend;
+    use majit_ir::FailDescr;
     use majit_metainterp::resume;
+
+    if std::env::var_os("PYRE_DEOPT_PROBE").is_some() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static ENTRIES: AtomicU64 = AtomicU64::new(0);
+        let n = ENTRIES.fetch_add(1, Ordering::Relaxed);
+        eprintln!("[deopt-probe] entry #{n} descr_addr={descr_addr:#x}");
+    }
 
     // 1. Recover descr Arc.
     let (driver, driver_vinfo) = crate::eval::driver_pair();
@@ -7115,6 +7123,26 @@ pub fn cranelift_resumedata_deopt(
     };
     let Some(rgd) = any.downcast_ref::<majit_backend::ResumeGuardDescr>() else {
         return false;
+    };
+
+    // A novable driver's resume data has no virtualizable section. Derive the
+    // owning driver from the guard descr, matching the blackhole path's
+    // caller-supplied distinction, rather than guessing from this callback's
+    // backend registration.
+    let novable = match rgd
+        .rd_loop_token_clt()
+        .and_then(|clt_any| {
+            clt_any.downcast_ref::<std::sync::Arc<majit_backend::CompiledLoopToken>>()
+        })
+        .and_then(|clt| clt.upgrade_loop_token())
+        .and_then(|token| token.outermost_jitdriver_index)
+        .and_then(|idx| driver.meta_interp().jitdriver_has_vinfo(idx))
+    {
+        Some(has_vinfo) => !has_vinfo,
+        // Synthetic descr, evicted token, or stale driver slot: decline to the
+        // existing recovery-layout fallback instead of choosing the wrong
+        // resume-data shape for one of the two driver kinds.
+        None => return false,
     };
 
     // 3. Extract resume payload.  Empty rd_numb → nothing to decode.
@@ -7161,7 +7189,17 @@ pub fn cranelift_resumedata_deopt(
     reader.prepare(rd_virtuals_slice, rd_pendingfields);
     let vinfo_dyn: &dyn resume::VirtualizableInfo = driver_vinfo.as_ref();
     let vrefinfo_dyn: &dyn resume::VRefInfo = driver.meta_interp().virtualref_info();
-    reader.consume_vref_and_vable(Some(vrefinfo_dyn), Some(vinfo_dyn), None, None);
+    if std::env::var_os("PYRE_DEOPT_PROBE").is_some() {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static HITS: AtomicU64 = AtomicU64::new(0);
+        let n = HITS.fetch_add(1, Ordering::Relaxed);
+        eprintln!(
+            "[deopt-probe] cranelift vinfo hand-off #{n} descr_addr={descr_addr:#x} novable={novable}"
+        );
+    }
+    let vinfo_arg: Option<&dyn resume::VirtualizableInfo> =
+        if novable { None } else { Some(vinfo_dyn) };
+    reader.consume_vref_and_vable(Some(vrefinfo_dyn), vinfo_arg, None, None);
 
     // 7. resume.py:1339 jitcodes[jitcode_pos] lookup — same shape as
     //    blackhole_resume_via_rd_numb's resolve_jitcode (line 1891),

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5579,6 +5579,37 @@ fn green_key_from_pycode(next_instr: usize, w_pycode: pyre_object::PyObjectRef) 
     Some(make_green_key(code_ptr, next_instr))
 }
 
+/// The typed `GreenKey` behind [`green_key_from_pycode`]'s `u64`.
+///
+/// `interp_jit.py:67-70` declares the portal greens as `[next_instr,
+/// is_being_profiled, pycode]`; `make_green_key` hashes exactly that tuple
+/// and returns only the hash, which is enough to find a warmstate bucket and
+/// not enough to pick a cell out of one (`JitCell.comparekey`,
+/// warmstate.py:575-582). Callers that read a cell take this; callers that
+/// only tick a counter can keep the hash.
+///
+/// `is_being_profiled` is folded to `false` here **because
+/// [`make_green_key`] folds it to `false`** — the two must agree or the typed
+/// and hash paths would resolve to different cells. That fold is itself a
+/// parity gap (upstream splits cells on the flag, pyre never does), tracked
+/// separately; it is not this function's to change.
+fn green_key_typed_from_pycode(
+    next_instr: usize,
+    w_pycode: pyre_object::PyObjectRef,
+) -> Option<majit_ir::GreenKey> {
+    // Safety: as `green_key_from_pycode` — `PyCode` is an owned pointer to a
+    // `CodeObject`.
+    let code_ptr = unsafe { pyre_interpreter::pycode::w_code_get_ptr(w_pycode) };
+    if code_ptr.is_null() {
+        return None;
+    }
+    Some(majit_ir::pypyjit_greenkey(
+        next_instr,
+        false,
+        code_ptr as u64,
+    ))
+}
+
 /// RPython interp_jit.py helper: get_printable_location.
 pub fn get_printable_location(
     next_instr: usize,
@@ -5687,13 +5718,16 @@ pub fn get_jitcell_at_key(
     _is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) -> pyre_object::PyObjectRef {
-    let key = green_key_from_pycode(next_instr, w_pycode);
+    // warmstate.py:607-609 `get_jit_cell_at_key(greenkey)` unwraps the
+    // greenkey and hands the green *args* to `get_jitcell`. The green args
+    // are this function's own parameters, so the typed key costs no plumbing.
+    let key = green_key_typed_from_pycode(next_instr, w_pycode);
     let (driver, _) = driver_pair();
     w_bool_from(key.is_some_and(|green_key| {
         driver
             .meta_interp_mut()
             .warm_state_mut()
-            .get_cell(green_key)
+            .get_cell_for_key(&green_key)
             .is_some()
     }))
 }
@@ -5706,14 +5740,17 @@ pub fn dont_trace_here(
     _is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) {
-    let Some(green_key) = green_key_from_pycode(next_instr, w_pycode) else {
+    // warmstate.py:644-646 `dont_trace_here(*greenargs)` reaches its cell
+    // through `_ensure_jit_cell_at_key(*greenargs)`, by comparekey. The green
+    // args are this function's parameters.
+    let Some(green_key) = green_key_typed_from_pycode(next_instr, w_pycode) else {
         return;
     };
     let (driver, _) = driver_pair();
     driver
         .meta_interp_mut()
         .warm_state_mut()
-        .disable_noninlinable_function(green_key);
+        .disable_noninlinable_function_for_key(&green_key);
 }
 
 /// interp_jit.py:233 — `@dont_look_inside`
@@ -5724,17 +5761,29 @@ pub fn mark_as_being_traced(
     _is_being_profiled: bool,
     w_pycode: pyre_object::PyObjectRef,
 ) {
-    let Some(green_key) = green_key_from_pycode(next_instr, w_pycode) else {
+    // warmstate.py:649-651 `mark_as_being_traced(*greenargs)` reaches its cell
+    // through `_ensure_jit_cell_at_key(*greenargs)`, by comparekey. The green
+    // args are this function's parameters.
+    let Some(green_key) = green_key_typed_from_pycode(next_instr, w_pycode) else {
         return;
     };
     let (driver, _) = driver_pair();
     driver
         .meta_interp_mut()
         .warm_state_mut()
-        .mark_as_being_traced(green_key);
+        .mark_as_being_traced_for_key(&green_key);
 }
 
 /// interp_jit.py:245 — `@dont_look_inside`
+///
+/// Keeps the bare hash **by the same rule that sends its siblings through a
+/// typed key**: `JitCell._trace_next_iteration` (warmstate.py:617-619) hashes
+/// the greenargs and calls `jitcounter.change_current_fraction(hash, 0.98)` —
+/// it never looks a cell up, so a hash is all the identity the operation
+/// has. Upstream makes the same call reachable by hash alone as
+/// `trace_next_iteration_hash` (warmstate.py:622-623), which is the only
+/// bare-hash entry point it offers. Route a cell read here and this comment
+/// stops being true.
 #[majit_macros::dont_look_inside]
 pub fn trace_next_iteration(
     _space: pyre_object::PyObjectRef,

--- a/pyre/pyre-jit/src/lib.rs
+++ b/pyre/pyre-jit/src/lib.rs
@@ -88,6 +88,7 @@ mod trace_verify;
 pub use pyre_jit_trace::jitcode_runtime::{
     descr_set_counts, descr_set_jit_stats, descr_spelling_gate_recheck_now,
     field_descr_identity_census_now, field_position_counts, field_position_jit_stats,
+    field_position_unresolved_report,
 };
 pub use pyre_jit_trace::{
     trace_box_float, trace_box_int, trace_float_binop, trace_float_compare, trace_int_binop,

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -934,6 +934,20 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
             counter("pyre_jit_field_pos_attached_checked", &mut missing);
         let field_pos_attached_misplaced =
             counter("pyre_jit_field_pos_attached_misplaced", &mut missing);
+        // The rest of the `field_position_census`. `field_pos_unresolved` is
+        // the only counter that sees fields whose parent does not contain them:
+        // both halves of the `attached_*` pair are counted inside a lookup that
+        // must first succeed, so that population is missing from numerator and
+        // denominator alike and the pair reads healthy while blind.
+        //
+        // Asking for them is what makes them gateable. The refusal below fires
+        // only for names in THIS list, so a counter nobody asks for is not
+        // caught by it — it simply never appears, and `_jit_stats_change` reads
+        // an absent field as 0, the healthy value.
+        let field_pos_parent_absent = counter("pyre_jit_field_pos_parent_absent", &mut missing);
+        let field_pos_parent_empty = counter("pyre_jit_field_pos_parent_empty", &mut missing);
+        let field_pos_rederived = counter("pyre_jit_field_pos_rederived", &mut missing);
+        let field_pos_unresolved = counter("pyre_jit_field_pos_unresolved", &mut missing);
         // Walks that ended uncommitted after a residual had already run an
         // irreversible effect. Reached through the slot-indexed `pyre_fbw_diag`
         // export rather than a counter of its own; slot 1 is
@@ -991,6 +1005,10 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
              field_pos_spec_misplaced={field_pos_spec_misplaced} \
              field_pos_attached_checked={field_pos_attached_checked} \
              field_pos_attached_misplaced={field_pos_attached_misplaced} \
+             field_pos_parent_absent={field_pos_parent_absent} \
+             field_pos_parent_empty={field_pos_parent_empty} \
+             field_pos_rederived={field_pos_rederived} \
+             field_pos_unresolved={field_pos_unresolved} \
              fbw_store_journal_rollback_failed={fbw_store_journal_rollback_failed} \
              fbw_blackhole_adopted_single_frame={fbw_blackhole_adopted_single_frame} \
              fbw_blackhole_adopted_multi_frame={fbw_blackhole_adopted_multi_frame}"

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -582,6 +582,43 @@ pub extern "C" fn pyre_jit_field_pos_attached_checked() -> u64 {
     pyre_jit::field_position_counts().attached_checked
 }
 
+/// The four `derive_index_in_parent` dispositions, the rest of the
+/// `field_position_census`.
+///
+/// `unresolved` — parent resolved, non-empty, field absent from it — is the
+/// population the `attached_*` pair structurally cannot see: both halves of
+/// that pair are counted inside a lookup that must first succeed, so a field
+/// its parent does not contain is counted by neither and numerator and
+/// denominator read healthy together. It is the only counter that reports it.
+///
+/// Export all dispositions explicitly: the runner can reject a requested
+/// missing symbol, but it cannot detect a counter it never requested. These
+/// counts describe name resolution rather than target-dependent offsets, but
+/// their values still depend on the workload.
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_field_pos_parent_absent() -> u64 {
+    pyre_jit::field_position_counts().parent_absent
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_field_pos_parent_empty() -> u64 {
+    pyre_jit::field_position_counts().parent_empty
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_field_pos_rederived() -> u64 {
+    pyre_jit::field_position_counts().rederived
+}
+
+#[cfg(all(target_arch = "wasm32", feature = "wasm-host"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn pyre_jit_field_pos_unresolved() -> u64 {
+    pyre_jit::field_position_counts().unresolved
+}
+
 #[cfg(any(feature = "web", feature = "wasm-host"))]
 static PANIC_HOOK: Once = Once::new();
 

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -22,11 +22,23 @@ name = "pyre-dynasm"
 path = "src/bin/pyre-dynasm.rs"
 required-features = ["dynasm"]
 
+# Allocation-site census. Declared rather than left to auto-discovery so that
+# what `--all-targets` builds is visible here; it carries no `required-features`
+# because nothing in it is feature-gated, and its own `#[global_allocator]` does
+# not collide with `mimalloc` (that one is declared in the bin targets above,
+# not in `lib.rs`, and an example links the library).
+[[example]]
+name = "allocsites"
+path = "examples/allocsites.rs"
+
 [features]
 default = ["dynasm", "mimalloc"]
 jit = []  # meta feature: enabled by cranelift or dynasm
 cranelift = ["jit", "pyre-jit/cranelift"]
 dynasm = ["jit", "pyre-jit/dynasm"]
+# Compile heavyweight JIT audits only in binaries built explicitly for
+# diagnosis. Ordinary debug and release binaries contain no audit call sites.
+jit-audits = ["pyre-jit/jit-audits", "majit-metainterp/jit-audits"]
 # Use mimalloc as the default global allocator. The bignum path allocates a
 # fresh limb Vec per rbigint op, and Python call/GC bookkeeping also performs
 # enough small host allocations for the platform allocator to be measurable.

--- a/pyre/pyrex/examples/allocsites.rs
+++ b/pyre/pyrex/examples/allocsites.rs
@@ -1,0 +1,319 @@
+//! Allocation-site census for a pyre run.
+//!
+//! ```text
+//! cargo run --release --example allocsites -- script.py
+//! cargo run --release --no-default-features --features cranelift \
+//!     --example allocsites -- script.py
+//! ```
+//!
+//! The global allocator is scoped to this example and uses `System`; the pyre
+//! binaries' `mimalloc` allocator is not linked here. Counters are process-global
+//! because `main_entry` runs the interpreter on a spawned thread.
+//!
+//! Total allocation counts are exact. Stack attribution is optional, windowed,
+//! and budgeted because capturing a backtrace for every allocation is too
+//! expensive. Allocations are grouped by captured stack rather than size.
+//!
+//! Warm the same binary before comparisons: frozen-importlib caches depend on
+//! the executable and make its first run materially different. Keep compared
+//! binaries in the same directory because stdlib discovery is location-relative.
+//! A `std::process::exit` path skips the final report; absence of the
+//! `=== allocsites ===` header means no result was produced.
+//!
+//! # Environment
+//!
+//! | var | default | meaning |
+//! |---|---|---|
+//! | `PYRE_ALLOCSITES` | unset | set to `1` to capture stacks at all |
+//! | `PYRE_ALLOCSITES_AFTER` | 0 | skip this many allocations first (startup) |
+//! | `PYRE_ALLOCSITES_BUDGET` | 20000 | stop capturing after this many stacks |
+//! | `PYRE_ALLOCSITES_EVERY` | 1 | capture 1 in N of the eligible allocations |
+//! | `PYRE_ALLOCSITES_ROWS` | 40 | how many site rows to print |
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::backtrace::Backtrace;
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering::Relaxed};
+
+/// Every allocation the program makes, whatever the configuration. Exact.
+static TOTAL_ALLOCS: AtomicU64 = AtomicU64::new(0);
+/// Allocations made by the capture machinery itself, kept out of `TOTAL_ALLOCS`
+/// so that turning capture on does not change the number capture is measuring.
+static INSTRUMENT_ALLOCS: AtomicU64 = AtomicU64::new(0);
+/// Allocations that fell inside the capture window and were eligible to be
+/// attributed (before `_EVERY` sampling).
+static ELIGIBLE: AtomicU64 = AtomicU64::new(0);
+/// Stacks actually recorded. `<= ELIGIBLE`.
+static CAPTURED: AtomicU64 = AtomicU64::new(0);
+/// Samples lost because another thread held the site map. Reported: a silent
+/// drop would understate a site by an unknown amount.
+static LOST_CONTENDED: AtomicU64 = AtomicU64::new(0);
+
+static CAPTURE_ON: AtomicBool = AtomicBool::new(false);
+static AFTER: AtomicU64 = AtomicU64::new(0);
+static BUDGET: AtomicU64 = AtomicU64::new(20_000);
+static EVERY: AtomicU64 = AtomicU64::new(1);
+static ROWS: AtomicUsize = AtomicUsize::new(40);
+
+/// Site signature -> count. This is process-global rather than thread-local
+/// because `main_entry` runs the interpreter on a spawned thread; `try_lock`
+/// keeps the allocator non-blocking.
+static SITES: Mutex<Option<HashMap<String, u64>>> = Mutex::new(None);
+
+std::thread_local! {
+    /// `Backtrace::force_capture`, `format!` and `HashMap::insert` all
+    /// allocate, and those allocations re-enter `alloc` immediately. Without
+    /// this the first capture recurses until the stack ends. Re-entrancy is
+    /// per-thread even though the counters are not. `const`-initialised so
+    /// first access does not itself allocate.
+    static IN_CAPTURE: Cell<bool> = const { Cell::new(false) };
+}
+
+struct Counting;
+
+/// True while this thread is inside the capture machinery.
+fn in_capture() -> bool {
+    IN_CAPTURE.try_with(Cell::get).unwrap_or(true)
+}
+
+#[cold]
+#[inline(never)]
+fn record_site() {
+    if IN_CAPTURE.try_with(|c| c.replace(true)).unwrap_or(true) {
+        return;
+    }
+    let bt = Backtrace::force_capture();
+    let sig = interesting_frames(&format!("{bt}"));
+    if !sig.is_empty() {
+        match SITES.try_lock() {
+            Ok(mut guard) => {
+                if let Some(map) = guard.as_mut() {
+                    *map.entry(sig).or_insert(0) += 1;
+                    CAPTURED.fetch_add(1, Relaxed);
+                }
+            }
+            Err(_) => {
+                LOST_CONTENDED.fetch_add(1, Relaxed);
+            }
+        }
+    }
+    let _ = IN_CAPTURE.try_with(|c| c.set(false));
+}
+
+/// Decide whether this allocation is inside the capture window. Runs on every
+/// allocation once capture is on, so it is loads and one modulo.
+#[inline]
+fn maybe_capture(n: u64) {
+    if n <= AFTER.load(Relaxed) {
+        return;
+    }
+    if CAPTURED.load(Relaxed) >= BUDGET.load(Relaxed) {
+        return;
+    }
+    let eligible = ELIGIBLE.fetch_add(1, Relaxed) + 1;
+    let every = EVERY.load(Relaxed);
+    if every > 1 && eligible % every != 0 {
+        return;
+    }
+    record_site();
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if in_capture() {
+            INSTRUMENT_ALLOCS.fetch_add(1, Relaxed);
+        } else {
+            let n = TOTAL_ALLOCS.fetch_add(1, Relaxed) + 1;
+            if CAPTURE_ON.load(Relaxed) {
+                maybe_capture(n);
+            }
+        }
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        // A realloc counts as an allocation: it is exactly what an unsized
+        // `Vec` pays per growth step, so count each growth allocation.
+        if in_capture() {
+            INSTRUMENT_ALLOCS.fetch_add(1, Relaxed);
+        } else {
+            let n = TOTAL_ALLOCS.fetch_add(1, Relaxed) + 1;
+            if CAPTURE_ON.load(Relaxed) {
+                maybe_capture(n);
+            }
+        }
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static COUNTING: Counting = Counting;
+
+/// Keep the frames naming this system; drop libstd, the allocator shim and the
+/// capture machinery. A raw backtrace here is ~60 frames.
+///
+/// `allocsites_probe_marker` is kept deliberately — it is what the non-vacuity
+/// check below looks for, and filtering the instrument's own frames out
+/// entirely would make that check unable to observe itself.
+fn interesting_frames(bt: &str) -> String {
+    bt.lines()
+        .map(str::trim)
+        .filter(|l| l.contains("::"))
+        .filter(|l| {
+            (l.contains("majit") || l.contains("pyre") || l.contains("allocsites_probe_marker"))
+                && !l.contains("record_site")
+                && !l.contains("maybe_capture")
+                && !l.contains("interesting_frames")
+                && !l.contains("Backtrace")
+                && !l.contains("backtrace")
+        })
+        .take(6)
+        .collect::<Vec<_>>()
+        .join(" <- ")
+}
+
+/// The allocations the non-vacuity check makes. Named so its frame survives
+/// `interesting_frames`, which is how the check proves the *whole* chain works
+/// — hook, backtrace, filter, map insert — and not merely the counter.
+#[inline(never)]
+fn allocsites_probe_marker(sink: &mut Vec<String>) {
+    for i in 0..PROBE_ALLOCS {
+        sink.push(format!("nonvacuity-{i}"));
+    }
+    std::hint::black_box(sink);
+}
+
+const PROBE_ALLOCS: u64 = 64;
+
+/// In-band non-vacuity check, printed every run.
+///
+/// An allocation counter that reads a plausible number while measuring nothing
+/// is the failure this instrument exists to avoid, and a plausible number looks
+/// exactly like a real one. So the harness makes a **known** number of
+/// allocations and reports whether it saw them.
+///
+/// It runs at report time rather than startup because the
+/// configuration that matters is the one in force during the measured run. A
+/// probe fired before `_AFTER` allocations had elapsed would sit outside the
+/// capture window and fail for a reason that says nothing about the run.
+fn nonvacuity() -> (u64, u64, bool) {
+    let total_before = TOTAL_ALLOCS.load(Relaxed);
+    let captured_before = CAPTURED.load(Relaxed);
+    let mut sink: Vec<String> = Vec::with_capacity(PROBE_ALLOCS as usize);
+    allocsites_probe_marker(&mut sink);
+    let counted = TOTAL_ALLOCS.load(Relaxed) - total_before;
+    let attributed = CAPTURED.load(Relaxed) - captured_before;
+    // The site half can only be asserted when capture is on and unexhausted.
+    let site_chain_testable = CAPTURE_ON.load(Relaxed)
+        && CAPTURED.load(Relaxed) < BUDGET.load(Relaxed)
+        && EVERY.load(Relaxed) == 1;
+    (counted, attributed, site_chain_testable)
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(default)
+}
+
+fn main() {
+    // Read configuration and build the map BEFORE arming: `std::env::var` and
+    // `HashMap::new` allocate, and doing this under a live counter would
+    // attribute the instrument's own setup to the program.
+    let capture = std::env::var("PYRE_ALLOCSITES").is_ok_and(|v| v == "1");
+    AFTER.store(env_u64("PYRE_ALLOCSITES_AFTER", 0), Relaxed);
+    BUDGET.store(env_u64("PYRE_ALLOCSITES_BUDGET", 20_000), Relaxed);
+    EVERY.store(env_u64("PYRE_ALLOCSITES_EVERY", 1).max(1), Relaxed);
+    ROWS.store(env_u64("PYRE_ALLOCSITES_ROWS", 40) as usize, Relaxed);
+    SITES.lock().unwrap().replace(HashMap::with_capacity(1024));
+    CAPTURE_ON.store(capture, Relaxed);
+
+    // The real CLI. argv is this example's own, so everything after `--`
+    // reaches `real_main` unchanged.
+    //
+    // A script that exits through `sys.exit()` bypasses the report below; see
+    // the module-level usage notes.
+    pyrex::main_entry("pyre-allocsites");
+
+    let (probe_counted, probe_attributed, site_testable) = nonvacuity();
+    CAPTURE_ON.store(false, Relaxed);
+
+    let total = TOTAL_ALLOCS.load(Relaxed);
+    let instrument = INSTRUMENT_ALLOCS.load(Relaxed);
+    let eligible = ELIGIBLE.load(Relaxed);
+    let captured = CAPTURED.load(Relaxed);
+    let lost = LOST_CONTENDED.load(Relaxed);
+
+    println!("\n=== allocsites ===");
+
+    // The non-vacuity verdict is printed FIRST, so a reader cannot reach the
+    // numbers without passing it.
+    let counter_ok = probe_counted >= PROBE_ALLOCS;
+    let sites_ok = !site_testable || probe_attributed > 0;
+    let verdict = match (counter_ok, sites_ok) {
+        (true, true) if site_testable => "PASS (counter + site chain)",
+        (true, true) => "PASS (counter only; site chain not testable in this config)",
+        (false, _) => {
+            "STOP: FAIL — the counter did not see allocations it just made. \
+                       Every number below is VOID, not small."
+        }
+        (_, false) => {
+            "STOP: FAIL — allocations were counted but none were attributed. \
+                       Site rows below are VOID."
+        }
+    };
+    println!(
+        "non-vacuity: made {PROBE_ALLOCS} allocations, counted {probe_counted}, \
+         attributed {probe_attributed}  [{verdict}]"
+    );
+
+    let window = if capture {
+        format!(
+            "after={} budget={} every={}",
+            AFTER.load(Relaxed),
+            BUDGET.load(Relaxed),
+            EVERY.load(Relaxed)
+        )
+    } else {
+        "off (set PYRE_ALLOCSITES=1)".to_string()
+    };
+    println!("capture window:      {window}");
+    println!("total allocations:   {total}   (exact, independent of the window)");
+    println!(
+        "WARNING: discard run 1 of any new binary NAME: the frozen-importlib marshal cache is\n\
+         \x20 keyed by basename and costs ~48k extra allocations to build, once."
+    );
+    println!("instrument's own:    {instrument}   (excluded from the total above)");
+    println!("eligible in window:  {eligible}");
+    println!("stacks recorded:     {captured}");
+    if lost > 0 {
+        println!("WARNING: samples lost to lock contention: {lost}");
+    }
+    if capture && captured >= BUDGET.load(Relaxed) {
+        println!(
+            "WARNING: BUDGET EXHAUSTED — the rows below describe the first {captured} \
+             eligible allocations only, not the run."
+        );
+    }
+
+    let map = SITES.lock().unwrap().take().unwrap_or_default();
+    let mut rows: Vec<(String, u64)> = map.into_iter().collect();
+    rows.sort_by(|a, b| b.1.cmp(&a.1));
+    let limit = ROWS.load(Relaxed);
+    println!("\ntop {limit} allocation sites (majit/pyre frames, innermost first):");
+    for (sig, count) in rows.iter().take(limit) {
+        println!("  {count:>9}  {sig}");
+    }
+    if rows.is_empty() {
+        println!("  (none)");
+    } else {
+        println!("\ndistinct sites: {}", rows.len());
+    }
+}

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -821,6 +821,7 @@ fn maybe_print_jit_stats() {
     maybe_print_mc_diag();
     maybe_print_gc_diag();
     maybe_print_spec_census();
+    maybe_print_cell_census();
     if std::env::var_os("MAJIT_STATS").is_none() {
         return;
     }
@@ -918,6 +919,14 @@ fn maybe_print_jit_stats() {
     // Whether those slots were filled CORRECTLY, which the line above
     // cannot say. See `field_position_jit_stats`.
     eprintln!("[jit-stats] {}", pyre_jit::field_position_jit_stats());
+    // Which mints those `field_pos_unresolved` are. Off unless
+    // `MAJIT_FIELD_POS_UNRESOLVED`, and it takes `all_descrs_len` because the
+    // table needs a denominator that is not one of its own numbers: a run that
+    // never loaded the descr universe records nothing, and so does a tree with
+    // nothing wrong.
+    for line in pyre_jit::field_position_unresolved_report(all_descrs_len) {
+        eprintln!("[jit-stats] {line}");
+    }
 }
 
 /// Names for the `MC_DIAG` tallies, in index order — the array
@@ -927,16 +936,6 @@ fn maybe_print_jit_stats() {
 /// program diffable field by field.
 use majit_metainterp::MC_DIAG_LABELS as MC_DIAG_FIELDS;
 
-/// Print the guard-failure → bridge-trace gate tallies. Until this existed the
-/// counters were bumped on every backend but only readable through the wasm
-/// guest export, so the question "did this guard failure ever reach a bridge,
-/// or was it short-circuited by the decline blacklist" could not be asked of a
-/// native run at all.
-///
-/// Deliberately NOT under the `[jit-stats]` prefix: `check.py`'s
-/// `_jit_stats_snapshot` keeps the LAST such line, so a second one would
-/// silently replace the committed per-bench baseline. Its own env gate keeps it
-/// off the default `check.py` run, which sets `MAJIT_STATS` for every bench.
 /// Print the GC's deterministic pressure counters.
 ///
 /// The perf question this answers is the one a loaded machine's clock cannot:
@@ -969,6 +968,16 @@ fn maybe_print_spec_census() {
     eprint!("{}", pyre_jit::spec_census_summary());
 }
 
+/// Print the guard-failure → bridge-trace gate tallies. Until this existed the
+/// counters were bumped on every backend but only readable through the wasm
+/// guest export, so the question "did this guard failure ever reach a bridge,
+/// or was it short-circuited by the decline blacklist" could not be asked of a
+/// native run at all.
+///
+/// Deliberately NOT under the `[jit-stats]` prefix: `check.py`'s
+/// `_jit_stats_snapshot` keeps the LAST such line, so a second one would
+/// silently replace the committed per-bench baseline. Its own env gate keeps it
+/// off the default `check.py` run, which sets `MAJIT_STATS` for every bench.
 fn maybe_print_mc_diag() {
     if std::env::var_os("PYRE_MC_DIAG").is_none() {
         return;
@@ -978,6 +987,56 @@ fn maybe_print_mc_diag() {
         line.push_str(&format!(" {name}={}", majit_metainterp::mc_diag(i)));
     }
     eprintln!("{line}");
+}
+
+/// Print the JIT cell table's occupancy at exit.
+///
+/// `WarmEnterState.cells` is an `IndexMap` keyed by the whole green-key hash,
+/// and nothing production-reachable removes an entry from it: `install_new_cell`
+/// prunes only within one bucket, which needs a hash collision, and `gc_cells` —
+/// the whole-table sweep — has `test_gc_cells` as its only caller. So the
+/// table's size is a function of the workload rather than of any bound, and the
+/// number nobody had was how fast it grows on a real program.
+///
+/// Read it as a ladder: the level alone is a workload fact, the slope across
+/// runs of increasing size is the rate. `loops_compiled` on the `[jit-stats]`
+/// line is the arming witness — a run that compiled nothing exercised no cell
+/// mint, and its `cells` says nothing about growth.
+///
+/// `pinned_refs` is normally 0 because `RetainedGreens` retains through
+/// `majit_ir::set_ref_resolver`,
+/// which no pyre frontend calls — the whole tree's only callers are in
+/// `warmstate.rs`'s own tests — so a stored `Ref` green owns nothing and the
+/// column reports the hook's absence, not an empty pinned set. A nonzero value
+/// here means somebody registered a resolver and this paragraph is stale.
+///
+/// Same prefix discipline as [`maybe_print_gc_diag`]: not `[jit-stats]`, and
+/// behind its own env gate, so the committed per-bench baselines never see it.
+/// Keep it off that line: `cells` depends on workload and host state, while
+/// `check.py` gates jit-stats rows on exact equality. A counter
+/// earns a gated row by being a function of the program alone.
+fn maybe_print_cell_census() {
+    if std::env::var_os("PYRE_CELL_CENSUS").is_none() {
+        return;
+    }
+    let stats = pyre_jit::eval::driver_pair()
+        .0
+        .meta_interp()
+        .warm_state_ref()
+        .get_stats();
+    // Unconditional once the gate is set, including on a zero: a missing line
+    // then means the probe is not in the binary, which is a different fact from
+    // an empty table and must not print the same bytes.
+    eprintln!(
+        "[jit-cell-census] cells={} compiled={} tracing={} invalidated={} \
+         dont_trace_here={} pinned_refs={}",
+        stats.num_cells,
+        stats.num_compiled,
+        stats.num_tracing,
+        stats.num_invalidated,
+        stats.num_disable_noninlinable_function,
+        stats.num_pinned_refs,
+    );
 }
 
 /// Shared top-level launcher bootstrap for `run_source` and `run_module`:

--- a/pyre/pyrex/tests/gate_triage_complete.rs
+++ b/pyre/pyrex/tests/gate_triage_complete.rs
@@ -1,34 +1,10 @@
-//! `pyre/gate-triage.md` and the tree's `PYRE_*` environment gates must name the
-//! same set — every gate read from a workspace member's Rust or from this
-//! project's own Python has a live entry, and every live entry has a reader.
+//! Checks that each environment-gate namespace and its triage document contain
+//! the same live names. The scan covers Rust workspace members and project-owned
+//! Python under `pyre/` and `scripts/`.
 //!
-//! The charter (§3.6) says a gate is a staging area, not a home, and
-//! `gate-triage.md` is the standing list of what to retire and when. That list
-//! only works if a gate joins it when it is born: audited by hand, it drifted to
-//! 63% empty — 66 of 105 live gates were absent — because nothing failed when a
-//! new gate skipped it. This test is that failure.
-//!
-//! Adding a gate therefore costs one row. The row is cheap; the alternative is
-//! another hand audit that goes stale the week after it lands.
-//!
-//! Both directions, because they rot differently and only one of them is loud. A
-//! gate with no row is a gate nobody will retire. A row with no reader is the
-//! quieter half: it survives the deletion of the code it describes, and the next
-//! sweep spends its time re-deriving that the name is already gone —
-//! `PYRE_FBW_REC_UNROLL` sat in the config-switch list from 2026-07-06, when
-//! PR#374 deleted `fbw_unroll_bound()`, until this test went looking.
-//!
-//! **Scope.** Rust sources in workspace member crates, and this project's own
-//! Python under `pyre/` and `scripts/`. The harness reads six gates that no Rust
-//! file reads — `check.py`, `check_synthetic.py`, the `extra_tests` runners and
-//! `scripts/llbc_extract.py` — and two of them, `PYRE_SYNTH_PYRE` and
-//! `PYRE_SYNTH_PYTHON`, were undocumented until this scan reached them.
-//!
-//! Shell and YAML are not scanned. Every `PYRE_*` in them is *set* for a child
-//! process whose reader is Rust or Python, so the read side is already covered
-//! here; the one remaining `PYRE_*` name outside both languages,
-//! `PYRE_CLASS_DESCRIPTORS`, is a linkme distributed slice and not an env var at
-//! all (`gate-triage.md` §2).
+//! Gate names in comments are not readers. Build-script
+//! `rerun-if-env-changed` declarations are readers because they affect Cargo's
+//! dependency tracking even when the environment lookup is indirect.
 
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
@@ -120,6 +96,43 @@ fn collect_sources(dir: &Path, ext: &str, out: &mut Vec<PathBuf>) {
 /// occur in Python, nor `environ.get(` in Rust.
 const READ_FORMS: [&str; 4] = ["env::var", "host_os::var", "getenv", "environ.get"];
 
+/// Cargo's build-script declaration that the build depends on a gate:
+/// `println!("cargo::rerun-if-env-changed=NAME")`.
+///
+/// This counts as a read because it controls when Cargo reruns the build script.
+/// It also covers gates passed through an indirect environment-read helper.
+const CARGO_ENV_DEP: &str = "rerun-if-env-changed=";
+
+/// A gate namespace: the prefix its names carry, and the document that owns them.
+///
+/// Each namespace owns a document so separately versioned components carry the
+/// retirement information for their own gates.
+struct GateNamespace {
+    prefix: &'static str,
+    doc: &'static str,
+}
+
+/// Adding a row arms both checks for the entire namespace. Add its triage
+/// document in the same change; otherwise every live name in the namespace is
+/// reported as undocumented.
+///
+/// The checks compare names; they do not validate a row's prose.
+const NAMESPACES: [GateNamespace; 2] = [
+    GateNamespace {
+        prefix: "PYRE_",
+        doc: "pyre/gate-triage.md",
+    },
+    GateNamespace {
+        prefix: "MAJIT_",
+        doc: "majit/gate-triage.md",
+    },
+];
+
+/// The namespace owning this gate name, if any.
+fn namespace_of(name: &str) -> Option<&'static GateNamespace> {
+    NAMESPACES.iter().find(|ns| name.starts_with(ns.prefix))
+}
+
 /// Gate names this text reads from the environment.
 ///
 /// Matches the read forms above rather than every mention of the name, so a gate
@@ -143,9 +156,21 @@ fn gates_read_by(text: &str) -> Vec<&str> {
             };
             let Some(end) = rest.find('"') else { continue };
             let name = &rest[..end];
-            if name.starts_with("PYRE_") {
+            if namespace_of(name).is_some() {
                 found.push(name);
             }
+        }
+    }
+    // The build-script dependency declaration, which carries its name bare
+    // rather than as a quoted call argument.
+    for (at, _) in text.match_indices(CARGO_ENV_DEP) {
+        let rest = &text[at + CARGO_ENV_DEP.len()..];
+        let end = rest
+            .find(|c: char| !(c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_'))
+            .unwrap_or(rest.len());
+        let name = &rest[..end];
+        if namespace_of(name).is_some() {
+            found.push(name);
         }
     }
     found
@@ -163,6 +188,7 @@ fn gates_read_by_matches_the_read_forms_and_nothing_else() {
         crate::host_seam::ops::getenv(b"PYRE_E");
         os.environ.get("PYRE_F")
         os.getenv("PYRE_G")
+        println!("cargo::rerun-if-env-changed=PYRE_H");
         # a gate written into a child's environment is not a read of ours
         env["PYRE_NOT_A_READ_EITHER"] = "1"
         // PYRE_MENTIONED_IN_A_COMMENT
@@ -176,7 +202,7 @@ fn gates_read_by_matches_the_read_forms_and_nothing_else() {
     assert_eq!(
         got,
         vec![
-            "PYRE_A", "PYRE_B", "PYRE_C", "PYRE_D", "PYRE_E", "PYRE_F", "PYRE_G"
+            "PYRE_A", "PYRE_B", "PYRE_C", "PYRE_D", "PYRE_E", "PYRE_F", "PYRE_G", "PYRE_H"
         ]
     );
 }
@@ -196,14 +222,19 @@ fn is_history_heading(heading: &str) -> bool {
     lower.contains("retired") || lower.contains("dead") || lower.contains("not gates")
 }
 
-/// The `PYRE_*` names this line spells out, in the order it spells them.
+/// The names carrying `prefix` that this line spells out, in the order it
+/// spells them.
 ///
 /// Tokenized rather than substring-searched: `contains("PYRE_A")` is satisfied
 /// by a documented `PYRE_ANCHOR_STRICT`, so a new gate whose name is a prefix of
 /// a listed one would slip through the brake unnoticed.
-fn pyre_names_in(line: &str) -> Vec<&str> {
+///
+/// The same tokenization keeps the two namespaces apart where they overlap in
+/// text: `PYRE_MAJIT_STATS_ANCESTOR` contains `MAJIT_`, and the preceding-
+/// character guard is what stops it being read as a majit gate.
+fn gate_names_in<'a>(line: &'a str, prefix: &str) -> Vec<&'a str> {
     let mut names = Vec::new();
-    for (at, _) in line.match_indices("PYRE_") {
+    for (at, _) in line.match_indices(prefix) {
         // A name preceded by a name character is the tail of a longer token.
         if line[..at]
             .chars()
@@ -240,17 +271,33 @@ fn pyre_names_in(line: &str) -> Vec<&str> {
 ///
 /// "retired", not "retire": §4 is a live section whose gates are the ones that
 /// "retire when the epic closes".
-fn gates_documented_in(triage: &str) -> BTreeSet<&str> {
+///
+/// A line that *negates* the word is refused rather than read either way — see
+/// `negates_retirement`.
+fn gates_documented_in<'a>(triage: &'a str, prefix: &str) -> BTreeSet<&'a str> {
     let mut live_names: BTreeSet<&str> = BTreeSet::new();
     let mut retired_subjects: BTreeSet<&str> = BTreeSet::new();
     let mut live = true;
-    for line in triage.lines() {
+    for (at, line) in triage.lines().enumerate() {
         if let Some(heading) = line.strip_prefix("## ") {
             live = !is_history_heading(heading);
         }
-        let names = pyre_names_in(line);
-        if line.to_ascii_lowercase().contains("retired") {
+        let names = gate_names_in(line, prefix);
+        let lower = line.to_ascii_lowercase();
+        if lower.contains("retired") {
             if let Some(&subject) = names.first() {
+                assert!(
+                    !negates_retirement(&lower),
+                    "line {} of the {prefix}* triage document names {subject} beside a \
+                     negated `retired`, so the scan cannot tell whether the line records \
+                     a retirement:\n  {line}\n\n\
+                     The scan reads `retired` as a verdict on the line's first name and \
+                     would drop {subject} from the live set wherever else the document \
+                     writes it — which a line saying it is *not* retired does not ask \
+                     for. Either state the retirement plainly, or write the note without \
+                     the word.",
+                    at + 1
+                );
                 retired_subjects.insert(subject);
             }
         } else if live {
@@ -259,6 +306,16 @@ fn gates_documented_in(triage: &str) -> BTreeSet<&str> {
     }
     live_names.retain(|name| !retired_subjects.contains(name));
     live_names
+}
+
+/// Does this line say a gate is *not* retired?
+///
+/// A negated retirement beside a gate name is ambiguous to the line-oriented
+/// parser, so it is rejected instead of silently dropping a live entry.
+fn negates_retirement(lowercased_line: &str) -> bool {
+    ["not retired", "never retired", "not yet retired"]
+        .iter()
+        .any(|negation| lowercased_line.contains(negation))
 }
 
 /// A documented token that is a wildcard's stem rather than a gate.
@@ -323,17 +380,30 @@ fn read_sites(root: &Path) -> BTreeSet<(String, String)> {
     sites
 }
 
-#[test]
-fn every_live_pyre_gate_has_a_gate_triage_entry() {
-    let root = repo_root();
-    let triage_path = root.join("pyre/gate-triage.md");
-    let triage = std::fs::read_to_string(&triage_path)
-        .unwrap_or_else(|e| panic!("cannot read {}: {e}", triage_path.display()));
-    let documented = gates_documented_in(&triage);
+/// The triage document owning `ns`, read from disk.
+fn triage_text(root: &Path, ns: &GateNamespace) -> String {
+    let path = root.join(ns.doc);
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("cannot read {}: {e}", path.display()))
+}
 
-    // Two anchors on the live/history split, because a heading reword would
-    // otherwise change what this test accepts without failing. One on each side:
-    // a retired name must not count, and a listed live name must.
+fn namespace(prefix: &str) -> &'static GateNamespace {
+    NAMESPACES
+        .iter()
+        .find(|ns| ns.prefix == prefix)
+        .expect("NAMESPACES names this prefix")
+}
+
+/// The live/history split in `gate-triage.md` is load-bearing for both brakes,
+/// and a heading reword would otherwise change what they accept without failing.
+/// Anchored on each side: a retired name must not count, a listed live name must.
+#[test]
+fn pyre_triage_live_history_split_holds_at_four_anchors() {
+    let root = repo_root();
+    let ns = namespace("PYRE_");
+    // Bound, not inlined: the returned set borrows the document text.
+    let triage = triage_text(&root, ns);
+    let documented = gates_documented_in(&triage, ns.prefix);
+
     assert!(
         !documented.contains("PYRE_SINGLE_PASS"),
         "PYRE_SINGLE_PASS is named only in a retirement section and has no read \
@@ -356,56 +426,131 @@ fn every_live_pyre_gate_has_a_gate_triage_entry() {
         "PYRE_JD1 is listed live in §6a but did not count as documented — \
          is_history_heading is excluding a live section"
     );
+}
 
-    let missing: BTreeSet<(String, String)> = read_sites(&root)
-        .into_iter()
-        .filter(|(name, _)| !documented.contains(name.as_str()))
-        .collect();
+#[test]
+fn every_live_gate_has_a_triage_entry() {
+    let root = repo_root();
+    let sites = read_sites(&root);
 
-    if !missing.is_empty() {
-        let listed = missing
+    for ns in &NAMESPACES {
+        let triage = triage_text(&root, ns);
+        let documented = gates_documented_in(&triage, ns.prefix);
+        let missing: Vec<&(String, String)> = sites
             .iter()
-            .map(|(name, file)| format!("  {name}  ({file})"))
-            .collect::<Vec<_>>()
-            .join("\n");
-        panic!(
-            "{} PYRE_* gate(s) are read from the environment but have no entry in \
-             pyre/gate-triage.md:\n{listed}\n\n\
+            .filter(|(name, _)| name.starts_with(ns.prefix) && !documented.contains(name.as_str()))
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "{} {}* gate(s) are read from the environment but have no entry in \
+             {}:\n{}\n\n\
              Add a row for each: what it gates, its default polarity, and — for a \
              default-ON experiment — the epic whose close retires it.",
-            missing.len()
+            missing.len(),
+            ns.prefix,
+            ns.doc,
+            missing
+                .iter()
+                .map(|(name, file)| format!("  {name}  ({file})"))
+                .collect::<Vec<_>>()
+                .join("\n")
         );
     }
 }
 
 #[test]
-fn every_live_gate_triage_entry_still_has_a_reader() {
+fn every_live_triage_entry_still_has_a_reader() {
     let root = repo_root();
-    let triage_path = root.join("pyre/gate-triage.md");
-    let triage = std::fs::read_to_string(&triage_path)
-        .unwrap_or_else(|e| panic!("cannot read {}: {e}", triage_path.display()));
-
     let read: BTreeSet<String> = read_sites(&root)
         .into_iter()
         .map(|(name, _)| name)
         .collect();
-    let stale: Vec<&str> = gates_documented_in(&triage)
-        .into_iter()
-        .filter(|name| !is_wildcard_stem(name) && !read.contains(*name))
-        .collect();
+
+    for ns in &NAMESPACES {
+        let triage = triage_text(&root, ns);
+        let stale: Vec<&str> = gates_documented_in(&triage, ns.prefix)
+            .into_iter()
+            .filter(|name| !is_wildcard_stem(name) && !read.contains(*name))
+            .collect();
+
+        assert!(
+            stale.is_empty(),
+            "{} name(s) are listed live in {} but nothing in the tree reads \
+             them:\n{}\n\n\
+             Deleting the row loses why the gate existed. Move each to a retirement \
+             section (§1c) naming the change that removed its reader — that is what \
+             stops the next reader of this name from passing on an obituary.",
+            stale.len(),
+            ns.doc,
+            stale
+                .iter()
+                .map(|name| format!("  {name}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+}
+
+/// Prove that each namespace is checked against its own document, rather than a
+/// union that could hide a name recorded in the wrong document.
+#[test]
+fn both_brakes_are_parameterized_over_the_namespace() {
+    let ex_doc = "## §1 live\n`EX_KNOWN` gates a thing.\n";
+    let syn_doc = "## §1 live\n`SYN_KNOWN` gates a thing.\n`EX_ELSEWHERE` is named here.\n";
 
     assert!(
-        stale.is_empty(),
-        "{} name(s) are listed live in pyre/gate-triage.md but nothing in the tree \
-         reads them:\n{}\n\n\
-         Deleting the row loses why the gate existed. Move each to a retirement \
-         section (§1c) naming the change that removed its reader — that is what \
-         stops the next reader of this name from passing on an obituary.",
-        stale.len(),
-        stale
-            .iter()
-            .map(|name| format!("  {name}"))
-            .collect::<Vec<_>>()
-            .join("\n")
+        gates_documented_in(ex_doc, "EX_").contains("EX_KNOWN"),
+        "prefix scan missed its own name"
+    );
+    assert!(
+        gates_documented_in(syn_doc, "SYN_").contains("SYN_KNOWN"),
+        "prefix scan missed its own name"
+    );
+
+    // Positive control: the name is findable by this scan, in the document that
+    // spells it.
+    assert!(
+        gates_documented_in(syn_doc, "EX_").contains("EX_ELSEWHERE"),
+        "the control failed — the scan cannot find EX_ELSEWHERE anywhere, so the \
+         assertion below would pass for the wrong reason"
+    );
+    // The check: it is not documented for `EX_`, because `EX_`'s document does
+    // not spell it. A scan over the union of all documents would pass the
+    // control and fail here — which is the failure that makes one shared
+    // document unsafe, and the reason `MAJIT_` cannot simply be pointed at
+    // `pyre/gate-triage.md`.
+    assert!(
+        !gates_documented_in(ex_doc, "EX_").contains("EX_ELSEWHERE"),
+        "a name absent from its own namespace's document counted as documented — \
+         the lookup is not per document"
+    );
+
+    // Retirement is per document too: the same name may be live in one and
+    // retired in the other, and each document governs only its own namespace.
+    let retired = gates_documented_in("## §1 live\n`EX_KNOWN` retired.\n", "EX_");
+    assert!(
+        !retired.contains("EX_KNOWN"),
+        "a retirement line in the namespace's own document did not retire its subject"
+    );
+}
+
+/// `PYRE_MAJIT_STATS_ANCESTOR` and friends spell `MAJIT_` inside a `PYRE_` name.
+///
+/// The preceding-character guard in `gate_names_in` is the only thing keeping
+/// them out of a future `MAJIT_` namespace, and it is one `continue` in a loop —
+/// cheap to lose in an edit, and its loss would silently move four documented
+/// pyre gates into majit's ledger.
+#[test]
+fn a_prefix_appearing_inside_a_longer_name_is_not_a_gate_of_that_namespace() {
+    let line = "`PYRE_MAJIT_STATS_ANCESTOR`, `PYRE_MAJIT_STATS_ROOT_ONLY`, `MAJIT_LOG`";
+    assert_eq!(
+        gate_names_in(line, "MAJIT_"),
+        vec!["MAJIT_LOG"],
+        "a `MAJIT_` embedded in a `PYRE_MAJIT_*` name was read as a majit gate"
+    );
+    assert_eq!(
+        gate_names_in(line, "PYRE_"),
+        vec!["PYRE_MAJIT_STATS_ANCESTOR", "PYRE_MAJIT_STATS_ROOT_ONLY"]
     );
 }

--- a/pyre/pyrex/tests/jit_trace_shape.rs
+++ b/pyre/pyrex/tests/jit_trace_shape.rs
@@ -1,0 +1,309 @@
+//! Pins the trace SHAPE a hot loop compiles to, read from the `MAJIT_LOG` dump.
+//!
+//! `loops_compiled` counts *compiles*, and a straight-line FINISH trace is one
+//! of them — so it reads `1` for a peeled loop and `1` for a program that
+//! compiled no loop at all. Nothing else in the tree distinguishes the two:
+//! `pyre/check.py`'s jit-stats gate compares counters, and an equality gate
+//! cannot fire on `1 -> 1`. The trace dump is the only instrument that can, and
+//! it needs no new counter because the emitter already labels each artifact.
+//!
+//! Only three dump headers identify a shape. The generic before/after headers
+//! occur on every compile path and are rejected explicitly by [`classify`].
+//!
+//! | header | what it tells you |
+//! |---|---|
+//! | `--- peeled trace (assembled) ---`      | loop, peeled   |
+//! | `--- simple loop trace (after opt) ---` | loop, unpeeled |
+//! | `--- finish trace (...) ---`            | **flat** — straight line, no loop |
+//! | `--- trace (before opt) ---`             | generic; rejected |
+//! | `--- trace (after opt) ---`              | generic; rejected |
+//!
+//! The test locates the transition within a declared window instead of pinning
+//! a trip count, because the hotness threshold and loop-body size can change.
+//!
+//! The scan is linear because a binary search would require compilation to be
+//! monotone in `n`. When the boundary leaves the window, the test says so.
+//!
+//! Do not invoke Cargo from this test: the parent `cargo test` holds the target
+//! directory lock. `CARGO_BIN_EXE_pyre-dynasm` supplies the binary Cargo already
+//! built for this integration test.
+
+// `pyre-dynasm` is `required-features = ["dynasm"]`, so under
+// `--no-default-features` the binary does not exist and `CARGO_BIN_EXE_…` is
+// unset — which would be a compile error rather than a skip. Compile this file
+// to nothing in that configuration instead.
+#![cfg(feature = "dynasm")]
+
+use std::process::Command;
+use std::sync::OnceLock;
+
+/// The dynasm-backend `pyre` binary cargo built for this test. See the module
+/// doc: resolving it this way rather than building it is what keeps the test
+/// from deadlocking against its own parent cargo.
+const PYRE: &str = env!("CARGO_BIN_EXE_pyre-dynasm");
+
+/// Trip counts scanned to locate the boundary, inclusive.
+///
+/// The window must straddle the transition: it needs at least one `n` below the
+/// boundary that compiles nothing, and at least one above it. Both edges are
+/// checked at run time (see `locate`), because a window that no longer
+/// straddles the boundary would otherwise report its own edge as the answer.
+const WINDOW_LO: u32 = 1030;
+const WINDOW_HI: u32 = 1050;
+
+/// What one scan observed. Fields are observations, not assertions — the tests
+/// do the asserting, so a failure message can show what was actually seen.
+struct Boundary {
+    /// Smallest `n` in the window that compiled anything at all.
+    n: u32,
+    shape_at_n: Shape,
+    shape_above: Shape,
+    loops_at_n: Option<u64>,
+    loops_above: Option<u64>,
+    headers_at_n: Vec<String>,
+    headers_above: Vec<String>,
+}
+
+/// The shape of the artifact a run compiled, as named by the dump itself.
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+enum Shape {
+    /// Straight-line FINISH trace: no loop was compiled.
+    Flat,
+    Peeled,
+    SimpleLoop,
+    /// Nothing was compiled at all — distinct from `Flat`, which DID compile.
+    None,
+}
+
+/// Classify a run's stderr by the dump's own artifact-kind header.
+///
+/// Generic before/after headers are ignored because every compile path emits
+/// them and they carry no shape information.
+fn classify(stderr: &str) -> Shape {
+    let mut shape = Shape::None;
+    for line in stderr.lines() {
+        let s = if line.starts_with("--- peeled trace") {
+            Shape::Peeled
+        } else if line.starts_with("--- simple loop trace") {
+            Shape::SimpleLoop
+        } else if line.starts_with("--- finish trace") {
+            Shape::Flat
+        } else {
+            continue;
+        };
+        // A loop header wins over a finish header: a peeled loop also emits
+        // finish traces for its bridges once guards start failing.
+        if shape == Shape::None || matches!(s, Shape::Peeled | Shape::SimpleLoop) {
+            shape = s;
+        }
+    }
+    shape
+}
+
+/// Every artifact-kind header a run emitted, for failure messages. Includes the
+/// generic ones precisely so a failure shows what WAS there.
+fn headers(stderr: &str) -> Vec<String> {
+    stderr
+        .lines()
+        .filter(|l| l.starts_with("--- "))
+        .map(str::to_owned)
+        .collect()
+}
+
+fn loops_compiled(stderr: &str) -> Option<u64> {
+    stderr
+        .split_whitespace()
+        .filter_map(|t| t.strip_prefix("loops_compiled="))
+        .last()
+        .and_then(|v| v.parse().ok())
+}
+
+/// Run a bare `while` loop of `n` trips and return the run's stderr. A bare
+/// loop is the smallest thing that can peel, with no calls to complicate the
+/// trace; `-c` keeps the probe out of the filesystem, so parallel tests cannot
+/// race on a shared scratch file.
+fn run_probe(n: u32) -> String {
+    // A raw string, NOT a `\`-continued one: Rust's line continuation strips
+    // the next line's leading whitespace, which would silently dedent `i += 1`
+    // out of the loop body and change the program being measured.
+    let src = format!(
+        r#"
+def f(n):
+    s = 0
+    i = 0
+    while i < n:
+        s += i
+        i += 1
+    return s
+
+print(f({n}))
+"#
+    );
+    let out = Command::new(PYRE)
+        .args(["-c", &src])
+        .env("MAJIT_LOG", "1")
+        .env("MAJIT_STATS", "1")
+        .output()
+        .expect("spawn pyre-dynasm");
+    assert!(
+        out.status.success(),
+        "probe at n={n} exited {:?}\nstderr tail:\n{}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+            .lines()
+            .rev()
+            .take(20)
+            .collect::<Vec<_>>()
+            .join("\n"),
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Scan the window and return the first trip count that compiles anything,
+/// together with what it and its successor produced.
+///
+/// Panics only when the window can no longer answer the question — never
+/// because the boundary moved *within* it. Those two cases are different and
+/// the messages say which.
+fn locate() -> Boundary {
+    let mut first = None;
+    for n in WINDOW_LO..=WINDOW_HI {
+        let err = run_probe(n);
+        if classify(&err) != Shape::None {
+            first = Some((n, err));
+            break;
+        }
+    }
+
+    let (n, err_at_n) = first.unwrap_or_else(|| {
+        panic!(
+            "no trip count in [{WINDOW_LO},{WINDOW_HI}] compiled anything at all. \
+             The boundary has left the window from ABOVE, or compilation is off \
+             in this build. Widen the window and re-derive; do not delete the \
+             assert."
+        )
+    });
+
+    // Require observations on both sides; otherwise the result is merely a
+    // window edge rather than a located transition.
+    assert!(
+        n > WINDOW_LO,
+        "the window floor n={WINDOW_LO} already compiles, so the boundary is at \
+         or below it and this scan never saw the non-compiling side. Lower \
+         WINDOW_LO and re-derive.",
+    );
+    assert!(
+        n < WINDOW_HI,
+        "the boundary landed on the window ceiling n={WINDOW_HI}, so there is no \
+         n+1 left to compare against. Raise WINDOW_HI and re-derive.",
+    );
+
+    let err_above = run_probe(n + 1);
+
+    // Reported, not asserted: this is the movable fact.
+    println!(
+        "[jit_trace_shape] located boundary: n={n} flat / n={} peeled",
+        n + 1
+    );
+
+    Boundary {
+        n,
+        shape_at_n: classify(&err_at_n),
+        shape_above: classify(&err_above),
+        loops_at_n: loops_compiled(&err_at_n),
+        loops_above: loops_compiled(&err_above),
+        headers_at_n: headers(&err_at_n),
+        headers_above: headers(&err_above),
+    }
+}
+
+/// One scan shared by both tests — the scan is ~20 subprocess runs and both
+/// tests need the same observation.
+fn boundary() -> &'static Boundary {
+    static BOUNDARY: OnceLock<Boundary> = OnceLock::new();
+    BOUNDARY.get_or_init(locate)
+}
+
+#[test]
+fn first_compiling_trip_count_is_flat_and_the_next_one_peels() {
+    let b = boundary();
+
+    assert_eq!(
+        b.shape_at_n,
+        Shape::Flat,
+        "THE TRACE SHAPE AT THE BOUNDARY CHANGED — re-derive it, do not delete \
+         or widen this assert.\n\
+         n={} is the first trip count in [{WINDOW_LO},{WINDOW_HI}] that compiled \
+         anything, so it should be the FLAT cell — the threshold trips with the \
+         loop already exhausted, the tracer never sees a back edge, and the tail \
+         is recorded as a straight line. It classified as {:?} instead.\n\
+         What to do: run the recipe in the WINDOW_LO doc above, confirm which \
+         trip counts now produce which shapes, and update the recorded boundary \
+         in that doc. If the JIT legitimately no longer emits a flat cell at \
+         all, update the test to document the new transition.\n\
+         headers at n={}: {:?}",
+        b.n,
+        b.shape_at_n,
+        b.n,
+        b.headers_at_n,
+    );
+    assert_eq!(
+        b.shape_above,
+        Shape::Peeled,
+        "THE TRACE SHAPE ABOVE THE BOUNDARY CHANGED — re-derive it, do not \
+         delete or widen this assert.\n\
+         n={} was expected to compile a peeled loop but classified as {:?}. \
+         The flat cell at n={} was found as expected, so the boundary itself is \
+         intact and only the shape above it moved — check the peeler before \
+         assuming the threshold slid.\n\
+         headers at n={}: {:?}",
+        b.n + 1,
+        b.shape_above,
+        b.n,
+        b.n + 1,
+        b.headers_above,
+    );
+}
+
+#[test]
+fn loops_compiled_cannot_tell_the_two_shapes_apart() {
+    let b = boundary();
+
+    // The equality below is meaningful only when the two runs have different
+    // shapes; otherwise it compares a shape with itself.
+    assert!(
+        b.shape_at_n != b.shape_above,
+        "n={} and n={} both compiled {:?}, so there is no shape change here for \
+         a counter to be blind TO. This test cannot say anything until the \
+         shapes differ.",
+        b.n,
+        b.n + 1,
+        b.shape_at_n,
+    );
+
+    let flat_n = b
+        .loops_at_n
+        .expect("no loops_compiled at the flat trip count");
+    let peeled_n = b
+        .loops_above
+        .expect("no loops_compiled at the peeled trip count");
+
+    // Both sides must actually have compiled something, or the equality below
+    // is satisfied by two zeros and asserts nothing.
+    assert!(
+        flat_n > 0 && peeled_n > 0,
+        "one side compiled nothing (flat={flat_n}, peeled={peeled_n}); this \
+         test's equality would then hold vacuously",
+    );
+    assert_eq!(
+        flat_n,
+        peeled_n,
+        "loops_compiled is expected to be BLIND to the shape change at \
+         n={} -> {}, but it moved {flat_n} -> {peeled_n}.\n\
+         If a counter now distinguishes flat from peeled, `pyre/check.py`'s \
+         jit-stats gate can see shape regressions and the note beside \
+         JITSTATS_SNAPSHOT_FIELDS saying it cannot should be revisited.",
+        b.n,
+        b.n + 1,
+    );
+}


### PR DESCRIPTION
## Summary

- separate reusable majit tracing hardening from CEL-specific work
- preserve virtualizable input identity across normal loop and bridge compilation
- harden typed green-key lookup, MIR lowering rollback, resume snapshots, and Cranelift deopt state recovery
- add opt-in opref, register-write, allocation-site, gate-catalog, and trace-shape diagnostics
- compile heavyweight opref and register-write instrumentation only with the non-default jit-audits feature
- add regression coverage for trace shape, gate completeness, lowering, and serialized descriptor behavior

## Why

The CEL branch accumulated general JIT infrastructure alongside CEL-specific implementation. Landing the reusable pieces independently reduces the remaining CEL patch while giving the shared tracing and diagnostic machinery focused review and test coverage.

## Impact

Ordinary debug and release builds contain no opref or register-write audit modules, call sites, TLS access, environment-gate strings, or report strings. Diagnostic binaries opt in with --features jit-audits; the existing environment variables then select an individual audit. Audit TLS remains limited to disposable per-thread diagnostic state and does not own semantic runtime identity or GC roots.

## Validation

- re-extracted majit-rlib, pyre-object, pyre-interpreter, and pyre-jit LLBC; all source fingerprints current
- cargo fmt --all -- --check
- git diff --check
- cargo check --features dynasm
- cargo test --features dynasm
- cargo check -p majit-metainterp --no-default-features --features dynasm
- cargo check -p majit-metainterp --no-default-features --features dynasm,jit-audits
- cargo check -p pyrex --no-default-features --features dynasm,jit-audits
- audit unit tests: 18/18
- gate completeness: 6/6
- trace shape: 2/2
- default release audit symbols and audit strings: 0
- python3 pyre/check.py --backend dynasm --no-synthetic: 17/17


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added opt-in JIT auditing and diagnostics for operation references, register access, allocation sites, cell tables, and field positions.
  - Added an allocation-attribution example with optional stack capture and summarized reporting.
  - Added clearer reporting for JIT statistics, deoptimization behavior, and performance baselines.

- **Bug Fixes**
  - Improved bridge compilation handling and typed JIT lookups.
  - Corrected process-creation argument validation and deterministic descriptor ordering.

- **Documentation**
  - Added comprehensive catalogs of runtime diagnostic settings and retirement criteria.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->