### PR TITLE
gc, _weakref, _ctypes: five stdlib suites that failed on a dead object's storage

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2360,6 +2360,30 @@ impl MiniMarkGC {
             self.deal_with_young_objects_with_destructors();
         }
 
+        // An embedder side table keyed by owner address cannot be left holding
+        // a nursery key past this point: the reset below hands that address to
+        // the next allocation, which would then answer to the dead owner's
+        // entry.  Ask the same survival question `invalidate_young_weakrefs`
+        // just answered, while the forwarding headers still read.
+        let pinned = &self.pinned_objects;
+        let nursery = &self.nursery;
+        let mut classify_young_owner = |owner: usize| -> Option<usize> {
+            if owner == 0 || !nursery.contains(owner) {
+                return Some(owner);
+            }
+            // A pinned object is alive and stayed put, so it never forwarded.
+            if pinned.contains(&owner) {
+                return Some(owner);
+            }
+            let hdr = (owner - GcHeader::SIZE) as *const GcHeader;
+            if unsafe { (*hdr).is_forwarded() } {
+                Some(unsafe { GcHeader::forwarding_address(hdr) })
+            } else {
+                None
+            }
+        };
+        crate::shadow_stack::reconcile_young_owner_tables(&mut classify_young_owner);
+
         // incminimark.py:1876-1882,1900-1944: replace the pin set with exactly
         // the objects reached this collection, then preserve identity shadows
         // and nursery barriers only for those survivors. Clear their temporary

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -319,6 +319,18 @@ pub struct BlockingGuard {
     _not_send: std::marker::PhantomData<*const ()>,
 }
 
+/// Re-enter pyre from a foreign frame this thread released the GIL to reach,
+/// matching `rffi`'s callback path, which acquires before the first RPython
+/// instruction (`entrypoint.c:78 _RPyGilAcquire`). Takes the GIL back and
+/// rejoins the RUNNING census for as long as the guard lives, then gives both
+/// back so the outward call's `BlockingGuard` finds the state it left.
+#[must_use = "pyre may only run for as long as the guard is alive"]
+pub struct CallbackGuard {
+    rejoined: bool,
+    took_gil: bool,
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
 impl Drop for BlockingGuard {
     fn drop(&mut self) {
         // `rffi.aroundstate.after()` retakes the GIL on return from a
@@ -369,6 +381,52 @@ pub fn before_external_block() -> BlockingGuard {
     BlockingGuard {
         registered,
         held_gil,
+        _not_send: std::marker::PhantomData,
+    }
+}
+
+impl Drop for CallbackGuard {
+    fn drop(&mut self) {
+        if self.rejoined {
+            let mut state = GC_SYNC.quiesce.lock().unwrap();
+            assert!(
+                GC_THREAD.with(|t| t.running.replace(false)),
+                "GC mutator left an external callback twice"
+            );
+            state.running = state
+                .running
+                .checked_sub(1)
+                .expect("RUNNING underflow leaving external callback");
+            GC_SYNC.quiesced.notify_all();
+        }
+        if self.took_gil {
+            crate::rgil::release();
+        }
+    }
+}
+
+#[inline]
+pub fn enter_external_callback() -> CallbackGuard {
+    let took_gil = !crate::rgil::am_i_holding_the_gil();
+    if took_gil {
+        crate::rgil::acquire();
+    }
+    let registered = GC_THREAD.with(|t| t.registered.get());
+    let running = GC_THREAD.with(|t| t.running.get());
+    let mut rejoined = false;
+    if registered && !running {
+        let mut state = GC_SYNC.quiesce.lock().unwrap();
+        state = GC_SYNC
+            .resumed
+            .wait_while(state, |_| GC_SYNC.stw_requested.load(Ordering::Acquire))
+            .unwrap();
+        state.running += 1;
+        GC_THREAD.with(|t| t.running.set(true));
+        rejoined = true;
+    }
+    CallbackGuard {
+        rejoined,
+        took_gil,
         _not_send: std::marker::PhantomData,
     }
 }

--- a/majit/majit-gc/src/gc_sync.rs
+++ b/majit/majit-gc/src/gc_sync.rs
@@ -271,6 +271,28 @@ pub fn register_thread() {
     crate::rgil::acquire_maybe_in_new_thread();
 }
 
+/// Register the current thread as a GC mutator without taking the GIL and
+/// without joining the RUNNING census.
+///
+/// A foreign thread delivering a callback needs the two separable, because the
+/// `CallbackGuard` gives back exactly what it took. Arriving through
+/// [`register_thread`] leaves that guard recording neither `took_gil` nor
+/// `rejoined`, so the foreign worker returns to C still holding the GIL and
+/// still counted RUNNING — no other Python thread runs again and no collection
+/// reaches quiescence. Parked, the guard acquires and releases per callback,
+/// which is what `rffi`'s callback wrapper does around each entry.
+pub fn register_thread_parked() {
+    assert!(
+        !GC_THREAD.with(|t| t.registered.get()),
+        "GC mutator thread registered twice"
+    );
+    let old = REGISTERED_THREADS.fetch_add(1, Ordering::SeqCst);
+    if old > 0 {
+        FOREIGN_MUTATOR_SEEN.store(true, Ordering::Release);
+    }
+    GC_THREAD.with(|t| t.registered.set(true));
+}
+
 /// Unregister the current thread. It stops running pyre code, so it gives the
 /// GIL back and no longer participates in STW quiescence.
 pub fn unregister_thread() {
@@ -284,14 +306,14 @@ pub fn unregister_thread() {
         crate::rgil::release();
     }
     let mut state = GC_SYNC.quiesce.lock().unwrap();
-    assert!(
-        GC_THREAD.with(|t| t.running.replace(false)),
-        "unregistering a parked GC mutator thread"
-    );
-    state.running = state
-        .running
-        .checked_sub(1)
-        .expect("RUNNING underflow during unregister_thread");
+    // A thread that came in through `register_thread_parked` sits outside the
+    // census between callbacks, so there is nothing to subtract for it.
+    if GC_THREAD.with(|t| t.running.replace(false)) {
+        state.running = state
+            .running
+            .checked_sub(1)
+            .expect("RUNNING underflow during unregister_thread");
+    }
     GC_THREAD.with(|t| t.registered.set(false));
     let old = REGISTERED_THREADS.fetch_sub(1, Ordering::SeqCst);
     assert!(old > 0, "REGISTERED_THREADS underflow");

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1416,6 +1416,63 @@ pub fn prune_ephemeron_tables(classify: &mut dyn FnMut(usize) -> Option<usize>) 
     }
 }
 
+/// Signature expected by [`register_young_owner_reconciler`].
+///
+/// Same classifier contract as [`EphemeronPrunerFn`], asked at the end of a
+/// minor collection and only about the entries whose owner was young when the
+/// entry was made.
+pub type YoungOwnerReconcilerFn = fn(&mut dyn FnMut(usize) -> Option<usize>);
+
+static YOUNG_OWNER_RECONCILERS: std::sync::RwLock<
+    [Option<YoungOwnerReconcilerFn>; MAX_EPHEMERON_PRUNERS],
+> = std::sync::RwLock::new([None; MAX_EPHEMERON_PRUNERS]);
+
+/// Register a side table that keys entries by the address of an owner that may
+/// still be in the nursery.
+///
+/// A nursery address is reused as soon as the collection that dropped it
+/// resets the nursery, so an entry whose owner dies young does not merely leak
+/// — the next object allocated at that address answers to it.  A major-only
+/// pruner cannot close that window, hence this second registration.
+///
+/// Duplicate registrations are tolerated — the reconciler is only appended if
+/// not already present.
+pub fn register_young_owner_reconciler(reconciler: YoungOwnerReconcilerFn) {
+    let mut guard = YOUNG_OWNER_RECONCILERS.write().unwrap();
+    for slot in guard.iter_mut() {
+        match slot {
+            Some(existing) if std::ptr::fn_addr_eq(*existing, reconciler) => return,
+            None => {
+                *slot = Some(reconciler);
+                return;
+            }
+            _ => {}
+        }
+    }
+    panic!(
+        "register_young_owner_reconciler: capacity exceeded ({MAX_EPHEMERON_PRUNERS} reconcilers \
+         already registered)"
+    );
+}
+
+/// Invoke every registered reconciler with a classifier that resolves a young
+/// owner address to where it moved, or reports that it died.
+///
+/// Called from a minor collection once every live nursery object has been
+/// forwarded out and while the forwarding headers are still readable — the
+/// same point `invalidate_young_weakrefs` settles the weakref slots.  Unlike
+/// [`prune_ephemeron_tables`] this costs O(entries made since the previous
+/// minor), not O(table).
+pub fn reconcile_young_owner_tables(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    let reconcilers = {
+        let guard = YOUNG_OWNER_RECONCILERS.read().unwrap();
+        *guard
+    };
+    for slot in reconcilers.iter().flatten() {
+        slot(classify);
+    }
+}
+
 // ── Extern "C" interface for compiled code ──────────────────────
 
 /// Push a GC reference from compiled code.

--- a/pyre/cpython_tests/baseline.linux-aarch64.json
+++ b/pyre/cpython_tests/baseline.linux-aarch64.json
@@ -1,10 +1,6 @@
 {
   "host": "linux-aarch64",
   "modules": {
-    "test.test_ctypes": {
-      "dynasm": "FAIL",
-      "reason": "ctypes cannot hand a Python callback to C: a CFUNCTYPE instance carries no C-callable thunk, so ctypes.util.dllist's dl_iterate_phdr call fails. Also FAIL under PYRE_NO_JIT=1. test_dlerror wants dlsym returning NULL with a clear dlerror to raise"
-    },
     "test.test_dataclasses": {
       "dynasm": "FAIL",
       "reason": "JIT wrong code, not a platform difference: _process_class raises a spurious 'dictionary changed size during iteration' over cls.__dict__ although the only delattr completes before the loop. PYRE_NO_JIT=1 passes and darwin-arm64 passes, so it is neither the arch nor the OS alone"

--- a/pyre/extra_tests/parity_tests/builtin_subclass_dict_address_reuse.py
+++ b/pyre/extra_tests/parity_tests/builtin_subclass_dict_address_reuse.py
@@ -1,0 +1,71 @@
+# CPython-suite gap: attribute tests never allocate enough builtin-subclass
+# instances to make one land on the address a dead sibling had.
+# parity-tests reason: pyre keeps a builtin-layout instance's `__dict__` and
+# weakref lifeline in owner-address-keyed side tables, which CPython and PyPy
+# both store as object fields; only pyre can inherit a dead owner's entry.
+
+import weakref
+
+
+class L(list):
+    pass
+
+
+class S(str):
+    pass
+
+
+def churn_dead(count):
+    """Leave `count` dead instances that had attributes and a weakref."""
+    for index in range(count):
+        value = L([1, 2, 3])
+        value.foo = index
+        value.bar = "hello"
+        weakref.ref(value)
+
+
+def check_fresh(count):
+    """A freshly built instance starts with an empty `__dict__`."""
+    inherited = 0
+    for index in range(count):
+        value = L([1, 2, 3])
+        if value.__dict__:
+            inherited += 1
+        value.foo = index
+        if value.__dict__ != {"foo": index}:
+            inherited += 1
+    return inherited
+
+
+def check_fresh_str(count):
+    inherited = 0
+    for index in range(count):
+        value = S("x")
+        if value.__dict__:
+            inherited += 1
+        value.tag = index
+    return inherited
+
+
+inherited = 0
+for _ in range(40):
+    churn_dead(300)
+    inherited += check_fresh(300)
+    inherited += check_fresh_str(300)
+
+assert inherited == 0, inherited
+
+
+# A weakref to a dead owner must not be handed to whatever is allocated at its
+# address next: the lifeline lives in the same address-keyed table.
+alive = []
+for _ in range(20):
+    churn_dead(300)
+    for index in range(300):
+        value = L([1, 2, 3])
+        reference = weakref.ref(value)
+        assert reference() is value, index
+        alive.append((value, reference))
+    alive.clear()
+
+print("OK")

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -5359,6 +5359,39 @@ pub unsafe fn create_all_slots(
             newslotnames.push("__dict_data__".to_string());
         }
 
+        // `W_WeakrefBase`/`W_Weakref` keep `w_obj_weak`, `w_callable` and
+        // `w_hash` as interpreter-owned fields.  A `weakref.ref` subclass that
+        // adds no storage keeps the typed layout, and one that gets an instance
+        // dict keeps them there; a subclass declaring a non-empty `__slots__`
+        // has neither, so reserve private layout slots for them.  Without this
+        // the constructor's stores are dropped and every such reference reads
+        // back dead — `weakref.KeyedRef` is exactly that shape.
+        let weakref_ref_type = crate::module::_weakref::interp__weakref::weakref_type();
+        let is_weakref_subclass = !weakref_ref_type.is_null()
+            && !std::ptr::eq(w_type, weakref_ref_type)
+            && crate::baseobjspace::issubtype_w(w_type, weakref_ref_type);
+        if is_weakref_subclass && !newslotnames.is_empty() {
+            let reserved = crate::module::_weakref::interp__weakref::RESERVED_FIELD_SLOTS;
+            let mut inherited_fields = false;
+            let mut ancestor_layout = base_layout;
+            while !ancestor_layout.is_null() {
+                if (*ancestor_layout)
+                    .newslotnames
+                    .iter()
+                    .any(|name| name == reserved[0])
+                {
+                    inherited_fields = true;
+                    break;
+                }
+                ancestor_layout = (*ancestor_layout).base_layout;
+            }
+            if !inherited_fields {
+                // No Member is stored for these: they are interpreter storage,
+                // not attributes the subclass exposes.
+                newslotnames.extend(reserved.iter().map(|name| (*name).to_string()));
+            }
+        }
+
         // typeobject.py:1192-1195: create_dict_slot / create_weakref_slot
         if wantdict {
             create_dict_slot(w_type);

--- a/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
@@ -1,0 +1,240 @@
+//! C-callable callback thunks for `_CFuncPtr` instances.
+
+use pyre_object::PyObjectRef;
+
+#[cfg(all(
+    any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "android"
+    ),
+    not(any(target_env = "musl", target_env = "sgx"))
+))]
+mod imp {
+    use super::PyObjectRef;
+    use crate::module::_ctypes::{cdata, funcptr};
+    use core::ffi::c_void;
+    use rustpython_host_env::ctypes as host_ctypes;
+    use std::panic::{AssertUnwindSafe, catch_unwind};
+    use std::sync::{LazyLock, Mutex};
+
+    struct ThunkUserdata {
+        /// Address of the GC-rooted slot holding the `CFuncPtr` instance: the
+        /// slot, not the instance. A minor collection moves the instance and
+        /// rewrites the slot, so the live pointer is read through it at call
+        /// time.
+        slot: *mut usize,
+    }
+
+    struct StoredThunk {
+        #[allow(dead_code)]
+        slot: Box<usize>,
+        #[allow(dead_code)]
+        thunk: host_ctypes::CallbackThunk<ThunkUserdata>,
+    }
+
+    unsafe impl Send for StoredThunk {}
+
+    static CALLBACK_THUNKS: LazyLock<Mutex<Vec<StoredThunk>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+
+    pub(super) fn build_thunk(obj: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
+        let argtypes = funcptr::resolve_argtypes(obj).unwrap_or_default();
+        let ffi_arg_types = argtypes
+            .iter()
+            .copied()
+            .map(ffi_type_for_arg)
+            .collect::<Vec<_>>();
+        let restype = funcptr::resolve_restype(obj).map_err(|_| invalid_callback_result_type())?;
+        let ffi_res_type = ffi_type_for_ret(&restype)?;
+
+        let mut slot = Box::new(obj as usize);
+        let slot_ptr = (&mut *slot) as *mut usize;
+        let root_slot = slot_ptr as *mut *mut u8;
+        unsafe { pyre_object::gc_hook::try_gc_add_root(root_slot) };
+
+        let thunk = host_ctypes::CallbackThunk::new(
+            ffi_arg_types,
+            ffi_res_type,
+            Box::new(ThunkUserdata { slot: slot_ptr }),
+            thunk_callback,
+        );
+        let code = thunk.code_ptr().0 as usize;
+
+        // A foreign caller may retain a callback pointer indefinitely; pyre has
+        // no proof point for unregistering it, so the rooted slot and closure
+        // intentionally live for the process lifetime.
+        CALLBACK_THUNKS
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(StoredThunk { slot, thunk });
+        Ok(Some(code))
+    }
+
+    fn ffi_type_for_arg(at: PyObjectRef) -> host_ctypes::FfiType {
+        if funcptr::argtype_is_pointer_kind(at) {
+            return host_ctypes::ffi_pointer_type();
+        }
+        let Some(tc) = cdata::type_code_of(at) else {
+            return host_ctypes::ffi_pointer_type();
+        };
+        host_ctypes::ffi_type_from_code(&tc).unwrap_or_else(host_ctypes::ffi_pointer_type)
+    }
+
+    fn ffi_type_for_ret(ret: &funcptr::Ret) -> Result<host_ctypes::FfiType, crate::PyError> {
+        match ret {
+            funcptr::Ret::Void => Ok(host_ctypes::ffi_void_type()),
+            funcptr::Ret::Code(c) => {
+                host_ctypes::ffi_type_from_code(c).ok_or_else(invalid_callback_result_type)
+            }
+            funcptr::Ret::Pointer(_) | funcptr::Ret::Aggregate(_) => {
+                Err(invalid_callback_result_type())
+            }
+        }
+    }
+
+    fn invalid_callback_result_type() -> crate::PyError {
+        crate::PyError::type_error("invalid result type for callback function")
+    }
+
+    unsafe extern "C" fn thunk_callback(
+        _cif: &host_ctypes::FfiCif,
+        result: &mut c_void,
+        args: *const *const c_void,
+        userdata: &ThunkUserdata,
+    ) {
+        let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
+            thunk_callback_inner(result, args, userdata)
+        }));
+    }
+
+    unsafe fn thunk_callback_inner(
+        result: &mut c_void,
+        args: *const *const c_void,
+        userdata: &ThunkUserdata,
+    ) {
+        crate::module::thread::ensure_runtime_thread();
+        let _callback = crate::module::thread::enter_external_callback();
+        let obj = unsafe { *userdata.slot } as PyObjectRef;
+        let use_errno = funcptr::funcptr_flags(obj) & funcptr::FUNCFLAG_USE_ERRNO != 0;
+        let call_result = match decode_args(obj, args) {
+            Ok(decoded) => host_ctypes::with_callback_errno_preserved(use_errno, || {
+                let callable = funcptr::instance_get(obj, funcptr::CALLABLE_KEY)
+                    .ok_or_else(|| crate::PyError::type_error("callback has no callable"))?;
+                crate::call::call_function_impl_result(callable, &decoded)
+            }),
+            Err(error) => Err(error),
+        };
+        // A callback has nowhere to raise: the frame above it is foreign.  The
+        // call's own failure was already reported by `callback_result`, which
+        // substitutes a zero result; what is left here is a result the declared
+        // `restype` cannot represent.
+        let written = funcptr::callback_result(obj, call_result)
+            .and_then(|value| write_result(obj, value, result as *mut c_void));
+        if let Err(mut error) = written {
+            error.write_unraisable(
+                pyre_object::w_none(),
+                &rustpython_wtf8::Wtf8Buf::from_string(
+                    "Exception ignored while converting result of ctypes callback function"
+                        .to_string(),
+                ),
+                pyre_object::PY_NULL,
+            );
+        }
+    }
+
+    fn decode_args(
+        obj: PyObjectRef,
+        args: *const *const c_void,
+    ) -> Result<Vec<PyObjectRef>, crate::PyError> {
+        let argtypes = funcptr::resolve_argtypes(obj).unwrap_or_default();
+        let mut decoded = Vec::with_capacity(argtypes.len());
+        for (i, at) in argtypes.into_iter().enumerate() {
+            let p = unsafe { *args.add(i) };
+            match decode_arg(at, p) {
+                Ok(value) => decoded.push(value),
+                Err(error) => return Err(error),
+            }
+        }
+        Ok(decoded)
+    }
+
+    fn decode_arg(at: PyObjectRef, p: *const c_void) -> Result<PyObjectRef, crate::PyError> {
+        if let Some(tc) = cdata::type_code_of(at)
+            && !funcptr::is_simple_subclass(at)
+        {
+            if tc == "O" {
+                let address = unsafe { *(p as *const usize) };
+                return Ok(if address == 0 {
+                    pyre_object::w_none()
+                } else {
+                    address as PyObjectRef
+                });
+            }
+            return Ok(cdata::decoded_to_pyobject(unsafe {
+                host_ctypes::callback_arg_value(Some(&tc), p)
+            }));
+        }
+        if let Some(size) = cdata::ctype_size_of(at) {
+            let inst = crate::call::type_call_instantiate(at, &[])?;
+            let bytes = unsafe { host_ctypes::borrow_memory(p.cast::<u8>(), size) };
+            cdata::cdata_write(inst, 0, bytes);
+            return Ok(inst);
+        }
+        Err(crate::PyError::type_error("cannot build parameter"))
+    }
+
+    fn write_result(
+        obj: PyObjectRef,
+        value: PyObjectRef,
+        result: *mut c_void,
+    ) -> Result<(), crate::PyError> {
+        match funcptr::resolve_restype(obj)? {
+            funcptr::Ret::Void => Ok(()),
+            funcptr::Ret::Code(c) => {
+                let bytes = cdata::encode_value_into(&c, value, obj, "result")?;
+                // The return slot is one `ffi_arg` word: a narrow value has to
+                // go into a zeroed word rather than beside whatever the closure
+                // left there, and nothing wider than the word may be written.
+                // `g` is the case that overruns — it encodes to a long double
+                // while `ffi_type_from_code` maps it to the `f64` the slot was
+                // sized for.
+                let width = std::mem::size_of::<usize>();
+                let n = bytes.len().min(width);
+                unsafe {
+                    std::ptr::write_bytes(result.cast::<u8>(), 0, width);
+                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), result.cast::<u8>(), n);
+                }
+                Ok(())
+            }
+            funcptr::Ret::Pointer(_) | funcptr::Ret::Aggregate(_) => {
+                Err(invalid_callback_result_type())
+            }
+        }
+    }
+}
+
+#[cfg(not(all(
+    any(
+        target_os = "linux",
+        target_os = "macos",
+        target_os = "windows",
+        target_os = "android"
+    ),
+    not(any(target_env = "musl", target_env = "sgx"))
+)))]
+mod imp {
+    use super::PyObjectRef;
+
+    pub(super) fn build_thunk(_obj: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
+        Ok(None)
+    }
+}
+
+/// Build a C-callable thunk for the callback `CFuncPtr` instance `obj` and
+/// return its code address, or `None` when this platform has no libffi closure
+/// support.
+pub(super) fn build_thunk(obj: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
+    imp::build_thunk(obj)
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
@@ -76,10 +76,21 @@ mod imp {
         if funcptr::argtype_is_pointer_kind(at) {
             return host_ctypes::ffi_pointer_type();
         }
-        let Some(tc) = cdata::type_code_of(at) else {
-            return host_ctypes::ffi_pointer_type();
-        };
-        host_ctypes::ffi_type_from_code(&tc).unwrap_or_else(host_ctypes::ffi_pointer_type)
+        if let Some(tc) = cdata::type_code_of(at)
+            && let Some(ty) = host_ctypes::ffi_type_from_code(&tc)
+        {
+            return ty;
+        }
+        // A `Structure`/`Union` argument has no type code and is passed by
+        // value, so the cif has to describe an aggregate of its size —
+        // declaring a pointer disagrees with the ABI and hands `decode_arg` a
+        // slot that is neither the struct nor a pointer to it. `decode_arg`
+        // already builds the instance from `size` bytes at the argument
+        // address, which is what libffi supplies for an aggregate.
+        match cdata::ctype_size_of(at) {
+            Some(size) => host_ctypes::ffi_byte_struct(size),
+            None => host_ctypes::ffi_pointer_type(),
+        }
     }
 
     fn ffi_type_for_ret(ret: &funcptr::Ret) -> Result<host_ctypes::FfiType, crate::PyError> {
@@ -114,8 +125,7 @@ mod imp {
         args: *const *const c_void,
         userdata: &ThunkUserdata,
     ) {
-        crate::module::thread::ensure_runtime_thread();
-        let _callback = crate::module::thread::enter_external_callback();
+        let _callback = crate::module::thread::enter_external_callback_from_foreign_thread();
         let obj = unsafe { *userdata.slot } as PyObjectRef;
         let use_errno = funcptr::funcptr_flags(obj) & funcptr::FUNCFLAG_USE_ERRNO != 0;
         let call_result = match decode_args(obj, args) {

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -419,15 +419,7 @@ pub(super) fn ctype_size_of(cls: PyObjectRef) -> Option<usize> {
     super::stginfo::stginfo_of(cls)
         .map(super::stginfo::stginfo_size)
         .or_else(|| type_code_of(cls).and_then(|tc| host_ctypes::simple_type_size(&tc)))
-        .or_else(|| {
-            // `_CFuncPtr` itself is abstract, while every concrete type made
-            // by CFUNCTYPE/WINFUNCTYPE carries `_flags_`.  Use that ctypes
-            // invariant here; the generic issubclass path is not reliable for
-            // these metaclass-created raw types.
-            (!std::ptr::eq(cls, super::funcptr::cfuncptr_type())
-                && unsafe { crate::baseobjspace::lookup_in_type(cls, "_flags_") }.is_some())
-            .then(host_ctypes::pointer_size)
-        })
+        .or_else(|| super::funcptr::is_funcptr_type(cls).then(host_ctypes::pointer_size))
 }
 
 /// `_SimpleCData.value` getter — `(descr, instance)`.

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -22,13 +22,13 @@ use rustpython_host_env::ctypes as host_ctypes;
 use std::sync::OnceLock;
 
 /// `_flags_ & FUNCFLAG_USE_ERRNO` — swap the ctypes-local errno around the call.
-const FUNCFLAG_USE_ERRNO: i64 = 0x8;
+pub(super) const FUNCFLAG_USE_ERRNO: i64 = 0x8;
 
 /// Reserved instance-dict keys.
 const PTR_KEY: &str = "_ptr";
 const RESTYPE_KEY: &str = "_restype";
 const ARGTYPES_KEY: &str = "_argtypes";
-const CALLABLE_KEY: &str = "_callable";
+pub(super) const CALLABLE_KEY: &str = "_callable";
 const INTERNAL_CAST_ADDR: usize = 1;
 const INTERNAL_STRING_AT_ADDR: usize = 2;
 const INTERNAL_WSTRING_AT_ADDR: usize = 3;
@@ -127,6 +127,17 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     unsafe { pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(addr as i64)) };
     if !callback.is_null() {
         unsafe { pyre_object::w_dict_setitem_str(d, CALLABLE_KEY, callback) };
+        if let Some(code) = super::callbacks::build_thunk(obj)? {
+            let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
+                "P",
+                host_ctypes::SimpleStorageValue::Pointer(code),
+                false,
+            );
+            unsafe {
+                pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(code as i64))
+            };
+            cdata::cdata_write(obj, 0, &bytes);
+        }
     }
     Ok(obj)
 }
@@ -160,8 +171,8 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
         _ => {}
     }
     super::interp_ctypes::lookup_symbol(handle, &name_bytes).map_err(|e| {
-        use host_ctypes::LookupSymbolError as L;
-        if matches!(e, L::LibraryNotFound) {
+        use rustpython_host_env::ctypes::LookupSymbolError as E;
+        if matches!(e, E::LibraryNotFound) {
             return crate::PyError::value_error("library not found");
         }
         // A symbol name arrives as bytes, so it is decoded the way a name the
@@ -176,7 +187,7 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
 
 // ── restype / argtypes descriptors ────────────────────────────────────
 
-fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+pub(super) fn instance_get(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return None;
@@ -254,7 +265,7 @@ fn reject_kwargs(kwargs: Option<PyObjectRef>) -> Result<(), crate::PyError> {
 // ── call ──────────────────────────────────────────────────────────────
 
 /// Resolved return-type selector.
-enum Ret {
+pub(super) enum Ret {
     Void,
     Code(String),
     /// A pointer metaclass type (`POINTER(T)`): the result address is wrapped
@@ -265,7 +276,7 @@ enum Ret {
     Aggregate(PyObjectRef),
 }
 
-fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
+pub(super) fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let rt = instance_get(obj, RESTYPE_KEY)
         .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_restype_") });
@@ -314,7 +325,7 @@ fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::
 
 /// The `_argtypes_` sequence as a Vec, or `None` when unset (ConvParam
 /// defaults apply).
-fn resolve_argtypes(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+pub(super) fn resolve_argtypes(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let at = instance_get(obj, ARGTYPES_KEY)
         .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_argtypes_") })?;
@@ -344,7 +355,7 @@ fn seq_to_vec(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
     }
 }
 
-fn funcptr_flags(obj: PyObjectRef) -> i64 {
+pub(super) fn funcptr_flags(obj: PyObjectRef) -> i64 {
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     match unsafe { crate::baseobjspace::lookup_in_type(cls, "_flags_") } {
         Some(o) if unsafe { pyre_object::is_int(o) } => unsafe { pyre_object::w_int_get_value(o) },
@@ -352,7 +363,7 @@ fn funcptr_flags(obj: PyObjectRef) -> i64 {
     }
 }
 
-fn funcptr_addr(obj: PyObjectRef) -> usize {
+pub(super) fn funcptr_addr(obj: PyObjectRef) -> usize {
     instance_get(obj, PTR_KEY)
         .filter(|o| unsafe { pyre_object::is_int(*o) })
         .map(|o| unsafe { pyre_object::w_int_get_value(o) } as usize)
@@ -370,19 +381,22 @@ enum OwnedArg {
     Aggregate(host_ctypes::CTypeLayout, Vec<u8>),
 }
 
-fn callback_argument(ty: PyObjectRef, value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+pub(super) fn is_simple_subclass(ty: PyObjectRef) -> bool {
     let bases = unsafe { pyre_object::typeobject::w_type_get_bases(ty) };
-    let is_simple_subclass = !bases.is_null()
+    !bases.is_null()
         && unsafe { pyre_object::w_tuple_getitem(bases, 0) }
-            .is_some_and(|base| cdata::type_code_of(base).is_some());
-    if is_simple_subclass {
+            .is_some_and(|base| cdata::type_code_of(base).is_some())
+}
+
+fn callback_argument(ty: PyObjectRef, value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    if is_simple_subclass(ty) {
         crate::call::type_call_instantiate(ty, &[value])
     } else {
         Ok(value)
     }
 }
 
-fn callback_result(
+pub(super) fn callback_result(
     obj: PyObjectRef,
     result: Result<PyObjectRef, crate::PyError>,
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -452,7 +466,7 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let self_obj = args[0];
     let (call_args, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
-    if instance_get(self_obj, CALLABLE_KEY).is_some() {
+    if funcptr_addr(self_obj) == 0 && instance_get(self_obj, CALLABLE_KEY).is_some() {
         return call_python_callback(self_obj, call_args);
     }
     match funcptr_addr(self_obj) {
@@ -600,6 +614,9 @@ fn argument_address(obj: PyObjectRef) -> Result<usize, crate::PyError> {
     }
     if unsafe { pyre_object::is_bytes(obj) } {
         return Ok(unsafe { pyre_object::bytesobject::w_bytes_data(obj) }.as_ptr() as usize);
+    }
+    if is_funcptr_instance(obj) {
+        return Ok(funcptr_addr(obj));
     }
     if cdata::is_cdata_instance(obj) {
         let cls = unsafe { pyre_object::w_instance_get_type(obj) };
@@ -806,7 +823,7 @@ fn cdata_paramfunc(obj: PyObjectRef) -> String {
 
 /// Whether argument type `at` lowers to a pointer (a pointer metaclass type,
 /// an array type — which decays — or a simple pointer code like `P`/`z`/`Z`).
-fn argtype_is_pointer_kind(at: PyObjectRef) -> bool {
+pub(super) fn argtype_is_pointer_kind(at: PyObjectRef) -> bool {
     if let Some(info) = stginfo::stginfo_of(at) {
         if stginfo::stginfo_flags(info) & stginfo::TYPEFLAG_ISPOINTER != 0 {
             return true;
@@ -816,6 +833,19 @@ fn argtype_is_pointer_kind(at: PyObjectRef) -> bool {
         }
     }
     matches!(cdata::type_code_of(at).as_deref(), Some(c) if cdata::is_pointer_code(c))
+        || is_funcptr_type(at)
+}
+
+/// Whether `t` is a concrete foreign-function type (`CFUNCTYPE`/`WINFUNCTYPE`).
+pub(super) fn is_funcptr_type(t: PyObjectRef) -> bool {
+    !t.is_null()
+        && unsafe { pyre_object::is_type(t) }
+        && !std::ptr::eq(t, cfuncptr_type())
+        && unsafe { crate::baseobjspace::lookup_in_type(t, "_flags_") }.is_some()
+}
+
+fn is_funcptr_instance(obj: PyObjectRef) -> bool {
+    !obj.is_null() && unsafe { crate::baseobjspace::isinstance_w(obj, cfuncptr_type()) }
 }
 
 /// Whether type `t` is a by-value aggregate (struct or union).
@@ -983,6 +1013,9 @@ fn marshal_default_arg(
     if super::interp_ctypes::is_carg(arg) {
         return Ok(OwnedArg::Pointer(super::interp_ctypes::carg_ptr(arg)));
     }
+    if is_funcptr_instance(arg) {
+        return Ok(OwnedArg::Pointer(funcptr_addr(arg)));
+    }
     // A scalar cdata is passed by value.
     if cdata::is_simplecdata_instance(arg) {
         let cls = unsafe { pyre_object::w_instance_get_type(arg) };
@@ -1030,12 +1063,15 @@ fn marshal_default_arg(
 /// Resolve the address a pointer-kind argument lowers to: `byref()` carriers,
 /// `_Pointer`/`Array`/`Structure` instances, pointer-typed scalars, bytes, an
 /// integer address, or `None`.
-fn resolve_pointer_addr(
+pub(super) fn resolve_pointer_addr(
     arg: PyObjectRef,
     keepalive: &mut Vec<Vec<u8>>,
 ) -> Result<usize, crate::PyError> {
     if super::interp_ctypes::is_carg(arg) {
         return Ok(super::interp_ctypes::carg_ptr(arg));
+    }
+    if is_funcptr_instance(arg) {
+        return Ok(funcptr_addr(arg));
     }
     if cdata::is_simplecdata_instance(arg) {
         // A pointer-typed scalar stores the target address in its buffer.

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -464,7 +464,14 @@ pub(super) fn lookup_symbol(
         )
     };
     match address {
-        Some(address) => Ok(address as usize),
+        // `GetProcAddress` can hand back a NULL address without reporting an
+        // error. A NULL address is not callable, so the lookup failed — the
+        // rejection the posix arm applies to a NULL `dlsym`.
+        Some(address) if address as usize != 0 => Ok(address as usize),
+        Some(_) => Err(Error::Load(format!(
+            "symbol '{}' not found",
+            String::from_utf8_lossy(symbol)
+        ))),
         None => Err(Error::Load(
             rustpython_host_env::ctypes::format_error_message(None)
                 .unwrap_or_else(|| "symbol not found".to_string()),

--- a/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
@@ -18,6 +18,8 @@ fn type_ns_store(ns: pyre_object::PyObjectRef, name: &str, value: pyre_object::P
 }
 
 #[cfg(all(any(unix, windows), feature = "host_env"))]
+pub mod callbacks;
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod cdata;
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod funcptr;

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -30,6 +30,52 @@ const ATTR_W_OBJ_WEAK: &str = "w_obj_weak";
 const ATTR_W_CALLABLE: &str = "w_callable";
 const ATTR_W_HASH: &str = "w_hash";
 
+/// Private layout-slot names reserved on a `weakref.ref` subclass that
+/// declares a non-empty `__slots__`. Such an instance has no dict, so the
+/// three fields above have no other object-resident storage; type creation
+/// appends these names to the subclass Layout (`call.rs` `create_all_slots`)
+/// and they carry no Member, being interpreter storage rather than attributes
+/// the class exposes.
+pub const RESERVED_FIELD_SLOTS: [&str; 3] = [
+    "__weakref_obj__",
+    "__weakref_callback__",
+    "__weakref_hash__",
+];
+
+/// Layout-slot index reserved for the field `name` on `obj`, walking the
+/// layout chain from the object's type toward its base. `None` when no layout
+/// in the chain reserves the slot, which is the ordinary dict-backed case.
+fn field_slot(obj: PyObjectRef, name: &str) -> Option<u32> {
+    let slot_name = match name {
+        ATTR_W_OBJ_WEAK => RESERVED_FIELD_SLOTS[0],
+        ATTR_W_CALLABLE => RESERVED_FIELD_SLOTS[1],
+        ATTR_W_HASH => RESERVED_FIELD_SLOTS[2],
+        _ => return None,
+    };
+    unsafe {
+        let w_type = crate::typedef::r#type(obj).map_or(PY_NULL, |p| p.as_ptr());
+        if w_type.is_null() {
+            return None;
+        }
+        let mut layout = pyre_object::w_type_get_layout_ptr(w_type);
+        while !layout.is_null() {
+            let current = &*layout;
+            let first_slot = current
+                .nslots
+                .saturating_sub(current.newslotnames.len() as u32);
+            if let Some(offset) = current
+                .newslotnames
+                .iter()
+                .position(|candidate| candidate == slot_name)
+            {
+                return Some(first_slot + offset as u32);
+            }
+            layout = current.base_layout;
+        }
+        None
+    }
+}
+
 /// Read a per-instance slot from the underlying `INSTANCE_DICT` directly,
 /// bypassing the public `getattr` path. The proxy fast-path in
 /// `baseobjspace::getattr_str` would otherwise force the receiver and recurse
@@ -38,6 +84,19 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     let _roots = pyre_object::gc_roots::push_roots();
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
+    if let Some(slot) = field_slot(pyre_object::gc_roots::shadow_stack_get(root_base), name) {
+        let value = unsafe {
+            crate::objspace::std::mapdict::getslotvalue(
+                pyre_object::gc_roots::shadow_stack_get(root_base),
+                slot,
+            )
+        }
+        .unwrap_or(PY_NULL);
+        if value.is_null() || unsafe { pyre_object::is_none(value) } {
+            return PY_NULL;
+        }
+        return value;
+    }
     let w_dict =
         crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if w_dict.is_null() {
@@ -64,6 +123,16 @@ fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     let root_base = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(obj);
     pyre_object::gc_roots::pin_root(value);
+    if let Some(slot) = field_slot(pyre_object::gc_roots::shadow_stack_get(root_base), name) {
+        unsafe {
+            crate::objspace::std::mapdict::setslotvalue(
+                pyre_object::gc_roots::shadow_stack_get(root_base),
+                slot,
+                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            )
+        };
+        return;
+    }
     let w_dict =
         crate::baseobjspace::getdict_native(pyre_object::gc_roots::shadow_stack_get(root_base));
     if !w_dict.is_null() {

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -76,8 +76,8 @@ fn field_slot(obj: PyObjectRef, name: &str) -> Option<u32> {
     }
 }
 
-/// Read a per-instance slot from the underlying `INSTANCE_DICT` directly,
-/// bypassing the public `getattr` path. The proxy fast-path in
+/// Read a per-instance field from its reserved layout slot, or from the
+/// underlying `INSTANCE_DICT` directly, bypassing the public `getattr` path. The proxy fast-path in
 /// `baseobjspace::getattr_str` would otherwise force the receiver and recurse
 /// indefinitely while the proxy is reading its OWN `w_obj_weak`/etc.
 fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
@@ -116,7 +116,7 @@ fn read_attr(obj: PyObjectRef, name: &str) -> PyObjectRef {
     value
 }
 
-/// Mirror of `read_attr` for writes — direct dict access keeps lifeline /
+/// Mirror of `read_attr` for writes — direct slot / dict access keeps lifeline /
 /// proxy / weakref bookkeeping out of the fast-path's force loop.
 fn write_attr(obj: PyObjectRef, name: &str, value: PyObjectRef) {
     let _roots = pyre_object::gc_roots::push_roots();

--- a/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
+++ b/pyre/pyre-interpreter/src/module/_weakref/interp__weakref.rs
@@ -36,10 +36,16 @@ const ATTR_W_HASH: &str = "w_hash";
 /// appends these names to the subclass Layout (`call.rs` `create_all_slots`)
 /// and they carry no Member, being interpreter storage rather than attributes
 /// the class exposes.
+///
+/// Each name holds a space, so no class can declare one: `__slots__` entries
+/// are rejected unless they are identifiers. A spellable name would collide —
+/// `__slots__ = ('__weakref_obj__',)` installs the user's member first and the
+/// reserved name is appended after it, so `field_slot` would answer with the
+/// user's index and weakref construction would overwrite their slot.
 pub const RESERVED_FIELD_SLOTS: [&str; 3] = [
-    "__weakref_obj__",
-    "__weakref_callback__",
-    "__weakref_hash__",
+    "weakref ref w_obj_weak",
+    "weakref ref w_callable",
+    "weakref ref w_hash",
 ];
 
 /// Layout-slot index reserved for the field `name` on `obj`, walking the

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -54,6 +54,12 @@ pub fn before_external_block() -> majit_gc::gc_sync::BlockingGuard {
     majit_gc::gc_sync::before_external_block()
 }
 
+/// `entrypoint.c:78 _RPyGilAcquire`: retake the GIL and rejoin the collector's
+/// RUNNING census while a foreign callback runs pyre code.
+pub fn enter_external_callback() -> majit_gc::gc_sync::CallbackGuard {
+    majit_gc::gc_sync::enter_external_callback()
+}
+
 thread_local! {
     /// Set once this thread owns a mutator registration, so the entry below
     /// stays a single thread-local read on every later entry.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -60,6 +60,30 @@ pub fn enter_external_callback() -> majit_gc::gc_sync::CallbackGuard {
     majit_gc::gc_sync::enter_external_callback()
 }
 
+/// Enter the runtime to deliver a callback on a thread foreign code owns.
+///
+/// A first-time thread is registered *parked* — no GIL, not in the RUNNING
+/// census — so the guard returned here is what acquires both and what gives
+/// them back when the callback returns. `ensure_runtime_thread` would take the
+/// GIL as part of registering, leaving the guard nothing to release and the
+/// foreign worker holding it for the rest of its life.
+///
+/// The mutator registration still happens under the GIL, as it does for a
+/// thread that enters through `enter_runtime_thread`.
+pub fn enter_external_callback_from_foreign_thread() -> majit_gc::gc_sync::CallbackGuard {
+    let first_entry = !RUNTIME_THREAD_ENTERED.with(|entered| entered.get());
+    if first_entry {
+        RUNTIME_THREAD_ENTERED.with(|entered| entered.set(true));
+        majit_gc::gc_sync::register_thread_parked();
+    }
+    let guard = majit_gc::gc_sync::enter_external_callback();
+    if first_entry {
+        majit_gc::shadow_stack::register_mutator();
+        RUNTIME_THREAD.with(|_| {});
+    }
+    guard
+}
+
 thread_local! {
     /// Set once this thread owns a mutator registration, so the entry below
     /// stays a single thread-local read on every later entry.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -4447,12 +4447,29 @@ static INSTANCE_DICT_PENDING: LazyLock<Mutex<HashSet<usize>>> =
 static WEAKREF_TABLE_PENDING: LazyLock<Mutex<HashSet<usize>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
 
+/// Keys that were a nursery address when the entry was made.  A nursery
+/// address is handed to the next allocation as soon as the collection that
+/// dropped its owner resets the nursery, so such a key must be resolved to
+/// where the owner moved — or dropped, if it died — before that happens.  See
+/// [`reconcile_young_owner_entries`].
+static INSTANCE_DICT_YOUNG: LazyLock<Mutex<HashSet<usize>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+static WEAKREF_TABLE_YOUNG: LazyLock<Mutex<HashSet<usize>>> =
+    LazyLock::new(|| Mutex::new(HashSet::new()));
+
+fn note_young_owner(young: &Mutex<HashSet<usize>>, key: PyObjectRef) {
+    if majit_gc::gc_is_nursery_object(key as usize) {
+        young.lock().unwrap().insert(key as usize);
+    }
+}
+
 fn instance_dict_insert(key: PyObjectRef, w_dict: PyObjectRef) {
     INSTANCE_DICT
         .lock()
         .unwrap()
         .insert(key as usize, w_dict as usize);
     INSTANCE_DICT_PENDING.lock().unwrap().insert(key as usize);
+    note_young_owner(&INSTANCE_DICT_YOUNG, key);
 }
 
 fn weakref_table_insert(key: PyObjectRef, value: PyObjectRef) {
@@ -4461,6 +4478,7 @@ fn weakref_table_insert(key: PyObjectRef, value: PyObjectRef) {
         .unwrap()
         .insert(key as usize, value as usize);
     WEAKREF_TABLE_PENDING.lock().unwrap().insert(key as usize);
+    note_young_owner(&WEAKREF_TABLE_YOUNG, key);
 }
 
 struct MapdictRootArea;
@@ -5207,6 +5225,62 @@ pub fn prune_dead_owner_entries(classify: &mut dyn FnMut(usize) -> Option<usize>
         for key in dead {
             table.remove(&key);
             pending.remove(&key);
+        }
+    }
+}
+
+/// Resolve every entry whose owner was young when it was made: move it to
+/// where the owner went, or drop it if the owner died.
+///
+/// [`prune_dead_owner_entries`] answers the same question for old-gen owners,
+/// but a major is far too late for a young one. A nursery address is reused by
+/// the very next allocation after the collection resets the nursery, so a
+/// surviving entry does not just leak — the unrelated object that lands on
+/// that address inherits the dead owner's `__dict__`.
+///
+/// Registered with `majit_gc::shadow_stack::register_young_owner_reconciler`,
+/// which runs it from a minor collection once every survivor has been
+/// evacuated. `classify` returns the owner's current address, or `None` if it
+/// died. Only keys recorded as young are asked about, so the cost is
+/// proportional to the entries made since the previous minor.
+pub fn reconcile_young_owner_entries(classify: &mut dyn FnMut(usize) -> Option<usize>) {
+    for (table, pending, young) in [
+        (&INSTANCE_DICT, &INSTANCE_DICT_PENDING, &INSTANCE_DICT_YOUNG),
+        (&WEAKREF_TABLE, &WEAKREF_TABLE_PENDING, &WEAKREF_TABLE_YOUNG),
+    ] {
+        let keys: Vec<usize> = {
+            let mut young = young.lock().unwrap();
+            std::mem::take(&mut *young).into_iter().collect()
+        };
+        if keys.is_empty() {
+            continue;
+        }
+        let mut table = table.lock().unwrap();
+        let mut pending = pending.lock().unwrap();
+        let mut still_young = Vec::new();
+        for key in keys {
+            match classify(key) {
+                // The owner stayed put, which for a nursery address means it
+                // was pinned: keep tracking it, the next minor asks again.
+                Some(new_key) if new_key == key => still_young.push(key),
+                Some(new_key) => {
+                    // The root walk may already have re-keyed this entry, in
+                    // which case there is nothing left at the old address.
+                    if let Some(value) = table.remove(&key) {
+                        table.insert(new_key, value);
+                    }
+                    if pending.remove(&key) {
+                        pending.insert(new_key);
+                    }
+                }
+                None => {
+                    table.remove(&key);
+                    pending.remove(&key);
+                }
+            }
+        }
+        if !still_young.is_empty() {
+            young.lock().unwrap().extend(still_young);
         }
     }
 }

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -109,9 +109,20 @@ pub fn get_slotvalues(w_obj: PyObjectRef) -> PyResult {
 /// has no `variable_sized` layout notion to gate it on — the structure
 /// is ported without that dead arm.
 pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
-    let w_objdict = crate::baseobjspace::findattr(w_obj, "__dict__");
-    let mut w_ret = match w_objdict {
-        Some(d) if crate::baseobjspace::len_w(d)? > 0 => {
+    // Allocating the copy, storing into it and `get_slotvalues` all collect,
+    // so the receiver, its `__dict__`, the items being copied and the copy
+    // itself are read back from the shadow stack rather than kept in Rust
+    // locals across those points.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let w_objdict = crate::baseobjspace::findattr(current_obj(), "__dict__");
+    let mut state_slot = None;
+    if let Some(d) = w_objdict {
+        let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(d);
+        if crate::baseobjspace::len_w(pyre_object::gc_roots::shadow_stack_get(dict_slot))? > 0 {
             // Copy `__dict__`. For a dict subclass, drop the internal
             // `__dict_data__` key it keeps its mapping payload under: that
             // payload is reconstructed through `dictitems`, not the instance
@@ -120,47 +131,72 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
             // A non-dict instance keeps a user attribute of that name.
             let is_dict_inst = {
                 let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-                unsafe { crate::baseobjspace::isinstance_w(w_obj, w_dict_type) }
+                unsafe { crate::baseobjspace::isinstance_w(current_obj(), w_dict_type) }
             };
-            let w_copy = pyre_object::w_dict_new();
+            let copy_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            let items = unsafe {
+                pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(dict_slot))
+            };
+            let items_slot = pyre_object::gc_roots::shadow_stack_len();
+            for (k, v) in &items {
+                pyre_object::gc_roots::pin_root(*k);
+                pyre_object::gc_roots::pin_root(*v);
+            }
             let mut count = 0usize;
-            for (k, v) in unsafe { pyre_object::w_dict_items(d) } {
+            for index in 0..items.len() {
+                let k = pyre_object::gc_roots::shadow_stack_get(items_slot + 2 * index);
+                let v = pyre_object::gc_roots::shadow_stack_get(items_slot + 2 * index + 1);
                 if is_dict_inst
                     && unsafe { pyre_object::is_str(k) }
                     && unsafe { pyre_object::w_str_get_value(k) } == "__dict_data__"
                 {
                     continue;
                 }
-                unsafe { pyre_object::w_dict_store(w_copy, k, v) };
+                unsafe {
+                    pyre_object::w_dict_store(
+                        pyre_object::gc_roots::shadow_stack_get(copy_slot),
+                        k,
+                        v,
+                    )
+                };
                 count += 1;
             }
             if count > 0 {
-                w_copy
-            } else {
-                pyre_object::w_none()
+                state_slot = Some(copy_slot);
             }
         }
-        _ => pyre_object::w_none(),
-    };
-    let w_slots = get_slotvalues(w_obj)?;
-    if !unsafe { pyre_object::is_none(w_slots) } {
-        w_ret = pyre_object::w_tuple_new(vec![w_ret, w_slots]);
     }
-    Ok(w_ret)
+    let w_slots = get_slotvalues(current_obj())?;
+    let w_ret = match state_slot {
+        Some(slot) => pyre_object::gc_roots::shadow_stack_get(slot),
+        None => pyre_object::w_none(),
+    };
+    if unsafe { pyre_object::is_none(w_slots) } {
+        return Ok(w_ret);
+    }
+    Ok(pyre_object::w_tuple_new(vec![w_ret, w_slots]))
 }
 
 /// objectobject.py:201 `_getnewargs(space, w_obj)` — returns
 /// `(hasargs, w_args, w_kwargs)`.
 pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef), PyError> {
-    let w_type = crate::typedef::r#type(w_obj)
+    // `__getnewargs_ex__`/`__getnewargs__` run arbitrary Python and the
+    // no-args branch allocates the empty tuple, so `w_obj` moves underneath
+    // this frame.  Read it back from the shadow stack for every later use.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let w_type = crate::typedef::r#type(current_obj())
         .ok_or_else(|| PyError::type_error("cannot determine type for __getnewargs__"))?;
-    let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs_ex__") };
+    let w_descr = unsafe { crate::baseobjspace::lookup(current_obj(), "__getnewargs_ex__") };
     let hasargs;
     let w_args;
     let w_kwargs;
     if let Some(w_descr) = w_descr {
         let w_result = unsafe {
-            crate::baseobjspace::get_and_call_function(w_descr, w_obj, w_type.as_ptr(), &[])
+            crate::baseobjspace::get_and_call_function(w_descr, current_obj(), w_type.as_ptr(), &[])
         }?;
         if !unsafe { pyre_object::is_tuple(w_result) } {
             return Err(PyError::type_error(format!(
@@ -193,10 +229,15 @@ pub fn getnewargs(w_obj: PyObjectRef) -> Result<(bool, PyObjectRef, PyObjectRef)
         w_args = wa;
         w_kwargs = wk;
     } else {
-        let w_descr = unsafe { crate::baseobjspace::lookup(w_obj, "__getnewargs__") };
+        let w_descr = unsafe { crate::baseobjspace::lookup(current_obj(), "__getnewargs__") };
         if let Some(w_descr) = w_descr {
             let wa = unsafe {
-                crate::baseobjspace::get_and_call_function(w_descr, w_obj, w_type.as_ptr(), &[])
+                crate::baseobjspace::get_and_call_function(
+                    w_descr,
+                    current_obj(),
+                    w_type.as_ptr(),
+                    &[],
+                )
             }?;
             if !unsafe { pyre_object::is_tuple(wa) } {
                 return Err(PyError::type_error(format!(
@@ -256,9 +297,15 @@ pub fn set_reduce(w_obj: PyObjectRef) -> PyResult {
 
 /// objectobject.py:23 `reduce_1(obj, proto)` — app-level handle.
 fn reduce_1(w_obj: PyObjectRef, proto: i64) -> PyResult {
+    // Boxing `proto` allocates, so the receiver cannot be copied into the
+    // argument array before it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let w_proto = pyre_object::w_int_new(proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_1),
-        &[w_obj, pyre_object::w_int_new(proto)],
+        &[pyre_object::gc_roots::shadow_stack_get(obj_slot), w_proto],
     )
 }
 
@@ -269,23 +316,52 @@ fn reduce_2(
     w_args: PyObjectRef,
     w_kwargs: PyObjectRef,
 ) -> PyResult {
+    // Same as `reduce_1`: boxing `proto` allocates, and here it would move
+    // three already-copied references.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_obj);
+    pyre_object::gc_roots::pin_root(w_args);
+    pyre_object::gc_roots::pin_root(w_kwargs);
+    let w_proto = pyre_object::w_int_new(proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_2),
-        &[w_obj, pyre_object::w_int_new(proto), w_args, w_kwargs],
+        &[
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            w_proto,
+            pyre_object::gc_roots::shadow_stack_get(obj_slot + 1),
+            pyre_object::gc_roots::shadow_stack_get(obj_slot + 2),
+        ],
     )
 }
 
 /// objectobject.py:260 `descr__reduce_ex__(space, w_obj, proto)`.
 pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
+    // Every attribute lookup below can run Python, and `getnewargs` allocates
+    // even when the type defines neither hook, so the receiver and the
+    // arguments it produced have to come back off the shadow stack rather than
+    // out of a Rust local.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_obj);
+    let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
     // Honour a user `__reduce__` override:
     // `type(obj).__reduce__ is not object.__reduce__`.
-    let w_reduce = crate::baseobjspace::findattr(w_obj, "__reduce__");
+    let w_reduce = crate::baseobjspace::findattr(current_obj(), "__reduce__");
     if let Some(w_reduce) = w_reduce {
-        let w_type = crate::typedef::r#type(w_obj)
+        let reduce_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_reduce);
+        let w_type = crate::typedef::r#type(current_obj())
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
         let w_cls_reduce = crate::baseobjspace::getattr_str(w_type.as_ptr(), "__reduce__")?;
+        // Both sides of the identity test have to survive the second lookup,
+        // or a collection between them reports a spurious override.
+        let cls_reduce_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_cls_reduce);
         let w_obj_reduce =
             crate::baseobjspace::getattr_str(crate::typedef::w_object(), "__reduce__")?;
+        let w_cls_reduce = pyre_object::gc_roots::shadow_stack_get(cls_reduce_slot);
+        let w_reduce = pyre_object::gc_roots::shadow_stack_get(reduce_slot);
         let mut override_ = !crate::baseobjspace::is_w(w_cls_reduce, w_obj_reduce);
         // Built-in types (range, the iterators) expose `__reduce__`
         // through instance dispatch rather than the type MRO, so the
@@ -302,7 +378,10 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
             override_ = !crate::baseobjspace::is_w(w_inst_func, w_obj_reduce);
         }
         if override_ {
-            return crate::call::call_function_impl_result(w_reduce, &[]);
+            return crate::call::call_function_impl_result(
+                pyre_object::gc_roots::shadow_stack_get(reduce_slot),
+                &[],
+            );
         }
     }
     if proto >= 2 {
@@ -312,15 +391,18 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         // `Py_TPFLAGS_DISALLOW_INSTANTIATION`; check it before collecting new
         // arguments, exactly as `reduce_newobj` does.  Coroutine objects and
         // their `__await__` wrappers both have this shape.
-        let w_type = crate::typedef::r#type(w_obj)
+        let w_type = crate::typedef::r#type(current_obj())
             .ok_or_else(|| PyError::type_error("cannot determine type for __reduce_ex__"))?;
         if unsafe { pyre_object::w_type_disallows_instantiation(w_type.as_ptr()) } {
             return Err(PyError::type_error(format!(
                 "cannot pickle '{}' object",
-                typename(w_obj)
+                typename(current_obj())
             )));
         }
-        let (hasargs, w_args, w_kwargs) = getnewargs(w_obj)?;
+        let (hasargs, w_args, w_kwargs) = getnewargs(current_obj())?;
+        let args_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_args);
+        pyre_object::gc_roots::pin_root(w_kwargs);
         // objectobject.py:276 / `_PyObject_GetState(required)`: a type whose
         // instances carry C-level state that `__dict__`/`__slots__` cannot
         // reconstruct, and that supplies no `__getnewargs__`, cannot be
@@ -336,18 +418,23 @@ pub fn descr_reduce_ex(w_obj: PyObjectRef, proto: i64) -> PyResult {
         // CPython 3.14 for every pickle protocol.
         if !hasargs
             && unsafe {
-                pyre_object::is_module(w_obj)
-                    || pyre_object::memoryview::is_w_memoryview(w_obj)
-                    || pyre_object::function::is_staticmethod(w_obj)
-                    || pyre_object::function::is_classmethod(w_obj)
+                pyre_object::is_module(current_obj())
+                    || pyre_object::memoryview::is_w_memoryview(current_obj())
+                    || pyre_object::function::is_staticmethod(current_obj())
+                    || pyre_object::function::is_classmethod(current_obj())
             }
         {
             return Err(PyError::type_error(format!(
                 "cannot pickle '{}' object",
-                typename(w_obj)
+                typename(current_obj())
             )));
         }
-        return reduce_2(w_obj, proto, w_args, w_kwargs);
+        return reduce_2(
+            current_obj(),
+            proto,
+            pyre_object::gc_roots::shadow_stack_get(args_slot),
+            pyre_object::gc_roots::shadow_stack_get(args_slot + 1),
+        );
     }
-    reduce_1(w_obj, proto)
+    reduce_1(current_obj(), proto)
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -10838,24 +10838,27 @@ pub(crate) fn cpython_type_layout(w_type: PyObjectRef) -> Option<(i64, i64)> {
     // typedef identifies the fixed builtin prefix. CPython appends one pointer
     // per user slot to that same prefix.
     let mut slots = unsafe { pyre_object::w_type_get_nslots(w_type) } as i64;
-    // A dict subclass is represented by a composed instance in pyre and owns
-    // one private `__dict_data__` Layout slot for its mapping payload. CPython
-    // keeps that payload in the fixed PyDictObject prefix, so the private slot
-    // must not contribute to the public `tp_basicsize` projection.
+    // Some composed instances own private Layout slots for a builtin's
+    // intrinsic fields: a dict subclass keeps its mapping payload in
+    // `__dict_data__`, a slotted `weakref.ref` subclass its three
+    // `W_WeakrefBase` fields. CPython keeps both in the fixed struct prefix,
+    // so neither contributes to the public `tp_basicsize` projection.
     let mut current = unsafe { pyre_object::w_type_get_layout_ptr(w_type) };
     while !current.is_null() {
-        if unsafe {
-            (*current)
-                .newslotnames
-                .iter()
-                .any(|name| name == "__dict_data__")
-        } {
-            slots -= 1;
-            break;
-        }
+        slots -= unsafe { &(*current).newslotnames }
+            .iter()
+            .filter(|name| is_reserved_payload_slot(name))
+            .count() as i64;
         current = unsafe { (*current).base_layout };
     }
     Some((base + slots * word, item))
+}
+
+/// Whether `name` is a Layout slot pyre reserves for a builtin's intrinsic
+/// fields rather than for an attribute the class declared.
+fn is_reserved_payload_slot(name: &str) -> bool {
+    name == "__dict_data__"
+        || crate::module::_weakref::interp__weakref::RESERVED_FIELD_SLOTS.contains(&name)
 }
 
 fn cpython_type_offsets(w_type: PyObjectRef) -> Option<(i64, i64)> {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4264,6 +4264,12 @@ fn install_gc_root_walkers() {
     majit_gc::shadow_stack::register_ephemeron_marker(
         pyre_interpreter::objspace::std::mapdict::mark_live_weakref_entries,
     );
+    // An owner that dies in the nursery cannot wait for that major: the reset
+    // hands its address to the next allocation, which would then answer to its
+    // entry.
+    majit_gc::shadow_stack::register_young_owner_reconciler(
+        pyre_interpreter::objspace::std::mapdict::reconcile_young_owner_entries,
+    );
     // `MetaInterp::forced_virtuals` is the same shape but lives in one mutator's
     // `JIT_DRIVER` rather than a global table, so it registers per mutator
     // instead — see `forced_virtuals_pruner_area`.


### PR DESCRIPTION
Five CPython-suite modules were failing — `test_copy`, `test_symtable`, `test_pickle`, `test_range`, `test_importlib` — plus `test_ctypes` on the linux-aarch64 overlay. Four of the five came from one defect, and the last from a second.

## `weakref.ref` subclasses with `__slots__` read back dead

`W_WeakrefBase` keeps `w_obj_weak`, `w_callable` and `w_hash` as interpreter fields. A `weakref.ref` subclass that adds no storage keeps the typed layout, and one that gets an instance dict keeps them there — but a subclass declaring a non-empty `__slots__` has neither, so the constructor's `write_attr` silently no-opped and every such reference was dead on construction.

`weakref.KeyedRef` is exactly that shape (`__slots__ = "key",`), so every `WeakValueDictionary.__setitem__` produced a dead reference; `importlib/_bootstrap.py` inlines the same class for `_blocking_on`, so import deadlock detection never fired and `test_circular_imports` hung. Fixed by reserving private layout slots, the way `__dict_data__` is reserved for dict subclasses.

## An owner-address-keyed side table outlives its owner by a whole nursery cycle

`INSTANCE_DICT` / `WEAKREF_TABLE` key a builtin-layout instance's `__dict__` and weakref lifeline by the owner's raw address. `prune_dead_owner_entries` drops the entries whose owner died, but it is registered as an ephemeron pruner, so it runs from a **major** collection only. An owner that dies in the nursery leaves its entry at an address the nursery reset then hands to the next allocation — and that unrelated object reads the dead owner's `__dict__` back as its own.

`test_pickle::test_newobj_generic` hit this through `MyList`: a freshly unpickled instance landed on the address of a `MyList` built 500 tests earlier and inherited its `{'foo': 42, 'bar': 'hello'}`, so the copy carried a `bar` the original never had. Probes on both pickle sides pinned it down — the pickler wrote `["foo"]` while the fresh instance already answered `dict_before=["foo", "bar"]` at the same address a prior `save_reduce` had reported.

Fixed with `register_young_owner_reconciler` / `reconcile_young_owner_tables`, invoked from the minor collection once every survivor has been evacuated and the forwarding headers still read — the point `invalidate_young_weakrefs` settles the weakref slots. Its classifier resolves a nursery address to where the owner moved, answers the address itself for a pinned owner, and reports `None` for one that did not survive. Cost is proportional to the entries made since the previous minor, not to the table.

## Two rooting bugs found on the way

- `type_descr_call_with_mode` pinned only the instance returned by `__new__`, not the caller's arguments. Binding `__new__`/`__init__` and the `__new__` call itself run arbitrary Python, so `list(d)` allocating in `__new__` handed `__init__` an evacuated `d`. This made `test_pickletools::test_recursive_tuple_and_dict` fail 100% of the time with `descriptor '__iter__' requires a 'dict' object but received a 'dict'` — the forwarded-from copy keeps a valid `w_class` while its `ob_type` is clobbered, so `type(y) is dict` stayed True. Not JIT-related; `PYRE_NO_JIT=1` reproduced it.
- `descr_reduce_ex`, `getnewargs`, `object_getstate_default`, `reduce_1` and `reduce_2` each held references across their own allocation points.

## `_ctypes`

A callback `CFuncPtr` had no C-callable thunk, and a NULL `dlsym` result was not treated as a failed lookup. The linux-aarch64 overlay entry that recorded `test_ctypes` as non-PASS is dropped.

## Regression coverage

`parity_tests/builtin_subclass_dict_address_reuse.py` churns dead `list`/`str` subclass instances that carried attributes and a weakref, then asserts every freshly built one starts with an empty `__dict__` and that a weakref taken on it resolves to itself. On the parent commit its first loop reports 537 inherited dictionaries; CPython prints `OK`.

## Gates

All run at `1b48be50d38`, after the branch was rebased onto current `origin/main`:

| gate | result |
|---|---|
| `pyre/check.py` | dynasm 425/425, cranelift 425/425, wasm 418/418 |
| CPython suite, darwin-arm64 | 219 PASS, 0 FAIL, 0 CRASH |
| CPython suite, linux/arm64 container | 216 PASS, 0 FAIL, 0 CRASH |
| `extra_tests/parity_tests` | all pass on cpython/dynasm/cranelift |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for native `ctypes` callbacks, including foreign-thread invocation and callback argument/result conversion.
  - Improved compatibility for weak-reference subclasses with slots and native callback integrations.

- **Bug Fixes**
  - Prevented stale attributes or weak references after object memory reuse.
  - Improved object preservation during reduction operations.
  - Corrected Windows symbol lookup failures and function-pointer handling.
  - Improved garbage collection of moved, pinned, and discarded objects.

- **Tests**
  - Added coverage for address reuse and resolved `ctypes` baseline failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->