### PR TITLE
jit(cranelift): re-apply the frame write barrier after reloading the frame

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6078,17 +6078,22 @@ fn ref_root_slots_with_future_regular_uses(
         .collect()
 }
 
-/// assembler.py:1369-1377 _reload_frame_if_necessary:
+/// assembler.py:1369-1383 _reload_frame_if_necessary:
 ///   MOV ecx, [rootstacktop]      // load shadow stack top pointer
 ///   MOV ebp, [ecx - WORD]        // load jf_ptr from topmost entry
+///   _write_barrier_fastpath(mc, wbdescr, [ebp], array=False, is_frame=True)
 ///
 /// After a collecting call, the GC may have copied the jitframe from
 /// nursery to old gen. The shadow stack entry was updated by the GC.
-/// Reload jf_ptr from the shadow stack top.
+/// Reload jf_ptr from the shadow stack top, then re-apply the non-array
+/// write barrier to the reloaded pointer. The `and wbdescr` guard is
+/// load-bearing: a collector that needs no write barrier reports none
+/// (`gc.py:156 GcLLDescr_boehm.write_barrier_descr = None`) and there is
+/// nothing to re-apply for it.
 fn emit_reload_frame_if_necessary(
     builder: &mut FunctionBuilder,
     ptr_type: cranelift_codegen::ir::Type,
-    _call_conv: cranelift_codegen::isa::CallConv,
+    call_conv: cranelift_codegen::isa::CallConv,
 ) -> CValue {
     let word = std::mem::size_of::<usize>() as i32;
     // MOV ecx, [rootstacktop]
@@ -6100,9 +6105,16 @@ fn emit_reload_frame_if_necessary(
         .ins()
         .load(ptr_type, MemFlagsData::trusted(), rst_addr, 0);
     // MOV ebp, [ecx - WORD]  — jf_ptr is at top - WORD
-    builder
+    let jf_ptr = builder
         .ins()
-        .load(ptr_type, MemFlagsData::trusted(), rst, -word)
+        .load(ptr_type, MemFlagsData::trusted(), rst, -word);
+    if with_cranelift_gc(|gc| gc.get_write_barrier_descr())
+        .flatten()
+        .is_some()
+    {
+        emit_jitframe_write_barrier(builder, ptr_type, call_conv, jf_ptr);
+    }
+    jf_ptr
 }
 
 /// llsupport/llmodel.py:229-234 `insert_stack_check` plus


### PR DESCRIPTION
## What this changes

`emit_reload_frame_if_necessary` ported only the shadow-stack reload half of
`_reload_frame_if_necessary` (x86 `assembler.py:1369-1377`) and dropped the half that
immediately follows it (x86 `assembler.py:1378-1383`, aarch64 `assembler.py:975-980`):

```python
wbdescr = self.cpu.gc_ll_descr.write_barrier_descr
if gcrootmap and wbdescr:
    # frame never uses card marking, so we enforce this is not an array
    self._write_barrier_fastpath(mc, wbdescr, [ebp], array=False, is_frame=True)
```

The dynasm backend already carries it on both arches, spelling the `and wbdescr` gate as
`dynasm_write_barrier_descr().is_some()`; `emit_jitframe_write_barrier` already existed in
the cranelift compiler with four other callers. The barrier now runs on the **reloaded**
pointer, and the `_call_conv` parameter that was threaded in unused is what the helper
consumes.

## What this does NOT fix

It does not fix the `GC BUG: invalid type_id … site=minor_custom_trace_target
parent_site=minor_remembered_set` abort that `test.test_datetime` produces under cranelift.
That reproduces 5/5 both without and with this change, signature unchanged
(`holder_type_id=Some(3)`, `holder_offset=Some(88)`, `jitframe_custom_trace` in the
backtrace).

## Root cause of that abort, for the follow-up

Recorded here so it is not re-derived. cranelift builds the **guard/finish** gcmap from the
fail-args alone (`bit i ⟺ fail_args[i] is Ref`), while the same frame simultaneously holds
live GC refs in the ref-root / demoted-home region at `ref_root_base_ofs + slot*8`. Those
slots are left unmarked, so a minor collection never forwards them.

Upstream `rpython/jit/backend/llsupport/regalloc.py:1093-1105 get_gcmap` builds this map
from **every live REF binding in the frame manager**, and feeds the same function to both
the per-call and the guard/finish sites. pyre's dynasm backend ports that faithfully in
`majit-backend-dynasm/src/regalloc.rs:2297-2330` — which is why the abort is cranelift-only.

Instrumented proof — one frame traced twice inside minor generation 76, with the same object
in two slots:

```
gen=76 (1st)  slot5=6da3ffe08 (unmarked)   slot33=6da3ffe08 (marked)
gen=76 (2nd)  slot5=6da3ffe08 (unmarked)   slot33=c8dcd7528 (marked)   <- forwarded
```

The marked copy is forwarded; the unmarked duplicate keeps the dead nursery address. The next
cycle's compiled code reads the stale home and republishes it as a marked Ref fail-arg:

| gen | frame | slot | marked |
|----|----|----|----|
| 70 | c7a99f608 | 121 | no |
| 76 | c8e360a88 | 5 | no |
| 76 | c8e360a88 | 33 | yes (forwarded) |
| 77 | c7a9a0c08 | 3 | yes → abort |

Two readings that look right and are wrong: the `invalid type_id` is not a type id (it is a
word read at `value - 8` inside a reused nursery, i.e. a neighbouring object's field — decode
it as an address), and "the frame was never write-barriered" is an artifact of
`do_write_barrier` returning early for nursery objects.

The direct fix — unioning the live ref-root bits into the guard map, with the bitmap widened
from a `u64` to a positions vector so nothing truncates past bit 63 — was measured and
**does not work**: it moves the signature to `holder_offset=Some(2776)` on a 340-slot frame
(slot 339, the ref-root region) and aborts in ~6 s instead of ~50 s. A call site always runs
`spill_ref_roots` immediately before `emit_push_gcmap`, so every slot its map marks has just
been written; a guard exit has no such spill, and `spill_ref_roots` is itself emitted inside
branches. The guard map therefore also needs "this slot holds a live value on every path
reaching here" — which upstream gets for free because `fm.bindings` only contains boxes that
actually have a frame home.

## Test plan

- `test.test_datetime` under cranelift: 5/5 abort before and after — this change is not
  claimed to move it.
- Both arms built clean at `cd73bb51c02`.
- Remaining gates left to CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved runtime stability during compiled-code execution and memory management.
  - Fixed an issue that could cause incorrect handling of references after execution frames were reloaded.
  - Added safeguards to ensure required memory-management operations are applied when supported by the runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->