### PR TITLE
jit: four bridge/retrace parity gaps, the x86 GUARD_VALUE counter stamp, and the f32 decay multiply

### DIFF
--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -5393,6 +5393,28 @@ impl<'a> Assembler386<'a> {
         // `AbstractFailDescr` (`history.py:132 _attrs_`) receives the
         // canonical copy.  Must follow the `meta_descr` stamp above.
         descr_fd.set_rd_locs(rd_locs);
+        // `regalloc.py:496-499 consider_guard_value` — every upstream backend
+        // stamps the per-value counter while laying the guard out, so
+        // `store_hash` (`compile.py:826-829`, gated on `status == 0`) leaves it
+        // alone and `must_compile` hashes the (guard, failing value) pair
+        // instead of the guard alone.  Without it a guard whose failing value
+        // never repeats still accumulates in one bucket and compiles another
+        // bridge every `trace_eagerness` failures, without bound.  The index is
+        // a fail-arg position because `must_compile_with_values` reads the value
+        // back out of `fail_values`.
+        if op.opcode == majit_ir::OpCode::GuardValue
+            && let Some(fa) = op.getfailargs()
+        {
+            let arg0 = op.arg(0).to_opref();
+            if let Some(idx) = fa.iter().position(|r| r.to_opref() == arg0) {
+                let type_tag = match descr_fd.fail_arg_types().get(idx) {
+                    Some(majit_ir::Type::Ref) => majit_backend::STATUS_TY_REF,
+                    Some(majit_ir::Type::Float) => majit_backend::STATUS_TY_FLOAT,
+                    _ => majit_backend::STATUS_TY_INT,
+                };
+                descr_fd.make_a_counter_per_value(idx as u32, type_tag);
+            }
+        }
         if crate::majit_log_enabled() {
             eprintln!(
                 "[dynasm] guard-token-slots: fail_index={} rd_locs={:?}",

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -665,6 +665,10 @@ pub struct CompiledWasmLoop {
     /// module lives as long as the source loop it attaches to, so its cells are
     /// freed when this loop drops. Appended by `compile_bridge`.
     pub _bridge_owned_cells: RefCell<Vec<Box<[u32]>>>,
+    /// `(descr identity, table slot)` for every label published by a bridge
+    /// chained onto this loop. The bridge module lives as long as its source
+    /// loop, so `Drop` retracts entries that still name that bridge's slot.
+    pub bridge_owned_label_targets: RefCell<Vec<(usize, u32)>>,
     /// Set when `compile_bridge` accepts a self-recursive `CallAssemblerR`
     /// bridge (`PYRE_WASM_CA`) for this loop. While set, `compile_bridge`
     /// declines chaining any FURTHER bridge into this recursion (the guard
@@ -733,10 +737,16 @@ impl Drop for CompiledWasmLoop {
         // survive the old loop's drop.
         let mut reg = LABEL_TARGETS.lock().unwrap();
         if let Some(map) = reg.as_mut() {
-            for &id in &self.label_descrs {
+            for (id, func_handle) in self
+                .label_descrs
+                .iter()
+                .copied()
+                .map(|id| (id, self.func_handle.get()))
+                .chain(self.bridge_owned_label_targets.get_mut().iter().copied())
+            {
                 if id != 0
                     && let Some(t) = map.get(&id)
-                    && t.func_handle == self.func_handle.get()
+                    && t.func_handle == func_handle
                 {
                     map.remove(&id);
                     crate::BRIDGE_DIAG[22].fetch_add(1, std::sync::atomic::Ordering::Relaxed);

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -37,10 +37,13 @@ use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 /// index-8 unresolved-target decline: 17 = the terminal JUMP carries no descr
 /// at all, 18 = the descr is present but `LABEL_TARGETS` holds no entry for it.
 /// Publish-side counterpart, so an unresolved lookup can be told from a label
-/// that was never offered: 19 = labels published off a peeled loop, 20 =
-/// published off a non-peeled loop, 21 = a non-peeled loop's first label left
+/// that was never offered: 19 = labels published off a peeled trace, 20 =
+/// published off a non-peeled trace, 21 = a non-peeled trace's first label left
 /// unpublished (no descr, or its arity is not the inputarg count), 22 = a
-/// dropped loop retracted a published entry. `compile_loop`'s own outcome
+/// dropped loop retracted a published entry. 19-21 count loops and
+/// LABEL-bearing bridges alike, since both go through the same publish step
+/// (`x86/assembler.py:990 fixup_target_tokens` runs on either path); a bridge
+/// with no LABEL is not tallied by 21. `compile_loop`'s own outcome
 /// split — every `Err` it returns is a `loops_aborted` bump in the metainterp,
 /// and the reason string never reaches the host from inside the guest, so the
 /// classification has to be a counter: 23 = compile_loop entered, 24 =
@@ -212,6 +215,143 @@ use failguard::{
 use majit_backend::{AsmInfo, BackendError, DeadFrame, JitCellToken};
 use majit_gc::GcAllocator;
 use majit_ir::{FailDescr, GcRef, InputArg, Op, OpRc, Value};
+
+/// `x86/assembler.py:990 fixup_target_tokens`, called from BOTH `assemble_loop`
+/// (:612) and `assemble_bridge` (:706) — a LABEL assembled inside a bridge is a
+/// jump target for later traces exactly like a loop's, and `compile_retrace`
+/// (compile.py:341-393) reaches the backend through `send_bridge_to_backend`,
+/// so a retrace IS a bridge that defines its own LABEL.
+///
+/// Returns `(label_descrs, published_descrs)`: the descr identity of every
+/// LABEL in ordinal order, and the subset actually entered into
+/// `LABEL_TARGETS`. `compile_loop` keeps the first for its own JUMP
+/// resolution; `compile_bridge` hands the second to the source loop so its
+/// `Drop` retracts them.
+fn stamp_and_publish_label_targets(
+    func_handle: u32,
+    frame: codegen::FrameGeometry,
+    inputargs: &[InputArg],
+    ops: &[Op],
+) -> (Vec<usize>, Vec<usize>) {
+    // Stamp each LABEL's loop-target descr with its ordinal (0, 1, 2, …) so a
+    // loop-closing bridge can recover which label its terminal JUMP targets:
+    // the JUMP and the LABEL share the descr by Arc identity, so the ordinal
+    // written here is readable from the bridge's JUMP in `compile_bridge`.
+    // Pure metadata — emits no wasm bytes, so the module shape is unchanged.
+    // Skip a LABEL whose descr is not loop-target-backed (`set_label_block_id`
+    // would panic on a non-`AtomicU32` slot).
+    let mut label_block_id: u32 = 0;
+    let mut label_descrs: Vec<usize> = Vec::new();
+    for op in ops.iter() {
+        if op.opcode != majit_ir::OpCode::Label {
+            continue;
+        }
+        // Descr identity of each label, in ordinal order, so
+        // `compile_bridge` can resolve which of THIS loop's labels a
+        // closing JUMP targets by Arc identity (the JUMP and the LABEL
+        // share the descr). The stamped `label_block_id` alone cannot: a
+        // loop retraced into several specializations re-stamps a shared
+        // descr, and every specialization's start label carries ordinal
+        // 0 — a bridge targeting ANOTHER specialization's label would
+        // otherwise be mis-chained into this one.
+        label_descrs.push(
+            op.getdescr()
+                .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
+                .unwrap_or(0),
+        );
+        if let Some(descr) = op.getdescr()
+            && let Some(target) = descr.as_loop_target_descr()
+        {
+            target.set_label_block_id(label_block_id);
+        }
+        label_block_id += 1;
+    }
+    // Per-label resume metadata (ordinal order) for `compile_bridge`'s
+    // accept condition: a loop-closing bridge may resume at ANY label via
+    // the entry `br_table`, provided its JUMP arity matches that label's
+    // arg count and the label's args are the complete live set of the
+    // trace remainder.
+    let label_num_args = codegen::label_arg_counts(ops);
+    let label_resume_info = codegen::label_resume_info(inputargs, ops, frame);
+    let mut published_descrs = Vec::new();
+
+    // Publish this loop's enterable labels so a loop-closing bridge from
+    // ANY loop can chain into them in-module (jump-to-existing-trace). A
+    // peeled loop's labels are each enterable through the entry br_table
+    // (key = ordinal + 1). A non-peeled loop has no dispatch: only its
+    // FIRST label is enterable — through the plain entry (key 0), whose
+    // input loader reads `num_inputs` positional slots — and only when
+    // the label's arity equals that (the standard loop shape, whose
+    // first label's args ARE the inputargs).
+    if codegen::is_resumable_peeled(ops) {
+        // Only labels at or before the loop header have a resume loader
+        // (`codegen::resumable_label_count`); the header is the last of
+        // them, and a bridge landing there re-runs no advancing segment.
+        let resumable = codegen::resumable_label_count(ops);
+        let header = resumable.saturating_sub(1);
+        for (j, &id) in label_descrs.iter().enumerate().take(resumable) {
+            if id == 0 {
+                continue;
+            }
+            diag_bump(19);
+            publish_label_target(
+                id,
+                LabelTarget {
+                    func_handle,
+                    key: j as u32 + 1,
+                    num_args: label_num_args[j],
+                    resume_safe: label_resume_info[j].0,
+                    requires_own_frame: label_resume_info[j].1,
+                    is_last_label: j == header,
+                    frame,
+                },
+            );
+            published_descrs.push(id);
+        }
+    } else {
+        // A LABEL with real work before it is not reachable through the plain
+        // entry: key 0 runs the function from its first op, so a bridge chaining
+        // there would re-run that work. Before the descr-strict dispatch every
+        // such trace was `is_resumable_peeled` and never reached this branch; a
+        // `jump_to_preamble` retrace (own LABEL, foreign closing JUMP) is not, so
+        // state the assumption the comment below already relies on.
+        let first_label_at_entry = ops
+            .iter()
+            .position(|op| op.opcode == majit_ir::OpCode::Label)
+            == Some(0);
+        let publishable = first_label_at_entry
+            && label_descrs.first().is_some_and(|&id| id != 0)
+            && label_num_args.first() == Some(&inputargs.len());
+        // Counter 21 answers "this trace HAS a first label and it was left
+        // unpublished". A trace with no LABEL at all — every ordinary bridge —
+        // has nothing to publish and nothing withheld, so it is not a tally.
+        if !publishable && !label_descrs.is_empty() {
+            diag_bump(21);
+        }
+        if publishable {
+            let id = label_descrs[0];
+            diag_bump(20);
+            publish_label_target(
+                id,
+                LabelTarget {
+                    func_handle,
+                    key: 0,
+                    num_args: inputargs.len(),
+                    resume_safe: true,
+                    requires_own_frame: false,
+                    // No real ops precede a non-peeled loop's header, so
+                    // an entry re-run lands at the header without any
+                    // advancing segment — the livelock check applies.
+                    is_last_label: true,
+                    frame,
+                },
+            );
+            published_descrs.push(id);
+        }
+    }
+
+    (label_descrs, published_descrs)
+}
 
 /// JIT exception state, mirroring the native backends' `JIT_EXC_VALUE` /
 /// `JIT_EXC_TYPE` globals. A can-raise helper publishes the pending exception
@@ -2306,119 +2446,10 @@ impl majit_backend::Backend for WasmBackend {
         // the last LABEL. Computed through the same predicate codegen's wrapper
         // gates on, so the recorded field and the emitted wrapper cannot drift.
         let has_preamble = codegen::is_resumable_peeled(ops);
-        // Stamp each LABEL's loop-target descr with its ordinal (0, 1, 2, …) so a
-        // loop-closing bridge can recover which label its terminal JUMP targets:
-        // the JUMP and the LABEL share the descr by Arc identity, so the ordinal
-        // written here is readable from the bridge's JUMP in `compile_bridge`.
-        // Pure metadata — emits no wasm bytes, so the module shape is unchanged.
-        // Skip a LABEL whose descr is not loop-target-backed (`set_label_block_id`
-        // would panic on a non-`AtomicU32` slot).
-        let mut label_block_id: u32 = 0;
-        let mut label_descrs: Vec<usize> = Vec::new();
-        for op in ops.iter() {
-            if op.opcode != majit_ir::OpCode::Label {
-                continue;
-            }
-            // Descr identity of each label, in ordinal order, so
-            // `compile_bridge` can resolve which of THIS loop's labels a
-            // closing JUMP targets by Arc identity (the JUMP and the LABEL
-            // share the descr). The stamped `label_block_id` alone cannot: a
-            // loop retraced into several specializations re-stamps a shared
-            // descr, and every specialization's start label carries ordinal
-            // 0 — a bridge targeting ANOTHER specialization's label would
-            // otherwise be mis-chained into this one.
-            label_descrs.push(
-                op.getdescr()
-                    .map(|d| std::sync::Arc::as_ptr(&d) as *const () as usize)
-                    .unwrap_or(0),
-            );
-            if let Some(descr) = op.getdescr()
-                && let Some(target) = descr.as_loop_target_descr()
-            {
-                target.set_label_block_id(label_block_id);
-            }
-            label_block_id += 1;
-        }
-        // Per-label resume metadata (ordinal order) for `compile_bridge`'s
-        // accept condition: a loop-closing bridge may resume at ANY label via
-        // the entry `br_table`, provided its JUMP arity matches that label's
-        // arg count and the label's args are the complete live set of the
-        // trace remainder.
-        let label_num_args = codegen::label_arg_counts(ops);
-        let label_resume_info = codegen::label_resume_info(inputargs, ops, frame);
+        let (label_descrs, _) = stamp_and_publish_label_targets(func_handle, frame, inputargs, ops);
         // Per-guard, per-fail-arg induction-advance flags for
         // `compile_bridge`'s livelock check (see `guard_fail_args_advanced`).
         let guard_fail_arg_advanced = guard_fail_args_advanced(ops, &guard_exits);
-
-        // Publish this loop's enterable labels so a loop-closing bridge from
-        // ANY loop can chain into them in-module (jump-to-existing-trace). A
-        // peeled loop's labels are each enterable through the entry br_table
-        // (key = ordinal + 1). A non-peeled loop has no dispatch: only its
-        // FIRST label is enterable — through the plain entry (key 0), whose
-        // input loader reads `num_inputs` positional slots — and only when
-        // the label's arity equals that (the standard loop shape, whose
-        // first label's args ARE the inputargs).
-        if has_preamble {
-            // Only labels at or before the loop header have a resume loader
-            // (`codegen::resumable_label_count`); the header is the last of
-            // them, and a bridge landing there re-runs no advancing segment.
-            let resumable = codegen::resumable_label_count(ops);
-            let header = resumable.saturating_sub(1);
-            for (j, &id) in label_descrs.iter().enumerate().take(resumable) {
-                if id == 0 {
-                    continue;
-                }
-                diag_bump(19);
-                publish_label_target(
-                    id,
-                    LabelTarget {
-                        func_handle,
-                        key: j as u32 + 1,
-                        num_args: label_num_args[j],
-                        resume_safe: label_resume_info[j].0,
-                        requires_own_frame: label_resume_info[j].1,
-                        is_last_label: j == header,
-                        frame,
-                    },
-                );
-            }
-        } else {
-            // A LABEL with real work before it is not reachable through the plain
-            // entry: key 0 runs the function from its first op, so a bridge chaining
-            // there would re-run that work. Before the descr-strict dispatch every
-            // such trace was `is_resumable_peeled` and never reached this branch; a
-            // `jump_to_preamble` retrace (own LABEL, foreign closing JUMP) is not, so
-            // state the assumption the comment below already relies on.
-            let first_label_at_entry = ops
-                .iter()
-                .position(|op| op.opcode == majit_ir::OpCode::Label)
-                == Some(0);
-            let publishable = first_label_at_entry
-                && label_descrs.first().is_some_and(|&id| id != 0)
-                && label_num_args.first() == Some(&inputargs.len());
-            if !publishable {
-                diag_bump(21);
-            }
-            if publishable {
-                let id = label_descrs[0];
-                diag_bump(20);
-                publish_label_target(
-                    id,
-                    LabelTarget {
-                        func_handle,
-                        key: 0,
-                        num_args: inputargs.len(),
-                        resume_safe: true,
-                        requires_own_frame: false,
-                        // No real ops precede a non-peeled loop's header, so
-                        // an entry re-run lands at the header without any
-                        // advancing segment — the livelock check applies.
-                        is_last_label: true,
-                        frame,
-                    },
-                );
-            }
-        }
 
         let compiled = CompiledWasmLoop {
             token_number: token.number,
@@ -2440,6 +2471,7 @@ impl majit_backend::Backend for WasmBackend {
             chained_trace_meta: std::cell::RefCell::new(std::collections::HashMap::new()),
             _bridge_cells_owner: bridge_cells_owner,
             _bridge_owned_cells: std::cell::RefCell::new(Vec::new()),
+            bridge_owned_label_targets: std::cell::RefCell::new(Vec::new()),
             ca_active: std::cell::Cell::new(false),
             ca_terminal_declined: std::cell::Cell::new(false),
             ca_callers: std::cell::RefCell::new(Vec::new()),
@@ -2911,6 +2943,20 @@ impl majit_backend::Backend for WasmBackend {
         }
         diag_bump(5); // bridge compiled — chained in-module
 
+        // x86/assembler.py:706 publishes the target tokens defined by an
+        // accepted bridge. `codegen::is_resumable_peeled` and
+        // `codegen::resumable_label_count` both use `find_loop_label_index`. A
+        // retrace closing onto its OWN new target token resolves the terminal
+        // JUMP among this trace's LABELs and is peeled: codegen emitted the
+        // resume `br_table`, and every resumable label is published at key
+        // ordinal + 1. A `jump_to_preamble` retrace closes onto the ORIGINAL
+        // loop's start descr, so it is not peeled and its first op is not a
+        // LABEL; the
+        // existing `first_label_at_entry` / arity guard correctly leaves that
+        // label unpublished, because key 0 would re-run the work before it.
+        let (_, published_label_descrs) =
+            stamp_and_publish_label_targets(bridge_slot, source_frame, inputargs, ops);
+
         {
             let source_loop = original_token
                 .compiled
@@ -2953,6 +2999,11 @@ impl majit_backend::Backend for WasmBackend {
             if let Some(owner) = bridge_cells_owner {
                 source_loop._bridge_owned_cells.borrow_mut().push(owner);
             }
+            source_loop.bridge_owned_label_targets.borrow_mut().extend(
+                published_label_descrs
+                    .into_iter()
+                    .map(|descr_id| (descr_id, bridge_slot)),
+            );
             if let Some(targets) = ca_targets.as_ref().filter(|_| allow_ca) {
                 // Freeze this recursion to the CA mechanism: no further bridge
                 // chains here (see the decline above the codegen call).

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -817,9 +817,14 @@ impl Optimizer {
             VirtualStateInfo::VArray { descr, items, .. } => {
                 let imported_items = items
                     .iter()
-                    .map(|item_info| {
-                        let r = Self::import_virtual_state_value(item_info, ctx);
-                        ctx.materialize_operand_at(r)
+                    .map(|item_info| match item_info {
+                        Some(item_info) => {
+                            let item_ref = Self::import_virtual_state_value(item_info, ctx);
+                            ctx.materialize_operand_at(item_ref)
+                        }
+                        // virtualstate.py:272-280: absent fieldstate remains
+                        // an unwritten virtual-array slot on import.
+                        None => Operand::None,
                     })
                     .collect();
                 ctx.set_ptr_info(
@@ -869,8 +874,17 @@ impl Optimizer {
                         fields
                             .iter()
                             .map(|(field_idx, field_info)| {
-                                let r = Self::import_virtual_state_value(field_info, ctx);
-                                (*field_idx, ctx.materialize_operand_at(r))
+                                let field = match field_info {
+                                    Some(field_info) => {
+                                        let field_ref =
+                                            Self::import_virtual_state_value(field_info, ctx);
+                                        ctx.materialize_operand_at(field_ref)
+                                    }
+                                    // virtualstate.py:328-354: retain the
+                                    // dense unwritten element-field slot.
+                                    None => Operand::None,
+                                };
+                                (*field_idx, field)
                             })
                             .collect()
                     })
@@ -1296,15 +1310,20 @@ impl Optimizer {
                 let (opref, head_box) = ctx.reserve_virtual_box(majit_ir::Type::Ref);
                 let imported_items = items
                     .iter()
-                    .map(|item_info| {
-                        let r = Self::import_virtual_state_from_label_args_recurse(
-                            item_info,
-                            imported_label_args,
-                            label_slot,
-                            ctx,
-                            walk_visited,
-                        );
-                        ctx.materialize_operand_at(r)
+                    .map(|item_info| match item_info {
+                        Some(item_info) => {
+                            let item_ref = Self::import_virtual_state_from_label_args_recurse(
+                                item_info,
+                                imported_label_args,
+                                label_slot,
+                                ctx,
+                                walk_visited,
+                            );
+                            ctx.materialize_operand_at(item_ref)
+                        }
+                        // virtualstate.py:272-280: absent fieldstate remains
+                        // an unwritten virtual-array slot on import.
+                        None => Operand::None,
                     })
                     .collect();
                 ctx.set_ptr_info(
@@ -1372,14 +1391,23 @@ impl Optimizer {
                         fields
                             .iter()
                             .map(|(field_idx, field_info)| {
-                                let r = Self::import_virtual_state_from_label_args_recurse(
-                                    field_info,
-                                    imported_label_args,
-                                    label_slot,
-                                    ctx,
-                                    walk_visited,
-                                );
-                                (*field_idx, ctx.materialize_operand_at(r))
+                                let field = match field_info {
+                                    Some(field_info) => {
+                                        let field_ref =
+                                            Self::import_virtual_state_from_label_args_recurse(
+                                                field_info,
+                                                imported_label_args,
+                                                label_slot,
+                                                ctx,
+                                                walk_visited,
+                                            );
+                                        ctx.materialize_operand_at(field_ref)
+                                    }
+                                    // virtualstate.py:328-354: retain the
+                                    // dense unwritten element-field slot.
+                                    None => Operand::None,
+                                };
+                                (*field_idx, field)
                             })
                             .collect()
                     })

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -2533,6 +2533,17 @@ impl Optimizer {
         // unbound terminal that fails `write_forwarded`'s bound-
         // precondition assert.
         ctx.bind_input_resops(ops);
+        // unroll.py:188 — the bridge iterator's fresh inputargs must enter
+        // optimization without forwarding.  This is deliberately a
+        // debug-only invariant, matching the upstream assertion without
+        // adding release-build work.
+        debug_assert!(
+            !self.building_bridge
+                || crate::optimizeopt::unroll::UnrollOptimizer::check_no_forwarding(
+                    &ctx,
+                    &ctx.inputargs,
+                )
+        );
         // Phase 1 emit ops: single source of truth for cross-phase OpRef →
         // `op.type_` lookup (history.py:220 parity).
         ctx.phase1_emit_ops = std::mem::take(&mut self.phase1_emit_ops);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -132,7 +132,9 @@ fn callee_rca_virtual_state_summary(
             }
             crate::optimizeopt::virtualstate::VirtualStateInfo::VArray { items, .. } => {
                 for (idx, child) in items.iter().enumerate() {
-                    walk(format!("{prefix}[{idx}]"), child, out, seen);
+                    if let Some(child) = child {
+                        walk(format!("{prefix}[{idx}]"), child, out, seen);
+                    }
                 }
             }
             crate::optimizeopt::virtualstate::VirtualStateInfo::VArrayStruct {
@@ -141,12 +143,14 @@ fn callee_rca_virtual_state_summary(
             } => {
                 for (elem_idx, fields) in element_fields.iter().enumerate() {
                     for (field_idx, child) in fields {
-                        walk(
-                            format!("{prefix}[{elem_idx}].{field_idx}"),
-                            child,
-                            out,
-                            seen,
-                        );
+                        if let Some(child) = child {
+                            walk(
+                                format!("{prefix}[{elem_idx}].{field_idx}"),
+                                child,
+                                out,
+                                seen,
+                            );
+                        }
                     }
                 }
             }

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -192,7 +192,9 @@ pub enum VirtualStateInfo {
     /// virtualstate.py: VArrayStateInfo — virtual array with known elements.
     VArray {
         descr: DescrRef,
-        items: Vec<Rc<VirtualStateInfoNode>>,
+        /// virtualstate.py:257-260 / :707-710: an unwritten array slot has
+        /// `fieldstate[i] is None` and is skipped by every state walk.
+        items: Vec<Option<Rc<VirtualStateInfoNode>>>,
         /// virtualstate.py: lenbound — known bounds on array length.
         /// None means unbounded.
         lenbound: Option<IntBound>,
@@ -210,7 +212,9 @@ pub enum VirtualStateInfo {
         descr: DescrRef,
         /// virtualstate.py:289: self.fielddescrs — InteriorFieldDescr per field slot.
         fielddescrs: Vec<DescrRef>,
-        element_fields: Vec<Vec<(u32, Rc<VirtualStateInfoNode>)>>,
+        /// virtualstate.py:316-320 / :707-710: dense element/field slots keep
+        /// `None` for unwritten fields.
+        element_fields: Vec<Vec<(u32, Option<Rc<VirtualStateInfoNode>>)>>,
     },
     /// Value has a known class (non-null).
     ///
@@ -335,14 +339,19 @@ impl VirtualStateInfoNode {
                 }
             }
             VirtualStateInfo::VArray { items, .. } => {
-                for child in items {
+                // virtualstate.py:277-280: absent fieldstate entries do not
+                // participate in position or notvirtual numbering.
+                for child in items.iter().flatten() {
                     child.enum_into(state);
                 }
             }
             VirtualStateInfo::VArrayStruct { element_fields, .. } => {
                 for fields in element_fields {
                     for (_, child) in fields {
-                        child.enum_into(state);
+                        // virtualstate.py:328-331: skip `None` fieldstate.
+                        if let Some(child) = child {
+                            child.enum_into(state);
+                        }
                     }
                 }
             }
@@ -490,7 +499,7 @@ impl VirtualState {
                     }
                 }
                 VirtualStateInfo::VArray { items, .. } => {
-                    for child in items {
+                    for child in items.iter_mut().flatten() {
                         visit_node(child, visitor, seen);
                     }
                 }
@@ -502,7 +511,9 @@ impl VirtualState {
                 VirtualStateInfo::VArrayStruct { element_fields, .. } => {
                     for fields in element_fields {
                         for (_, child) in fields {
-                            visit_node(child, visitor, seen);
+                            if let Some(child) = child {
+                                visit_node(child, visitor, seen);
+                            }
                         }
                     }
                 }
@@ -594,14 +605,16 @@ impl VirtualState {
                 }
             }
             VirtualStateInfo::VArray { items, .. } => {
-                for child in items {
+                for child in items.iter().flatten() {
                     Self::reset_positions_walk(child, visited);
                 }
             }
             VirtualStateInfo::VArrayStruct { element_fields, .. } => {
                 for fields in element_fields {
                     for (_, child) in fields {
-                        Self::reset_positions_walk(child, visited);
+                        if let Some(child) = child {
+                            Self::reset_positions_walk(child, visited);
+                        }
                     }
                 }
             }
@@ -661,11 +674,12 @@ impl VirtualState {
             }
             VirtualStateInfo::VArray { items, .. } => items
                 .iter()
+                .flatten()
                 .map(|child| Self::count_forced_boxes_for_entry_rc(child, visited))
                 .sum(),
             VirtualStateInfo::VArrayStruct { element_fields, .. } => element_fields
                 .iter()
-                .flat_map(|fields| fields.iter().map(|(_, child)| child))
+                .flat_map(|fields| fields.iter().filter_map(|(_, child)| child.as_ref()))
                 .map(|child| Self::count_forced_boxes_for_entry_rc(child, visited))
                 .sum(),
             VirtualStateInfo::KnownClass { .. }
@@ -987,6 +1001,11 @@ impl VirtualState {
                         .and_then(|info| info.getitem(index))
                         .and_then(|e| e.as_opref())
                         .unwrap_or(OpRef::NONE);
+                    // virtualstate.py:272-275: an absent fieldstate is not a
+                    // forced box and contributes no notvirtual slot.
+                    let Some(item_state) = item_state else {
+                        continue;
+                    };
                     // virtualstate.py:274 `if state.position > self.position`
                     if item_state.position.get() > node.position.get() {
                         Self::enum_forced_boxes_for_entry(
@@ -1016,11 +1035,6 @@ impl VirtualState {
                 //           if fieldstate.position > self.position:
                 //               fieldstate.enum_forced_boxes(boxes, itembox, ...)
                 //
-                // pyre stores element_fields sparsely: each inner Vec only
-                // contains the fields that have a state. The "fieldstate is
-                // None" case corresponds to a field_idx present in the
-                // runtime's vinfo but absent from the state's element_fields,
-                // which signals a schema mismatch.
                 let runtime_fields: Vec<Vec<(u32, OpRef)>> = match ctx
                     .get_box_replacement_operand_opt(opref)
                     .as_ref()
@@ -1038,10 +1052,6 @@ impl VirtualState {
                 }
                 for (elem_idx, fields) in element_fields.iter().enumerate() {
                     let runtime_elem = &runtime_fields[elem_idx];
-                    // virtualstate.py:347-349: if fieldstate is None and
-                    // itembox is not None → raise. In pyre's sparse model,
-                    // a runtime field absent from the state's element_fields
-                    // is the equivalent mismatch.
                     for (rt_field_idx, _) in runtime_elem {
                         if !fields.iter().any(|(fdidx, _)| fdidx == rt_field_idx) {
                             return Err(VirtualStatesCantMatch::default());
@@ -1056,6 +1066,14 @@ impl VirtualState {
                             .find(|(fdidx, _)| fdidx == field_idx)
                             .map(|(_, op)| *op)
                             .unwrap_or(OpRef::NONE);
+                        // virtualstate.py:347-350: absent state requires an
+                        // equally unwritten item and then skips recursion.
+                        let Some(field_state) = field_state else {
+                            if !item_ref.is_none() {
+                                return Err(VirtualStatesCantMatch::default());
+                            }
+                            continue;
+                        };
                         // virtualstate.py:352 `if state.position > self.position`
                         if field_state.position.get() > node.position.get() {
                             Self::enum_forced_boxes_for_entry(
@@ -1878,6 +1896,14 @@ impl VirtualState {
                     None
                 };
                 for (i, (ec, ic)) in ei.iter().zip(ii.iter()).enumerate() {
+                    // virtualstate.py:257-260: expected `None` skips the
+                    // slot; expected state against incoming `None` cannot
+                    // match. Only present pairs recurse.
+                    let (ec, ic) = match (ec, ic) {
+                        (None, _) => continue,
+                        (Some(_), None) => return Err(VirtualStatesCantMatch::default()),
+                        (Some(ec), Some(ic)) => (ec, ic),
+                    };
                     // virtualstate.py:251-256 + :72-76: `fieldbox` and
                     // `fieldbox_runtime` are both `None` when the parent's
                     // `_items[i]` slot is unset. pyre's VirtualArrayInfo
@@ -1974,12 +2000,28 @@ impl VirtualState {
                                 _ => None,
                             }
                         });
+                    // virtualstate.py:316-320: the positional helper's
+                    // missing-field cases are the direct `None` semantics:
+                    // expected absent skips, incoming absent against an
+                    // expected state rejects.
+                    let expected_present: Vec<(u32, Rc<VirtualStateInfoNode>)> = e_fields
+                        .iter()
+                        .filter_map(|(idx, child)| {
+                            child.as_ref().map(|child| (*idx, Rc::clone(child)))
+                        })
+                        .collect();
+                    let incoming_present: Vec<(u32, Rc<VirtualStateInfoNode>)> = i_fields
+                        .iter()
+                        .filter_map(|(idx, child)| {
+                            child.as_ref().map(|child| (*idx, Rc::clone(child)))
+                        })
+                        .collect();
                     Self::generate_guards_recurse_positional_fields(
                         arg_idx,
                         efd,
                         ifd,
-                        e_fields,
-                        i_fields,
+                        &expected_present,
+                        &incoming_present,
                         parent_fields.as_deref(),
                         runtime_box,
                         // virtualstate.py:316 `for descr in self.fielddescrs:
@@ -2316,7 +2358,7 @@ fn deep_clone_node(
             descr: descr.clone(),
             items: items
                 .iter()
-                .map(|child| deep_clone_node(child, cache))
+                .map(|child| child.as_ref().map(|child| deep_clone_node(child, cache)))
                 .collect(),
             lenbound: lenbound.clone(),
         },
@@ -2332,7 +2374,12 @@ fn deep_clone_node(
                 .map(|fields| {
                     fields
                         .iter()
-                        .map(|(idx, child)| (*idx, deep_clone_node(child, cache)))
+                        .map(|(idx, child)| {
+                            (
+                                *idx,
+                                child.as_ref().map(|child| deep_clone_node(child, cache)),
+                            )
+                        })
                         .collect()
                 })
                 .collect(),
@@ -2601,6 +2648,22 @@ impl ExportCache {
     }
 }
 
+/// virtualstate.py:707-710 `VirtualStateConstructor.create_state_or_none`.
+/// This is the single export boundary that maps an unwritten virtual slot to
+/// absent fieldstate; every present operand follows the ordinary state cache.
+fn create_state_or_none(
+    operand: &majit_ir::operand::Operand,
+    ctx: &OptContext,
+    cache: &mut ExportCache,
+) -> Option<Rc<VirtualStateInfoNode>> {
+    let opref = operand.to_opref();
+    if opref.is_none() {
+        None
+    } else {
+        Some(export_single_value(opref, ctx, cache))
+    }
+}
+
 /// Export abstract info for a single value, sharing `Rc<VirtualStateInfoNode>`
 /// across recursive calls so the resulting tree is a DAG: aliased boxes
 /// converge on a single shared `VirtualStateInfo`. virtualstate.py:712-728
@@ -2740,10 +2803,12 @@ fn export_single_value_inner(
                 };
             }
             PtrInfo::VirtualArray(vinfo) => {
-                let items: Vec<Rc<VirtualStateInfoNode>> = vinfo
+                // virtualstate.py:724-725: every fieldbox is routed through
+                // `create_state_or_none`, preserving unwritten slots.
+                let items: Vec<Option<Rc<VirtualStateInfoNode>>> = vinfo
                     .items
                     .iter()
-                    .map(|item_ref| export_single_value(item_ref.to_opref(), ctx, cache))
+                    .map(|item_ref| create_state_or_none(item_ref, ctx, cache))
                     .collect();
                 let len = items.len();
                 return VirtualStateInfo::VArray {
@@ -2775,8 +2840,9 @@ fn export_single_value_inner(
                         fields
                             .iter()
                             .map(|(field_idx, field_ref)| {
-                                let field_state =
-                                    export_single_value(field_ref.to_opref(), ctx, cache);
+                                // virtualstate.py:724-725: retain the dense
+                                // field slot while making unwritten state absent.
+                                let field_state = create_state_or_none(field_ref, ctx, cache);
                                 (*field_idx, field_state)
                             })
                             .collect()
@@ -2841,40 +2907,19 @@ fn export_single_value_inner(
     // is picked by `box.type` which is ALWAYS set on RPython Boxes.
     // pyre's OptContext::opref_type reconstructs it from value_types
     // (seeded from trace_inputargs) / producing-op result_type.
-    // The "0 hits" measured here covered the benchmark population; the
-    // example crates' test binaries are a population it did not enumerate,
-    // and one of them hits. `cel tests::policy_gates` reaches this line
-    // under a plain `cargo test --release -p cel` and panics, running
-    // `policy::run_gates` — the full pipeline, not the hand-built minimal
-    // OptContext the fallback below was written for.
-    //
-    // `cfg!(test)` is evaluated in majit-metainterp, so that fallback covers
-    // this crate's own unit tests and nothing else: downstream majit-metainterp
-    // is a plain dependency, `cfg!(test)` is false inside a downstream test
-    // binary too, and the panic is armed there. The firing is the proof — had
-    // the flag been true in cel's build, `Type::Int` would have been returned
-    // instead. So the fallback disarms the check exactly where this crate can
-    // exercise it, and leaves it live where a failure is hardest to attribute.
     let tp = ctx.opref_type(opref).unwrap_or_else(|| {
-        if !cfg!(test) {
-            // Two different failures reach this line, and the message used to
-            // spell both of them `None`: `OpRef::None` is the absent-operand
-            // sentinel arriving as the argument, while a named ref means
-            // value_types holds no entry for a ref that does exist. Which one
-            // was seen is the difference between "an unbound operand was
-            // exported" and "a seeding gap", so name it rather than printing
-            // a line that reads as a tautology.
-            let seen = if opref.is_none() {
-                "the absent-operand sentinel reached export_state"
-            } else {
-                "no type recorded for a ref that does exist"
-            };
-            panic!(
-                "not_virtual: opref_type({opref:?}) found no type — {seen}; \
-                 RPython box.type is always set (virtualstate.py:360)",
-            );
-        }
-        Type::Int
+        // Two different failures reach this line: the absent-operand sentinel
+        // is unexpected outside `create_state_or_none`, while a named ref
+        // means value_types lacks an entry for a real box. Keep both loud.
+        let seen = if opref.is_none() {
+            "the absent-operand sentinel reached export_state"
+        } else {
+            "no type recorded for a ref that does exist"
+        };
+        panic!(
+            "not_virtual: opref_type({opref:?}) found no type — {seen}; \
+             RPython box.type is always set (virtualstate.py:360)",
+        );
     });
     // virtualstate.py:476-481 NotVirtualStateInfoInt.__init__: an int leaf's
     // info is `getintbound(op)` (optimizer.py:335-338 — always an IntBound for a
@@ -2904,7 +2949,7 @@ fn export_single_value_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::optimizeopt::info::VirtualStructInfo;
+    use crate::optimizeopt::info::{VirtualArrayInfo, VirtualStructInfo};
     use majit_ir::operand::Operand;
     use majit_ir::{Descr, FieldDescr, GcRef, Type};
     use std::sync::Arc;
@@ -3068,23 +3113,31 @@ mod tests {
         let a1 = vs1(VirtualStateInfo::VArray {
             descr: descr.clone(),
             items: vec![
-                VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(Value::Int(1))),
-                VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(Type::Int)),
+                Some(VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
+                    Value::Int(1),
+                ))),
+                Some(VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(
+                    Type::Int,
+                ))),
             ],
             lenbound: None,
         });
         let a2 = vs1(VirtualStateInfo::VArray {
             descr: descr.clone(),
             items: vec![
-                VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(Value::Int(1))),
-                VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(Value::Int(2))),
+                Some(VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
+                    Value::Int(1),
+                ))),
+                Some(VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
+                    Value::Int(2),
+                ))),
             ],
             lenbound: None,
         });
         let a3 = vs1(VirtualStateInfo::VArray {
             descr: descr.clone(),
-            items: vec![VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
-                Value::Int(1),
+            items: vec![Some(VirtualStateInfoNode::new_rc(
+                VirtualStateInfo::Constant(Value::Int(1)),
             ))],
             lenbound: None,
         });
@@ -3266,8 +3319,8 @@ mod tests {
             VirtualState::new(vec![VirtualStateInfo::Constant(Value::Ref(GcRef(0x1234)))]);
         let incoming = VirtualState::new(vec![VirtualStateInfo::VArray {
             descr,
-            items: vec![VirtualStateInfoNode::new_rc(VirtualStateInfo::Constant(
-                Value::Int(1),
+            items: vec![Some(VirtualStateInfoNode::new_rc(
+                VirtualStateInfo::Constant(Value::Int(1)),
             ))],
             lenbound: None,
         }]);
@@ -3323,6 +3376,45 @@ mod tests {
             .expect("non-virtual array length bound");
         assert_eq!((lenbound.lower, lenbound.upper), (0, 10));
         assert!(lenbound.are_knownbits_implied());
+    }
+
+    #[test]
+    fn test_export_virtual_array_skips_unwritten_slot() {
+        // virtualstate.py:707-710 / :724-725: an unwritten fieldbox exports
+        // as absent fieldstate. virtualstate.py:272-280 then gives it neither
+        // a forced box nor a position_in_notvirtuals slot.
+        let mut ctx = OptContext::new(32);
+        let array_ref = OpRef::ref_op(10);
+        let written_ref = OpRef::int_op(11);
+        let array_box = ctx.materialize_operand_at(array_ref);
+        let written_box = ctx.materialize_operand_at(written_ref);
+        ctx.set_ptr_info(
+            &array_box,
+            PtrInfo::VirtualArray(VirtualArrayInfo {
+                descr: test_descr(21),
+                clear: false,
+                items: vec![Operand::None, written_box],
+                last_guard_pos: -1,
+                avpi: crate::optimizeopt::info::AbstractVirtualPtrInfo::new(),
+            }),
+        );
+
+        let state = export_state(&[array_ref], &ctx);
+        let VirtualStateInfo::VArray { items, .. } = &state.state[0].info else {
+            panic!("exported state is not a virtual array");
+        };
+        assert!(items[0].is_none(), "unwritten slot must stay absent");
+        let written_state = items[1].as_ref().expect("written slot state");
+        assert_eq!(written_state.position_in_notvirtuals.get(), 0);
+
+        // Hand-computed LABEL/JUMP arity: virtual head 0 + absent slot 0 +
+        // one written Unknown(Int) leaf 1 = one non-virtual argument.
+        assert_eq!(state.num_boxes(), 1);
+        let mut optimizer = crate::optimizeopt::optimizer::Optimizer::new();
+        let inputargs = state
+            .make_inputargs(&[array_ref], &mut optimizer, &mut ctx, false)
+            .expect("exported virtual array must enumerate its written slot");
+        assert_eq!(inputargs, vec![written_ref]);
     }
 
     #[test]
@@ -3634,8 +3726,8 @@ mod tests {
             VirtualStateInfo::NonNull,
             VirtualStateInfo::VArray {
                 descr,
-                items: vec![VirtualStateInfoNode::new_rc(VirtualStateInfo::Unknown(
-                    Type::Int,
+                items: vec![Some(VirtualStateInfoNode::new_rc(
+                    VirtualStateInfo::Unknown(Type::Int),
                 ))],
                 lenbound: None,
             },

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -85,6 +85,7 @@ impl Drop for DebugSectionRollback {
 use crate::history::TreeLoop;
 use crate::warmstate::{HotResult, WarmEnterState};
 use majit_ir::descr::DescrRef;
+use majit_ir::forwarding::ForwardingHost;
 use majit_ir::{
     Const, FailDescr, GcRef, IndexMapExt, InputArg, Op, OpCode, OpRc, OpRef, Type, Value,
 };
@@ -112,6 +113,32 @@ use crate::virtualizable::VirtualizableInfo;
 fn guardlog_enabled() -> bool {
     static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *ENABLED.get_or_init(|| std::env::var_os("MAJIT_GUARDLOG").is_some())
+}
+
+/// compile.py:496-502 `forget_optimization_info` — discard optimizer-only
+/// forwarding state before handing a trace to the backend.  The
+/// `reset_values` arm is unported because neither send-to-backend call site
+/// passes it.
+fn forget_optimization_info<T: OptimizationInfoItem>(items: &[T]) {
+    for item in items {
+        item.clear_optimization_info();
+    }
+}
+
+trait OptimizationInfoItem {
+    fn clear_optimization_info(&self);
+}
+
+impl OptimizationInfoItem for OpRc {
+    fn clear_optimization_info(&self) {
+        self.as_ref().clear_forwarded();
+    }
+}
+
+impl OptimizationInfoItem for InputArg {
+    fn clear_optimization_info(&self) {
+        self.clear_forwarded();
+    }
 }
 
 /// No direct RPython equivalent — Rust struct carrying data that RPython
@@ -6936,6 +6963,8 @@ impl<M: Clone> MetaInterp<M> {
             );
         }
         let compile_start = Instant::now();
+        forget_optimization_info(&compiled_ops);
+        forget_optimization_info(&inputargs);
         let compile_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -8220,6 +8249,8 @@ impl<M: Clone> MetaInterp<M> {
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_start = Instant::now();
+        forget_optimization_info(&combined_ops);
+        forget_optimization_info(&inputargs);
         let compile_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -8546,6 +8577,8 @@ impl<M: Clone> MetaInterp<M> {
         // compile.py:589-599 `debug_start("jit-backend") +
         // profiler.start_backend() ... try: do_compile_bridge ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
+        forget_optimization_info(&combined_ops);
+        forget_optimization_info(&inputargs);
         let bridge_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
@@ -9558,6 +9591,8 @@ impl<M: Clone> MetaInterp<M> {
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_start = Instant::now();
+        forget_optimization_info(&compiled_ops);
+        forget_optimization_info(&inputargs);
         let compile_loop_result = {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend.compile_loop(
@@ -12896,6 +12931,8 @@ impl<M: Clone> MetaInterp<M> {
             // profiler.start_backend() ... try: do_compile_bridge ...
             // finally: ... profiler.end_backend() +
             // debug_stop("jit-backend")`.
+            forget_optimization_info(&optimized_ops);
+            forget_optimization_info(bridge_inputargs);
             let bridge_result = {
                 let _backend_scope = self.staticdata.profiler.enter_backend();
                 std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/majit/majit-trace/src/counter.rs
+++ b/majit/majit-trace/src/counter.rs
@@ -165,12 +165,14 @@ impl JitCounter {
                 // This predicate is &self, so decay-adjust the read instead of
                 // mutating the table to apply the pending generations. Step
                 // through them one at a time rather than raising the multiplier
-                // to `elapsed`: `decay_all_counters` rounds back to f32 after
-                // every step, and this answer has to be the one a `tick` would
-                // give once it drains the same generations.
+                // to `elapsed`: every step rounds back to f32, and this answer
+                // has to be the one a `tick` would give once it drains the same
+                // generations. Narrow the multiplier the way decay_all_counters
+                // does, for the same reason.
+                let mult = self.decay_by_mult as f32;
                 let mut time = entry.times[i];
                 for _ in 0..elapsed {
-                    time = (time as f64 * self.decay_by_mult) as f32;
+                    time *= mult;
                 }
                 return time as f64 + increment >= 1.0;
             }
@@ -273,11 +275,18 @@ impl JitCounter {
     }
 
     /// counter.py:266-278 decay_all_counters()
+    ///
+    /// counter.py:278-279 hands `decay_by_mult` to `pypy__decay_jit_counters`,
+    /// whose C body narrows it with `float f = (float)f1` once and then
+    /// multiplies each entry in single precision. Narrowing the multiplier here
+    /// rather than the product keeps those bits: widening the entry to f64,
+    /// multiplying, and narrowing back rounds twice, and the two disagree
+    /// whenever the exact product lands near an f32 tie.
     pub fn decay_all_counters(&mut self) {
-        let mult = self.decay_by_mult;
+        let mult = self.decay_by_mult as f32;
         for entry in &mut self.timetable {
             for time in &mut entry.times {
-                *time = (*time as f64 * mult) as f32;
+                *time *= mult;
             }
         }
     }
@@ -495,8 +504,10 @@ mod tests {
         let increment = 0.001;
         assert!(!counter.tick(h, increment));
 
-        let expected =
-            (((0.5f32 as f64 * 0.96) as f32 as f64 * 0.96) as f32 as f64 + increment) as f32;
+        // pypy__decay_jit_counters narrows the multiplier once and multiplies
+        // in single precision; two elapsed intervals are two such multiplies.
+        let mult = 0.96f64 as f32;
+        let expected = ((0.5f32 * mult * mult) as f64 + increment) as f32;
         let actual = counter_time(&counter, h);
         assert!((actual - expected).abs() < 1.0e-6, "actual={actual}");
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3226,6 +3226,34 @@ pub fn trace_and_compile_from_bridge(
     // blackhole re-run on a path that would ignore the concrete result.
     allow_finish_direct_return: bool,
 ) -> BridgeResolution {
+    /// Publish the live callee frame's address to the handshake cells the CA
+    /// slow path's back-to-back blackhole hook reads
+    /// (`jit_blackhole_resume_from_guard`). Always re-read through
+    /// `FrameRoot::frame`, i.e. off the shadow stack, and always at a return
+    /// site: the walk that decides these flags runs before the bridge is
+    /// optimised and compiled, and that work allocates, so an address copied
+    /// while the walk was still running can name a frame the collector has
+    /// since moved. The blackhole compares the adopted cell against the
+    /// deadframe's slot 0, which IS forwarded across the same region, so a
+    /// stale copy here misses the handshake and lets the guard-state resume
+    /// re-run a region the walk already executed.
+    fn stamp_ca_walk_frames(
+        bridge_frame_root: &mut FrameRoot,
+        stamp_resume_frame: bool,
+        stamp_adopted_frame: bool,
+    ) {
+        if !stamp_resume_frame && !stamp_adopted_frame {
+            return;
+        }
+        let frame = bridge_frame_root.frame() as *mut PyFrame as usize;
+        if stamp_resume_frame {
+            CA_WALK_RESUME_FRAME.with(|c| c.set(frame));
+        }
+        if stamp_adopted_frame {
+            CA_WALK_ADOPTED_FRAME.with(|c| c.set(frame));
+        }
+    }
+
     {
         let (driver, _) = crate::eval::driver_pair();
         driver.clear_last_compiled_artifact_invalidation_flag();
@@ -3676,10 +3704,6 @@ pub fn trace_and_compile_from_bridge(
                     let frame = bridge_frame_root.frame();
                     frame.restore_resume_state_from(&executed);
                     adopted_walk_end_state = true;
-                    if !allow_finish_direct_return {
-                        let adopted_frame = frame as *mut PyFrame as usize;
-                        CA_WALK_ADOPTED_FRAME.with(|c| c.set(adopted_frame));
-                    }
                 }
                 action
             },
@@ -3724,6 +3748,12 @@ pub fn trace_and_compile_from_bridge(
         if pyre_jit_trace::jitcode_dispatch::fbw_finish_concrete_peek().is_some() {
             let finished_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
             CA_WALK_FINISHED_FRAME.with(|c| c.set(finished_frame));
+            // This return site predates the four below, so it needs the
+            // adopted stamp too: the finished cell only answers the hook's
+            // first question, and a walk that both committed its end state and
+            // kept a finish-concrete stash still has to answer the second one
+            // if the first handshake does not match.
+            stamp_ca_walk_frames(&mut bridge_frame_root, false, adopted_walk_end_state);
             if majit_metainterp::majit_log_enabled() {
                 eprintln!(
                     "[jit][bridge-trace] ca-finish-noreplay at resume_pc={} key={}",
@@ -3793,10 +3823,11 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, resume_via_blackhole
             );
         }
-        if !allow_finish_direct_return && resume_via_blackhole {
-            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
-            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
-        }
+        stamp_ca_walk_frames(
+            &mut bridge_frame_root,
+            !allow_finish_direct_return && resume_via_blackhole,
+            !allow_finish_direct_return && adopted_walk_end_state,
+        );
         return bridge_resolution_from_bool(!resume_via_blackhole);
     }
 
@@ -3822,10 +3853,11 @@ pub fn trace_and_compile_from_bridge(
                 resume_pc, green_key, resume_via_blackhole
             );
         }
-        if !allow_finish_direct_return && resume_via_blackhole {
-            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
-            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
-        }
+        stamp_ca_walk_frames(
+            &mut bridge_frame_root,
+            !allow_finish_direct_return && resume_via_blackhole,
+            !allow_finish_direct_return && adopted_walk_end_state,
+        );
         return bridge_resolution_from_bool(!resume_via_blackhole);
     }
 
@@ -3854,10 +3886,11 @@ pub fn trace_and_compile_from_bridge(
             );
         }
         let continue_compiled = compiled || adopted_walk_end_state;
-        if !allow_finish_direct_return && !continue_compiled {
-            let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
-            CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
-        }
+        stamp_ca_walk_frames(
+            &mut bridge_frame_root,
+            !allow_finish_direct_return && !continue_compiled,
+            !allow_finish_direct_return && adopted_walk_end_state,
+        );
         return bridge_resolution_from_bool(continue_compiled);
     }
 
@@ -3875,10 +3908,11 @@ pub fn trace_and_compile_from_bridge(
     }
     // A committed walk has already executed the region into the live
     // frame; the blackhole replay must not run even on this abort path.
-    if !allow_finish_direct_return && !adopted_walk_end_state {
-        let resume_frame = bridge_frame_root.frame() as *mut PyFrame as usize;
-        CA_WALK_RESUME_FRAME.with(|c| c.set(resume_frame));
-    }
+    stamp_ca_walk_frames(
+        &mut bridge_frame_root,
+        !allow_finish_direct_return && !adopted_walk_end_state,
+        !allow_finish_direct_return && adopted_walk_end_state,
+    );
     bridge_resolution_from_bool(adopted_walk_end_state)
 }
 
@@ -4045,11 +4079,13 @@ fn jit_ca_handle_guard_failure(
     }
 
     drop(_raw_values_roots);
-    if !compiled {
-        CA_WALK_RESUME_DEADFRAME.with(|c| {
-            *c.borrow_mut() = Some(raw_values_vec);
-        });
-    }
+    // compile.py:701-717 is an exclusive bridge/blackhole branch, but pyre's
+    // handle_fail_resume_guard in majit-backend-dynasm always runs the
+    // blackhole hook after this bridge hook. Its caller buffer is not rooted,
+    // so the blackhole must read the values rooted here on both outcomes.
+    CA_WALK_RESUME_DEADFRAME.with(|c| {
+        *c.borrow_mut() = Some(raw_values_vec);
+    });
 
     compiled
 }


### PR DESCRIPTION
Four unported pieces of the bridge/retrace path, plus two counter fixes carried
over from #1207's review.

## Bridge / retrace

**`jit: represent an unwritten virtual-array slot as absent fieldstate`**
`VArray::items` and `VArrayStruct::element_fields` held a bare
`Rc<VirtualStateInfoNode>`, so there was no way to say what upstream says with
`None`. An unwritten slot's `OpRef::NONE` reached `export_state`'s
unreachable-panic — except under `cfg!(test)`, where an arm fabricated an
`Unknown(Type::Int)` leaf, so test builds numbered a slot a release build could
not export at all. Both vectors become `Option<...>`, filled through a named
`create_state_or_none` (virtualstate.py:707-710), and the VArray / VArrayStruct
guard arms take upstream's asymmetry verbatim (virtualstate.py:257-260,
:316-320): expected absent continues, expected present against incoming absent
raises.

**`jit: hand the CA blackhole leg the deadframe copy this hook rooted`**
compile.py:701-717 is an exclusive if/else, but pyre's
`handle_fail_resume_guard` runs the bridge hook and the blackhole hook back to
back over one host `Vec<i64>` that is not a GC root.
`jit_ca_handle_guard_failure` rooted its own copy but published it through
`CA_WALK_RESUME_DEADFRAME` only on the `!compiled` arm, leaving the successful
attach reading the caller's un-rooted buffer. Publish on both arms.
`CA_WALK_ADOPTED_FRAME` was also stamped from inside the walk closure, before
the bridge is optimised and compiled — work that allocates. It now stamps at the
return sites from a fresh `FrameRoot::frame` read, sharing a helper with the
four `CA_WALK_RESUME_FRAME` stamps.

**`wasm: publish the LABEL target tokens a bridge defines`**
`fixup_target_tokens` runs at the end of both `assemble_loop` and
`assemble_bridge` upstream (x86/assembler.py:612 and :706), and pyre's x86,
aarch64 and cranelift backends all run their publish step on the bridge path.
wasm ran it only from `compile_loop`. Nothing declines a LABEL-bearing bridge:
`compile_retrace` (compile.py:341-393) reaches the backend through
`send_bridge_to_backend`, so a retrace is a bridge with its own LABEL, and its
label never entered `LABEL_TARGETS`. The existing peeled / non-peeled split
needs no new gate — a retrace closing onto its own target token is peeled and
publishes, while a `jump_to_preamble` retrace is not peeled and correctly stays
unpublished. `CompiledWasmLoop` gains `bridge_owned_label_targets` and retracts
them in `Drop` under the same registry guard the loop's own labels use.

**`jit: clear optimizer forwarding before handing a trace to the backend`**
`forget_optimization_info` (compile.py:496-502) is the first statement of both
`send_loop_to_backend` and `send_bridge_to_backend`; pyre had no port, so the
optimizer's output ops reached the backend and were stored verbatim as
`CompiledTrace.ops` with their `forwarded` slots still populated, pinning that
trace's `PtrInfo` graph for the artifact's lifetime. Ported over `OpRc` and
`InputArg` and called at the five backend boundaries. The `reset_values` arm
stays unported — neither call site passes it. `check_no_forwarding` existed with
no caller; it is now a `debug_assert!` on the bridge leg where unroll.py:188
asserts it.

## Counters (follow-ups to #1207's review)

**`dynasm(x86): restore the GUARD_VALUE per-value counter stamp`**
regalloc.py:496-499 calls `make_a_counter_per_value` while laying out every
GUARD_VALUE. aarch64 dynasm, cranelift and wasm all do; the x86 emitter had it
and lost it in an unrelated 254-line deletion. Without the stamp the descr keeps
`store_hash`'s plain per-guard hash, so `must_compile` takes compile.py:745's
common-case arm instead of the per-value bucketing at compile.py:753-781 — every
failure of a polymorphic GUARD_VALUE ticks one bucket and it compiles a bridge
specialised to a value that does not recur. x86-only code, so the local darwin
gate cannot reach it; verified with
`cargo check --target x86_64-apple-darwin -p majit-backend-dynasm`. It will move
jit-stats counters on the linux and windows legs.

**`jit: narrow the decay multiplier to f32 before multiplying, as the C helper does`**
`pypy__decay_jit_counters` does `float f = (float)f1` once and multiplies in
single precision. pyre widened each entry to f64, multiplied by the f64
multiplier and narrowed the product — two roundings, which disagree when the
exact product lands near an f32 tie. `would_tick_fire` narrows the same way so
the predicate still agrees with the `tick` draining the same generations.

## Verification

`pyre/check.py` on darwin arm64, all three backends: **dynasm 427/427**.

Two categories of pre-existing red remain, neither from this branch:

- `synth/str_fstring` cranelift jitstats, `657 -> 658`. The committed per-OS
  baselines for this fixture disagree with what each host observes, on main
  itself; the same +1 gap is measurable on this base with these four commits
  reverted. #1194 shifted the observation and the baseline together by one, so
  the gap is unchanged. Being re-recorded separately.
- Execution-ratio rows. The local machine was at load 26-56 (ten cores, four
  sibling worktrees building), so these are not measurements: this run failed
  `cranelift fib_recursive` (5s timeout) and `wasm fannkuch` (3.2x), while an
  earlier run on a quieter machine passed both and instead failed
  `global_quasiimmut_invalidation` and `short_circuit_value_kept_stack` — two
  rows main's own ubuntu leg also fails, along with `raise_catch`, which this
  branch passes. CI is the measurement that counts here.

The x86 GUARD_VALUE stamp cannot be exercised by a darwin gate at all; it is
compile-checked against `x86_64-apple-darwin` and will show up on the linux and
windows legs.

— *authored by Claude*
