### PR TITLE
majit: judge each retarget edge against its own target block

### DIFF
--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -2449,51 +2449,60 @@ pub fn eliminate_empty_blocks(graph: &mut FunctionGraph) {
 ///
 /// Returns the number of retargeted edges.
 pub fn retarget_assert_raise_blocks(graph: &mut FunctionGraph) -> usize {
-    use crate::flowspace::model::HOST_ENV;
+    use crate::flowspace::model::{HOST_ENV, HostObject};
+
+    /// The raise args of a block that exists only to raise the implicit
+    /// `AssertionError`; `None` for anything else.
+    fn bare_assert_raise_args<'a>(
+        block: &'a Block,
+        exceptblock: BlockId,
+        assert_err_class: &HostObject,
+    ) -> Option<&'a Vec<LinkArg>> {
+        let [exit] = block.exits.as_slice() else {
+            return None;
+        };
+        if exit.target != exceptblock {
+            return None;
+        }
+        if !matches!(
+            exit.args.first(),
+            Some(LinkArg::Const(c))
+                if matches!(
+                    &c.value,
+                    ConstValue::HostObject(h) if h == assert_err_class
+                )
+        ) {
+            return None;
+        }
+        block
+            .operations
+            .iter()
+            .all(|op| crate::inline::can_remove_op(&op.kind))
+            .then_some(&exit.args)
+    }
 
     let assert_err_class = HOST_ENV
         .lookup_builtin("AssertionError")
         .expect("HOST_ENV missing AssertionError");
     let exceptblock = graph.exceptblock;
-    let mut raise_args: std::collections::HashMap<BlockId, Vec<LinkArg>> =
-        std::collections::HashMap::new();
-    for block in &graph.blocks {
-        if block.id == exceptblock || block.exits.len() != 1 {
-            continue;
-        }
-        let exit = &block.exits[0];
-        let raises = exit.target == exceptblock
-            && matches!(
-                exit.args.first(),
-                Some(LinkArg::Const(c))
-                    if matches!(
-                        &c.value,
-                        ConstValue::HostObject(h) if *h == assert_err_class
-                    )
-            );
-        if !raises {
-            continue;
-        }
-        if !block
-            .operations
-            .iter()
-            .all(|op| crate::inline::can_remove_op(&op.kind))
-        {
-            continue;
-        }
-        raise_args.insert(block.id, exit.args.clone());
-    }
-    if raise_args.is_empty() {
-        return 0;
-    }
     let mut retargeted = 0usize;
+    // Each edge asks its own target, so there is no side table to keep in
+    // step with the mutation — upstream carries no such map either, and a
+    // qualifying block is cheap to recognise: one exit, one constant, and
+    // operations the dead-op pass would reclaim.
     for block_idx in 0..graph.blocks.len() {
-        if raise_args.contains_key(&graph.blocks[block_idx].id) {
-            continue;
-        }
         for exit_idx in 0..graph.blocks[block_idx].exits.len() {
             let target = graph.blocks[block_idx].exits[exit_idx].target;
-            let Some(args) = raise_args.get(&target).cloned() else {
+            // An edge already naming `exceptblock` is the shape the pass
+            // matches; it is also every qualifying block's own exit, which is
+            // what keeps this from rewriting the raise onto itself.
+            if target == exceptblock {
+                continue;
+            }
+            let Some(args) =
+                bare_assert_raise_args(graph.block(target), exceptblock, &assert_err_class)
+                    .cloned()
+            else {
                 continue;
             };
             let exit = &mut graph.blocks[block_idx].exits[exit_idx];


### PR DESCRIPTION
Follow-up to the Codex review on #1208 (P1: *"Replace the unbacked HashMap with dense block storage"*).

`retarget_assert_raise_blocks` collected qualifying blocks into a `HashMap<BlockId, Vec<LinkArg>>` in a first pass and consulted it while rewriting edges in a second. The map indexed by `BlockId` while the rewrite loop walked `graph.blocks` by position, and it had to be kept in step with the mutation it drove.

Each edge now asks its own target directly through `bare_assert_raise_args`, which returns the raise args of a block whose sole exit names `exceptblock` with the `AssertionError` constant and whose operations all pass `can_remove_op`. The first pass and the map are gone. The source-block exclusion becomes a check on the edge itself: an edge already naming `exceptblock` is skipped, which is every qualifying block's own exit.

### Equivalence

Address-free comparison of the generated jitcodes against the previous implementation over the same corpus:

| | result |
|---|---|
| jitcodes | 2001 / 2001, identical name sets |
| `code`, register counts, constant-pool lengths, `resulttypes`, `startpoints` | **0 differing** |
| `jitcodes_index.bin`, `insns.bin`, `liveness.bin`, `jit_trace_gen.rs` | byte-identical |
| `fnaddr_bindings.bin`, `static_*_bindings.bin` | identical sizes; contents are per-process host addresses |

`cargo test -p majit-translate` passes, including `retarget_assert_raise_blocks_judges_the_block_by_can_remove`.

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of assertion-related exception control flow.
  * Prevented invalid self-retargeting when processing exception paths.
  * Added validation to ensure only eligible assertion blocks are transformed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->