### PR TITLE
signal: describe what the OS handler actually writes, and cover duck-typed re group selectors

### DIFF
--- a/pyre/extra_tests/snippets/stdlib_re.py
+++ b/pyre/extra_tests/snippets/stdlib_re.py
@@ -91,3 +91,22 @@ assert re.fullmatch(r"([0-9]++(?:\.[0-9]+)*+)", "1.25.38").group(0) == "1.25.38"
 
 # Combining characters; issue #7518
 assert not re.match(r"\w", "\u0345"), r"\w should not match U+0345 (category Mn)"
+
+
+# A group selector is taken as a number when its type has `__index__`, and as a
+# name otherwise, so a duck-typed operand reaches every span accessor.
+class DuckIndex:
+    def __index__(self):
+        return 1
+
+
+mo = re.compile("(a+)(b+)").match("aabb")
+assert mo.group(DuckIndex()) == "aa"
+assert mo[DuckIndex()] == "aa"
+assert mo.start(DuckIndex()) == 0
+assert mo.end(DuckIndex()) == 2
+assert mo.span(DuckIndex()) == (0, 2)
+assert mo.group(DuckIndex(), DuckIndex()) == ("aa", "aa")
+
+mo = re.compile("(?P<first>a+)(?P<second>b+)").match("aabb")
+assert mo.group("second") == "bb"

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -484,8 +484,12 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
             Box::leak(CheckSignalAction::new(ec.space));
         action.register_periodic_action(ec.actionflag.shared_mut(), false);
 
-        // Hand the ticker cell address to the OS handler so it can force the
-        // ticker negative (rsignal.py:31-32 `pypysig_getaddr_occurred`).
+        // Hand the ticker cell address to the OS handler (rsignal.py:31-32
+        // `pypysig_getaddr_occurred`).  The handler itself only arms the
+        // eval-breaker's async bit, which is a lock-free atomic RMW and so
+        // async-signal-safe; `ExecutionContext::bytecode_trace` is what turns
+        // that request into a negative ticker, under the GIL.  Writing this
+        // cell from the handler would not be signal-safe.
         let ticker_addr = ec.actionflag.ticker_addr();
         signalstate::register_ticker(ticker_addr);
 

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -45,9 +45,11 @@ pub fn get_wakeup_fd_write_errno() -> i32 {
     WAKEUP_FD_WRITE_ERRNO.swap(0, Ordering::SeqCst)
 }
 
-/// Register the address of the `ActionFlag` ticker so the OS handler can
-/// force it negative.  Called once at startup from
-/// `install_signal_handling`.
+/// Register the address of the `ActionFlag` ticker.  The OS handler never
+/// writes this cell — it arms the eval-breaker's async bit and lets
+/// `sync_async_ticker` make the ticker negative under the GIL — so the address
+/// serves to identify which ticker the shared breaker drives.  Called once at
+/// startup from `install_signal_handling`.
 pub fn register_ticker(ptr: *mut isize) {
     TICKER_PTR.store(ptr, Ordering::SeqCst);
 }
@@ -69,9 +71,11 @@ pub(crate) fn rearm_ticker() {
 
 // ── pending-signal bitmask (signals.c pypysig_pushback / pypysig_poll) ──
 
-/// `signals.c:98-114 pypysig_pushback` — set the pending bit for
-/// `signum` and force the ticker to -1.  Both the OS handler and
-/// `set_interrupt` reach signal delivery through here.
+/// `signals.c:98-114 pypysig_pushback` — set the pending bit for `signum` and
+/// arm the eval-breaker's async bit.  Upstream's handler drives the ticker
+/// negative here; this defers that write to `sync_async_ticker` under the GIL
+/// so the whole path stays two lock-free atomics, which is what lets the OS
+/// handler call it.  `set_interrupt` reaches signal delivery through here too.
 pub fn signal_pushback(signum: i32) {
     if (0..NSIG).contains(&signum) {
         let bitmask = 1i64 << signum;


### PR DESCRIPTION
Two independent follow-ups from the #1209 review.

### `signal`: the ticker comments named the wrong writer

Three comments — `register_ticker`, `signal_pushback`, and the `ticker_addr` handoff in `install_signal_handling` — documented the OS signal handler as forcing the `ActionFlag` ticker negative. It does not. The handler sets the pending bit and arms the eval-breaker's async bit, both lock-free atomics; `sync_async_ticker` drives the ticker negative later, under the GIL. That split is exactly what keeps the handler async-signal-safe, so the comments now say why the handler must not write that cell.

Comments only; no behaviour change. A reviewer named one of the three sites — the other two carried the same claim.

### `re`: `__index__` arm of the group-selector conversion was uncovered

`group`, `__getitem__`, `start`, `end`, and `span` take a selector as a number when its type supplies `__index__` and as a name otherwise. `stdlib_re.py` only ever passed literal integers and literal names, so the conversion's `__index__` arm — which runs arbitrary Python — was never exercised.

### Not included

The review's Critical finding on `sre_match_group` (an unrooted `*const W_SRE_Match` held across `do_span`, which can run arbitrary Python) is **refuted**. `W_SRE_Match` is built only by `w_sre_match_new` → `W_SRE_Match::allocate_stable` → `alloc_in_oldgen`; MiniMark's mark-sweep never moves old-gen objects, and `drag_out_root` relocates only `is_nursery_object_start` refs. `allocate_stable` exists precisely so callers can hold the raw pointer on the Rust stack without rooting it. I did write that "fix" before checking the allocator, then reverted it.