### PR TITLE
Report the stack limit the process kept, reject a non-None siginfo, and make the empty-file parity case test a zero

### DIFF
--- a/pyre/extra_tests/parity_tests/fileio_stat_atopen_staleness.py
+++ b/pyre/extra_tests/parity_tests/fileio_stat_atopen_staleness.py
@@ -31,13 +31,15 @@ with open(path, "r+b") as stream:
     stream.seek(0)
     assert stream.read() == b"Hello"
 
-# An empty file records a size that says nothing about where its end is.
+# A file that is empty at the moment it is opened records a size that says
+# nothing about where its end will be, so the reader has to open first for the
+# zero to be the snapshot a later read works from.
 empty = os.path.join(directory, "empty")
 with open(empty, "wb"):
     pass
-with open(empty, "ab") as appender:
-    appender.write(b"x" * 5000)
 with open(empty, "rb") as stream:
+    with open(empty, "ab") as appender:
+        appender.write(b"x" * 5000)
     assert stream.read() == b"x" * 5000
 
 # A character device has no meaningful size at all, and reading one must still

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -1226,6 +1226,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "pidfd_send_signal() requires at least 2 arguments",
                         ));
                     }
+                    // The syscall's `siginfo` argument is not exposed, so the
+                    // only value that can be honoured is None.  Ignoring
+                    // anything else would deliver the very signal the caller
+                    // asked to have rejected.
+                    if args.len() >= 3 && !unsafe { pyre_object::is_none(args[2]) } {
+                        return Err(crate::PyError::type_error("siginfo must be None"));
+                    }
                     let pidfd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
                     let sig = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
                     let flags = if args.len() >= 4 {

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -320,14 +320,22 @@ pub fn raise_main_thread_stack_limit(size: usize) -> usize {
     if limit.rlim_max != libc::RLIM_INFINITY {
         wanted = wanted.min(limit.rlim_max);
     }
-    if wanted > limit.rlim_cur {
+    let granted = if wanted > limit.rlim_cur {
+        let previous = limit.rlim_cur;
         limit.rlim_cur = wanted;
-        if unsafe { libc::setrlimit(libc::RLIMIT_STACK, &limit) } != 0 {
-            // Keep describing what the process already had.
-            unsafe { libc::getrlimit(libc::RLIMIT_STACK, &mut limit) };
+        // A refused `setrlimit` changes nothing, so the limit read above is
+        // still what the process has.  Reporting the request instead would
+        // buy a byte budget the stack cannot hold, and the guard would sit
+        // past the guard page.
+        if unsafe { libc::setrlimit(libc::RLIMIT_STACK, &limit) } == 0 {
+            wanted
+        } else {
+            previous
         }
-    }
-    usize::try_from(limit.rlim_cur).unwrap_or(usize::MAX)
+    } else {
+        limit.rlim_cur
+    };
+    usize::try_from(granted).unwrap_or(usize::MAX)
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
Three defects, two of them review findings on #1216 that were raised after the branch had already been merged, so they never landed.

## 1. `raise_main_thread_stack_limit` could report a stack the process does not have

`pyre/pyre-interpreter/src/stack_check.rs`. When `setrlimit` failed, the recovery re-read the limit with `getrlimit` and ignored *its* return value too. If both syscalls failed, `rlim_cur` still held the value written for the attempt, and the function returned the **request** rather than what the process kept.

That return value is what `main_entry` uses to decide whether to announce `DEFAULT_RUNTIME_THREAD_STACK_SIZE` as the byte budget. Announcing a budget larger than the real stack puts the `stack_check` guard past the guard page, so the interpreter faults where it should raise `RecursionError` — the exact failure this helper exists to avoid.

A refused `setrlimit` changes nothing, so the limit read before the attempt is authoritative. Keep it and drop the second query.

## 2. `signal.pidfd_send_signal` ignored its `siginfo` argument

`pyre/pyre-interpreter/src/module/signal/interp_signal.rs`. It read arguments 0, 1 and 3 and silently dropped argument 2, so a caller passing a `siginfo` object had the signal **delivered** instead of rejected.

`test_signal.test_pidfd_send_signal` passes `object()` and expects `TypeError: siginfo must be None`; running it against a build without this check ends the test in `KeyboardInterrupt`, because the SIGINT it meant to have rejected reaches the interpreter. The syscall's `siginfo` argument is not exposed here, so None is the only honourable value. PyPy does not implement this function.

This is Linux-only (`#[cfg(target_os = "linux")]`), so it is the ubuntu leg that compiles it.

## 3. The parity fixture's empty-file case never tested a zero

`pyre/extra_tests/parity_tests/fileio_stat_atopen_staleness.py`. The case opened its reader *after* the append, so the open-time snapshot it read back already carried the final size — the zero the comment describes was never in play, and the case would have passed against an implementation that trusts a stale size. Open the reader while the file is still empty, then append through a second handle.

## Verification

Findings 1 and 3 passed the full gate on the previous base (`d5ae6806bbe`): `check.py` 427/427 on both backends, parity suite green including the strengthened fixture (still OK on CPython 3.14, which is what makes the stronger case correct rather than merely different), `cargo test --all --no-default-features --features dynasm` 122 binaries / 7863 passed / 0 failed, `cargo fmt --check` clean.

The tree has since been rebased onto `45d3ebaae6c` and finding 2 added. `cargo fmt --check` is clean on the current tree; the rest of the local gate is re-running now and I will report it. Finding 2's arm does not compile on darwin at all, so CI's ubuntu leg is its first real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - `signal.pidfd_send_signal` now clearly rejects unsupported `siginfo` values instead of ignoring them.
  - Improved stack-limit reporting when a system limit update fails or is unnecessary.
  - Corrected file staleness test behavior by capturing the reader’s initial empty state before appending data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->