### PR TITLE
pip on windows: _socket and select host layers, binary-mode descriptors, and the wheel tags

### DIFF
--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -419,17 +419,21 @@ class EnvBuilder:
 
             if do_copies:
                 for dest, src in copy_sources.items():
-                    if not os.path.isfile(src):
+                    source = src
+                    if not os.path.isfile(source):
                         # No launcher stub is shipped with this interpreter.
                         # It locates its own stdlib and honours pyvenv.cfg, so
                         # a plain copy of the running executable behaves like
-                        # the launcher would.
-                        src = context.executable
+                        # the launcher would.  There is one executable and it
+                        # is a console one, so the pythonw names get it too:
+                        # a console window is a smaller surprise than a
+                        # Scripts directory missing pythonw.exe entirely.
+                        source = context.executable
                     dest = os.path.join(binpath, dest)
                     try:
-                        shutil.copy2(src, dest)
+                        shutil.copy2(source, dest)
                     except OSError:
-                        logger.warning('Unable to copy %r to %r', src, dest)
+                        logger.warning('Unable to copy %r to %r', source, dest)
 
             if sysconfig.is_python_build():
                 # copy init.tcl

--- a/lib-python/3/venv/__init__.py
+++ b/lib-python/3/venv/__init__.py
@@ -419,6 +419,12 @@ class EnvBuilder:
 
             if do_copies:
                 for dest, src in copy_sources.items():
+                    if not os.path.isfile(src):
+                        # No launcher stub is shipped with this interpreter.
+                        # It locates its own stdlib and honours pyvenv.cfg, so
+                        # a plain copy of the running executable behaves like
+                        # the launcher would.
+                        src = context.executable
                     dest = os.path.join(binpath, dest)
                     try:
                         shutil.copy2(src, dest)

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2270,6 +2270,24 @@ fn build_function(
     // Def / last-use positions for the post-collection Ref reload filter.
     let liveness = HomeLiveness::collect(inputargs, ops);
 
+    // `LOAD_FROM_GC_TABLE` is the backend form of a ConstPtr.  Native PyPy
+    // keeps such loop-invariant references in their allocated location across
+    // a loop; reloading the GC-table slot on every iteration is not part of
+    // the operation's semantics.  Do the same for a trace with no collecting
+    // operation: eager loads are safe, and no moving collection can stale the
+    // local before the trace exits.  Traces containing a call/allocation keep
+    // the original program points and the ordinary home/reload machinery.
+    let hoisted_gc_table_loads: indexmap::IndexSet<OpRef> =
+        if has_loop && !ops.iter().any(|op| op.opcode.can_malloc()) {
+            ops.iter()
+                .filter(|op| op.opcode == OpCode::LoadFromGcTable)
+                .map(|op| op.pos.get())
+                .filter(|result| *result != OpRef::NONE && !result.is_constant())
+                .collect()
+        } else {
+            indexmap::IndexSet::new()
+        };
+
     // Resume-at-LABEL: a peeled loop wraps its preamble in a dispatch so a
     // loop-closing bridge can re-enter AT any LABEL — key = label ordinal + 1
     // — skipping the code before it, in-module instead of round-tripping
@@ -2368,6 +2386,32 @@ fn build_function(
         }
     }
 
+    // Seed loop-invariant GC-table references after the fresh-entry home clear
+    // and input setup.  Store-on-def is mirrored here because the original op
+    // arm and its common tail are skipped below.
+    for result in &hoisted_gc_table_loads {
+        let op = ops
+            .iter()
+            .find(|op| op.pos.get() == *result)
+            .expect("hoisted GC-table result must have a producer");
+        let index = resolve_const_bits(constants, op.arg(0).to_opref());
+        let slot =
+            gc_table_base as u64 + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
+        sink.i32_const(slot as i32);
+        sink.i32_load(MemArg {
+            offset: 0,
+            align: 2,
+            memory_index: 0,
+        });
+        sink.i64_extend_i32_u();
+        sink.local_set(value_types.local(result.raw()));
+        if let Some(h) = ref_homes.home(*result) {
+            sink.local_get(0);
+            sink.local_get(value_types.local(result.raw()));
+            sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
+        }
+    }
+
     // Seed with the fail-index base so each guard/finish exit writes
     // `base + local` into `frame[0]` (every trace passes the next free index
     // of the global fail-index space, `failguard::fail_descr_base`). The local
@@ -2446,6 +2490,34 @@ fn build_function(
                     sink.local_get(value_types.local(r.raw()));
                     sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
                 }
+            }
+            // The dispatch branch skipped the eager ConstPtr loads emitted on
+            // key 0.  This JitFrame has already run the preamble, so recover
+            // those loop-invariant refs from their GC-forwarded homes.
+            for result in &hoisted_gc_table_loads {
+                if let Some(h) = ref_homes.home(*result) {
+                    sink.local_get(0);
+                    sink.i64_load(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
+                } else {
+                    // A ref unused across a collecting op has no ordinary
+                    // home.  LABEL entry is cold, so reload its table slot
+                    // directly rather than manufacturing a GC root.
+                    let producer = ops
+                        .iter()
+                        .find(|op| op.pos.get() == *result)
+                        .expect("hoisted GC-table result must have a producer");
+                    let index = resolve_const_bits(constants, producer.arg(0).to_opref());
+                    let slot = gc_table_base as u64
+                        + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
+                    sink.i32_const(slot as i32);
+                    sink.i32_load(MemArg {
+                        offset: 0,
+                        align: 2,
+                        memory_index: 0,
+                    });
+                    sink.i64_extend_i32_u();
+                }
+                sink.local_set(value_types.local(result.raw()));
             }
             sink.end(); // end B_j $past_loader
             labels_passed += 1;
@@ -3742,7 +3814,7 @@ fn build_function(
                 // address; the collector forwards the slot in place, so the load
                 // reads the reference at its current address.
                 let vi = op.pos.get().raw();
-                if !OpRef::raw_is_constant(vi) {
+                if !OpRef::raw_is_constant(vi) && !hoisted_gc_table_loads.contains(&op.pos.get()) {
                     let index = resolve_const_bits(constants, op.arg(0).to_opref());
                     let slot = gc_table_base as u64
                         + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
@@ -5058,7 +5130,9 @@ fn build_function(
         // skipped. Each value-producing arm is operand-stack-neutral, so this
         // appended store is balanced.
         let result = op.pos.get();
-        if let Some(h) = ref_homes.home(result) {
+        if !hoisted_gc_table_loads.contains(&result)
+            && let Some(h) = ref_homes.home(result)
+        {
             sink.local_get(0);
             sink.local_get(value_types.local(result.raw()));
             sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2390,26 +2390,16 @@ fn build_function(
     // and input setup.  Store-on-def is mirrored here because the original op
     // arm and its common tail are skipped below.
     for result in &hoisted_gc_table_loads {
-        let op = ops
-            .iter()
-            .find(|op| op.pos.get() == *result)
-            .expect("hoisted GC-table result must have a producer");
-        let index = resolve_const_bits(constants, op.arg(0).to_opref());
-        let slot =
-            gc_table_base as u64 + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
-        sink.i32_const(slot as i32);
-        sink.i32_load(MemArg {
-            offset: 0,
-            align: 2,
-            memory_index: 0,
-        });
-        sink.i64_extend_i32_u();
-        sink.local_set(value_types.local(result.raw()));
-        if let Some(h) = ref_homes.home(*result) {
-            sink.local_get(0);
-            sink.local_get(value_types.local(result.raw()));
-            sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
-        }
+        emit_seed_gc_table_ref(
+            &mut sink,
+            ops,
+            constants,
+            value_types,
+            ref_homes,
+            frame,
+            gc_table_base,
+            *result,
+        );
     }
 
     // Seed with the fail-index base so each guard/finish exit writes
@@ -2492,32 +2482,22 @@ fn build_function(
                 }
             }
             // The dispatch branch skipped the eager ConstPtr loads emitted on
-            // key 0.  This JitFrame has already run the preamble, so recover
-            // those loop-invariant refs from their GC-forwarded homes.
+            // key 0.  Their ordinary homes are the low prefix a chained bridge
+            // clears and remaps for its own Refs, so what sits there on resume
+            // may be zero or another trace's object; the gc_table slot is the
+            // root the collector forwards in place, so read it again exactly
+            // as fresh entry does.  LABEL entry is cold enough to pay for it.
             for result in &hoisted_gc_table_loads {
-                if let Some(h) = ref_homes.home(*result) {
-                    sink.local_get(0);
-                    sink.i64_load(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
-                } else {
-                    // A ref unused across a collecting op has no ordinary
-                    // home.  LABEL entry is cold, so reload its table slot
-                    // directly rather than manufacturing a GC root.
-                    let producer = ops
-                        .iter()
-                        .find(|op| op.pos.get() == *result)
-                        .expect("hoisted GC-table result must have a producer");
-                    let index = resolve_const_bits(constants, producer.arg(0).to_opref());
-                    let slot = gc_table_base as u64
-                        + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
-                    sink.i32_const(slot as i32);
-                    sink.i32_load(MemArg {
-                        offset: 0,
-                        align: 2,
-                        memory_index: 0,
-                    });
-                    sink.i64_extend_i32_u();
-                }
-                sink.local_set(value_types.local(result.raw()));
+                emit_seed_gc_table_ref(
+                    &mut sink,
+                    ops,
+                    constants,
+                    value_types,
+                    ref_homes,
+                    frame,
+                    gc_table_base,
+                    *result,
+                );
             }
             sink.end(); // end B_j $past_loader
             labels_passed += 1;
@@ -5367,6 +5347,44 @@ fn resolve_const_bits(constants: &indexmap::IndexMap<u32, i64>, opref: OpRef) ->
             .copied()
             .unwrap_or_else(|| missing_emit_const(opref))
     })
+}
+
+/// Load one hoisted `LoadFromGcTable` result from its table slot into its
+/// local and refresh the ordinary Ref home the in-loop reload path reads.
+///
+/// The table slot is the root the collector forwards in place
+/// (`assembler.py:1545 genop_load_from_gc_table`), which is why both the
+/// fresh-entry seeding and the LABEL resume loader read it rather than a home.
+#[allow(clippy::too_many_arguments)]
+fn emit_seed_gc_table_ref(
+    sink: &mut InstructionSink<'_>,
+    ops: &[Op],
+    constants: &indexmap::IndexMap<u32, i64>,
+    value_types: &ValueLocals,
+    ref_homes: &RefHomes,
+    frame: FrameGeometry,
+    gc_table_base: u32,
+    result: OpRef,
+) {
+    let producer = ops
+        .iter()
+        .find(|op| op.pos.get() == result)
+        .expect("hoisted GC-table result must have a producer");
+    let index = resolve_const_bits(constants, producer.arg(0).to_opref());
+    let slot = gc_table_base as u64 + index as u64 * std::mem::size_of::<majit_ir::GcRef>() as u64;
+    sink.i32_const(slot as i32);
+    sink.i32_load(MemArg {
+        offset: 0,
+        align: 2,
+        memory_index: 0,
+    });
+    sink.i64_extend_i32_u();
+    sink.local_set(value_types.local(result.raw()));
+    if let Some(h) = ref_homes.home(result) {
+        sink.local_get(0);
+        sink.local_get(value_types.local(result.raw()));
+        sink.i64_store(mem64(frame.home_slot_base + h as u64 * SLOT_SIZE));
+    }
 }
 
 fn emit_resolve(

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2066,6 +2066,13 @@ pub fn dead_frame_from_ran_frame(_compiled_ptr: usize, frame_ptr: usize) -> Dead
 }
 
 impl majit_backend::Backend for WasmBackend {
+    fn supports_efficient_uint_mul_high(&self) -> bool {
+        // WebAssembly has no high-half integer multiply.  The fallback in
+        // codegen is multi-precision software, while i64.div/rem are native
+        // Wasm operations.
+        false
+    }
+
     fn cpu_tracker(&self) -> &std::sync::Arc<majit_backend::CpuTotalTracker> {
         &self.cpu_tracker
     }

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2071,12 +2071,15 @@ fn loop_invariant_gc_table_load_stays_outside_non_collecting_loop() {
     let mut control_stack = Vec::new();
     let mut gc_table_address_on_stack = false;
     let mut loads_inside_loop = 0usize;
+    let mut loads_outside_loop = 0usize;
+    let mut saw_loop = false;
     for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
         if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
             let mut operators = body.get_operators_reader().unwrap();
             while !operators.eof() {
                 match operators.read().unwrap() {
                     wasmparser::Operator::Loop { .. } => {
+                        saw_loop = true;
                         control_stack.push(true);
                         gc_table_address_on_stack = false;
                     }
@@ -2094,6 +2097,8 @@ fn loop_invariant_gc_table_load_stays_outside_non_collecting_loop() {
                     wasmparser::Operator::I32Load { .. } if gc_table_address_on_stack => {
                         if control_stack.contains(&true) {
                             loads_inside_loop += 1;
+                        } else {
+                            loads_outside_loop += 1;
                         }
                         gc_table_address_on_stack = false;
                     }
@@ -2102,6 +2107,13 @@ fn loop_invariant_gc_table_load_stays_outside_non_collecting_loop() {
             }
         }
     }
+    // Without these two, the zero above also holds for a body that emitted no
+    // loop at all, or dropped the table load entirely.
+    assert!(saw_loop, "codegen emitted no loop for a looping trace");
+    assert!(
+        loads_outside_loop > 0,
+        "the hoisted ConstPtr table slot is never loaded"
+    );
     assert_eq!(
         loads_inside_loop, 0,
         "ConstPtr table slot was reloaded on the hot backedge"

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -2020,6 +2020,95 @@ fn test_single_label_peeled_loop_validates() {
 }
 
 #[test]
+fn loop_invariant_gc_table_load_stays_outside_non_collecting_loop() {
+    let inputargs = vec![InputArg::from_type(Type::Int, 0)];
+    let ops = vec![
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::input_arg_int(0), OpRef::const_int(1)],
+            OpRef::int_op(1),
+        ),
+        Op::new(OpCode::Label, &[rb(OpRef::int_op(1))]),
+        make_op(
+            OpCode::LoadFromGcTable,
+            &[OpRef::const_int(0)],
+            OpRef::ref_op(2),
+        ),
+        make_guard(
+            OpCode::GuardNonnull,
+            &[OpRef::ref_op(2)],
+            &[OpRef::int_op(1)],
+        ),
+        make_op(
+            OpCode::IntAdd,
+            &[OpRef::int_op(1), OpRef::const_int(1)],
+            OpRef::int_op(3),
+        ),
+        Op::new(OpCode::Jump, &[rb(OpRef::int_op(3))]),
+    ];
+    let gc_table_base = 4096;
+    let (bytes, _, _, _, _) = codegen::build_wasm_module(
+        &inputargs,
+        &ops,
+        &indexmap::IndexMap::new(),
+        Some(0),
+        &HashMap::new(),
+        &codegen::GuardGcTypeInfo::default(),
+        codegen::AllocHelpers::default(),
+        0,
+        None,
+        0,
+        gc_table_base,
+        0,
+        0,
+        0,
+        codegen::FrameGeometry::fixed(),
+        codegen::CaParams::default(),
+    )
+    .expect("wasm codegen should succeed");
+    validate_wasm(&bytes);
+
+    let mut control_stack = Vec::new();
+    let mut gc_table_address_on_stack = false;
+    let mut loads_inside_loop = 0usize;
+    for payload in wasmparser::Parser::new(0).parse_all(&bytes) {
+        if let wasmparser::Payload::CodeSectionEntry(body) = payload.unwrap() {
+            let mut operators = body.get_operators_reader().unwrap();
+            while !operators.eof() {
+                match operators.read().unwrap() {
+                    wasmparser::Operator::Loop { .. } => {
+                        control_stack.push(true);
+                        gc_table_address_on_stack = false;
+                    }
+                    wasmparser::Operator::Block { .. } | wasmparser::Operator::If { .. } => {
+                        control_stack.push(false);
+                        gc_table_address_on_stack = false;
+                    }
+                    wasmparser::Operator::End => {
+                        control_stack.pop();
+                        gc_table_address_on_stack = false;
+                    }
+                    wasmparser::Operator::I32Const { value } if value == gc_table_base as i32 => {
+                        gc_table_address_on_stack = true;
+                    }
+                    wasmparser::Operator::I32Load { .. } if gc_table_address_on_stack => {
+                        if control_stack.contains(&true) {
+                            loads_inside_loop += 1;
+                        }
+                        gc_table_address_on_stack = false;
+                    }
+                    _ => gc_table_address_on_stack = false,
+                }
+            }
+        }
+    }
+    assert_eq!(
+        loads_inside_loop, 0,
+        "ConstPtr table slot was reloaded on the hot backedge"
+    );
+}
+
+#[test]
 fn test_peeled_label_captures_missing_ref_livein_in_frozen_frame() {
     let inputargs = vec![
         InputArg::from_type(Type::Ref, 0),

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -2154,6 +2154,16 @@ fn flush_instruction_cache(ptr: *const u8, len: usize) {
 ///
 /// Mirrors rpython/jit/backend/model.py AbstractCPU.
 pub trait Backend: Send {
+    /// Whether `UINT_MUL_HIGH` is an efficient backend primitive.
+    ///
+    /// RPython's constant-division rewrite assumes the machine backend can
+    /// lower `uint_mul_high` to a native high-half multiply instruction.
+    /// Backends without one must keep division/modulo intact instead of
+    /// expanding a more expensive software multiply.
+    fn supports_efficient_uint_mul_high(&self) -> bool {
+        true
+    }
+
     /// `rpython/jit/backend/model.py:28-29` `self.tracker =
     /// CPUTotalTracker()` parity — each backend instance owns its
     /// own [`CpuTotalTracker`].  [`record_compiled_loop_token`] and

--- a/majit/majit-charon-reader/src/ullbc.rs
+++ b/majit/majit-charon-reader/src/ullbc.rs
@@ -261,6 +261,12 @@ pub enum TypeDeclKind {
     /// carries its own field list (zero-arg for unit variants, named
     /// for `Foo { a: ... }`, positional for `Bar(T)`).
     Enum(Vec<VariantDecl>),
+    /// Union body — a field list shaped like `Struct`'s, but every field
+    /// starts at offset 0 and only one is live at a time. Foreign C unions
+    /// reach the table through the dependency closure (`windows-sys`'
+    /// `IN_ADDR_0`), so the variant must parse even though no field-offset
+    /// row can be projected from it.
+    Union(Vec<FieldDecl>),
     /// Type alias (`type T = ...`). The aliased type lives in
     /// `rest["aliased_ty"]`; not currently consumed.
     Alias(Value),

--- a/majit/majit-charon-reader/src/ullbc.rs
+++ b/majit/majit-charon-reader/src/ullbc.rs
@@ -855,4 +855,23 @@ mod tests {
         // empty list → None
         assert!(select_target_layout(Vec::new(), "aarch64-apple-darwin").is_none());
     }
+
+    /// A union body keeps its field list. `#[serde(other)]` turns any tag this
+    /// enum does not name into `Unknown`, so a missing `Union` arm would lose
+    /// the fields silently rather than fail to parse — the shape `IN_ADDR_0`
+    /// arrives in through the `windows-sys` dependency closure.
+    #[test]
+    fn union_decl_kind_keeps_its_fields() {
+        let json = r#"{"Union": [
+            {"name": "S_un_b", "ty": {"Deduplicated": 170}, "attr_info": null},
+            {"name": "S_addr", "ty": {"Deduplicated": 42}, "attr_info": null}
+        ]}"#;
+        let kind: TypeDeclKind = serde_json::from_str(json).unwrap();
+        let TypeDeclKind::Union(fields) = kind else {
+            panic!("union body parsed as {kind:?}");
+        };
+        assert_eq!(fields.len(), 2);
+        assert_eq!(fields[0].name.as_deref(), Some("S_un_b"));
+        assert_eq!(fields[1].ty.label(), "ty#42");
+    }
 }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2365,7 +2365,11 @@ impl MiniMarkGC {
         // the next allocation, which would then answer to the dead owner's
         // entry.  Ask the same survival question `invalidate_young_weakrefs`
         // just answered, while the forwarding headers still read.
-        let pinned = &self.pinned_objects;
+        // The trace above rebuilt the live pin set in
+        // `surviving_pinned_objects`; `pinned_objects` is the previous
+        // collection's snapshot until the swap below.  A pin that died this
+        // cycle must not keep an address-keyed owner table entry alive.
+        let pinned = &self.surviving_pinned_objects;
         let nursery = &self.nursery;
         let mut classify_young_owner = |owner: usize| -> Option<usize> {
             if owner == 0 || !nursery.contains(owner) {

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -526,6 +526,8 @@ use crate::optimizeopt::info::PtrInfoExt;
 ///
 /// Holds the shared state that passes read from and write to.
 pub struct OptContext {
+    /// Backend cost capability for RPython's constant-division rewrite.
+    pub supports_efficient_uint_mul_high: bool,
     /// The output operation list being built.
     pub new_operations: Vec<majit_ir::OpRc>,
     /// Once the output buffer is drained, PtrInfo guard positions stamped
@@ -1672,6 +1674,7 @@ impl OptContext {
 
     pub fn new(estimated_ops: usize) -> Self {
         OptContext {
+            supports_efficient_uint_mul_high: true,
             new_operations: Vec::with_capacity(estimated_ops),
             new_operations_drained: false,
             new_operations_index: FxHashMap::with_capacity_and_hasher(
@@ -2296,6 +2299,7 @@ impl OptContext {
         start_next_pos: u32,
     ) -> Self {
         OptContext {
+            supports_efficient_uint_mul_high: true,
             new_operations: Vec::with_capacity(estimated_ops),
             new_operations_drained: false,
             new_operations_index: FxHashMap::with_capacity_and_hasher(

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -327,6 +327,8 @@ pub(crate) struct PendingBridgeRd {
 ///
 /// RPython optimizer.py: Optimizer class with pass chain and shared state.
 pub struct Optimizer {
+    /// Backend capability threaded into each optimization context.
+    pub supports_efficient_uint_mul_high: bool,
     passes: Vec<Box<dyn Optimization>>,
     pub pureop_historylength: usize,
     /// Final num_inputs after optimization (may increase if virtualizable
@@ -1460,6 +1462,7 @@ impl Optimizer {
 
     pub fn new() -> Self {
         Optimizer {
+            supports_efficient_uint_mul_high: true,
             passes: Vec::new(),
             pureop_historylength: crate::jit::PARAMETERS.pureop_historylength as usize,
             final_num_inputs: 0,
@@ -2491,6 +2494,7 @@ impl Optimizer {
         // `cpu.cls_of_box(runtime_box)` when the optimizer-tracked
         // PtrInfo has no `known_class` recorded.
         ctx.cpu = self.cpu.clone();
+        ctx.supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
         // RPython resume.py parity: Phase 2 optimizer needs imported_label_args
         // to resolve NONE positions in fail_args inherited from Phase 1.
         ctx.imported_virtuals = self.imported_virtuals.clone();

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1136,7 +1136,12 @@ impl OptRewrite {
             ctx.last_op_removed = true;
             return Some(OptimizationResult::Remove);
         }
-        // rewrite.py:797-805: intdiv.modulo_operations fallback
+        // rewrite.py:797-805: intdiv.modulo_operations fallback, which emits
+        // UINT_MUL_HIGH.  A backend without one leaves the residual call in
+        // place, the same answer the IntMod arm gives.
+        if !ctx.supports_efficient_uint_mul_high {
+            return None;
+        }
         let known_nonneg = b1.known_nonnegative();
         let result_ref = crate::optimizeopt::intdiv::modulo_operations(
             arg1.to_opref(),
@@ -1239,7 +1244,12 @@ impl OptRewrite {
             ctx.last_op_removed = true;
             return Some(OptimizationResult::Remove);
         }
-        // rewrite.py:758-766: intdiv.division_operations fallback
+        // rewrite.py:758-766: intdiv.division_operations fallback, which emits
+        // UINT_MUL_HIGH.  A backend without one leaves the residual call in
+        // place, the same answer the IntFloorDiv arm gives.
+        if !ctx.supports_efficient_uint_mul_high {
+            return None;
+        }
         let known_nonneg = b1.known_nonnegative();
         let result_ref = crate::optimizeopt::intdiv::division_operations(
             arg1.to_opref(),
@@ -2785,6 +2795,59 @@ mod tests {
         assert_binop_self(OpCode::IntMod, Some(0));
     }
 
+    /// Whether the magic-number expansion ran.  `intdiv` queues its sequence
+    /// through `emit_extra`, so it is still in `extra_operations_after` when
+    /// the pass returns.
+    fn emitted_uint_mul_high(ctx: &OptContext) -> bool {
+        ctx.new_operations
+            .iter()
+            .map(|op| op.opcode)
+            .chain(ctx.extra_operations_after.iter().map(|(_, op)| op.opcode))
+            .any(|opcode| opcode == OpCode::UintMulHigh)
+    }
+
+    /// A `CALL_PURE_I` carrying one of the Python division oopspecs, with the
+    /// divisor already constant-folded — the shape `optimize_call_int_py_div`
+    /// and `optimize_call_int_py_mod` are reached through.
+    fn run_int_py_call(
+        oopspecindex: majit_ir::OopSpecIndex,
+        divisor: i64,
+        supports_efficient_uint_mul_high: bool,
+    ) -> (OptimizationResult, OptContext) {
+        let ops = build_specs(&[same_i(), same_i(), same_i()]);
+        let mut ctx = OptContext::new(4);
+        ctx.supports_efficient_uint_mul_high = supports_efficient_uint_mul_high;
+        for op in &ops {
+            ctx.emit((**op).clone());
+        }
+        let b = ctx.materialize_operand_at(OpRef::int_op(2));
+        ctx.make_constant_box(&b, Value::Int(divisor));
+
+        let mut call = Op::new(
+            OpCode::CallPureI,
+            &[
+                Operand::from_bound_op(&ops[0]),
+                Operand::from_bound_op(&ops[1]),
+                Operand::from_bound_op(&ops[2]),
+            ],
+        );
+        call.pos.set(OpRef::int_op(3));
+        call.setdescr(std::sync::Arc::new(majit_ir::SimpleCallDescr::new(
+            0,
+            vec![majit_ir::Type::Int, majit_ir::Type::Int],
+            majit_ir::Type::Int,
+            true,
+            std::mem::size_of::<i64>(),
+            majit_ir::EffectInfo::new(majit_ir::ExtraEffect::ElidableCanRaise, oopspecindex),
+        )));
+        resolve_op_args_in_ctx(&mut call, &mut ctx);
+        let op_rc = std::rc::Rc::new(call.clone());
+        ctx.bind_input_resops(std::slice::from_ref(&op_rc));
+        let mut pass = OptRewrite::new();
+        let result = pass.propagate_forward(&call, &op_rc, &mut ctx);
+        (result, ctx)
+    }
+
     #[test]
     fn backend_without_mul_high_keeps_native_constant_division_and_modulo() {
         for opcode in [OpCode::IntFloorDiv, OpCode::IntMod] {
@@ -2796,10 +2859,47 @@ mod tests {
             );
             assert_pass_on(&result);
             assert!(
-                ctx.new_operations
-                    .iter()
-                    .all(|op| op.opcode != OpCode::UintMulHigh),
+                !emitted_uint_mul_high(&ctx),
                 "{opcode:?} expanded through UintMulHigh on a backend that lacks it"
+            );
+        }
+    }
+
+    #[test]
+    fn backend_with_mul_high_expands_constant_division_and_modulo() {
+        for opcode in [OpCode::IntFloorDiv, OpCode::IntMod] {
+            let (_result, ctx) = run_one_rewrite_only_with_mul_high(
+                vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
+                2,
+                &[(OpRef::int_op(1), Value::Int(100))],
+                true,
+            );
+            assert!(
+                emitted_uint_mul_high(&ctx),
+                "{opcode:?} kept the native division on a backend that has UintMulHigh"
+            );
+        }
+    }
+
+    /// The call-based helpers share the magic-number expansion with the
+    /// native opcodes, so they answer to the same capability.
+    #[test]
+    fn call_int_py_div_and_mod_follow_the_mul_high_capability() {
+        for oopspecindex in [
+            majit_ir::OopSpecIndex::IntPyDiv,
+            majit_ir::OopSpecIndex::IntPyMod,
+        ] {
+            let (result, ctx) = run_int_py_call(oopspecindex, 100, false);
+            assert_pass_on(&result);
+            assert!(
+                !emitted_uint_mul_high(&ctx),
+                "{oopspecindex:?} expanded through UintMulHigh on a backend that lacks it"
+            );
+
+            let (_result, ctx) = run_int_py_call(oopspecindex, 100, true);
+            assert!(
+                emitted_uint_mul_high(&ctx),
+                "{oopspecindex:?} left the residual call on a backend that has UintMulHigh"
             );
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -214,7 +214,7 @@ impl OptRewrite {
             }
 
             // General constant divisor >= 3: magic number multiplication
-            if divisor >= 3 {
+            if divisor >= 3 && ctx.supports_efficient_uint_mul_high {
                 // rewrite.py:770 `known_nonneg = b1.known_nonnegative()`:
                 // a non-negative dividend skips the sign-correction ops.
                 let known_nonneg = ctx
@@ -309,6 +309,7 @@ impl OptRewrite {
             .and_then(|b| ctx.get_constant_int_box(&b))
             && divisor >= 3
             && divisor.count_ones() != 1
+            && ctx.supports_efficient_uint_mul_high
         {
             // rewrite.py:809 `known_nonneg = b1.known_nonnegative()`:
             // a non-negative dividend skips the sign-correction ops.
@@ -2539,8 +2540,18 @@ mod tests {
         target: usize,
         constants: &[(OpRef, Value)],
     ) -> (OptimizationResult, OptContext) {
+        run_one_rewrite_only_with_mul_high(specs, target, constants, true)
+    }
+
+    fn run_one_rewrite_only_with_mul_high(
+        specs: Vec<OpSpec>,
+        target: usize,
+        constants: &[(OpRef, Value)],
+        supports_efficient_uint_mul_high: bool,
+    ) -> (OptimizationResult, OptContext) {
         let ops = build_specs(&specs);
         let mut ctx = OptContext::new(ops.len());
+        ctx.supports_efficient_uint_mul_high = supports_efficient_uint_mul_high;
         for op in &ops[..target] {
             ctx.emit((**op).clone());
         }
@@ -2772,6 +2783,25 @@ mod tests {
         assert_int_const(&ctx, OpRef::int_op(2), 0);
         // x % x = 0
         assert_binop_self(OpCode::IntMod, Some(0));
+    }
+
+    #[test]
+    fn backend_without_mul_high_keeps_native_constant_division_and_modulo() {
+        for opcode in [OpCode::IntFloorDiv, OpCode::IntMod] {
+            let (result, ctx) = run_one_rewrite_only_with_mul_high(
+                vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
+                2,
+                &[(OpRef::int_op(1), Value::Int(100))],
+                false,
+            );
+            assert_pass_on(&result);
+            assert!(
+                ctx.new_operations
+                    .iter()
+                    .all(|op| op.opcode != OpCode::UintMulHigh),
+                "{opcode:?} expanded through UintMulHigh on a backend that lacks it"
+            );
+        }
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -499,6 +499,10 @@ impl UnrollOptimizer {
     /// gcref failed type validation) and should propagate.
     pub fn optimize_preamble(&mut self, ops: &[Op]) -> Vec<Op> {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::default_pipeline();
+        // A fresh optimizer defaults the capability to present; carry the
+        // backend's answer over as the two-phase path does, or these callers
+        // get UINT_MUL_HIGH on a backend that has none.
+        optimizer.supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
         optimizer.add_pass(Box::new(OptUnroll::new()));
         optimizer.propagate_all_forward(ops)
     }
@@ -510,8 +514,10 @@ impl UnrollOptimizer {
     /// speculative imports that may fail type validation —
     /// `unroll.py:119-123 except SpeculativeError: raise InvalidLoop`.
     pub fn optimize_peeled_loop(&mut self, ops: &[Op]) -> Vec<Op> {
+        let supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
         with_speculative_to_invalid_loop(|| {
             let mut optimizer = crate::optimizeopt::optimizer::Optimizer::default_pipeline();
+            optimizer.supports_efficient_uint_mul_high = supports_efficient_uint_mul_high;
             optimizer.propagate_all_forward(ops)
         })
     }
@@ -572,6 +578,7 @@ impl UnrollOptimizer {
         constants: &mut majit_ir::ConstMap<majit_ir::Value>,
     ) -> Vec<Op> {
         let mut optimizer = crate::optimizeopt::optimizer::Optimizer::default_pipeline();
+        optimizer.supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
         optimizer.add_pass(Box::new(OptUnroll::new()));
         let result = optimizer.optimize_with_constants(ops, constants);
         let sp = crate::optimizeopt::shortpreamble::extract_short_preamble(&result);

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -250,6 +250,8 @@ fn refresh_forwarded_const_ref(
 /// - optimize_preamble: process and optimize the first iteration
 /// - optimize_peeled_loop: optimize the main loop body
 pub struct UnrollOptimizer {
+    /// Backend capability propagated to both phase optimizers.
+    pub supports_efficient_uint_mul_high: bool,
     /// The short preamble from the preamble optimization pass.
     pub short_preamble: Option<crate::optimizeopt::shortpreamble::ShortPreamble>,
     /// history.py: JitCellToken.target_tokens — compiled versions of this loop.
@@ -411,6 +413,7 @@ impl UnrollOptimizer {
 
     pub fn new() -> Self {
         UnrollOptimizer {
+            supports_efficient_uint_mul_high: true,
             short_preamble: None,
             target_tokens: Vec::new(),
             attach_jitcell_token_number: None,
@@ -671,6 +674,7 @@ impl UnrollOptimizer {
             opt_p1.all_descrs = std::mem::take(&mut self.all_descrs);
             opt_p1.callinfocollection = self.callinfocollection.clone();
             opt_p1.cpu = self.cpu.clone();
+            opt_p1.supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
             opt_p1.trace_inputargs = self.trace_inputargs.clone();
             opt_p1.snapshot_boxes = self.snapshot_boxes.clone();
             opt_p1.snapshot_frame_sizes = self.snapshot_frame_sizes.clone();
@@ -967,6 +971,7 @@ impl UnrollOptimizer {
         opt_p2.all_descrs = std::mem::take(&mut self.all_descrs);
         opt_p2.callinfocollection = self.callinfocollection.clone();
         opt_p2.cpu = self.cpu.clone();
+        opt_p2.supports_efficient_uint_mul_high = self.supports_efficient_uint_mul_high;
         // Phase 2 (peeled-loop pass) runtime value seed.
         // The remap is deferred until after the Phase 2 `TraceIterator`
         // builds its `_cache`, because both inputargs AND body op results

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4300,6 +4300,7 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             Optimizer::default_pipeline()
         };
+        opt.supports_efficient_uint_mul_high = self.backend.supports_efficient_uint_mul_high();
         opt.set_pureop_historylength(self.warm_state.pureop_historylength() as usize);
         // `virtualize.py:140` `vrefinfo =
         // self.optimizer.metainterp_sd.virtualref_info` — install the
@@ -6377,6 +6378,8 @@ impl<M: Clone> MetaInterp<M> {
             .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
             .unwrap_or_default();
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
+        unroll_opt.supports_efficient_uint_mul_high =
+            self.backend.supports_efficient_uint_mul_high();
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
@@ -6541,6 +6544,8 @@ impl<M: Clone> MetaInterp<M> {
                         } else {
                             Optimizer::default_pipeline()
                         };
+                        simple_opt.supports_efficient_uint_mul_high =
+                            self.backend.supports_efficient_uint_mul_high();
                         // Clone rather than move: only the success arm below hands
                         // the list back, so a retry that aborts would otherwise
                         // leave `unroll_opt.all_descrs` empty, and the
@@ -8052,6 +8057,8 @@ impl<M: Clone> MetaInterp<M> {
             .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
             .unwrap_or_default();
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
+        unroll_opt.supports_efficient_uint_mul_high =
+            self.backend.supports_efficient_uint_mul_high();
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
@@ -9060,6 +9067,8 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             Optimizer::default_pipeline()
         };
+        optimizer.supports_efficient_uint_mul_high =
+            self.backend.supports_efficient_uint_mul_high();
         optimizer.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         optimizer.call_pure_results = simple_data.call_pure_results.clone();
         // history.py:_make_op parity: every InputArg carries its type
@@ -9507,6 +9516,8 @@ impl<M: Clone> MetaInterp<M> {
         } else {
             Optimizer::default_pipeline()
         };
+        optimizer.supports_efficient_uint_mul_high =
+            self.backend.supports_efficient_uint_mul_high();
         optimizer.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         optimizer.call_pure_results = simple_data.call_pure_results.clone();
         // history.py:220/261/307 — `Const.type` / `InputArg.type` are

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1746,7 +1746,13 @@ fn derive_program_metadata(
                     enum_variant_by_discriminant.insert(leaf, by_discr);
                 }
             }
-            TypeDeclKind::Alias(_) | TypeDeclKind::Opaque | TypeDeclKind::Unknown => {}
+            // A union's fields all start at offset 0 and only one is live,
+            // so there is no field-offset row to project; the declarations
+            // that reach here are foreign (`windows-sys`' `IN_ADDR_0`).
+            TypeDeclKind::Union(_)
+            | TypeDeclKind::Alias(_)
+            | TypeDeclKind::Opaque
+            | TypeDeclKind::Unknown => {}
         }
     }
 

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=8
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1645
+guard_failures=1501
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_recursive.cranelift.jitstats
+++ b/pyre/bench/fib_recursive.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=8
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1501
+guard_failures=1645
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=8
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1645
+guard_failures=1501
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=8
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1501
+guard_failures=1645
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2287,14 +2287,24 @@ class Check:
         # ratio compares a pinned run against an unpinned one. It was also the
         # one pyre spawn left outside `pyre_env()`, which is how a bytecode
         # cache still appeared under a run that pins PYTHONDONTWRITEBYTECODE.
-        baseline_env = pyre_env() if baseline_key in ALL_BACKENDS else None
+        baseline_is_pyre = baseline_key in ALL_BACKENDS
+        baseline_env = pyre_env() if baseline_is_pyre else None
         pyre_times = []
         baseline_times = []
         for _ in range(attempts):
-            _, baseline_time, baseline_code, _ = run_timed(
+            baseline_output, baseline_time, baseline_code, baseline_stderr = run_timed(
                 baseline_cmd, timeout_s=effective_timeout, env=baseline_env,
             )
             if baseline_code != 0:
+                return None
+            # A pyre baseline is under test itself, so it answers to the same
+            # bar as the numerator: a median built on a denominator that
+            # printed the wrong answer or panicked out of the JIT would let the
+            # failing gate pass on a time no correct run produced.
+            if baseline_is_pyre and (
+                baseline_output != expected_output
+                or _jit_panic_reason(baseline_stderr)
+            ):
                 return None
             output, elapsed, code, stderr = run_timed(
                 [self._pyre(backend), script], timeout_s=effective_timeout,

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -464,6 +464,98 @@ def run_timed(args, timeout_s=None, env=None):
     return out.replace("\r\n", "\n"), t, rc, err
 
 
+# Names the child is allowed to inherit. Everything else in this process's
+# environment is dropped before the child sees it — see `child_env_base`.
+ENV_ALLOWLIST = (
+    # Locating the loader, the shell a subprocess needs, and scratch space.
+    "PATH",
+    "PATHEXT",
+    "COMSPEC",
+    "SHELL",
+    "TEMP",
+    "TMP",
+    "TMPDIR",
+    # Windows refuses to start a process, resolve a system DLL or initialise
+    # WinSock without these.
+    "SYSTEMROOT",
+    "SYSTEMDRIVE",
+    "WINDIR",
+    "NUMBER_OF_PROCESSORS",
+    "PROCESSOR_ARCHITECTURE",
+    # The home a `~` expands to, and the account naming it.
+    "HOME",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "USERPROFILE",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMDATA",
+    "USER",
+    "USERNAME",
+    "LOGNAME",
+    # Shared-library search, which a build out of the source tree depends on.
+    "LD_LIBRARY_PATH",
+    "DYLD_LIBRARY_PATH",
+    "DYLD_FALLBACK_LIBRARY_PATH",
+    # The locale chain, because an unset chain resolves to the C locale and
+    # changes how the child decodes its own stdio — not something to vary
+    # under a run whose stdout is diffed against an oracle.
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "PYTHONIOENCODING",
+)
+
+# Prefixes a developer sets deliberately to steer this run, kept so an A/B
+# stays reachable without editing this file.
+ENV_ALLOWLIST_PREFIXES = ("PYRE_", "MAJIT_", "PYPY_", "PYTHON")
+
+
+def child_env_base():
+    """The environment a measured child starts from: an allowlist, not a copy.
+
+    pyre copies every environment entry into `posix.environ` at startup
+    (`interp_posix.rs:882 create_environ`, PyPy's `_convertenviron`), so the
+    environment's total size is startup allocation like any other. That
+    allocation moves where the nursery fills, which moves where a collection
+    lands, which changes how many times a compiled trace re-enters a guarded
+    branch afterwards — and `guard_failures` counts those re-entries.
+
+    Measured on one binary with nothing but unrelated variables added:
+    `str_fstring` read 658 or 659, entirely from one guard in trace 6 firing
+    51 times or 52. `loops_compiled` and `bridges_compiled` did not move at
+    all, so nothing about what was compiled differed — only how often the
+    compiled code re-entered one branch. That fixture no longer demonstrates
+    it: its trip counts were halved so it stops short of the major-collection
+    threshold entirely, which is the durable fix for one fixture and not for
+    the input.
+
+    A CI runner injects dozens of variables a developer's shell does not
+    (GITHUB_*, RUNNER_*, JAVA_HOME, and the rest), and those are exactly the
+    class of input shown above to move a counter. Dropping them removes that
+    input rather than relaxing the comparison. It is not established that it
+    is the *only* per-host input — this pin narrows what a counter can depend
+    on; it does not prove a counter now depends on nothing but the tree.
+
+    The allowlist is not a fixed environment either: the `PYTHON` prefix keeps
+    whatever a host names that way (PYTHONLOCATION, PYTHON3_ROOT_DIR on the
+    runners), because the same prefix carries the PYTHONSAFEPATH and
+    PYTHONDONTWRITEBYTECODE overrides a developer sets deliberately and that
+    `LAUNCH_ENV_NAMES` forwards to the wasm guest. What it removes is the bulk.
+
+    Any non-empty `PYRE_CHECK_INHERIT_ENV` restores the old whole-environment
+    copy, so the effect of this normalisation stays measurable.
+    """
+    if os.environ.get("PYRE_CHECK_INHERIT_ENV"):
+        return dict(os.environ)
+    env = {}
+    for name, value in os.environ.items():
+        upper = name.upper()
+        if upper in ENV_ALLOWLIST or upper.startswith(ENV_ALLOWLIST_PREFIXES):
+            env[name] = value
+    return env
+
+
 def pyre_env():
     """Child environment for pyre runs: strict JIT plus one-line stats.
 
@@ -479,7 +571,7 @@ def pyre_env():
     cannot reproduce, the name is the whole diagnosis. Naming costs one stderr
     line per member and only ever prints when a member fails to resolve.
     """
-    env = dict(os.environ)
+    env = child_env_base()
     env["MAJIT_STRICT"] = "1"
     env["MAJIT_STATS"] = "1"
     env["PYRE_DESCR_SPELLING_GATE"] = "1"
@@ -553,7 +645,20 @@ def pyre_env():
     # `build_set_hashability` 4 and 1, `str_fstring` 658 and 657. So the pin
     # narrows the class and does not close it, which is why the counter split
     # above exists — those 11 were the fixtures that flipped between hosts.
-    # Host RAM cannot re-open it: `max_delta`
+    #
+    # The residual is not more of the same class, though, and calling those 21
+    # "poll failures" is wrong. Taking `str_fstring` apart guard by guard: its
+    # 658-vs-657 is one guard in trace 6 firing 52 times or 51, and that guard
+    # is an ordinary branch, not the breaker poll. The poll is what bails out;
+    # re-entry after the bailout takes the branch once more, and that hit is
+    # what the counter records. So the counter split above removed the poll
+    # class exactly as described, and what is left is a real deopt the split
+    # cannot absorb and no GC pin closes, because it is not a crossing being
+    # counted. What closes it for a fixture is keeping the fixture short of the
+    # crossing — see `str_fstring.py`'s header, where halving the trip counts
+    # is what settled this one. Holding the startup allocation still
+    # (`child_env_base`) narrows what can move the placement; it does not
+    # remove the placement. Host RAM cannot re-open it: `max_delta`
     # (0.125 * total memory) enters only as an upper bound at collector.rs:3570
     # and the `min_heap_size` floor is applied after it (:2452), so the floor
     # wins on every host.
@@ -643,6 +748,37 @@ def pyre_env():
     # stays reachable for an A/B: pyre reads the variable as a presence flag, so
     # passing it empty is what turns the flag back off.
     env.setdefault("PYTHONSAFEPATH", "1")
+    # Write no bytecode cache, so a reading describes the tree rather than what
+    # earlier runs left on disk. Importing a module the cache already holds
+    # unmarshals where importing it cold compiles, and that difference reaches
+    # jit-stats the same way the ambient import loop above does: `import json,
+    # base64, textwrap` alone drops 30 `__pycache__/*.pyre314.pyc` files into
+    # the pinned stdlib, so the first run of a fresh checkout and every run
+    # after it measure different work.
+    #
+    # It also removes a class of platform disagreement rather than papering
+    # over it. On Windows nothing pyre wrote was readable until FileIO put an
+    # adopted descriptor in binary mode — `_write_atomic` wraps a raw fd, whose
+    # CRT text mode turned every `\n` into `\r\n` — so the same tree read one
+    # set of counters while the cache was dead and another once it worked.
+    #
+    # This suppresses writing only; a stale cache from before this pin is still
+    # read, so an A/B against an older tree wants `__pycache__` cleared first.
+    # `launch_env::finalize` folds the name as an integer flag, so an explicit
+    # PYTHONDONTWRITEBYTECODE=0 turns it back off. It reaches the wasm guest
+    # too: the name is in `LAUNCH_ENV_NAMES`, which the runner forwards through
+    # `pyre_set_launch_env`.
+    #
+    # Only pyre is pinned this way. The oracles are spawned with the inherited
+    # environment (`run_timed([PYTHON3, script])`), so they keep writing and
+    # reading their own caches and import warm from their first run onward,
+    # while pyre now imports cold on every run. Startup subtraction covers the
+    # imports an empty program performs, not the ones a fixture adds on top, so
+    # for the handful that `import json` / `re` / `pickle` the ratio carries
+    # that difference. Determinism is the trade taken here: a warm pyre depends
+    # on what earlier runs left behind, and a ratio that moves with disk state
+    # is worse than one that is consistently cold.
+    env.setdefault("PYTHONDONTWRITEBYTECODE", "1")
     # Pin the vendored, `_sre.MAGIC`-matched stdlib so pyre never picks up a
     # version-mismatched host `python3` off the PATH. An explicit PYRE_STDLIB
     # in the environment wins.
@@ -1747,11 +1883,18 @@ class Check:
         # content is not a host disagreement, it is a boundary the harness has
         # not pinned yet. An overlay would have frozen it per platform instead.
         #
-        # An overlay also shadows the shared baseline permanently, so one
-        # written against a value that later converges becomes a failure main
-        # does not have: `recursive_call_frame_relocation` was given one for
-        # 637, and windows later converged on its shared value. Read all three
-        # runners back before adding or retaining another.
+        # `child_env_base` since removed the environment term of that volume:
+        # a child starts from an allowlist rather than a copy of the runner's
+        # environment. That closes one input, not the class -- any other change
+        # in allocation volume still moves the point, which is why taking the
+        # fixture off the threshold is what actually settled it.
+        #
+        # An overlay also shadows the shared baseline permanently, so one written
+        # against a value that later converges becomes a failure main does not
+        # have: `recursive_call_frame_relocation` was given one for 637, and
+        # windows later converged on its shared value. Read all three runners
+        # back before adding one, and prefer removing the fixture's dependence on
+        # the host input to recording the host.
         source = Path(script)
         if os.environ.get("GITHUB_ACTIONS") == "true":
             github_runner = source.with_name(
@@ -2129,6 +2272,7 @@ class Check:
 
     def _retry_performance_gate(
         self, backend, script, timeout, baseline_cmd, expected_output,
+        baseline_key,
     ):
         """Return median (pyre, baseline) timings after a slow first sample.
 
@@ -2138,11 +2282,17 @@ class Check:
         """
         attempts = PERF_RETRY_RUNS
         effective_timeout = scaled_timeout(timeout, self._timeout_scale(backend))
+        # The wasm gate's baseline is a pyre binary, not an oracle, so it needs
+        # the pyre environment the numerator already runs under — otherwise the
+        # ratio compares a pinned run against an unpinned one. It was also the
+        # one pyre spawn left outside `pyre_env()`, which is how a bytecode
+        # cache still appeared under a run that pins PYTHONDONTWRITEBYTECODE.
+        baseline_env = pyre_env() if baseline_key in ALL_BACKENDS else None
         pyre_times = []
         baseline_times = []
         for _ in range(attempts):
             _, baseline_time, baseline_code, _ = run_timed(
-                baseline_cmd, timeout_s=effective_timeout,
+                baseline_cmd, timeout_s=effective_timeout, env=baseline_env,
             )
             if baseline_code != 0:
                 return None
@@ -2271,6 +2421,7 @@ class Check:
 
         retry = self._retry_performance_gate(
             backend, script, timeout, baseline_cmd, expected_output,
+            baseline_key,
         )
         if retry is not None:
             median_elapsed, median_baseline = retry

--- a/pyre/extra_tests/parity_tests/builtin_subclass_dict_address_reuse.py
+++ b/pyre/extra_tests/parity_tests/builtin_subclass_dict_address_reuse.py
@@ -44,6 +44,8 @@ def check_fresh_str(count):
         if value.__dict__:
             inherited += 1
         value.tag = index
+        if value.__dict__ != {"tag": index}:
+            inherited += 1
     return inherited
 
 

--- a/pyre/extra_tests/parity_tests/ctypes_callback_abi.py
+++ b/pyre/extra_tests/parity_tests/ctypes_callback_abi.py
@@ -1,7 +1,18 @@
 # CPython-suite gap: test_ctypes does not exercise pyre's callback libffi CIF.
 # parity-tests reason: callback argument/result ABI and nested function pointers.
 
-from ctypes import CFUNCTYPE, Structure, c_double, c_int, c_longlong, c_void_p, cast
+from ctypes import (
+    CFUNCTYPE,
+    Structure,
+    c_byte,
+    c_double,
+    c_int,
+    c_longlong,
+    c_short,
+    c_ubyte,
+    c_void_p,
+    cast,
+)
 
 
 class Pair(Structure):
@@ -19,12 +30,44 @@ I64_CALLBACK = CFUNCTYPE(c_longlong, c_longlong)
 i64_callback = I64_CALLBACK(lambda value: value + 0x100000000)
 assert i64_callback(9) == 0x100000009
 
-# Function-pointer parameters arrive as callable `_CFuncPtr` instances whose
-# `_ptr` and CData buffer both contain the foreign address.
+# A result narrower than the return word owns the whole word: its unwritten
+# bytes are whatever the closure left there unless the slot is cleared first,
+# and a negative value must still read back negative.
+BYTE_CALLBACK = CFUNCTYPE(c_byte, c_byte)
+byte_callback = BYTE_CALLBACK(lambda value: value)
+assert byte_callback(-1) == -1
+assert byte_callback(127) == 127
+
+UBYTE_CALLBACK = CFUNCTYPE(c_ubyte, c_ubyte)
+ubyte_callback = UBYTE_CALLBACK(lambda value: value)
+assert ubyte_callback(255) == 255
+
+SHORT_CALLBACK = CFUNCTYPE(c_short, c_short)
+short_callback = SHORT_CALLBACK(lambda value: value)
+assert short_callback(-2) == -2
+assert short_callback(0x7FFF) == 0x7FFF
+
+INT_CALLBACK = CFUNCTYPE(c_int, c_int)
+int_callback = INT_CALLBACK(lambda value: value)
+assert int_callback(-3) == -3
+assert int_callback(0x7FFFFFFF) == 0x7FFFFFFF
+
+# Function-pointer parameters arrive as callable `_CFuncPtr` instances holding
+# the foreign address, not as the integer a scalar decoder would produce.  A
+# failed assertion inside a callback has nowhere to propagate, so it is
+# reported and the call returns zero — which the outer comparison then catches.
 INNER = CFUNCTYPE(c_int, c_int)
 APPLY = CFUNCTYPE(c_int, INNER, c_int)
 inner = INNER(lambda value: value + 1)
-apply = APPLY(lambda function, value: function(value) * 2)
+inner_address = cast(inner, c_void_p).value
+
+
+def apply_body(function, value):
+    assert cast(function, c_void_p).value == inner_address
+    return function(value) * 2
+
+
+apply = APPLY(apply_body)
 assert apply(inner, 20) == 42
 
 assert cast(pair_callback, c_void_p).value

--- a/pyre/extra_tests/parity_tests/ctypes_callback_abi.py
+++ b/pyre/extra_tests/parity_tests/ctypes_callback_abi.py
@@ -1,0 +1,31 @@
+# CPython-suite gap: test_ctypes does not exercise pyre's callback libffi CIF.
+# parity-tests reason: callback argument/result ABI and nested function pointers.
+
+from ctypes import CFUNCTYPE, Structure, c_double, c_int, c_longlong, c_void_p, cast
+
+
+class Pair(Structure):
+    _fields_ = [("x", c_int), ("y", c_double)]
+
+
+# An aggregate argument must retain its field layout.  Describing these bytes
+# as a pointer or an all-byte struct changes Win64/SysV register classification.
+PAIR_CALLBACK = CFUNCTYPE(c_double, Pair)
+pair_callback = PAIR_CALLBACK(lambda pair: pair.x + pair.y)
+assert pair_callback(Pair(7, 0.5)) == 7.5
+
+# The callback result slot has the declared scalar width, not pointer width.
+I64_CALLBACK = CFUNCTYPE(c_longlong, c_longlong)
+i64_callback = I64_CALLBACK(lambda value: value + 0x100000000)
+assert i64_callback(9) == 0x100000009
+
+# Function-pointer parameters arrive as callable `_CFuncPtr` instances whose
+# `_ptr` and CData buffer both contain the foreign address.
+INNER = CFUNCTYPE(c_int, c_int)
+APPLY = CFUNCTYPE(c_int, INNER, c_int)
+inner = INNER(lambda value: value + 1)
+apply = APPLY(lambda function, value: function(value) * 2)
+assert apply(inner, 20) == 42
+
+assert cast(pair_callback, c_void_p).value
+print("OK")

--- a/pyre/extra_tests/parity_tests/fileio_stat_atopen_staleness.py
+++ b/pyre/extra_tests/parity_tests/fileio_stat_atopen_staleness.py
@@ -10,7 +10,6 @@ one below changes the file after the open and asks again.
 """
 
 import os
-import sys
 import tempfile
 
 directory = tempfile.mkdtemp()
@@ -50,16 +49,23 @@ if os.path.exists("/dev/zero"):
         assert stream.read(8) == b"\x00" * 8
 
 # Seekability is a property of the descriptor, so the answer may be kept, but
-# it belongs to that stream alone. Only the unseekable half is platform-bound:
-# a Windows anonymous-pipe descriptor answers `seekable()` True, under the
-# reference CPython as much as here, so asking it there compares a backend
-# against a failing reference. The seekable half below still runs everywhere.
-if sys.platform != "win32":
-    read_fd, write_fd = os.pipe()
-    with open(read_fd, "rb") as pipe:
-        assert pipe.seekable() is False
-        assert pipe.seekable() is False
-    os.close(write_fd)
+# it belongs to that stream alone. Which answer a pipe gets is the platform's
+# call: `lseek` fails on one under POSIX, while a Windows anonymous-pipe
+# descriptor takes it and so answers `seekable()` True. Hard-coding either
+# spelling asks one of the two platforms to disagree with its own reference, so
+# the expectation comes from the same probe the open would make and the case
+# runs everywhere.
+read_fd, write_fd = os.pipe()
+try:
+    os.lseek(read_fd, 0, os.SEEK_CUR)
+except OSError:
+    pipe_seekable = False
+else:
+    pipe_seekable = True
+with open(read_fd, "rb") as pipe:
+    assert pipe.seekable() is pipe_seekable
+    assert pipe.seekable() is pipe_seekable
+os.close(write_fd)
 with open(path, "rb") as stream:
     assert stream.seekable() is True
     assert stream.seekable() is True

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -968,13 +968,13 @@ the folds it selects, not before them.
 `PYRE_FBW_SPEC_CENSUS` in §6c is its read-only half: the per-fold
 consulted/fired tallies.
 
-### §6c — Default-OFF diagnostics, censuses and probes (61): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (62): keep, cost nothing
 
 Each is inert unless set, so none is a removal target by this file's
 already-ON criterion. They are listed so they cannot be missed again.
 
 `PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
-`PYRE_CELL_CENSUS`,
+`PYRE_CELL_CENSUS`, `PYRE_CHECK_INHERIT_ENV`,
 `PYRE_DESCR_SPELLING_GATE`,
 `PYRE_DEOPT_PROBE`, `PYRE_DIAG_51C`, `PYRE_DIAG_GIN`, `PYRE_DIAG_INLINE_RECOG`,
 `PYRE_DETERMINISM_TRACE`, `PYRE_DTRACE_CONST_BT`,
@@ -1003,6 +1003,13 @@ example; it is unset by default. Its `AFTER`, `BUDGET`, `EVERY`, and `ROWS`
 value knobs bound the capture window, sampling rate, and report size. This is a
 diagnostic tool rather than a temporary runtime experiment, so it retires only
 if the example itself is removed.
+
+`PYRE_CHECK_INHERIT_ENV` is the other odd one: an A/B switch, not a report.
+`check.py` starts a benchmark child from an allowlisted environment because the
+inherited one is startup allocation and moves `guard_failures`; setting the
+gate restores the whole-environment copy, so the size of that effect stays
+measurable on one binary. It goes when the allowlist stops being the thing
+under measurement.
 
 ## §7 — General MAJIT gates
 

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -90,11 +90,13 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 
 [target.'cfg(windows)'.dependencies]
 # The nt calls host_env does not wrap (AddDllDirectory/RemoveDllDirectory,
-# GetFileInformationByHandle, CreateHardLinkW and ShellExecuteW). Kept on the
-# same 0.61 line rustpython-host_env's nt module resolves to, so HANDLE types
+# GetFileInformationByHandle, CreateHardLinkW and ShellExecuteW), plus the
+# WinSock entry points `_socket`'s host layer is built on. Kept on the same
+# 0.61 line rustpython-host_env's nt module resolves to, so HANDLE types
 # match at the boundary.
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Networking_WinSock",
     "Win32_Storage_FileSystem",
     "Win32_Security",
     "Win32_System_LibraryLoader",

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -91,14 +91,16 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 [target.'cfg(windows)'.dependencies]
 # The nt calls host_env does not wrap (AddDllDirectory/RemoveDllDirectory,
 # GetFileInformationByHandle, CreateHardLinkW and ShellExecuteW), plus the
-# WinSock entry points `_socket`'s host layer is built on. Kept on the same
-# 0.61 line rustpython-host_env's nt module resolves to, so HANDLE types
-# match at the boundary.
+# WinSock entry points `_socket`'s host layer is built on, and the crypt32
+# store readers (CertOpenStore/CertEnumCertificatesInStore) behind
+# `_ssl.enum_certificates`. Kept on the same 0.61 line rustpython-host_env's
+# nt module resolves to, so HANDLE types match at the boundary.
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Networking_WinSock",
     "Win32_Storage_FileSystem",
     "Win32_Security",
+    "Win32_Security_Cryptography",
     "Win32_System_LibraryLoader",
     "Win32_System_Threading",
     "Win32_UI_Shell",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15219,8 +15219,15 @@ fn fileio_clear_stat_atopen(self_obj: PyObjectRef) {
     );
 }
 
+/// What the open-time fstat yields, where there is a seam that performs one.
+/// Only the descriptor checks run elsewhere, so the answer carries nothing.
 #[cfg(unix)]
-fn fileio_store_stat_atopen(self_obj: PyObjectRef, stat: &crate::host_seam::StatBuf) {
+type FileioStatAtOpen = crate::host_seam::StatBuf;
+#[cfg(not(unix))]
+type FileioStatAtOpen = ();
+
+#[cfg(unix)]
+fn fileio_store_stat_atopen(self_obj: PyObjectRef, stat: &FileioStatAtOpen) {
     for (name, value) in [
         ("__file_stat_mode__", stat.mode as i64),
         ("__file_stat_size__", stat.size as i64),
@@ -15229,6 +15236,11 @@ fn fileio_store_stat_atopen(self_obj: PyObjectRef, stat: &crate::host_seam::Stat
         crate::baseobjspace::setdictvalue_native(self_obj, name, w_int_new(value));
     }
 }
+
+/// The slots keep whatever `fileio_clear_stat_atopen` left them, so a reader
+/// falls back to the per-call stat it would have taken anyway.
+#[cfg(not(unix))]
+fn fileio_store_stat_atopen(_self_obj: PyObjectRef, _stat: &FileioStatAtOpen) {}
 
 fn fileio_copy_stat_atopen(self_obj: PyObjectRef, opened: PyObjectRef) {
     for name in FILEIO_STAT_SLOTS {
@@ -16569,22 +16581,68 @@ fn open_flags_for_mode(_mode: &str) -> i32 {
 /// PyPy `W_FileIO.descr_init`: immediately fstat every supplied/opened fd and
 /// reject directory descriptors before publishing the FileIO object.
 #[cfg(unix)]
-fn fileio_validate_fd(
-    fd: i32,
-    w_name: PyObjectRef,
-) -> Result<crate::host_seam::StatBuf, crate::PyError> {
+fn fileio_validate_fd(fd: i32, w_name: PyObjectRef) -> Result<FileioStatAtOpen, crate::PyError> {
     let st = crate::host_seam::ops::fstat(fd)
         .map_err(|error| crate::host_seam::seam_os_err(error, ""))?;
-    #[cfg(unix)]
     if st.mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32 {
         return Err(crate::PyError::os_error_syscall(libc::EISDIR, w_name));
     }
     Ok(st)
 }
 
-#[cfg(unix)]
+/// The same check where the descriptor is a CRT one. `fileutils::fstat`
+/// resolves the handle behind the descriptor, so a descriptor number nothing
+/// has opened reports `ERROR_INVALID_HANDLE` — the error `_io.open(999, 'wb')`
+/// owes its caller instead of a stream over a descriptor that does not exist.
+/// The buffer it fills has no block size, so nothing is published from it and
+/// the stat slots stay empty.
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+fn fileio_validate_fd(fd: i32, w_name: PyObjectRef) -> Result<FileioStatAtOpen, crate::PyError> {
+    let borrowed = unsafe { rustpython_host_env::crt_fd::Borrowed::borrow_raw(fd) };
+    let st = rustpython_host_env::fileutils::fstat(borrowed).map_err(|error| {
+        crate::PyError::os_error_win32_syscall2(
+            error
+                .raw_os_error()
+                .unwrap_or(windows_sys::Win32::Foundation::ERROR_INVALID_HANDLE as i32),
+            pyre_object::PY_NULL,
+            pyre_object::PY_NULL,
+        )
+    })?;
+    if i32::from(st.st_mode) & libc::S_IFMT == libc::S_IFDIR {
+        return Err(crate::PyError::os_error_syscall(libc::EISDIR, w_name));
+    }
+    Ok(())
+}
+
+#[cfg(not(any(unix, all(windows, feature = "host_env", not(feature = "sandbox")))))]
+fn fileio_validate_fd(_fd: i32, _w_name: PyObjectRef) -> Result<FileioStatAtOpen, crate::PyError> {
+    Ok(())
+}
+
+/// A CRT descriptor starts in text mode, where a written `\n` leaves as
+/// `\r\n` and a read `\r\n` collapses back. `W_FileIO` is a binary raw stream
+/// whose buffered/text layers own every translation, so each descriptor it
+/// adopts is switched to binary before any I/O reaches it. A pathname the
+/// stream opens itself already carries `O_BINARY` from [`open_flags_for_mode`];
+/// a caller-supplied descriptor and an opener's return value do not.
+fn fileio_set_binary_mode(fd: i32) {
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    if let Ok(borrowed) = unsafe { rustpython_host_env::crt_fd::Borrowed::try_borrow_raw(fd) } {
+        rustpython_host_env::msvcrt::setmode_binary(borrowed);
+    }
+    #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
+    let _ = fd;
+}
+
 fn fileio_close_owned_fd(fd: i32) {
+    #[cfg(unix)]
     let _ = crate::host_seam::ops::close(fd);
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    let _ = rustpython_host_env::crt_fd::close(unsafe {
+        rustpython_host_env::crt_fd::Owned::from_raw(fd)
+    });
+    #[cfg(not(any(unix, all(windows, feature = "host_env", not(feature = "sandbox")))))]
+    let _ = fd;
 }
 
 /// PyPy `_open_inhcache.set_non_inheritable(fd)` / `rposix.set_inheritable`.
@@ -16918,8 +16976,8 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         if fd < 0 {
             return Err(crate::PyError::value_error("negative file descriptor"));
         }
-        #[cfg(unix)]
         let stat_atopen = fileio_validate_fd(fd, path_obj)?;
+        fileio_set_binary_mode(fd);
         let closefd = match closefd_obj {
             Some(value) => crate::baseobjspace::is_true(value)?,
             None => true,
@@ -16935,7 +16993,6 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
         let _ = crate::baseobjspace::setattr_str(wrapper, "closefd", w_bool_from(closefd));
         let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
-        #[cfg(unix)]
         fileio_store_stat_atopen(wrapper, &stat_atopen);
         return Ok(wrapper);
     }
@@ -16984,7 +17041,6 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             fileio_close_owned_fd(fd);
             return Err(error);
         }
-        #[cfg(unix)]
         let stat_atopen = match fileio_validate_fd(fd, resolved_path.w_path()) {
             Ok(stat) => stat,
             Err(error) => {
@@ -16992,6 +17048,9 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 return Err(error);
             }
         };
+        // An opener is free to ignore the flags it was handed, so the binary
+        // mode `open_flags_for_mode` asked for is only guaranteed here.
+        fileio_set_binary_mode(fd);
         let wrapper = pyre_object::w_instance_new(file_wrapper_type());
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_fd__", w_int_new(fd as i64));
         let _ = crate::baseobjspace::setattr_str(wrapper, "__file_binary__", w_bool_from(binary));
@@ -17001,7 +17060,6 @@ fn open_raw_file(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let _ = crate::baseobjspace::setattr_str(wrapper, "name", path_obj);
         let _ = crate::baseobjspace::setattr_str(wrapper, "mode", w_str_new(&mode));
         let _ = crate::baseobjspace::setattr_str(wrapper, "closed", w_bool_from(false));
-        #[cfg(unix)]
         fileio_store_stat_atopen(wrapper, &stat_atopen);
         return Ok(wrapper);
     }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15757,24 +15757,29 @@ fn fileio_method_truncate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             fileio_clear_stat_atopen(self_obj);
             return Ok(index);
         }
-        #[cfg(all(windows, not(feature = "sandbox")))]
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         {
-            // rposix.py:597 binds `_chsize_s` where the posix branch binds
-            // `ftruncate`. It reports failure as its return value rather than
-            // through -1, so the errno comes from the call itself; `crt_call!`
-            // supplies the invalid-parameter suppression `ftruncate` gets from
-            // `SuppressIPH` at rposix.py:606.
-            unsafe extern "C" {
-                fn _chsize_s(fd: i32, size: i64) -> i32;
-            }
-            let rc = crt_call!(_chsize_s(fd, size as i64));
-            if rc != 0 {
-                return Err(fd_errno_err(rc));
-            }
+            // `W_FileIO.truncate` delegates to `rposix.ftruncate`, which binds
+            // `_chsize_s` on Windows (rposix.py:597) under the
+            // invalid-parameter suppression of `SuppressIPH` (rposix.py:606).
+            // `crt_fd::ftruncate` is that same call, suppression and all, and
+            // it keeps the errno `_chsize_s` returns rather than reading the
+            // one a -1 return would have set.  The GIL is released around it,
+            // as the `rffi.llexternal(..., releasegil=True)` seam does.
+            use rustpython_host_env::os::ErrorExt;
+
+            let borrowed = unsafe { rustpython_host_env::crt_fd::Borrowed::borrow_raw(fd) };
+            let (result, _errno) = crate::module::thread::call_external_function(|| {
+                rustpython_host_env::crt_fd::ftruncate(borrowed, size)
+            });
+            result.map_err(|error| fd_errno_err(error.posix_errno()))?;
             fileio_clear_stat_atopen(self_obj);
             return Ok(index);
         }
-        #[cfg(any(all(not(unix), not(windows)), feature = "sandbox"))]
+        #[cfg(any(
+            feature = "sandbox",
+            not(any(unix, all(windows, feature = "host_env")))
+        ))]
         {
             let _ = (fd, size);
             return Err(crate::PyError::not_implemented(

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -846,16 +846,21 @@ fn init_string_module(ns: PyObjectRef) {
 /// first `get_config_var` call rather than the `None` the `.get()` readers
 /// take. Pyre runs its mutators without a global interpreter lock, so
 /// `Py_GIL_DISABLED` is 1 and the derived `ABIFLAGS` is `t`; `Py_DEBUG` is 0.
-/// `EXT_SUFFIX` and `SOABI` name pyre's own cpyext ABI (never CPython's ABI
-/// tag) and track `_imp.extension_suffixes()`: a `cpyext` build names one, and
-/// without the feature there is no extension ABI to name, so both keys stay
-/// absent for the `.get()` readers.
+///
+/// `EXT_SUFFIX` and `SOABI` name pyre's own cpyext ABI, never CPython's ABI
+/// tag. They are build metadata rather than a claim that an extension loader
+/// exists: `packaging.tags` derives a wheel's ABI tag from `EXT_SUFFIX` and
+/// fails outright when the key is absent, so every `pip install` needs it.
+/// `_sysconfigdata` publishes the same pair for `_init_posix`, and both read
+/// it from `extension_abi_suffix`, so one interpreter never spells its own
+/// ABI two ways.
 fn init_sysconfig_stub(ns: PyObjectRef) {
     crate::module_ns_store(
         ns,
         "config_vars",
         crate::make_builtin_function("config_vars", |_| {
             let vars = pyre_object::w_dict_new();
+            let so_ext = extension_abi_suffix();
             unsafe {
                 for (name, value) in [("Py_DEBUG", 0), ("Py_GIL_DISABLED", 1)] {
                     pyre_object::w_dict_store(
@@ -864,27 +869,36 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
                         pyre_object::w_int_new(value),
                     );
                 }
-                #[cfg(all(
-                    feature = "cpyext",
-                    not(feature = "sandbox"),
-                    any(target_os = "macos", target_os = "linux")
-                ))]
-                {
+                for (name, value) in [
+                    ("SOABI", soabi_tag(&so_ext)),
+                    ("EXT_SUFFIX", so_ext.clone()),
+                ] {
                     pyre_object::w_dict_store(
                         vars,
-                        pyre_object::w_str_new("SOABI"),
-                        pyre_object::w_str_new(crate::cpyext::soabi()),
-                    );
-                    pyre_object::w_dict_store(
-                        vars,
-                        pyre_object::w_str_new("EXT_SUFFIX"),
-                        pyre_object::w_str_new(crate::cpyext::extension_suffix()),
+                        pyre_object::w_str_new(name),
+                        pyre_object::w_str_new(&value),
                     );
                 }
             }
             Ok(vars)
         }),
     );
+}
+
+/// The `SOABI` tag: the ABI half of the extension suffix.
+///
+/// PEP 3149 spells the middle component "ABI tag"-"platform tag"; this is the
+/// ABI tag alone. wheel 0.34.2 depends on the shorter form, so do not widen it
+/// without checking wheel — `pep425tags.get_abi_tag` special-cases CPython.
+fn soabi_tag(so_ext: &str) -> String {
+    so_ext
+        .split('.')
+        .nth(1)
+        .unwrap_or_default()
+        .split('-')
+        .take(2)
+        .collect::<Vec<_>>()
+        .join("-")
 }
 
 /// The platform half of the extension ABI, empty where there is none.
@@ -1007,19 +1021,7 @@ fn init_sysconfigdata(ns: PyObjectRef) {
     }
 
     let so_ext = extension_abi_suffix();
-    // SOABI is PEP 3149 compliant, but CPython3 has `so_ext.split('.')[1]`
-    // ("ABI tag"-"platform tag") where this is the ABI tag only.  wheel 0.34.2
-    // depends on this value, so don't make it CPython compliant without
-    // checking wheel: it uses `pep425tags.get_abi_tag` with special handling
-    // for CPython.
-    let soabi = so_ext
-        .split('.')
-        .nth(1)
-        .unwrap_or_default()
-        .split('-')
-        .take(2)
-        .collect::<Vec<_>>()
-        .join("-");
+    let soabi = soabi_tag(&so_ext);
 
     let gnuld = on_path("gcc");
     // Darwin names the architecture in CC and CXX, and `platform.machine()`

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -594,6 +594,11 @@ pub fn install_builtin_modules() {
     // `_winapi` import even though the Windows build installs `posix`.
     #[cfg(windows)]
     pyre_install_module!(_winapi);
+    // PyPy's `lib_pypy/_overlapped.py`: asyncio's proactor backend owns one
+    // OVERLAPPED record per operation and reaches the Win32/WinSock calls
+    // through this Windows-only builtin.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    pyre_install_module!(_overlapped);
     // `importlib._bootstrap_external` eagerly `import winreg`s on win32; the
     // module must exist for the import machinery (and `import site`) to start.
     #[cfg(windows)]

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -856,9 +856,10 @@ fn init_string_module(ns: PyObjectRef) {
 /// tag. They are build metadata rather than a claim that an extension loader
 /// exists: `packaging.tags` derives a wheel's ABI tag from `EXT_SUFFIX` and
 /// fails outright when the key is absent, so every `pip install` needs it.
-/// `_sysconfigdata` publishes the same pair for `_init_posix`, and both read
-/// it from `extension_abi_suffix`, so one interpreter never spells its own
-/// ABI two ways.
+/// Both come from `extension_abi_suffix`, and the pair keeps the relation the
+/// suffix is built from: `EXT_SUFFIX == "." + SOABI + shared-library
+/// extension`. `_sysconfigdata` publishes the same keys for `_init_posix` but
+/// spells `SOABI` shorter — see [`soabi_tag`].
 fn init_sysconfig_stub(ns: PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -875,7 +876,7 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
                     );
                 }
                 for (name, value) in [
-                    ("SOABI", soabi_tag(&so_ext)),
+                    ("SOABI", soabi_middle(&so_ext)),
                     ("EXT_SUFFIX", so_ext.clone()),
                 ] {
                     pyre_object::w_dict_store(
@@ -890,11 +891,18 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
     );
 }
 
-/// The `SOABI` tag: the ABI half of the extension suffix.
+/// The whole middle component of the extension suffix — PEP 3149's "ABI
+/// tag"-"platform tag" together, the spelling `_sysconfig.config_vars()` uses
+/// so that `EXT_SUFFIX` stays `"." + SOABI + shared-library extension`.
+fn soabi_middle(so_ext: &str) -> String {
+    so_ext.split('.').nth(1).unwrap_or_default().to_string()
+}
+
+/// The `SOABI` `_sysconfigdata` publishes: the ABI half of the extension
+/// suffix alone, without the platform tag (`_sysconfigdata.py:19`).
 ///
-/// PEP 3149 spells the middle component "ABI tag"-"platform tag"; this is the
-/// ABI tag alone. wheel 0.34.2 depends on the shorter form, so do not widen it
-/// without checking wheel — `pep425tags.get_abi_tag` special-cases CPython.
+/// wheel 0.34.2 depends on the shorter form, so do not widen it without
+/// checking wheel — `pep425tags.get_abi_tag` special-cases CPython.
 fn soabi_tag(so_ext: &str) -> String {
     so_ext
         .split('.')

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1149,6 +1149,12 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
         subclass_range_alias(178, typed::<crate::module::mmap::W_MMap>()),
+        // Windows asyncio's Overlapped owner follows mmap at the native tail.
+        // It is a non-subclassable builtin in Python, but still participates
+        // in the rclass hierarchy because its managed header and retained
+        // buffer/result fields are traced by the ordinary object marker.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        subclass_range_alias(179, typed::<crate::module::_overlapped::W_Overlapped>()),
     ]
 }
 
@@ -1167,7 +1173,14 @@ pub fn active_subclass_range_hierarchy() -> &'static [(u32, Option<u32>)] {
         const MMAP_HIERARCHY_SLOTS: usize = 1;
         #[cfg(not(any(unix, windows)))]
         const MMAP_HIERARCHY_SLOTS: usize = 0;
-        &hierarchy[..hierarchy.len() - SSL_HIERARCHY_SLOTS - MMAP_HIERARCHY_SLOTS]
+        #[cfg(windows)]
+        const OVERLAPPED_HIERARCHY_SLOTS: usize = 1;
+        #[cfg(not(windows))]
+        const OVERLAPPED_HIERARCHY_SLOTS: usize = 0;
+        &hierarchy[..hierarchy.len()
+            - SSL_HIERARCHY_SLOTS
+            - MMAP_HIERARCHY_SLOTS
+            - OVERLAPPED_HIERARCHY_SLOTS]
     }
     #[cfg(not(all(not(target_arch = "wasm32"), feature = "sandbox")))]
     {

--- a/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
@@ -25,6 +25,10 @@ mod imp {
         /// rewrites the slot, so the live pointer is read through it at call
         /// time.
         slot: *mut usize,
+        /// Size of the libffi result slot described by the callback CIF.
+        /// Kept here so the outer panic boundary can initialize it before any
+        /// Python/runtime work is attempted.
+        result_width: usize,
     }
 
     struct StoredThunk {
@@ -40,16 +44,24 @@ mod imp {
         LazyLock::new(|| Mutex::new(Vec::new()));
 
     pub(super) fn build_thunk(obj: PyObjectRef) -> Result<Option<usize>, crate::PyError> {
-        let argtypes = funcptr::resolve_argtypes(obj).unwrap_or_default();
-        let ffi_arg_types = argtypes
-            .iter()
-            .copied()
-            .map(ffi_type_for_arg)
-            .collect::<Vec<_>>();
-        let restype = funcptr::resolve_restype(obj).map_err(|_| invalid_callback_result_type())?;
+        let _roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let argtypes = funcptr::resolve_argtypes(current_obj()).unwrap_or_default();
+        let argtypes_slot = pyre_object::gc_roots::shadow_stack_len();
+        for &argtype in &argtypes {
+            pyre_object::gc_roots::pin_root(argtype);
+        }
+        let ffi_arg_types = (0..argtypes.len())
+            .map(|i| ffi_type_for_arg(pyre_object::gc_roots::shadow_stack_get(argtypes_slot + i)))
+            .collect::<Result<Vec<_>, _>>()?;
+        let restype =
+            funcptr::resolve_restype(current_obj()).map_err(|_| invalid_callback_result_type())?;
         let ffi_res_type = ffi_type_for_ret(&restype)?;
+        let result_width = ffi_result_width(&restype);
 
-        let mut slot = Box::new(obj as usize);
+        let mut slot = Box::new(current_obj() as usize);
         let slot_ptr = (&mut *slot) as *mut usize;
         let root_slot = slot_ptr as *mut *mut u8;
         unsafe { pyre_object::gc_hook::try_gc_add_root(root_slot) };
@@ -57,7 +69,10 @@ mod imp {
         let thunk = host_ctypes::CallbackThunk::new(
             ffi_arg_types,
             ffi_res_type,
-            Box::new(ThunkUserdata { slot: slot_ptr }),
+            Box::new(ThunkUserdata {
+                slot: slot_ptr,
+                result_width,
+            }),
             thunk_callback,
         );
         let code = thunk.code_ptr().0 as usize;
@@ -72,24 +87,59 @@ mod imp {
         Ok(Some(code))
     }
 
-    fn ffi_type_for_arg(at: PyObjectRef) -> host_ctypes::FfiType {
+    fn ffi_type_for_arg(at: PyObjectRef) -> Result<host_ctypes::FfiType, crate::PyError> {
         if funcptr::argtype_is_pointer_kind(at) {
-            return host_ctypes::ffi_pointer_type();
+            return Ok(host_ctypes::ffi_pointer_type());
         }
         if let Some(tc) = cdata::type_code_of(at)
             && let Some(ty) = host_ctypes::ffi_type_from_code(&tc)
         {
-            return ty;
+            return Ok(ty);
         }
-        // A `Structure`/`Union` argument has no type code and is passed by
-        // value, so the cif has to describe an aggregate of its size —
-        // declaring a pointer disagrees with the ABI and hands `decode_arg` a
-        // slot that is neither the struct nor a pointer to it. `decode_arg`
-        // already builds the instance from `size` bytes at the argument
-        // address, which is what libffi supplies for an aggregate.
-        match cdata::ctype_size_of(at) {
-            Some(size) => host_ctypes::ffi_byte_struct(size),
-            None => host_ctypes::ffi_pointer_type(),
+        ffi_type_for_layout(&funcptr::build_layout(at)?)
+    }
+
+    /// Lower the same recursive layout foreign calls use to the callback CIF.
+    /// Struct field kinds determine register classification on every major
+    /// ABI; a byte-struct of the same size is not equivalent.
+    fn ffi_type_for_layout(
+        layout: &host_ctypes::CTypeLayout,
+    ) -> Result<host_ctypes::FfiType, crate::PyError> {
+        use host_ctypes::CTypeLayout;
+        match layout {
+            CTypeLayout::Simple(code) => {
+                let mut buf = [0u8; 4];
+                host_ctypes::ffi_type_from_code(code.encode_utf8(&mut buf))
+                    .ok_or_else(|| crate::PyError::type_error("unknown callback argument type"))
+            }
+            CTypeLayout::Pointer => Ok(host_ctypes::ffi_pointer_type()),
+            CTypeLayout::Struct { fields, .. } => fields
+                .iter()
+                .map(ffi_type_for_layout)
+                .collect::<Result<Vec<_>, _>>()
+                .map(host_ctypes::FfiType::structure),
+            CTypeLayout::Array {
+                element, length, ..
+            } => Ok(host_ctypes::ffi_repeat_type(
+                ffi_type_for_layout(element)?,
+                *length,
+            )),
+            CTypeLayout::Union { size, .. } | CTypeLayout::Opaque { size } => {
+                Ok(host_ctypes::ffi_byte_struct(*size))
+            }
+        }
+    }
+
+    fn ffi_result_width(ret: &funcptr::Ret) -> usize {
+        match ret {
+            funcptr::Ret::Void => 0,
+            // host_env intentionally declares ctypes long double (`g`) as
+            // libffi f64, so use the CIF width rather than its 16-byte cdata
+            // storage size on Unix.
+            funcptr::Ret::Code(code) if code == "g" => 8,
+            funcptr::Ret::Code(code) => host_ctypes::simple_type_size(code).unwrap_or(0),
+            funcptr::Ret::Pointer(_) => host_ctypes::pointer_size(),
+            funcptr::Ret::Aggregate(_) => 0,
         }
     }
 
@@ -115,6 +165,15 @@ mod imp {
         args: *const *const c_void,
         userdata: &ThunkUserdata,
     ) {
+        if userdata.result_width != 0 {
+            unsafe {
+                std::ptr::write_bytes(
+                    (result as *mut c_void).cast::<u8>(),
+                    0,
+                    userdata.result_width,
+                )
+            };
+        }
         let _ = catch_unwind(AssertUnwindSafe(|| unsafe {
             thunk_callback_inner(result, args, userdata)
         }));
@@ -126,13 +185,21 @@ mod imp {
         userdata: &ThunkUserdata,
     ) {
         let _callback = crate::module::thread::enter_external_callback_from_foreign_thread();
-        let obj = unsafe { *userdata.slot } as PyObjectRef;
-        let use_errno = funcptr::funcptr_flags(obj) & funcptr::FUNCFLAG_USE_ERRNO != 0;
-        let call_result = match decode_args(obj, args) {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(unsafe { *userdata.slot } as PyObjectRef);
+        let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let use_errno = funcptr::funcptr_flags(current_obj()) & funcptr::FUNCFLAG_USE_ERRNO != 0;
+        let call_result = match decode_args(current_obj(), args) {
             Ok(decoded) => host_ctypes::with_callback_errno_preserved(use_errno, || {
-                let callable = funcptr::instance_get(obj, funcptr::CALLABLE_KEY)
+                let callable = funcptr::instance_get(current_obj(), funcptr::CALLABLE_KEY)
                     .ok_or_else(|| crate::PyError::type_error("callback has no callable"))?;
-                crate::call::call_function_impl_result(callable, &decoded)
+                pyre_object::gc_roots::pin_root(callable);
+                let callable_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                crate::call::call_function_impl_result(
+                    pyre_object::gc_roots::shadow_stack_get(callable_slot),
+                    &decoded,
+                )
             }),
             Err(error) => Err(error),
         };
@@ -140,8 +207,18 @@ mod imp {
         // call's own failure was already reported by `callback_result`, which
         // substitutes a zero result; what is left here is a result the declared
         // `restype` cannot represent.
-        let written = funcptr::callback_result(obj, call_result)
-            .and_then(|value| write_result(obj, value, result as *mut c_void));
+        let written = match funcptr::callback_result(current_obj(), call_result) {
+            Ok(value) => {
+                pyre_object::gc_roots::pin_root(value);
+                let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+                write_result(
+                    current_obj(),
+                    pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    result as *mut c_void,
+                )
+            }
+            Err(error) => Err(error),
+        };
         if let Err(mut error) = written {
             error.write_unraisable(
                 pyre_object::w_none(),
@@ -159,18 +236,49 @@ mod imp {
         args: *const *const c_void,
     ) -> Result<Vec<PyObjectRef>, crate::PyError> {
         let argtypes = funcptr::resolve_argtypes(obj).unwrap_or_default();
-        let mut decoded = Vec::with_capacity(argtypes.len());
-        for (i, at) in argtypes.into_iter().enumerate() {
+        let argtypes_slot = pyre_object::gc_roots::shadow_stack_len();
+        for &argtype in &argtypes {
+            pyre_object::gc_roots::pin_root(argtype);
+        }
+        // `decode_arg` may itself pin construction intermediates (aggregate
+        // and function-pointer instances), so decoded results are not
+        // necessarily contiguous on the shadow stack.  Record each result's
+        // actual slot instead of deriving `base + index`.
+        let mut decoded_slots = Vec::with_capacity(argtypes.len());
+        for i in 0..argtypes.len() {
+            let at = pyre_object::gc_roots::shadow_stack_get(argtypes_slot + i);
             let p = unsafe { *args.add(i) };
             match decode_arg(at, p) {
-                Ok(value) => decoded.push(value),
+                Ok(value) => {
+                    decoded_slots.push(pyre_object::gc_roots::shadow_stack_len());
+                    pyre_object::gc_roots::pin_root(value);
+                }
                 Err(error) => return Err(error),
             }
         }
-        Ok(decoded)
+        Ok(decoded_slots
+            .into_iter()
+            .map(pyre_object::gc_roots::shadow_stack_get)
+            .collect())
     }
 
     fn decode_arg(at: PyObjectRef, p: *const c_void) -> Result<PyObjectRef, crate::PyError> {
+        // A `_CFuncPtr` can expose the pointer type code too, but Python must
+        // receive a callable function-pointer instance, not the integer that
+        // the generic simple decoder would produce.  CPython's
+        // `ConvParam`/`PyCFuncPtrType` path likewise resolves this before the
+        // scalar fallback.
+        if funcptr::is_funcptr_type(at) {
+            let address = unsafe { *(p as *const usize) };
+            let inst = crate::call::type_call_instantiate(at, &[])?;
+            let inst_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(inst);
+            funcptr::store_funcptr_addr(
+                pyre_object::gc_roots::shadow_stack_get(inst_slot),
+                address,
+            )?;
+            return Ok(pyre_object::gc_roots::shadow_stack_get(inst_slot));
+        }
         if let Some(tc) = cdata::type_code_of(at)
             && !funcptr::is_simple_subclass(at)
         {
@@ -188,9 +296,11 @@ mod imp {
         }
         if let Some(size) = cdata::ctype_size_of(at) {
             let inst = crate::call::type_call_instantiate(at, &[])?;
+            let inst_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(inst);
             let bytes = unsafe { host_ctypes::borrow_memory(p.cast::<u8>(), size) };
-            cdata::cdata_write(inst, 0, bytes);
-            return Ok(inst);
+            cdata::cdata_write(pyre_object::gc_roots::shadow_stack_get(inst_slot), 0, bytes);
+            return Ok(pyre_object::gc_roots::shadow_stack_get(inst_slot));
         }
         Err(crate::PyError::type_error("cannot build parameter"))
     }
@@ -210,10 +320,9 @@ mod imp {
                 // `g` is the case that overruns — it encodes to a long double
                 // while `ffi_type_from_code` maps it to the `f64` the slot was
                 // sized for.
-                let width = std::mem::size_of::<usize>();
+                let width = ffi_result_width(&funcptr::Ret::Code(c.clone()));
                 let n = bytes.len().min(width);
                 unsafe {
-                    std::ptr::write_bytes(result.cast::<u8>(), 0, width);
                     std::ptr::copy_nonoverlapping(bytes.as_ptr(), result.cast::<u8>(), n);
                 }
                 Ok(())

--- a/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/callbacks.rs
@@ -25,9 +25,10 @@ mod imp {
         /// rewrites the slot, so the live pointer is read through it at call
         /// time.
         slot: *mut usize,
-        /// Size of the libffi result slot described by the callback CIF.
-        /// Kept here so the outer panic boundary can initialize it before any
-        /// Python/runtime work is attempted.
+        /// Size of the libffi result slot the callback CIF returns through —
+        /// one `ffi_arg` word for an integral result narrower than that.  Kept
+        /// here so the outer panic boundary can initialize the whole slot
+        /// before any Python/runtime work is attempted.
         result_width: usize,
     }
 
@@ -49,17 +50,17 @@ mod imp {
         pyre_object::gc_roots::pin_root(obj);
         let current_obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let argtypes = funcptr::resolve_argtypes(current_obj()).unwrap_or_default();
-        let argtypes_slot = pyre_object::gc_roots::shadow_stack_len();
-        for &argtype in &argtypes {
-            pyre_object::gc_roots::pin_root(argtype);
-        }
+        // The whole livevar set is published before the first forwarding query:
+        // `pin_root` in a loop queries after the first write, and that query is
+        // a safepoint at which the entries still only in the `Vec` can move.
+        let argtypes_slot = pyre_object::gc_roots::pin_roots(&argtypes);
         let ffi_arg_types = (0..argtypes.len())
             .map(|i| ffi_type_for_arg(pyre_object::gc_roots::shadow_stack_get(argtypes_slot + i)))
             .collect::<Result<Vec<_>, _>>()?;
         let restype =
             funcptr::resolve_restype(current_obj()).map_err(|_| invalid_callback_result_type())?;
         let ffi_res_type = ffi_type_for_ret(&restype)?;
-        let result_width = ffi_result_width(&restype);
+        let result_width = ffi_result_slot_width(&restype);
 
         let mut slot = Box::new(current_obj() as usize);
         let slot_ptr = (&mut *slot) as *mut usize;
@@ -140,6 +141,38 @@ mod imp {
             funcptr::Ret::Code(code) => host_ctypes::simple_type_size(code).unwrap_or(0),
             funcptr::Ret::Pointer(_) => host_ctypes::pointer_size(),
             funcptr::Ret::Aggregate(_) => 0,
+        }
+    }
+
+    /// Width of `ffi_arg`, the word a libffi closure reserves for an integral
+    /// return however narrow the declared result is.
+    const FFI_ARG_SIZE: usize = std::mem::size_of::<usize>();
+
+    /// A floating-point result code, which libffi returns through its own
+    /// register file and never widens to `ffi_arg`.
+    fn is_float_code(code: &str) -> bool {
+        matches!(code, "f" | "d" | "g")
+    }
+
+    /// Bytes of the closure's return slot the result owns.  An integral result
+    /// narrower than `ffi_arg` still owns the whole word, so that is what gets
+    /// cleared and what the value is placed within.
+    fn ffi_result_slot_width(ret: &funcptr::Ret) -> usize {
+        let width = ffi_result_width(ret);
+        match ret {
+            funcptr::Ret::Code(code) if !is_float_code(code) => width.max(FFI_ARG_SIZE),
+            _ => width,
+        }
+    }
+
+    /// Offset of an `n`-byte value inside its `ffi_arg` return slot: a
+    /// big-endian ABI keeps the value at the end of the word
+    /// (`callbacks.c:234-239`).
+    fn ffi_result_offset(ret: &funcptr::Ret, n: usize) -> usize {
+        if cfg!(target_endian = "big") {
+            ffi_result_slot_width(ret).saturating_sub(n)
+        } else {
+            0
         }
     }
 
@@ -236,10 +269,10 @@ mod imp {
         args: *const *const c_void,
     ) -> Result<Vec<PyObjectRef>, crate::PyError> {
         let argtypes = funcptr::resolve_argtypes(obj).unwrap_or_default();
-        let argtypes_slot = pyre_object::gc_roots::shadow_stack_len();
-        for &argtype in &argtypes {
-            pyre_object::gc_roots::pin_root(argtype);
-        }
+        // Published as one set for the reason `pin_roots` documents: pinning
+        // them one at a time makes the first query a safepoint at which the
+        // still-unpinned entries can move.
+        let argtypes_slot = pyre_object::gc_roots::pin_roots(&argtypes);
         // `decode_arg` may itself pin construction intermediates (aggregate
         // and function-pointer instances), so decoded results are not
         // necessarily contiguous on the shadow stack.  Record each result's
@@ -314,16 +347,20 @@ mod imp {
             funcptr::Ret::Void => Ok(()),
             funcptr::Ret::Code(c) => {
                 let bytes = cdata::encode_value_into(&c, value, obj, "result")?;
-                // The return slot is one `ffi_arg` word: a narrow value has to
-                // go into a zeroed word rather than beside whatever the closure
-                // left there, and nothing wider than the word may be written.
-                // `g` is the case that overruns — it encodes to a long double
-                // while `ffi_type_from_code` maps it to the `f64` the slot was
-                // sized for.
-                let width = ffi_result_width(&funcptr::Ret::Code(c.clone()));
-                let n = bytes.len().min(width);
+                // The return slot is one `ffi_arg` word: a narrow value goes
+                // into a word `thunk_callback` already cleared rather than
+                // beside whatever the closure left there, and nothing wider
+                // than the CIF's own type may be written.  `g` is the case that
+                // overruns — it encodes to a long double while
+                // `ffi_type_from_code` maps it to the `f64` the slot holds.
+                let ret = funcptr::Ret::Code(c.clone());
+                let n = bytes.len().min(ffi_result_width(&ret));
                 unsafe {
-                    std::ptr::copy_nonoverlapping(bytes.as_ptr(), result.cast::<u8>(), n);
+                    std::ptr::copy_nonoverlapping(
+                        bytes.as_ptr(),
+                        result.cast::<u8>().add(ffi_result_offset(&ret, n)),
+                        n,
+                    );
                 }
                 Ok(())
             }

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -91,7 +91,10 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "CFuncPtr.__new__(): not enough arguments",
         ));
     }
-    let cls = args[0];
+    let _roots = pyre_object::gc_roots::push_roots();
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
+    let cls = pyre_object::gc_roots::shadow_stack_get(cls_slot);
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
     let mut callback = pyre_object::PY_NULL;
@@ -117,29 +120,41 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             0
         }
     };
-    let obj = cdata::new_cdata_obj_from_bytes(cls, host_ctypes::pointer_size(), &[])?;
-    let d = crate::baseobjspace::getdict_native(obj);
-    if d.is_null() {
-        return Err(crate::PyError::type_error(
-            "CFuncPtr instance has no instance dict",
-        ));
-    }
-    unsafe { pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(addr as i64)) };
+    let callback_slot = if callback.is_null() {
+        None
+    } else {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(callback);
+        Some(slot)
+    };
+    let obj = cdata::new_cdata_obj_from_bytes(
+        pyre_object::gc_roots::shadow_stack_get(cls_slot),
+        host_ctypes::pointer_size(),
+        &[],
+    )?;
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    store_funcptr_addr(pyre_object::gc_roots::shadow_stack_get(obj_slot), addr)?;
     if !callback.is_null() {
-        unsafe { pyre_object::w_dict_setitem_str(d, CALLABLE_KEY, callback) };
-        if let Some(code) = super::callbacks::build_thunk(obj)? {
-            let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
-                "P",
-                host_ctypes::SimpleStorageValue::Pointer(code),
-                false,
-            );
-            unsafe {
-                pyre_object::w_dict_setitem_str(d, PTR_KEY, pyre_object::w_int_new(code as i64))
-            };
-            cdata::cdata_write(obj, 0, &bytes);
+        let current_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+        let d = crate::baseobjspace::getdict_native(current_obj);
+        pyre_object::gc_roots::pin_root(d);
+        let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let callback = pyre_object::gc_roots::shadow_stack_get(callback_slot.unwrap());
+        unsafe {
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+                CALLABLE_KEY,
+                callback,
+            )
+        };
+        if let Some(code) =
+            super::callbacks::build_thunk(pyre_object::gc_roots::shadow_stack_get(obj_slot))?
+        {
+            store_funcptr_addr(pyre_object::gc_roots::shadow_stack_get(obj_slot), code)?;
         }
     }
-    Ok(obj)
+    Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot))
 }
 
 /// `(name, dll)` → resolved symbol address.  `dll._handle` is the integer
@@ -368,6 +383,41 @@ pub(super) fn funcptr_addr(obj: PyObjectRef) -> usize {
         .filter(|o| unsafe { pyre_object::is_int(*o) })
         .map(|o| unsafe { pyre_object::w_int_get_value(o) } as usize)
         .unwrap_or(0)
+}
+
+/// Store a function address in both `_ptr` and the pointer-sized CData buffer.
+/// The object and boxed integer are rooted independently because either the
+/// integer allocation or the dict write may move the instance.
+pub(super) fn store_funcptr_addr(obj: PyObjectRef, addr: usize) -> Result<(), crate::PyError> {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let w_addr = pyre_object::w_int_new(addr as i64);
+    let addr_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_addr);
+    let current_obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let d = crate::baseobjspace::getdict_native(current_obj);
+    if d.is_null() {
+        return Err(crate::PyError::type_error(
+            "CFuncPtr instance has no instance dict",
+        ));
+    }
+    pyre_object::gc_roots::pin_root(d);
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    unsafe {
+        pyre_object::w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            PTR_KEY,
+            pyre_object::gc_roots::shadow_stack_get(addr_slot),
+        )
+    };
+    let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
+        "P",
+        host_ctypes::SimpleStorageValue::Pointer(addr),
+        false,
+    );
+    cdata::cdata_write(pyre_object::gc_roots::shadow_stack_get(obj_slot), 0, &bytes);
+    Ok(())
 }
 
 /// Owned argument data whose buffers must outlive the borrowed `CallArg`s
@@ -909,7 +959,7 @@ fn struct_field_types(t: PyObjectRef) -> Result<Vec<PyObjectRef>, crate::PyError
 /// Build the recursive `CTypeLayout` of a ctypes type, driven by its `StgInfo`
 /// `paramfunc`: simple → code, pointer → `Pointer`, array → element layout +
 /// length, struct/union → per-field layouts from `_fields_`.
-fn build_layout(t: PyObjectRef) -> Result<host_ctypes::CTypeLayout, crate::PyError> {
+pub(super) fn build_layout(t: PyObjectRef) -> Result<host_ctypes::CTypeLayout, crate::PyError> {
     use host_ctypes::CTypeLayout;
     let info = stginfo::stginfo_of(t)
         .ok_or_else(|| crate::PyError::type_error("type has no ctypes layout info"))?;

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -472,10 +472,13 @@ pub(super) fn lookup_symbol(
             "symbol '{}' not found",
             String::from_utf8_lossy(symbol)
         ))),
-        None => Err(Error::Load(
-            rustpython_host_env::ctypes::format_error_message(None)
-                .unwrap_or_else(|| "symbol not found".to_string()),
-        )),
+        // windows-sys represents the documented NULL miss as `None`.
+        // This is the normal not-found result, not a loader failure carrying
+        // a meaningful last-error message.
+        None => Err(Error::Load(format!(
+            "symbol '{}' not found",
+            String::from_utf8_lossy(symbol)
+        ))),
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_overlapped/mod.rs
@@ -1,0 +1,1127 @@
+//! Windows overlapped I/O — PyPy: `lib_pypy/_overlapped.py`.
+//!
+//! PyPy keeps the `OVERLAPPED`, native buffers, operation tag and handle on
+//! each `Overlapped` instance.  This port preserves that ownership exactly:
+//! the W_Root owns one stable native state box and its writable-buffer lease.
+//! The actual Win32/WinSock calls are the shared, pinned
+//! `rustpython_host_env::overlapped` implementation.
+
+use pyre_object::{PY_NULL, PyObject, PyObjectRef};
+use rustpython_host_env::{
+    overlapped as host_overlapped, winapi as host_winapi, windows as host_windows,
+};
+use std::sync::{Mutex, OnceLock};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlappedType {
+    None,
+    NotStarted,
+    Read,
+    ReadInto,
+    Write,
+    Accept,
+    Connect,
+    Disconnect,
+    ConnectNamedPipe,
+    TransmitFile,
+    ReadFrom,
+    WriteTo,
+    ReadFromInto,
+}
+
+struct NativeOverlapped {
+    overlapped: host_overlapped::OverlappedIo,
+    handle: host_overlapped::Handle,
+    error: u32,
+    kind: OverlappedType,
+    buffer: Vec<u8>,
+    address: Vec<u8>,
+    recv_address: host_overlapped::SocketAddrV6,
+    recv_address_length: i32,
+    buffer_export_held: bool,
+}
+
+// The OS may complete an operation on a Windows worker thread.  Access from
+// Python remains serialized through the per-object mutex; the raw pointers
+// handed to Windows all name fields/buffers owned by the stable Box.
+unsafe impl Send for NativeOverlapped {}
+
+#[crate::pyre_class("_overlapped.Overlapped")]
+#[derive(Default)]
+pub struct W_Overlapped {
+    backend: *mut Mutex<NativeOverlapped>,
+    /// CPython's/PyPy's retained Py_buffer owner for Read*Into.  Keeping it
+    /// inline makes it an ordinary traced edge, not a process side table.
+    w_buffer: PyObjectRef,
+    /// Concrete exporter whose resize lock was acquired.
+    w_buffer_owner: PyObjectRef,
+    /// Cached `(buffer, address)` / `(count, address)` result for recvfrom.
+    w_result: PyObjectRef,
+}
+
+fn this(obj: PyObjectRef) -> Result<&'static mut W_Overlapped, crate::PyError> {
+    W_Overlapped::from_obj(obj)
+        .ok_or_else(|| crate::PyError::type_error("expected _overlapped.Overlapped object"))
+}
+
+fn native(obj: PyObjectRef) -> Result<&'static Mutex<NativeOverlapped>, crate::PyError> {
+    let this = this(obj)?;
+    if this.backend.is_null() {
+        return Err(crate::PyError::value_error("invalid overlapped object"));
+    }
+    Ok(unsafe { &*this.backend })
+}
+
+fn arg(args: &[PyObjectRef], index: usize, name: &str) -> Result<PyObjectRef, crate::PyError> {
+    args.get(index)
+        .copied()
+        .ok_or_else(|| crate::PyError::type_error(format!("{name}() missing required argument")))
+}
+
+fn method_arity(
+    args: &[PyObjectRef],
+    name: &str,
+    min: usize,
+    max: usize,
+) -> Result<(), crate::PyError> {
+    if (min..=max).contains(&args.len()) {
+        Ok(())
+    } else if min == max {
+        Err(crate::PyError::type_error(format!(
+            "{name}() takes exactly {} argument{}",
+            min - 1,
+            if min == 2 { "" } else { "s" }
+        )))
+    } else {
+        Err(crate::PyError::type_error(format!(
+            "{name}() takes from {} to {} arguments",
+            min - 1,
+            max - 1
+        )))
+    }
+}
+
+fn handle_w(obj: PyObjectRef) -> Result<host_overlapped::Handle, crate::PyError> {
+    Ok(crate::baseobjspace::int_w(obj)? as isize as host_overlapped::Handle)
+}
+
+fn isize_w(obj: PyObjectRef) -> Result<isize, crate::PyError> {
+    Ok(crate::baseobjspace::int_w(obj)? as isize)
+}
+
+fn usize_w(obj: PyObjectRef) -> Result<usize, crate::PyError> {
+    Ok(crate::baseobjspace::int_w(obj)? as usize)
+}
+
+fn u32_w(obj: PyObjectRef) -> Result<u32, crate::PyError> {
+    crate::baseobjspace::c_uint_w(obj)
+}
+
+fn win32_err_code(code: u32) -> crate::PyError {
+    crate::PyError::os_error_win32_syscall2(code as i32, PY_NULL, PY_NULL)
+}
+
+fn win32_err(err: std::io::Error) -> crate::PyError {
+    win32_err_code(err.raw_os_error().unwrap_or(0) as u32)
+}
+
+fn set_object_refs(
+    obj: PyObjectRef,
+    w_buffer: PyObjectRef,
+    w_owner: PyObjectRef,
+    w_result: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    let this = this(obj)?;
+    this.w_buffer = w_buffer;
+    this.w_buffer_owner = w_owner;
+    this.w_result = w_result;
+    pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+    Ok(())
+}
+
+/// PyPy `ffi.from_buffer(bufobj)` / CPython `PyBUF_WRITABLE`: resolve the
+/// contiguous writable window and the concrete exporter whose resize lock is
+/// held until the Overlapped object is swept.
+fn writable_buffer(obj: PyObjectRef) -> Result<(&'static mut [u8], PyObjectRef), crate::PyError> {
+    if unsafe { pyre_object::bytearrayobject::is_bytearray(obj) } {
+        return Ok((
+            unsafe { pyre_object::bytearrayobject::w_bytearray_data_mut(obj) },
+            obj,
+        ));
+    }
+    if unsafe { pyre_object::interp_array::is_array(obj) } {
+        return Ok((
+            unsafe { pyre_object::interp_array::w_array_vec_mut(obj).as_mut_slice() },
+            obj,
+        ));
+    }
+    if unsafe { pyre_object::memoryview::is_w_memoryview(obj) } {
+        unsafe { crate::builtins::memoryview_check_released(obj) }?;
+        if unsafe { pyre_object::memoryview::w_memoryview_readonly(obj) }
+            || !unsafe { crate::builtins::memoryview_contiguity(obj).0 }
+        {
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::BufferError,
+                "buffer is not contiguous and writable",
+            ));
+        }
+        let view = unsafe { pyre_object::memoryview::w_memoryview_view(obj) };
+        let Some(full) = (unsafe { view.backing().as_bytes_mut() }) else {
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::BufferError,
+                "buffer is not writable",
+            ));
+        };
+        let offset = unsafe { view.offset() } as usize;
+        let length = unsafe { pyre_object::memoryview::w_memoryview_length(obj) } as usize;
+        if offset
+            .checked_add(length)
+            .is_none_or(|end| end > full.len())
+        {
+            return Err(crate::PyError::value_error(
+                "memoryview buffer is no longer valid",
+            ));
+        }
+        return Ok((&mut full[offset..offset + length], obj));
+    }
+    Err(crate::PyError::type_error(
+        "a writable bytes-like object is required",
+    ))
+}
+
+fn retain_writable_buffer(
+    obj: PyObjectRef,
+    w_buffer: PyObjectRef,
+) -> Result<usize, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_roots(&[obj, w_buffer]);
+    let base = pyre_object::gc_roots::shadow_stack_len() - 2;
+    let r_buffer = pyre_object::gc_roots::shadow_stack_get(base + 1);
+    let (slice, owner) = writable_buffer(r_buffer)?;
+    let length = slice.len();
+    pyre_object::gc_roots::pin_root(owner);
+    let owner_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let held = unsafe {
+        crate::builtins::buffer_export_incref(pyre_object::gc_roots::shadow_stack_get(owner_slot))
+    };
+    let r_obj = pyre_object::gc_roots::shadow_stack_get(base);
+    let r_buffer = pyre_object::gc_roots::shadow_stack_get(base + 1);
+    let r_owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
+    set_object_refs(r_obj, r_buffer, r_owner, PY_NULL)?;
+    let mut state = native(r_obj)?.lock().unwrap();
+    state.buffer_export_held = held;
+    drop(roots);
+    Ok(length)
+}
+
+fn release_writable_buffer(obj: PyObjectRef) -> Result<(), crate::PyError> {
+    let owner = this(obj)?.w_buffer_owner;
+    let mut state = native(obj)?.lock().unwrap();
+    if state.buffer_export_held && !owner.is_null() {
+        unsafe { crate::builtins::buffer_export_decref(owner) };
+        state.buffer_export_held = false;
+    }
+    drop(state);
+    set_object_refs(obj, PY_NULL, PY_NULL, PY_NULL)
+}
+
+fn copied_read_buffer(obj: PyObjectRef, name: &str) -> Result<Vec<u8>, crate::PyError> {
+    let Some(buffer) = crate::baseobjspace::simple_buffer_bytes(obj)? else {
+        return Err(crate::PyError::type_error(format!(
+            "{name}() argument must be a bytes-like object"
+        )));
+    };
+    let bytes = buffer.as_bytes().to_vec();
+    buffer.release();
+    Ok(bytes)
+}
+
+fn parse_address(obj: PyObjectRef) -> Result<(Vec<u8>, i32), crate::PyError> {
+    let items = crate::baseobjspace::unpackiterable(obj, -1)?;
+    match items.as_slice() {
+        [host, port] => {
+            let host = crate::baseobjspace::text_w(*host)?;
+            let port = u32_w(*port)?;
+            let port = u16::try_from(port)
+                .map_err(|_| crate::PyError::overflow_error("port must be 0-65535"))?;
+            host_overlapped::parse_address_v4(host, port).map_err(win32_err)
+        }
+        [host, port, flowinfo, scope_id] => {
+            let host = crate::baseobjspace::text_w(*host)?;
+            let port = u32_w(*port)?;
+            let port = u16::try_from(port)
+                .map_err(|_| crate::PyError::overflow_error("port must be 0-65535"))?;
+            host_overlapped::parse_address_v6(host, port, u32_w(*flowinfo)?, u32_w(*scope_id)?)
+                .map_err(win32_err)
+        }
+        _ => Err(crate::PyError::value_error(
+            "expected tuple of length 2 or 4",
+        )),
+    }
+}
+
+fn unparse_address(
+    address: &host_overlapped::SocketAddrV6,
+    length: i32,
+) -> Result<PyObjectRef, crate::PyError> {
+    match host_overlapped::unparse_address(
+        address as *const _ as *const host_overlapped::SocketAddrRaw,
+        length,
+    )
+    .map_err(|_| crate::PyError::value_error("recvfrom returned unsupported address family"))?
+    {
+        host_overlapped::SocketAddress::V4 { host, port } => Ok(pyre_object::w_tuple_new(vec![
+            pyre_object::w_str_new(&host),
+            pyre_object::w_int_new(port as i64),
+        ])),
+        host_overlapped::SocketAddress::V6 {
+            host,
+            port,
+            flowinfo,
+            scope_id,
+        } => Ok(pyre_object::w_tuple_new(vec![
+            pyre_object::w_str_new(&host),
+            pyre_object::w_int_new(port as i64),
+            pyre_object::w_int_new(flowinfo as i64),
+            pyre_object::w_int_new(scope_id as i64),
+        ])),
+    }
+}
+
+fn operation_already_attempted(state: &NativeOverlapped) -> Result<(), crate::PyError> {
+    if state.kind != OverlappedType::None {
+        Err(crate::PyError::value_error("operation already attempted"))
+    } else {
+        Ok(())
+    }
+}
+
+fn accept_read_start_error(
+    state: &mut NativeOverlapped,
+    error: u32,
+) -> Result<PyObjectRef, crate::PyError> {
+    use host_winapi::{ERROR_BROKEN_PIPE, ERROR_IO_PENDING, ERROR_MORE_DATA, ERROR_SUCCESS};
+    state.error = error;
+    match error {
+        ERROR_BROKEN_PIPE => {
+            host_overlapped::mark_as_completed(&mut state.overlapped);
+            Err(win32_err_code(error))
+        }
+        ERROR_SUCCESS | ERROR_MORE_DATA | ERROR_IO_PENDING => Ok(pyre_object::w_none()),
+        _ => {
+            state.kind = OverlappedType::NotStarted;
+            Err(win32_err_code(error))
+        }
+    }
+}
+
+fn accept_write_start_error(
+    state: &mut NativeOverlapped,
+    error: u32,
+) -> Result<PyObjectRef, crate::PyError> {
+    state.error = error;
+    match error {
+        host_winapi::ERROR_SUCCESS | host_winapi::ERROR_IO_PENDING => Ok(pyre_object::w_none()),
+        _ => {
+            state.kind = OverlappedType::NotStarted;
+            Err(win32_err_code(error))
+        }
+    }
+}
+
+fn overlapped_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = args.first().copied().unwrap_or_else(overlapped_type);
+    if args.len() > 2 {
+        return Err(crate::PyError::type_error(
+            "Overlapped() takes at most one argument",
+        ));
+    }
+    let mut event = match args.get(1).copied() {
+        Some(w) => isize_w(w)?,
+        None => host_overlapped::INVALID_HANDLE_VALUE_ISIZE,
+    };
+    if event == host_overlapped::INVALID_HANDLE_VALUE_ISIZE {
+        event = host_winapi::create_event_w(true, false, None).map_err(win32_err)? as isize;
+    }
+    let mut overlapped: host_overlapped::OverlappedIo = unsafe { core::mem::zeroed() };
+    if event != 0 {
+        overlapped.hEvent = event as host_overlapped::Handle;
+    }
+    let backend = Box::into_raw(Box::new(Mutex::new(NativeOverlapped {
+        overlapped,
+        handle: std::ptr::null_mut(),
+        error: 0,
+        kind: OverlappedType::None,
+        buffer: Vec::new(),
+        address: Vec::new(),
+        recv_address: unsafe { core::mem::zeroed() },
+        recv_address_length: 0,
+        buffer_export_held: false,
+    })));
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(cls);
+    let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let obj = W_Overlapped::allocate_stable(W_Overlapped {
+        ob: PyObject::default(),
+        backend,
+        w_buffer: PY_NULL,
+        w_buffer_owner: PY_NULL,
+        w_result: PY_NULL,
+    });
+    Ok(crate::typedef::tag_subclass_instance(obj, unsafe {
+        pyre_object::gc_roots::shadow_stack_get(cls_slot)
+    }))
+}
+
+fn overlapped_cancel(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "cancel", 1, 1)?;
+    let obj = arg(args, 0, "cancel")?;
+    let state = native(obj)?.lock().unwrap();
+    if matches!(state.kind, OverlappedType::NotStarted) {
+        return Ok(pyre_object::w_none());
+    }
+    if !host_overlapped::has_overlapped_io_completed(&state.overlapped) {
+        host_overlapped::cancel_overlapped(state.handle, &state.overlapped).map_err(win32_err)?;
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn overlapped_getresult(args: &[PyObjectRef]) -> crate::PyResult {
+    use host_winapi::{ERROR_BROKEN_PIPE, ERROR_MORE_DATA, ERROR_SUCCESS};
+    method_arity(args, "getresult", 1, 2)?;
+    let obj = arg(args, 0, "getresult")?;
+    let wait = match args.get(1).copied() {
+        Some(w) => crate::baseobjspace::is_true(w)?,
+        None => false,
+    };
+    let mut state = native(obj)?.lock().unwrap();
+    match state.kind {
+        OverlappedType::None => {
+            return Err(crate::PyError::value_error("operation not yet attempted"));
+        }
+        OverlappedType::NotStarted => {
+            return Err(crate::PyError::value_error("operation failed to start"));
+        }
+        _ => {}
+    }
+    let result = host_overlapped::get_overlapped_result(state.handle, &state.overlapped, wait);
+    let transferred = result.transferred as usize;
+    state.error = result.error;
+    let broken_pipe_ok = matches!(
+        state.kind,
+        OverlappedType::Read
+            | OverlappedType::ReadInto
+            | OverlappedType::ReadFrom
+            | OverlappedType::ReadFromInto
+    );
+    match result.error {
+        ERROR_SUCCESS | ERROR_MORE_DATA => {}
+        ERROR_BROKEN_PIPE if broken_pipe_ok => {}
+        error => return Err(win32_err_code(error)),
+    }
+
+    match state.kind {
+        OverlappedType::Read => {
+            let count = transferred.min(state.buffer.len());
+            Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+                &state.buffer[..count],
+            ))
+        }
+        OverlappedType::ReadInto => {
+            let count = transferred.min(state.buffer.len());
+            let destination = writable_buffer(this(obj)?.w_buffer)?.0;
+            let count = count.min(destination.len());
+            destination[..count].copy_from_slice(&state.buffer[..count]);
+            Ok(pyre_object::w_int_new(count as i64))
+        }
+        OverlappedType::ReadFrom | OverlappedType::ReadFromInto => {
+            let cached = this(obj)?.w_result;
+            if !cached.is_null() {
+                return Ok(cached);
+            }
+            let address = unparse_address(&state.recv_address, state.recv_address_length)?;
+            let first = if state.kind == OverlappedType::ReadFrom {
+                let count = transferred.min(state.buffer.len());
+                pyre_object::bytesobject::w_bytes_from_bytes(&state.buffer[..count])
+            } else {
+                let count = transferred.min(state.buffer.len());
+                let destination = writable_buffer(this(obj)?.w_buffer)?.0;
+                let count = count.min(destination.len());
+                destination[..count].copy_from_slice(&state.buffer[..count]);
+                pyre_object::w_int_new(count as i64)
+            };
+            let result = pyre_object::w_tuple_new(vec![first, address]);
+            this(obj)?.w_result = result;
+            pyre_object::gc_hook::try_gc_write_barrier(obj as *mut u8);
+            Ok(result)
+        }
+        _ => Ok(pyre_object::w_int_new(transferred as i64)),
+    }
+}
+
+fn overlapped_read_file(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "ReadFile", 3, 3)?;
+    let obj = arg(args, 0, "ReadFile")?;
+    let handle = handle_w(arg(args, 1, "ReadFile")?)?;
+    let size = u32_w(arg(args, 2, "ReadFile")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle;
+    state.kind = OverlappedType::Read;
+    state.buffer = vec![0; usize::max(size as usize, 1)];
+    let error = host_overlapped::start_read_file(
+        handle,
+        state.buffer.as_mut_ptr(),
+        size,
+        &mut state.overlapped,
+    );
+    accept_read_start_error(&mut state, error)
+}
+
+fn overlapped_read_file_into(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "ReadFileInto", 3, 3)?;
+    let obj = arg(args, 0, "ReadFileInto")?;
+    let handle = handle_w(arg(args, 1, "ReadFileInto")?)?;
+    let w_buffer = arg(args, 2, "ReadFileInto")?;
+    {
+        let state = native(obj)?.lock().unwrap();
+        operation_already_attempted(&state)?;
+    }
+    let length = retain_writable_buffer(obj, w_buffer)?;
+    let size =
+        u32::try_from(length).map_err(|_| crate::PyError::value_error("buffer too large"))?;
+    let mut state = native(obj)?.lock().unwrap();
+    state.handle = handle;
+    state.kind = OverlappedType::ReadInto;
+    state.buffer = vec![0; usize::max(length, 1)];
+    let error = host_overlapped::start_read_file(
+        handle,
+        state.buffer.as_mut_ptr(),
+        size,
+        &mut state.overlapped,
+    );
+    accept_read_start_error(&mut state, error)
+}
+
+fn overlapped_write_file(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WriteFile", 3, 3)?;
+    let obj = arg(args, 0, "WriteFile")?;
+    let handle = handle_w(arg(args, 1, "WriteFile")?)?;
+    let buffer = copied_read_buffer(arg(args, 2, "WriteFile")?, "WriteFile")?;
+    let size =
+        u32::try_from(buffer.len()).map_err(|_| crate::PyError::value_error("buffer too large"))?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle;
+    state.kind = OverlappedType::Write;
+    state.buffer = buffer;
+    let error = host_overlapped::start_write_file(
+        handle,
+        state.buffer.as_ptr(),
+        size,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_wsa_recv(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSARecv", 3, 4)?;
+    let obj = arg(args, 0, "WSARecv")?;
+    let handle = isize_w(arg(args, 1, "WSARecv")?)?;
+    let size = u32_w(arg(args, 2, "WSARecv")?)?;
+    let mut flags = match args.get(3).copied() {
+        Some(w) => u32_w(w)?,
+        None => 0,
+    };
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle as host_overlapped::Handle;
+    state.kind = OverlappedType::Read;
+    state.buffer = vec![0; usize::max(size as usize, 1)];
+    let error = host_overlapped::start_wsa_recv(
+        handle as usize,
+        state.buffer.as_mut_ptr(),
+        size,
+        &mut flags,
+        &mut state.overlapped,
+    );
+    accept_read_start_error(&mut state, error)
+}
+
+fn overlapped_wsa_recv_into(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSARecvInto", 4, 4)?;
+    let obj = arg(args, 0, "WSARecvInto")?;
+    let handle = isize_w(arg(args, 1, "WSARecvInto")?)?;
+    let w_buffer = arg(args, 2, "WSARecvInto")?;
+    let mut flags = u32_w(arg(args, 3, "WSARecvInto")?)?;
+    {
+        let state = native(obj)?.lock().unwrap();
+        operation_already_attempted(&state)?;
+    }
+    let length = retain_writable_buffer(obj, w_buffer)?;
+    let size =
+        u32::try_from(length).map_err(|_| crate::PyError::value_error("buffer too large"))?;
+    let mut state = native(obj)?.lock().unwrap();
+    state.handle = handle as host_overlapped::Handle;
+    state.kind = OverlappedType::ReadInto;
+    state.buffer = vec![0; usize::max(length, 1)];
+    let error = host_overlapped::start_wsa_recv(
+        handle as usize,
+        state.buffer.as_mut_ptr(),
+        size,
+        &mut flags,
+        &mut state.overlapped,
+    );
+    accept_read_start_error(&mut state, error)
+}
+
+fn overlapped_wsa_send(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSASend", 4, 4)?;
+    let obj = arg(args, 0, "WSASend")?;
+    let handle = isize_w(arg(args, 1, "WSASend")?)?;
+    let buffer = copied_read_buffer(arg(args, 2, "WSASend")?, "WSASend")?;
+    let flags = u32_w(arg(args, 3, "WSASend")?)?;
+    let size =
+        u32::try_from(buffer.len()).map_err(|_| crate::PyError::value_error("buffer too large"))?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle as host_overlapped::Handle;
+    state.kind = OverlappedType::Write;
+    state.buffer = buffer;
+    let error = host_overlapped::start_wsa_send(
+        handle as usize,
+        state.buffer.as_ptr(),
+        size,
+        flags,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_accept_ex(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "AcceptEx", 3, 3)?;
+    let obj = arg(args, 0, "AcceptEx")?;
+    let listen = isize_w(arg(args, 1, "AcceptEx")?)?;
+    let accept = isize_w(arg(args, 2, "AcceptEx")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    let address_size = core::mem::size_of::<host_overlapped::SocketAddrV6>() + 16;
+    state.handle = listen as host_overlapped::Handle;
+    state.kind = OverlappedType::Accept;
+    state.buffer = vec![0; address_size * 2];
+    let error = host_overlapped::start_accept_ex(
+        listen as usize,
+        accept as usize,
+        state.buffer.as_mut_ptr(),
+        address_size as u32,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_connect_ex(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "ConnectEx", 3, 3)?;
+    let obj = arg(args, 0, "ConnectEx")?;
+    let socket = isize_w(arg(args, 1, "ConnectEx")?)?;
+    let (address, length) = parse_address(arg(args, 2, "ConnectEx")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = socket as host_overlapped::Handle;
+    state.kind = OverlappedType::Connect;
+    state.address = address;
+    let error = host_overlapped::start_connect_ex(
+        socket as usize,
+        state.address.as_ptr() as *const host_overlapped::SocketAddrRaw,
+        length,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_disconnect_ex(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "DisconnectEx", 3, 3)?;
+    let obj = arg(args, 0, "DisconnectEx")?;
+    let socket = isize_w(arg(args, 1, "DisconnectEx")?)?;
+    let flags = u32_w(arg(args, 2, "DisconnectEx")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = socket as host_overlapped::Handle;
+    state.kind = OverlappedType::Disconnect;
+    let error = host_overlapped::start_disconnect_ex(socket as usize, flags, &mut state.overlapped);
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_transmit_file(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "TransmitFile", 8, 8)?;
+    let obj = arg(args, 0, "TransmitFile")?;
+    let socket = isize_w(arg(args, 1, "TransmitFile")?)?;
+    let file = handle_w(arg(args, 2, "TransmitFile")?)?;
+    let offset = u32_w(arg(args, 3, "TransmitFile")?)?;
+    let offset_high = u32_w(arg(args, 4, "TransmitFile")?)?;
+    let count = u32_w(arg(args, 5, "TransmitFile")?)?;
+    let per_send = u32_w(arg(args, 6, "TransmitFile")?)?;
+    let flags = u32_w(arg(args, 7, "TransmitFile")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = socket as host_overlapped::Handle;
+    state.kind = OverlappedType::TransmitFile;
+    let error = host_overlapped::start_transmit_file(
+        socket as usize,
+        file,
+        count,
+        per_send,
+        flags,
+        offset,
+        offset_high,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn overlapped_connect_named_pipe(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "ConnectNamedPipe", 2, 2)?;
+    let obj = arg(args, 0, "ConnectNamedPipe")?;
+    let pipe = handle_w(arg(args, 1, "ConnectNamedPipe")?)?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = pipe;
+    state.kind = OverlappedType::ConnectNamedPipe;
+    let error = host_overlapped::start_connect_named_pipe(pipe, &mut state.overlapped);
+    state.error = error;
+    match error {
+        host_winapi::ERROR_PIPE_CONNECTED => {
+            host_overlapped::mark_as_completed(&mut state.overlapped);
+            Ok(pyre_object::w_bool_from(true))
+        }
+        host_winapi::ERROR_SUCCESS | host_winapi::ERROR_IO_PENDING => {
+            Ok(pyre_object::w_bool_from(false))
+        }
+        _ => {
+            state.kind = OverlappedType::NotStarted;
+            Err(win32_err_code(error))
+        }
+    }
+}
+
+fn start_recv_from(
+    obj: PyObjectRef,
+    handle: isize,
+    size: u32,
+    mut flags: u32,
+    kind: OverlappedType,
+) -> crate::PyResult {
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle as host_overlapped::Handle;
+    state.kind = kind;
+    state.buffer = vec![0; usize::max(size as usize, 1)];
+    state.recv_address = unsafe { core::mem::zeroed() };
+    state.recv_address_length = core::mem::size_of::<host_overlapped::SocketAddrV6>() as i32;
+    let state_ptr: *mut NativeOverlapped = &mut *state;
+    let error = unsafe {
+        host_overlapped::start_wsa_recv_from(
+            handle as usize,
+            (*state_ptr).buffer.as_mut_ptr(),
+            size,
+            &mut flags,
+            &mut (*state_ptr).recv_address as *mut _ as *mut host_overlapped::SocketAddrRaw,
+            &mut (*state_ptr).recv_address_length,
+            &mut (*state_ptr).overlapped,
+        )
+    };
+    accept_read_start_error(&mut state, error)
+}
+
+fn overlapped_wsa_recv_from(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSARecvFrom", 3, 4)?;
+    let obj = arg(args, 0, "WSARecvFrom")?;
+    let handle = isize_w(arg(args, 1, "WSARecvFrom")?)?;
+    let size = u32_w(arg(args, 2, "WSARecvFrom")?)?;
+    let flags = match args.get(3).copied() {
+        Some(w) => u32_w(w)?,
+        None => 0,
+    };
+    start_recv_from(obj, handle, size, flags, OverlappedType::ReadFrom)
+}
+
+fn overlapped_wsa_recv_from_into(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSARecvFromInto", 4, 5)?;
+    let obj = arg(args, 0, "WSARecvFromInto")?;
+    let handle = isize_w(arg(args, 1, "WSARecvFromInto")?)?;
+    let w_buffer = arg(args, 2, "WSARecvFromInto")?;
+    let requested = u32_w(arg(args, 3, "WSARecvFromInto")?)?;
+    let flags = match args.get(4).copied() {
+        Some(w) => u32_w(w)?,
+        None => 0,
+    };
+    {
+        let state = native(obj)?.lock().unwrap();
+        operation_already_attempted(&state)?;
+    }
+    let length = retain_writable_buffer(obj, w_buffer)?;
+    if requested as usize > length {
+        release_writable_buffer(obj)?;
+        return Err(crate::PyError::value_error("buffer too small"));
+    }
+    start_recv_from(obj, handle, requested, flags, OverlappedType::ReadFromInto)
+}
+
+fn overlapped_wsa_send_to(args: &[PyObjectRef]) -> crate::PyResult {
+    method_arity(args, "WSASendTo", 5, 5)?;
+    let obj = arg(args, 0, "WSASendTo")?;
+    let handle = isize_w(arg(args, 1, "WSASendTo")?)?;
+    let buffer = copied_read_buffer(arg(args, 2, "WSASendTo")?, "WSASendTo")?;
+    let flags = u32_w(arg(args, 3, "WSASendTo")?)?;
+    let (address, address_length) = parse_address(arg(args, 4, "WSASendTo")?)?;
+    let size =
+        u32::try_from(buffer.len()).map_err(|_| crate::PyError::value_error("buffer too large"))?;
+    let mut state = native(obj)?.lock().unwrap();
+    operation_already_attempted(&state)?;
+    state.handle = handle as host_overlapped::Handle;
+    state.kind = OverlappedType::WriteTo;
+    state.buffer = buffer;
+    state.address = address;
+    let error = host_overlapped::start_wsa_send_to(
+        handle as usize,
+        state.buffer.as_ptr(),
+        size,
+        flags,
+        state.address.as_ptr() as *const host_overlapped::SocketAddrRaw,
+        address_length,
+        &mut state.overlapped,
+    );
+    accept_write_start_error(&mut state, error)
+}
+
+fn property(ns: PyObjectRef, name: &'static str, getter: crate::BuiltinCodeFn) {
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            name,
+            crate::typedef::make_getset_descriptor_named(
+                crate::make_builtin_function_with_arity(name, getter, 2),
+                name,
+            ),
+        )
+    };
+}
+
+fn init_overlapped_type(ns: PyObjectRef) {
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__new__",
+            crate::typedef::make_new_descr(overlapped_new),
+        )
+    };
+    for (name, function) in [
+        ("cancel", overlapped_cancel as crate::BuiltinCodeFn),
+        ("getresult", overlapped_getresult),
+        ("ReadFile", overlapped_read_file),
+        ("ReadFileInto", overlapped_read_file_into),
+        ("WriteFile", overlapped_write_file),
+        ("WSARecv", overlapped_wsa_recv),
+        ("WSARecvInto", overlapped_wsa_recv_into),
+        ("WSASend", overlapped_wsa_send),
+        ("AcceptEx", overlapped_accept_ex),
+        ("ConnectEx", overlapped_connect_ex),
+        ("DisconnectEx", overlapped_disconnect_ex),
+        ("TransmitFile", overlapped_transmit_file),
+        ("ConnectNamedPipe", overlapped_connect_named_pipe),
+        ("WSARecvFrom", overlapped_wsa_recv_from),
+        ("WSARecvFromInto", overlapped_wsa_recv_from_into),
+        ("WSASendTo", overlapped_wsa_send_to),
+    ] {
+        unsafe {
+            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+                ns,
+                name,
+                crate::make_builtin_function(name, function),
+            )
+        };
+    }
+    property(ns, "address", |args| {
+        let state = native(arg(args, 1, "address")?)?.lock().unwrap();
+        Ok(pyre_object::w_int_new(
+            &state.overlapped as *const _ as usize as i64,
+        ))
+    });
+    property(ns, "pending", |args| {
+        let state = native(arg(args, 1, "pending")?)?.lock().unwrap();
+        Ok(pyre_object::w_bool_from(
+            !host_overlapped::has_overlapped_io_completed(&state.overlapped)
+                && state.kind != OverlappedType::NotStarted,
+        ))
+    });
+    property(ns, "error", |args| {
+        let state = native(arg(args, 1, "error")?)?.lock().unwrap();
+        Ok(pyre_object::w_int_new(state.error as i64))
+    });
+    property(ns, "event", |args| {
+        let state = native(arg(args, 1, "event")?)?.lock().unwrap();
+        Ok(pyre_object::w_int_new(
+            state.overlapped.hEvent as isize as i64,
+        ))
+    });
+}
+
+static OVERLAPPED_RUNTIME_TYPE: OnceLock<usize> = OnceLock::new();
+
+pub fn overlapped_type() -> PyObjectRef {
+    *OVERLAPPED_RUNTIME_TYPE.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type_with_layout(
+            "_overlapped.Overlapped",
+            init_overlapped_type,
+            crate::typedef::w_object(),
+            <W_Overlapped as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE,
+        );
+        pyre_object::pyobject::set_instantiate(
+            unsafe { &*<W_Overlapped as pyre_object::lltype::PyreClassPyTypeOf>::PYTYPE },
+            tp,
+        );
+        unsafe { pyre_object::w_type_set_acceptable_as_base_class(tp, false) };
+        tp as usize
+    }) as PyObjectRef
+}
+
+/// PyPy `Overlapped.__del__`: wait/cancel before native buffers are released,
+/// then close the event and restore the thread's last-error value.
+pub unsafe fn w_overlapped_dealloc(obj: PyObjectRef) {
+    let Some(this) = W_Overlapped::from_obj(obj) else {
+        return;
+    };
+    if this.backend.is_null() {
+        return;
+    }
+    let backend = unsafe { Box::from_raw(this.backend) };
+    this.backend = std::ptr::null_mut();
+    let mut state = backend.lock().unwrap();
+    let old_error = host_winapi::get_last_error();
+    if !host_overlapped::has_overlapped_io_completed(&state.overlapped)
+        && state.kind != OverlappedType::NotStarted
+    {
+        let _ = host_overlapped::cancel_overlapped_for_drop(state.handle, &state.overlapped);
+    }
+    if !state.overlapped.hEvent.is_null() {
+        let _ = host_winapi::close_handle(state.overlapped.hEvent);
+        state.overlapped.hEvent = std::ptr::null_mut();
+    }
+    if state.buffer_export_held && !this.w_buffer_owner.is_null() {
+        unsafe { crate::builtins::buffer_export_decref(this.w_buffer_owner) };
+        state.buffer_export_held = false;
+    }
+    host_windows::set_last_error(old_error);
+}
+
+fn connect_pipe(args: &[PyObjectRef]) -> crate::PyResult {
+    let address = crate::baseobjspace::text_w(arg(args, 0, "ConnectPipe")?)?;
+    host_overlapped::connect_pipe(address)
+        .map(|handle| pyre_object::w_int_new(handle as i64))
+        .map_err(win32_err)
+}
+
+fn create_iocp(args: &[PyObjectRef]) -> crate::PyResult {
+    host_overlapped::create_io_completion_port(
+        isize_w(arg(args, 0, "CreateIoCompletionPort")?)?,
+        isize_w(arg(args, 1, "CreateIoCompletionPort")?)?,
+        usize_w(arg(args, 2, "CreateIoCompletionPort")?)?,
+        u32_w(arg(args, 3, "CreateIoCompletionPort")?)?,
+    )
+    .map(|handle| pyre_object::w_int_new(handle as i64))
+    .map_err(win32_err)
+}
+
+fn get_queued_completion_status(args: &[PyObjectRef]) -> crate::PyResult {
+    match host_overlapped::get_queued_completion_status(
+        isize_w(arg(args, 0, "GetQueuedCompletionStatus")?)?,
+        u32_w(arg(args, 1, "GetQueuedCompletionStatus")?)?,
+    )
+    .map_err(win32_err)?
+    {
+        host_overlapped::WaitResult::Timeout => Ok(pyre_object::w_none()),
+        host_overlapped::WaitResult::Queued(status) => Ok(pyre_object::w_tuple_new(vec![
+            pyre_object::w_int_new(status.error as i64),
+            pyre_object::w_int_new(status.bytes_transferred as i64),
+            pyre_object::w_int_new(status.completion_key as i64),
+            pyre_object::w_int_new(status.overlapped as i64),
+        ])),
+    }
+}
+
+fn post_queued_completion_status(args: &[PyObjectRef]) -> crate::PyResult {
+    host_overlapped::post_queued_completion_status(
+        isize_w(arg(args, 0, "PostQueuedCompletionStatus")?)?,
+        u32_w(arg(args, 1, "PostQueuedCompletionStatus")?)?,
+        usize_w(arg(args, 2, "PostQueuedCompletionStatus")?)?,
+        usize_w(arg(args, 3, "PostQueuedCompletionStatus")?)?,
+    )
+    .map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn register_wait_with_queue(args: &[PyObjectRef]) -> crate::PyResult {
+    host_overlapped::register_wait_with_queue(
+        isize_w(arg(args, 0, "RegisterWaitWithQueue")?)?,
+        isize_w(arg(args, 1, "RegisterWaitWithQueue")?)?,
+        usize_w(arg(args, 2, "RegisterWaitWithQueue")?)?,
+        u32_w(arg(args, 3, "RegisterWaitWithQueue")?)?,
+    )
+    .map(|handle| pyre_object::w_int_new(handle as i64))
+    .map_err(win32_err)
+}
+
+fn unregister_wait(args: &[PyObjectRef]) -> crate::PyResult {
+    host_overlapped::unregister_wait(isize_w(arg(args, 0, "UnregisterWait")?)?)
+        .map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn unregister_wait_ex(args: &[PyObjectRef]) -> crate::PyResult {
+    host_overlapped::unregister_wait_ex(
+        isize_w(arg(args, 0, "UnregisterWaitEx")?)?,
+        isize_w(arg(args, 1, "UnregisterWaitEx")?)?,
+    )
+    .map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn bind_local(args: &[PyObjectRef]) -> crate::PyResult {
+    let socket = isize_w(arg(args, 0, "BindLocal")?)?;
+    let family = crate::baseobjspace::c_int_w(arg(args, 1, "BindLocal")?)?;
+    if family != host_overlapped::AF_INET_FAMILY && family != host_overlapped::AF_INET6_FAMILY {
+        return Err(crate::PyError::value_error(
+            "expected tuple of length 2 or 4",
+        ));
+    }
+    host_overlapped::bind_local(socket, family).map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn format_message(args: &[PyObjectRef]) -> crate::PyResult {
+    Ok(pyre_object::w_str_new(&host_overlapped::format_message(
+        u32_w(arg(args, 0, "FormatMessage")?)?,
+    )))
+}
+
+fn wsa_connect(args: &[PyObjectRef]) -> crate::PyResult {
+    let socket = isize_w(arg(args, 0, "WSAConnect")?)?;
+    let (address, length) = parse_address(arg(args, 1, "WSAConnect")?)?;
+    host_overlapped::wsa_connect(
+        socket,
+        address.as_ptr() as *const host_overlapped::SocketAddrRaw,
+        length,
+    )
+    .map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn create_event(args: &[PyObjectRef]) -> crate::PyResult {
+    let attributes = arg(args, 0, "CreateEvent")?;
+    if !unsafe { pyre_object::is_none(attributes) } {
+        return Err(crate::PyError::value_error("EventAttributes must be None"));
+    }
+    let manual_reset = crate::baseobjspace::is_true(arg(args, 1, "CreateEvent")?)?;
+    let initial_state = crate::baseobjspace::is_true(arg(args, 2, "CreateEvent")?)?;
+    let w_name = arg(args, 3, "CreateEvent")?;
+    let name = if unsafe { pyre_object::is_none(w_name) } {
+        None
+    } else {
+        Some(
+            widestring::WideCString::from_str(crate::baseobjspace::text_w(w_name)?)
+                .map_err(|_| crate::PyError::value_error("embedded null character"))?,
+        )
+    };
+    host_winapi::create_event_w(manual_reset, initial_state, name.as_deref())
+        .map(|handle| pyre_object::w_int_new(handle as isize as i64))
+        .map_err(win32_err)
+}
+
+fn set_event(args: &[PyObjectRef]) -> crate::PyResult {
+    host_winapi::set_event(handle_w(arg(args, 0, "SetEvent")?)?).map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+fn reset_event(args: &[PyObjectRef]) -> crate::PyResult {
+    host_winapi::reset_event(handle_w(arg(args, 0, "ResetEvent")?)?).map_err(win32_err)?;
+    Ok(pyre_object::w_none())
+}
+
+pub fn init(ns: PyObjectRef) {
+    // PyPy imports `_socket` before resolving the extension-function GUIDs.
+    // The host layer exposes the same process-global WSAStartup owner, so the
+    // builtin can establish that prerequisite without creating a second
+    // module-local or thread-local socket state.
+    host_windows::init_winsock();
+    if let Err(error) = host_overlapped::initialize_winsock_extensions() {
+        // Module initialization cannot return a PyResult in the current mixed
+        // module ABI.  `_socket` repeats WSA startup and each operation reports
+        // its own exact error; retain the importable module surface here.
+        let _ = error;
+    }
+    for (name, value) in [
+        ("ERROR_IO_PENDING", host_winapi::ERROR_IO_PENDING as i64),
+        (
+            "ERROR_NETNAME_DELETED",
+            host_winapi::ERROR_NETNAME_DELETED as i64,
+        ),
+        (
+            "ERROR_OPERATION_ABORTED",
+            host_winapi::ERROR_OPERATION_ABORTED as i64,
+        ),
+        ("ERROR_PIPE_BUSY", host_winapi::ERROR_PIPE_BUSY as i64),
+        (
+            "ERROR_PORT_UNREACHABLE",
+            host_winapi::ERROR_PORT_UNREACHABLE as i64,
+        ),
+        ("ERROR_SEM_TIMEOUT", host_winapi::ERROR_SEM_TIMEOUT as i64),
+        (
+            "SO_UPDATE_ACCEPT_CONTEXT",
+            host_overlapped::SO_UPDATE_ACCEPT_CONTEXT_VALUE as i64,
+        ),
+        (
+            "SO_UPDATE_CONNECT_CONTEXT",
+            host_overlapped::SO_UPDATE_CONNECT_CONTEXT_VALUE as i64,
+        ),
+        (
+            "TF_REUSE_SOCKET",
+            host_overlapped::TF_REUSE_SOCKET_FLAG as i64,
+        ),
+        ("INFINITE", host_winapi::INFINITE_TIMEOUT as i64),
+        (
+            "INVALID_HANDLE_VALUE",
+            host_overlapped::INVALID_HANDLE_VALUE_ISIZE as i64,
+        ),
+        ("NULL", 0),
+    ] {
+        crate::module_ns_store(ns, name, pyre_object::w_int_new(value));
+    }
+    crate::module_ns_store(ns, "Overlapped", overlapped_type());
+    for (name, arity, function) in [
+        ("ConnectPipe", 1, connect_pipe as crate::BuiltinCodeFn),
+        ("CreateIoCompletionPort", 4, create_iocp),
+        ("GetQueuedCompletionStatus", 2, get_queued_completion_status),
+        (
+            "PostQueuedCompletionStatus",
+            4,
+            post_queued_completion_status,
+        ),
+        ("RegisterWaitWithQueue", 4, register_wait_with_queue),
+        ("UnregisterWait", 1, unregister_wait),
+        ("UnregisterWaitEx", 2, unregister_wait_ex),
+        ("BindLocal", 2, bind_local),
+        ("FormatMessage", 1, format_message),
+        ("WSAConnect", 2, wsa_connect),
+        ("CreateEvent", 4, create_event),
+        ("SetEvent", 1, set_event),
+        ("ResetEvent", 1, reset_event),
+    ] {
+        crate::module_ns_store(
+            ns,
+            name,
+            crate::gateway::with_module(
+                "_overlapped",
+                crate::make_module_builtin_function_with_arity(name, function, arity),
+            ),
+        );
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -13,64 +13,6 @@
 #[cfg(any(unix, windows))]
 use super::rsocket_rffi as rffi;
 
-// The legacy <netdb.h> resolver entry points, missing from libc 0.2.186.
-// They return pointers into process-global storage and have no WinSock
-// counterpart with the same struct layout, so their callers stay POSIX-only.
-#[cfg(unix)]
-unsafe extern "C" {
-    fn gethostbyname(name: *const libc::c_char) -> *mut HostentRaw;
-    fn gethostbyaddr(
-        addr: *const libc::c_void,
-        len: libc::socklen_t,
-        family: libc::c_int,
-    ) -> *mut HostentRaw;
-    fn getservbyname(name: *const libc::c_char, proto: *const libc::c_char) -> *mut ServentRaw;
-    fn getservbyport(port: libc::c_int, proto: *const libc::c_char) -> *mut ServentRaw;
-}
-
-/// Minimal mirror of `struct hostent` — we only read `h_addr_list[0]`
-/// and `h_length`, so the rest can stay opaque.
-#[cfg(unix)]
-#[repr(C)]
-#[allow(non_snake_case, dead_code)]
-struct HostentRaw {
-    h_name: *const libc::c_char,
-    h_aliases: *mut *mut libc::c_char,
-    h_addrtype: libc::c_int,
-    h_length: libc::c_int,
-    h_addr_list: *mut *mut libc::c_char,
-}
-
-/// Darwin's resolver may pack the pointer arrays owned by `hostent` at
-/// byte-aligned addresses (for example, immediately after a C string).
-/// C permits the resulting unaligned pointer loads; Rust references do not.
-/// Read each array slot as raw C storage, matching RPython's rffi access in
-/// `rsocket.gethost_common` without manufacturing an aligned reference.
-#[cfg(unix)]
-unsafe fn hostent_pointer_at(array: *mut *mut libc::c_char, index: usize) -> *mut libc::c_char {
-    unsafe { std::ptr::read_unaligned(array.add(index)) }
-}
-
-/// Minimal mirror of `struct servent` — we read `s_name` and `s_port`.
-#[cfg(unix)]
-#[repr(C)]
-#[allow(non_snake_case, dead_code)]
-struct ServentRaw {
-    s_name: *const libc::c_char,
-    s_aliases: *mut *mut libc::c_char,
-    s_port: libc::c_int,
-    s_proto: *const libc::c_char,
-}
-
-/// RPython `rsocket._get_netdb_lock_thread`: legacy gethostbyname/
-/// gethostbyaddr return pointers into one process-global static hostent.
-/// Keep lookup and copying under the same process-global lock.
-#[cfg(unix)]
-fn netdb_lock() -> std::sync::MutexGuard<'static, ()> {
-    static NETDB_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-    NETDB_LOCK.lock().unwrap_or_else(|poisoned| poisoned.into_inner())
-}
-
 /// _socket module — PyPy: pypy/module/_socket/.
 ///
 /// **Slice S1: constants + name resolution helpers.**
@@ -982,12 +924,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
     }
 
-    // The legacy resolver entry points and `sethostname`, which have no
-    // WinSock counterpart this module can reach through the same struct.
-    #[cfg(unix)]
+    // `sethostname` alone stays POSIX-only: WinSock has no counterpart and
+    // `moduledef.py` does not export it where rsocket cannot provide it.
+    #[cfg(all(unix, feature = "host_env"))]
     {
         // sethostname(name) → None  (host_env::socket-backed)
-        #[cfg(feature = "host_env")]
         crate::module_ns_store(
             ns,
             "sethostname",
@@ -1030,7 +971,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 1,
             ),
         );
+    }
 
+    // The legacy resolvers. Both platforms reach them through
+    // `rsocket_rffi`'s accessors, because the records they answer with are
+    // not the same type on each — see the netdb section there.
+    #[cfg(any(unix, windows))]
+    {
         // gethostbyname(name) → ip_string.  `interp_func.py:32-44` —
         // host argument runs through encode_idna (→ idna_converter)
         // before the rsocket call.
@@ -1048,8 +995,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let host_bytes = socket_idna_converter(args[0])?;
                     let c = std::ffi::CString::new(host_bytes.clone())
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let _netdb = netdb_lock();
-                    let he = unsafe { gethostbyname(c.as_ptr()) };
+                    let _netdb = rffi::netdb_lock();
+                    let he = unsafe { rffi::host_by_name(c.as_ptr()) };
                     if he.is_null() {
                         let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
                         return Err(socket_converted_error(
@@ -1059,9 +1006,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     unsafe {
-                        let h = &*he;
-                        let first_addr = hostent_pointer_at(h.h_addr_list, 0);
-                        if h.h_length != 4 || first_addr.is_null() {
+                        let first_addr = rffi::pointer_at(rffi::hostent_addr_list(he), 0);
+                        if rffi::hostent_length(he) != 4 || first_addr.is_null() {
                             return Err(socket_converted_error(
                                 "gaierror",
                                 None,
@@ -1100,8 +1046,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let host_bytes = socket_idna_converter(args[0])?;
                     let c = std::ffi::CString::new(host_bytes.clone())
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let _netdb = netdb_lock();
-                    let he = unsafe { gethostbyname(c.as_ptr()) };
+                    let _netdb = rffi::netdb_lock();
+                    let he = unsafe { rffi::host_by_name(c.as_ptr()) };
                     if he.is_null() {
                         let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
                         return Err(socket_converted_error(
@@ -1134,7 +1080,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let host_bytes = socket_idna_converter(args[0])?;
                     let c = std::ffi::CString::new(host_bytes.clone())
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
-                    let _netdb = netdb_lock();
+                    let _netdb = rffi::netdb_lock();
                     // Try IPv4 first, then IPv6, then fall back to
                     // gethostbyname → hostent.h_addr to obtain a raw
                     // bytestring for gethostbyaddr.
@@ -1167,8 +1113,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             // FFI call safely.
                             let mut owned: [u8; 16] = buf6;
                             let he = unsafe {
-                                gethostbyaddr(
-                                    owned.as_mut_ptr() as *mut libc::c_void,
+                                rffi::host_by_addr(
+                                    owned.as_mut_ptr() as *const libc::c_void,
                                     16 as rffi::SockLen,
                                     rffi::AF_INET6,
                                 )
@@ -1184,7 +1130,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             return unpack_hostent(he);
                         }
                         // Fall back: name → hostent → first IPv4 addr
-                        let he = unsafe { gethostbyname(c.as_ptr()) };
+                        let he = unsafe { rffi::host_by_name(c.as_ptr()) };
                         if he.is_null() {
                             let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
                             return Err(socket_converted_error(
@@ -1194,8 +1140,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             ));
                         }
                         unsafe {
-                            let h = &*he;
-                            let first_addr = hostent_pointer_at(h.h_addr_list, 0);
+                            let first_addr =
+                                rffi::pointer_at(rffi::hostent_addr_list(he), 0);
                             if first_addr.is_null() {
                                 return Err(socket_converted_error(
                                     "herror",
@@ -1204,13 +1150,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                 ));
                             }
                             (
-                                h.h_addrtype as libc::c_int,
+                                rffi::hostent_addr_type(he),
                                 first_addr as *const libc::c_void,
-                                h.h_length as rffi::SockLen,
+                                rffi::hostent_length(he) as rffi::SockLen,
                             )
                         }
                     };
-                    let he = unsafe { gethostbyaddr(addr_ptr, addr_len, family) };
+                    let he = unsafe { rffi::host_by_addr(addr_ptr, addr_len, family) };
                     if he.is_null() {
                         let host_repr = String::from_utf8_lossy(&host_bytes).into_owned();
                         return Err(socket_converted_error(
@@ -1256,7 +1202,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         None
                     };
                 let p = unsafe {
-                    getservbyname(
+                    rffi::serv_by_name(
                         c_name.as_ptr(),
                         proto_c
                             .as_ref()
@@ -1271,7 +1217,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         &format!("service/proto not found: {name}"),
                     ));
                 }
-                let port = unsafe { u16::from_be((*p).s_port as u16) };
+                let port = unsafe { u16::from_be(rffi::servent_port(p)) };
                 Ok(pyre_object::w_int_new(port as i64))
             }),
         );
@@ -1298,7 +1244,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         None
                     };
                 let p = unsafe {
-                    getservbyport(
+                    rffi::serv_by_port(
                         port.to_be() as libc::c_int,
                         proto_c
                             .as_ref()
@@ -1314,7 +1260,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     ));
                 }
                 let name = unsafe {
-                    std::ffi::CStr::from_ptr((*p).s_name)
+                    std::ffi::CStr::from_ptr(rffi::servent_name(p))
                         .to_string_lossy()
                         .into_owned()
                 };
@@ -1775,26 +1721,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 }
 
 // ── hostent → (name, aliases, addrs) ──
-// `interp_func.py:46-51 common_wrapgethost` — packs a libc hostent
+// `interp_func.py:46-51 common_wrapgethost` — packs a resolver hostent
 // into the 3-tuple shape used by gethostbyname_ex / gethostbyaddr.
-#[cfg(unix)]
-fn unpack_hostent(he: *mut HostentRaw) -> Result<pyre_object::PyObjectRef, crate::PyError> {
+#[cfg(any(unix, windows))]
+fn unpack_hostent(he: *mut rffi::Hostent) -> Result<pyre_object::PyObjectRef, crate::PyError> {
     unsafe {
-        let h = &*he;
-        let name = if h.h_name.is_null() {
+        let host_name = rffi::hostent_name(he);
+        let name = if host_name.is_null() {
             String::new()
         } else {
-            std::ffi::CStr::from_ptr(h.h_name)
+            std::ffi::CStr::from_ptr(host_name)
                 .to_string_lossy()
                 .into_owned()
         };
         // Copy all resolver-owned storage while the process-global netdb lock
         // is held, before allocating any Python objects.
+        let aliases = rffi::hostent_aliases(he);
         let mut alias_strings = Vec::new();
-        if !h.h_aliases.is_null() {
+        if !aliases.is_null() {
             let mut index = 0;
             loop {
-                let alias = hostent_pointer_at(h.h_aliases, index);
+                let alias = rffi::pointer_at(aliases, index);
                 if alias.is_null() {
                     break;
                 }
@@ -1802,18 +1749,21 @@ fn unpack_hostent(he: *mut HostentRaw) -> Result<pyre_object::PyObjectRef, crate
                 index += 1;
             }
         }
+        let addr_list = rffi::hostent_addr_list(he);
+        let addr_type = rffi::hostent_addr_type(he);
+        let addr_length = rffi::hostent_length(he);
         let mut addr_strings = Vec::new();
-        if !h.h_addr_list.is_null() {
+        if !addr_list.is_null() {
             let mut index = 0;
             loop {
-                let addr_ptr = hostent_pointer_at(h.h_addr_list, index);
+                let addr_ptr = rffi::pointer_at(addr_list, index);
                 if addr_ptr.is_null() {
                     break;
                 }
-                let addr_str = if h.h_addrtype == rffi::AF_INET && h.h_length == 4 {
+                let addr_str = if addr_type == rffi::AF_INET && addr_length == 4 {
                     let packed = std::ptr::read_unaligned(addr_ptr as *const u32).to_ne_bytes();
                     rffi::inet_ntoa(packed).unwrap_or_default()
-                } else if h.h_addrtype == rffi::AF_INET6 && h.h_length == 16 {
+                } else if addr_type == rffi::AF_INET6 && addr_length == 16 {
                     let mut packed_addr = [0u8; 16];
                     std::ptr::copy_nonoverlapping(
                         addr_ptr as *const u8,
@@ -1847,10 +1797,19 @@ fn unpack_hostent(he: *mut HostentRaw) -> Result<pyre_object::PyObjectRef, crate
             .iter()
             .map(|addr| pyre_object::w_str_new(addr))
             .collect();
+        // `w_list_new` roots the items it is handed, not the header it returns,
+        // and that header is a movable nursery object (`rlist.py:116 LIST =
+        // GcStruct`). Each list therefore stays pinned across the allocation
+        // that follows it and is re-read from its slot afterwards.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let aliases_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_list_new(aliases));
+        let addrs_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::w_list_new(addrs));
         Ok(pyre_object::w_tuple_new(vec![
             pyre_object::w_str_new(&name),
-            pyre_object::w_list_new(aliases),
-            pyre_object::w_list_new(addrs),
+            pyre_object::gc_roots::shadow_stack_get(aliases_slot),
+            pyre_object::gc_roots::shadow_stack_get(addrs_slot),
         ]))
     }
 }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -7,22 +7,17 @@
 //! functions and the `socket` type definition.
 
 
-// POSIX socket FFI declarations missing from libc 0.2.186.  These are
-// universal symbols from <arpa/inet.h>, <netdb.h>, <unistd.h>; we
-// declare them at module scope so both init_socket and the socket()
-// instance methods can call them.
+/// The host socket layer, in the role `_rsocket_rffi.py` plays for rsocket:
+/// one set of names over libc and WinSock, so the bodies below name a single
+/// API.
+#[cfg(any(unix, windows))]
+use super::rsocket_rffi as rffi;
+
+// The legacy <netdb.h> resolver entry points, missing from libc 0.2.186.
+// They return pointers into process-global storage and have no WinSock
+// counterpart with the same struct layout, so their callers stay POSIX-only.
 #[cfg(unix)]
 unsafe extern "C" {
-    fn inet_aton(cp: *const libc::c_char, inp: *mut libc::in_addr) -> libc::c_int;
-    fn inet_ntoa(addr: libc::in_addr) -> *mut libc::c_char;
-    fn inet_pton(af: libc::c_int, src: *const libc::c_char, dst: *mut libc::c_void) -> libc::c_int;
-    fn inet_ntop(
-        af: libc::c_int,
-        src: *const libc::c_void,
-        dst: *mut libc::c_char,
-        size: libc::socklen_t,
-    ) -> *const libc::c_char;
-    fn gethostname(name: *mut libc::c_char, len: libc::size_t) -> libc::c_int;
     fn gethostbyname(name: *const libc::c_char) -> *mut HostentRaw;
     fn gethostbyaddr(
         addr: *const libc::c_void,
@@ -114,7 +109,7 @@ fn netdb_lock() -> std::sync::MutexGuard<'static, ()> {
 /// UnicodeEncodeError falls back to the `idna` codec.  Embedded null
 /// bytes raise TypeError (matching `:120-122`).  Other input types
 /// raise TypeError.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     if w_host.is_null() {
         return Err(crate::PyError::type_error(
@@ -153,7 +148,7 @@ fn socket_idna_converter(w_host: pyre_object::PyObjectRef) -> Result<Vec<u8>, cr
     Ok(bytes)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_converted_error(
     applevelerrcls: &str,
     errno: Option<i32>,
@@ -191,7 +186,7 @@ fn socket_converted_error(
 /// requested object and the concrete storage owner are both rooted, because
 /// the release in `Drop` has to name the owner after whatever Python ran in
 /// between.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 struct SocketWritableBuffer {
     _roots: pyre_object::gc_roots::RootScope,
     owner_slot: usize,
@@ -200,7 +195,7 @@ struct SocketWritableBuffer {
     length: usize,
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 impl SocketWritableBuffer {
     unsafe fn acquire(obj: pyre_object::PyObjectRef) -> Result<Self, crate::PyError> {
         let roots = pyre_object::gc_roots::push_roots();
@@ -226,7 +221,7 @@ impl SocketWritableBuffer {
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 impl Drop for SocketWritableBuffer {
     fn drop(&mut self) {
         if self.held {
@@ -241,7 +236,7 @@ impl Drop for SocketWritableBuffer {
 /// PyPy accepts any object exporting a writable buffer; pyre's writable byte
 /// stores are `bytearray` and a `memoryview` over one, so those are resolved
 /// here and anything else is rejected as `writebuf_w` does.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_writebuf(
     obj: pyre_object::PyObjectRef,
 ) -> Result<(&'static mut [u8], pyre_object::PyObjectRef), crate::PyError> {
@@ -308,6 +303,14 @@ fn socket_writebuf(
 }
 
 pub fn register_module(ns: pyre_object::PyObjectRef) {
+    // `_rsocket_rffi.py:1150 rwin32.get_wsa_error`'s companion: WinSock has to
+    // be started before any of its entry points answers, so the module takes
+    // that cost at import rather than leaving the first call to fail with
+    // WSANOTINITIALISED.  The individual entry points repeat it, since nothing
+    // guarantees `_socket` is the first importer.
+    #[cfg(any(unix, windows))]
+    rffi::init();
+
     // `_rsocket_rffi.py:140-220 constant_names` + `:234-262
     // constants_w_defaults` — populated through the libc crate where
     // available, hardcoded for platform-specific constants the crate
@@ -558,6 +561,180 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("SOMAXCONN", libc::SOMAXCONN);
     }
 
+    // `_rsocket_rffi.py` keeps a separate `_MSVC` constant list because the
+    // two headers name overlapping but different sets; this is that list.
+    // The `Networking::WinSock` values are `<winsock2.h>`/`<ws2tcpip.h>`
+    // themselves, so what is absent here is absent from the platform.
+    #[cfg(windows)]
+    {
+        use windows_sys::Win32::Networking::WinSock as ws;
+        macro_rules! cst {
+            ($name:literal, $val:expr) => {
+                crate::module_ns_store(ns, $name, pyre_object::w_int_new($val as i64));
+            };
+        }
+        // ── Address families ──
+        cst!("AF_UNSPEC", ws::AF_UNSPEC);
+        cst!("AF_INET", ws::AF_INET);
+        cst!("AF_INET6", ws::AF_INET6);
+        cst!("AF_APPLETALK", ws::AF_APPLETALK);
+        cst!("AF_DECnet", ws::AF_DECnet);
+        cst!("AF_IPX", ws::AF_IPX);
+        cst!("AF_LINK", ws::AF_LINK);
+        // ── Socket types ──
+        cst!("SOCK_STREAM", ws::SOCK_STREAM);
+        cst!("SOCK_DGRAM", ws::SOCK_DGRAM);
+        cst!("SOCK_RAW", ws::SOCK_RAW);
+        cst!("SOCK_RDM", ws::SOCK_RDM);
+        cst!("SOCK_SEQPACKET", ws::SOCK_SEQPACKET);
+        // ── Protocols ──
+        cst!("IPPROTO_IP", ws::IPPROTO_IP);
+        cst!("IPPROTO_HOPOPTS", ws::IPPROTO_HOPOPTS);
+        cst!("IPPROTO_ICMP", ws::IPPROTO_ICMP);
+        cst!("IPPROTO_IGMP", ws::IPPROTO_IGMP);
+        cst!("IPPROTO_GGP", ws::IPPROTO_GGP);
+        cst!("IPPROTO_IPV4", ws::IPPROTO_IPV4);
+        cst!("IPPROTO_TCP", ws::IPPROTO_TCP);
+        cst!("IPPROTO_EGP", ws::IPPROTO_EGP);
+        cst!("IPPROTO_PUP", ws::IPPROTO_PUP);
+        cst!("IPPROTO_UDP", ws::IPPROTO_UDP);
+        cst!("IPPROTO_IDP", ws::IPPROTO_IDP);
+        cst!("IPPROTO_IPV6", ws::IPPROTO_IPV6);
+        cst!("IPPROTO_ROUTING", ws::IPPROTO_ROUTING);
+        cst!("IPPROTO_FRAGMENT", ws::IPPROTO_FRAGMENT);
+        cst!("IPPROTO_ESP", ws::IPPROTO_ESP);
+        cst!("IPPROTO_AH", ws::IPPROTO_AH);
+        cst!("IPPROTO_ICMPV6", ws::IPPROTO_ICMPV6);
+        cst!("IPPROTO_NONE", ws::IPPROTO_NONE);
+        cst!("IPPROTO_DSTOPTS", ws::IPPROTO_DSTOPTS);
+        cst!("IPPROTO_ND", ws::IPPROTO_ND);
+        cst!("IPPROTO_PIM", ws::IPPROTO_PIM);
+        cst!("IPPROTO_PGM", ws::IPPROTO_PGM);
+        cst!("IPPROTO_RDP", ws::IPPROTO_RDP);
+        cst!("IPPROTO_SCTP", ws::IPPROTO_SCTP);
+        cst!("IPPROTO_RAW", ws::IPPROTO_RAW);
+        cst!("IPPROTO_MAX", ws::IPPROTO_MAX);
+        // `_rsocket_rffi.py:234-241 constants_w_defaults` — SOL_IP/TCP/UDP
+        // kept for PyPy compatibility.
+        cst!("SOL_IP", 0);
+        cst!("SOL_TCP", 6);
+        cst!("SOL_UDP", 17);
+        // ── INADDR_* (host byte order) ──
+        cst!("INADDR_ANY", ws::INADDR_ANY);
+        cst!("INADDR_LOOPBACK", ws::INADDR_LOOPBACK);
+        cst!("INADDR_BROADCAST", ws::INADDR_BROADCAST);
+        cst!("INADDR_NONE", ws::INADDR_NONE);
+        cst!("INADDR_ALLHOSTS_GROUP", 0xe0000001u32);
+        cst!("INADDR_UNSPEC_GROUP", 0xe0000000u32);
+        cst!("INADDR_MAX_LOCAL_GROUP", 0xe00000ffu32);
+        cst!("IPPORT_RESERVED", ws::IPPORT_RESERVED);
+        cst!("IPPORT_USERRESERVED", 5000);
+        // ── SOL_* / SO_* (socket level) ──
+        cst!("SOL_SOCKET", ws::SOL_SOCKET);
+        cst!("SO_REUSEADDR", ws::SO_REUSEADDR);
+        cst!("SO_EXCLUSIVEADDRUSE", ws::SO_EXCLUSIVEADDRUSE);
+        cst!("SO_KEEPALIVE", ws::SO_KEEPALIVE);
+        cst!("SO_BROADCAST", ws::SO_BROADCAST);
+        cst!("SO_DEBUG", ws::SO_DEBUG);
+        cst!("SO_DONTROUTE", ws::SO_DONTROUTE);
+        cst!("SO_LINGER", ws::SO_LINGER);
+        cst!("SO_OOBINLINE", ws::SO_OOBINLINE);
+        cst!("SO_RCVBUF", ws::SO_RCVBUF);
+        cst!("SO_SNDBUF", ws::SO_SNDBUF);
+        cst!("SO_RCVTIMEO", ws::SO_RCVTIMEO);
+        cst!("SO_SNDTIMEO", ws::SO_SNDTIMEO);
+        cst!("SO_ERROR", ws::SO_ERROR);
+        cst!("SO_TYPE", ws::SO_TYPE);
+        cst!("SO_ACCEPTCONN", ws::SO_ACCEPTCONN);
+        cst!("SO_USELOOPBACK", ws::SO_USELOOPBACK);
+        // ── TCP-level ──
+        cst!("TCP_NODELAY", ws::TCP_NODELAY);
+        cst!("TCP_MAXSEG", ws::TCP_MAXSEG);
+        cst!("TCP_KEEPALIVE", ws::TCP_KEEPALIVE);
+        // ── IP-level ──
+        cst!("IP_TTL", ws::IP_TTL);
+        cst!("IP_TOS", ws::IP_TOS);
+        cst!("IP_OPTIONS", ws::IP_OPTIONS);
+        cst!("IP_MULTICAST_TTL", ws::IP_MULTICAST_TTL);
+        cst!("IP_MULTICAST_LOOP", ws::IP_MULTICAST_LOOP);
+        cst!("IP_MULTICAST_IF", ws::IP_MULTICAST_IF);
+        cst!("IP_ADD_MEMBERSHIP", ws::IP_ADD_MEMBERSHIP);
+        cst!("IP_DROP_MEMBERSHIP", ws::IP_DROP_MEMBERSHIP);
+        cst!("IP_HDRINCL", ws::IP_HDRINCL);
+        cst!("IP_RECVDSTADDR", ws::IP_RECVDSTADDR);
+        cst!("IP_DEFAULT_MULTICAST_LOOP", 1);
+        cst!("IP_DEFAULT_MULTICAST_TTL", 1);
+        cst!("IP_MAX_MEMBERSHIPS", 20);
+        // ── IPv6 ──
+        cst!("IPV6_V6ONLY", ws::IPV6_V6ONLY);
+        cst!("IPV6_CHECKSUM", ws::IPV6_CHECKSUM);
+        cst!("IPV6_DONTFRAG", ws::IPV6_DONTFRAG);
+        cst!("IPV6_HOPLIMIT", ws::IPV6_HOPLIMIT);
+        cst!("IPV6_HOPOPTS", ws::IPV6_HOPOPTS);
+        cst!("IPV6_JOIN_GROUP", ws::IPV6_JOIN_GROUP);
+        cst!("IPV6_LEAVE_GROUP", ws::IPV6_LEAVE_GROUP);
+        cst!("IPV6_MULTICAST_HOPS", ws::IPV6_MULTICAST_HOPS);
+        cst!("IPV6_MULTICAST_IF", ws::IPV6_MULTICAST_IF);
+        cst!("IPV6_MULTICAST_LOOP", ws::IPV6_MULTICAST_LOOP);
+        cst!("IPV6_PKTINFO", ws::IPV6_PKTINFO);
+        cst!("IPV6_RECVRTHDR", ws::IPV6_RECVRTHDR);
+        cst!("IPV6_RECVTCLASS", ws::IPV6_RECVTCLASS);
+        cst!("IPV6_RTHDR", ws::IPV6_RTHDR);
+        cst!("IPV6_TCLASS", ws::IPV6_TCLASS);
+        cst!("IPV6_UNICAST_HOPS", ws::IPV6_UNICAST_HOPS);
+        // ── shutdown how ──
+        cst!("SHUT_RD", ws::SD_RECEIVE);
+        cst!("SHUT_WR", ws::SD_SEND);
+        cst!("SHUT_RDWR", ws::SD_BOTH);
+        // ── Message flags ──
+        cst!("MSG_OOB", ws::MSG_OOB);
+        cst!("MSG_PEEK", ws::MSG_PEEK);
+        cst!("MSG_DONTROUTE", ws::MSG_DONTROUTE);
+        cst!("MSG_WAITALL", ws::MSG_WAITALL);
+        cst!("MSG_CTRUNC", ws::MSG_CTRUNC);
+        cst!("MSG_TRUNC", ws::MSG_TRUNC);
+        cst!("MSG_BCAST", ws::MSG_BCAST);
+        cst!("MSG_MCAST", ws::MSG_MCAST);
+        // ── Address-info flags ──
+        cst!("AI_PASSIVE", ws::AI_PASSIVE);
+        cst!("AI_CANONNAME", ws::AI_CANONNAME);
+        cst!("AI_NUMERICHOST", ws::AI_NUMERICHOST);
+        cst!("AI_NUMERICSERV", ws::AI_NUMERICSERV);
+        cst!("AI_ADDRCONFIG", ws::AI_ADDRCONFIG);
+        cst!("AI_V4MAPPED", ws::AI_V4MAPPED);
+        cst!("AI_ALL", ws::AI_ALL);
+        // ── Name-info flags ──
+        cst!("NI_NUMERICHOST", ws::NI_NUMERICHOST);
+        cst!("NI_NUMERICSERV", ws::NI_NUMERICSERV);
+        cst!("NI_NOFQDN", ws::NI_NOFQDN);
+        cst!("NI_NAMEREQD", ws::NI_NAMEREQD);
+        cst!("NI_DGRAM", ws::NI_DGRAM);
+        cst!("NI_MAXHOST", ws::NI_MAXHOST);
+        cst!("NI_MAXSERV", ws::NI_MAXSERV);
+        // ── EAI_* — WSA error codes under their <ws2tcpip.h> aliases ──
+        cst!("EAI_AGAIN", ws::WSATRY_AGAIN);
+        cst!("EAI_BADFLAGS", ws::WSAEINVAL);
+        cst!("EAI_FAIL", ws::WSANO_RECOVERY);
+        cst!("EAI_FAMILY", ws::WSAEAFNOSUPPORT);
+        cst!("EAI_MEMORY", ws::WSA_NOT_ENOUGH_MEMORY);
+        cst!("EAI_NODATA", ws::WSANO_DATA);
+        cst!("EAI_NONAME", ws::WSAHOST_NOT_FOUND);
+        cst!("EAI_SERVICE", ws::WSATYPE_NOT_FOUND);
+        cst!("EAI_SOCKTYPE", ws::WSAESOCKTNOSUPPORT);
+        // ── WSAIoctl codes `socket.ioctl` names ──
+        cst!("SIO_RCVALL", ws::SIO_RCVALL);
+        cst!("SIO_KEEPALIVE_VALS", ws::SIO_KEEPALIVE_VALS);
+        cst!("SIO_LOOPBACK_FAST_PATH", ws::SIO_LOOPBACK_FAST_PATH);
+        cst!("RCVALL_OFF", ws::RCVALL_OFF);
+        cst!("RCVALL_ON", ws::RCVALL_ON);
+        cst!("RCVALL_SOCKETLEVELONLY", ws::RCVALL_SOCKETLEVELONLY);
+        cst!("RCVALL_IPLEVEL", ws::RCVALL_IPLEVEL);
+        // ── socket-level cap ──
+        // `<winsock2.h>` defines SOMAXCONN as 0x7fffffff; the WinSock 1.1
+        // value of 5 the metadata carries is the one `listen` outgrew.
+        cst!("SOMAXCONN", 0x7fffffffi64);
+    }
+
     // ── htons / htonl / ntohs / ntohl ──
     crate::module_ns_store(
         ns,
@@ -621,7 +798,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
 
     // ── inet_aton / inet_ntoa ──
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         crate::module_ns_store(
             ns,
@@ -642,14 +819,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     };
                     let c = std::ffi::CString::new(s.as_bytes())
                         .map_err(|_| crate::PyError::value_error("embedded null in argument"))?;
-                    let mut addr: libc::in_addr = unsafe { std::mem::zeroed() };
-                    let r = unsafe { inet_aton(c.as_ptr(), &mut addr) };
-                    if r == 0 {
+                    let Some(bytes) = rffi::inet_aton(&c) else {
                         return Err(crate::PyError::os_error(
                             "illegal IP address string passed to inet_aton",
                         ));
-                    }
-                    let bytes = addr.s_addr.to_ne_bytes();
+                    };
                     Ok(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
                 },
                 1,
@@ -677,15 +851,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "packed IP wrong length for inet_ntoa",
                         ));
                     }
-                    let addr = libc::in_addr {
-                        s_addr: u32::from_ne_bytes([data[0], data[1], data[2], data[3]]),
-                    };
-                    let p = unsafe { inet_ntoa(addr) };
-                    if p.is_null() {
+                    let Some(text) = rffi::inet_ntoa([data[0], data[1], data[2], data[3]]) else {
                         return Err(crate::PyError::os_error("inet_ntoa failed"));
-                    }
-                    let cs = unsafe { std::ffi::CStr::from_ptr(p) };
-                    Ok(pyre_object::w_str_new(&cs.to_string_lossy()))
+                    };
+                    Ok(pyre_object::w_str_new(&text))
                 },
                 1,
             ),
@@ -716,7 +885,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         .map_err(|_| crate::PyError::value_error("embedded null"))?;
                     let mut buf = [0u8; 16];
                     let r = unsafe {
-                        inet_pton(af, c_ip.as_ptr(), buf.as_mut_ptr() as *mut libc::c_void)
+                        rffi::inet_pton(af, c_ip.as_ptr(), buf.as_mut_ptr() as *mut libc::c_void)
                     };
                     if r != 1 {
                         return Err(crate::PyError::os_error(
@@ -724,8 +893,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let n = match af {
-                        x if x == libc::AF_INET => 4,
-                        x if x == libc::AF_INET6 => 16,
+                        x if x == rffi::AF_INET => 4,
+                        x if x == rffi::AF_INET6 => 16,
                         _ => {
                             return Err(crate::PyError::value_error("unknown address family"));
                         }
@@ -758,8 +927,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         pyre_object::bytesobject::bytes_like_data(args[1])
                     };
                     let expected = match af {
-                        x if x == libc::AF_INET => 4,
-                        x if x == libc::AF_INET6 => 16,
+                        x if x == rffi::AF_INET => 4,
+                        x if x == rffi::AF_INET6 => 16,
                         _ => {
                             return Err(crate::PyError::value_error("unknown address family"));
                         }
@@ -771,11 +940,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     let mut buf = [0u8; 64];
                     let r = unsafe {
-                        inet_ntop(
+                        rffi::inet_ntop(
                             af,
                             data.as_ptr() as *const libc::c_void,
                             buf.as_mut_ptr() as *mut libc::c_char,
-                            buf.len() as libc::socklen_t,
+                            buf.len() as rffi::SockLen,
                         )
                     };
                     if r.is_null() {
@@ -795,27 +964,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "gethostname",
                 |_| {
-                    let mut buf = [0u8; 256];
-                    let r =
-                        unsafe { gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) };
-                    if r != 0 {
-                        return Err(crate::PyError::os_error_with_errno(
-                            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+                    let name = rffi::hostname().map_err(|e| {
+                        crate::PyError::os_error_with_errno(
+                            e.raw_os_error().unwrap_or(0),
                             "gethostname",
-                        ));
-                    }
-                    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+                        )
+                    })?;
                     // `interp_func.py:24` is
                     // `space.fsdecode(space.newbytes(res))` -- the hostname is
                     // opaque kernel bytes (`sethostname(2)` takes a plain
                     // `const char*`), so a byte with no UTF-8 spelling has to
                     // survive as its surrogate escape.
-                    Ok(crate::gateway::fsdecode_filename_bytes(&buf[..end]))
+                    Ok(crate::gateway::fsdecode_os_str(&name))
                 },
                 0,
             ),
         );
+    }
 
+    // The legacy resolver entry points and `sethostname`, which have no
+    // WinSock counterpart this module can reach through the same struct.
+    #[cfg(unix)]
+    {
         // sethostname(name) → None  (host_env::socket-backed)
         #[cfg(feature = "host_env")]
         crate::module_ns_store(
@@ -898,13 +1068,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                                 "gethostbyname: no IPv4 address",
                             ));
                         }
-                        let addr = libc::in_addr {
-                            s_addr: std::ptr::read_unaligned(first_addr as *const u32),
+                        let packed = std::ptr::read_unaligned(first_addr as *const u32);
+                        let Some(text) = rffi::inet_ntoa(packed.to_ne_bytes()) else {
+                            return Err(socket_converted_error(
+                                "gaierror",
+                                None,
+                                "gethostbyname: address is not representable",
+                            ));
                         };
-                        let p = inet_ntoa(addr);
-                        Ok(pyre_object::w_str_new(
-                            &std::ffi::CStr::from_ptr(p).to_string_lossy(),
-                        ))
+                        Ok(pyre_object::w_str_new(&text))
                     }
                 },
                 1,
@@ -968,23 +1140,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // bytestring for gethostbyaddr.
                     let mut buf4 = [0u8; 4];
                     let r4 = unsafe {
-                        inet_pton(
-                            libc::AF_INET,
+                        rffi::inet_pton(
+                            rffi::AF_INET,
                             c.as_ptr(),
                             buf4.as_mut_ptr() as *mut libc::c_void,
                         )
                     };
                     let (family, addr_ptr, addr_len) = if r4 == 1 {
                         (
-                            libc::AF_INET,
+                            rffi::AF_INET,
                             buf4.as_ptr() as *const libc::c_void,
-                            4 as libc::socklen_t,
+                            4 as rffi::SockLen,
                         )
                     } else {
                         let mut buf6 = [0u8; 16];
                         let r6 = unsafe {
-                            inet_pton(
-                                libc::AF_INET6,
+                            rffi::inet_pton(
+                                rffi::AF_INET6,
                                 c.as_ptr(),
                                 buf6.as_mut_ptr() as *mut libc::c_void,
                             )
@@ -997,8 +1169,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             let he = unsafe {
                                 gethostbyaddr(
                                     owned.as_mut_ptr() as *mut libc::c_void,
-                                    16 as libc::socklen_t,
-                                    libc::AF_INET6,
+                                    16 as rffi::SockLen,
+                                    rffi::AF_INET6,
                                 )
                             };
                             if he.is_null() {
@@ -1034,7 +1206,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             (
                                 h.h_addrtype as libc::c_int,
                                 first_addr as *const libc::c_void,
-                                h.h_length as libc::socklen_t,
+                                h.h_length as rffi::SockLen,
                             )
                         }
                     };
@@ -1242,9 +1414,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     );
 
     // ── module-level close(fd) ──
-    // `interp_socket.py:close(fd)` — raw libc close, used for fd
-    // cleanup when callers obtain a bare fd via .detach().
-    #[cfg(unix)]
+    // `interp_socket.py:close(fd)` — the bare host close, used for
+    // cleanup when callers obtain a descriptor via .detach().
+    #[cfg(any(unix, windows))]
     crate::module_ns_store(
         ns,
         "close",
@@ -1257,10 +1429,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if !unsafe { pyre_object::is_int(args[0]) } {
                     return Err(crate::PyError::type_error("close: fd must be an integer"));
                 }
-                let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
-                let r = unsafe { libc::close(fd) };
-                if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                let fd = rffi::socket_from_i64(unsafe { pyre_object::w_int_get_value(args[0]) });
+                if unsafe { rffi::close(fd) } != 0 {
+                    return Err(socket_last_error());
                 }
                 Ok(pyre_object::w_none())
             },
@@ -1272,7 +1443,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // `interp_func.py:125-134` — returns the IPPROTO_* number for a
     // protocol name.  libc getprotobyname returns NULL on lookup
     // failure; we surface that as OSError to match `converted_error`.
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     crate::module_ns_store(
         ns,
         "getprotobyname",
@@ -1287,11 +1458,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let name = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
                 let c_name = std::ffi::CString::new(name.as_bytes())
                     .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
-                let pe = unsafe { libc::getprotobyname(c_name.as_ptr()) };
-                if pe.is_null() {
+                let Some(proto) = rffi::protocol_by_name(&c_name) else {
                     return Err(socket_converted_error("error", None, "protocol not found"));
-                }
-                let proto = unsafe { (*pe).p_proto };
+                };
                 Ok(pyre_object::w_int_new(proto as i64))
             },
             1,
@@ -1311,7 +1480,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 |_| {
                     let head = unsafe { libc::if_nameindex() };
                     if head.is_null() {
-                        return Err(socket_io_err(std::io::Error::last_os_error()));
+                        return Err(socket_last_error());
                     }
                     let mut items = Vec::new();
                     let mut p = head;
@@ -1363,7 +1532,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
                     let idx = unsafe { libc::if_nametoindex(c_name.as_ptr()) };
                     if idx == 0 {
-                        return Err(socket_io_err(std::io::Error::last_os_error()));
+                        return Err(socket_last_error());
                     }
                     Ok(pyre_object::w_int_new(idx as i64))
                 },
@@ -1386,7 +1555,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let p =
                         unsafe { libc::if_indextoname(idx, buf.as_mut_ptr() as *mut libc::c_char) };
                     if p.is_null() {
-                        return Err(socket_io_err(std::io::Error::last_os_error()));
+                        return Err(socket_last_error());
                     }
                     let s = unsafe { std::ffi::CStr::from_ptr(p) };
                     Ok(crate::gateway::fsdecode_filename_bytes(s.to_bytes()))
@@ -1462,20 +1631,27 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
 
     // ── getaddrinfo / getnameinfo ──
     // `interp_func.py:294-339` (getaddrinfo) and `:137-156`
-    // (getnameinfo) — directly wrap libc's getaddrinfo / getnameinfo
+    // (getnameinfo) — directly wrap the host's getaddrinfo / getnameinfo
     // and walk the addrinfo linked list.
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     init_socket_getaddrinfo(ns);
 
     // ── socket class (slice S2) ──
-    #[cfg(unix)]
+    #[cfg(any(unix, windows))]
     {
         let socket_tp = socket_type();
         // Expose the type itself as `socket` AND `SocketType` so the
         // stdlib's `class socket(_socket.socket):` pattern works.
         crate::module_ns_store(ns, "socket", socket_tp);
         crate::module_ns_store(ns, "SocketType", socket_tp);
+    }
 
+    // `socket.py:662` reaches for `_socket.socketpair` and falls back to its
+    // own AF_INET pair when the module does not carry one; `dup`/`fromfd`
+    // likewise have no WinSock spelling that duplicates a descriptor in
+    // place.  All three stay with the POSIX calls they are built on.
+    #[cfg(unix)]
+    {
         // socketpair(family=AF_UNIX, type=SOCK_STREAM, proto=0)
         crate::module_ns_store(
             ns,
@@ -1494,7 +1670,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     unsafe { pyre_object::w_int_get_value(args[0]) as libc::c_int }
                 };
                 let ty = if args.len() < 2 {
-                    libc::SOCK_STREAM
+                    rffi::SOCK_STREAM
                 } else {
                     unsafe { pyre_object::w_int_get_value(args[1]) as libc::c_int }
                 };
@@ -1506,7 +1682,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let mut fds = [0 as libc::c_int; 2];
                 let r = unsafe { libc::socketpair(family, ty, proto, fds.as_mut_ptr()) };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 // `rsocket.py:socketpair(inheritable=False)` — every
                 // socket pyre creates from the module starts with
@@ -1540,7 +1716,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let fd = (unsafe { pyre_object::w_int_get_value(args[0]) }) as libc::c_int;
                     let n = unsafe { libc::dup(fd) };
                     if n < 0 {
-                        return Err(socket_io_err(std::io::Error::last_os_error()));
+                        return Err(socket_last_error());
                     }
                     unsafe {
                         libc::fcntl(n, libc::F_SETFD, libc::FD_CLOEXEC);
@@ -1587,7 +1763,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 };
                 let new_fd = unsafe { libc::dup(fd) };
                 if new_fd < 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 unsafe {
                     libc::fcntl(new_fd, libc::F_SETFD, libc::FD_CLOEXEC);
@@ -1634,13 +1810,10 @@ fn unpack_hostent(he: *mut HostentRaw) -> Result<pyre_object::PyObjectRef, crate
                 if addr_ptr.is_null() {
                     break;
                 }
-                let addr_str = if h.h_addrtype == libc::AF_INET && h.h_length == 4 {
-                    let addr = libc::in_addr {
-                        s_addr: std::ptr::read_unaligned(addr_ptr as *const u32),
-                    };
-                    let s = inet_ntoa(addr);
-                    std::ffi::CStr::from_ptr(s).to_string_lossy().into_owned()
-                } else if h.h_addrtype == libc::AF_INET6 && h.h_length == 16 {
+                let addr_str = if h.h_addrtype == rffi::AF_INET && h.h_length == 4 {
+                    let packed = std::ptr::read_unaligned(addr_ptr as *const u32).to_ne_bytes();
+                    rffi::inet_ntoa(packed).unwrap_or_default()
+                } else if h.h_addrtype == rffi::AF_INET6 && h.h_length == 16 {
                     let mut packed_addr = [0u8; 16];
                     std::ptr::copy_nonoverlapping(
                         addr_ptr as *const u8,
@@ -1648,11 +1821,11 @@ fn unpack_hostent(he: *mut HostentRaw) -> Result<pyre_object::PyObjectRef, crate
                         packed_addr.len(),
                     );
                     let mut buf = [0u8; 64];
-                    let q = inet_ntop(
-                        libc::AF_INET6,
+                    let q = rffi::inet_ntop(
+                        rffi::AF_INET6,
                         packed_addr.as_ptr() as *const libc::c_void,
                         buf.as_mut_ptr() as *mut libc::c_char,
-                        buf.len() as libc::socklen_t,
+                        buf.len() as rffi::SockLen,
                     );
                     if q.is_null() {
                         String::new()
@@ -1722,7 +1895,7 @@ fn set_default_socket_timeout(v: Option<f64>) {
 // proto, canonname, sockaddr)`.  `getnameinfo` is the symmetric
 // path used by stdlib socket.getnameinfo.
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -1798,18 +1971,18 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                         Ok(default)
                     }
                 };
-            let family = int_arg(2, libc::AF_UNSPEC)?;
+            let family = int_arg(2, rffi::AF_UNSPEC)?;
             let socktype = int_arg(3, 0)?;
             let proto = int_arg(4, 0)?;
             let flags = int_arg(5, 0)?;
 
-            let mut hints: libc::addrinfo = unsafe { std::mem::zeroed() };
+            let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
             hints.ai_family = family;
             hints.ai_socktype = socktype;
             hints.ai_protocol = proto;
             hints.ai_flags = flags;
 
-            let mut res: *mut libc::addrinfo = std::ptr::null_mut();
+            let mut res: *mut rffi::addrinfo = std::ptr::null_mut();
             let host_ptr = host
                 .as_ref()
                 .map(|c| c.as_ptr())
@@ -1821,14 +1994,10 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
             // A name lookup goes to the resolver and can take seconds.
             let rc = {
                 let _blocked = crate::module::thread::before_external_block();
-                unsafe { libc::getaddrinfo(host_ptr, port_ptr, &hints, &mut res) }
+                unsafe { rffi::getaddrinfo(host_ptr, port_ptr, &hints, &mut res) }
             };
             if rc != 0 {
-                let msg = unsafe {
-                    std::ffi::CStr::from_ptr(libc::gai_strerror(rc))
-                        .to_string_lossy()
-                        .into_owned()
-                };
+                let msg = rffi::gai_strerror(rc);
                 return Err(socket_converted_error("gaierror", Some(rc), &msg));
             }
 
@@ -1840,21 +2009,21 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     let canon = if ai.ai_canonname.is_null() {
                         String::new()
                     } else {
-                        std::ffi::CStr::from_ptr(ai.ai_canonname)
+                        std::ffi::CStr::from_ptr(ai.ai_canonname.cast())
                             .to_string_lossy()
                             .into_owned()
                     };
                     // Copy sockaddr into our sockaddr_storage so we can
                     // reuse unpack_inet_addr.
-                    let mut storage: libc::sockaddr_storage = std::mem::zeroed();
+                    let mut storage: rffi::sockaddr_storage = std::mem::zeroed();
                     let copy_len = (ai.ai_addrlen as usize)
-                        .min(core::mem::size_of::<libc::sockaddr_storage>());
+                        .min(core::mem::size_of::<rffi::sockaddr_storage>());
                     std::ptr::copy_nonoverlapping(
                         ai.ai_addr as *const u8,
                         &mut storage as *mut _ as *mut u8,
                         copy_len,
                     );
-                    let addr = unpack_inet_addr(&storage, copy_len as libc::socklen_t);
+                    let addr = unpack_inet_addr(&storage, copy_len as rffi::SockLen);
                     items.push(pyre_object::w_tuple_new(vec![
                         pyre_object::w_int_new(ai.ai_family as i64),
                         pyre_object::w_int_new(ai.ai_socktype as i64),
@@ -1864,7 +2033,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     ]));
                     cur = ai.ai_next;
                 }
-                libc::freeaddrinfo(res);
+                rffi::freeaddrinfo(res);
             }
             Ok(pyre_object::w_list_new(items))
         }),
@@ -1916,57 +2085,49 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
                     .map_err(|_| crate::PyError::value_error("embedded null in host"))?;
                 let c_port = std::ffi::CString::new(format!("{port_v}")).unwrap();
 
-                let mut hints: libc::addrinfo = unsafe { std::mem::zeroed() };
-                hints.ai_family = libc::AF_UNSPEC;
-                hints.ai_socktype = libc::SOCK_DGRAM;
-                hints.ai_flags = libc::AI_NUMERICHOST;
-                let mut res: *mut libc::addrinfo = std::ptr::null_mut();
+                let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
+                hints.ai_family = rffi::AF_UNSPEC;
+                hints.ai_socktype = rffi::SOCK_DGRAM;
+                hints.ai_flags = rffi::AI_NUMERICHOST;
+                let mut res: *mut rffi::addrinfo = std::ptr::null_mut();
                 let rc = {
                     let _blocked = crate::module::thread::before_external_block();
-                    unsafe { libc::getaddrinfo(c_host.as_ptr(), c_port.as_ptr(), &hints, &mut res) }
+                    unsafe { rffi::getaddrinfo(c_host.as_ptr(), c_port.as_ptr(), &hints, &mut res) }
                 };
                 if rc != 0 {
-                    let msg = unsafe {
-                        std::ffi::CStr::from_ptr(libc::gai_strerror(rc))
-                            .to_string_lossy()
-                            .into_owned()
-                    };
+                    let msg = rffi::gai_strerror(rc);
                     return Err(socket_converted_error("gaierror", Some(rc), &msg));
                 }
                 let head = res;
                 let ai = unsafe { &*head };
                 if !ai.ai_next.is_null() {
-                    unsafe { libc::freeaddrinfo(head) };
+                    unsafe { rffi::freeaddrinfo(head) };
                     return Err(socket_converted_error(
                         "error",
                         None,
                         "sockaddr resolved to multiple addresses",
                     ));
                 }
-                let mut host_buf = [0 as libc::c_char; libc::NI_MAXHOST as usize];
+                let mut host_buf = [0 as libc::c_char; rffi::NI_MAXHOST as usize];
                 let mut serv_buf = [0 as libc::c_char; 32];
                 // A reverse lookup goes to the resolver and can take seconds.
                 let nrc = {
                     let _blocked = crate::module::thread::before_external_block();
                     unsafe {
-                        libc::getnameinfo(
+                        rffi::getnameinfo(
                             ai.ai_addr,
-                            ai.ai_addrlen,
+                            ai.ai_addrlen as rffi::SockLen,
                             host_buf.as_mut_ptr(),
-                            host_buf.len() as libc::socklen_t,
+                            host_buf.len() as rffi::SockLen,
                             serv_buf.as_mut_ptr(),
-                            serv_buf.len() as libc::socklen_t,
+                            serv_buf.len() as rffi::SockLen,
                             flags,
                         )
                     }
                 };
-                unsafe { libc::freeaddrinfo(head) };
+                unsafe { rffi::freeaddrinfo(head) };
                 if nrc != 0 {
-                    let msg = unsafe {
-                        std::ffi::CStr::from_ptr(libc::gai_strerror(nrc))
-                            .to_string_lossy()
-                            .into_owned()
-                    };
+                    let msg = rffi::gai_strerror(nrc);
                     return Err(socket_converted_error("gaierror", Some(nrc), &msg));
                 }
                 let host_s = unsafe {
@@ -1995,7 +2156,7 @@ fn init_socket_getaddrinfo(ns: pyre_object::PyObjectRef) {
 // `_fd` (int) / `_family` (int) / `_type` (int) / `_proto` (int) /
 // `_timeout` (float or None).  Methods read/write via baseobjspace.
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_type() -> pyre_object::PyObjectRef {
     // Process-global immortal type object (see `make_builtin_type`).
     static SOCKET_TYPE_OBJ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
@@ -2007,62 +2168,96 @@ fn socket_type() -> pyre_object::PyObjectRef {
     }) as pyre_object::PyObjectRef
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_io_err(e: std::io::Error) -> crate::PyError {
-    let errno = e.raw_os_error().unwrap_or(0);
+    let code = e.raw_os_error().unwrap_or(0);
+    // `socketmodule.c set_error` raises a WinSock failure through
+    // `PyErr_SetExcFromWindowsErr`: the code is a Win32 one, so it belongs in
+    // `.winerror` with `.errno` derived from it, not read as an errno itself.
+    #[cfg(windows)]
+    {
+        crate::PyError::os_error_win32_syscall2(code, pyre_object::PY_NULL, pyre_object::PY_NULL)
+    }
     // `rsocket.py` carries the C `strerror` text; build the OSError in
     // its `(errno, strerror)` form so `e.errno` and `str(e)` match.
-    let strerror = unsafe {
-        let p = libc::strerror(errno);
-        if p.is_null() {
-            format!("Unknown error {errno}")
-        } else {
-            std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
-        }
-    };
-    crate::PyError::os_error_errno_strerror(errno, strerror)
+    #[cfg(not(windows))]
+    {
+        let strerror = unsafe {
+            let p = libc::strerror(code);
+            if p.is_null() {
+                format!("Unknown error {code}")
+            } else {
+                std::ffi::CStr::from_ptr(p).to_string_lossy().into_owned()
+            }
+        };
+        crate::PyError::os_error_errno_strerror(code, strerror)
+    }
 }
 
-#[cfg(unix)]
+/// The exception for a socket call that has just failed, read from wherever
+/// the host records it.
+#[cfg(any(unix, windows))]
+fn socket_last_error() -> crate::PyError {
+    socket_io_err(rffi::last_error())
+}
+
+/// `call_external_function` with the failure code the socket API reports.
+/// That helper reads the C runtime's `errno`, which WinSock never writes —
+/// it keeps its own last-error slot — so the code has to come from `rffi`.
+#[cfg(any(unix, windows))]
+fn socket_call<R>(f: impl FnOnce() -> R) -> (R, i32) {
+    #[cfg(windows)]
+    {
+        let _blocked = crate::module::thread::before_external_block();
+        let result = f();
+        (result, rffi::last_error_code())
+    }
+    #[cfg(not(windows))]
+    {
+        crate::module::thread::call_external_function(f)
+    }
+}
+
+#[cfg(any(unix, windows))]
 fn socket_io_err_for_operation(
     obj: pyre_object::PyObjectRef,
     e: std::io::Error,
 ) -> crate::PyError {
     let errno = e.raw_os_error().unwrap_or(0);
-    if errno == libc::EAGAIN || errno == libc::EWOULDBLOCK {
-        let d = crate::baseobjspace::getdict_native(obj);
-        if !d.is_null()
-            && let Some(timeout) = unsafe { pyre_object::w_dict_getitem_str(d, "_timeout") }
-            && unsafe { pyre_object::is_float(timeout) }
-            && unsafe { pyre_object::floatobject::w_float_get_value(timeout) } > 0.0
-        {
-            // RPython's RSocket._select() turns expiry of a positive timeout
-            // into SocketTimeout, which interp_socket maps to TimeoutError.
-            // This backend uses SO_RCVTIMEO/SO_SNDTIMEO, whose equivalent
-            // expiry signal is EAGAIN/EWOULDBLOCK.
-            return socket_converted_error("timeout", None, "timed out");
-        }
+    if rffi::error_is_would_block(errno) && socket_positive_timeout(obj).is_some() {
+        // RPython's RSocket._select() turns expiry of a positive timeout
+        // into SocketTimeout, which interp_socket maps to TimeoutError.
+        // This backend uses SO_RCVTIMEO/SO_SNDTIMEO, whose equivalent
+        // expiry signal is EAGAIN/EWOULDBLOCK.
+        return socket_converted_error("timeout", None, "timed out");
     }
     socket_io_err(e)
+}
+
+/// The socket's timeout when it is a positive number of seconds — the state in
+/// which a call has to be bounded rather than left to block.  `None` covers
+/// both of the other two: blocking forever, and non-blocking.
+#[cfg(any(unix, windows))]
+fn socket_positive_timeout(obj: pyre_object::PyObjectRef) -> Option<f64> {
+    let dict = crate::baseobjspace::getdict_native(obj);
+    (!dict.is_null())
+        .then(|| unsafe { pyre_object::w_dict_getitem_str(dict, "_timeout") })
+        .flatten()
+        .filter(|timeout| unsafe { pyre_object::is_float(*timeout) })
+        .map(|timeout| unsafe { pyre_object::floatobject::w_float_get_value(timeout) })
+        .filter(|timeout| *timeout > 0.0)
 }
 
 /// RPython `RSocket._select(False)` used by `RSocket.accept`: a positive
 /// Python timeout is enforced with poll before entering the libc operation.
 /// Darwin does not reliably apply SO_RCVTIMEO to accept(), so relying on that
 /// socket option leaves timeout-driven server loops blocked indefinitely.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_wait_readable(
     obj: pyre_object::PyObjectRef,
-    fd: libc::c_int,
+    fd: rffi::Socket,
 ) -> Result<(), crate::PyError> {
-    let dict = crate::baseobjspace::getdict_native(obj);
-    let Some(timeout) = (!dict.is_null())
-        .then(|| unsafe { pyre_object::w_dict_getitem_str(dict, "_timeout") })
-        .flatten()
-        .filter(|timeout| unsafe { pyre_object::is_float(*timeout) })
-        .map(|timeout| unsafe { pyre_object::floatobject::w_float_get_value(timeout) })
-        .filter(|timeout| *timeout > 0.0)
-    else {
+    let Some(timeout) = socket_positive_timeout(obj) else {
         return Ok(());
     };
     // A handled signal restarts the wait, so the deadline is computed once:
@@ -2080,28 +2275,80 @@ fn socket_wait_readable(
         // poll's resolution is one millisecond; a shorter remainder must still
         // wait rather than degenerate into a busy loop.
         let timeout_ms = remaining.as_millis().max(1).min(i32::MAX as u128) as i32;
-        let mut pollfd = libc::pollfd {
-            fd,
-            events: libc::POLLIN,
-            revents: 0,
-        };
-        let (ready, errno) = crate::module::thread::call_external_function(|| unsafe {
-            libc::poll(&mut pollfd, 1, timeout_ms)
-        });
+        let (ready, errno) = rffi::poll_readable(fd, timeout_ms);
         if ready > 0 {
             return Ok(());
         }
         if ready == 0 {
             return Err(socket_converted_error("timeout", None, "timed out"));
         }
-        if errno != libc::EINTR {
+        if !rffi::error_is_interrupted(errno) {
             return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
         }
         crate::module::signal::interp_signal::checksignals_now()?;
     }
 }
 
-#[cfg(unix)]
+/// `internal_connect` for a socket carrying a positive timeout.  WinSock does
+/// not apply `SO_SNDTIMEO` to `connect`, so the call runs in non-blocking mode
+/// and the wait for its outcome is explicit; POSIX's `SO_SNDTIMEO` already
+/// bounds the call and keeps the straight-line path.
+///
+/// Returns the code the attempt reported, `WSAETIMEDOUT` on expiry, so both
+/// `connect` and `connect_ex` can shape it the way each one answers.
+#[cfg(windows)]
+fn socket_connect_timed(
+    fd: rffi::Socket,
+    storage: &rffi::sockaddr_storage,
+    slen: rffi::SockLen,
+    timeout: f64,
+) -> Result<(), i32> {
+    rffi::apply_timeout(fd, 0.0).map_err(|e| e.raw_os_error().unwrap_or(0))?;
+    let outcome = socket_connect_wait(fd, storage, slen, timeout);
+    // The socket goes back to the mode its own timeout declares whatever the
+    // connect did; failing to restore it is not the answer the caller asked
+    // for.
+    let _ = rffi::apply_timeout(fd, timeout);
+    outcome
+}
+
+#[cfg(windows)]
+fn socket_connect_wait(
+    fd: rffi::Socket,
+    storage: &rffi::sockaddr_storage,
+    slen: rffi::SockLen,
+    timeout: f64,
+) -> Result<(), i32> {
+    let (started, errno) = socket_call(|| unsafe {
+        rffi::connect(fd, storage as *const _ as *const rffi::sockaddr, slen)
+    });
+    if started == 0 {
+        return Ok(());
+    }
+    if !rffi::error_is_would_block(errno) {
+        return Err(errno);
+    }
+    // The connection is under way and reports its outcome by making the socket
+    // writable.  A single wait is enough: Windows does not interrupt it.
+    let timeout_ms = (timeout * 1000.0).round().clamp(1.0, i32::MAX as f64) as i32;
+    let (ready, poll_errno) = rffi::poll_writable(fd, timeout_ms);
+    if ready < 0 {
+        return Err(poll_errno);
+    }
+    if ready == 0 {
+        return Err(rffi::ETIMEDOUT);
+    }
+    // `SO_ERROR` carries the outcome of a connect that finished after its call
+    // returned; zero means it succeeded.
+    match socket_getsockopt_int(fd, rffi::SOL_SOCKET, rffi::SO_ERROR) {
+        Ok(0) => Ok(()),
+        Ok(errno) => Err(errno),
+        // Reading the option failed; the last-error slot still holds why.
+        Err(_) => Err(rffi::last_error_code()),
+    }
+}
+
+#[cfg(any(unix, windows))]
 fn socket_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
@@ -2114,7 +2361,7 @@ fn socket_get_attr_i64(obj: pyre_object::PyObjectRef, key: &str) -> i64 {
     -1
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_set_attr(obj: pyre_object::PyObjectRef, key: &str, v: pyre_object::PyObjectRef) {
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
@@ -2135,70 +2382,23 @@ fn socket_set_attr(obj: pyre_object::PyObjectRef, key: &str, v: pyre_object::PyO
 ///
 /// Until this helper landed, `settimeout` only stashed the value in the
 /// instance dict and `recv`/`send` blocked indefinitely regardless.
-#[cfg(unix)]
-fn socket_apply_timeout(fd: libc::c_int, timeout: f64) -> Result<(), crate::PyError> {
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
-    if flags < 0 {
-        return Err(socket_io_err(std::io::Error::last_os_error()));
-    }
-    let want_nonblock = timeout == 0.0;
-    // Bit-clear without unary `!` so the static analyzer accepts the
-    // helper (the analyzer rejects bitwise-not on signed `c_int`).
-    let new_flags = if want_nonblock {
-        flags | libc::O_NONBLOCK
-    } else if (flags & libc::O_NONBLOCK) != 0 {
-        flags - libc::O_NONBLOCK
-    } else {
-        flags
-    };
-    if new_flags != flags {
-        let r = unsafe { libc::fcntl(fd, libc::F_SETFL, new_flags) };
-        if r < 0 {
-            return Err(socket_io_err(std::io::Error::last_os_error()));
-        }
-    }
-    let tv = if timeout > 0.0 {
-        let sec = timeout.trunc() as libc::time_t;
-        let usec = ((timeout - timeout.trunc()) * 1_000_000.0).round() as libc::suseconds_t;
-        libc::timeval {
-            tv_sec: sec,
-            tv_usec: usec,
-        }
-    } else {
-        libc::timeval {
-            tv_sec: 0,
-            tv_usec: 0,
-        }
-    };
-    for opt in [libc::SO_RCVTIMEO, libc::SO_SNDTIMEO] {
-        let r = unsafe {
-            libc::setsockopt(
-                fd,
-                libc::SOL_SOCKET,
-                opt,
-                &tv as *const _ as *const libc::c_void,
-                core::mem::size_of::<libc::timeval>() as libc::socklen_t,
-            )
-        };
-        if r != 0 {
-            return Err(socket_io_err(std::io::Error::last_os_error()));
-        }
-    }
-    Ok(())
+#[cfg(any(unix, windows))]
+fn socket_apply_timeout(fd: rffi::Socket, timeout: f64) -> Result<(), crate::PyError> {
+    rffi::apply_timeout(fd, timeout).map_err(socket_io_err)
 }
 
-#[cfg(unix)]
-fn socket_fd(obj: pyre_object::PyObjectRef) -> Result<libc::c_int, crate::PyError> {
-    let fd = socket_get_attr_i64(obj, "_fd") as libc::c_int;
-    if fd < 0 {
+#[cfg(any(unix, windows))]
+fn socket_fd(obj: pyre_object::PyObjectRef) -> Result<rffi::Socket, crate::PyError> {
+    let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
+    if rffi::is_invalid(fd) {
         return Err(crate::PyError::os_error("Bad file descriptor"));
     }
     Ok(fd)
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_from_fd(
-    fd: libc::c_int,
+    fd: rffi::Socket,
     family: libc::c_int,
     ty: libc::c_int,
     proto: libc::c_int,
@@ -2206,9 +2406,9 @@ fn socket_from_fd(
     socket_from_fd_with_class(fd, family, ty, proto, socket_type())
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_from_fd_with_class(
-    fd: libc::c_int,
+    fd: rffi::Socket,
     family: libc::c_int,
     ty: libc::c_int,
     proto: libc::c_int,
@@ -2223,15 +2423,15 @@ fn socket_from_fd_with_class(
     obj
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_init_state(
     obj: pyre_object::PyObjectRef,
-    fd: libc::c_int,
+    fd: rffi::Socket,
     family: libc::c_int,
     ty: libc::c_int,
     proto: libc::c_int,
 ) {
-    socket_set_attr(obj, "_fd", pyre_object::w_int_new(fd as i64));
+    socket_set_attr(obj, "_fd", pyre_object::w_int_new(rffi::socket_to_i64(fd)));
     socket_set_attr(obj, "_family", pyre_object::w_int_new(family as i64));
     socket_set_attr(obj, "_type", pyre_object::w_int_new(ty as i64));
     socket_set_attr(obj, "_proto", pyre_object::w_int_new(proto as i64));
@@ -2244,29 +2444,28 @@ fn socket_init_state(
 
 /// `rsocket.py:1694 get_socket_family` — the family of an existing fd,
 /// read from `getsockname`'s returned `sa_family`.
-#[cfg(unix)]
-fn socket_detect_family(fd: libc::c_int) -> Result<libc::c_int, crate::PyError> {
-    let mut addr: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-    let mut len = std::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
-    let res =
-        unsafe { libc::getsockname(fd, &mut addr as *mut _ as *mut libc::sockaddr, &mut len) };
-    if res < 0 {
-        return Err(socket_io_err(std::io::Error::last_os_error()));
+#[cfg(any(unix, windows))]
+fn socket_detect_family(fd: rffi::Socket) -> Result<libc::c_int, crate::PyError> {
+    let mut addr: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+    let mut len = std::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
+    let res = unsafe { rffi::getsockname(fd, &mut addr as *mut _ as *mut rffi::sockaddr, &mut len) };
+    if res != 0 {
+        return Err(socket_last_error());
     }
     Ok(addr.ss_family as libc::c_int)
 }
 
 /// `rsocket.py:1678 getsockopt_int` — a single int socket option.
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn socket_getsockopt_int(
-    fd: libc::c_int,
+    fd: rffi::Socket,
     level: libc::c_int,
     option: libc::c_int,
 ) -> Result<libc::c_int, crate::PyError> {
     let mut val: libc::c_int = 0;
-    let mut len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    let mut len = std::mem::size_of::<libc::c_int>() as rffi::SockLen;
     let res = unsafe {
-        libc::getsockopt(
+        rffi::getsockopt(
             fd,
             level,
             option,
@@ -2274,20 +2473,20 @@ fn socket_getsockopt_int(
             &mut len,
         )
     };
-    if res < 0 {
-        return Err(socket_io_err(std::io::Error::last_os_error()));
+    if res != 0 {
+        return Err(socket_last_error());
     }
     Ok(val)
 }
 
 /// `interp_socket.py:93 get_so_protocol` — the protocol of an existing
 /// fd via `SO_PROTOCOL`, or `-1` on platforms without it (`HAS_SO_PROTOCOL`).
-#[cfg(all(unix, any(target_os = "linux", target_os = "android")))]
-fn socket_get_so_protocol(fd: libc::c_int) -> Result<libc::c_int, crate::PyError> {
-    socket_getsockopt_int(fd, libc::SOL_SOCKET, libc::SO_PROTOCOL)
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn socket_get_so_protocol(fd: rffi::Socket) -> Result<libc::c_int, crate::PyError> {
+    socket_getsockopt_int(fd, rffi::SOL_SOCKET, libc::SO_PROTOCOL)
 }
-#[cfg(all(unix, not(any(target_os = "linux", target_os = "android"))))]
-fn socket_get_so_protocol(_fd: libc::c_int) -> Result<libc::c_int, crate::PyError> {
+#[cfg(all(any(unix, windows), not(any(target_os = "linux", target_os = "android"))))]
+fn socket_get_so_protocol(_fd: rffi::Socket) -> Result<libc::c_int, crate::PyError> {
     Ok(-1)
 }
 
@@ -2303,16 +2502,17 @@ fn socket_get_so_protocol(_fd: libc::c_int) -> Result<libc::c_int, crate::PyErro
 #[cfg(unix)]
 const SUN_PATH_OFFSET: usize = core::mem::offset_of!(libc::sockaddr_un, sun_path);
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn pack_inet_addr(
     family: libc::c_int,
     addr: pyre_object::PyObjectRef,
-) -> Result<(libc::sockaddr_storage, libc::socklen_t), crate::PyError> {
-    let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+) -> Result<(rffi::sockaddr_storage, rffi::SockLen), crate::PyError> {
+    let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
     // AF_UNIX is special: rsocket.py:RSocket.bind/connect accept a bare
     // bytes/str path (or a 1-tuple wrapping the path).  Pull the path
     // out before touching tuple[1], which only the AF_INET/AF_INET6
     // forms guarantee.
+    #[cfg(unix)]
     if family == libc::AF_UNIX {
         let path_obj = if unsafe { pyre_object::is_tuple(addr) } {
             unsafe { pyre_object::w_tuple_getitem(addr, 0) }
@@ -2336,7 +2536,7 @@ fn pack_inet_addr(
             }
         };
         let sun = unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_un) };
-        sun.sun_family = libc::AF_UNIX as libc::sa_family_t;
+        sun.sun_family = libc::AF_UNIX as rffi::SaFamily;
         let abstract_name = cfg!(target_os = "linux") && path_bytes_vec.first() == Some(&0);
         // `rsocket.py:412-420 UNIXAddress.__init__`: an abstract name may fill
         // `sun_path` exactly, a regular one has to leave room for its
@@ -2351,7 +2551,7 @@ fn pack_inet_addr(
         // `rsocket.py:409-410 self.setdata(sun, baseofs + len(path))`: the
         // terminator is counted only for a regular name that has one.
         let addrlen = SUN_PATH_OFFSET + path_bytes_vec.len() + usize::from(!abstract_name);
-        return Ok((storage, addrlen as libc::socklen_t));
+        return Ok((storage, addrlen as rffi::SockLen));
     }
 
     if !unsafe { pyre_object::is_tuple(addr) } {
@@ -2362,12 +2562,12 @@ fn pack_inet_addr(
     // `getsockaddrarg` parses the AF_INET form with `"O&i"` — exactly two
     // items — and the AF_INET6 form with `"O&i|II"` — two to four.
     let len = unsafe { pyre_object::w_tuple_len(addr) };
-    if family == libc::AF_INET && len != 2 {
+    if family == rffi::AF_INET && len != 2 {
         return Err(crate::PyError::type_error(
             "AF_INET address must be a pair (host, port)",
         ));
     }
-    if family == libc::AF_INET6 && !(2..=4).contains(&len) {
+    if family == rffi::AF_INET6 && !(2..=4).contains(&len) {
         return Err(crate::PyError::type_error(
             "AF_INET6 address must be a tuple (host, port[, flowinfo[, scopeid]])",
         ));
@@ -2395,20 +2595,20 @@ fn pack_inet_addr(
 
     let c_host = std::ffi::CString::new(host.as_bytes())
         .map_err(|_| crate::PyError::value_error("embedded null in host"))?;
-    if family == libc::AF_INET {
-        let sin = unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_in) };
-        sin.sin_family = libc::AF_INET as libc::sa_family_t;
+    if family == rffi::AF_INET {
+        let sin = unsafe { &mut *(&mut storage as *mut _ as *mut rffi::sockaddr_in) };
+        sin.sin_family = rffi::AF_INET as rffi::SaFamily;
         sin.sin_port = port;
         // inet_pton handles both "0.0.0.0" and dotted-quad.
         let r = if host.is_empty() {
             // RSocket.makeipaddr('', result) uses the wildcard address for
             // bind(), as required by socketserver and socket_helper.bind_port.
-            sin.sin_addr.s_addr = libc::INADDR_ANY;
+            rffi::sockaddr_in_set_addr(sin, rffi::INADDR_ANY);
             1
         } else {
             unsafe {
-                inet_pton(
-                    libc::AF_INET,
+                rffi::inet_pton(
+                    rffi::AF_INET,
                     c_host.as_ptr(),
                     &mut sin.sin_addr as *mut _ as *mut libc::c_void,
                 )
@@ -2419,12 +2619,12 @@ fn pack_inet_addr(
             // copies the resulting address into its INETAddress.  Do the
             // same here: gethostbyname's process-global result buffer is not
             // re-entrant and was corrupted by socketserver worker threads.
-            let mut hints: libc::addrinfo = unsafe { std::mem::zeroed() };
-            hints.ai_family = libc::AF_INET;
-            let mut result: *mut libc::addrinfo = std::ptr::null_mut();
+            let mut hints: rffi::addrinfo = unsafe { std::mem::zeroed() };
+            hints.ai_family = rffi::AF_INET;
+            let mut result: *mut rffi::addrinfo = std::ptr::null_mut();
             let rc = {
                 let _blocked = crate::module::thread::before_external_block();
-                unsafe { libc::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
+                unsafe { rffi::getaddrinfo(c_host.as_ptr(), std::ptr::null(), &hints, &mut result) }
             };
             if rc != 0 || result.is_null() {
                 return Err(crate::PyError::os_error(format!(
@@ -2435,37 +2635,37 @@ fn pack_inet_addr(
             let mut resolved = None;
             while !current.is_null() {
                 let info = unsafe { &*current };
-                if info.ai_family == libc::AF_INET
+                if info.ai_family == rffi::AF_INET
                     && !info.ai_addr.is_null()
-                    && info.ai_addrlen as usize >= core::mem::size_of::<libc::sockaddr_in>()
+                    && info.ai_addrlen as usize >= core::mem::size_of::<rffi::sockaddr_in>()
                 {
-                    let resolved_addr =
-                        unsafe { &*(info.ai_addr as *const libc::sockaddr_in) };
-                    resolved = Some(resolved_addr.sin_addr);
+                    let resolved_addr = unsafe { &*(info.ai_addr as *const rffi::sockaddr_in) };
+                    resolved = Some(rffi::sockaddr_in_get_addr(resolved_addr));
                     break;
                 }
                 current = info.ai_next;
             }
-            unsafe { libc::freeaddrinfo(result) };
-            sin.sin_addr = resolved.ok_or_else(|| {
+            unsafe { rffi::freeaddrinfo(result) };
+            let resolved = resolved.ok_or_else(|| {
                 crate::PyError::os_error(format!("name or service not known: {host}"))
             })?;
+            rffi::sockaddr_in_set_addr(sin, resolved);
         }
         Ok((
             storage,
-            core::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
+            core::mem::size_of::<rffi::sockaddr_in>() as rffi::SockLen,
         ))
-    } else if family == libc::AF_INET6 {
-        let sin6 = unsafe { &mut *(&mut storage as *mut _ as *mut libc::sockaddr_in6) };
-        sin6.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+    } else if family == rffi::AF_INET6 {
+        let sin6 = unsafe { &mut *(&mut storage as *mut _ as *mut rffi::sockaddr_in6) };
+        sin6.sin6_family = rffi::AF_INET6 as rffi::SaFamily;
         sin6.sin6_port = port;
         let mut buf = [0u8; 16];
         let r = if host.is_empty() {
             1
         } else {
             unsafe {
-                inet_pton(
-                    libc::AF_INET6,
+                rffi::inet_pton(
+                    rffi::AF_INET6,
                     c_host.as_ptr(),
                     buf.as_mut_ptr() as *mut libc::c_void,
                 )
@@ -2476,18 +2676,19 @@ fn pack_inet_addr(
                 "invalid IPv6 address: {host}"
             )));
         }
-        sin6.sin6_addr.s6_addr = buf;
+        rffi::sockaddr_in6_set_addr(sin6, buf);
         if len >= 3
             && let Some(v) = unsafe { pyre_object::w_tuple_getitem(addr, 2) } {
                 sin6.sin6_flowinfo = unsafe { pyre_object::w_int_get_value(v) } as u32;
             }
         if len >= 4
             && let Some(v) = unsafe { pyre_object::w_tuple_getitem(addr, 3) } {
-                sin6.sin6_scope_id = unsafe { pyre_object::w_int_get_value(v) } as u32;
+                let scope_id = unsafe { pyre_object::w_int_get_value(v) } as u32;
+                rffi::sockaddr_in6_set_scope_id(sin6, scope_id);
             }
         Ok((
             storage,
-            core::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t,
+            core::mem::size_of::<rffi::sockaddr_in6>() as rffi::SockLen,
         ))
     } else {
         Err(crate::PyError::os_error(format!(
@@ -2496,21 +2697,21 @@ fn pack_inet_addr(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any(unix, windows))]
 fn unpack_inet_addr(
-    storage: &libc::sockaddr_storage,
-    addrlen: libc::socklen_t,
+    storage: &rffi::sockaddr_storage,
+    addrlen: rffi::SockLen,
 ) -> pyre_object::PyObjectRef {
     let family = storage.ss_family as libc::c_int;
-    if family == libc::AF_INET {
-        let sin = unsafe { &*(storage as *const _ as *const libc::sockaddr_in) };
+    if family == rffi::AF_INET {
+        let sin = unsafe { &*(storage as *const _ as *const rffi::sockaddr_in) };
         let mut buf = [0u8; 64];
         let p = unsafe {
-            inet_ntop(
-                libc::AF_INET,
+            rffi::inet_ntop(
+                rffi::AF_INET,
                 &sin.sin_addr as *const _ as *const libc::c_void,
                 buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len() as libc::socklen_t,
+                buf.len() as rffi::SockLen,
             )
         };
         let host = if p.is_null() {
@@ -2523,15 +2724,15 @@ fn unpack_inet_addr(
             pyre_object::w_str_new(&host),
             pyre_object::w_int_new(port),
         ])
-    } else if family == libc::AF_INET6 {
-        let sin6 = unsafe { &*(storage as *const _ as *const libc::sockaddr_in6) };
+    } else if family == rffi::AF_INET6 {
+        let sin6 = unsafe { &*(storage as *const _ as *const rffi::sockaddr_in6) };
         let mut buf = [0u8; 64];
         let p = unsafe {
-            inet_ntop(
-                libc::AF_INET6,
+            rffi::inet_ntop(
+                rffi::AF_INET6,
                 &sin6.sin6_addr as *const _ as *const libc::c_void,
                 buf.as_mut_ptr() as *mut libc::c_char,
-                buf.len() as libc::socklen_t,
+                buf.len() as rffi::SockLen,
             )
         };
         let host = if p.is_null() {
@@ -2544,37 +2745,48 @@ fn unpack_inet_addr(
             pyre_object::w_str_new(&host),
             pyre_object::w_int_new(port),
             pyre_object::w_int_new(sin6.sin6_flowinfo as i64),
-            pyre_object::w_int_new(sin6.sin6_scope_id as i64),
+            pyre_object::w_int_new(rffi::sockaddr_in6_get_scope_id(sin6) as i64),
         ])
-    } else if family == libc::AF_UNIX {
-        let sun = unsafe { &*(storage as *const _ as *const libc::sockaddr_un) };
-        let maxlength = (addrlen as usize)
-            .saturating_sub(SUN_PATH_OFFSET)
-            .min(sun.sun_path.len());
-        let abstract_name = cfg!(target_os = "linux") && maxlength > 0 && sun.sun_path[0] == 0;
-        let end = if abstract_name {
-            maxlength
-        } else {
-            sun.sun_path[..maxlength]
-                .iter()
-                .position(|&b| b == 0)
-                .unwrap_or(maxlength)
-        };
-        let bytes: Vec<u8> = sun.sun_path[..end].iter().map(|&b| b as u8).collect();
-        if abstract_name {
-            // `interp_socket.py:45 space.newbytes(path)`: abstract names are bytes.
-            pyre_object::bytesobject::w_bytes_from_bytes(&bytes)
-        } else {
-            // `interp_socket.py:47 space.newfilename(path)`: read-back uses the filesystem
-            // decoding so a byte with no UTF-8 spelling survives the round trip.
-            crate::gateway::fsdecode_filename_bytes(&bytes)
-        }
     } else {
+        #[cfg(unix)]
+        if family == libc::AF_UNIX {
+            return unpack_unix_addr(storage, addrlen);
+        }
         pyre_object::w_tuple_new(vec![])
     }
 }
 
+/// `interp_socket.py:40-47` — the `sockaddr_un` half of `unpack_inet_addr`.
 #[cfg(unix)]
+fn unpack_unix_addr(
+    storage: &rffi::sockaddr_storage,
+    addrlen: rffi::SockLen,
+) -> pyre_object::PyObjectRef {
+    let sun = unsafe { &*(storage as *const _ as *const libc::sockaddr_un) };
+    let maxlength = (addrlen as usize)
+        .saturating_sub(SUN_PATH_OFFSET)
+        .min(sun.sun_path.len());
+    let abstract_name = cfg!(target_os = "linux") && maxlength > 0 && sun.sun_path[0] == 0;
+    let end = if abstract_name {
+        maxlength
+    } else {
+        sun.sun_path[..maxlength]
+            .iter()
+            .position(|&b| b == 0)
+            .unwrap_or(maxlength)
+    };
+    let bytes: Vec<u8> = sun.sun_path[..end].iter().map(|&b| b as u8).collect();
+    if abstract_name {
+        // `interp_socket.py:45 space.newbytes(path)`: abstract names are bytes.
+        pyre_object::bytesobject::w_bytes_from_bytes(&bytes)
+    } else {
+        // `interp_socket.py:47 space.newfilename(path)`: read-back uses the filesystem
+        // decoding so a byte with no UTF-8 spelling survives the round trip.
+        crate::gateway::fsdecode_filename_bytes(&bytes)
+    }
+}
+
+#[cfg(any(unix, windows))]
 fn init_socket_type(ns: pyre_object::PyObjectRef) {
     // `interp_socket.py:W_Socket.__init__` first creates an empty wrapper;
     // `descr_init` below installs the RSocket state.  Keeping allocation and
@@ -2599,8 +2811,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "__del__",
             |args| {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let fd = socket_get_attr_i64(obj, "_fd") as libc::c_int;
-                if fd >= 0 {
+                let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
+                if !rffi::is_invalid(fd) {
                     if let Ok(repr) = unsafe { crate::display::py_repr_wtf8(obj) } {
                         let _ = crate::warn::warn_category(
                             &format!("unclosed {}", repr.to_string_lossy()),
@@ -2608,7 +2820,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                             1,
                         );
                     }
-                    let _ = unsafe { libc::close(fd) };
+                    let _ = unsafe { rffi::close(fd) };
                     socket_set_attr(obj, "_fd", pyre_object::w_int_new(-1));
                 }
                 Ok(pyre_object::w_none())
@@ -2678,23 +2890,21 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 // `interp_socket.py:219-225` — without a fileno the
                 // sentinels resolve to AF_INET / SOCK_STREAM / 0.
                 if family == -1 {
-                    family = libc::AF_INET;
+                    family = rffi::AF_INET;
                 }
                 if ty == -1 {
-                    ty = libc::SOCK_STREAM;
+                    ty = rffi::SOCK_STREAM;
                 }
                 if proto == -1 {
                     proto = 0;
                 }
-                let fd = unsafe { libc::socket(family, ty, proto) };
-                if fd < 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                let fd = unsafe { rffi::socket(family, ty, proto) };
+                if rffi::is_invalid(fd) {
+                    return Err(socket_last_error());
                 }
-                // `rsocket.py:RSocket.__init__` sets FD_CLOEXEC on every
-                // newly created socket (PEP 446).
-                unsafe {
-                    libc::fcntl(fd, libc::F_SETFD, libc::FD_CLOEXEC);
-                }
+                // `rsocket.py:RSocket.__init__` keeps every newly created
+                // socket out of an exec'd child (PEP 446).
+                rffi::set_cloexec(fd);
                 socket_init_state(obj, fd, family, ty, proto);
                 return Ok(pyre_object::w_none());
             }
@@ -2713,12 +2923,12 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             if fd < 0 {
                 return Err(crate::PyError::value_error("negative file descriptor"));
             }
-            let fd = fd as libc::c_int;
+            let fd = rffi::socket_from_i64(fd);
             if family == -1 {
                 family = socket_detect_family(fd)?;
             }
             if ty == -1 {
-                ty = socket_getsockopt_int(fd, libc::SOL_SOCKET, libc::SO_TYPE)?;
+                ty = socket_getsockopt_int(fd, rffi::SOL_SOCKET, rffi::SO_TYPE)?;
             }
             if proto == -1 {
                 proto = socket_get_so_protocol(fd)?;
@@ -2810,9 +3020,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "close",
             |args| {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
-                let fd = socket_get_attr_i64(obj, "_fd") as libc::c_int;
-                if fd >= 0 {
-                    let _ = unsafe { libc::close(fd) };
+                let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
+                if !rffi::is_invalid(fd) {
+                    let _ = unsafe { rffi::close(fd) };
                     socket_set_attr(obj, "_fd", pyre_object::w_int_new(-1));
                 }
                 Ok(pyre_object::w_none())
@@ -2869,9 +3079,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let next = n - 1;
                 socket_set_attr(obj, "_usecount", pyre_object::w_int_new(next));
                 if next <= 0 {
-                    let fd = socket_get_attr_i64(obj, "_fd") as libc::c_int;
-                    if fd >= 0 {
-                        let _ = unsafe { libc::close(fd) };
+                    let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
+                    if !rffi::is_invalid(fd) {
+                        let _ = unsafe { rffi::close(fd) };
                         socket_set_attr(obj, "_fd", pyre_object::w_int_new(-1));
                     }
                 }
@@ -2897,9 +3107,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, args[1])?;
                 let r =
-                    unsafe { libc::bind(fd, &storage as *const _ as *const libc::sockaddr, slen) };
+                    unsafe { rffi::bind(fd, &storage as *const _ as *const rffi::sockaddr, slen) };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 Ok(pyre_object::w_none())
             },
@@ -2918,9 +3128,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             } else {
                 128
             };
-            let r = unsafe { libc::listen(fd, backlog) };
+            let r = unsafe { rffi::listen(fd, backlog) };
             if r != 0 {
-                return Err(socket_io_err(std::io::Error::last_os_error()));
+                return Err(socket_last_error());
             }
             Ok(pyre_object::w_none())
         }),
@@ -2938,16 +3148,16 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let ty = socket_get_attr_i64(obj, "_type") as libc::c_int;
                 let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
-                let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-                let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+                let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 let cfd = loop {
-                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::accept(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
+                    let (r, errno) = socket_call(|| unsafe {
+                        rffi::accept(fd, &mut storage as *mut _ as *mut rffi::sockaddr, &mut slen)
                     });
-                    if r >= 0 {
+                    if !rffi::is_invalid(r) {
                         break r;
                     }
-                    if errno != libc::EINTR {
+                    if !rffi::error_is_interrupted(errno) {
                         return Err(socket_io_err_for_operation(
                             obj,
                             std::io::Error::from_raw_os_error(errno),
@@ -2957,12 +3167,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     // (`converted_error` eintr_retry).
                     crate::module::signal::interp_signal::checksignals_now()?;
                 };
-                // `rsocket.py:RSocket._accept` returns the new fd with
-                // FD_CLOEXEC set (rsocket uses accept4(SOCK_CLOEXEC) on
-                // Linux; we use the portable fcntl path).
-                unsafe {
-                    libc::fcntl(cfd, libc::F_SETFD, libc::FD_CLOEXEC);
-                }
+                // `rsocket.py:RSocket._accept` returns the new descriptor
+                // already closed over an exec (rsocket uses
+                // accept4(SOCK_CLOEXEC) on Linux; this is the portable path).
+                rffi::set_cloexec(cfd);
                 let new_sock = socket_from_fd(cfd, family, ty, proto);
                 let addr = unpack_inet_addr(&storage, slen);
                 Ok(pyre_object::w_tuple_new(vec![new_sock, addr]))
@@ -2985,16 +3193,16 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
                 let fd = socket_fd(obj)?;
                 socket_wait_readable(obj, fd)?;
-                let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-                let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+                let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 let cfd = loop {
-                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::accept(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
+                    let (r, errno) = socket_call(|| unsafe {
+                        rffi::accept(fd, &mut storage as *mut _ as *mut rffi::sockaddr, &mut slen)
                     });
-                    if r >= 0 {
+                    if !rffi::is_invalid(r) {
                         break r;
                     }
-                    if errno != libc::EINTR {
+                    if !rffi::error_is_interrupted(errno) {
                         return Err(socket_io_err_for_operation(
                             obj,
                             std::io::Error::from_raw_os_error(errno),
@@ -3004,12 +3212,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     // (`converted_error` eintr_retry).
                     crate::module::signal::interp_signal::checksignals_now()?;
                 };
-                unsafe {
-                    libc::fcntl(cfd, libc::F_SETFD, libc::FD_CLOEXEC);
-                }
+                rffi::set_cloexec(cfd);
                 let addr = unpack_inet_addr(&storage, slen);
                 Ok(pyre_object::w_tuple_new(vec![
-                    pyre_object::w_int_new(cfd as i64),
+                    pyre_object::w_int_new(rffi::socket_to_i64(cfd)),
                     addr,
                 ]))
             },
@@ -3030,14 +3236,24 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, args[1])?;
+                #[cfg(windows)]
+                if let Some(timeout) = socket_positive_timeout(obj) {
+                    return match socket_connect_timed(fd, &storage, slen, timeout) {
+                        Ok(()) => Ok(pyre_object::w_none()),
+                        Err(errno) => Err(socket_io_err_for_operation(
+                            obj,
+                            std::io::Error::from_raw_os_error(errno),
+                        )),
+                    };
+                }
                 loop {
-                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::connect(fd, &storage as *const _ as *const libc::sockaddr, slen)
+                    let (r, errno) = socket_call(|| unsafe {
+                        rffi::connect(fd, &storage as *const _ as *const rffi::sockaddr, slen)
                     });
                     if r == 0 {
                         break;
                     }
-                    if errno != libc::EINTR {
+                    if !rffi::error_is_interrupted(errno) {
                         return Err(socket_io_err(std::io::Error::from_raw_os_error(errno)));
                     }
                     // EINTR: deliver a pending signal, then retry
@@ -3066,16 +3282,21 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, args[1])?;
+                #[cfg(windows)]
+                if let Some(timeout) = socket_positive_timeout(obj) {
+                    let err = socket_connect_timed(fd, &storage, slen, timeout).err();
+                    return Ok(pyre_object::w_int_new(err.unwrap_or(0) as i64));
+                }
                 // `interp_socket.py:387-391` — retry while the call is
                 // interrupted (EINTR), otherwise return the errno.
                 let err = loop {
-                    let (r, e) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::connect(fd, &storage as *const _ as *const libc::sockaddr, slen)
+                    let (r, e) = socket_call(|| unsafe {
+                        rffi::connect(fd, &storage as *const _ as *const rffi::sockaddr, slen)
                     });
                     if r == 0 {
                         break 0;
                     }
-                    if e != libc::EINTR {
+                    if !rffi::error_is_interrupted(e) {
                         break e;
                     }
                     // `interp_socket.py:391` — deliver a pending signal, then
@@ -3113,13 +3334,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let result = (|| -> Result<isize, crate::PyError> {
                 let buf = buffer.as_bytes();
                 loop {
-                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), flags)
+                    let (r, errno) = socket_call(|| unsafe {
+                        rffi::send(fd, buf.as_ptr() as *const libc::c_void, buf.len(), flags)
                     });
                     if r >= 0 {
                         return Ok(r);
                     }
-                    if errno != libc::EINTR {
+                    if !rffi::error_is_interrupted(errno) {
                         return Err(socket_io_err_for_operation(
                             obj,
                             std::io::Error::from_raw_os_error(errno),
@@ -3158,8 +3379,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let buf = buffer.as_bytes();
                 let mut off = 0usize;
                 while off < buf.len() {
-                    let (n, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::send(
+                    let (n, errno) = socket_call(|| unsafe {
+                        rffi::send(
                             fd,
                             buf[off..].as_ptr() as *const libc::c_void,
                             buf.len() - off,
@@ -3167,7 +3388,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         )
                     });
                     if n < 0 {
-                        if errno == libc::EINTR {
+                        if rffi::error_is_interrupted(errno) {
                             // `rsocket.py:1132` signal_checker — deliver a
                             // pending signal, then retry the remaining bytes.
                             crate::module::signal::interp_signal::checksignals_now()?;
@@ -3215,13 +3436,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             };
             let mut buf = vec![0u8; n];
             let got = loop {
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                    libc::recv(fd, buf.as_mut_ptr() as *mut libc::c_void, n, flags)
+                let (r, errno) = socket_call(|| unsafe {
+                    rffi::recv(fd, buf.as_mut_ptr() as *mut libc::c_void, n, flags)
                 });
                 if r >= 0 {
                     break r;
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         obj,
                         std::io::Error::from_raw_os_error(errno),
@@ -3270,20 +3491,20 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
                 let (storage, slen) = pack_inet_addr(family, addr_obj)?;
                 loop {
-                    let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::sendto(
+                    let (r, errno) = socket_call(|| unsafe {
+                        rffi::sendto(
                             fd,
                             buf.as_ptr() as *const libc::c_void,
                             buf.len(),
                             flags,
-                            &storage as *const _ as *const libc::sockaddr,
+                            &storage as *const _ as *const rffi::sockaddr,
                             slen,
                         )
                     });
                     if r >= 0 {
                         return Ok(r);
                     }
-                    if errno != libc::EINTR {
+                    if !rffi::error_is_interrupted(errno) {
                         return Err(socket_io_err_for_operation(
                             obj,
                             std::io::Error::from_raw_os_error(errno),
@@ -3331,23 +3552,23 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 0
             };
             let mut buf = vec![0u8; n];
-            let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+            let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
             let got = loop {
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                    libc::recvfrom(
+                let (r, errno) = socket_call(|| unsafe {
+                    rffi::recvfrom(
                         fd,
                         buf.as_mut_ptr() as *mut libc::c_void,
                         n,
                         flags,
-                        &mut storage as *mut _ as *mut libc::sockaddr,
+                        &mut storage as *mut _ as *mut rffi::sockaddr,
                         &mut slen,
                     )
                 });
                 if r >= 0 {
                     break r;
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         obj,
                         std::io::Error::from_raw_os_error(errno),
@@ -3415,13 +3636,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             };
             let fd = socket_fd(obj)?;
             let got = loop {
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                    libc::recv(fd, slot.as_mut_ptr() as *mut libc::c_void, nbytes, flags)
+                let (r, errno) = socket_call(|| unsafe {
+                    rffi::recv(fd, slot.as_mut_ptr() as *mut libc::c_void, nbytes, flags)
                 });
                 if r >= 0 {
                     break r;
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         obj,
                         std::io::Error::from_raw_os_error(errno),
@@ -3483,23 +3704,23 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 0
             };
             let fd = socket_fd(obj)?;
-            let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-            let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+            let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
             let got = loop {
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
-                    libc::recvfrom(
+                let (r, errno) = socket_call(|| unsafe {
+                    rffi::recvfrom(
                         fd,
                         slot.as_mut_ptr() as *mut libc::c_void,
                         nbytes,
                         flags,
-                        &mut storage as *mut _ as *mut libc::sockaddr,
+                        &mut storage as *mut _ as *mut rffi::sockaddr,
                         &mut slen,
                     )
                 });
                 if r >= 0 {
                     break r;
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         obj,
                         std::io::Error::from_raw_os_error(errno),
@@ -3522,6 +3743,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
     // via libc::recvmsg.  ancdata is a list of (cmsg_level, cmsg_type,
     // cmsg_data:bytes) triples walked through CMSG_FIRSTHDR /
     // CMSG_NXTHDR / CMSG_DATA.
+    // The scatter/gather calls and their ancillary data are POSIX-only;
+    // `socket.py:557,569` test for each before reaching for it.
+    #[cfg(unix)]
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "recvmsg",
@@ -3571,7 +3795,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
 
             let mut data = vec![0u8; bufsize];
             let mut control = vec![0u8; ancbufsize];
-            let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
             let (got, msg_flags, msg_namelen) = loop {
                 let mut iov = libc::iovec {
                     iov_base: data.as_mut_ptr() as *mut libc::c_void,
@@ -3579,20 +3803,20 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 };
                 let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
                 msg.msg_name = &mut storage as *mut _ as *mut libc::c_void;
-                msg.msg_namelen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                msg.msg_namelen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 msg.msg_iov = &mut iov;
                 msg.msg_iovlen = 1;
                 if ancbufsize > 0 {
                     msg.msg_control = control.as_mut_ptr() as *mut libc::c_void;
                     msg.msg_controllen = ancbufsize as _;
                 }
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                let (r, errno) = socket_call(|| unsafe {
                     libc::recvmsg(fd, &mut msg, flags)
                 });
                 if r >= 0 {
                     break (r, msg.msg_flags, msg.msg_namelen);
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         args[0],
                         std::io::Error::from_raw_os_error(errno),
@@ -3653,6 +3877,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
     // `interp_socket.py:572-652 recvmsg_into_w` — scatter-receive into
     // a list/tuple of writable buffers; each `writebuf_w` slice
     // contributes one iovec entry.
+    // The scatter/gather calls and their ancillary data are POSIX-only;
+    // `socket.py:557,569` test for each before reaching for it.
+    #[cfg(unix)]
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "recvmsg_into",
@@ -3726,24 +3953,24 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 })
                 .collect();
             let mut control = vec![0u8; ancbufsize];
-            let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
+            let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
             let (got, msg_flags, msg_namelen, controllen) = loop {
                 let mut msg: libc::msghdr = unsafe { std::mem::zeroed() };
                 msg.msg_name = &mut storage as *mut _ as *mut libc::c_void;
-                msg.msg_namelen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                msg.msg_namelen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 msg.msg_iov = iovs.as_mut_ptr();
                 msg.msg_iovlen = iovs.len() as _;
                 if ancbufsize > 0 {
                     msg.msg_control = control.as_mut_ptr() as *mut libc::c_void;
                     msg.msg_controllen = ancbufsize as _;
                 }
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                let (r, errno) = socket_call(|| unsafe {
                     libc::recvmsg(fd, &mut msg, flags)
                 });
                 if r >= 0 {
                     break (r, msg.msg_flags, msg.msg_namelen, msg.msg_controllen);
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         args[0],
                         std::io::Error::from_raw_os_error(errno),
@@ -3801,6 +4028,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
     // buffers plus optional ancillary control messages.  Each cmsg is
     // a (cmsg_level, cmsg_type, cmsg_data) 3-tuple; we lay them out
     // into a single control buffer via CMSG_SPACE / CMSG_NXTHDR.
+    // The scatter/gather calls and their ancillary data are POSIX-only;
+    // `socket.py:557,569` test for each before reaching for it.
+    #[cfg(unix)]
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "sendmsg",
@@ -3961,13 +4191,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             }
 
             let sent = loop {
-                let (r, errno) = crate::module::thread::call_external_function(|| unsafe {
+                let (r, errno) = socket_call(|| unsafe {
                     libc::sendmsg(fd, &msg, flags)
                 });
                 if r >= 0 {
                     break r;
                 }
-                if errno != libc::EINTR {
+                if !rffi::error_is_interrupted(errno) {
                     return Err(socket_io_err_for_operation(
                         obj,
                         std::io::Error::from_raw_os_error(errno),
@@ -3992,9 +4222,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 }
                 let fd = socket_fd(args[0])?;
                 let how = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
-                let r = unsafe { libc::shutdown(fd, how) };
+                let r = unsafe { rffi::shutdown(fd, how) };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 Ok(pyre_object::w_none())
             },
@@ -4009,13 +4239,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "getsockname",
             |args| {
                 let fd = socket_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
-                let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-                let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+                let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 let r = unsafe {
-                    libc::getsockname(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
+                    rffi::getsockname(fd, &mut storage as *mut _ as *mut rffi::sockaddr, &mut slen)
                 };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 Ok(unpack_inet_addr(&storage, slen))
             },
@@ -4030,13 +4260,13 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "getpeername",
             |args| {
                 let fd = socket_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
-                let mut storage: libc::sockaddr_storage = unsafe { std::mem::zeroed() };
-                let mut slen = core::mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+                let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
+                let mut slen = core::mem::size_of::<rffi::sockaddr_storage>() as rffi::SockLen;
                 let r = unsafe {
-                    libc::getpeername(fd, &mut storage as *mut _ as *mut libc::sockaddr, &mut slen)
+                    rffi::getpeername(fd, &mut storage as *mut _ as *mut rffi::sockaddr, &mut slen)
                 };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 Ok(unpack_inet_addr(&storage, slen))
             },
@@ -4060,21 +4290,21 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let r = unsafe {
                 if pyre_object::is_int(val) {
                     let v = pyre_object::w_int_get_value(val) as libc::c_int;
-                    libc::setsockopt(
+                    rffi::setsockopt(
                         fd,
                         level,
                         name,
                         &v as *const _ as *const libc::c_void,
-                        core::mem::size_of::<libc::c_int>() as libc::socklen_t,
+                        core::mem::size_of::<libc::c_int>() as rffi::SockLen,
                     )
                 } else if pyre_object::bytesobject::is_bytes_like(val) {
                     let data = pyre_object::bytesobject::bytes_like_data(val);
-                    libc::setsockopt(
+                    rffi::setsockopt(
                         fd,
                         level,
                         name,
                         data.as_ptr() as *const libc::c_void,
-                        data.len() as libc::socklen_t,
+                        data.len() as rffi::SockLen,
                     )
                 } else {
                     return Err(crate::PyError::type_error(
@@ -4083,7 +4313,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 }
             };
             if r != 0 {
-                return Err(socket_io_err(std::io::Error::last_os_error()));
+                return Err(socket_last_error());
             }
             Ok(pyre_object::w_none())
         }),
@@ -4111,9 +4341,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             };
             if buflen == 0 {
                 let mut v: libc::c_int = 0;
-                let mut sz = core::mem::size_of::<libc::c_int>() as libc::socklen_t;
+                let mut sz = core::mem::size_of::<libc::c_int>() as rffi::SockLen;
                 let r = unsafe {
-                    libc::getsockopt(
+                    rffi::getsockopt(
                         fd,
                         level,
                         name,
@@ -4122,7 +4352,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     )
                 };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 Ok(pyre_object::w_int_new(v as i64))
             } else {
@@ -4131,9 +4361,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 }
                 let buflen = buflen as usize;
                 let mut buf = vec![0u8; buflen];
-                let mut sz = buflen as libc::socklen_t;
+                let mut sz = buflen as rffi::SockLen;
                 let r = unsafe {
-                    libc::getsockopt(
+                    rffi::getsockopt(
                         fd,
                         level,
                         name,
@@ -4142,7 +4372,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                     )
                 };
                 if r != 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
+                    return Err(socket_last_error());
                 }
                 buf.truncate(sz as usize);
                 Ok(pyre_object::bytesobject::w_bytes_from_bytes(&buf))
@@ -4189,12 +4419,19 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "getblocking",
             |args| {
-                let fd = socket_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
-                let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
-                if flags < 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
-                }
-                Ok(pyre_object::w_bool_from(flags & libc::O_NONBLOCK == 0))
+                let obj = args.first().copied().unwrap_or(pyre_object::PY_NULL);
+                socket_fd(obj)?;
+                // `sock_getblocking` answers from the stored timeout rather
+                // than from the descriptor: `settimeout` is its only writer,
+                // and WinSock's `FIONBIO` cannot be read back.
+                let d = crate::baseobjspace::getdict_native(obj);
+                let blocking = d.is_null()
+                    || unsafe { pyre_object::w_dict_getitem_str(d, "_timeout") }
+                        .filter(|t| unsafe { pyre_object::is_float(*t) })
+                        .is_none_or(|t| unsafe {
+                            pyre_object::floatobject::w_float_get_value(t) != 0.0
+                        });
+                Ok(pyre_object::w_bool_from(blocking))
             },
             1,
         ),
@@ -4285,9 +4522,9 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
         "__exit__",
         crate::make_builtin_function("__exit__", |args| {
             if let Some(&obj) = args.first() {
-                let fd = socket_get_attr_i64(obj, "_fd") as libc::c_int;
-                if fd >= 0 {
-                    let _ = unsafe { libc::close(fd) };
+                let fd = rffi::socket_from_i64(socket_get_attr_i64(obj, "_fd"));
+                if !rffi::is_invalid(fd) {
+                    let _ = unsafe { rffi::close(fd) };
                     socket_set_attr(obj, "_fd", pyre_object::w_int_new(-1));
                 }
             }
@@ -4316,8 +4553,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
         ),
     ) };
 
-    // set_inheritable / get_inheritable — `interp_socket.py` wraps
-    // the FD_CLOEXEC bit on `F_GETFD` / `F_SETFD`.
+    // set_inheritable / get_inheritable — `interp_socket.py` wraps whether
+    // an exec'd child keeps the descriptor.
     unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
         ns,
         "set_inheritable",
@@ -4341,21 +4578,7 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                 };
-                let cur = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-                if cur < 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
-                }
-                let new = if want_inheritable {
-                    cur & !libc::FD_CLOEXEC
-                } else {
-                    cur | libc::FD_CLOEXEC
-                };
-                if new != cur {
-                    let r = unsafe { libc::fcntl(fd, libc::F_SETFD, new) };
-                    if r < 0 {
-                        return Err(socket_io_err(std::io::Error::last_os_error()));
-                    }
-                }
+                rffi::set_inheritable(fd, want_inheritable).map_err(socket_io_err)?;
                 Ok(pyre_object::w_none())
             },
             2,
@@ -4368,18 +4591,11 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             "get_inheritable",
             |args| {
                 let fd = socket_fd(args.first().copied().unwrap_or(pyre_object::PY_NULL))?;
-                let r = unsafe { libc::fcntl(fd, libc::F_GETFD) };
-                if r < 0 {
-                    return Err(socket_io_err(std::io::Error::last_os_error()));
-                }
-                Ok(pyre_object::w_bool_from((r & libc::FD_CLOEXEC) == 0))
+                let inheritable = rffi::get_inheritable(fd).map_err(socket_io_err)?;
+                Ok(pyre_object::w_bool_from(inheritable))
             },
             1,
         ),
     ) };
 }
 
-#[cfg(not(unix))]
-fn socket_type() -> pyre_object::PyObjectRef {
-    crate::typedef::w_object()
-}

--- a/pyre/pyre-interpreter/src/module/_socket/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/mod.rs
@@ -2,6 +2,14 @@
 //!
 //! Provides the lowest-level socket API exposed to Python.  The
 //! interp_socket submodule carries the W_Socket class implementation
-//! plus address conversion / IDNA / error mapping helpers.
+//! plus address conversion / IDNA / error mapping helpers, and
+//! rsocket_rffi carries the host socket layer both platforms reach it
+//! through.  It exists only where such a layer does: a target that is
+//! neither POSIX nor Windows keeps the module's platform-neutral surface
+//! (the error classes, the byte-order helpers, the default timeout) and
+//! nothing that would need a descriptor behind it.
+
+#[cfg(any(unix, windows))]
+mod rsocket_rffi;
 
 crate::pyre_module_init!(interp_socket);

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -248,6 +248,12 @@ pub fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
 }
 #[cfg(windows)]
 pub fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
+    // `INADDR_NONE` is both the failure report and the broadcast address, so
+    // the one spelling that collides is answered before the call — the
+    // substitution `rsocket.py`'s own `inet_addr` fallback makes.
+    if text.to_bytes() == b"255.255.255.255" {
+        return Some([0xff; 4]);
+    }
     init();
     let addr = unsafe { ws::inet_addr(text.as_ptr() as *const u8) };
     (addr != ws::INADDR_NONE).then(|| addr.to_ne_bytes())
@@ -868,4 +874,190 @@ pub unsafe fn inet_ntop(
 ) -> *const libc::c_char {
     init();
     unsafe { ws::inet_ntop(family, src, dst as *mut u8, size as usize) as *const libc::c_char }
+}
+
+// ---------------------------------------------------------------------------
+// The legacy `<netdb.h>` resolvers.
+//
+// `libc` 0.2.186 declares none of them, and the two records they answer with
+// are not the same type on both platforms: `hostent`'s `h_addrtype` and
+// `h_length` are `int` on POSIX and `short` in WinSock, and `servent` orders
+// `s_proto` before `s_port` on Win64 and the other way round everywhere else.
+// A single `#[repr(C)]` mirror would therefore be wrong on one side, so the
+// record stays opaque and every field is read through an accessor.
+// ---------------------------------------------------------------------------
+
+/// The resolver's `hostent` record. Never constructed here — only the pointer
+/// the resolver returns is ever held, and it points into process-global
+/// storage that the next lookup overwrites.
+#[cfg(unix)]
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct Hostent {
+    h_name: *const libc::c_char,
+    h_aliases: *mut *mut libc::c_char,
+    h_addrtype: libc::c_int,
+    h_length: libc::c_int,
+    h_addr_list: *mut *mut libc::c_char,
+}
+#[cfg(windows)]
+pub type Hostent = ws::HOSTENT;
+
+/// The resolver's `servent` record, held on the same terms as [`Hostent`].
+#[cfg(unix)]
+#[repr(C)]
+#[allow(non_snake_case)]
+pub struct Servent {
+    s_name: *const libc::c_char,
+    s_aliases: *mut *mut libc::c_char,
+    s_port: libc::c_int,
+    s_proto: *const libc::c_char,
+}
+#[cfg(windows)]
+pub type Servent = ws::SERVENT;
+
+#[cfg(unix)]
+unsafe extern "C" {
+    #[link_name = "gethostbyname"]
+    fn c_gethostbyname(name: *const libc::c_char) -> *mut Hostent;
+    #[link_name = "gethostbyaddr"]
+    fn c_gethostbyaddr(
+        addr: *const libc::c_void,
+        len: libc::socklen_t,
+        family: libc::c_int,
+    ) -> *mut Hostent;
+    #[link_name = "getservbyname"]
+    fn c_getservbyname(name: *const libc::c_char, proto: *const libc::c_char) -> *mut Servent;
+    #[link_name = "getservbyport"]
+    fn c_getservbyport(port: libc::c_int, proto: *const libc::c_char) -> *mut Servent;
+}
+
+/// `rsocket._get_netdb_lock_thread`: the lookups below answer with a pointer
+/// into one process-global record, so a second lookup on another thread
+/// invalidates the first one's answer. Hold this across both the lookup and
+/// the copying out of everything the caller needs.
+pub fn netdb_lock() -> std::sync::MutexGuard<'static, ()> {
+    static NETDB_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    NETDB_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// Read one slot of a `char **` array the resolver owns.
+///
+/// Darwin packs these arrays at byte-aligned addresses — immediately after a C
+/// string, for instance. C permits the resulting unaligned pointer load and
+/// Rust references do not, so the slot is read as raw storage, matching
+/// `rsocket.gethost_common`'s rffi access rather than manufacturing an aligned
+/// reference.
+pub unsafe fn pointer_at(array: *mut *mut libc::c_char, index: usize) -> *mut libc::c_char {
+    unsafe { std::ptr::read_unaligned(array.add(index)) }
+}
+
+/// # Safety
+/// `name` must be a valid NUL-terminated C string. The returned pointer is
+/// borrowed from process-global storage — see [`netdb_lock`].
+pub unsafe fn host_by_name(name: *const libc::c_char) -> *mut Hostent {
+    #[cfg(unix)]
+    {
+        unsafe { c_gethostbyname(name) }
+    }
+    #[cfg(windows)]
+    {
+        init();
+        unsafe { ws::gethostbyname(name as *const u8) }
+    }
+}
+
+/// # Safety
+/// `addr` must point to `len` readable bytes, and the answer is borrowed —
+/// see [`host_by_name`].
+pub unsafe fn host_by_addr(
+    addr: *const libc::c_void,
+    len: SockLen,
+    family: libc::c_int,
+) -> *mut Hostent {
+    #[cfg(unix)]
+    {
+        unsafe { c_gethostbyaddr(addr, len, family) }
+    }
+    #[cfg(windows)]
+    {
+        init();
+        unsafe { ws::gethostbyaddr(addr as *const u8, len, family) }
+    }
+}
+
+/// # Safety
+/// Both arguments must be valid NUL-terminated C strings or null, and the
+/// answer is borrowed — see [`host_by_name`].
+pub unsafe fn serv_by_name(name: *const libc::c_char, proto: *const libc::c_char) -> *mut Servent {
+    #[cfg(unix)]
+    {
+        unsafe { c_getservbyname(name, proto) }
+    }
+    #[cfg(windows)]
+    {
+        init();
+        unsafe { ws::getservbyname(name as *const u8, proto as *const u8) }
+    }
+}
+
+/// # Safety
+/// `proto` must be a valid NUL-terminated C string or null, and the answer is
+/// borrowed — see [`host_by_name`].
+pub unsafe fn serv_by_port(port: libc::c_int, proto: *const libc::c_char) -> *mut Servent {
+    #[cfg(unix)]
+    {
+        unsafe { c_getservbyport(port, proto) }
+    }
+    #[cfg(windows)]
+    {
+        init();
+        unsafe { ws::getservbyport(port, proto as *const u8) }
+    }
+}
+
+/// # Safety
+/// `h` must be a live answer from one of the host lookups above.
+pub unsafe fn hostent_name(h: *mut Hostent) -> *const libc::c_char {
+    unsafe { (*h).h_name as *const libc::c_char }
+}
+
+/// # Safety
+/// See [`hostent_name`].
+pub unsafe fn hostent_aliases(h: *mut Hostent) -> *mut *mut libc::c_char {
+    unsafe { (*h).h_aliases as *mut *mut libc::c_char }
+}
+
+/// # Safety
+/// See [`hostent_name`].
+pub unsafe fn hostent_addr_type(h: *mut Hostent) -> libc::c_int {
+    unsafe { (*h).h_addrtype as libc::c_int }
+}
+
+/// # Safety
+/// See [`hostent_name`].
+pub unsafe fn hostent_length(h: *mut Hostent) -> libc::c_int {
+    unsafe { (*h).h_length as libc::c_int }
+}
+
+/// # Safety
+/// See [`hostent_name`].
+pub unsafe fn hostent_addr_list(h: *mut Hostent) -> *mut *mut libc::c_char {
+    unsafe { (*h).h_addr_list as *mut *mut libc::c_char }
+}
+
+/// # Safety
+/// `s` must be a live answer from one of the service lookups above.
+pub unsafe fn servent_name(s: *mut Servent) -> *const libc::c_char {
+    unsafe { (*s).s_name as *const libc::c_char }
+}
+
+/// The port as the record stores it: network byte order, in the low 16 bits.
+///
+/// # Safety
+/// See [`servent_name`].
+pub unsafe fn servent_port(s: *mut Servent) -> u16 {
+    unsafe { (*s).s_port as u16 }
 }

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -1,0 +1,871 @@
+//! Host socket layer — PyPy: `rpython/rlib/_rsocket_rffi.py`.
+//!
+//! `_rsocket_rffi.py` is the single place where rsocket's POSIX and `_MSVC`
+//! spellings of the same call meet; everything above it names one API.  This
+//! module plays that role for `interp_socket`: one set of names, a libc body
+//! on unix and a WinSock body on Windows, so the module's own code stays
+//! platform-neutral.  Anything with no counterpart on the other side
+//! (`recvmsg`, `AF_UNIX`, the POSIX-only options) stays gated at the call
+//! site instead of being faked here.
+
+#[cfg(unix)]
+pub use libc::{addrinfo, sockaddr, sockaddr_in, sockaddr_in6, sockaddr_storage};
+
+#[cfg(windows)]
+use windows_sys::Win32::Networking::WinSock as ws;
+
+#[cfg(windows)]
+pub use ws::{
+    ADDRINFOA as addrinfo, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in,
+    SOCKADDR_IN6 as sockaddr_in6, SOCKADDR_STORAGE as sockaddr_storage,
+};
+
+/// The descriptor a socket call takes.  POSIX numbers sockets alongside every
+/// other file descriptor; WinSock hands out an unsigned kernel handle, so the
+/// two differ in both width and signedness and only this alias may be assumed.
+#[cfg(unix)]
+pub type Socket = libc::c_int;
+#[cfg(windows)]
+pub type Socket = ws::SOCKET;
+
+/// `getsockname`'s length argument.  `socklen_t` on POSIX, a plain `int` in
+/// WinSock's prototypes.
+#[cfg(unix)]
+pub type SockLen = libc::socklen_t;
+#[cfg(windows)]
+pub type SockLen = i32;
+
+/// The width `sockaddr.sa_family` is written through.
+#[cfg(unix)]
+pub type SaFamily = libc::sa_family_t;
+#[cfg(windows)]
+pub type SaFamily = ws::ADDRESS_FAMILY;
+
+/// Whether a descriptor names no socket.  POSIX reserves every negative value.
+/// Windows reserves only `INVALID_SOCKET` — `(SOCKET)~0` — and every handle it
+/// hands out is unsigned and may exceed `i32::MAX`, so a socket there must
+/// never be range-tested with `< 0`.
+#[cfg(unix)]
+pub fn is_invalid(s: Socket) -> bool {
+    s < 0
+}
+#[cfg(windows)]
+pub fn is_invalid(s: Socket) -> bool {
+    s == ws::INVALID_SOCKET
+}
+
+/// `fileno()` reports the descriptor as a Python int, and `_fd` stores it as
+/// one.  `PyLong_FromSocket_t` widens the Windows handle through a signed
+/// 64-bit integer, so `INVALID_SOCKET` reads back as `-1` there too and the
+/// closed-socket sentinel is the same value on both platforms.
+pub fn socket_to_i64(s: Socket) -> i64 {
+    s as i64
+}
+
+pub fn socket_from_i64(v: i64) -> Socket {
+    v as Socket
+}
+
+// ── constants the shared body compares against ──
+
+#[cfg(unix)]
+pub use libc::{
+    AF_INET, AF_INET6, AF_UNSPEC, SO_ERROR, SO_TYPE, SOCK_DGRAM, SOCK_STREAM, SOL_SOCKET,
+};
+#[cfg(unix)]
+pub const NI_MAXHOST: usize = libc::NI_MAXHOST as usize;
+#[cfg(unix)]
+pub const INADDR_ANY: u32 = libc::INADDR_ANY;
+#[cfg(unix)]
+pub const AI_NUMERICHOST: libc::c_int = libc::AI_NUMERICHOST;
+
+#[cfg(windows)]
+pub const AF_UNSPEC: libc::c_int = ws::AF_UNSPEC as libc::c_int;
+#[cfg(windows)]
+pub const AF_INET: libc::c_int = ws::AF_INET as libc::c_int;
+#[cfg(windows)]
+pub const AF_INET6: libc::c_int = ws::AF_INET6 as libc::c_int;
+#[cfg(windows)]
+pub const SOCK_STREAM: libc::c_int = ws::SOCK_STREAM;
+#[cfg(windows)]
+pub const SOCK_DGRAM: libc::c_int = ws::SOCK_DGRAM;
+#[cfg(windows)]
+pub const SOL_SOCKET: libc::c_int = ws::SOL_SOCKET;
+#[cfg(windows)]
+pub const SO_TYPE: libc::c_int = ws::SO_TYPE;
+#[cfg(windows)]
+pub const SO_ERROR: libc::c_int = ws::SO_ERROR;
+/// The code an expired wait reports, so a timeout this module times itself
+/// reads back the same as one the host produced.
+#[cfg(windows)]
+pub const ETIMEDOUT: i32 = ws::WSAETIMEDOUT;
+#[cfg(windows)]
+pub const NI_MAXHOST: usize = ws::NI_MAXHOST as usize;
+#[cfg(windows)]
+pub const INADDR_ANY: u32 = ws::INADDR_ANY;
+#[cfg(windows)]
+pub const AI_NUMERICHOST: libc::c_int = ws::AI_NUMERICHOST as libc::c_int;
+
+// ── WinSock initialisation ──
+
+/// `WSAStartup`.  Every WinSock entry point fails with `WSANOTINITIALISED`
+/// until the process has made this call, and the only other things that make
+/// it are the standard library's own socket code and socket2 — neither of
+/// which this module goes through.  Idempotent, so the entry points below can
+/// each open with it rather than depend on an initialisation order.
+#[cfg(windows)]
+pub fn init() {
+    static STARTUP: std::sync::Once = std::sync::Once::new();
+    STARTUP.call_once(|| {
+        let mut data: ws::WSADATA = unsafe { core::mem::zeroed() };
+        // 2.2 is the version every supported Windows implements; the process
+        // keeps the library loaded for its whole life, so no WSACleanup pairs
+        // with it.
+        unsafe { ws::WSAStartup(0x0202, &mut data) };
+    });
+}
+
+#[cfg(unix)]
+pub fn init() {}
+
+// ── error reporting ──
+
+/// The code the last socket call failed with.  WinSock reports through
+/// `WSAGetLastError` and never touches the C runtime's `errno`, which is what
+/// `call_external_function` reads.
+#[cfg(unix)]
+pub fn last_error_code() -> i32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
+}
+#[cfg(windows)]
+pub fn last_error_code() -> i32 {
+    unsafe { ws::WSAGetLastError() }
+}
+
+pub fn last_error() -> std::io::Error {
+    std::io::Error::from_raw_os_error(last_error_code())
+}
+
+/// Whether a code means "a signal arrived, nothing happened" and the call is
+/// to be retried.
+#[cfg(unix)]
+pub fn error_is_interrupted(code: i32) -> bool {
+    code == libc::EINTR
+}
+#[cfg(windows)]
+pub fn error_is_interrupted(code: i32) -> bool {
+    code == ws::WSAEINTR
+}
+
+/// Whether a code means the operation would have blocked.  A positive timeout
+/// is carried by `SO_RCVTIMEO`/`SO_SNDTIMEO`, whose expiry WinSock reports as
+/// `WSAETIMEDOUT` rather than as a would-block, so both spell the same
+/// `TimeoutError` here.
+#[cfg(unix)]
+pub fn error_is_would_block(code: i32) -> bool {
+    code == libc::EAGAIN || code == libc::EWOULDBLOCK
+}
+#[cfg(windows)]
+pub fn error_is_would_block(code: i32) -> bool {
+    code == ws::WSAEWOULDBLOCK || code == ws::WSAETIMEDOUT
+}
+
+/// `gai_strerror`.  The symbol is a header-level inline on Windows, where the
+/// `EAI_*` codes are WSA error codes and the system message table describes
+/// them.
+#[cfg(unix)]
+pub fn gai_strerror(code: libc::c_int) -> String {
+    unsafe { std::ffi::CStr::from_ptr(libc::gai_strerror(code)) }
+        .to_string_lossy()
+        .into_owned()
+}
+#[cfg(all(windows, feature = "host_env"))]
+pub fn gai_strerror(code: libc::c_int) -> String {
+    rustpython_host_env::windows::format_error_message(Some(code as u32))
+        .map(|message| {
+            message
+                .trim_end_matches(|c: char| c <= ' ' || c == '.')
+                .to_string()
+        })
+        .unwrap_or_else(|| format!("Unknown error {code}"))
+}
+#[cfg(all(windows, not(feature = "host_env")))]
+pub fn gai_strerror(code: libc::c_int) -> String {
+    format!("Unknown error {code}")
+}
+
+// ── name lookups ──
+
+/// `interp_func.py:24 gethostname` — the host's own name, as the opaque OS
+/// string it is (`sethostname(2)` takes a plain `const char *`), so a byte or
+/// code unit with no text spelling survives the caller's filesystem decode.
+#[cfg(unix)]
+pub fn hostname() -> std::io::Result<std::ffi::OsString> {
+    use std::os::unix::ffi::OsStringExt;
+    let mut buf = [0u8; 256];
+    if unsafe { libc::gethostname(buf.as_mut_ptr() as *mut libc::c_char, buf.len()) } != 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let end = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    Ok(std::ffi::OsString::from_vec(buf[..end].to_vec()))
+}
+#[cfg(all(windows, feature = "host_env"))]
+pub fn hostname() -> std::io::Result<std::ffi::OsString> {
+    init();
+    Ok(rustpython_host_env::socket::hostname())
+}
+#[cfg(all(windows, not(feature = "host_env")))]
+pub fn hostname() -> std::io::Result<std::ffi::OsString> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+/// `interp_func.py:125-134 getprotobyname` — the `IPPROTO_*` number a protocol
+/// name stands for, or `None` when the database does not name it.
+#[cfg(unix)]
+pub fn protocol_by_name(name: &std::ffi::CStr) -> Option<libc::c_int> {
+    let entry = unsafe { libc::getprotobyname(name.as_ptr()) };
+    (!entry.is_null()).then(|| unsafe { (*entry).p_proto })
+}
+#[cfg(windows)]
+pub fn protocol_by_name(name: &std::ffi::CStr) -> Option<libc::c_int> {
+    init();
+    let entry = unsafe { ws::getprotobyname(name.as_ptr() as *const u8) };
+    (!entry.is_null()).then(|| unsafe { (*entry).p_proto as libc::c_int })
+}
+
+/// `inet_aton` — the lenient dotted-quad parser, returning the four address
+/// bytes in network order.  WinSock has no `inet_aton`; `inet_addr` accepts
+/// the same spellings and reports failure as `INADDR_NONE`, which is the
+/// substitution `socketmodule.c socket_inet_aton` makes without one.
+#[cfg(unix)]
+pub fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
+    unsafe extern "C" {
+        #[link_name = "inet_aton"]
+        fn c_inet_aton(cp: *const libc::c_char, inp: *mut libc::in_addr) -> libc::c_int;
+    }
+    let mut addr: libc::in_addr = unsafe { core::mem::zeroed() };
+    (unsafe { c_inet_aton(text.as_ptr(), &mut addr) } != 0).then(|| addr.s_addr.to_ne_bytes())
+}
+#[cfg(windows)]
+pub fn inet_aton(text: &std::ffi::CStr) -> Option<[u8; 4]> {
+    init();
+    let addr = unsafe { ws::inet_addr(text.as_ptr() as *const u8) };
+    (addr != ws::INADDR_NONE).then(|| addr.to_ne_bytes())
+}
+
+/// `inet_ntoa` — the dotted-quad spelling of four address bytes in network
+/// order.
+#[cfg(unix)]
+pub fn inet_ntoa(packed: [u8; 4]) -> Option<String> {
+    unsafe extern "C" {
+        #[link_name = "inet_ntoa"]
+        fn c_inet_ntoa(addr: libc::in_addr) -> *mut libc::c_char;
+    }
+    let addr = libc::in_addr {
+        s_addr: u32::from_ne_bytes(packed),
+    };
+    let text = unsafe { c_inet_ntoa(addr) };
+    (!text.is_null()).then(|| {
+        unsafe { std::ffi::CStr::from_ptr(text) }
+            .to_string_lossy()
+            .into_owned()
+    })
+}
+#[cfg(windows)]
+pub fn inet_ntoa(packed: [u8; 4]) -> Option<String> {
+    init();
+    let addr = ws::IN_ADDR {
+        S_un: ws::IN_ADDR_0 {
+            S_addr: u32::from_ne_bytes(packed),
+        },
+    };
+    let text = unsafe { ws::inet_ntoa(addr) };
+    (!text.is_null()).then(|| {
+        unsafe { std::ffi::CStr::from_ptr(text as *const libc::c_char) }
+            .to_string_lossy()
+            .into_owned()
+    })
+}
+
+// ── descriptor inheritance ──
+
+/// `rsocket.py:RSocket.__init__` closes every socket it creates over an exec
+/// (PEP 446).  POSIX spells that as `FD_CLOEXEC`, Windows as the handle's
+/// inherit flag.  Best-effort, like the `fcntl` call it replaces.
+#[cfg(unix)]
+pub fn set_cloexec(s: Socket) {
+    unsafe { libc::fcntl(s, libc::F_SETFD, libc::FD_CLOEXEC) };
+}
+#[cfg(all(windows, feature = "host_env"))]
+pub fn set_cloexec(s: Socket) {
+    let _ = rustpython_host_env::socket::set_socket_inheritable(s, false);
+}
+#[cfg(all(windows, not(feature = "host_env")))]
+pub fn set_cloexec(_s: Socket) {}
+
+/// `interp_socket.py set_inheritable_w` — whether an exec'd child keeps this
+/// socket.  POSIX inverts `FD_CLOEXEC`, Windows reads the handle's own flag.
+#[cfg(unix)]
+pub fn get_inheritable(s: Socket) -> std::io::Result<bool> {
+    let flags = unsafe { libc::fcntl(s, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok((flags & libc::FD_CLOEXEC) == 0)
+}
+#[cfg(all(windows, feature = "host_env"))]
+pub fn get_inheritable(s: Socket) -> std::io::Result<bool> {
+    rustpython_host_env::nt::get_handle_inheritable(s as _)
+}
+#[cfg(all(windows, not(feature = "host_env")))]
+pub fn get_inheritable(_s: Socket) -> std::io::Result<bool> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+#[cfg(unix)]
+pub fn set_inheritable(s: Socket, inheritable: bool) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(s, libc::F_GETFD) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let wanted = if inheritable {
+        flags & !libc::FD_CLOEXEC
+    } else {
+        flags | libc::FD_CLOEXEC
+    };
+    if wanted != flags && unsafe { libc::fcntl(s, libc::F_SETFD, wanted) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    Ok(())
+}
+#[cfg(all(windows, feature = "host_env"))]
+pub fn set_inheritable(s: Socket, inheritable: bool) -> std::io::Result<()> {
+    rustpython_host_env::socket::set_socket_inheritable(s, inheritable)
+}
+#[cfg(all(windows, not(feature = "host_env")))]
+pub fn set_inheritable(_s: Socket, _inheritable: bool) -> std::io::Result<()> {
+    Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
+}
+
+// ── blocking mode and timeouts ──
+
+/// `rsocket.py:RSocket.settimeout` — put a live socket into the blocking mode
+/// a Python timeout asks for.  A negative `timeout` is the `None` sentinel
+/// (block indefinitely), `0.0` is non-blocking, and a positive one blocks with
+/// `SO_RCVTIMEO`/`SO_SNDTIMEO` bounding each wait.
+///
+/// POSIX carries the mode in the descriptor's `O_NONBLOCK` and the durations
+/// as `struct timeval`; WinSock has `FIONBIO` and a `DWORD` of milliseconds.
+#[cfg(unix)]
+pub fn apply_timeout(s: Socket, timeout: f64) -> std::io::Result<()> {
+    let flags = unsafe { libc::fcntl(s, libc::F_GETFL, 0) };
+    if flags < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // Bit-clear without unary `!` so the static analyzer accepts the helper
+    // (the analyzer rejects bitwise-not on signed `c_int`).
+    let new_flags = if timeout == 0.0 {
+        flags | libc::O_NONBLOCK
+    } else if (flags & libc::O_NONBLOCK) != 0 {
+        flags - libc::O_NONBLOCK
+    } else {
+        flags
+    };
+    if new_flags != flags && unsafe { libc::fcntl(s, libc::F_SETFL, new_flags) } < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let tv = if timeout > 0.0 {
+        libc::timeval {
+            tv_sec: timeout.trunc() as libc::time_t,
+            tv_usec: ((timeout - timeout.trunc()) * 1_000_000.0).round() as libc::suseconds_t,
+        }
+    } else {
+        libc::timeval {
+            tv_sec: 0,
+            tv_usec: 0,
+        }
+    };
+    for option in [libc::SO_RCVTIMEO, libc::SO_SNDTIMEO] {
+        let r = unsafe {
+            libc::setsockopt(
+                s,
+                libc::SOL_SOCKET,
+                option,
+                &tv as *const _ as *const libc::c_void,
+                core::mem::size_of::<libc::timeval>() as SockLen,
+            )
+        };
+        if r != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+pub fn apply_timeout(s: Socket, timeout: f64) -> std::io::Result<()> {
+    let mut nonblocking: u32 = u32::from(timeout == 0.0);
+    if unsafe { ws::ioctlsocket(s, ws::FIONBIO, &mut nonblocking) } == ws::SOCKET_ERROR {
+        return Err(last_error());
+    }
+    // `SO_RCVTIMEO` reads a millisecond count, and zero there means "no
+    // timeout"; a sub-millisecond request still has to expire, so it waits the
+    // shortest period the option can express.
+    let millis: u32 = if timeout > 0.0 {
+        ((timeout * 1000.0).round() as u64).clamp(1, u32::MAX as u64) as u32
+    } else {
+        0
+    };
+    for option in [ws::SO_RCVTIMEO, ws::SO_SNDTIMEO] {
+        let r = unsafe {
+            ws::setsockopt(
+                s,
+                ws::SOL_SOCKET,
+                option,
+                &millis as *const u32 as *const u8,
+                core::mem::size_of::<u32>() as i32,
+            )
+        };
+        if r == ws::SOCKET_ERROR {
+            return Err(last_error());
+        }
+    }
+    Ok(())
+}
+
+/// `RSocket._select(False)`: wait until a socket has something to read, for at
+/// most `timeout_ms`.  Returns the call's result — positive when ready, `0` on
+/// expiry, negative on failure — paired with the code a failure reported.
+#[cfg(unix)]
+pub fn poll_readable(s: Socket, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
+    let mut pollfd = libc::pollfd {
+        fd: s,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    crate::module::thread::call_external_function(|| unsafe {
+        libc::poll(&mut pollfd, 1, timeout_ms)
+    })
+}
+#[cfg(windows)]
+pub fn poll_readable(s: Socket, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
+    poll_one(s, ws::POLLIN, timeout_ms)
+}
+
+/// The other half of `RSocket._select`, which `internal_connect` waits on: a
+/// connection started in non-blocking mode reports its outcome by making the
+/// socket writable.  Windows-only because `SO_SNDTIMEO` already bounds a
+/// POSIX connect.
+#[cfg(windows)]
+pub fn poll_writable(s: Socket, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
+    poll_one(s, ws::POLLOUT, timeout_ms)
+}
+
+#[cfg(windows)]
+fn poll_one(s: Socket, events: i16, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
+    let mut pollfd = ws::WSAPOLLFD {
+        fd: s,
+        events,
+        revents: 0,
+    };
+    let _blocked = crate::module::thread::before_external_block();
+    let ready = unsafe { ws::WSAPoll(&mut pollfd, 1, timeout_ms) };
+    (ready, last_error_code())
+}
+
+// ── address-structure accessors ──
+//
+// The fields these reach are the ones the two platforms spell differently:
+// WinSock wraps `in_addr` / `in6_addr` / the IPv6 scope id in anonymous
+// unions, so they cannot be read or written by name from shared code.
+
+#[cfg(unix)]
+pub fn sockaddr_in_get_addr(sin: &sockaddr_in) -> u32 {
+    sin.sin_addr.s_addr
+}
+#[cfg(windows)]
+pub fn sockaddr_in_get_addr(sin: &sockaddr_in) -> u32 {
+    unsafe { sin.sin_addr.S_un.S_addr }
+}
+
+/// The IPv4 address in network byte order, as `inet_pton` writes it.
+#[cfg(unix)]
+pub fn sockaddr_in_set_addr(sin: &mut sockaddr_in, addr: u32) {
+    sin.sin_addr.s_addr = addr;
+}
+#[cfg(windows)]
+pub fn sockaddr_in_set_addr(sin: &mut sockaddr_in, addr: u32) {
+    sin.sin_addr.S_un.S_addr = addr;
+}
+
+#[cfg(unix)]
+pub fn sockaddr_in6_set_addr(sin6: &mut sockaddr_in6, addr: [u8; 16]) {
+    sin6.sin6_addr.s6_addr = addr;
+}
+#[cfg(windows)]
+pub fn sockaddr_in6_set_addr(sin6: &mut sockaddr_in6, addr: [u8; 16]) {
+    sin6.sin6_addr.u.Byte = addr;
+}
+
+#[cfg(unix)]
+pub fn sockaddr_in6_get_scope_id(sin6: &sockaddr_in6) -> u32 {
+    sin6.sin6_scope_id
+}
+#[cfg(windows)]
+pub fn sockaddr_in6_get_scope_id(sin6: &sockaddr_in6) -> u32 {
+    unsafe { sin6.Anonymous.sin6_scope_id }
+}
+
+#[cfg(unix)]
+pub fn sockaddr_in6_set_scope_id(sin6: &mut sockaddr_in6, scope_id: u32) {
+    sin6.sin6_scope_id = scope_id;
+}
+#[cfg(windows)]
+pub fn sockaddr_in6_set_scope_id(sin6: &mut sockaddr_in6, scope_id: u32) {
+    sin6.Anonymous.sin6_scope_id = scope_id;
+}
+
+// ── the calls themselves ──
+//
+// One signature per call, taking the widths the shared body already works in:
+// byte counts as `usize`, transfer results as `isize`.  WinSock's `int`-shaped
+// prototypes are narrowed here, at the single place that knows the ceiling.
+
+/// WinSock counts a transfer in an `int`, so a single call can move at most
+/// `i32::MAX` bytes; a longer request is served over several calls, exactly as
+/// a short read leaves the caller looping today.
+#[cfg(windows)]
+fn clamp_transfer_len(len: usize) -> i32 {
+    len.min(i32::MAX as usize) as i32
+}
+
+#[cfg(unix)]
+pub unsafe fn socket(family: libc::c_int, ty: libc::c_int, proto: libc::c_int) -> Socket {
+    unsafe { libc::socket(family, ty, proto) }
+}
+#[cfg(windows)]
+pub unsafe fn socket(family: libc::c_int, ty: libc::c_int, proto: libc::c_int) -> Socket {
+    init();
+    unsafe { ws::socket(family, ty, proto) }
+}
+
+#[cfg(unix)]
+pub unsafe fn close(s: Socket) -> libc::c_int {
+    unsafe { libc::close(s) }
+}
+#[cfg(windows)]
+pub unsafe fn close(s: Socket) -> libc::c_int {
+    unsafe { ws::closesocket(s) }
+}
+
+#[cfg(unix)]
+pub unsafe fn bind(s: Socket, addr: *const sockaddr, len: SockLen) -> libc::c_int {
+    unsafe { libc::bind(s, addr, len) }
+}
+#[cfg(windows)]
+pub unsafe fn bind(s: Socket, addr: *const sockaddr, len: SockLen) -> libc::c_int {
+    unsafe { ws::bind(s, addr, len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn connect(s: Socket, addr: *const sockaddr, len: SockLen) -> libc::c_int {
+    unsafe { libc::connect(s, addr, len) }
+}
+#[cfg(windows)]
+pub unsafe fn connect(s: Socket, addr: *const sockaddr, len: SockLen) -> libc::c_int {
+    unsafe { ws::connect(s, addr, len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn listen(s: Socket, backlog: libc::c_int) -> libc::c_int {
+    unsafe { libc::listen(s, backlog) }
+}
+#[cfg(windows)]
+pub unsafe fn listen(s: Socket, backlog: libc::c_int) -> libc::c_int {
+    unsafe { ws::listen(s, backlog) }
+}
+
+#[cfg(unix)]
+pub unsafe fn accept(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> Socket {
+    unsafe { libc::accept(s, addr, len) }
+}
+#[cfg(windows)]
+pub unsafe fn accept(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> Socket {
+    unsafe { ws::accept(s, addr, len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn send(
+    s: Socket,
+    buf: *const core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+) -> isize {
+    unsafe { libc::send(s, buf, len, flags) }
+}
+#[cfg(windows)]
+pub unsafe fn send(
+    s: Socket,
+    buf: *const core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+) -> isize {
+    unsafe { ws::send(s, buf.cast(), clamp_transfer_len(len), flags) as isize }
+}
+
+#[cfg(unix)]
+pub unsafe fn recv(
+    s: Socket,
+    buf: *mut core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+) -> isize {
+    unsafe { libc::recv(s, buf, len, flags) }
+}
+#[cfg(windows)]
+pub unsafe fn recv(
+    s: Socket,
+    buf: *mut core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+) -> isize {
+    unsafe { ws::recv(s, buf.cast(), clamp_transfer_len(len), flags) as isize }
+}
+
+#[cfg(unix)]
+pub unsafe fn sendto(
+    s: Socket,
+    buf: *const core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+    addr: *const sockaddr,
+    addrlen: SockLen,
+) -> isize {
+    unsafe { libc::sendto(s, buf, len, flags, addr, addrlen) }
+}
+#[cfg(windows)]
+pub unsafe fn sendto(
+    s: Socket,
+    buf: *const core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+    addr: *const sockaddr,
+    addrlen: SockLen,
+) -> isize {
+    unsafe { ws::sendto(s, buf.cast(), clamp_transfer_len(len), flags, addr, addrlen) as isize }
+}
+
+#[cfg(unix)]
+pub unsafe fn recvfrom(
+    s: Socket,
+    buf: *mut core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+    addr: *mut sockaddr,
+    addrlen: *mut SockLen,
+) -> isize {
+    unsafe { libc::recvfrom(s, buf, len, flags, addr, addrlen) }
+}
+#[cfg(windows)]
+pub unsafe fn recvfrom(
+    s: Socket,
+    buf: *mut core::ffi::c_void,
+    len: usize,
+    flags: libc::c_int,
+    addr: *mut sockaddr,
+    addrlen: *mut SockLen,
+) -> isize {
+    unsafe { ws::recvfrom(s, buf.cast(), clamp_transfer_len(len), flags, addr, addrlen) as isize }
+}
+
+#[cfg(unix)]
+pub unsafe fn getsockname(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> libc::c_int {
+    unsafe { libc::getsockname(s, addr, len) }
+}
+#[cfg(windows)]
+pub unsafe fn getsockname(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> libc::c_int {
+    unsafe { ws::getsockname(s, addr, len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn getpeername(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> libc::c_int {
+    unsafe { libc::getpeername(s, addr, len) }
+}
+#[cfg(windows)]
+pub unsafe fn getpeername(s: Socket, addr: *mut sockaddr, len: *mut SockLen) -> libc::c_int {
+    unsafe { ws::getpeername(s, addr, len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn getsockopt(
+    s: Socket,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: *mut core::ffi::c_void,
+    len: *mut SockLen,
+) -> libc::c_int {
+    unsafe { libc::getsockopt(s, level, option, value, len) }
+}
+#[cfg(windows)]
+pub unsafe fn getsockopt(
+    s: Socket,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: *mut core::ffi::c_void,
+    len: *mut SockLen,
+) -> libc::c_int {
+    unsafe { ws::getsockopt(s, level, option, value.cast(), len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn setsockopt(
+    s: Socket,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: *const core::ffi::c_void,
+    len: SockLen,
+) -> libc::c_int {
+    unsafe { libc::setsockopt(s, level, option, value, len) }
+}
+#[cfg(windows)]
+pub unsafe fn setsockopt(
+    s: Socket,
+    level: libc::c_int,
+    option: libc::c_int,
+    value: *const core::ffi::c_void,
+    len: SockLen,
+) -> libc::c_int {
+    unsafe { ws::setsockopt(s, level, option, value.cast(), len) }
+}
+
+#[cfg(unix)]
+pub unsafe fn shutdown(s: Socket, how: libc::c_int) -> libc::c_int {
+    unsafe { libc::shutdown(s, how) }
+}
+#[cfg(windows)]
+pub unsafe fn shutdown(s: Socket, how: libc::c_int) -> libc::c_int {
+    unsafe { ws::shutdown(s, how) }
+}
+
+#[cfg(unix)]
+pub unsafe fn getaddrinfo(
+    node: *const libc::c_char,
+    service: *const libc::c_char,
+    hints: *const addrinfo,
+    res: *mut *mut addrinfo,
+) -> libc::c_int {
+    unsafe { libc::getaddrinfo(node, service, hints, res) }
+}
+#[cfg(windows)]
+pub unsafe fn getaddrinfo(
+    node: *const libc::c_char,
+    service: *const libc::c_char,
+    hints: *const addrinfo,
+    res: *mut *mut addrinfo,
+) -> libc::c_int {
+    init();
+    unsafe { ws::getaddrinfo(node as *const u8, service as *const u8, hints, res) }
+}
+
+#[cfg(unix)]
+pub unsafe fn freeaddrinfo(res: *mut addrinfo) {
+    unsafe { libc::freeaddrinfo(res) }
+}
+#[cfg(windows)]
+pub unsafe fn freeaddrinfo(res: *mut addrinfo) {
+    unsafe { ws::freeaddrinfo(res) }
+}
+
+#[cfg(unix)]
+pub unsafe fn getnameinfo(
+    addr: *const sockaddr,
+    addrlen: SockLen,
+    host: *mut libc::c_char,
+    hostlen: SockLen,
+    service: *mut libc::c_char,
+    servicelen: SockLen,
+    flags: libc::c_int,
+) -> libc::c_int {
+    unsafe { libc::getnameinfo(addr, addrlen, host, hostlen, service, servicelen, flags) }
+}
+#[cfg(windows)]
+pub unsafe fn getnameinfo(
+    addr: *const sockaddr,
+    addrlen: SockLen,
+    host: *mut libc::c_char,
+    hostlen: SockLen,
+    service: *mut libc::c_char,
+    servicelen: SockLen,
+    flags: libc::c_int,
+) -> libc::c_int {
+    init();
+    unsafe {
+        ws::getnameinfo(
+            addr,
+            addrlen,
+            host as *mut u8,
+            hostlen as u32,
+            service as *mut u8,
+            servicelen as u32,
+            flags,
+        )
+    }
+}
+
+// <arpa/inet.h>'s two address converters, which the libc crate does not
+// declare on any unix target we ship.  Aliased so the wrappers below can keep
+// the header's names.
+#[cfg(unix)]
+unsafe extern "C" {
+    #[link_name = "inet_pton"]
+    fn c_inet_pton(
+        af: libc::c_int,
+        src: *const libc::c_char,
+        dst: *mut libc::c_void,
+    ) -> libc::c_int;
+    #[link_name = "inet_ntop"]
+    fn c_inet_ntop(
+        af: libc::c_int,
+        src: *const libc::c_void,
+        dst: *mut libc::c_char,
+        size: libc::socklen_t,
+    ) -> *const libc::c_char;
+}
+
+#[cfg(unix)]
+pub unsafe fn inet_pton(
+    family: libc::c_int,
+    src: *const libc::c_char,
+    dst: *mut core::ffi::c_void,
+) -> libc::c_int {
+    unsafe { c_inet_pton(family, src, dst as *mut libc::c_void) }
+}
+#[cfg(windows)]
+pub unsafe fn inet_pton(
+    family: libc::c_int,
+    src: *const libc::c_char,
+    dst: *mut core::ffi::c_void,
+) -> libc::c_int {
+    init();
+    unsafe { ws::inet_pton(family, src as *const u8, dst) }
+}
+
+#[cfg(unix)]
+pub unsafe fn inet_ntop(
+    family: libc::c_int,
+    src: *const core::ffi::c_void,
+    dst: *mut libc::c_char,
+    size: SockLen,
+) -> *const libc::c_char {
+    unsafe { c_inet_ntop(family, src as *const libc::c_void, dst, size) }
+}
+#[cfg(windows)]
+pub unsafe fn inet_ntop(
+    family: libc::c_int,
+    src: *const core::ffi::c_void,
+    dst: *mut libc::c_char,
+    size: SockLen,
+) -> *const libc::c_char {
+    init();
+    unsafe { ws::inet_ntop(family, src, dst as *mut u8, size as usize) as *const libc::c_char }
+}

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -59,7 +59,9 @@ pub fn is_invalid(s: Socket) -> bool {
 /// 64-bit integer, so `INVALID_SOCKET` reads back as `-1` there too and the
 /// closed-socket sentinel is the same value on both platforms.
 pub fn socket_to_i64(s: Socket) -> i64 {
-    s as i64
+    // Through the pointer-width signed type, so a 32-bit `SOCKET` reaches the
+    // widening as `-1` rather than as `4294967295`.
+    s as isize as i64
 }
 
 pub fn socket_from_i64(v: i64) -> Socket {
@@ -462,9 +464,37 @@ pub fn poll_readable(s: Socket, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
 /// connection started in non-blocking mode reports its outcome by making the
 /// socket writable.  Windows-only because `SO_SNDTIMEO` already bounds a
 /// POSIX connect.
+///
+/// `select` with the socket in `exceptfds` as well as `writefds`, which is how
+/// `internal_select(connect=1)` waits: a refused connection makes the socket
+/// readable and exceptional rather than writable, and `WSAPoll` did not wake
+/// for one at all before Windows 10 version 2004 — the caller would read
+/// `WSAETIMEDOUT` where the connection error belongs.
 #[cfg(windows)]
 pub fn poll_writable(s: Socket, timeout_ms: libc::c_int) -> (libc::c_int, i32) {
-    poll_one(s, ws::POLLOUT, timeout_ms)
+    let mut writefds = ws::FD_SET {
+        fd_count: 1,
+        ..Default::default()
+    };
+    writefds.fd_array[0] = s;
+    let mut exceptfds = writefds;
+    let timeout = ws::TIMEVAL {
+        tv_sec: timeout_ms / 1000,
+        tv_usec: (timeout_ms % 1000) * 1000,
+    };
+    let _blocked = crate::module::thread::before_external_block();
+    // WinSock ignores `nfds`: its fd_set is a counted SOCKET array, not a
+    // descriptor-indexed bitmap.
+    let ready = unsafe {
+        ws::select(
+            0,
+            std::ptr::null_mut(),
+            &mut writefds,
+            &mut exceptfds,
+            &timeout,
+        )
+    };
+    (ready, last_error_code())
 }
 
 #[cfg(windows)]

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2364,6 +2364,26 @@ fn get_default_verify_paths(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     ]))
 }
 
+/// `enum_certificates(store_name)` and `enum_crls(store_name)` report the
+/// contents of a Windows system certificate store: the first as
+/// (cert_bytes, encoding_type, trust) triples, where `encoding_type` is
+/// `"x509_asn"` or `"pkcs_7_asn"` and `trust` is either a frozenset of
+/// enhanced-key-usage OIDs or `True` for "valid for every purpose"; the second
+/// as (crl_bytes, encoding_type) pairs.
+///
+/// Both stores always read as empty.  Walking one means CertOpenStore plus
+/// CertEnumCertificatesInStore/CertEnumCRLsInStore, and this build links no
+/// wincrypt binding to reach them.  Verification does not depend on it —
+/// `set_default_verify_paths` loads the Windows roots through the platform
+/// certificate provider — but callers that mine the store themselves
+/// (`ssl.enum_certificates`, `wincertstore`) see nothing.  `ssl.py` imports
+/// both names unconditionally on win32, which is why they exist at all.
+#[cfg(windows)]
+fn enum_windows_cert_store(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    crate::baseobjspace::str_utf8_w(args[0])?;
+    Ok(w_list_new(Vec::new()))
+}
+
 fn test_decode_cert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let path = path_string(args[0])?;
     let cert = native_result(pyre_native::ssl::certificate_decode_file(&path))?;
@@ -2495,6 +2515,22 @@ crate::py_module! {
         "_test_decode_cert" / 1 = test_decode_cert
     },
     extra_init: |ns| {
+        // The Windows-only store readers. They live here rather than in
+        // `functions:` because that table has no per-entry platform guard, and
+        // `ssl.py:257-258` imports both names behind `sys.platform == "win32"`.
+        #[cfg(windows)]
+        for (name, func) in [
+            (
+                "enum_certificates",
+                crate::py_module_fn!("enum_certificates", 1, enum_windows_cert_store),
+            ),
+            (
+                "enum_crls",
+                crate::py_module_fn!("enum_crls", 1, enum_windows_cert_store),
+            ),
+        ] {
+            crate::module_ns_store(ns, name, crate::gateway::with_module("_ssl", func));
+        }
         let ssl_error = crate::builtins::lookup_exc_class("_ssl.SSLError")
             .expect("SSLError installed");
         let ssl_error_dict =

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2544,10 +2544,7 @@ mod cert_store {
                     pyre_object::gc_roots::pin_root(trust.unwrap_or_else(|| w_bool_from(true)));
                     let cert_slot = pyre_object::gc_roots::shadow_stack_len();
                     pyre_object::gc_roots::pin_root(w_bytes_from_bytes(
-                        std::slice::from_raw_parts(
-                            cert.pbCertEncoded,
-                            cert.cbCertEncoded as usize,
-                        ),
+                        std::slice::from_raw_parts(cert.pbCertEncoded, cert.cbCertEncoded as usize),
                     ));
                     let encoding = encoding_type(cert.dwCertEncodingType);
                     Ok(w_tuple_new(vec![

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2459,15 +2459,27 @@ mod cert_store {
         free: unsafe extern "system" fn(*const T) -> BOOL,
         convert: impl Fn(&T) -> Result<PyObjectRef, crate::PyError>,
     ) -> Result<Vec<PyObjectRef>, crate::PyError> {
-        let mut items = Vec::new();
+        // A store such as `ROOT` holds hundreds of entries and every `convert`
+        // allocates, so the items walked so far are live values across the
+        // conversions that follow them.  A plain `Vec` is invisible to the
+        // collector, so they are accumulated on the shadow stack and read back
+        // from their slots once the walk is over.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::shadow_stack_len();
+        let mut count = 0usize;
         let mut context: *mut T = std::ptr::null_mut();
         loop {
             context = next(store, context);
             if context.is_null() {
-                return Ok(items);
+                return Ok((0..count)
+                    .map(|i| pyre_object::gc_roots::shadow_stack_get(base + i))
+                    .collect());
             }
             match convert(&*context) {
-                Ok(item) => items.push(item),
+                Ok(item) => {
+                    pyre_object::gc_roots::pin_root(item);
+                    count += 1;
+                }
                 Err(error) => {
                     free(context);
                     return Err(error);
@@ -2524,13 +2536,24 @@ mod cert_store {
                             Some(oids) => Some(oids),
                             None => enhanced_key_usage(cert, CERT_FIND_EXT_ONLY_ENHKEY_USAGE_FLAG)?,
                         };
-                    Ok(w_tuple_new(vec![
-                        w_bytes_from_bytes(std::slice::from_raw_parts(
+                    // The trust value and the certificate bytes are each built
+                    // before a further allocation, so both stay pinned until
+                    // the tuple that consumes them roots them itself.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let trust_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(trust.unwrap_or_else(|| w_bool_from(true)));
+                    let cert_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(w_bytes_from_bytes(
+                        std::slice::from_raw_parts(
                             cert.pbCertEncoded,
                             cert.cbCertEncoded as usize,
-                        )),
-                        encoding_type(cert.dwCertEncodingType),
-                        trust.unwrap_or_else(|| w_bool_from(true)),
+                        ),
+                    ));
+                    let encoding = encoding_type(cert.dwCertEncodingType);
+                    Ok(w_tuple_new(vec![
+                        pyre_object::gc_roots::shadow_stack_get(cert_slot),
+                        encoding,
+                        pyre_object::gc_roots::shadow_stack_get(trust_slot),
                     ]))
                 },
             )
@@ -2542,12 +2565,17 @@ mod cert_store {
     pub fn enum_crls(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         enum_store(args, |store| unsafe {
             walk_store(store, CertEnumCRLsInStore, CertFreeCRLContext, |crl| {
+                // The CRL bytes are live across the encoding value's allocation.
+                let _roots = pyre_object::gc_roots::push_roots();
+                let crl_slot = pyre_object::gc_roots::shadow_stack_len();
+                pyre_object::gc_roots::pin_root(w_bytes_from_bytes(std::slice::from_raw_parts(
+                    crl.pbCrlEncoded,
+                    crl.cbCrlEncoded as usize,
+                )));
+                let encoding = encoding_type(crl.dwCertEncodingType);
                 Ok(w_tuple_new(vec![
-                    w_bytes_from_bytes(std::slice::from_raw_parts(
-                        crl.pbCrlEncoded,
-                        crl.cbCrlEncoded as usize,
-                    )),
-                    encoding_type(crl.dwCertEncodingType),
+                    pyre_object::gc_roots::shadow_stack_get(crl_slot),
+                    encoding,
                 ]))
             })
         })

--- a/pyre/pyre-interpreter/src/module/_ssl/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ssl/mod.rs
@@ -2364,24 +2364,194 @@ fn get_default_verify_paths(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     ]))
 }
 
-/// `enum_certificates(store_name)` and `enum_crls(store_name)` report the
-/// contents of a Windows system certificate store: the first as
-/// (cert_bytes, encoding_type, trust) triples, where `encoding_type` is
-/// `"x509_asn"` or `"pkcs_7_asn"` and `trust` is either a frozenset of
-/// enhanced-key-usage OIDs or `True` for "valid for every purpose"; the second
-/// as (crl_bytes, encoding_type) pairs.
-///
-/// Both stores always read as empty.  Walking one means CertOpenStore plus
-/// CertEnumCertificatesInStore/CertEnumCRLsInStore, and this build links no
-/// wincrypt binding to reach them.  Verification does not depend on it —
-/// `set_default_verify_paths` loads the Windows roots through the platform
-/// certificate provider — but callers that mine the store themselves
-/// (`ssl.enum_certificates`, `wincertstore`) see nothing.  `ssl.py` imports
-/// both names unconditionally on win32, which is why they exist at all.
+/// The Windows system-certificate-store readers behind `ssl.enum_certificates`
+/// and `ssl.enum_crls` (`_ssl_enum_certificates_impl`, `_ssl_enum_crls_impl`).
+/// Verification does not depend on them — `set_default_verify_paths` loads the
+/// Windows roots through the platform certificate provider — but callers that
+/// mine the store themselves (`wincertstore`, trust-list builders) read it
+/// through these.
 #[cfg(windows)]
-fn enum_windows_cert_store(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    crate::baseobjspace::str_utf8_w(args[0])?;
-    Ok(w_list_new(Vec::new()))
+mod cert_store {
+    use pyre_object::{
+        PyObjectRef, w_bool_from, w_bytes_from_bytes, w_frozenset_from_items, w_int_new,
+        w_list_new, w_str_new, w_tuple_new,
+    };
+    use windows_sys::Win32::Foundation::CRYPT_E_NOT_FOUND;
+    use windows_sys::Win32::Security::Cryptography::{
+        CERT_CONTEXT, CERT_FIND_EXT_ONLY_ENHKEY_USAGE_FLAG, CERT_FIND_PROP_ONLY_ENHKEY_USAGE_FLAG,
+        CERT_STORE_PROV_SYSTEM_A, CERT_STORE_READONLY_FLAG, CERT_SYSTEM_STORE_LOCAL_MACHINE,
+        CRL_CONTEXT, CTL_USAGE, CertCloseStore, CertEnumCRLsInStore, CertEnumCertificatesInStore,
+        CertFreeCRLContext, CertFreeCertificateContext, CertGetEnhancedKeyUsage, CertOpenStore,
+        HCERTSTORE, PKCS_7_ASN_ENCODING, X509_ASN_ENCODING,
+    };
+    use windows_sys::core::BOOL;
+
+    /// The OSError the calling thread's last Win32 error names
+    /// (`PyErr_SetFromWindowsErr`).
+    fn last_win32_error() -> crate::PyError {
+        crate::PyError::os_error_win32_syscall2(
+            std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+            pyre_object::PY_NULL,
+            pyre_object::PY_NULL,
+        )
+    }
+
+    /// The encoding-type element of a result tuple: `"x509_asn"` for
+    /// `X509_ASN_ENCODING`, `"pkcs_7_asn"` for `PKCS_7_ASN_ENCODING`, and the
+    /// raw flag value for anything else (`certEncodingType`).
+    fn encoding_type(encoding: u32) -> PyObjectRef {
+        match encoding {
+            X509_ASN_ENCODING => w_str_new("x509_asn"),
+            PKCS_7_ASN_ENCODING => w_str_new("pkcs_7_asn"),
+            other => w_int_new(other as i64),
+        }
+    }
+
+    /// A `CertGetEnhancedKeyUsage` failure: `CRYPT_E_NOT_FOUND` means no EKU
+    /// restriction is recorded — the certificate is valid for every purpose —
+    /// and anything else is an error.
+    fn key_usage_not_found() -> Result<Option<PyObjectRef>, crate::PyError> {
+        match std::io::Error::last_os_error().raw_os_error().unwrap_or(0) {
+            CRYPT_E_NOT_FOUND => Ok(None),
+            _ => Err(last_win32_error()),
+        }
+    }
+
+    /// The enhanced-key-usage OIDs `CertGetEnhancedKeyUsage` reports for
+    /// `flags`, as a frozenset of dotted-decimal strings, or `None` for a
+    /// certificate valid for every purpose (`parseKeyUsage`).
+    unsafe fn enhanced_key_usage(
+        cert: *const CERT_CONTEXT,
+        flags: u32,
+    ) -> Result<Option<PyObjectRef>, crate::PyError> {
+        let mut size = 0u32;
+        if CertGetEnhancedKeyUsage(cert, flags, std::ptr::null_mut(), &mut size) == 0 {
+            return key_usage_not_found();
+        }
+        // The byte count is read back through a `CTL_USAGE`, so give the
+        // buffer that struct's alignment and at least its size.
+        let words = (size as usize)
+            .max(std::mem::size_of::<CTL_USAGE>())
+            .div_ceil(std::mem::size_of::<u64>());
+        let mut buffer = vec![0u64; words];
+        let usage = buffer.as_mut_ptr() as *mut CTL_USAGE;
+        if CertGetEnhancedKeyUsage(cert, flags, usage, &mut size) == 0 {
+            return key_usage_not_found();
+        }
+        let usage = &*usage;
+        let mut oids = Vec::with_capacity(usage.cUsageIdentifier as usize);
+        for i in 0..usage.cUsageIdentifier as usize {
+            let oid = *usage.rgpszUsageIdentifier.add(i);
+            if !oid.is_null() {
+                let oid = std::ffi::CStr::from_ptr(oid.cast());
+                oids.push(w_str_new(&oid.to_string_lossy()));
+            }
+        }
+        Ok(Some(w_frozenset_from_items(&oids)))
+    }
+
+    /// Walk one kind of store content: `next` is `CertEnumCertificatesInStore`
+    /// or `CertEnumCRLsInStore`, which frees the context handed back to it, so
+    /// the explicit `free` runs only when `convert` bails mid-walk.
+    unsafe fn walk_store<T>(
+        store: HCERTSTORE,
+        next: unsafe extern "system" fn(HCERTSTORE, *const T) -> *mut T,
+        free: unsafe extern "system" fn(*const T) -> BOOL,
+        convert: impl Fn(&T) -> Result<PyObjectRef, crate::PyError>,
+    ) -> Result<Vec<PyObjectRef>, crate::PyError> {
+        let mut items = Vec::new();
+        let mut context: *mut T = std::ptr::null_mut();
+        loop {
+            context = next(store, context);
+            if context.is_null() {
+                return Ok(items);
+            }
+            match convert(&*context) {
+                Ok(item) => items.push(item),
+                Err(error) => {
+                    free(context);
+                    return Err(error);
+                }
+            }
+        }
+    }
+
+    /// The frame both readers share: open the named local-machine system store
+    /// read-only, hand it to `walk`, and always close it.  A store that cannot
+    /// be opened — an unknown or empty name — raises OSError from the Win32
+    /// code, as does a failing close, which may shadow a walk error.
+    fn enum_store(
+        args: &[PyObjectRef],
+        walk: impl Fn(HCERTSTORE) -> Result<Vec<PyObjectRef>, crate::PyError>,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        let name = crate::baseobjspace::str_utf8_w(args[0])?;
+        let name = std::ffi::CString::new(name)
+            .map_err(|_| crate::PyError::value_error("embedded null character".to_string()))?;
+        let store = unsafe {
+            CertOpenStore(
+                CERT_STORE_PROV_SYSTEM_A,
+                0,
+                0,
+                CERT_SYSTEM_STORE_LOCAL_MACHINE | CERT_STORE_READONLY_FLAG,
+                name.as_ptr().cast(),
+            )
+        };
+        if store.is_null() {
+            return Err(last_win32_error());
+        }
+        let items = walk(store);
+        if unsafe { CertCloseStore(store, 0) } == 0 {
+            return Err(last_win32_error());
+        }
+        Ok(w_list_new(items?))
+    }
+
+    /// `enum_certificates(store_name)` — the store's certificates as
+    /// (cert_bytes, encoding_type, trust) triples, where `trust` is a
+    /// frozenset of enhanced-key-usage OID strings or `True` for a
+    /// certificate valid for every purpose.
+    pub fn enum_certificates(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        enum_store(args, |store| unsafe {
+            walk_store(
+                store,
+                CertEnumCertificatesInStore,
+                CertFreeCertificateContext,
+                |cert| {
+                    // The EKU property is consulted first; only a certificate
+                    // it leaves unrestricted falls through to the extension.
+                    let trust =
+                        match enhanced_key_usage(cert, CERT_FIND_PROP_ONLY_ENHKEY_USAGE_FLAG)? {
+                            Some(oids) => Some(oids),
+                            None => enhanced_key_usage(cert, CERT_FIND_EXT_ONLY_ENHKEY_USAGE_FLAG)?,
+                        };
+                    Ok(w_tuple_new(vec![
+                        w_bytes_from_bytes(std::slice::from_raw_parts(
+                            cert.pbCertEncoded,
+                            cert.cbCertEncoded as usize,
+                        )),
+                        encoding_type(cert.dwCertEncodingType),
+                        trust.unwrap_or_else(|| w_bool_from(true)),
+                    ]))
+                },
+            )
+        })
+    }
+
+    /// `enum_crls(store_name)` — the store's certificate-revocation lists as
+    /// (crl_bytes, encoding_type) pairs.
+    pub fn enum_crls(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        enum_store(args, |store| unsafe {
+            walk_store(store, CertEnumCRLsInStore, CertFreeCRLContext, |crl| {
+                Ok(w_tuple_new(vec![
+                    w_bytes_from_bytes(std::slice::from_raw_parts(
+                        crl.pbCrlEncoded,
+                        crl.cbCrlEncoded as usize,
+                    )),
+                    encoding_type(crl.dwCertEncodingType),
+                ]))
+            })
+        })
+    }
 }
 
 fn test_decode_cert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2522,11 +2692,11 @@ crate::py_module! {
         for (name, func) in [
             (
                 "enum_certificates",
-                crate::py_module_fn!("enum_certificates", 1, enum_windows_cert_store),
+                crate::py_module_fn!("enum_certificates", 1, cert_store::enum_certificates),
             ),
             (
                 "enum_crls",
-                crate::py_module_fn!("enum_crls", 1, enum_windows_cert_store),
+                crate::py_module_fn!("enum_crls", 1, cert_store::enum_crls),
             ),
         ] {
             crate::module_ns_store(ns, name, crate::gateway::with_module("_ssl", func));

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -376,6 +376,7 @@ crate::py_module! {
         "DUPLICATE_SAME_ACCESS" => 0x0000_0002,
         "DUPLICATE_CLOSE_SOURCE" => 0x0000_0001,
         "INVALID_HANDLE_VALUE" => -1,
+        "NULL" => 0,
         // `GetFileType` answers.  A console handle is the one a caller drops
         // from an inherited handle list (`Popen._filter_handle_list`).
         "FILE_TYPE_UNKNOWN" => 0x0000,
@@ -455,7 +456,8 @@ crate::py_module! {
                 );
             }
             // Fixed-arity builtin fast paths only cover zero through four
-            // arguments. CreateProcess still needs an exact-arity check, so
+            // arguments (`gateway.py:948-1038 BuiltinCode0..BuiltinCode4`), and
+            // CreateProcess takes nine. It still needs an exact-arity check, so
             // register it through the general call path with a checked body.
             crate::module_ns_store(
                 ns,

--- a/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
+++ b/pyre/pyre-interpreter/src/module/imp/interp_imp.rs
@@ -680,6 +680,14 @@ pub(crate) fn frozen_cache_load(cache_key: &str, source: &str) -> Option<pyre_ob
 /// `_cached_compile` store half (best effort): write the marshalled code with
 /// the validating header.  I/O failures (e.g. a read-only stdlib) are ignored —
 /// the next startup simply recompiles.
+///
+/// `-B` / PYTHONDONTWRITEBYTECODE does **not** suppress this, even though the
+/// file lands in `__pycache__`.  A frozen module is marshalled into the binary
+/// at build time and never recompiled; pyre keeps the source and caches the
+/// compile instead, so this file stands in for that build step rather than for
+/// an import-time `.pyc`.  Letting `-B` reach it would make the flag force a
+/// recompile of the ~116 KB bootstrap on every startup, which nothing else
+/// does.
 #[cfg(all(feature = "host_env", not(feature = "sandbox")))]
 pub(crate) fn frozen_cache_store(cache_key: &str, source: &str, code: pyre_object::PyObjectRef) {
     let Some(path) = frozen_cache_path(cache_key) else {

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -42,6 +42,9 @@ pub mod _multiprocessing;
 #[allow(non_snake_case)]
 pub mod _opcode;
 #[allow(non_snake_case)]
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+pub mod _overlapped;
+#[allow(non_snake_case)]
 pub mod _pickle;
 #[allow(non_snake_case)]
 #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -737,6 +737,24 @@ mod win_nt {
         }
     }
 
+    /// ntpath.realpath helper — the final component's on-disk name, read out of
+    /// the `cFileName` FindFirstFileW fills in. This is the only way to learn
+    /// the long name behind an 8.3 alias (`C:\PROGRA~1` → `Program Files`) when
+    /// the file cannot be opened, so `_getfinalpathname_nonstrict` falls back
+    /// to it on the winerrors that mean "found it, but no handle for you"
+    /// (`ntpath.py:648-655`). Only the leaf is returned; the caller splits the
+    /// parent off itself.
+    pub fn _findfirstfile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+        let (path, as_bytes, resolved) = arg_path(args, "_findfirstfile")?;
+        if path.as_encoded_bytes().contains(&0) {
+            return Err(crate::PyError::value_error("embedded null character"));
+        }
+        match host_nt::find_first_file_name(Path::new(&path)) {
+            Ok(name) => Ok(wrap_path(&name, as_bytes)),
+            Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
+        }
+    }
+
     /// os.stat helper for ntpath.samefile — (volume serial, file index high,
     /// file index low) uniquely identifies a file across handles. host_env has
     /// no wrapper for GetFileInformationByHandle, so call windows-sys directly.
@@ -3118,6 +3136,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 1u16,
             ),
             ("_getfinalpathname", win_nt::_getfinalpathname, 1),
+            ("_findfirstfile", win_nt::_findfirstfile, 1),
             ("_getfileinformation", win_nt::_getfileinformation, 1),
             ("_getdiskusage", win_nt::_getdiskusage, 1),
             ("get_handle_inheritable", win_nt::get_handle_inheritable, 1),

--- a/pyre/pyre-interpreter/src/module/select/interp_select.rs
+++ b/pyre/pyre-interpreter/src/module/select/interp_select.rs
@@ -2,7 +2,7 @@
 //!
 //! Verbatim move of the inline block previously in importing.rs.
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 use pyre_object::PyObjectRef;
 
 /// `select.poll` object — PyPy: `interp_select.py:26 class Poll`.
@@ -26,7 +26,7 @@ fn default_poll_events() -> i16 {
 
 /// Resolve a Python fd argument (int or object with `fileno()`) to a
 /// raw descriptor — `space.c_filedescriptor_w`.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 pub(crate) fn filedescriptor_w(w_fd: PyObjectRef) -> Result<i32, crate::PyError> {
     unsafe {
         // A real int (or int subclass / bignum) is taken directly; otherwise
@@ -227,12 +227,82 @@ impl Poll {
     }
 }
 
+/// Convert a descriptor resolved from one of the three sequences into what
+/// the platform's fd_set holds, rejecting one the set cannot represent —
+/// `seq2set`.  `index` is how many entries that sequence already contributed.
+///
+/// A POSIX fd_set is a bitmap indexed by the descriptor, so `FD_SET` on an fd
+/// at or above FD_SETSIZE writes outside it (`_PyIsSelectable_fd`).
+#[cfg(all(unix, feature = "host_env"))]
+fn selectable_fd(
+    fd: i32,
+    _index: usize,
+) -> Result<rustpython_host_env::select::RawFd, crate::PyError> {
+    if fd >= libc::FD_SETSIZE as i32 {
+        return Err(crate::PyError::value_error(
+            "file descriptor out of range in select()",
+        ));
+    }
+    Ok(fd)
+}
+
+/// `selectable_fd` for WinSock, whose fd_set is a count plus an array of
+/// SOCKETs instead of a bitmap: the handle value itself is unconstrained, but
+/// only FD_SETSIZE of them fit and `FD_SET` past that silently drops the
+/// socket.  The array is sized by the `windows-sys` declaration, so the limit
+/// is the stock 64 rather than the 512 a C build can ask for.
+#[cfg(all(windows, feature = "host_env"))]
+fn selectable_fd(
+    fd: i32,
+    index: usize,
+) -> Result<rustpython_host_env::select::RawFd, crate::PyError> {
+    if index >= rustpython_host_env::select::platform::FD_SETSIZE as usize {
+        return Err(crate::PyError::value_error(
+            "too many file descriptors in select()",
+        ));
+    }
+    // `select()` takes SOCKET handles here, never CRT file descriptors; a
+    // handle is 32-bit significant, which is what `fileno()` hands back.  A
+    // descriptor that is not a socket fails the call itself with WSAENOTSOCK.
+    Ok(fd as rustpython_host_env::select::RawFd)
+}
+
+/// Dispose of a failed `select()`.  `Ok` means the call was interrupted and
+/// the caller must retry it with the remaining timeout.
+///
+/// `interp_select.py:182` — an EINTR return delivers the pending signal first,
+/// so a handler that raises (KeyboardInterrupt) wins over the retry.
+#[cfg(all(unix, feature = "host_env"))]
+fn select_failure(e: std::io::Error) -> Result<(), crate::PyError> {
+    if e.raw_os_error() == Some(libc::EINTR) {
+        return crate::module::signal::interp_signal::checksignals_now();
+    }
+    Err(crate::PyError::os_error_with_errno(
+        e.raw_os_error().unwrap_or(0),
+        format!("select: {e}"),
+    ))
+}
+
+/// `select_failure` for WinSock, which reports through `WSAGetLastError`: the
+/// code is a Win32 error kept in `.winerror`, not an errno
+/// (`PyErr_SetExcFromWindowsErr`).  A blocking WinSock call is not interrupted
+/// by a signal, so there is nothing to retry.
+#[cfg(all(windows, feature = "host_env"))]
+fn select_failure(e: std::io::Error) -> Result<(), crate::PyError> {
+    Err(crate::PyError::os_error_win32_syscall2(
+        e.raw_os_error().unwrap_or(0),
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+    ))
+}
+
 /// _select module — PyPy: pypy/module/select/.
 ///
 /// Implements `select.select(rlist, wlist, xlist, timeout=None)` via
-/// `rustpython_host_env::select::{FdSet, select, sec_to_timeval}` and the
-/// `select.poll()` polling object.  epoll / kqueue object types are not
-/// implemented yet.
+/// `rustpython_host_env::select::{FdSet, select, sec_to_timeval}` — on
+/// Windows over WinSock's `select`, which accepts sockets only — and the
+/// `select.poll()` polling object, which POSIX alone has.  epoll / kqueue
+/// object types are not implemented yet.
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -242,7 +312,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // descriptor-shaped builtin would bind the selector instance and
         // shift the three fd-set arguments.
         crate::make_module_builtin_function("select", |args| {
-            #[cfg(all(unix, feature = "host_env"))]
+            #[cfg(all(any(unix, windows), feature = "host_env"))]
             {
                 use rustpython_host_env::select as host_select;
 
@@ -257,21 +327,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // fd or an object exposing fileno().
                 fn collect_fds(
                     seq: pyre_object::PyObjectRef,
-                ) -> Result<Vec<(pyre_object::PyObjectRef, i32)>, crate::PyError> {
+                ) -> Result<Vec<(pyre_object::PyObjectRef, host_select::RawFd)>, crate::PyError>
+                {
                     let items = crate::baseobjspace::unpackiterable(seq, -1)?;
                     let mut out = Vec::with_capacity(items.len());
                     for item in items {
                         // `interp_select.py:132 _build_fd_set` — each item is
-                        // resolved through `space.c_filedescriptor_w`.
+                        // resolved through `space.c_filedescriptor_w`, then
+                        // checked against what this platform's fd_set holds.
                         let fd = filedescriptor_w(item)?;
-                        // `fd >= FD_SETSIZE` is rejected: `FD_SET` on such an
-                        // fd writes outside the `fd_set` bitmap.
-                        if fd >= libc::FD_SETSIZE as i32 {
-                            return Err(crate::PyError::value_error(
-                                "file descriptor out of range in select()",
-                            ));
-                        }
-                        out.push((item, fd));
+                        out.push((item, selectable_fd(fd, out.len())?));
                     }
                     Ok(out)
                 }
@@ -280,14 +345,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let wfds = collect_fds(args[1])?;
                 let xfds = collect_fds(args[2])?;
 
-                let mut nfds: i32 = -1;
-                for fds in [&rfds, &wfds, &xfds] {
-                    for &(_, fd) in fds {
-                        if fd > nfds {
-                            nfds = fd;
+                // The first `select()` argument: POSIX scans descriptors
+                // `0..nfds`, so it must exceed the highest one.
+                #[cfg(unix)]
+                let nfds: i32 = {
+                    let mut highest: i32 = -1;
+                    for fds in [&rfds, &wfds, &xfds] {
+                        for &(_, fd) in fds {
+                            if fd > highest {
+                                highest = fd;
+                            }
                         }
                     }
-                }
+                    highest + 1
+                };
+                // WinSock ignores it: each fd_set carries its own count.
+                #[cfg(windows)]
+                let nfds: i32 = 0;
 
                 // `interp_select.py:230-235` — `None` blocks forever, else
                 // `space.float_w` (applies `__float__`); a negative count is
@@ -361,35 +435,20 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // `io::Error`, so the guard only has to span the call.
                     let outcome = {
                         let _blocked = crate::module::thread::before_external_block();
-                        host_select::select(
-                            nfds + 1,
-                            &mut rset,
-                            &mut wset,
-                            &mut xset,
-                            timeout_ref,
-                        )
+                        host_select::select(nfds, &mut rset, &mut wset, &mut xset, timeout_ref)
                     };
                     match outcome {
                         Ok(_) => break,
-                        Err(e) if e.raw_os_error() == Some(libc::EINTR) => {
-                            // `interp_select.py:182` — deliver a pending
-                            // signal, then retry with the remaining timeout
-                            // recomputed at the loop head.
-                            crate::module::signal::interp_signal::checksignals_now()?;
-                            continue;
-                        }
-                        Err(e) => {
-                            return Err(crate::PyError::os_error_with_errno(
-                                e.raw_os_error().unwrap_or(0),
-                                format!("select: {e}"),
-                            ));
-                        }
+                        // A retryable failure returns `Ok`, having delivered
+                        // any pending signal; the loop head then recomputes
+                        // the remaining timeout and rebuilds the fd sets.
+                        Err(e) => select_failure(e)?,
                     }
                 }
 
                 fn build_ready(
                     set: &mut host_select::FdSet,
-                    inputs: &[(pyre_object::PyObjectRef, i32)],
+                    inputs: &[(pyre_object::PyObjectRef, host_select::RawFd)],
                 ) -> pyre_object::PyObjectRef {
                     let items: Vec<_> = inputs
                         .iter()
@@ -403,11 +462,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 let x_ready = build_ready(&mut xset, &xfds);
                 Ok(pyre_object::w_tuple_new(vec![r_ready, w_ready, x_ready]))
             }
-            #[cfg(not(all(unix, feature = "host_env")))]
+            #[cfg(not(all(any(unix, windows), feature = "host_env")))]
             {
                 let _ = args;
                 Err(crate::PyError::not_implemented(
-                    "select.select requires host_env feature on a Unix platform",
+                    "select.select requires host_env feature on a Unix or Windows platform",
                 ))
             }
         }),

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2625,8 +2625,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // sys.meta_path — empty
     module_ns_store(ns, "meta_path", w_list_new(vec![]));
     // sys.dont_write_bytecode — mirrors `sys.flags.dont_write_bytecode`
-    // (`-B` / PYTHONDONTWRITEBYTECODE); no bytecode cache is written regardless,
-    // but the reported value tracks the flag for compatibility.
+    // (`-B` / PYTHONDONTWRITEBYTECODE). The flag is honoured, not merely
+    // reported: `_bootstrap_external` writes `__pycache__/*.pyre314.pyc` next
+    // to every source it imports unless it is set.
     module_ns_store(
         ns,
         "dont_write_bytecode",

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1200,7 +1200,29 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(ns, "_xoptions", xoptions);
     // Format matches `platform._sys_version`'s CPython parser:
     // `version (buildinfo) [compiler]`.
-    module_ns_store(ns, "version", w_str_new("3.14.6 (pyre 0.0.1) [Rust]"));
+    //
+    // On Windows the compiler slot also names the bitness and the processor,
+    // the way the `MSC v.1944 64 bit (AMD64)` token does. That token is the
+    // only place the architecture is published: `sysconfig.get_platform`
+    // reads it back out of `sys.version` to answer `win-amd64`/`win-arm64`,
+    // and pip turns that answer into the wheel platform tag. Elsewhere the
+    // compiler string carries no architecture, so neither does this one.
+    let compiler = if !cfg!(windows) {
+        "Rust"
+    } else if cfg!(target_arch = "x86_64") {
+        "Rust 64 bit (AMD64)"
+    } else if cfg!(target_arch = "aarch64") {
+        "Rust 64 bit (ARM64)"
+    } else if cfg!(target_arch = "arm") {
+        "Rust 32 bit (ARM)"
+    } else {
+        "Rust 32 bit (Intel)"
+    };
+    module_ns_store(
+        ns,
+        "version",
+        w_str_new(&format!("3.14.6 (pyre 0.0.1) [{compiler}]")),
+    );
     module_ns_store(
         ns,
         "platform",

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -303,9 +303,14 @@ fn reduce_1(w_obj: PyObjectRef, proto: i64) -> PyResult {
     let obj_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(w_obj);
     let w_proto = pyre_object::w_int_new(proto);
+    let proto_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_1),
-        &[pyre_object::gc_roots::shadow_stack_get(obj_slot), w_proto],
+        &[
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            pyre_object::gc_roots::shadow_stack_get(proto_slot),
+        ],
     )
 }
 
@@ -324,11 +329,13 @@ fn reduce_2(
     pyre_object::gc_roots::pin_root(w_args);
     pyre_object::gc_roots::pin_root(w_kwargs);
     let w_proto = pyre_object::w_int_new(proto);
+    let proto_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_proto);
     crate::call::call_function_impl_result(
         handle(REDUCE_2),
         &[
             pyre_object::gc_roots::shadow_stack_get(obj_slot),
-            w_proto,
+            pyre_object::gc_roots::shadow_stack_get(proto_slot),
             pyre_object::gc_roots::shadow_stack_get(obj_slot + 1),
             pyre_object::gc_roots::shadow_stack_get(obj_slot + 2),
         ],

--- a/pyre/pyre-interpreter/src/stack_check.rs
+++ b/pyre/pyre-interpreter/src/stack_check.rs
@@ -97,9 +97,15 @@ pub const MAX_STACK_SIZE: usize = 48 << 18;
 /// implementation default.
 ///
 /// [`effective_stack_length`] leaves a quarter of the stack to the Rust/C
-/// frames between the probe and the guard page, so 20 MiB buys a 15 MiB
-/// ceiling.  That covers the measured guard-resume cost at the default limit
-/// (and the 90% lower bound at 2000 used by the parity fixture) without making
+/// frames between the probe and the guard page.  Most hosts use 20 MiB (a
+/// 15 MiB ceiling). Windows uses 24 MiB (an 18 MiB ceiling): Cranelift's Win64
+/// prologue/resume frames need about 16.8 MiB to reach Python's logical cutoff
+/// at a recursion limit of 2000.  Keeping the native guard above that cutoff
+/// makes the Python 3.14 logical-depth check decide the observable limit, while
+/// the native guard remains the hard-stop PyPy's `rstack` design requires.
+/// Both stay far below the 256 MiB interpreter stack reserved by
+/// `pyrex::main_entry`.  These ceilings cover the measured guard-resume cost
+/// without making
 /// `support.infinite_recursion(20_000)` consume the much larger interpreter
 /// stack before its native guard fires.  At 8 MiB the clamp cut a thread's
 /// budget below what the *default* limit is worth, so the guard, not the limit,
@@ -115,6 +121,9 @@ pub const MAX_STACK_SIZE: usize = 48 << 18;
 /// path.  A single figure for all Python-running threads keeps that shared
 /// word meaningful; upstream gets the same uniformity for free because
 /// `_ll_stack_os_limit` reads `getrlimit`, which is process-wide.
+#[cfg(windows)]
+pub const DEFAULT_RUNTIME_THREAD_STACK_SIZE: usize = 24 * 1024 * 1024;
+#[cfg(not(windows))]
 pub const DEFAULT_RUNTIME_THREAD_STACK_SIZE: usize = 20 * 1024 * 1024;
 
 /// Process-wide requested byte budget, corresponding to RPython's

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -741,6 +741,15 @@ unsafe fn zlib_zdecompress_destructor(obj_addr: usize) {
     };
 }
 
+#[cfg(all(windows, not(feature = "sandbox")))]
+unsafe fn overlapped_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_overlapped::w_overlapped_dealloc(
+            obj_addr as pyre_object::PyObjectRef,
+        )
+    };
+}
+
 /// Custom trace for objects carrying the `MapdictStorageMixin` prefix
 /// (`W_ObjectObject` and native-layout Python subclasses such as
 /// `W_Random`; instance `map`+`storage`, `mapdict.py:907-910`).
@@ -3824,6 +3833,17 @@ fn build_gc() -> Box<MiniMarkGC> {
             mmap_descr.pytype_ptr as usize,
             mmap_descr.ptr_offsets,
         );
+    }
+    // `lib_pypy/_overlapped.py Overlapped`: the object owns its native
+    // OVERLAPPED record and pending buffers until cancellation/completion.
+    // Its three Python fields are ordinary generated trace offsets; sweep
+    // performs PyPy's cancel/wait-before-free ordering and closes hEvent.
+    #[cfg(all(windows, not(feature = "sandbox")))]
+    {
+        let descr = <pyre_interpreter::module::_overlapped::W_Overlapped
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+        let tid = register_pyre_class(&mut gc, &mut pytype_to_tid, descr);
+        gc.types.set_destructor(tid, overlapped_destructor);
     }
     // `rrandom.Random` — the Mersenne Twister `interp_random.py:21` allocates
     // beside its holder. Like W_DequeBlock it is GC-managed without being an

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8243,6 +8243,11 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
     // eval_frame_plain here would skip maybe_enter_jit at every
     // opcode of the recursive portal frame, which breaks parity for
     // bhimpl_recursive_call_* paths.
+    // `ll_portal_runner` is an activation entry in its own right: recursive
+    // portal calls can reach it without the ordinary `eval_with_jit_inner`
+    // wrapper.  Account before constructing `FrameRoot`, because a moving GC
+    // may change the frame's address while the activation remains the same.
+    let _recursion_depth = pyre_interpreter::call::enter_recursive_frame(frame);
     let mut frame_root = FrameRoot::new(frame);
     frame_root.frame().fix_array_ptrs();
     let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
@@ -8352,10 +8357,11 @@ fn eval_loop_jit(frame: &mut PyFrame) -> LoopResult {
     // FBW FOR_ITER Option-C guard snapshots this around a residual call to
     // detect a body effect that ran through user code.
     pyre_interpreter::call::bump_frame_entry_count();
-    // Spend one unit of the recursion budget on this frame's activation, in
-    // case this loop was reached without going through `eval_with_jit_inner`.
-    // A frame the wrapper already accounted spends nothing here.
-    let _recursion_depth = pyre_interpreter::call::enter_recursive_frame(frame_root.frame());
+    // Recursion accounting belongs to the activation seams
+    // (`eval_with_jit_inner` and `portal_runner_result`), not this re-entrant
+    // dispatch loop.  In particular, `FrameRoot` may have forwarded a moving
+    // frame since the seam; keying the same activation again by its new
+    // address would spend a second recursion unit.
     // Count this eval-loop activation for the GC safepoint's
     // at_outermost_activation gate (gh#393). The gate allows collection
     // at depth ≤ 2 (module + one called function) where the CALL opcode

--- a/pyre/pyre-native/src/ssl.rs
+++ b/pyre/pyre-native/src/ssl.rs
@@ -2953,6 +2953,36 @@ impl TlsConnection {
             self.pending_tls.clear();
             self.pending_tls_start = 0;
         }
+        if self.inner.is_none() {
+            return Ok(());
+        }
+        loop {
+            self.write_pending_tls()?;
+            // `wants_read` is also false while an outgoing flight is still
+            // queued and application data cannot flow yet, which is the state
+            // a client is in between emitting its ChangeCipherSpec and its
+            // Finished.  A peer flight that arrives in a single read therefore
+            // leaves a tail in `pending_received_tls` that no later call comes
+            // back for: the transport goes straight to a blocking receive
+            // while the peer waits for the rest of our handshake, and both
+            // sides stop.  Emptying the queued flight above lifts the refusal,
+            // so re-offer the tail here and write out whatever it produces.
+            let remaining = self.pending_received_tls.len() - self.pending_received_tls_start;
+            if remaining == 0 {
+                break;
+            }
+            self.process_received_tls()?;
+            // Every extra pass must consume ciphertext, so the loop ends.
+            if self.pending_received_tls.len() - self.pending_received_tls_start >= remaining {
+                break;
+            }
+        }
+        self.capture_tls_unique();
+        Ok(())
+    }
+
+    /// Move every record rustls has queued for the peer into `pending_tls`.
+    fn write_pending_tls(&mut self) -> TlsResult<()> {
         let Some(inner) = self.inner.as_mut() else {
             return Ok(());
         };
@@ -2971,7 +3001,6 @@ impl TlsConnection {
                 break;
             }
         }
-        self.capture_tls_unique();
         Ok(())
     }
 
@@ -2998,9 +3027,11 @@ impl TlsConnection {
             let Some(inner) = self.inner.as_mut() else {
                 return Ok(());
             };
-            // rustls signals plaintext backpressure through `wants_read`; the
-            // corresponding `read_tls` failure carries only an unstable
-            // message string.
+            // `wants_read` covers two refusals: plaintext backpressure, and an
+            // outgoing flight still queued before application data may flow.
+            // The corresponding `read_tls` failure carries only an unstable
+            // message string.  Either way the untouched tail stays queued, and
+            // `fill_pending_tls` re-offers it once the refusal lifts.
             if !inner.wants_read() {
                 return Ok(());
             }

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -681,6 +681,11 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
     (178, Some(0)),
+    // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
+    // retained Python buffers.  pyre-interpreter supplies the vtable alias;
+    // the object layer owns only the append-only hierarchy slot.
+    #[cfg(windows)]
+    (179, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyrex/Cargo.toml
+++ b/pyre/pyrex/Cargo.toml
@@ -32,7 +32,8 @@ name = "allocsites"
 path = "examples/allocsites.rs"
 
 [features]
-default = ["dynasm", "mimalloc"]
+default = ["dynasm", "host_env", "mimalloc"]
+host_env = ["pyre-interpreter/host_env"]
 jit = []  # meta feature: enabled by cranelift or dynasm
 cranelift = ["jit", "pyre-jit/cranelift"]
 dynasm = ["jit", "pyre-jit/dynasm"]

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -2650,6 +2650,16 @@ def run_cli(
     external_inputs: tuple[Path, ...] = (),
 ) -> None:
     """Argparse UX shared by every driver (positional crates, --force, …)."""
+    # This file writes en/em dashes and arrows in its diagnostics, and Windows
+    # hands a console the ANSI codepage (cp949 here), which cannot encode them.
+    # A print then raises UnicodeEncodeError from inside the extraction, which
+    # is how a "REFUSING to stamp" notice became a traceback that also skipped
+    # the crates queued behind it. Encode as UTF-8 and never let a character
+    # class decide whether an artefact gets built.
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is not None:
+            reconfigure(encoding="utf-8", errors="replace")
     all_crates = " ".join(specs)
     parser = argparse.ArgumentParser(
         description="Extract Charon ULLBC artefacts with source-fingerprint skip logic."


### PR DESCRIPTION
## Summary

Follows #1190, which brought pip up on POSIX. These are the elements that still stopped it on Windows.

- add a Windows host layer to `_socket` (`rsocket_rffi`, spelled from `windows-sys`' WinSock entry points) and widen `select`'s gates to it, so the two modules pip needs for HTTPS exist on the platform at all
- publish `SOABI`/`EXT_SUFFIX` unconditionally, and name the bitness and processor in `sys.version`'s compiler slot: `packaging.tags` derives a wheel's ABI tag from `EXT_SUFFIX` and `sysconfig.get_platform` parses the architecture back out of `sys.version`, so between them every `pip install` reads both
- switch every descriptor `_io` adopts to binary mode, so a `\n` written through `FileIO` does not leave as `\r\n`
- re-offer queued ciphertext once an outgoing TLS flight has been written
- register `_ssl.enum_certificates` / `enum_crls` and `nt._findfirstfile`, which `ssl.py` and `ntpath.py` reach for on Windows
- copy the interpreter where `venv` expects a launcher stub this build does not ship
- parse a union type declaration in the charon reader

## Why

`EXT_SUFFIX` was gated on the cpyext feature and on macOS/linux, so `packaging.tags` failed outright before any download started; `sys.version`'s `[Rust]` token parsed to no architecture, so `get_platform()` could not name a wheel platform tag. Behind those, `_socket` and `select` had no Windows body to compile, and `ssl.py` and `ntpath.py` import names that did not exist.

The remaining two are not Windows-specific in cause. `process_received_tls` returned early whenever `wants_read` was false, which is also the state between a client's ChangeCipherSpec and its Finished — so a peer flight that arrived in a single read left a tail nothing came back for, and the handshake stalled with both sides waiting. And a CRT descriptor starts in text mode, so every `.pyc` the import machinery wrote came back corrupt: the cache was dead and importing the stdlib took 1241 ms where it now takes 210 ms.

`windows-sys`' `IN_ADDR_0` is the first C union to enter the dependency closure. `TypeDeclKind` had no `Union` arm, so it fell to the unit `#[serde(other)] Unknown` variant and its payload failed the whole ullbc parse — the release build could not link until the reader could read it.

## Validation

On Windows 11, `x86_64-pc-windows-msvc`, against a freshly extracted LLBC:

- `python3 scripts/extract-llbc.py pyre-interpreter pyre-jit`, then `cargo build --release -p pyrex --features dynasm`
- `_socket`, `socket`, `ssl`, `select`, `sysconfig` import; `EXT_SUFFIX` `.pyre314.pyd`, `SOABI` `pyre314`, `get_platform()` `win-amd64`, `os.path.realpath('C:/PROGRA~1')` `C:\Program Files`
- a written `.pyc` survives `marshal.loads`
- offline `pip install --target` from the bundled wheel, `pip --version`, and `ensurepip --root`
- `pyre -m venv V`, then `V/Scripts/pip.exe install requests` — 5 wheels resolved and downloaded from PyPI, then `import requests` and an HTTPS GET returning 200

The wasm32 target compiles: the widened gates are `any(unix, windows)`, not removals, and `rsocket_rffi` is behind the same predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Windows support for asynchronous I/O through the `_overlapped` module.
  - Added Windows certificate and CRL enumeration through `_ssl`.
  - Improved Windows socket, `select`, file descriptor, and filesystem compatibility.
  - Added Windows `nt._findfirstfile` and `_winapi.NULL` support.
  - Expanded ctypes callbacks for structures, arrays, unions, and varied return types.
  - Added C union parsing and improved WebAssembly loop performance.

- **Bug Fixes**
  - Improved TLS handshakes, virtual-environment creation, garbage collection, and platform-specific error handling.
  - Corrected ABI metadata and runtime stack sizing on Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->