### PR TITLE
majit: stop treating header-less array buffers as GC-managed arrays

### DIFF
--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -1192,7 +1192,7 @@ impl EffectInfo {
     /// minted per-`MetaInterpStaticData` in `dispatch_array_descr_cache` at
     /// trace time, while the write-EI is built during jitcode assembly, so the
     /// two are never the same `Arc`.  Structure is the right key regardless:
-    /// `Assembler::add_gc_int_array_descr` already dedups on exactly this
+    /// `Assembler::add_raw_int_array_descr_signed` already dedups on exactly this
     /// tuple, so for these arrays the shape IS the identity.
     ///
     /// Conflating two arrays that share a shape can only over-invalidate,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -1897,7 +1897,7 @@ pub(super) fn env_array_descr_expr(config: Option<&LowererConfig>) -> proc_macro
             let __env_item = ::core::mem::size_of::<
                 <#env_ty as ::core::ops::Index<usize>>::Output,
             >();
-            __builder.add_gc_int_array_descr(__env_item, __env_item != 1)
+            __builder.add_env_int_array_descr(__env_item, __env_item != 1)
         }},
         None => quote::quote! { __builder.add_gc_byte_array_descr() },
     }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1617,11 +1617,11 @@ impl JitCodeBuilder {
         self.push_reg_u8(dst, "getarrayitem_gc_r dst");
     }
 
-    /// Add a GC-array descriptor for a byte-element array to the descrs pool.
+    /// Add the array descriptor for a byte-element array to the descrs pool.
     ///
     /// Returns the descr index to pass as `descr_idx` to `getarrayitem_gc_i`.
-    /// The descriptor models a `u8`-element GC array — the `program: &[u8]`
-    /// bytecode slice used by the dispatch JitCode body.
+    /// The descriptor models the `program: &[u8]` bytecode slice used by the
+    /// dispatch JitCode body.
     ///
     /// Deduped: multiple calls with the same shape return the same index.
     ///
@@ -1631,11 +1631,27 @@ impl JitCodeBuilder {
     /// to `i64`, never sign-extend); the `u8` SUB-INTERVAL property must
     /// not be widened to a signed `i64` at the descr boundary or the
     /// backend would emit `movsx` on byte loads ≥ `0x80` and corrupt
-    /// opcode dispatch.  `base_size=0` because Rust `&[u8]` data pointers
-    /// (codegen_trace.rs:193 `*const #env_type as *const ()`) point
-    /// directly at the first element without any GC header.
+    /// opcode dispatch.
     pub fn add_gc_byte_array_descr(&mut self) -> u16 {
-        self.add_gc_int_array_descr(1, false)
+        self.add_env_int_array_descr(1, false)
+    }
+
+    /// Add the array descriptor for an integer-element `env` array whose items
+    /// are `item_size` bytes wide (`is_item_signed` selects sign- vs
+    /// zero-extension on sub-word loads).  Generalizes
+    /// [`Self::add_gc_byte_array_descr`] so a wider env element type (`&[i64]`,
+    /// `item_size = 8`) reads the element at byte offset `item_size * index`
+    /// instead of the raw byte at `index`.
+    ///
+    /// The array is NOT GC-managed and carries no length word: a Rust slice
+    /// (`&[T]`) data pointer (`codegen_trace.rs:193 *const #env_type as
+    /// *const ()`) points directly at `items[0]`, and the length travels in the
+    /// fat pointer's other half, which never reaches the trace.  This is the
+    /// `arraydescrof(rffi.CArray(T))` shape, so it is
+    /// [`Self::add_raw_int_array_descr_signed`] — see the note there for what
+    /// the GC-managed flag would cost.
+    pub fn add_env_int_array_descr(&mut self, item_size: usize, is_item_signed: bool) -> u16 {
+        self.add_raw_int_array_descr_signed(item_size, is_item_signed)
     }
 
     /// Add a descriptor for a `raw_store_i` / `raw_load_i` against raw
@@ -1664,7 +1680,7 @@ impl JitCodeBuilder {
     /// `ptr - GcHeader::SIZE`; ahead of such a buffer that word belongs to
     /// whatever precedes the allocation, so once the base is red the guard
     /// fails or faults on short-preamble re-entry.  The `&[u8]` `env` array
-    /// keeps `add_gc_int_array_descr` because its base is a green constant and
+    /// is the same descr: a Rust slice data pointer has no header either, and
     /// the optimizer therefore gives it `PtrInfo::Constant`, never this arm.
     pub fn add_raw_int_array_descr_signed(
         &mut self,
@@ -1761,44 +1777,6 @@ impl JitCodeBuilder {
         self.push_reg_u8(ea_reg, "raw_store_i ea");
         self.push_reg_u8(value_reg, "raw_store_i value");
         self.push_u16(descr_idx);
-    }
-
-    /// Add a GC-array descriptor for an integer-element `env` array whose
-    /// items are `item_size` bytes wide (`is_item_signed` selects sign- vs
-    /// zero-extension on sub-word loads).  Generalizes
-    /// `add_gc_byte_array_descr` so a wider env element type (`&[i64]`,
-    /// `item_size = 8`) reads the element at byte offset `item_size * index`
-    /// instead of the raw byte at `index`.  `base_size = 0` because Rust
-    /// slice (`&[T]`) data pointers point directly at `items[0]` with no GC
-    /// header; the structural tuple (base_size=0, itemsize, item_type=Int,
-    /// signedness) uniquely identifies the descr for `add_bh_descr` dedup.
-    /// For an 8-byte item signedness is moot (full-word load), but for `&[u8]`
-    /// it must stay unsigned: a signed byte descr makes the backend emit
-    /// `movsx` on bytes ≥ `0x80` and corrupt opcode dispatch.
-    pub fn add_gc_int_array_descr(&mut self, item_size: usize, is_item_signed: bool) -> u16 {
-        self.add_bh_descr(CanonicalBhDescr::Array {
-            base_size: 0,
-            itemsize: item_size,
-            // base_size=0 → no length header (raw slice data pointer points
-            // directly at items[0]); descr.py:359-362 nolength shape carries
-            // `lendescr=None`.
-            len_offset: None,
-            type_id: 0,
-            gc_type_id: 0,
-            item_type: majit_ir::value::Type::Int,
-            is_array_of_pointers: false,
-            is_array_of_structs: false,
-            is_item_signed,
-            ei_index: u32::MAX,
-            array_type_id: None,
-            interior_fields: Vec::new(),
-            // Preserve existing GUARD_GC_TYPE behavior for the `&[u8]`
-            // program-array path (only the `pool_arrays` base flips to
-            // raw via `add_ptr_array_descr`).  A header-less buffer reached
-            // through a `*mut T` field takes `add_raw_int_array_descr_signed`
-            // instead — see the note there.
-            is_gc_managed: true,
-        })
     }
 
     /// Add a GC-array descriptor for a raw-pointer-element array (one-word
@@ -1988,7 +1966,7 @@ impl JitCodeBuilder {
     ///             [value_reg u8][descr_idx lo u8][descr_idx hi u8]`.
     ///
     /// Store counterpart of [`Self::getarrayitem_gc_i`]. Both take the
-    /// element descr from [`Self::add_gc_int_array_descr`], so a store
+    /// element descr from [`Self::add_env_int_array_descr`], so a store
     /// invalidates the heapcache entry the matching load populated.
     pub fn setarrayitem_gc_i(
         &mut self,
@@ -7169,7 +7147,7 @@ mod tests {
         // argcode string it is registered under. Pin that order here so
         // the emit side cannot drift from the handler that decodes it.
         let mut builder = JitCodeBuilder::new();
-        let descr_idx = builder.add_gc_int_array_descr(8, true);
+        let descr_idx = builder.add_env_int_array_descr(8, true);
         builder.setarrayitem_gc_i(1, 2, 3, descr_idx);
         let jitcode = builder.finish();
         let opcode = jitcode::insn_byte("setarrayitem_gc_i/riid");
@@ -7198,7 +7176,7 @@ mod tests {
         // reads `code[position + 1]` as an index REGISTER and
         // `code[position + 2]` as a signed inline byte.
         let mut builder = JitCodeBuilder::new();
-        let descr_idx = builder.add_gc_int_array_descr(8, true);
+        let descr_idx = builder.add_env_int_array_descr(8, true);
         builder.setarrayitem_gc_i_c(1, 2, -5, descr_idx);
         let jitcode = builder.finish();
         let opcode = jitcode::insn_byte("setarrayitem_gc_i/ricd");

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -673,11 +673,26 @@ impl PtrInfoExt for PtrInfo {
                         &[op_b.clone(), type_id_const.clone()],
                     ));
                 }
-                // Always emit ARRAYLEN_GC + bound guards: pyre's
-                // ArrayPtrInfo.lenbound is a plain `IntBound`, not an
-                // `Option`, so the parity check is on `is_unbounded()`
-                // rather than `is None`.
-                if !info.lenbound.is_unbounded() {
+                // Emit ARRAYLEN_GC + bound guards: pyre's ArrayPtrInfo.lenbound
+                // is a plain `IntBound`, not an `Option`, so the parity check
+                // is on `is_unbounded()` rather than `is None`.
+                //
+                // A length-less array descr (`len_offset = None`, the shape a
+                // header-less buffer takes) has no length word to read, and
+                // the mandatory GC rewrite unwraps the lendescr unconditionally
+                // (`majit-gc/src/rewrite.rs:2477`) — emitting the op there
+                // panics.  The bound itself is reachable on such an array: a
+                // constant-index element read narrows it through
+                // `getlenbound().make_gt_const(index)` (`heap.py:676-681`,
+                // ported at `optimizeopt/heap.rs:2873`) without ever consulting
+                // the descr.  Upstream cannot reach this because a raw array
+                // gets `getarrayitem_raw_*` and an `AbstractRawPtrInfo`, never
+                // `ArrayPtrInfo`; pyre routes both families through one info
+                // type, so the gate belongs here, alongside the `is_gc_managed`
+                // gate above.  Nothing is lost by skipping it — with no length
+                // in memory there is no length any guard could establish.
+                let has_length = ad.len_descr().is_some();
+                if has_length && !info.lenbound.is_unbounded() {
                     let mut lenop = Op::with_descr(
                         OpCode::ArraylenGc,
                         std::slice::from_ref(&op_b),
@@ -1803,6 +1818,83 @@ mod tests {
     /// the field-value analog of the old `from_opref` test stand-ins.
     fn field_op(tp: Type, pos: u32) -> Operand {
         crate::history::test_support::rooted_resop_operand(tp, pos)
+    }
+
+    /// A one-byte integer array descr, with or without a length word.
+    /// `lendescr: None` is the shape a header-less buffer takes — the `&[u8]`
+    /// `env` slice and every `array_fields` element array.
+    fn byte_array_descr(with_length: bool) -> DescrRef {
+        let lendescr = with_length.then(|| {
+            majit_ir::descr::make_field_descr(
+                /* offset */ 0,
+                /* field_size */ std::mem::size_of::<usize>(),
+                Type::Int,
+                majit_ir::descr::ArrayFlag::Unsigned,
+            )
+        });
+        majit_ir::descr::make_array_descr_from_lltype_shape(
+            /* type_id */ 0,
+            /* base_size */ if with_length { 8 } else { 0 },
+            /* item_size */ 1,
+            /* len_offset */ if with_length { Some(0) } else { None },
+            Type::Int,
+            /* is_array_of_pointers */ false,
+            /* is_array_of_structs */ false,
+            /* is_item_signed */ false,
+            /* is_gc_managed */ false,
+            lendescr,
+            /* is_pure */ false,
+            /* ei_index */ u32::MAX,
+            /* interior_field_descrs */ Vec::new(),
+        )
+    }
+
+    /// The short-preamble guards `ArrayPtrInfo::make_guards` emits for an array
+    /// whose length bound was narrowed.
+    fn array_short_preamble_opcodes(with_length: bool) -> Vec<OpCode> {
+        let info = PtrInfo::Array(majit_ir::ptr_info::ArrayPtrInfo {
+            descr: byte_array_descr(with_length),
+            // What a constant-index element read leaves behind:
+            // `getlenbound().make_gt_const(index)` (`heap.py:676-681`).
+            lenbound: IntBound::from_constant(8),
+            items: Vec::new(),
+            last_guard_pos: -1,
+        });
+        let mut ctx = OptContext::new(8);
+        let array_box = field_op(Type::Ref, 3);
+        let mut short = Vec::new();
+        info.make_guards(array_box.to_opref(), &mut short, &mut ctx);
+        short.iter().map(|op| op.opcode).collect()
+    }
+
+    /// A length-less array descr has no length word to read, and the mandatory
+    /// GC rewrite unwraps the lendescr unconditionally
+    /// (`majit-gc/src/rewrite.rs:2477`), so emitting `ARRAYLEN_GC` for one
+    /// panics the compile. The bound that triggers the emission is reachable —
+    /// a constant-index element read narrows it without ever consulting the
+    /// descr — which is why the gate has to be here rather than at the
+    /// narrowing site.
+    #[test]
+    fn a_lengthless_array_emits_no_arraylen_guard() {
+        let opcodes = array_short_preamble_opcodes(/* with_length */ false);
+        assert!(
+            !opcodes.contains(&OpCode::ArraylenGc),
+            "a length-less array descr must not get an ARRAYLEN_GC guard; \
+             emitted {opcodes:?}"
+        );
+    }
+
+    /// The control: with a length word the guard must still be emitted, or the
+    /// test above passes because `make_guards` stopped emitting it for
+    /// everything.
+    #[test]
+    fn an_array_with_a_length_word_still_gets_its_arraylen_guard() {
+        let opcodes = array_short_preamble_opcodes(/* with_length */ true);
+        assert!(
+            opcodes.contains(&OpCode::ArraylenGc),
+            "a length-carrying array must keep its ARRAYLEN_GC guard; \
+             emitted {opcodes:?}"
+        );
     }
 
     #[test]

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -500,7 +500,7 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
 /// one is minted during jitcode assembly, so the two are never the same `Arc`.
 /// The array descrs built here therefore only have to carry the right SHAPE;
 /// `EffectInfo::writes_array_descr_by_shape` is what reads them back, and the
-/// remaining fields are pinned to the `Assembler::add_gc_int_array_descr` shape
+/// remaining fields are pinned to the `Assembler::add_raw_int_array_descr_signed` shape
 /// the reads intern (`base_size = 0`, no length header, `Type::Int`).
 ///
 /// An empty `arrays` leaves the affirmative "writes no arrays" that

--- a/majit/majit-metainterp/tests/array_write_set_invalidation.rs
+++ b/majit/majit-metainterp/tests/array_write_set_invalidation.rs
@@ -22,7 +22,7 @@ use majit_ir::Type;
 use majit_ir::descr::make_array_descr_from_lltype_shape;
 use majit_ir::{DescrRef, EffectInfo, ExtraEffect, OopSpecIndex};
 
-/// The shape `Assembler::add_raw_int_array_descr(item_size, is_item_signed)`
+/// The shape `Assembler::add_raw_int_array_descr_signed(item_size, signed)`
 /// interns for an `array_fields` element access: a header-less buffer pointer
 /// (`base_size = 0`, no length word, not GC-managed) over `item_size` items.
 fn mint_element_array_descr_of(item_size: usize, is_item_signed: bool) -> DescrRef {
@@ -118,24 +118,11 @@ fn array_write_set_is_visible_to_force_from_effectinfo() {
 }
 
 /// The shape the opcode-fetch path interns: `program: &[u8]`, one-byte
-/// unsigned items. Signedness matters — a signed byte descr makes the backend
-/// emit `movsx` and corrupt dispatch — so this is a genuinely distinct array.
+/// unsigned items.  A Rust slice data pointer is header-less too, so this is
+/// the same raw shape a one-byte `array_fields` element would take — the
+/// element-size difference below is what makes it a different array here.
 fn mint_program_byte_array_descr() -> DescrRef {
-    make_array_descr_from_lltype_shape(
-        0,
-        0,
-        1,
-        None,
-        Type::Int,
-        false,
-        false,
-        /* is_item_signed */ false,
-        true,
-        None,
-        false,
-        u32::MAX,
-        Vec::new(),
-    )
+    mint_element_array_descr_of(1, false)
 }
 
 /// The write set is built during jitcode assembly and the cached read descr is
@@ -190,7 +177,7 @@ fn the_emitted_array_spec_mints_the_shape_the_reads_intern() {
     assert!(
         ei.writes_array_descr_by_shape(&mint_element_array_descr()),
         "the descr minted from the emitted spec must match the one \
-         `add_gc_int_array_descr(8, true)` interns for the read"
+         `add_raw_int_array_descr_signed(8, true)` interns for the read"
     );
     assert!(
         !ei.writes_array_descr_by_shape(&mint_program_byte_array_descr()),


### PR DESCRIPTION
Follow-up to #1213, addressing §2 and §3 of that PR's Codex parity review.

## The ARRAYLEN_GC crash

The parity review's §2 said `array_fields` models a header-less native `*mut T` but lowers it through GC-array operations, where upstream would use raw ones. Following that through, the mismatch has a live crash path, not just a stale guard:

1. A constant-index element read narrows the array's `lenbound` via `getlenbound().make_gt_const(index)` (`optimizeopt/heap.rs:2873`, `heap.py:676-681`) — without consulting the descr.
2. `ArrayPtrInfo::make_guards` sees a bounded `lenbound` and emits `ARRAYLEN_GC` (`optimizeopt/info.rs:680`, `info.py:632-639`).
3. The mandatory GC rewrite unwraps the lendescr unconditionally — `expect("ARRAYLEN_GC descr must have lendescr")` (`majit-gc/src/rewrite.rs:2477`) — and a header-less buffer's descr carries `len_offset: None`. Panic.

Upstream cannot reach this: `jtransform.py:775-783` selects the op family by `ARRAY._gckind`, so a raw array gets `getarrayitem_raw_*` and therefore an `AbstractRawPtrInfo`, never an `ArrayPtrInfo`. Pyre routes both families through one info type, so the gate belongs in `make_guards`, next to the `is_gc_managed` gate that is already there for `GUARD_GC_TYPE`. Nothing is lost by skipping it — with no length word in memory there is no length any guard could establish.

## §3: the `&[u8]` env array

Same shape, same reasoning. A Rust slice data pointer carries no object header either, so the `env` array was already the `arraydescrof(rffi.CArray(T))` shape, and marking it GC-managed exposed it to a `GUARD_GC_TYPE` reading a type id at `ptr - GcHeader::SIZE` — against a type id of `0`. `add_gc_int_array_descr` is replaced by `add_env_int_array_descr`, which forwards to the existing `add_raw_int_array_descr_signed`.

## What is deliberately NOT changed

Switching `array_fields` element access from `getarrayitem_gc_i` to `getarrayitem_raw_i` would match upstream's op-family selection, and it would also delete the feature #1213 just landed: neither `heap.py:439` nor `optimizeopt/heap.rs:3070` heapcaches a raw array read, so the element cache — and with it every `residual_writes = { field[] => [...] }` declaration — would become inert. Marking the descriptor raw removes the unsound guard, which is what the review's actionable half asked for; the op-family divergence is a separate decision about whether pyre keeps caching these reads at all.

## Tests

`a_lengthless_array_emits_no_arraylen_guard` plus its control `an_array_with_a_length_word_still_gets_its_arraylen_guard`. Removing the gate reddens the first with `emitted [GuardNonnull, ArraylenGc, GuardValue]` — the op that would have panicked.

`majit-metainterp` 1670 passed / 0 failed (`--features dynasm`); `majit-gc` + `majit-ir` + `majit-backend` 595 passed / 0 failed; `cargo check --workspace --all-targets` and `cargo fmt --check` clean. `pyre/check.py` has not been re-run on this commit.

— *authored by Claude*