### PR TITLE
jit: seven bridge/retrace parity gaps — dropped bridge operations, an unrooted frontend snapshot, a desynced class bitfield, and two inert guards

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
+++ b/majit/majit-metainterp/src/optimizeopt/bridgeopt.rs
@@ -100,14 +100,30 @@ pub fn serialize_optimizer_knowledge(
     // disagree on which Ref-typed slots get a bitfield bit, producing
     // an out-of-bounds rd_numb read in `deserialize_optimizer_knowledge`
     // when super-instruction GEN widens the live register set.
+    //
+    // bridgeopt.py:76-77 opens the loop with `if box is None or box.type != "r"`,
+    // so upstream emits no bit for a hole. It can also afford not to test for one
+    // when reading (bridgeopt.py:135), because
+    // `initialize_state_from_guard_failure` has already dropped them —
+    // `return [box for box in inputargs_and_holes if box]` (pyjitpl.py:3310).
+    // pyre has no such filter: a bridge's inputargs are one per fail-arg slot,
+    // holes included, and `store_final_boxes_in_guard` types every hole `Ref`.
+    // The reader therefore walks the hole positions, and skipping them here
+    // would leave it one bit ahead per hole — reading each later Ref slot's
+    // predecessor's bit, and eventually crossing into the heap section a whole
+    // word early. Emit the hole's bit instead, always clear: an absent box has
+    // no known class, so the reader learns nothing from it and the two walks
+    // stay in step.
     let mut bitfield: i32 = 0;
     let mut shifts = 0;
-    for opref in liveboxes.iter().flatten() {
-        let livebox_tp = numb_state
-            .livebox_types
-            .get(opref)
-            .copied()
-            .unwrap_or_else(|| env.get_type(*opref));
+    for slot in liveboxes.iter() {
+        let livebox_tp = slot.map_or(majit_ir::Type::Ref, |opref| {
+            numb_state
+                .livebox_types
+                .get(&opref)
+                .copied()
+                .unwrap_or_else(|| env.get_type(opref))
+        });
         if livebox_tp != majit_ir::Type::Ref {
             continue;
         }
@@ -115,7 +131,7 @@ pub fn serialize_optimizer_knowledge(
         // `bridgeopt.serialize_optimizer_knowledge` obtains `info` with
         // `getptrinfo(box)` and records whether it has a known class.
         // known_class = info is not None and info.get_known_class(cpu) is not None
-        if env.has_known_class(*opref) {
+        if slot.is_some_and(|opref| env.has_known_class(opref)) {
             bitfield |= 1;
         }
         shifts += 1;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -528,6 +528,9 @@ use crate::optimizeopt::info::PtrInfoExt;
 pub struct OptContext {
     /// The output operation list being built.
     pub new_operations: Vec<majit_ir::OpRc>,
+    /// Once the output buffer is drained, PtrInfo guard positions stamped
+    /// against the old buffer no longer name operations in this context.
+    new_operations_drained: bool,
     /// O(1) `OpRef → OpRc` index mirroring `new_operations`, keyed by each
     /// op's result position. `find_producer_op`'s highest-priority lookup
     /// otherwise scans `new_operations` with `iter().rfind(...)`, which is
@@ -1660,6 +1663,7 @@ impl OptContext {
     pub fn new(estimated_ops: usize) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
+            new_operations_drained: false,
             new_operations_index: FxHashMap::with_capacity_and_hasher(
                 estimated_ops,
                 Default::default(),
@@ -2282,6 +2286,7 @@ impl OptContext {
     ) -> Self {
         OptContext {
             new_operations: Vec::with_capacity(estimated_ops),
+            new_operations_drained: false,
             new_operations_index: FxHashMap::with_capacity_and_hasher(
                 estimated_ops,
                 Default::default(),
@@ -4523,10 +4528,18 @@ impl OptContext {
     /// stored `last_guard_pos`, or `None` when the slot is `-1` (no guard
     /// recorded) or the operand has no PtrInfo.
     pub fn get_last_guard(&self, op: &Operand) -> Option<&Op> {
+        if self.new_operations_drained {
+            return None;
+        }
         // info.py:100-103: read last_guard_pos from terminal PtrInfo.
         let resolved = op.get_box_replacement(false);
         let pos = resolved.ptr_info().and_then(|p| p.get_last_guard_pos())?;
-        self.new_operations.get(pos).map(|rc| rc.as_ref())
+        let op = self.new_operations.get(pos).map(|rc| rc.as_ref())?;
+        debug_assert!(
+            op.opcode.is_guard(),
+            "info.py:118 last_guard_pos must denote a guard"
+        );
+        Some(op)
     }
 
     /// resoperation.py:57-68 get_box_replacement: follow the forwarding
@@ -5098,6 +5111,9 @@ impl OptContext {
     /// `info.py:91-103 PtrInfo.get_last_guard_pos` operand-direct reader.
     /// Walks chain to terminal and reads its `_forwarded` PtrInfo slot.
     pub fn last_guard_pos(&self, op: &Operand) -> Option<usize> {
+        if self.new_operations_drained {
+            return None;
+        }
         op.get_box_replacement(false)
             .ptr_info()
             .and_then(|p| p.get_last_guard_pos())
@@ -8533,13 +8549,20 @@ impl OptContext {
     /// compile.ResumeAtPositionDescr).
     /// guard_pos is a _newoperations index (info.py:100-103).
     pub fn is_resume_at_position_guard(&self, guard_pos: i32) -> bool {
-        if guard_pos < 0 {
+        if self.new_operations_drained || guard_pos < 0 {
             return false;
         }
         self.new_operations
             .get(guard_pos as usize)
             .and_then(|op| op.getdescr())
             .is_some_and(|descr| descr.is_resume_at_position())
+    }
+
+    /// Drain the emitted-operation buffer and invalidate every PtrInfo guard
+    /// position that named the old buffer.
+    pub(crate) fn take_new_operations(&mut self) -> Vec<majit_ir::OpRc> {
+        self.new_operations_drained = true;
+        std::mem::take(&mut self.new_operations)
     }
 
     /// Take ownership of PtrInfo, replacing with None.
@@ -9294,6 +9317,22 @@ mod boxref_forwarding_tests {
             ctx.peek_ptr_info(&b).and_then(|i| i.get_last_guard_pos()),
             Some(5)
         );
+    }
+
+    #[test]
+    fn drained_operations_invalidate_recorded_guard_positions() {
+        let (mut ctx, b) = ctx_with_one_ref_box();
+        let guard = std::rc::Rc::new(Op::new(OpCode::GuardNonnull, std::slice::from_ref(&b)));
+        ctx.push_new_operation(guard);
+        ctx.set_ptr_info(&b, PtrInfo::NonNull { last_guard_pos: 0 });
+        assert!(ctx.get_last_guard(&b).is_some());
+
+        let _old_operations = ctx.take_new_operations();
+        ctx.push_new_operation(std::rc::Rc::new(Op::new(OpCode::IntAdd, &[])));
+
+        assert!(ctx.get_last_guard(&b).is_none());
+        assert!(ctx.last_guard_pos(&b).is_none());
+        assert!(!ctx.is_resume_at_position_guard(0));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -677,7 +677,7 @@ pub struct OptContext {
     pub exported_short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     /// optimizer.py: `can_replace_guards` — disable guard replacement during
     /// bridge compilation. Defaults to true for preamble.
-    pub can_replace_guards: bool,
+    can_replace_guards: bool,
     /// RPython optimizer.py: `patchguardop` — the last GUARD_FUTURE_CONDITION op.
     /// Used by unroll to attach resume data to extra guards from short preamble.
     pub patchguardop: Option<Op>,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -3930,7 +3930,7 @@ impl Optimizer {
         );
 
         // Preserve final context for jump_to_existing_trace.
-        let mut ops = std::mem::take(&mut ctx.new_operations);
+        let mut ops = ctx.take_new_operations();
 
         // RPython compile.py:327 final loop assembly:
         //   loop.operations = ([start_label] + preamble_ops

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1690,37 +1690,23 @@ impl Optimizer {
     /// the inner restore must preserve that.
     ///
     /// ```text
-    /// let guard = optimizer.cant_replace_guards();
+    /// let guard = optimizer.cant_replace_guards(ctx);
     /// // ... guarded section ...
-    /// optimizer.restore_can_replace_guards(guard);
+    /// optimizer.restore_can_replace_guards(ctx, guard);
     /// ```
-    pub fn cant_replace_guards(&mut self) -> CantReplaceGuards {
+    pub fn cant_replace_guards(&mut self, ctx: &mut OptContext) -> CantReplaceGuards {
+        debug_assert_eq!(self.can_replace_guards, ctx.can_replace_guards);
         let oldval = self.can_replace_guards;
         self.can_replace_guards = false;
+        ctx.can_replace_guards = false;
         CantReplaceGuards::new(oldval)
     }
 
     /// Pair with `cant_replace_guards` — restores the saved oldval.
     /// Matches `CantReplaceGuards.__exit__` (optimizer.py:908-909).
-    pub fn restore_can_replace_guards(&mut self, guard: CantReplaceGuards) {
+    pub fn restore_can_replace_guards(&mut self, ctx: &mut OptContext, guard: CantReplaceGuards) {
         self.can_replace_guards = guard.oldval;
-    }
-
-    /// **Legacy flat setter** kept for tests that exercise the flag
-    /// outside the cant_replace_guards save/restore pattern. New
-    /// production callers should use `cant_replace_guards()` +
-    /// `restore_can_replace_guards(oldval)` so nested scopes preserve
-    /// the outer value. Test-only entry; production unroll path
-    /// already migrated to the save/restore pair.
-    #[cfg(test)]
-    pub fn disable_guard_replacement(&mut self) {
-        self.can_replace_guards = false;
-    }
-
-    /// Companion to `disable_guard_replacement` — test-only.
-    #[cfg(test)]
-    pub fn enable_guard_replacement(&mut self) {
-        self.can_replace_guards = true;
+        ctx.can_replace_guards = guard.oldval;
     }
 
     /// `optimizer.py:243` + `heap.py:807-808`
@@ -7103,11 +7089,14 @@ mod tests {
     #[test]
     fn test_guard_replacement_flag() {
         let mut opt = Optimizer::new();
+        let mut ctx = OptContext::new(0);
         assert!(opt.can_replace_guards);
-        opt.disable_guard_replacement();
+        let guard = opt.cant_replace_guards(&mut ctx);
         assert!(!opt.can_replace_guards);
-        opt.enable_guard_replacement();
+        assert!(!ctx.can_replace_guards);
+        opt.restore_can_replace_guards(&mut ctx, guard);
         assert!(opt.can_replace_guards);
+        assert!(ctx.can_replace_guards);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4313,7 +4313,9 @@ impl Optimizer {
                     result.append(&mut ctx.new_operations);
                     return Ok((result, false));
                 }
-                return Ok((optimized_ops, false));
+                let mut result = optimized_ops;
+                result.append(&mut ctx.new_operations);
+                return Ok((result, false));
             }
         };
 
@@ -4345,7 +4347,16 @@ impl Optimizer {
             if let Some(ref mut state) = self.exported_loop_state {
                 state.runtime_boxes = runtime_boxes.to_vec();
             }
-            return Ok((optimized_ops, true));
+            // unroll.py:234-236 returns `self._newoperations` whole, so the
+            // retrace is built on the flush + end-of-preamble force + failed
+            // match guards above, not on the body alone. `retarget_close_jump`
+            // set `self.skip_flush`, which suppressed the in-body flush, so
+            // OptHeap's deferred setfield_gc stores are exactly what the
+            // `self.flush` above emitted — dropping this buffer would erase a
+            // heap store the bridge body performed.
+            let mut result = optimized_ops;
+            result.append(&mut ctx.new_operations);
+            return Ok((result, true));
         }
 
         // unroll.py:220-227: retrace limit reached, try force_boxes=True.
@@ -4400,7 +4411,9 @@ impl Optimizer {
             result.append(&mut ctx.new_operations);
             Ok((result, false))
         } else {
-            Ok((optimized_ops, false))
+            let mut result = optimized_ops;
+            result.append(&mut ctx.new_operations);
+            Ok((result, false))
         }
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1763,7 +1763,7 @@ impl UnrollOptimizer {
             if jumped && redirected_tail_ops.is_empty() {
                 // Only take jump_ctx ops if we don't already have
                 // a self-loop Jump from the retrace path.
-                redirected_tail_ops = std::mem::take(&mut jump_ctx.new_operations);
+                redirected_tail_ops = jump_ctx.take_new_operations();
                 // A close onto the body token this compilation just minted is
                 // always legal. A close onto any other token is legal exactly
                 // when that token belongs to the artifact this compilation will
@@ -1907,8 +1907,7 @@ impl UnrollOptimizer {
                     // carries it out (final_ctx is abandoned with the
                     // discarded trace).
                     opt_p2.send_extra_operation(&end_jump, &mut final_ctx)?;
-                    let redirected_tail_ops: Vec<majit_ir::OpRc> =
-                        std::mem::take(&mut final_ctx.new_operations);
+                    let redirected_tail_ops: Vec<majit_ir::OpRc> = final_ctx.take_new_operations();
                     opt_p2.final_ctx = Some(final_ctx);
                     body_ops = splice_redirected_tail(&body_ops, &redirected_tail_ops);
                 } else {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3328,7 +3328,7 @@ impl OptUnroll {
         // preserve the outer False via the saved token. An InvalidLoop is
         // recorded as a deferred signal on `ctx` (no unwinding), so a plain
         // call + restore preserves the "restore on exit" contract.
-        let guard = optimizer.cant_replace_guards();
+        let guard = optimizer.cant_replace_guards(ctx);
         let result = self.jump_to_existing_trace_impl(
             jump_args,
             current_label_args,
@@ -3339,7 +3339,7 @@ impl OptUnroll {
             runtime_boxes,
             pre_vs,
         );
-        optimizer.restore_can_replace_guards(guard);
+        optimizer.restore_can_replace_guards(ctx, guard);
         result
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -385,6 +385,30 @@ pub struct UnrollOptimizer {
 }
 
 impl UnrollOptimizer {
+    /// Supply the target tokens an earlier compile of this green key left
+    /// behind, stripped of their short-preamble producers.
+    ///
+    /// unroll.py:250 declares `short_preamble_producer = None` on `OptUnroll`
+    /// and only `finalize_short_preamble` (unroll.py:298) ever sets it, so
+    /// upstream enters every compile with exactly one producer: the one for
+    /// the target token that compile is minting. That is what lets
+    /// `inline_short_preamble` decide by identity — `sb.target_token is
+    /// target_token` (unroll.py:376-385) — whether it may set the builder up
+    /// in place against the current label args.
+    ///
+    /// pyre parks the producer on the `TargetToken` instead, and the tokens
+    /// resupplied here are clones of a previous compile's. Left intact, the
+    /// first one whose virtual state matches would hand out that compile's
+    /// builder, which would then be set up against this trace's label args and
+    /// have its stored short preamble overwritten with one naming this
+    /// compile's boxes.
+    pub fn seed_prior_target_tokens(&mut self, mut tokens: Vec<TargetToken>) {
+        for token in &mut tokens {
+            token.short_preamble_producer = None;
+        }
+        self.target_tokens = tokens;
+    }
+
     pub fn new() -> Self {
         UnrollOptimizer {
             short_preamble: None,
@@ -3521,6 +3545,12 @@ impl OptUnroll {
             let mut extra = Vec::new();
             if let Some(sp) = target_token.short_preamble.clone() {
                 if let Some(mut builder) = target_token.short_preamble_producer.take() {
+                    // unroll.py:376-385 inline_short_preamble sets a builder up
+                    // in place only when `sb.target_token is target_token`.
+                    // pyre needs no such test here: a producer exists only on
+                    // the token this compile minted, because
+                    // `seed_prior_target_tokens` strips the ones an earlier
+                    // compile left behind.
                     if let Some(label_args) = current_label_args {
                         // shortpreamble.py:283-296 / 311-341 parity:
                         // setup() returns false when an op references an

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9200,6 +9200,8 @@ impl<M: Clone> MetaInterp<M> {
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_start = Instant::now();
+        forget_optimization_info(&optimized_ops);
+        forget_optimization_info(&inputargs);
         let compile_loop_result = {
             let _backend_guard = self.staticdata.profiler.enter_backend();
             self.backend
@@ -12111,6 +12113,8 @@ impl<M: Clone> MetaInterp<M> {
         // profiler.start_backend() ... try: do_compile_loop ... finally:
         // ... profiler.end_backend() + debug_stop("jit-backend")`.
         let compile_start = Instant::now();
+        forget_optimization_info(&optimized_ops);
+        forget_optimization_info(&entry_inputargs);
         let compile_result = {
             let _backend_scope = self.staticdata.profiler.enter_backend();
             std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1538,6 +1538,9 @@ pub struct MetaInterp<M: Clone> {
     /// guard failure DeadFrame. Saved by start_retrace_from_guard, used
     /// by compile_bridge for cls_of_box during deserialize_optimizer_knowledge.
     pending_frontend_boxes: Option<Vec<i64>>,
+    /// Types parallel to `pending_frontend_boxes`, used to forward only Ref
+    /// slots while the bridge trace and compile are active.
+    pending_frontend_box_types: Option<Vec<Type>>,
     /// `optimizer.cpu` (model.py:39 `AbstractCPU`) backref.  Hosts
     /// `cls_of_box(box)` (model.py:199-201) and, going forward, the
     /// rest of the AbstractCPU surface (`bh_*` runtime calls, GC type
@@ -2145,6 +2148,18 @@ impl<M: Clone> MetaInterp<M> {
                 // positions (ResOp / InputArg refs) carry no inline ref.
                 if let Some(majit_ir::OpRef::ConstPtr(gcref)) = slot.as_mut() {
                     visitor(gcref);
+                }
+            }
+        }
+        if let (Some(values), Some(types)) = (
+            self.pending_frontend_boxes.as_mut(),
+            self.pending_frontend_box_types.as_deref(),
+        ) {
+            for (value, ty) in values.iter_mut().zip(types.iter()) {
+                if *ty == Type::Ref && *value != 0 {
+                    let mut gcref = GcRef(*value as usize);
+                    visitor(&mut gcref);
+                    *value = gcref.0 as i64;
                 }
             }
         }
@@ -2950,6 +2965,7 @@ impl<M: Clone> MetaInterp<M> {
             declined_bridge_guards: std::collections::HashSet::new(),
             pending_preamble_tokens: indexmap::IndexMap::new(),
             pending_frontend_boxes: None,
+            pending_frontend_box_types: None,
             cpu: crate::cpu::default_cpu(),
             issubclass: Some(default_issubclass),
             staticdata: std::sync::Arc::new(MetaInterpStaticData::new()),
@@ -7437,6 +7453,7 @@ impl<M: Clone> MetaInterp<M> {
         // trip the bridgeopt.py:126 `len(frontend_boxes) == len(liveboxes)`
         // assertion against the entry bridge's own inputargs.
         self.pending_frontend_boxes = None;
+        self.pending_frontend_box_types = None;
         self.compile_trace_inner(
             green_key,
             finish_args,
@@ -13161,6 +13178,9 @@ impl<M: Clone> MetaInterp<M> {
         // bridgeopt.py:124 frontend_boxes come directly from the guard
         // failure values in fail_arg_types order.
         self.pending_frontend_boxes = Some(fail_values.to_vec());
+        self.pending_frontend_box_types = descr_arc
+            .as_fail_descr()
+            .map(|fd| fd.fail_arg_types().to_vec());
         let _compiled = match self.compiled_loops.get(&green_key) {
             Some(c) => c,
             None => {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6325,7 +6325,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
-        unroll_opt.target_tokens = prior_front_target_tokens.clone();
+        unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
         unroll_opt.retraced_count = prior_retraced_count_early;
         unroll_opt.retrace_limit = self.warm_state.retrace_limit();
         unroll_opt.max_retrace_guards = self.warm_state.max_retrace_guards();
@@ -8000,7 +8000,7 @@ impl<M: Clone> MetaInterp<M> {
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
-        unroll_opt.target_tokens = prior_front_target_tokens.clone();
+        unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
         // `compile.py:797-811` — a retrace grown from a guard failure is
         // installed under the source guard's own loop token, so a close onto
         // one of that token's target tokens stays inside a single live code


### PR DESCRIPTION
Follow-up to #1222. Seven more bridge/retrace divergences from the vendored
RPython sources, found by re-reading `optimize_bridge`, the guard-failure seam,
and the short-preamble producer's lifetime against their upstream counterparts.

## `optimize_bridge` dropped the operations emitted after the flush

unroll.py:196-236 accumulates into one buffer and returns `self._newoperations`
from every exit, the retrace exit at :234-236 included. By that point the buffer
holds the body plus everything `self.flush()` (:203), the
`force_box_for_end_of_preamble` loop (:204-205) and a failed
`jump_to_existing_trace` (:207) emitted — unroll.py:305-318 states outright that
those bogus operations are deliberately left in place.

pyre splits that into `optimized_ops`, taken from `ctx.new_operations` before the
flush, plus whatever the re-acquired context accumulates after it. Four exits
spliced the two back together; three did not. On the retrace exit that loses
OptHeap's deferred `setfield_gc` stores: `retarget_close_jump` sets
`self.skip_flush`, so the in-body flush is suppressed and those stores are
emitted by exactly the call whose output was being discarded — a heap store the
bridge body performed never reached the `PartialTrace` `compile_retrace` builds
the specialization from.

The terminal JUMP is not in `optimized_ops` on this path (it was taken into
`self.terminal_op`), so appending adds nothing past a terminator.

## The bridge's frontend boxes were an unrooted raw-address snapshot

`start_retrace_from_guard` copied the guard failure values into a plain
`Vec<i64>` on the `MetaInterp`, and nothing walked it — `walk_active_trace_refs`
covers the framestack ref registers, the recorder, `initial_inputarg_consts`,
virtualizables, the heapcache and the per-TargetToken short-preamble producer.

The caller's copy of those same words is rooted for exactly this window:
`ResumeDeadframeRoots::register` adds a root per `Type::Ref` deadframe slot and
holds it across trace-and-compile. So a moving collection forwarded the caller's
words and left this copy naming the old address, which
`deserialize_optimizer_knowledge` then dereferenced through `default_cls_of_box`
(model.py:199-201) and installed via `make_constant_class` with no guard emitted
(bridgeopt.py:145-146). Upstream holds live boxes rather than words —
`frontend_inputargs = trace.inputargs` (unroll.py:186-192).

Now the descr's `fail_arg_types` are stashed alongside the values and the
`Type::Ref` entries are walked, using the same type filter and null skip the
deadframe rooting applies. With no types recorded nothing is walked, so an
integer is never forwarded as a pointer.

## Two backend boundaries still shipped optimizer forwarding

`forget_optimization_info` (compile.py:496-502) is the first statement of
`send_loop_to_backend` (compile.py:505-507), which
`ResumeFromInterpDescr.compile_and_attach` (compile.py:1013-1017) reaches for both
the entry bridge and the root FINISH trace. #1222 wired five of the seven
`backend.compile_loop` boundaries; `finish_and_compile` and `compile_entry_bridge`
were missed.

Generated code is unaffected — the backends deep-clone each op out of its `OpRc`
and `Op::clone` resets the forwarded slot. What it fixes is retention: the
optimizer's `PtrInfo` / `IntBound` graph, plus `Operand` handles to operations the
optimizer removed from the output, stayed pinned for the life of the compiled
trace.

## A resupplied target token carried the previous compile's short-preamble producer

unroll.py:250 declares `short_preamble_producer = None` on `OptUnroll` and only
`finalize_short_preamble` (unroll.py:298) assigns it, so upstream enters each
compile holding exactly one producer — the one for the token that compile is
minting. That is what `inline_short_preamble` decides on with
`sb.target_token is target_token` (unroll.py:376-385).

pyre parks the producer on the `TargetToken` and never clears it, while the loop
leg reseeds `unroll_opt.target_tokens` from a previous compile's tokens. The
first resupplied token whose virtual state matched therefore handed out that
compile's builder, which was then set up against the current trace's label args
and had its stored `short_preamble` overwritten; the ownership re-check
afterwards clears only the redirect, not the mutation.

Stripping the producer from the resupplied tokens restores upstream's invariant
directly, so no identity test is needed at the use site — a token carrying a
producer is by construction the one this compile minted.

## The bridge class bitfield was read over more slots than it was written over

bridgeopt.py:76-77 opens the serialize loop with `if box is None or box.type !=
"r": continue`, so upstream writes no bit for a hole. Its deserialize loop
(bridgeopt.py:135-136) tests only `box.type != "r"` and needs no hole test,
because `initialize_state_from_guard_failure` already dropped them —
`return [box for box in inputargs_and_holes if box]` (pyjitpl.py:3310).

pyre has no counterpart to that filter: a bridge's inputargs are one per fail-arg
slot, holes included, and `store_final_boxes_in_guard` types every hole `Ref`. So
the reader walked the hole positions while the writer skipped them and ran one
bit ahead per hole — every later Ref slot read its predecessor's bit, installing
`make_constant_class` for a class the parent trace never proved, and once the
surplus crossed a six-bit word the reader entered the heap section a whole word
early, taking the struct-triple count and the `all_descrs` index from the wrong
words. The hole's bit is now emitted, always clear.

## `can_replace_guards` existed twice, and the live one was not the one read

optimizer.py declares a single flag; unroll.py:317 is its only writer, wrapping
`jump_to_existing_trace`, and rewrite.py:343 / :423 read it to bail out before
replacing a guard. pyre had it on both `Optimizer` and `OptContext`. The unroll
path drove the first; both of rewrite.rs's guard-strengthening sites read the
second, which was initialized true and assigned false nowhere in the tree. Those
early returns were dead, so pyre replaced guards throughout the window upstream
closes — including for the GUARD_VALUEs `generate_guards` emits while matching
virtual state. One flag now, written through the save/restore pair.

## Guard queries answered with positions into a buffer that had been drained

`mark_last_guard` stamps an absolute index into the emitted-operation buffer.
optimizer.py:245 is the only assignment to `_newoperations`, which is why
info.py:118 can assert the stamp always denotes a guard. pyre drains that buffer
in `optimize_bridge` and in the peeled-trace assembly and then keeps emitting
into the same context, while the PtrInfos — which live on the operands'
forwarding slots — survive with indices naming whatever now sits at that offset.
`get_last_guard` returned it with no opcode check, so a deferred `setfield_gc`
from the flush could answer as the last guard and have that store overwritten by
a GUARD_VALUE. The drains go through one accessor now, and the three readers
report no recorded guard afterwards.

## Verification

`pyre/check.py`, darwin arm64, all three backends, on a quiet machine (load 1.9 at
completion, so the execution-ratio rows are real measurements rather than
contention). This run covers the first four commits; the last three are
compile-checked and pass `cargo test -p majit-metainterp --features dynasm`, and
a full re-run is in flight:

    ALL PASSED: dynasm 435/435
    ALL PASSED: wasm 428/428
    FAILED: cranelift 1 failed, 434 passed

The single failure is `synth/str_fstring` cranelift `guard_failures 657 -> 658`,
a committed-baseline disagreement that reproduces on this base with these commits
reverted and is being re-recorded separately.

Worth noting for anyone reading earlier runs of this branch: on a loaded machine
this same tree failed `wasm fannkuch`, `wasm global_quasiimmut_invalidation`,
`wasm short_circuit_value_kept_stack` and `cranelift fib_recursive` in varying
combinations. All of them pass when the machine is idle.

— *authored by Claude*
