### PR TITLE
Publish the operands nine interpreter paths read back across a Python call, and reuse a dict source's stored hashes

### DIFF
--- a/pyre/extra_tests/snippets/builtin_dict_union.py
+++ b/pyre/extra_tests/snippets/builtin_dict_union.py
@@ -93,3 +93,29 @@ skip_if_unsupported(3, 9, test_dunion_or0)
 skip_if_unsupported(3, 9, test_dunion_or1)
 skip_if_unsupported(3, 9, test_dunion_ror0)
 skip_if_unsupported(3, 9, test_dunion_other_types)
+
+
+def test_dunion_preserves_left_hashes():
+    # `d | other` copies the left operand and updates the copy, so the left
+    # keys keep their stored hashes instead of being re-hashed one at a time.
+    calls = []
+
+    class Key:
+        def __init__(self, i):
+            self.i = i
+
+        def __hash__(self):
+            calls.append(self.i)
+            return self.i
+
+        def __eq__(self, other):
+            return isinstance(other, Key) and self.i == other.i
+
+    left = {Key(i): i for i in range(5)}
+    calls.clear()
+    merged = left | {}
+    assert calls == [], f"left operand was re-hashed: {calls=}"
+    assert len(merged) == 5, f"unexpected merge result {merged=}"
+
+
+skip_if_unsupported(3, 9, test_dunion_preserves_left_hashes)

--- a/pyre/extra_tests/snippets/builtin_dict_union.py
+++ b/pyre/extra_tests/snippets/builtin_dict_union.py
@@ -95,9 +95,10 @@ skip_if_unsupported(3, 9, test_dunion_ror0)
 skip_if_unsupported(3, 9, test_dunion_other_types)
 
 
-def test_dunion_preserves_left_hashes():
-    # `d | other` copies the left operand and updates the copy, so the left
-    # keys keep their stored hashes instead of being re-hashed one at a time.
+def test_dunion_preserves_stored_hashes():
+    # `d | other` copies the left operand and updates the copy from the right,
+    # and a dict-to-dict update reuses each key's stored hash.  Neither half
+    # re-invokes `__hash__`, which is observable for a key that records it.
     calls = []
 
     class Key:
@@ -112,10 +113,29 @@ def test_dunion_preserves_left_hashes():
             return isinstance(other, Key) and self.i == other.i
 
     left = {Key(i): i for i in range(5)}
+    right = {Key(50 + i): i for i in range(3)}
+
     calls.clear()
     merged = left | {}
     assert calls == [], f"left operand was re-hashed: {calls=}"
     assert len(merged) == 5, f"unexpected merge result {merged=}"
 
+    calls.clear()
+    merged = left | right
+    assert calls == [], f"merge re-hashed an operand: {calls=}"
+    assert len(merged) == 8, f"unexpected merge result {merged=}"
 
-skip_if_unsupported(3, 9, test_dunion_preserves_left_hashes)
+    # The same reuse applies to `update` into a destination that is not empty,
+    # which is the path the merge above takes for its right operand.
+    destination = {Key(99): 0}
+    calls.clear()
+    destination.update(left)
+    assert calls == [], f"update re-hashed the source: {calls=}"
+    assert len(destination) == 6, f"unexpected update result {destination=}"
+
+    # Typed-strategy sources carry no stored hash and take the plain walk.
+    assert {1: "a"} | {2: "b"} == {1: "a", 2: "b"}
+    assert {"x": 1} | {"y": 2} == {"x": 1, "y": 2}
+
+
+skip_if_unsupported(3, 9, test_dunion_preserves_stored_hashes)

--- a/pyre/extra_tests/snippets/call_kwargs_merge_collecting_mapping.py
+++ b/pyre/extra_tests/snippets/call_kwargs_merge_collecting_mapping.py
@@ -1,0 +1,72 @@
+"""``f(**mapping)`` when the mapping runs a collection while it is read.
+
+``DICT_MERGE`` calls the mapping's ``keys()``, then ``__getitem__`` per key, and
+tests each key against the accumulated target.  Every one of those runs Python,
+so a mapping that collects between them exercises whether the merge still reads
+the objects it started with.
+"""
+
+import gc
+
+from testutils import assert_raises
+
+
+def f(*args, **kwargs):
+    return args, sorted(kwargs.items())
+
+
+class CollectingMapping:
+    def keys(self):
+        gc.collect()
+        return ["w", "x"]
+
+    def __getitem__(self, key):
+        gc.collect()
+        return key.upper()
+
+
+class CollectingKeys(dict):
+    def keys(self):
+        gc.collect()
+        return super().keys()
+
+
+class CollectingGetItem(dict):
+    def keys(self):
+        return super().keys()
+
+    def __getitem__(self, key):
+        gc.collect()
+        return super().__getitem__(key)
+
+
+assert f(**CollectingMapping()) == ((), [("w", "W"), ("x", "X")])
+assert f(**CollectingKeys(w=1, x=2)) == ((), [("w", 1), ("x", 2)])
+assert f(**CollectingGetItem(w=1, x=2)) == ((), [("w", 1), ("x", 2)])
+
+# A `*` unpack ahead of the merge is a collection point of its own, and the
+# callable and the already-merged names have to survive it.
+assert f(*[1, 2], **CollectingMapping()) == ((1, 2), [("w", "W"), ("x", "X")])
+assert f(*[1, 2], **CollectingKeys(w=1)) == ((1, 2), [("w", 1)])
+
+# Two mappings merged into one call: the second sees a non-empty target, which
+# is the arm that tests each key for membership.
+assert f(**CollectingMapping(), **CollectingKeys(y=3)) == (
+    (),
+    [("w", "W"), ("x", "X"), ("y", 3)],
+)
+
+# The duplicate report names the key and the callable, and reaches the same
+# membership test.
+assert_raises(
+    TypeError,
+    lambda: f(**CollectingMapping(), **CollectingKeys(w=1)),
+    _msg="f() got multiple values for keyword argument 'w'",
+)
+
+# A non-mapping after ** is still rejected by its own message.
+assert_raises(
+    TypeError,
+    lambda: f(**[1, 2]),
+    _msg="f() argument after ** must be a mapping, not list",
+)

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -521,8 +521,8 @@ pub fn combine_starstarargs_wrapped(
             // Pyre's `findattr` matches the same shape (Option<W>),
             // modulo async-propagation (still a known gap covered by
             // the `findattr` TODO).
-            let w_obj_type =
-                crate::typedef::r#type(w_starstararg()).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
+            let w_obj_type = crate::typedef::r#type(w_starstararg())
+                .map_or(pyre_object::PY_NULL, |p| p.as_ptr());
             let lhs = if w_obj_type.is_null() {
                 None
             } else {

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -243,7 +243,34 @@ pub fn do_combine_starstarargs_wrapped(
     // present-but-unread per `seen[key] = None` at line 446).
     let mut seen: std::collections::HashMap<rustpython_wtf8::Wtf8Buf, ()> =
         std::collections::HashMap::new();
-    for (i, &w_key) in keys_w.iter().enumerate() {
+    // The per-key value lookup below runs `__getitem__` (or the dict
+    // descriptor, which hashes the key), so every turn is a collection point.
+    // The key list, the mapping, the callable, the names the caller already
+    // accepted and the pairs filled so far are native locals no root walker
+    // updates, so publish the whole set and read each one back on the turn
+    // that uses it.  The two output slices are written from the published
+    // pairs once the loop is done.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_starstararg);
+    pyre_object::gc_roots::pin_root(w_function);
+    let existing_base = pyre_object::gc_roots::shadow_stack_len();
+    let existing_len = existingkeywords_w.map_or(0, |existing| existing.len());
+    for &w_name in existingkeywords_w.unwrap_or_default() {
+        pyre_object::gc_roots::pin_root(w_name);
+    }
+    let keys_base = pyre_object::gc_roots::shadow_stack_len();
+    for &key in keys_w {
+        pyre_object::gc_roots::pin_root(key);
+    }
+    let pairs_base = pyre_object::gc_roots::shadow_stack_len();
+    for _ in 0..2 * keys_w.len() {
+        pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+    }
+    let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    for i in 0..keys_w.len() {
+        let w_key = pyre_object::gc_roots::shadow_stack_get(keys_base + i);
         // argument.py:431 — `key = space.text_w(w_key)`; raise TypeError
         // if w_key is not a string.  `_PyStack_UnpackDict` reports this
         // without the callable's qualname or the offending key's type, where
@@ -260,17 +287,20 @@ pub fn do_combine_starstarargs_wrapped(
         };
         // argument.py:439-445 — duplicate check against existing kwargs +
         // already-seen names in this iteration.
-        let already_in_existing = existingkeywords_w
-            .map(|existing| contains_w_names(w_key, existing))
-            .unwrap_or(false);
+        let already_in_existing = existing_len != 0 && {
+            let existing_now: Vec<PyObjectRef> = (0..existing_len)
+                .map(|j| pyre_object::gc_roots::shadow_stack_get(existing_base + j))
+                .collect();
+            contains_w_names(w_key, &existing_now)
+        };
         if already_in_existing || seen.contains_key(&key) {
             return Err(raise_type_error(
-                w_function,
+                w_function(),
                 format!("got multiple values for keyword argument '{key}'"),
             ));
         }
         // argument.py:448 — `keyword_names_w[i] = w_key`.
-        keyword_names_w[i] = w_key;
+        pyre_object::gc_roots::shadow_stack_set(pairs_base + 2 * i, w_key);
         // argument.py:449-457 — value lookup.
         let w_value = if is_dict {
             // argument.py:449-455 — `dict_getitem` direct-storage
@@ -295,7 +325,7 @@ pub fn do_combine_starstarargs_wrapped(
             // `w_dict_getitem_str` returns None is mid-iteration
             // mutation, which `dict.__getitem__` (the descriptor PyPy
             // calls via `dict_getitem`) surfaces as KeyError.
-            let backing = crate::type_methods::resolve_dict_backing(w_starstararg);
+            let backing = crate::type_methods::resolve_dict_backing(w_starstararg());
             let direct = if backing.is_null() {
                 None
             } else {
@@ -307,12 +337,16 @@ pub fn do_combine_starstarargs_wrapped(
             }
         } else {
             // argument.py:457 — `w_value = space.getitem(...)`.
-            crate::baseobjspace::getitem(w_starstararg, w_key)?
+            crate::baseobjspace::getitem(w_starstararg(), w_key)?
         };
-        keywords_w[i] = w_value;
+        pyre_object::gc_roots::shadow_stack_set(pairs_base + 2 * i + 1, w_value);
         // argument.py:446 `seen[key] = None` — record key, value slot
         // is unread.
         seen.insert(key, ());
+    }
+    for i in 0..keys_w.len() {
+        keyword_names_w[i] = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i);
+        keywords_w[i] = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i + 1);
     }
     Ok(())
 }
@@ -419,16 +453,26 @@ pub fn combine_starstarargs_wrapped(
     w_starstararg: PyObjectRef,
     w_function: PyObjectRef,
 ) -> Result<(), crate::PyError> {
+    // Deriving the key list reaches `__getattribute__` and the mapping's own
+    // `keys()`, both of which run Python, and `w_starstararg` is read again
+    // afterwards to fetch each value.  Publish the mapping and the callable so
+    // that later read is of the live object, not the address they had on entry.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_starstararg);
+    pyre_object::gc_roots::pin_root(w_function);
+    let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
     // argument.py:109 — fast path via view_as_kwargs.  Both halves of
     // the tuple are `Option`; PyPy's base default is `(None, None)`
     // while the kwargsdict-aware override returns `(Some, Some)`.
-    let (fast_names, fast_values) = crate::baseobjspace::view_as_kwargs(w_starstararg);
+    let (fast_names, fast_values) = crate::baseobjspace::view_as_kwargs(w_starstararg());
     if let Some(names) = fast_names {
         let values = fast_values
             .expect("baseobjspace.py:1159 view_as_kwargs returns matching Some/Some or None/None");
         // argument.py:111-119 — merge with optional duplicate check.
         if !keyword_names_out.is_empty() {
-            check_not_duplicate_kwargs(keyword_names_out, &names, &values, w_function)?;
+            check_not_duplicate_kwargs(keyword_names_out, &names, &values, w_function())?;
         }
         keyword_names_out.extend(names);
         keywords_out.extend(values);
@@ -462,9 +506,9 @@ pub fn combine_starstarargs_wrapped(
     // path, the fallback collapses to dead code.
     let is_dict = unsafe {
         let isinst = if w_dict_type.is_null() {
-            pyre_object::is_dict(w_starstararg)
+            pyre_object::is_dict(w_starstararg())
         } else {
-            crate::baseobjspace::isinstance_w(w_starstararg, w_dict_type)
+            crate::baseobjspace::isinstance_w(w_starstararg(), w_dict_type)
         };
         if !isinst {
             false
@@ -478,7 +522,7 @@ pub fn combine_starstarargs_wrapped(
             // modulo async-propagation (still a known gap covered by
             // the `findattr` TODO).
             let w_obj_type =
-                crate::typedef::r#type(w_starstararg).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
+                crate::typedef::r#type(w_starstararg()).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
             let lhs = if w_obj_type.is_null() {
                 None
             } else {
@@ -498,18 +542,18 @@ pub fn combine_starstarargs_wrapped(
         }
     };
     let keys_w: Vec<PyObjectRef> = if is_dict {
-        crate::baseobjspace::unpackiterable(w_starstararg, -1)?
+        crate::baseobjspace::unpackiterable(w_starstararg(), -1)?
     } else {
         // argument.py:131-138 — the `try` covers the whole
         // `space.call_method(w_starstararg, "keys")`, so an
         // AttributeError raised either while finding `keys` OR inside
         // the keys() call is converted to the mapping TypeError below.
-        let w_keys_meth = match crate::baseobjspace::getattr_str(w_starstararg, "keys") {
+        let w_keys_meth = match crate::baseobjspace::getattr_str(w_starstararg(), "keys") {
             Ok(m) => m,
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                let tp = type_name_of(w_starstararg);
+                let tp = type_name_of(w_starstararg());
                 return Err(raise_type_error(
-                    w_function,
+                    w_function(),
                     format!("argument after ** must be a mapping, not {tp}"),
                 ));
             }
@@ -518,9 +562,9 @@ pub fn combine_starstarargs_wrapped(
         let w_keys = match crate::call::call_function_impl_result(w_keys_meth, &[]) {
             Ok(w) => w,
             Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-                let tp = type_name_of(w_starstararg);
+                let tp = type_name_of(w_starstararg());
                 return Err(raise_type_error(
-                    w_function,
+                    w_function(),
                     format!("argument after ** must be a mapping, not {tp}"),
                 ));
             }
@@ -541,12 +585,12 @@ pub fn combine_starstarargs_wrapped(
     };
     do_combine_starstarargs_wrapped(
         &keys_w,
-        w_starstararg,
+        w_starstararg(),
         &mut keyword_names_w,
         &mut keywords_w,
         existing,
         is_dict,
-        w_function,
+        w_function(),
     )?;
     // argument.py:145-150 — merge into the running output buffers.
     keyword_names_out.extend(keyword_names_w);

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -13701,28 +13701,42 @@ fn _unpackiterable_known_length_jitlook(
     w_iterator: PyObjectRef,
     expected_length: usize,
 ) -> Result<Vec<PyObjectRef>, crate::PyError> {
-    let mut items: Vec<PyObjectRef> = Vec::with_capacity(expected_length);
+    // Each `next` runs the iterator's `__next__`, so every loop turn is a
+    // collection point.  A plain `Vec` accumulator is scanned by no root
+    // walker, which would leave every item already pulled unreachable while
+    // the next one is produced, and `w_iterator` is a native copy the
+    // collector does not update.  `_unpackiterable_unknown_length`
+    // accumulates into a rooted `W_List` for this reason; the flat return
+    // shape here is rebuilt from the published set instead.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iterator);
+    let iterator = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let mut count = 0usize;
     loop {
-        match next(w_iterator) {
+        match next(iterator()) {
             Ok(w_item) => {
-                if items.len() == expected_length {
+                if count == expected_length {
                     return Err(crate::PyError::value_error(format!(
                         "too many values to unpack (expected {expected_length})",
                     )));
                 }
-                items.push(w_item);
+                pyre_object::gc_roots::pin_root(w_item);
+                count += 1;
             }
             Err(e) if e.kind == crate::PyErrorKind::StopIteration => break,
             Err(e) => return Err(e),
         }
     }
-    if items.len() < expected_length {
+    if count < expected_length {
         return Err(crate::PyError::value_error(format!(
             "not enough values to unpack (expected {expected_length}, got {got})",
-            got = items.len(),
+            got = count,
         )));
     }
-    Ok(items)
+    Ok((0..count)
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + index))
+        .collect())
 }
 
 /// pypy/interpreter/baseobjspace.py:1159-1163 base default + the

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -1150,23 +1150,37 @@ pub fn call_function_ex_in_ctx(
     starargs: PyObjectRef,
     kwargs_or_null: PyObjectRef,
 ) -> PyResult {
+    // Unpacking `*` already runs Python — a generator body, or a subtype's
+    // `__iter__` — so `callable`, the mapping and the prepended receiver are
+    // stale by the time the `**` merge and the dispatch read them.  Publish
+    // them before the first unpack, not after it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let callable_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(callable);
+    pyre_object::gc_roots::pin_root(kwargs_or_null);
+    pyre_object::gc_roots::pin_root(self_or_null);
+    pyre_object::gc_roots::pin_root(starargs);
+    let callable = || pyre_object::gc_roots::shadow_stack_get(callable_slot);
+    let kwargs_or_null = || pyre_object::gc_roots::shadow_stack_get(callable_slot + 1);
+    let self_or_null = || pyre_object::gc_roots::shadow_stack_get(callable_slot + 2);
+    let starargs = || pyre_object::gc_roots::shadow_stack_get(callable_slot + 3);
     let mut args: Vec<PyObjectRef> = unsafe {
         // argument.py:92-104 reaches `space.fixedview`, whose fast paths
         // (`objspace.py:519-527`) are a tuple whose `__iter__` is still
         // `tuple.__iter__` and an exact list.  A subtype that replaced
         // `__iter__` falls through to the generic path so the override runs.
-        if pyre_object::is_tuple(starargs)
-            && crate::baseobjspace::builtin_iter_replacement(starargs, &pyre_object::TUPLE_TYPE)
+        if pyre_object::is_tuple(starargs())
+            && crate::baseobjspace::builtin_iter_replacement(starargs(), &pyre_object::TUPLE_TYPE)
                 .is_none()
         {
-            let n = pyre_object::w_tuple_len(starargs);
+            let n = pyre_object::w_tuple_len(starargs());
             (0..n as i64)
-                .filter_map(|i| pyre_object::w_tuple_getitem(starargs, i))
+                .filter_map(|i| pyre_object::w_tuple_getitem(starargs(), i))
                 .collect()
-        } else if pyre_object::is_exact_list(starargs) {
-            let n = pyre_object::w_list_len(starargs);
+        } else if pyre_object::is_exact_list(starargs()) {
+            let n = pyre_object::w_list_len(starargs());
             (0..n as i64)
-                .filter_map(|i| pyre_object::w_list_getitem(starargs, i))
+                .filter_map(|i| pyre_object::w_list_getitem(starargs(), i))
                 .collect()
         } else {
             // argument.py:92-104 `_combine_starargs_wrapped` — a non-tuple/list
@@ -1174,27 +1188,41 @@ pub fn call_function_ex_in_ctx(
             // "argument after * must be an iterable, not %T" (not the bare
             // `iter()` TypeError).
             let mut unpacked: Vec<PyObjectRef> = Vec::new();
-            crate::argument::combine_starargs_wrapped(&mut unpacked, starargs, callable)?;
+            crate::argument::combine_starargs_wrapped(&mut unpacked, starargs(), callable())?;
             unpacked
         }
     };
-    if !self_or_null.is_null() {
-        args.insert(0, self_or_null);
+    if !self_or_null().is_null() {
+        args.insert(0, self_or_null());
     }
+
+    // The unpacked positional set is a native `Vec` no root walker updates and
+    // the `**` merge below runs Python too, so publish it and rebuild the
+    // slice for the dispatch.
+    let args_base = pyre_object::gc_roots::shadow_stack_len();
+    for &arg in &args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let nargs = args.len();
+    let args = || -> Vec<PyObjectRef> {
+        (0..nargs)
+            .map(|index| pyre_object::gc_roots::shadow_stack_get(args_base + index))
+            .collect()
+    };
 
     // Merge the `**` mapping into the call.  argument.py:106-150
     // `_combine_starstarargs_wrapped` accepts any mapping — the dict fast
     // path or an arbitrary object via `keys()` / `__getitem__` — raising
     // "argument after ** must be a mapping" for a non-mapping and
     // "keywords must be strings" for a non-str key.
-    if !kwargs_or_null.is_null() {
+    if !kwargs_or_null().is_null() {
         let mut keyword_names_w: Vec<PyObjectRef> = Vec::new();
         let mut keywords_w: Vec<PyObjectRef> = Vec::new();
         crate::argument::combine_starstarargs_wrapped(
             &mut keyword_names_w,
             &mut keywords_w,
-            kwargs_or_null,
-            callable,
+            kwargs_or_null(),
+            callable(),
         )?;
         if !keyword_names_w.is_empty() {
             let entries: Vec<(Wtf8Buf, PyObjectRef)> = keyword_names_w
@@ -1202,11 +1230,11 @@ pub fn call_function_ex_in_ctx(
                 .zip(keywords_w.iter())
                 .map(|(&k, &v)| (unsafe { pyre_object::w_str_get_wtf8(k) }.to_owned(), v))
                 .collect();
-            return call_with_kwargs_in_ctx(execution_context, callable, &args, &entries);
+            return call_with_kwargs_in_ctx(execution_context, callable(), &args(), &entries);
         }
     }
 
-    call_callable_in_ctx(execution_context, callable, &args)
+    call_callable_in_ctx(execution_context, callable(), &args())
 }
 
 /// [`call_kw_in_ctx`] reached from a frame — the `pyopcode.py:1402

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -906,7 +906,21 @@ fn writer_writerow_impl(
     let n = row.len();
     let mut rec = rustpython_wtf8::Wtf8Buf::new();
 
-    for (i, &w_field) in row.iter().enumerate() {
+    // Rendering a field runs its `__str__` / `__repr__` and `float_w` its
+    // `__float__`, so every turn is a collection point.  The collected row and
+    // the bound `_write` are native locals no root walker updates, so publish
+    // them and read each field back after the render that precedes its
+    // remaining type queries.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let write_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_filewrite);
+    let row_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &row {
+        pyre_object::gc_roots::pin_root(item);
+    }
+
+    for i in 0..n {
+        let w_field = pyre_object::gc_roots::shadow_stack_get(row_base + i);
         let field = if unsafe { pyre_object::is_none(w_field) } {
             rustpython_wtf8::Wtf8Buf::new()
         } else if unsafe { pyre_object::is_float(w_field) } {
@@ -914,6 +928,7 @@ fn writer_writerow_impl(
         } else {
             unsafe { crate::display::py_str_wtf8(w_field) }?
         };
+        let w_field = pyre_object::gc_roots::shadow_stack_get(row_base + i);
 
         let mut quoted = match cfg.quoting {
             QUOTE_NONNUMERIC => crate::baseobjspace::float_w(w_field).is_err(),
@@ -1013,7 +1028,10 @@ fn writer_writerow_impl(
     }
 
     rec.push_str(&cfg.lineterminator);
-    crate::call::call_function_impl_result(w_filewrite, &[pyre_object::w_str_from_wtf8(rec)])
+    crate::call::call_function_impl_result(
+        pyre_object::gc_roots::shadow_stack_get(write_slot),
+        &[pyre_object::w_str_from_wtf8(rec)],
+    )
 }
 
 /// `W_Writer.writerows` — serialize a sequence of records.

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -1233,15 +1233,42 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
             "Inputs are not the same length",
         ));
     }
+    // `mul` and `add` dispatch to the operands' `__mul__` / `__add__`, so a
+    // Decimal or Fraction element makes every turn a collection point.  Both
+    // collected sequences and the running total are native locals no root
+    // walker updates, so publish them and read each operand back per turn.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let p_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &p {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let q_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &q {
+        pyre_object::gc_roots::pin_root(item);
+    }
     // The accumulator starts as int 0 so type coercion follows the pure
     // Python `total = 0; total += p_i * q_i` recipe: int stays int, and a
     // Decimal/Fraction/float product widens the running total on first add.
-    let mut acc: PyObjectRef = w_int_new(0);
-    for (a, b) in p.iter().zip(q.iter()) {
-        let prod = crate::baseobjspace::mul(*a, *b)?;
-        acc = crate::baseobjspace::add(acc, prod)?;
+    let acc_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_int_new(0));
+    for index in 0..p.len() {
+        let prod = crate::baseobjspace::mul(
+            pyre_object::gc_roots::shadow_stack_get(p_base + index),
+            pyre_object::gc_roots::shadow_stack_get(q_base + index),
+        )?;
+        // `prod` is fresh and `add` runs Python; it needs a root of its own for
+        // that call, released again each turn so the bracket stays fixed-size.
+        let iteration_roots = pyre_object::gc_roots::push_roots();
+        let prod_slot = pyre_object::gc_roots::shadow_stack_len();
+        iteration_roots.pin_root(prod);
+        let total = crate::baseobjspace::add(
+            pyre_object::gc_roots::shadow_stack_get(acc_slot),
+            pyre_object::gc_roots::shadow_stack_get(prod_slot),
+        )?;
+        drop(iteration_roots);
+        pyre_object::gc_roots::shadow_stack_set(acc_slot, total);
     }
-    Ok(acc)
+    Ok(pyre_object::gc_roots::shadow_stack_get(acc_slot))
 }
 
 pub fn frexp(args: &[PyObjectRef]) -> PyResult {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4989,9 +4989,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                 pyre_object::w_dict_len(pyre_object::gc_roots::shadow_stack_get(root_base + 1));
             let mut equal = la == lb;
             if equal {
-                let items = pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(
-                    root_base,
-                ));
+                let items =
+                    pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(root_base));
                 let items_base = pyre_object::gc_roots::shadow_stack_len();
                 for &(k, v) in &items {
                     pyre_object::gc_roots::pin_root(k);
@@ -5012,9 +5011,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                         Some(other_v) => {
                             // dictmultiobject.py:664 `if not space.eq_w(w_val,
                             // w_rightval): return space.w_False`
-                            let v = pyre_object::gc_roots::shadow_stack_get(
-                                items_base + index * 2 + 1,
-                            );
+                            let v =
+                                pyre_object::gc_roots::shadow_stack_get(items_base + index * 2 + 1);
                             if !crate::baseobjspace::eq_w(v, other_v)? {
                                 equal = false;
                                 break;

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4687,14 +4687,23 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // dict | dict — PEP 584 merge. PyPy: dictmultiobject.py descr_or.
         // Returns a new dict built from `a`'s items, then updated with `b`'s.
         if pyre_object::is_dict(a) && pyre_object::is_dict(b) {
-            let new_dict = pyre_object::w_dict_new();
-            for (k, v) in pyre_object::w_dict_items(a) {
-                pyre_object::w_dict_store(new_dict, k, v);
-            }
-            for (k, v) in pyre_object::w_dict_items(b) {
-                pyre_object::w_dict_store(new_dict, k, v);
-            }
-            return Ok(new_dict);
+            // `dictmultiobject.py:288-293 descr_or` — `copyself = self.copy()`
+            // then `update1(space, copyself, w_other)`.  Storing `a`'s items
+            // one at a time instead re-hashes every key through its `__hash__`,
+            // which the strategy copy does not do.  Each of those hashes also
+            // runs Python, and the merge target, both operands and the item
+            // snapshots are bare locals no root walker scans; `dict_update1`
+            // already brackets its own operands for that reason.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(a);
+            pyre_object::gc_roots::pin_root(b);
+            let src = || pyre_object::gc_roots::shadow_stack_get(root_base);
+            let other = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+            let merged = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
+            pyre_object::gc_roots::pin_root(crate::type_methods::dict_method_copy(&[src()])?);
+            crate::type_methods::dict_update1(merged(), other())?;
+            return Ok(merged());
         }
         // user-class + typedef (dict_view, …) dispatch: forward __or__ then reflected
         // __ror__, exactly once.  Skipped when a gated special above already ran, so a

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -4974,17 +4974,47 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             && is_exact_type(b, &pyre_object::DICT_TYPE)
             && matches!(op, CompareOp::Eq | CompareOp::Ne)
         {
-            let la = pyre_object::w_dict_len(a);
-            let lb = pyre_object::w_dict_len(b);
+            // `w_dict_lookup_checked` hashes `k` through its `__hash__` and
+            // `eq_w` runs the values' `__eq__`; both are collection points.
+            // `b` and every entry of the `w_dict_items` snapshot are native
+            // locals no root walker updates, and the operands were popped off
+            // the value stack before this dispatch, so publish the whole set
+            // and read each entry back after the comparisons that precede it.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(a);
+            pyre_object::gc_roots::pin_root(b);
+            let la = pyre_object::w_dict_len(pyre_object::gc_roots::shadow_stack_get(root_base));
+            let lb =
+                pyre_object::w_dict_len(pyre_object::gc_roots::shadow_stack_get(root_base + 1));
             let mut equal = la == lb;
             if equal {
-                for (k, v) in pyre_object::w_dict_items(a) {
-                    match pyre_object::dictmultiobject::w_dict_lookup_checked(b, k)
-                        .map_err(|_| crate::baseobjspace::take_pending_dict_key_error(k))?
-                    {
+                let items = pyre_object::w_dict_items(pyre_object::gc_roots::shadow_stack_get(
+                    root_base,
+                ));
+                let items_base = pyre_object::gc_roots::shadow_stack_len();
+                for &(k, v) in &items {
+                    pyre_object::gc_roots::pin_root(k);
+                    pyre_object::gc_roots::pin_root(v);
+                }
+                for index in 0..items.len() {
+                    let k = pyre_object::gc_roots::shadow_stack_get(items_base + index * 2);
+                    let other = pyre_object::dictmultiobject::w_dict_lookup_checked(
+                        pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+                        k,
+                    )
+                    .map_err(|_| {
+                        crate::baseobjspace::take_pending_dict_key_error(
+                            pyre_object::gc_roots::shadow_stack_get(items_base + index * 2),
+                        )
+                    })?;
+                    match other {
                         Some(other_v) => {
                             // dictmultiobject.py:664 `if not space.eq_w(w_val,
                             // w_rightval): return space.w_False`
+                            let v = pyre_object::gc_roots::shadow_stack_get(
+                                items_base + index * 2 + 1,
+                            );
                             if !crate::baseobjspace::eq_w(v, other_v)? {
                                 equal = false;
                                 break;
@@ -5081,23 +5111,35 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
         // the live lists (CPython 3.14 `list_richcompare_impl`; PyPy
         // `list_eq` / `_compare_unwrappeditems`).
         if is_list(a) && is_list(b) {
+            // `eq_w` below runs a user `__eq__`, which is a collection point,
+            // and `a`/`b` are native copies no root walker updates — the
+            // operands were popped off the value stack before this dispatch, so
+            // the frame no longer roots them either.  Publish both and read
+            // them back at every loop boundary and length read, which is also
+            // what makes the "read the live lists" contract above hold.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(a);
+            pyre_object::gc_roots::pin_root(b);
+            let a = || pyre_object::gc_roots::shadow_stack_get(root_base);
+            let b = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
             if matches!(op, CompareOp::Eq | CompareOp::Ne)
-                && pyre_object::w_list_len(a) != pyre_object::w_list_len(b)
+                && pyre_object::w_list_len(a()) != pyre_object::w_list_len(b())
             {
                 return Ok(w_bool_from(matches!(op, CompareOp::Ne)));
             }
 
             let mut i = 0usize;
-            while i < pyre_object::w_list_len(a) && i < pyre_object::w_list_len(b) {
-                let ea = pyre_object::w_list_getitem(a, i as i64).unwrap_or(PY_NULL);
-                let eb = pyre_object::w_list_getitem(b, i as i64).unwrap_or(PY_NULL);
+            while i < pyre_object::w_list_len(a()) && i < pyre_object::w_list_len(b()) {
+                let ea = pyre_object::w_list_getitem(a(), i as i64).unwrap_or(PY_NULL);
+                let eb = pyre_object::w_list_getitem(b(), i as i64).unwrap_or(PY_NULL);
                 if !crate::baseobjspace::eq_w(ea, eb)? {
                     break;
                 }
                 i += 1;
             }
-            let la = pyre_object::w_list_len(a);
-            let lb = pyre_object::w_list_len(b);
+            let la = pyre_object::w_list_len(a());
+            let lb = pyre_object::w_list_len(b());
             if i >= la || i >= lb {
                 return Ok(w_bool_from(match op {
                     CompareOp::Lt => la < lb,
@@ -5113,8 +5155,8 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
             }
             // CPython deliberately fetches the live items again: equality may
             // have replaced either element before the ordering comparison.
-            let ea = pyre_object::w_list_getitem(a, i as i64).unwrap_or(PY_NULL);
-            let eb = pyre_object::w_list_getitem(b, i as i64).unwrap_or(PY_NULL);
+            let ea = pyre_object::w_list_getitem(a(), i as i64).unwrap_or(PY_NULL);
+            let eb = pyre_object::w_list_getitem(b(), i as i64).unwrap_or(PY_NULL);
             return compare(ea, eb, op);
         }
         // range value comparison — functional.py W_Range.descr_eq:

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -820,9 +820,8 @@ pub fn dict_merge_value(
     )?;
     let keys_obj_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(keys_obj);
-    let keys = crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(
-        keys_obj_slot,
-    ))?;
+    let keys =
+        crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(keys_obj_slot))?;
     let keys_base = pyre_object::gc_roots::shadow_stack_len();
     for &key in &keys {
         pyre_object::gc_roots::pin_root(key);

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -728,11 +728,27 @@ pub fn dict_merge_value(
     w_callable: PyObjectRef,
 ) -> Result<(), PyError> {
     // pyopcode.py:1979 `_dict_merge`.
+    // `__len__`, `keys()`, `__getitem__` and `__contains__` all run Python, so
+    // every step below is a collection point, and the three operands arrive as
+    // native copies no root walker updates — the dispatch peeked them and the
+    // frame slots that rooted them are gone by the time a subclass' `keys()`
+    // returns.  Publish them and read each one back per use: a stale target
+    // reaches `dict.__contains__` as a receiver its own type check rejects,
+    // and a stale source is read as a mapping it no longer is.  `dict_update`
+    // above brackets the same walk.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(dict);
+    pyre_object::gc_roots::pin_root(source);
+    pyre_object::gc_roots::pin_root(w_callable);
+    let dict = || pyre_object::gc_roots::shadow_stack_get(root_base);
+    let source = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    let w_callable = || pyre_object::gc_roots::shadow_stack_get(root_base + 2);
     let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
     // `space.isinstance_w(w_dict, space.w_dict)` accepts dict subclasses;
     // a non-dict target is a RuntimeError, not a TypeError.
-    if !unsafe { crate::baseobjspace::isinstance_w(dict, w_dict_type) } {
-        let type_name = unsafe { (*(*dict).ob_type).name };
+    if !unsafe { crate::baseobjspace::isinstance_w(dict(), w_dict_type) } {
+        let type_name = unsafe { (*(*dict()).ob_type).name };
         return Err(PyError::new(
             crate::PyErrorKind::RuntimeError,
             format!("expected a dict, got {type_name}"),
@@ -740,15 +756,15 @@ pub fn dict_merge_value(
     }
     // `space.len_w` is a generic `__len__` dispatch — a raw `w_dict_len`
     // would be UB on a dict subclass whose layout is not `W_DictObject`.
-    let l1 = crate::baseobjspace::len_w(dict)?;
-    let source_is_dict = unsafe { crate::baseobjspace::isinstance_w(source, w_dict_type) };
+    let l1 = crate::baseobjspace::len_w(dict())?;
+    let source_is_dict = unsafe { crate::baseobjspace::isinstance_w(source(), w_dict_type) };
     if !source_is_dict {
         // `if not space.ismapping_w(w_item): raise oefmt(... "%s argument
         // after ** must be a mapping, not %T")`.
-        if !crate::baseobjspace::ismapping_w(source) {
-            let type_name = unsafe { pyre_object::type_name_of(source) };
+        if !crate::baseobjspace::ismapping_w(source()) {
+            let type_name = unsafe { pyre_object::type_name_of(source()) };
             return Err(crate::argument::raise_type_error(
-                w_callable,
+                w_callable(),
                 format!("argument after ** must be a mapping, not {type_name}"),
             ));
         }
@@ -757,12 +773,24 @@ pub fn dict_merge_value(
         // duplicate check (`update1`); an empty source is a no-op.  The raw
         // items walk is exact-dict only — a dict subclass may override
         // `keys()` / `__getitem__`, so it falls through to the generic loop.
-        let l2 = crate::baseobjspace::len_w(source)?;
-        if l1 == 0 && unsafe { pyre_object::is_dict(source) } {
-            unsafe {
-                for (k, v) in pyre_object::w_dict_items(source) {
-                    pyre_object::w_dict_store(dict, k, v);
-                }
+        let l2 = crate::baseobjspace::len_w(source())?;
+        if l1 == 0 && unsafe { pyre_object::is_dict(source()) } {
+            // A store into the target allocates the storage it grows into, so
+            // the snapshot has to be published too.
+            let items = unsafe { pyre_object::w_dict_items(source()) };
+            let items_base = pyre_object::gc_roots::shadow_stack_len();
+            for &(k, v) in &items {
+                pyre_object::gc_roots::pin_root(k);
+                pyre_object::gc_roots::pin_root(v);
+            }
+            for index in 0..items.len() {
+                unsafe {
+                    pyre_object::w_dict_store(
+                        dict(),
+                        pyre_object::gc_roots::shadow_stack_get(items_base + index * 2),
+                        pyre_object::gc_roots::shadow_stack_get(items_base + index * 2 + 1),
+                    )
+                };
             }
             return Ok(());
         }
@@ -773,25 +801,45 @@ pub fn dict_merge_value(
     // `_dict_merge_loop`: iterate `iter(w_item.keys())`, look each value up
     // with `space.getitem`, reject a key already present in the target with
     // `"%s got multiple values for keyword argument '%S'"`, then store.
-    let keys_method = match crate::baseobjspace::getattr_str(source, "keys") {
+    let keys_method = match crate::baseobjspace::getattr_str(source(), "keys") {
         Ok(m) => m,
         Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
-            let type_name = unsafe { (*(*source).ob_type).name };
+            let type_name = unsafe { (*(*source()).ob_type).name };
             return Err(crate::argument::raise_type_error(
-                w_callable,
+                w_callable(),
                 format!("argument after ** must be a mapping, not {type_name}"),
             ));
         }
         Err(e) => return Err(e),
     };
-    let keys_obj = crate::call::call_function_impl_result(keys_method, &[])?;
-    let keys = crate::builtins::collect_iterable(keys_obj)?;
-    for key in keys {
-        let val = crate::baseobjspace::getitem(source, key)?;
-        if crate::baseobjspace::contains(dict, key)? {
-            let key_str = unsafe { crate::display::py_str_wtf8(key) }?;
+    let keys_method_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(keys_method);
+    let keys_obj = crate::call::call_function_impl_result(
+        pyre_object::gc_roots::shadow_stack_get(keys_method_slot),
+        &[],
+    )?;
+    let keys_obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(keys_obj);
+    let keys = crate::builtins::collect_iterable(pyre_object::gc_roots::shadow_stack_get(
+        keys_obj_slot,
+    ))?;
+    let keys_base = pyre_object::gc_roots::shadow_stack_len();
+    for &key in &keys {
+        pyre_object::gc_roots::pin_root(key);
+    }
+    for index in 0..keys.len() {
+        let key = || pyre_object::gc_roots::shadow_stack_get(keys_base + index);
+        let val = crate::baseobjspace::getitem(source(), key())?;
+        // `val` is fresh and `__contains__` runs Python; it needs a root of its
+        // own for that call, released again each turn so the bracket stays
+        // fixed-size.
+        let _iteration_roots = pyre_object::gc_roots::push_roots();
+        let val_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(val);
+        if crate::baseobjspace::contains(dict(), key())? {
+            let key_str = unsafe { crate::display::py_str_wtf8(key()) }?;
             return Err(crate::argument::raise_type_error(
-                w_callable,
+                w_callable(),
                 crate::display::wtf8_format!(
                     "got multiple values for keyword argument '",
                     key_str,
@@ -799,7 +847,13 @@ pub fn dict_merge_value(
                 ),
             ));
         }
-        unsafe { pyre_object::w_dict_store(dict, key, val) };
+        unsafe {
+            pyre_object::w_dict_store(
+                dict(),
+                key(),
+                pyre_object::gc_roots::shadow_stack_get(val_slot),
+            )
+        };
     }
     Ok(())
 }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -291,8 +291,22 @@ pub mod frame_locals_proxy {
                 return Err(crate::call::take_call_error()
                     .unwrap_or_else(|| crate::PyError::runtime_error("update failed")));
             }
-            for (key, value) in unsafe { pyre_object::dictmultiobject::w_dict_items(incoming) } {
-                self.setitem_value(key, value)?;
+            // `setitem_value` can hash the key into `f_extra_locals`, which
+            // runs `__hash__` and collects.  `incoming` and the item snapshot
+            // are native locals no root walker updates, so publish the set and
+            // read each pair back across the stores that precede it.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let items_base = pyre_object::gc_roots::shadow_stack_len();
+            let items = unsafe { pyre_object::dictmultiobject::w_dict_items(incoming) };
+            for &(key, value) in &items {
+                pyre_object::gc_roots::pin_root(key);
+                pyre_object::gc_roots::pin_root(value);
+            }
+            for index in 0..items.len() {
+                self.setitem_value(
+                    pyre_object::gc_roots::shadow_stack_get(items_base + index * 2),
+                    pyre_object::gc_roots::shadow_stack_get(items_base + index * 2 + 1),
+                )?;
             }
             Ok(())
         }

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -578,16 +578,32 @@ pub fn build_tuple_from_refs(items: &[PyObjectRef]) -> PyObjectRef {
 /// `__hash__` / `__eq__`); an unhashable key raises, so — like
 /// `build_set_from_refs` — this is fallible.
 pub fn build_map_from_refs(items: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let dict = w_dict_new();
-    for pair in items.chunks_exact(2) {
-        let key = pair[0];
-        let value = pair[1];
+    // Each store hashes its key through `__hash__`, so every turn is a
+    // collection point.  The fresh dict and `items` — for the JIT entries a
+    // copy of the compiled call's argument registers — are native locals no
+    // root walker updates, so publish the whole set and read every operand
+    // back.  `build_set_from_refs` reaches the same bracket through
+    // `builtin_set_add_items_impl`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let items_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in items {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_dict_new());
+    let dict = || pyre_object::gc_roots::shadow_stack_get(dict_slot);
+    for index in (0..items.len() - items.len() % 2).step_by(2) {
+        let key = pyre_object::gc_roots::shadow_stack_get(items_base + index);
+        let value = pyre_object::gc_roots::shadow_stack_get(items_base + index + 1);
         unsafe {
-            w_dict_store_checked(dict, key, value)
-                .map_err(|_| crate::baseobjspace::take_pending_dict_key_error(key))?;
+            w_dict_store_checked(dict(), key, value).map_err(|_| {
+                crate::baseobjspace::take_pending_dict_key_error(
+                    pyre_object::gc_roots::shadow_stack_get(items_base + index),
+                )
+            })?;
         }
     }
-    Ok(dict)
+    Ok(dict())
 }
 
 /// BUILD_SET evaluation, shared by the JIT residual (`bh_build_set_from_array`).
@@ -1295,19 +1311,32 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
         Err(e) if e.kind == PyErrorKind::TypeError => return Err(non_iterable()),
         Err(e) => return Err(e),
     };
-    let mut items = Vec::with_capacity(count);
+    // `next` runs the iterator's `__next__` on every turn, so the accumulator
+    // cannot be a plain `Vec` — nothing scans it, which would leave each item
+    // already pulled unreachable while the next one is produced, and `iter` is
+    // a native copy the collector does not update.  Publish the whole set and
+    // rebuild the flat return from it, as `_unpackiterable_known_length_jitlook`
+    // does for the same loop.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let seq_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(seq);
+    pyre_object::gc_roots::pin_root(iter);
+    let seq = || pyre_object::gc_roots::shadow_stack_get(seq_slot);
+    let iter = || pyre_object::gc_roots::shadow_stack_get(seq_slot + 1);
+    let root_base = seq_slot + 1;
+    let mut pulled = 0usize;
     loop {
-        match crate::baseobjspace::next(iter) {
+        match crate::baseobjspace::next(iter()) {
             Ok(val) => {
-                if items.len() == count {
+                if pulled == count {
                     // CPython 3.14 ceval.c:2313-2320 checks the original
                     // object's exact builtin kind only after `PyIter_Next`
                     // found the first excess item.  Lists and tuples took the
                     // fast path above; exact dicts reach this iterator path.
                     // Keep dict subclasses generic so their `__len__` is not
                     // observed and the message has no total.
-                    if unsafe { pyre_object::is_exact_type(seq, &pyre_object::DICT_TYPE) } {
-                        let len = unsafe { pyre_object::w_dict_len(seq) };
+                    if unsafe { pyre_object::is_exact_type(seq(), &pyre_object::DICT_TYPE) } {
+                        let len = unsafe { pyre_object::w_dict_len(seq()) };
                         if len > count {
                             return Err(PyError::value_error(format!(
                                 "too many values to unpack (expected {count}, got {len})"
@@ -1318,20 +1347,22 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
                         "too many values to unpack (expected {count})"
                     )));
                 }
-                items.push(val);
+                pyre_object::gc_roots::pin_root(val);
+                pulled += 1;
             }
             Err(e) if e.kind == PyErrorKind::StopIteration => break,
             Err(e) if e.kind == PyErrorKind::TypeError => return Err(non_iterable()),
             Err(e) => return Err(e),
         }
     }
-    if items.len() < count {
+    if pulled < count {
         return Err(PyError::value_error(format!(
-            "not enough values to unpack (expected {count}, got {})",
-            items.len()
+            "not enough values to unpack (expected {count}, got {pulled})"
         )));
     }
-    Ok(items)
+    Ok((0..pulled)
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(root_base + 1 + index))
+        .collect())
 }
 
 /// UNPACK_EX — split `value` for `a, *b, c = value` into `before` head

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6512,15 +6512,13 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                     let k = pyre_object::gc_roots::shadow_stack_get(iteration_roots);
                     let v = pyre_object::gc_roots::shadow_stack_get(iteration_roots + 1);
                     match hashed {
-                        Some(key) => {
-                            pyre_object::dictmultiobject::w_dict_store_hashed_checked(
-                                dict(),
-                                k,
-                                v,
-                                key.hash,
-                            )
-                            .map_err(|_| crate::baseobjspace::take_pending_dict_key_error(k))?
-                        }
+                        Some(key) => pyre_object::dictmultiobject::w_dict_store_hashed_checked(
+                            dict(),
+                            k,
+                            v,
+                            key.hash,
+                        )
+                        .map_err(|_| crate::baseobjspace::take_pending_dict_key_error(k))?,
                         None => dict_store_checked(dict(), k, v)?,
                     }
                     if orig_size

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6486,10 +6486,23 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                 let orig_size = pyre_object::dictmultiobject::w_dict_len(source);
                 let mut i = 0;
                 loop {
-                    let Some((k, v)) = pyre_object::dictmultiobject::w_dict_nth_item(
-                        resolve_dict_backing(data()),
-                        i,
-                    ) else {
+                    // `getiteritems_with_hash` (`dictmultiobject.py:991`) — an
+                    // object- or unicode-shaped source already stores each key's
+                    // hash, so reusing it keeps `__hash__` at the single call
+                    // that filled the source.  Re-deriving it here is observable
+                    // for a key whose `__hash__` has side effects, and it puts
+                    // an extra Python call inside this walk.  Typed strategies
+                    // store no hash and `w_dict_nth_hashed_key` returns `None`
+                    // for them, which selects the plain walk below.
+                    let source_now = resolve_dict_backing(data());
+                    let hashed = pyre_object::is_exact_type(source_now, &pyre_object::DICT_TYPE)
+                        .then(|| pyre_object::dictmultiobject::w_dict_nth_hashed_key(source_now, i))
+                        .flatten();
+                    let Some((k, v)) = (match hashed {
+                        Some(key) => pyre_object::dictmultiobject::w_dict_nth_value(source_now, i)
+                            .map(|v| (key.obj, v)),
+                        None => pyre_object::dictmultiobject::w_dict_nth_item(source_now, i),
+                    }) else {
                         break;
                     };
                     let _iteration_roots = pyre_object::gc_roots::push_roots();
@@ -6498,7 +6511,18 @@ pub(crate) fn dict_update1(w_dict: PyObjectRef, w_data: PyObjectRef) -> Result<(
                     pyre_object::gc_roots::pin_root(v);
                     let k = pyre_object::gc_roots::shadow_stack_get(iteration_roots);
                     let v = pyre_object::gc_roots::shadow_stack_get(iteration_roots + 1);
-                    dict_store_checked(dict(), k, v)?;
+                    match hashed {
+                        Some(key) => {
+                            pyre_object::dictmultiobject::w_dict_store_hashed_checked(
+                                dict(),
+                                k,
+                                v,
+                                key.hash,
+                            )
+                            .map_err(|_| crate::baseobjspace::take_pending_dict_key_error(k))?
+                        }
+                        None => dict_store_checked(dict(), k, v)?,
+                    }
                     if orig_size
                         != pyre_object::dictmultiobject::w_dict_len(resolve_dict_backing(data()))
                     {


### PR DESCRIPTION
## What

Three commits, in order.

### `dict: merge \`|\` by copying the left operand instead of storing its items`

`dictmultiobject.py:288-293 descr_or` is `copyself = self.copy()` then
`update1(space, copyself, w_other)`. pyre built a fresh dict and stored every
item of both operands into it, re-hashing each left-operand key:
`{Key(i): i for i in range(5)} | {}` called `__hash__` five times where CPython
calls it none.

### `dict: reuse a dict source's stored hashes in \`update1\``

`dictmultiobject.py:991 getiteritems_with_hash` walks an object- or
unicode-shaped source as `(hash, key, value)` triples and `setitem_with_hash`
stores them without hashing again. `dict_update1` derived the hash from the key
instead, so `update` into a non-empty destination called `__hash__` once per
key. Typed strategies store no hash and keep the plain walk.

### `interp: publish the operands nine paths read back across a Python call`

`gc_roots` is the shadow stack a minor collection updates. A `PyObjectRef` held
in a Rust local or a `Vec` is not updated, so a path that reads one back after
running Python reads the address the object had before it moved. Nine paths did
that; the commit message lists each one.

## Evidence

One of the nine reproduces as a user-visible failure:

```python
import gc
def f(**kw): return sorted(kw.items())
class M:
    def keys(self): gc.collect(); return ["w"]
    def __getitem__(self, k): return 1
f(**M())
```

Before: `TypeError: descriptor '__contains__' for 'dict' objects doesn't apply
to a 'dict' object`. The lldb backtrace is
`receiver_mismatch <- call_builtin_code_positional <- contains_slot <-
opcode_ops::dict_merge_value` — `dict_merge_value` passed the target's
pre-collection address to `dict.__contains__`, which its own receiver check
rejects. `dict_update_value` next to it already brackets the same walk.

`f(*gen(2), **Quiet(w=1))` — a mapping that does not collect, behind a generator
that does — also returned `[('i', 1)]` instead of `[('w', 1)]`, the generator's
last dict leaking into the kwargs; that one is
`call::call_function_ex_in_ctx` taking its roots after the `*` unpack.

The other seven are sites that did not honour an already-established invariant.
They are not each backed by a reproduction.

## Verification

- LLBC re-extracted for this tree; `extract-llbc.py --check` exits 0 with
  `fingerprint matches the tree`, so the numbers below are taken from a binary
  built **without** `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`.
- `cargo check --all --tests --no-default-features --features dynasm` — clean.
- `cargo build --release -p pyrex --bin pyre-dynasm --no-default-features --features dynasm` — clean.
- `extra_tests/snippets`: 238 pass, 9 fail, on causes this branch does not touch.
  `stdlib_sqlite` has no `_sqlite3`; `stdlib_gc` wants `gc.collect()` to return
  an `int` and it returns `None`; `pickle_disallow`, `stdlib_sys` and
  `stdlib_io_bytesio` assert on `__flags__`, `sys._getframemodulename` and
  `BytesIO.__dict__`; `xfail_assert` is an expected failure. The remaining three
  (`builtin_list`, `builtin_tuple`, `builtin_slice`) all reduce to one `is`:
  `float('nan') is float('nan')` is `True` here and `False` on CPython, so every
  identity-first sequence comparison — `==`, `in`, `.index` — follows it. `tuple`
  and `slice` comparison are not touched by this branch and fail the same way.
- New snippet `call_kwargs_merge_collecting_mapping.py` passes under CPython 3.14
  and under `pyre-dynasm`.

## Not in this branch

`h(*gen(3))`, where the generator calls `gc.collect()`, panics with
`GC BUG: invalid major child ... site=major_varsize_item` at shutdown. It is a
base defect, not this branch's:

- Two control builds — one with the `call.rs` hunk reverted, one with `call.rs`,
  `baseobjspace.rs` and `runtime_ops.rs` all reverted — reproduce it identically.
- It survives `PYRE_NO_JIT=1` and `PYRE_JIT=0`, 5/5, and a decoy env var does not
  move it, so it is not a layout lottery.
- It reproduces on a **freshly extracted LLBC** with no
  `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, so it is not a stale-field-offset artefact.

The threshold is exactly three unpacked items; `[*gen(3)]`, `(*gen(3),)`,
`list(gen(3))`, `h(*[0,1,2])` and a non-collecting generator are all clean, and
`**` is irrelevant. `holder_in_remembered=false` with `gc_state=Marking` points
at the incremental-marking write barrier rather than at rooting. The new snippet
avoids that shape so this PR is not red for it.

— *opened by Claude*

