### PR TITLE
majit: lower discarded inline-helper results, and give the degraded-arm registry a denominator

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -531,9 +531,39 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     maybe_dump_liveness(&helper_name, &lowerer.op_metadata);
     let liveness_prebuild =
         liveness_prebuild_tokens(&lowerer.op_metadata, &lowerer.inline_liveness_prebuild);
+    // The body has lowered, so the consulted-key set is final. Reported per
+    // HELPER, not per machine: each `#[jit_inline]` carries its own
+    // `int_fields` / `ref_fields`, and a key one helper consults says nothing
+    // about the helper next to it.
+    //
+    // This surface is where the population lives. A `#[jit_interp]` machine
+    // declares a handful of keys; a consumer's helpers repeat theirs at every
+    // site, and a key that matches nothing at one site matches nothing at
+    // dozens.
+    let unconsulted_declarations = match inline_config.as_ref() {
+        Some(config) => {
+            let consulted = config.consulted_field_keys.borrow();
+            let mut keys: Vec<&String> = config
+                .int_fields
+                .keys()
+                .chain(config.ref_fields.keys())
+                .filter(|key| !consulted.contains(*key))
+                .collect();
+            keys.sort();
+            keys.dedup();
+            let records = keys.into_iter().map(|key| {
+                quote! {
+                    majit_metainterp::record_unconsulted_field_declaration(#helper_name, #key);
+                }
+            });
+            quote! { #(#records)* }
+        }
+        None => quote! {},
+    };
     let statements = lowerer.statements;
     Ok(Some(InlineHelperJitCode {
         body: quote! {
+            #unconsulted_declarations
             #(#statements)*
         },
         return_reg,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -2498,6 +2498,22 @@ pub(super) fn lower_dispatch_chain(
         lowerer.emit_jump(&default_label);
     }
 
+    // The denominator for `record_degraded_dispatch_arm` below, staged from the
+    // same loop's own admission test so the two cannot drift: an arm is counted
+    // here exactly when the loop emits a body for it.  Without it an empty
+    // degraded registry reads as "nothing degraded" and as "no portal was
+    // built" at once, and only the first is a pass.
+    {
+        let census_interp = config.state_type_name.clone();
+        let census_arms = classified_arms
+            .iter()
+            .filter(|arm| !matches!(arm.pat, Pat::Wild(_)) && !is_lowercase_binding_pat(&arm.pat))
+            .count();
+        lowerer.emit_aux(quote::quote! {
+            majit_metainterp::record_dispatch_arm_census(#census_interp, #census_arms);
+        });
+    }
+
     for (arm_idx, arm) in classified_arms.iter().enumerate() {
         // `_` wildcard: skip here; handled by the default GOTO below.
         // All other patterns (including Pat::Ident like `OP_NOP`) are

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/dispatch.rs
@@ -3023,6 +3023,33 @@ pub(super) fn lower_dispatch_chain(
         }
     }
 
+    // Every arm has lowered, so the consulted-key set is final: report the
+    // declared `int_fields` / `ref_fields` keys no access site asked about.
+    //
+    // Reported rather than rejected, and the reason is the degraded arm. An
+    // arm that refused to lower never reached its field accesses, so a key
+    // used only there is unconsulted through no fault of the declaration —
+    // failing the build on it would turn one refusal into two. The consumer's
+    // gate reads this alongside `degraded_dispatch_arms` and can tell them
+    // apart; a compile error could not.
+    {
+        let interp = config.state_type_name.clone();
+        let consulted = config.consulted_field_keys.borrow();
+        let mut unconsulted: Vec<&String> = config
+            .int_fields
+            .keys()
+            .chain(config.ref_fields.keys())
+            .filter(|key| !consulted.contains(*key))
+            .collect();
+        unconsulted.sort();
+        unconsulted.dedup();
+        for key in unconsulted {
+            lowerer.emit_aux(quote::quote! {
+                majit_metainterp::record_unconsulted_field_declaration(#interp, #key);
+            });
+        }
+    }
+
     // After all arm guards, the default/exit path: unconditional GOTO.
     // default_label is bound at the typed-return emission site in
     // lower_dispatch_body (Task 1.7).

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -1494,6 +1494,52 @@ impl<'c> Lowerer<'c> {
                     );
                     self.emit_op(OpMeta::live_marker(), post_live);
                 }
+                // A result-returning inline helper whose result the statement
+                // discards. The sub-jitcode still ends in a typed return
+                // opcode, so it needs a destination even though nothing reads
+                // it; `alloc_reg` mints one, the same way the discarded
+                // `ResidualInt` family below does. Everything else is the
+                // value-position lowering verbatim.
+                //
+                // Without this arm the call reaches `_ => return None` and the
+                // statement is dropped: `explicit_call_emits_post_live` already
+                // answers for these kinds, so the accounting says the policy is
+                // handled while the lowering says it is not, and the effect the
+                // helper performs leaves the trace with no diagnostic. The
+                // workaround is to bind the result to `let _x = ...`, which is
+                // a source change the declaration does not ask for.
+                crate::jit_interp::CallPolicyKind::InlineInt
+                | crate::jit_interp::CallPolicyKind::InlineRef
+                | crate::jit_interp::CallPolicyKind::InlineFloat => {
+                    let result_kind = binding_kind_for_inline_policy(kind)
+                        .expect("the arm's own patterns are the inline result policies");
+                    let throwaway_reg = self.alloc_reg();
+                    let builder_path = inline_builder_path(&call.func)?;
+                    let prebuild_path = inline_prebuild_path(&call.func)?;
+                    let (inline_call, post_live) = inline_call_tokens(&arg_bindings, throwaway_reg);
+                    let __arg_regs: Vec<Register> =
+                        arg_bindings.iter().map(Register::from_binding).collect();
+                    self.inline_liveness_prebuild.push(quote! {
+                        #prebuild_path(__asm);
+                    });
+                    self.emit_op(
+                        OpMeta::linear(
+                            OpKind::InlineCall,
+                            __arg_regs,
+                            vec![Register::new(result_kind, throwaway_reg)],
+                        ),
+                        quote! {
+                            use majit_metainterp::jitcode::JitCodeRuntimeExt as _;
+                            let __sub_jitcode = #builder_path(__asm);
+                            let (__sub_return_kind, _) = __sub_jitcode
+                                .trailing_return_info()
+                                .expect("inline helper jitcode must end in a typed return opcode");
+                            let __sub_idx = __builder.add_sub_jitcode(__sub_jitcode);
+                            #inline_call
+                        },
+                    );
+                    self.emit_op(OpMeta::live_marker(), post_live);
+                }
                 crate::jit_interp::CallPolicyKind::MayForceVoid => {
                     if let Some(arg_regs) = int_arg_regs(&arg_bindings) {
                         let typed_args = quote! {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -98,6 +98,48 @@ fn ref_field_witness_tokens(
     }
 }
 
+/// The `(base_size, len_offset, witness)` a `pool_arrays` declaration reports
+/// for its array, and the compile-time checks that the declaration describes
+/// the struct it names.
+///
+/// Both numbers are `offset_of!` on the declaration's own field names, so a
+/// field reordered ahead of the items moves the read with it instead of leaving
+/// it behind.  The witnesses cover what an offset cannot: that `items` really
+/// is an array of pointer-width elements, and that `len` really is a `usize` —
+/// the width the descr's lendescr reads it at.  Without the second one, a `u32`
+/// length word would be read as a machine word with its top half taken from
+/// whatever follows.
+///
+/// The element witness needs the declared pointee, so it is emitted only for a
+/// declaration that names one.  `offset_of!` is unconditional.
+fn pool_array_layout_tokens(
+    entry: &super::PoolArrayLowering,
+) -> (TokenStream, TokenStream, TokenStream) {
+    let struct_path = &entry.struct_path;
+    let items = &entry.items_field;
+    let base_size = quote! { ::core::mem::offset_of!(#struct_path, #items) };
+    let (len_offset, len_witness) = match &entry.len_field {
+        Some(len) => (
+            quote! { ::core::option::Option::Some(::core::mem::offset_of!(#struct_path, #len)) },
+            quote! {
+                const _: fn(&#struct_path) -> usize = |__s| __s.#len;
+            },
+        ),
+        None => (quote! { ::core::option::Option::None }, quote! {}),
+    };
+    let element_witness = match &entry.element_type {
+        Some(element) => quote! {
+            const _: fn(&#struct_path) -> *mut #element = |__s| __s.#items[0];
+        },
+        None => quote! {},
+    };
+    (
+        base_size,
+        len_offset,
+        quote! { #len_witness #element_witness },
+    )
+}
+
 /// A `<local ref binding>.<field>` access that `array_fields` declares, resolved
 /// but not yet emitted.  See [`JitCodeLowerer::match_array_field_base`].
 struct ArrayFieldBase {
@@ -1434,8 +1476,9 @@ impl<'c> Lowerer<'c> {
 
     /// Recognizes a pool-array element read through the registered getter call
     /// `<getter>(state.<pool_base_ref>, <int index>)` → `getarrayitem_gc_r` on
-    /// the raw-pointer array (`[*mut U; N]` at offset 0) the ref-scalar points
-    /// at — the `pools[selected]` read.  Unlike the residual-call form (an
+    /// the raw-pointer array (`[*mut U; N]` at the declared `items` offset) the
+    /// ref-scalar points at — the `pools[selected]` read.  Unlike the
+    /// residual-call form (an
     /// opaque CALL_R the optimizer can neither re-produce in the short preamble
     /// nor invalidate), the getarrayitem on the immutable `pools` array
     /// re-derives the element each loop entry from the consistent `selected`
@@ -1448,7 +1491,8 @@ impl<'c> Lowerer<'c> {
     /// `(state.<base>, int)` arg shape does NOT match, so it is not miscompiled
     /// into a pool read — it falls through to its own residual body (which is
     /// also the getter's concrete fallback when no `pool_arrays` is configured).
-    /// Pointer elements are 8 bytes at array offset 0 (`add_ptr_array_descr`).
+    /// Elements are pointer-width; where they start, and whether a length word
+    /// precedes them, come from the declaration (`pool_array_layout_tokens`).
     pub(super) fn lower_pool_array_get_call(&mut self, call: &syn::ExprCall) -> Option<Binding> {
         let config = self.config?;
         if call.args.len() != 2 {
@@ -1468,12 +1512,12 @@ impl<'c> Lowerer<'c> {
         // fallback (the marker function's own body) rather than miscompiling an
         // unrelated helper into a `getarrayitem_gc_r`.
         let func_segments = canonical_expr_segments(&call.func)?;
-        let element_type = config
+        let entry = config
             .pool_arrays
             .iter()
-            .find(|(base, getter, _)| base == &base_name && getter == &func_segments)?
-            .2
-            .clone();
+            .find(|entry| entry.base == base_name && entry.getter == func_segments)?;
+        let element_type = entry.element_type.clone();
+        let (base_size, len_offset, layout_witness) = pool_array_layout_tokens(entry);
         // Lower the `state.<base>` ref-scalar (declares its ref identity slot
         // live for resume) and the index, then read the pointer element.
         let base = self.lower_state_field_read(&call.args[0])?;
@@ -1494,7 +1538,8 @@ impl<'c> Lowerer<'c> {
                 vec![Register::ref_(result_reg)],
             ),
             quote! {
-                let __descr_idx = __builder.add_ptr_array_descr();
+                #layout_witness
+                let __descr_idx = __builder.add_ptr_array_descr(#base_size, #len_offset);
                 __builder.getarrayitem_gc_r(
                     #result_reg as u16,
                     #base_reg as u16,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -13,11 +13,18 @@ pub(super) fn field_scalar_tokens(
     struct_path: &syn::Path,
     member: &syn::Member,
 ) -> (TokenStream, TokenStream, TokenStream) {
-    // Every `int_fields` / `ref_fields` consultation reaches the maps through
-    // here, so this one line is the whole record of which declared keys an
-    // access site asked about.  Recorded whether or not the key is declared:
-    // the report is over the DECLARED keys, and an undeclared one describes
-    // nothing to begin with.
+    // Every consultation THIS lowering makes reaches the maps through here, so
+    // one line records which declared keys an access site asked about.
+    // Recorded whether or not the key is declared: the report is over the
+    // DECLARED keys, and an undeclared one describes nothing to begin with.
+    //
+    // Not the only reader of `ref_fields`, and the difference bounds what the
+    // report can claim.  `RefFieldRewriter` consults it too, to rewrite the
+    // CONCRETE body's `x.field` into a deref of the raw-pointer carrier.  Both
+    // walk the same source, so they normally agree — they diverge exactly where
+    // this lowering stopped early and the rewriter did not, which is a degraded
+    // arm.  That is why an unconsulted key is reported rather than rejected,
+    // and why the gate prints the degraded arms beside it.
     config
         .consulted_field_keys
         .borrow_mut()

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -29,8 +29,65 @@ pub(super) fn field_scalar_tokens(
         None => (
             quote! { ::core::mem::size_of::<i64>() },
             quote! { true },
-            quote! {},
+            ref_field_witness_tokens(&config.ref_fields, key, struct_path, member),
         ),
+    }
+}
+
+/// A compile-time check that a `ref_fields` entry describes the field it names.
+///
+/// The lowering trusts the declaration twice and verifies it nowhere: the read
+/// becomes `getfield_gc_r` into the ref bank, and the binding's `struct_type`
+/// is what the NEXT hop resolves `offset_of!` against.  So a field that is not
+/// a pointer to the declared pointee produces either a ref-bank read of
+/// something that is not a reference, or an offset computed in the wrong
+/// struct, and nothing between the declaration and the emitted descr says so.
+///
+/// `usize` is admitted alongside the two raw-pointer spellings because it is
+/// the sanctioned carrier for a pointer whose declaring crate would rather not
+/// name the pointee's type.  A carrier's pointee is not checkable, which is the
+/// price of the carrier — what survives for it is that the field is
+/// pointer-width and pointer-kind, not an `i64` or a `u32` that drifted into
+/// the ref map.
+///
+/// The witness names the pointee rather than a whole pointer type so that
+/// `*mut T` and `*const T` both satisfy it, mirroring `emit_array_field_base`.
+///
+/// Where this adds coverage, measured rather than assumed.  On the
+/// `#[jit_inline]` path a drifted pointee on a raw-pointer field already fails
+/// the build: the concrete rewriter types the loaded value against the
+/// declaration and reports E0308.  On the `#[jit_interp]` state-field path it
+/// does not — a machine declaring `Holder::link => Wrong` over a
+/// `link: *mut Holder` compiles clean and faults at run time.  That path is
+/// what this witness closes; on the inline path it is a second, earlier line.
+///
+/// Empty for a key `ref_fields` does not declare, and that is a decision, not
+/// an omission: an undeclared field reads into the Int bank, and stable Rust
+/// has no way to assert that a type is *not* a pointer.  Catching that half
+/// needs a different mechanism — a same-offset `is_ref` disagreement reaching
+/// `Assembler::register_struct_layout`, which today merges by offset alone and
+/// keeps whichever registration arrived first.
+fn ref_field_witness_tokens(
+    ref_fields: &HashMap<String, (syn::Path, Ident, syn::Path)>,
+    key: &str,
+    struct_path: &syn::Path,
+    member: &syn::Member,
+) -> TokenStream {
+    let Some((_, _, pointee)) = ref_fields.get(key) else {
+        return quote! {};
+    };
+    quote! {
+        const _: () = {
+            trait __MajitRefField {}
+            impl __MajitRefField for *mut #pointee {}
+            impl __MajitRefField for *const #pointee {}
+            impl __MajitRefField for usize {}
+            #[allow(dead_code)]
+            fn __majit_ref_field_witness(__s: &#struct_path) {
+                fn __accept<T: __MajitRefField>(_: T) {}
+                __accept(__s.#member);
+            }
+        };
     }
 }
 
@@ -1721,5 +1778,72 @@ impl<'c> Lowerer<'c> {
             depends_on_stack: false,
             struct_type: None,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ref_fields_map(
+        entries: &[(&str, &str, &str, &str)],
+    ) -> HashMap<String, (syn::Path, Ident, syn::Path)> {
+        entries
+            .iter()
+            .map(|(key, struct_path, field, pointee)| {
+                (
+                    (*key).to_string(),
+                    (
+                        syn::parse_str::<syn::Path>(struct_path).expect("struct path"),
+                        syn::parse_str::<Ident>(field).expect("field ident"),
+                        syn::parse_str::<syn::Path>(pointee).expect("pointee path"),
+                    ),
+                )
+            })
+            .collect()
+    }
+
+    fn witness_for(key: &str) -> String {
+        let map = ref_fields_map(&[("Stack::head", "Stack", "head", "Node")]);
+        let struct_path: syn::Path = syn::parse_str("Stack").expect("struct path");
+        let member: syn::Member = syn::parse_str("head").expect("member");
+        ref_field_witness_tokens(&map, key, &struct_path, &member).to_string()
+    }
+
+    /// A declared ref field admits the three spellings the lowering can
+    /// actually receive, and no others. The pointee is named once per pointer
+    /// spelling, which is what turns a drifted declaration into a type error.
+    #[test]
+    fn a_declared_ref_field_witnesses_its_pointee() {
+        let tokens = witness_for("Stack::head");
+        for expected in [
+            "impl __MajitRefField for * mut Node",
+            "impl __MajitRefField for * const Node",
+            "impl __MajitRefField for usize",
+        ] {
+            assert!(
+                tokens.contains(expected),
+                "the witness must admit `{expected}`; tokens={tokens}"
+            );
+        }
+        assert!(
+            tokens.contains("__accept (__s . head)"),
+            "the witness must touch the field it names, or it witnesses \
+             nothing about the struct; tokens={tokens}"
+        );
+    }
+
+    /// The other half of the same predicate, stated so the gap is a decision
+    /// rather than an oversight: a field named in no map reads into the Int
+    /// bank, and stable Rust cannot assert that a type is *not* a pointer, so
+    /// no witness is emitted for it.
+    #[test]
+    fn an_undeclared_field_gets_no_ref_witness() {
+        assert_eq!(
+            witness_for("Stack::size"),
+            "",
+            "a key `ref_fields` does not declare must emit nothing; emitting a \
+             witness there would reject every legitimate integer field"
+        );
     }
 }

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -13,6 +13,15 @@ pub(super) fn field_scalar_tokens(
     struct_path: &syn::Path,
     member: &syn::Member,
 ) -> (TokenStream, TokenStream, TokenStream) {
+    // Every `int_fields` / `ref_fields` consultation reaches the maps through
+    // here, so this one line is the whole record of which declared keys an
+    // access site asked about.  Recorded whether or not the key is declared:
+    // the report is over the DECLARED keys, and an undeclared one describes
+    // nothing to begin with.
+    config
+        .consulted_field_keys
+        .borrow_mut()
+        .insert(key.to_string());
     match config.int_fields.get(key) {
         Some((ty, signed)) => (
             quote! { ::core::mem::size_of::<#ty>() },

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -64,9 +64,16 @@ pub(super) fn field_scalar_tokens(
 /// Empty for a key `ref_fields` does not declare, and that is a decision, not
 /// an omission: an undeclared field reads into the Int bank, and stable Rust
 /// has no way to assert that a type is *not* a pointer.  Catching that half
-/// needs a different mechanism — a same-offset `is_ref` disagreement reaching
-/// `Assembler::register_struct_layout`, which today merges by offset alone and
-/// keeps whichever registration arrived first.
+/// takes a mechanism that works by disagreement instead of by declaration —
+/// `Assembler::register_struct_layout`'s conflict check, which reports one word
+/// registered as a pointer at one emit site and as a scalar at another.
+///
+/// It is not a general second line for this one, and the reason is worth
+/// stating: each jitcode gets its OWN layout map, so two *declarations* never
+/// meet there.  What meets is two emit sites within one jitcode — the same
+/// member reached by two lowering paths.  A machine whose sole access to an
+/// undeclared pointer field goes through one path stays undetected by both
+/// mechanisms.
 fn ref_field_witness_tokens(
     ref_fields: &HashMap<String, (syn::Path, Ident, syn::Path)>,
     key: &str,

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -103,6 +103,28 @@ where
 
 // ── LowererConfig ────────────────────────────────────────────────────
 
+/// One `pool_arrays` declaration, resolved against the state's `ref(_)` fields.
+///
+/// `JitInterpConfig.PoolArrayEntry` names the base by its state-field name;
+/// this carries the base struct's `Path` alongside it, recovered from
+/// `state_ref_scalars`, because the emitted `offset_of!` needs the type and the
+/// declaration only names the field.
+#[derive(Clone)]
+pub(super) struct PoolArrayLowering {
+    /// The `ref(T)` state field that holds the base pointer.
+    pub(super) base: String,
+    /// The marker function whose call indexes the array, canonicalized.
+    pub(super) getter: Vec<String>,
+    /// `T` of the `ref(T)` — the struct the array lives in.
+    pub(super) struct_path: syn::Path,
+    /// The array field inside `struct_path`.
+    pub(super) items_field: Ident,
+    /// A length word ahead of the items, when the consumer keeps one.
+    pub(super) len_field: Option<Ident>,
+    /// The element's pointee type, when declared.
+    pub(super) element_type: Option<syn::Path>,
+}
+
 /// Configuration for state_fields-aware JitCode lowering.
 ///
 /// Built from `JitInterpConfig` at proc-macro time and passed to the Lowerer
@@ -186,11 +208,10 @@ pub struct LowererConfig {
     /// The trailing `bool` is the `[]` suffix: the helper writes the ELEMENTS
     /// of the array the field points at, rather than the field itself.
     pub(super) residual_writes: Vec<(Vec<String>, syn::Path, Ident, bool)>,
-    /// `(pool-base ref-scalar name, getter function path segments, element type)`.
     /// A call `<getter>(state.<base>, <int>)` whose function path matches
     /// `getter` AND whose arg0 is the `base` lowers to `getarrayitem_gc_r`
     /// instead of a residual CALL_R.  Source: `JitInterpConfig.pool_arrays`.
-    pub(super) pool_arrays: Vec<(String, Vec<String>, Option<syn::Path>)>,
+    pub(super) pool_arrays: Vec<PoolArrayLowering>,
     /// Ref-kind struct field declarations.  Key = `"StructType::field"`,
     /// value = `(struct_path, field_ident, pointee_path)`.  When the lowerer
     /// encounters a field access and the `(struct, field)` pair matches, it
@@ -1201,6 +1222,26 @@ impl LowererConfig {
                 )
             })
             .collect();
+        // Resolved before the struct literal takes `state_ref_scalars`: the
+        // emitted `offset_of!` needs the base struct's type, and the
+        // declaration names only its state-field.
+        let pool_arrays: Vec<PoolArrayLowering> = pool_arrays
+            .iter()
+            .map(|entry| {
+                let base = entry.base.to_string();
+                let (_, struct_path) = state_ref_scalars
+                    .get(&base)
+                    .expect("the loop above rejected a base that is not a ref(_) state field");
+                PoolArrayLowering {
+                    base,
+                    getter: canonical_path_segments(&entry.getter),
+                    struct_path: struct_path.clone(),
+                    items_field: entry.items_field.clone(),
+                    len_field: entry.len_field.clone(),
+                    element_type: entry.element_type.clone(),
+                }
+            })
+            .collect();
         Self {
             io_shims,
             calls,
@@ -1231,16 +1272,7 @@ impl LowererConfig {
                 .iter()
                 .map(canonical_path_segments)
                 .collect(),
-            pool_arrays: pool_arrays
-                .iter()
-                .map(|entry| {
-                    (
-                        entry.base.to_string(),
-                        canonical_path_segments(&entry.getter),
-                        entry.element_type.clone(),
-                    )
-                })
-                .collect(),
+            pool_arrays,
             native_int_binops: native_int_binops
                 .iter()
                 .map(|(path, op)| (canonical_path_segments(path), op.to_string()))

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -230,6 +230,17 @@ pub struct LowererConfig {
     /// width and signedness with the struct layout instead of the machine-word
     /// default, which is what makes `descr.is_integer_bounded()` true for it.
     pub(super) int_fields: HashMap<String, (Ident, bool)>,
+    /// `"StructType::field"` keys some access site asked about while lowering.
+    ///
+    /// A declared key that never appears here matched no access, so it emitted
+    /// nothing — no descr width, and no witness either. That is what makes it
+    /// worth reporting rather than merely tidying: an entry that produces no
+    /// tokens is also an entry whose claim about the field was never checked,
+    /// and the two are indistinguishable from the declaration alone.
+    ///
+    /// Shared rather than cloned: the config is cloned per lowering entry
+    /// point, and a key consulted by any of them counts for all.
+    pub(super) consulted_field_keys: std::rc::Rc<std::cell::RefCell<HashSet<String>>>,
     /// Return struct type for ref-returning calls.  Key = canonical func
     /// path segments, value = struct type path.  When a `residual_ref` call
     /// result is bound, the lowerer sets `Binding.struct_type` from this map
@@ -992,6 +1003,7 @@ impl LowererConfig {
             ref_fields: ref_fields_map,
             array_fields: array_fields_map,
             int_fields: int_fields_map(int_fields),
+            consulted_field_keys: Default::default(),
             call_returns: HashMap::new(),
             headerless_structs: headerless_structs
                 .iter()
@@ -1264,6 +1276,7 @@ impl LowererConfig {
             ref_fields: ref_fields_map,
             array_fields: array_fields_map,
             int_fields: int_fields_map(int_fields),
+            consulted_field_keys: Default::default(),
             call_returns: call_returns
                 .iter()
                 .map(|(func, ret_type)| (canonical_path_segments(func), ret_type.clone()))

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -383,17 +383,29 @@ pub struct ResidualWriteEntry {
 
 /// A `ref(T)` state scalar that is the base of a contiguous raw-pointer array,
 /// paired with the marker `getter` function whose call indexes it.  Declared as
-/// `pool_arrays = { <ref> => <getter> [-> ElementType], ... }`.  The lowering
-/// recognizes a pool read only when BOTH the call's function path matches
-/// `getter` AND arg0 is `state.<base>` — operation identity, not arg shape
-/// alone, so an unrelated helper that happens to take the same
+/// `pool_arrays = { <ref>.<items>[<len>] => <getter> [-> ElementType], ... }`.
+/// The lowering recognizes a pool read only when BOTH the call's function path
+/// matches `getter` AND arg0 is `state.<base>` — operation identity, not arg
+/// shape alone, so an unrelated helper that happens to take the same
 /// `(state.<base>, int)` shape is not miscompiled into a `getarrayitem_gc_r`.
 #[derive(Clone)]
 pub struct PoolArrayEntry {
     pub base: Ident,
     pub getter: Path,
-    /// The concrete element type each array slot points at (`pools: [*mut T; N]`),
-    /// declared as `<base> => <getter> -> T`.  Supplies `struct_type` for the
+    /// The array field inside the base struct, e.g. `pools` in
+    /// `Storage { pools: [*mut T; N], .. }`.  Its `offset_of!` is what the
+    /// element read adds to the base pointer.  Naming it is what leaves the
+    /// struct free to hold anything else: undeclared, the read has to assume a
+    /// layout and the consumer has to build its struct to match, with the
+    /// agreement written on neither side in anything the compiler checks.
+    pub items_field: Ident,
+    /// A length word ahead of the items, declared as `<items>[<len>]`.  Absent
+    /// for a plain fixed-size array, which has no length in memory; present
+    /// when the consumer keeps one, which buys the `len > index` bound the
+    /// short preamble re-establishes on each loop entry.
+    pub len_field: Option<Ident>,
+    /// The concrete element type each array slot points at (`items: [*mut T; N]`),
+    /// declared as `... => <getter> -> T`.  Supplies `struct_type` for the
     /// getter's ref binding so field access on a LOCAL `let x = <getter>(...)`
     /// resolves the layout (state-field refs get this from their decl instead).
     pub element_type: Option<Path>,
@@ -844,15 +856,29 @@ fn parse_residual_writes_map(input: ParseStream) -> syn::Result<Vec<ResidualWrit
     Ok(entries)
 }
 
-/// Parse `pool_arrays = { <ref> => <getter> [-> ElementType], ... }`.  Each
-/// entry maps a `ref(T)` state scalar (the array base) to the marker function
-/// whose call indexes it, optionally tagging the loaded element's struct type.
+/// Parse `pool_arrays = { <ref>.<items>[<len>] => <getter> [-> ElementType],
+/// ... }`.  Each entry maps a `ref(T)` state scalar (the array base) and the
+/// array field inside it to the marker function whose call indexes it,
+/// optionally naming a length word ahead of the items and tagging the loaded
+/// element's struct type.
+///
+/// `<items>` is mandatory: the read has to add some offset to the base, and the
+/// only alternatives to declaring it are assuming one or hard-coding one.
 fn parse_pool_arrays_map(input: ParseStream) -> syn::Result<Vec<PoolArrayEntry>> {
     let content;
     braced!(content in input);
     let mut entries = Vec::new();
     while !content.is_empty() {
         let base: Ident = content.parse()?;
+        content.parse::<Token![.]>()?;
+        let items_field: Ident = content.parse()?;
+        let len_field = if content.peek(syn::token::Bracket) {
+            let len;
+            syn::bracketed!(len in content);
+            Some(len.parse::<Ident>()?)
+        } else {
+            None
+        };
         content.parse::<Token![=>]>()?;
         let getter: Path = content.parse()?;
         let element_type = if content.peek(Token![->]) {
@@ -864,6 +890,8 @@ fn parse_pool_arrays_map(input: ParseStream) -> syn::Result<Vec<PoolArrayEntry>>
         entries.push(PoolArrayEntry {
             base,
             getter,
+            items_field,
+            len_field,
             element_type,
         });
         let _ = content.parse::<Token![,]>();

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -1865,22 +1865,30 @@ impl JitCodeBuilder {
 
     /// Add a GC-array descriptor for a raw-pointer-element array (one-word
     /// `*mut T` items) to the descrs pool; returns the descr index for
-    /// `getarrayitem_gc_r`.  Models a length-prefixed `{ len: usize,
-    /// items: [*mut T; N] }` whose base pointer points at the `len` word:
-    /// `base_size = 8` (items start one word in), `len_offset = Some(0)`
-    /// (length at the base).  The lendescr is required: the optimizer
-    /// narrows the array's lenbound on a constant-index read (`heap.py:676
-    /// getlenbound().make_gt_const(index)`) and the short preamble re-emits
-    /// `ARRAYLEN_GC` to re-establish the `len > index` guard each loop entry
-    /// — without a lendescr the GC rewrite of that `ARRAYLEN_GC` panics.
-    /// An interpreter supplies that header itself — a length word at offset
-    /// 0 with the pointer array at offset 8.  Deduped structurally by
-    /// `add_bh_descr`.
-    pub fn add_ptr_array_descr(&mut self) -> u16 {
+    /// `getarrayitem_gc_r`.  Models `[*mut T; N]` living inside a struct the
+    /// caller owns: `base_size` is the byte offset of the first item from the
+    /// pointer the read indexes off, and `len_offset` names a length word
+    /// ahead of it when the caller keeps one.
+    ///
+    /// Both are the caller's to state because both are its layout.  RPython
+    /// derives them from the lltype (`descr.py get_array_descr(gccache,
+    /// ARRAY)`); a hand-written consumer struct has no lltype, so the values
+    /// arrive from the declaration or they are guessed.
+    ///
+    /// `len_offset = None` is a supported shape, not a degraded one: a plain
+    /// fixed-size inline array has no length in memory, and
+    /// `ArrayPtrInfo.make_guards` skips the short preamble's `ARRAYLEN_GC` for
+    /// a descr without a lendescr (`optimizeopt/info.rs`) rather than emitting
+    /// an op the mandatory GC rewrite would then unwrap.  With a length word
+    /// declared, the read keeps the `len > index` bound the optimizer narrows
+    /// on a constant index (`heap.py:676 getlenbound().make_gt_const(index)`).
+    ///
+    /// Deduped structurally by `add_bh_descr`.
+    pub fn add_ptr_array_descr(&mut self, base_size: usize, len_offset: Option<usize>) -> u16 {
         self.add_array_descr(CanonicalBhDescr::Array {
-            base_size: std::mem::size_of::<usize>(),
+            base_size,
             itemsize: scalar_size(majit_ir::value::Type::Ref),
-            len_offset: Some(0),
+            len_offset,
             type_id: 0,
             gc_type_id: 0,
             item_type: majit_ir::value::Type::Ref,

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -628,6 +628,7 @@ impl JitCodeBuilder {
         headerless: bool,
         fields: &[(usize, bool, &str, usize, bool)],
     ) {
+        crate::note_struct_layout_registration(fields.len());
         // Every emit site re-registers the layout it accesses, so the same few
         // type_ids arrive hundreds of times.  When the spec already lists an
         // offset for each incoming field the merge below pushes nothing, and
@@ -636,19 +637,20 @@ impl JitCodeBuilder {
         // `is_gc_managed` or `headerless`, so returning here is exactly
         // equivalent and skips building `new_fields` (one owned String per
         // field) only to discard it.
-        if self
-            .struct_size_specs
-            .get(&type_id)
-            .is_some_and(|existing| {
-                fields.iter().all(|&(offset, _, _, _, _)| {
-                    existing
-                        .all_fielddescrs
-                        .iter()
-                        .any(|ef| ef.offset == offset)
-                })
-            })
-        {
-            return;
+        //
+        // The same walk answers whether the offset that made a field redundant
+        // was really *this* field's, so `Self::record_layout_conflicts` runs
+        // off it rather than repeating it.
+        if let Some(existing) = self.struct_size_specs.get(&type_id) {
+            let mut every_offset_known = true;
+            for &field in fields {
+                if !Self::record_layout_conflicts(existing, type_id, field) {
+                    every_offset_known = false;
+                }
+            }
+            if every_offset_known {
+                return;
+            }
         }
         let new_fields = Self::field_specs_from_layout(fields);
         // Merge into existing spec if present — each getfield/setfield
@@ -687,6 +689,88 @@ impl JitCodeBuilder {
                 },
             );
         }
+    }
+
+    /// Whether `existing` already lists `field`'s offset, recording what the
+    /// offset-keyed dedup would discard if it does so for the wrong reason.
+    ///
+    /// The dedup key is the byte offset, but an offset does not identify a
+    /// field: a flattened inline aggregate and its first leaf sit at one
+    /// address, and the corpus really contains such pairs. So a hit at a known
+    /// offset splits three ways.
+    ///
+    /// * The same name, described the same way — the redundant re-registration
+    ///   every emit site performs, and what the dedup exists for.
+    /// * The same name, described differently — one site calls the word a GC
+    ///   pointer and another a scalar, so emit order decides what the collector
+    ///   traces.
+    /// * A different name — a real sibling, which the merge then drops. The
+    ///   spec is left short an entry that `add_struct_field_descr` resolves
+    ///   `index_in_parent` and `name` against.
+    ///
+    /// Only the first is silent. The other two are recorded and the caller
+    /// still merges as before: this reports the disagreement, it does not
+    /// arbitrate it.
+    fn record_layout_conflicts(
+        existing: &BhSizeSpec,
+        type_id: u64,
+        (offset, is_ref, name, decl_size, decl_signed): (usize, bool, &str, usize, bool),
+    ) -> bool {
+        let mut at_offset = existing
+            .all_fielddescrs
+            .iter()
+            .filter(|ef| ef.offset == offset)
+            .peekable();
+        if at_offset.peek().is_none() {
+            return false;
+        }
+        crate::note_struct_layout_comparison();
+        // Both sides are compared in the form the spec RETAINS, not the form
+        // the caller submitted: `field_specs_from_layout` discards a ref
+        // field's declared width and sign for the pointer word's own, so a
+        // recorded ref never remembers what it was handed. Normalising the
+        // incoming field the same way is what keeps two agreeing ref
+        // registrations from reading as a disagreement.
+        let incoming = crate::StructLayoutField {
+            name: name.to_string(),
+            is_ref,
+            size: if is_ref {
+                scalar_size(majit_ir::value::Type::Ref)
+            } else {
+                decl_size
+            },
+            signed: !is_ref && decl_signed,
+        };
+        let describe = |ef: &BhFieldSpec| crate::StructLayoutField {
+            name: ef.name.clone(),
+            is_ref: matches!(ef.field_type, majit_ir::value::Type::Ref),
+            size: ef.field_size,
+            signed: ef.is_field_signed,
+        };
+        let mut same_name = at_offset.clone().filter(|ef| ef.name == name).peekable();
+        let (kept, kind) = match same_name.peek() {
+            Some(&ef) => (describe(ef), crate::StructLayoutConflictKind::Redescribed),
+            // Every field at this offset is named something else, so this one is
+            // a sibling the merge has no slot for. Report it against the entry
+            // the dedup will keep: the lowest-ranked one there.
+            None => {
+                let ef = at_offset.next().expect("peeked Some above");
+                (
+                    describe(ef),
+                    crate::StructLayoutConflictKind::DroppedSibling,
+                )
+            }
+        };
+        if kept != incoming {
+            crate::record_struct_layout_conflict(crate::StructLayoutConflict {
+                type_id,
+                offset,
+                kind,
+                kept,
+                dropped: incoming,
+            });
+        }
+        true
     }
 
     /// Build `Vec<BhFieldSpec>` from a `(offset, is_ref, name)` layout,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -529,6 +529,91 @@ pub fn degraded_dispatch_arms() -> Vec<DegradedDispatchArm> {
         .clone()
 }
 
+/// How many dispatch arms one machine's portal emitted, recorded whether or
+/// not any of them degraded.
+///
+/// [`degraded_dispatch_arms`] is a numerator. On its own an empty result reads
+/// as "no arm degraded" and is indistinguishable from "no portal was ever
+/// built" — the same shape as the defect it exists to report, one level up. A
+/// consumer's gate therefore has to supply its own proof that the portal was
+/// installed, and every one of them supplies a different one.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct DispatchArmCensus {
+    /// The machine's declared `state = T` type name, matching
+    /// [`DegradedDispatchArm::interp`].
+    pub interp: &'static str,
+    /// Arms the portal emitted a body for. The `_` wildcard and a lowercase
+    /// binding pattern are excluded: both are the default edge rather than an
+    /// opcode, and neither can degrade.
+    pub arms: usize,
+}
+
+static DISPATCH_ARM_CENSUS: std::sync::Mutex<Vec<DispatchArmCensus>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Record that `interp`'s portal emitted `arms` dispatch arms.
+///
+/// Called from the `__dispatch_jitcode_*` body alongside
+/// [`record_degraded_dispatch_arm`], so the denominator and the numerator are
+/// written in the same install. Deduplicated by content for the same reason:
+/// a portal may be built more than once per process and the fact is per
+/// machine, not per build.
+pub fn record_dispatch_arm_census(interp: &'static str, arms: usize) {
+    let entry = DispatchArmCensus { interp, arms };
+    let mut census = DISPATCH_ARM_CENSUS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if census.contains(&entry) {
+        return;
+    }
+    census.push(entry);
+}
+
+/// Snapshot of every portal's arm count recorded so far.
+pub fn dispatch_arm_census() -> Vec<DispatchArmCensus> {
+    DISPATCH_ARM_CENSUS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+/// Panic unless `interp`'s portal was installed AND none of its arms degraded.
+///
+/// This is the gate every consumer would otherwise write, denominator and all.
+/// Reading `degraded_dispatch_arms()` alone cannot be that gate: it passes on
+/// an empty registry, and an empty registry is also what a portal that was
+/// never built produces. The census settles which one happened, so the two
+/// failures get two different messages instead of one silent pass.
+///
+/// Call it after whatever installs the portal. `#[jit_interp]` records both
+/// facts at install, not at trace time, so running the machine is not required
+/// — but nothing is recorded until the portal is built at least once.
+pub fn assert_no_degraded_dispatch_arms(interp: &str) {
+    let census = dispatch_arm_census();
+    let Some(entry) = census.iter().find(|e| e.interp == interp) else {
+        panic!(
+            "no dispatch-arm census for `{interp}`: its portal was never \
+             installed in this process, so an empty degraded list says nothing \
+             about it. Build the dispatch JitCode (or run the machine) first. \
+             Recorded machines: {:?}",
+            census.iter().map(|e| e.interp).collect::<Vec<_>>()
+        );
+    };
+    let degraded: Vec<DegradedDispatchArm> = degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == interp)
+        .collect();
+    assert!(
+        degraded.is_empty(),
+        "{} of `{interp}`'s {} dispatch arms lowered to an abort stub. Every \
+         trace that reaches one of these opcodes aborts, once per threshold, \
+         forever: {:#?}",
+        degraded.len(),
+        entry.arms,
+        degraded
+    );
+}
+
 /// The shape of a compiled loop body, as a tier gate needs to read it.
 ///
 /// A compile counter says a trace was *compiled*; an op count says the body is

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -614,6 +614,160 @@ pub fn assert_no_degraded_dispatch_arms(interp: &str) {
     );
 }
 
+/// One field of a struct layout, as an emit site described it.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StructLayoutField {
+    /// The field's declared name — its identity. Empty at the mint sites that
+    /// carry none, where the byte offset is all there is to key on.
+    pub name: String,
+    /// Whether the word holds a GC pointer. Decides `ArrayFlag::Pointer` vs a
+    /// signed/unsigned integer flag, and with it whether the collector traces
+    /// through the word.
+    pub is_ref: bool,
+    /// The field's width in bytes. A ref is a pointer word by construction.
+    pub size: usize,
+    /// Signedness, for an integer field.
+    pub signed: bool,
+}
+
+/// Why a struct-layout registration could not be honoured as submitted.
+///
+/// `JitCodeBuilder::register_struct_layout` accumulates a struct's layout
+/// across the emit sites that touch it, and dedups on the byte offset alone.
+/// An offset does not identify a field, so a second registration at a known
+/// offset is one of three things and only the first is benign: the same field
+/// again (the common case — every emit site re-registers what it accesses), a
+/// different field that happens to sit there, or the same field described
+/// differently. The latter two are these variants.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum StructLayoutConflictKind {
+    /// A field arrived at an offset the spec already lists under a *different*
+    /// name, so the offset-keyed dedup discarded it. A flattened inline
+    /// aggregate and its first leaf share an address, which is how two real
+    /// fields legitimately collide.
+    ///
+    /// The spec is then short an entry: `add_struct_field_descr` resolves
+    /// `index_in_parent` and `name` against it, so an access to the dropped
+    /// field either resolves to its sibling's slot or fails to resolve at all.
+    DroppedSibling,
+    /// The *same* named field arrived described differently — most consequentially
+    /// as a GC pointer at one site and as a scalar at another. Whichever
+    /// registration arrived first decides what the collector believes about the
+    /// word, so the outcome depends on emit order.
+    Redescribed,
+}
+
+/// A struct-layout registration that disagreed with what was already recorded.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct StructLayoutConflict {
+    /// The struct's `path_hash` type id, the key of the layout cache.
+    pub type_id: u64,
+    /// The byte offset both registrations name.
+    pub offset: usize,
+    pub kind: StructLayoutConflictKind,
+    /// What the spec holds — the registration that arrived first.
+    pub kept: StructLayoutField,
+    /// What arrived second and was discarded.
+    pub dropped: StructLayoutField,
+}
+
+static STRUCT_LAYOUT_CONFLICTS: std::sync::Mutex<Vec<StructLayoutConflict>> =
+    std::sync::Mutex::new(Vec::new());
+
+static STRUCT_LAYOUT_REGISTRATIONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+static STRUCT_LAYOUT_COMPARISONS: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+
+/// Record that a layout registration disagreed with the recorded spec.
+///
+/// Deduplicated by content: a jitcode may be built many times per process and
+/// the fact reported is per-disagreement, not per-build.
+pub fn record_struct_layout_conflict(conflict: StructLayoutConflict) {
+    let mut conflicts = STRUCT_LAYOUT_CONFLICTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if conflicts.contains(&conflict) {
+        return;
+    }
+    if majit_log_enabled() {
+        eprintln!("[jit] struct layout conflict: {conflict:?}");
+    }
+    conflicts.push(conflict);
+}
+
+/// Count `fields` submitted field descriptions.
+pub fn note_struct_layout_registration(fields: usize) {
+    STRUCT_LAYOUT_REGISTRATIONS.fetch_add(fields, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Count one field that met an entry already recorded at its offset — i.e. one
+/// field the conflict check actually had something to compare against.
+///
+/// The first one announces itself under `MAJIT_LOG`. A run that reports no
+/// conflicts has said nothing until something says the check ran at all, and
+/// the only other way to learn that from outside the process is to read
+/// [`struct_layout_comparisons`], which a binary does not expose.
+pub fn note_struct_layout_comparison() {
+    let previous = STRUCT_LAYOUT_COMPARISONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    if previous == 0 && majit_log_enabled() {
+        eprintln!("[jit] struct layout conflict check is live");
+    }
+}
+
+/// Snapshot of every layout disagreement recorded so far.
+pub fn struct_layout_conflicts() -> Vec<StructLayoutConflict> {
+    STRUCT_LAYOUT_CONFLICTS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+/// Field descriptions submitted to `register_struct_layout` so far.
+pub fn struct_layout_registrations() -> usize {
+    STRUCT_LAYOUT_REGISTRATIONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Submitted fields that arrived at an offset already recorded for their
+/// struct — the denominator for [`struct_layout_conflicts`].
+///
+/// [`struct_layout_registrations`] is the wrong one. A field at an offset
+/// nobody has registered yet is simply appended: there is nothing to disagree
+/// with, so it does not exercise the check. A corpus could submit thousands of
+/// those, report zero conflicts, and never have compared anything. This counts
+/// the fields that were actually compared.
+pub fn struct_layout_comparisons() -> usize {
+    STRUCT_LAYOUT_COMPARISONS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Panic unless some layout was re-registered AND none of the re-registrations
+/// disagreed.
+///
+/// Call it after whatever builds the jitcodes. Layouts are registered as the
+/// bytecode is emitted, so building the portal is enough — running the machine
+/// is not required.
+pub fn assert_no_struct_layout_conflicts() {
+    let comparisons = struct_layout_comparisons();
+    assert!(
+        comparisons > 0,
+        "no field was ever submitted at an offset already recorded for its \
+         struct, so the conflict check never compared anything and its empty \
+         result says nothing. {} field descriptions were registered in total. \
+         Build the jitcodes (or run the machine) first.",
+        struct_layout_registrations(),
+    );
+    let conflicts = struct_layout_conflicts();
+    assert!(
+        conflicts.is_empty(),
+        "{} of {comparisons} re-registered field descriptions disagreed with \
+         the layout already recorded for their struct. The first registration \
+         wins, so what the optimizer and the collector believe about these \
+         words depends on emit order: {conflicts:#?}",
+        conflicts.len(),
+    );
+}
+
 /// The shape of a compiled loop body, as a tier gate needs to read it.
 ///
 /// A compile counter says a trace was *compiled*; an op count says the body is

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -614,6 +614,96 @@ pub fn assert_no_degraded_dispatch_arms(interp: &str) {
     );
 }
 
+/// A declared field key that no access site asked about.
+///
+/// `int_fields` and `ref_fields` are consulted by key —
+/// `"StructType::field"`, built from the *declared* type of the base an access
+/// goes through. A key that matches no access emits nothing: no descr width,
+/// and no witness either. So the entry is at once inert and an unchecked claim
+/// about the field, and the declaration alone cannot say which.
+///
+/// Reported rather than rejected. A dispatch arm that refused to lower never
+/// reached its field accesses, so a key used only in that arm is unconsulted
+/// through no fault of the declaration; read this beside
+/// [`degraded_dispatch_arms`] before concluding an entry is dead.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub struct UnconsultedFieldDeclaration {
+    /// The machine's declared `state = T` type name, matching
+    /// [`DegradedDispatchArm::interp`].
+    pub interp: &'static str,
+    /// The declaration's key, as written: `"StructType::field"`.
+    pub key: &'static str,
+}
+
+static UNCONSULTED_FIELD_DECLARATIONS: std::sync::Mutex<Vec<UnconsultedFieldDeclaration>> =
+    std::sync::Mutex::new(Vec::new());
+
+/// Record that `interp` declares `key` and no access site consulted it.
+///
+/// Emitted into the `__dispatch_jitcode_*` body beside
+/// [`record_dispatch_arm_census`], so it fires when the portal is installed.
+/// Deduplicated by content: a portal may be built more than once per process
+/// and the fact is per declaration, not per build.
+pub fn record_unconsulted_field_declaration(interp: &'static str, key: &'static str) {
+    let entry = UnconsultedFieldDeclaration { interp, key };
+    let mut entries = UNCONSULTED_FIELD_DECLARATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if entries.contains(&entry) {
+        return;
+    }
+    if majit_log_enabled() {
+        eprintln!("[jit] unconsulted field declaration: {interp} declares {key}, unused");
+    }
+    entries.push(entry);
+}
+
+/// Snapshot of every unconsulted field declaration recorded so far.
+pub fn unconsulted_field_declarations() -> Vec<UnconsultedFieldDeclaration> {
+    UNCONSULTED_FIELD_DECLARATIONS
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone()
+}
+
+/// Panic unless `interp`'s portal was installed AND every field declaration it
+/// carries was consulted.
+///
+/// Takes its denominator from the same census as
+/// [`assert_no_degraded_dispatch_arms`], for the same reason: an empty result
+/// is also what a portal that was never built produces.
+pub fn assert_no_unconsulted_field_declarations(interp: &str) {
+    let census = dispatch_arm_census();
+    let Some(entry) = census.iter().find(|e| e.interp == interp) else {
+        panic!(
+            "no dispatch-arm census for `{interp}`: its portal was never \
+             installed in this process, so an empty unconsulted list says \
+             nothing about it. Build the dispatch JitCode (or run the machine) \
+             first. Recorded machines: {:?}",
+            census.iter().map(|e| e.interp).collect::<Vec<_>>()
+        );
+    };
+    let unconsulted: Vec<UnconsultedFieldDeclaration> = unconsulted_field_declarations()
+        .into_iter()
+        .filter(|e| e.interp == interp)
+        .collect();
+    let degraded: Vec<DegradedDispatchArm> = degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == interp)
+        .collect();
+    assert!(
+        unconsulted.is_empty(),
+        "`{interp}` declares {} field key(s) no access site consulted, across \
+         its {} dispatch arms. Each emitted no width and no witness, so the \
+         declaration was never checked against the struct it names: {unconsulted:#?}. \
+         {} of its arms degraded, and a key used only in one of those is \
+         unconsulted for that reason rather than for being stale: {degraded:#?}",
+        unconsulted.len(),
+        entry.arms,
+        degraded.len(),
+    );
+}
+
 /// One field of a struct layout, as an emit site described it.
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub struct StructLayoutField {

--- a/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
+++ b/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
@@ -1,0 +1,234 @@
+//! A dispatch arm may call a result-returning inline helper for its effect.
+//!
+//! `inline_int` / `inline_ref` / `inline_float` helpers were lowered in value
+//! position only. In statement position — the result discarded — they reached
+//! the trailing `_ => return None` of `lower_config_call_stmt`, and a statement
+//! that does not lower takes its whole arm with it: the arm becomes an abort
+//! stub and every trace that reaches the opcode aborts, forever.
+//!
+//! Two things made that hard to see. `explicit_call_emits_post_live` already
+//! answers for these three kinds, so the accounting said the policy was handled
+//! while the lowering did not handle it. And the workaround is invisible in the
+//! result — binding the value to a `let _x` the arm never reads makes the same
+//! source lower, so a machine that hit this looks like one that never did.
+//!
+//! `#[jit_inline]` fails the build on the same input
+//! (`jit_interp_inline_helper_typed_return.rs` pins that half). `#[jit_interp]`
+//! does not: it degrades the arm and keeps going, which is why this file
+//! grades the registry rather than the compiler.
+
+use majit_macros::jit_inline;
+use majit_metainterp::{Assembler, JitDriver};
+
+#[repr(C)]
+struct PopNode {
+    value: i64,
+    next: *mut PopNode,
+}
+
+#[repr(C)]
+struct PopStack {
+    head: *mut PopNode,
+    size: i64,
+}
+
+/// The subject helper: it RETURNS the popped value and MUTATES the stack, so a
+/// caller that wants only the mutation has no reason to bind the result.
+#[jit_inline(
+    ref_params = {
+        stack: ref(PopStack),
+    },
+    ref_fields = {
+        PopStack::head => PopNode,
+        PopNode::next => PopNode,
+    },
+)]
+fn pop_stack(stack: usize) -> i64 {
+    let head = stack.head;
+    let value = head.value;
+    let next = head.next;
+    stack.head = next;
+    stack.size = stack.size - 1i64;
+    value
+}
+
+struct PopState {
+    total: i64,
+    sel: usize,
+}
+
+pub type Bytecode = [u8];
+
+/// The subject: the helper's result is discarded.
+const OP_DISCARD_POP: u8 = 1;
+/// The control: the same helper, same arguments, result bound. This is the
+/// spelling that already lowered, and it is what the workaround turns the
+/// subject into — so it must stay green for the subject's failure to mean
+/// anything.
+const OP_BIND_POP: u8 = 2;
+/// The denominator. An empty degraded registry means either "no arm degraded"
+/// or "no arm was looked at", and only the first is a pass. This arm is
+/// unlowerable on purpose (a `break` enclosed in an `if`), so its presence in
+/// the registry proves the registry was written to at all.
+const OP_ENCLOSED_BREAK: u8 = 3;
+const OP_BACK: u8 = 4;
+
+#[majit_macros::jit_interp(
+    state = PopState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = { total: int, sel: ref(PopStack) },
+    calls = { pop_stack => inline_int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_pop(program: &Bytecode, threshold: u32) -> i64 {
+    let mut driver: JitDriver<PopState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = PopState { total: 0, sel: 0 };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_DISCARD_POP => {
+                pop_stack(state.sel);
+            }
+            OP_BIND_POP => {
+                let popped = pop_stack(state.sel);
+                state.total = state.total + popped;
+            }
+            OP_ENCLOSED_BREAK => {
+                if state.total == 0 {
+                    break;
+                }
+            }
+            OP_BACK => {
+                if state.total != 0 {
+                    pc = 0;
+                    continue;
+                }
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+/// The dispatch portal, plus the helper's own jitcode body built off the SAME
+/// assembler. Sub-JitCodes carry no name, so the helper's byte body is what
+/// identifies its splices in the portal's descr list; building it from a second
+/// assembler would give it different liveness offsets and match nothing.
+fn install() -> (majit_metainterp::JitCode, Vec<u8>) {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_pop(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    let dispatch_jc =
+        __dispatch_jitcode_dispatch_pop(&mut asm, 0i64).expect("dispatch lower must succeed");
+    let helper_code = __majit_inline_jitcode_pop_stack_with_asm(&mut asm)
+        .code
+        .clone();
+    (dispatch_jc, helper_code)
+}
+
+fn degraded_arms() -> Vec<String> {
+    let _ = install();
+    majit_metainterp::degraded_dispatch_arms()
+        .into_iter()
+        .filter(|e| e.interp == "PopState")
+        .map(|e| e.arm.to_string())
+        .collect()
+}
+
+/// The subject. Read the denominator first: without the control arm in the
+/// registry, "the subject is absent" is what a registry nobody wrote to also
+/// looks like.
+#[test]
+fn a_discarded_inline_int_call_does_not_degrade_its_arm() {
+    let degraded = degraded_arms();
+
+    assert!(
+        degraded.iter().any(|arm| arm == "OP_ENCLOSED_BREAK"),
+        "denominator: the deliberately-unlowerable arm must be recorded, or an \
+         empty registry is indistinguishable from an unread one; degraded={degraded:?}"
+    );
+    assert!(
+        !degraded.iter().any(|arm| arm == "OP_DISCARD_POP"),
+        "an `inline_int` helper called for its effect degraded its arm to an \
+         abort stub. Every trace reaching that opcode aborts and the storage \
+         mutation never enters the trace; degraded={degraded:?}"
+    );
+    assert!(
+        !degraded.iter().any(|arm| arm == "OP_BIND_POP"),
+        "control: binding the result has always lowered. If this fails the \
+         helper itself stopped lowering and the subject above is measuring \
+         something else; degraded={degraded:?}"
+    );
+}
+
+/// …and the arm must carry the splice, not merely avoid degrading. An arm that
+/// lowered while silently dropping the call would pass the test above.
+///
+/// The oracle is the portal's sub-JitCode list — one `add_sub_jitcode` per
+/// splice site — not a byte scan of the bodies. A jitcode body is a bytecode
+/// stream whose operands are bytes too, so `code.contains(&BC_INLINE_CALL)`
+/// answers about any operand that happens to equal that opcode: counting
+/// `BC_INLINE_CALL` bytes here returns 2 even with the discarding arm degraded
+/// to `[BC_ABORT]`, which is exactly the reading this test exists to reject.
+#[test]
+fn the_discarded_call_is_spliced_into_a_jitcode_body() {
+    let (dispatch_jc, helper_code) = install();
+    let sub_bodies: Vec<&[u8]> = dispatch_jc
+        .exec
+        .descrs
+        .iter()
+        .filter_map(|descr| descr.as_jitcode())
+        .map(|sub| sub.code.as_slice())
+        .collect();
+    let helper_splices = sub_bodies
+        .iter()
+        .filter(|body| **body == helper_code.as_slice())
+        .count();
+    assert_eq!(
+        helper_splices, 2,
+        "exactly two arms call `pop_stack` — the discarding one and the \
+         binding one — so the portal must register the helper twice. One \
+         registration means the discarding arm dropped its call; \
+         helper={helper_code:?} sub-bodies={sub_bodies:?}"
+    );
+}
+
+/// The concrete path must perform the same mutation the trace now carries.
+#[test]
+fn the_discarded_call_still_pops_on_the_concrete_path() {
+    let mut second = PopNode {
+        value: 22,
+        next: std::ptr::null_mut(),
+    };
+    let mut first = PopNode {
+        value: 11,
+        next: &mut second,
+    };
+    let mut stack = PopStack {
+        head: &mut first,
+        size: 2,
+    };
+
+    pop_stack(&mut stack as *mut PopStack as usize);
+
+    assert_eq!(
+        stack.size, 1,
+        "the discarded pop must still shrink the stack"
+    );
+    assert_eq!(
+        unsafe { (*stack.head).value },
+        22,
+        "the discarded pop must still advance head past the popped node"
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
+++ b/majit/majit-metainterp/tests/jit_interp_discarded_inline_result.rs
@@ -146,12 +146,28 @@ fn degraded_arms() -> Vec<String> {
         .collect()
 }
 
-/// The subject. Read the denominator first: without the control arm in the
-/// registry, "the subject is absent" is what a registry nobody wrote to also
-/// looks like.
+/// The subject. Read the denominator first: without it, "the subject is
+/// absent" is what a registry nobody wrote to also looks like.
+///
+/// Two denominators, and they answer different questions.
+/// `dispatch_arm_census()` says the portal was installed at all — that is the
+/// one `assert_no_degraded_dispatch_arms` consults, and the one every machine
+/// gets for free. `OP_ENCLOSED_BREAK` says the degraded registry itself is
+/// reachable from this fixture, which the census cannot say.
 #[test]
 fn a_discarded_inline_int_call_does_not_degrade_its_arm() {
     let degraded = degraded_arms();
+
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "PopState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; census={census:?}"));
+    assert_eq!(
+        counted.arms, 4,
+        "the census must count the four opcode arms and not the `_` default; \
+         census={census:?}"
+    );
 
     assert!(
         degraded.iter().any(|arm| arm == "OP_ENCLOSED_BREAK"),
@@ -231,4 +247,49 @@ fn the_discarded_call_still_pops_on_the_concrete_path() {
         22,
         "the discarded pop must still advance head past the popped node"
     );
+}
+
+/// `assert_no_degraded_dispatch_arms` must distinguish its two failures.
+///
+/// This machine has a degraded arm on purpose, so the helper must reject it —
+/// and it must reject a machine that was never installed with a *different*
+/// message, because the two are the same empty list. A gate that only reads
+/// `degraded_dispatch_arms()` passes the second case silently, which is the
+/// whole reason the census exists.
+#[test]
+fn the_gate_separates_a_degraded_arm_from_an_uninstalled_portal() {
+    let _ = install();
+
+    let degraded =
+        std::panic::catch_unwind(|| majit_metainterp::assert_no_degraded_dispatch_arms("PopState"))
+            .expect_err("this fixture degrades OP_ENCLOSED_BREAK on purpose");
+    let degraded = panic_message(&degraded);
+    assert!(
+        degraded.contains("lowered to an abort stub"),
+        "an installed portal with a degraded arm must fail on the arm; \
+         got {degraded:?}"
+    );
+
+    let uninstalled = std::panic::catch_unwind(|| {
+        majit_metainterp::assert_no_degraded_dispatch_arms("NoSuchState")
+    })
+    .expect_err("a machine that was never installed cannot be graded");
+    let uninstalled = panic_message(&uninstalled);
+    assert!(
+        uninstalled.contains("never installed"),
+        "an absent portal must fail on the denominator, not silently pass \
+         because its degraded list is empty; got {uninstalled:?}"
+    );
+    assert_ne!(
+        degraded, uninstalled,
+        "the two failures must not read the same, or the census bought nothing"
+    );
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_string()))
+        .unwrap_or_default()
 }

--- a/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_helper_typed_return.rs
@@ -104,6 +104,14 @@ fn inline_typed_stack_swap_caller(stack: usize) {
     inline_typed_stack_swap(stack);
 }
 
+/// The same `inline_int` helper as `inline_typed_stack_pop_caller`, called for
+/// its effect with the result discarded. This is what a "pop and throw away"
+/// opcode looks like, and it is a statement, not a value.
+#[jit_inline(calls = { inline_typed_stack_pop => inline_int })]
+fn inline_typed_stack_pop_discarding_caller(stack: usize) {
+    inline_typed_stack_pop(stack);
+}
+
 #[dont_look_inside]
 fn wrapped_ref_identity(ptr: *const i64) -> *const i64 {
     ptr
@@ -796,4 +804,89 @@ fn jit_inline_array_field_keeps_interpreter_behavior() {
     assert_eq!(stack.sp, 1);
     assert_eq!(inline_array_stack_pop(stack_ptr), 10);
     assert_eq!(stack.sp, 0);
+}
+
+/// A result-returning inline helper called for its effect alone must still be
+/// spliced into the caller.
+///
+/// Statement position and value position are lowered by two different
+/// functions, and only the value one had arms for `inline_int` / `inline_ref` /
+/// `inline_float`. In statement position they reached the trailing
+/// `_ => return None`, and the helper below did not compile at all:
+/// `#[jit_inline] could not lower this helper into JitCode`. The workaround is
+/// to bind the result to a `let _x` nothing reads, which is a source change the
+/// declaration never asked for.
+///
+/// The loudness is specific to `#[jit_inline]`. The same input inside a
+/// `#[jit_interp]` dispatch arm degrades the arm to an abort stub and builds
+/// clean — `jit_interp_discarded_inline_result.rs` pins that half, which is the
+/// one with no diagnostic.
+#[test]
+fn a_discarded_inline_int_result_still_splices_the_helper() {
+    let inline_call = majit_metainterp::jitcode::insns::BC_INLINE_CALL;
+    let residual_calls = [
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_R_I,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IR_I,
+        majit_metainterp::jitcode::insns::BC_RESIDUAL_CALL_IRF_I,
+    ];
+
+    let mut asm = majit_metainterp::Assembler::new();
+    let caller = __majit_inline_jitcode_inline_typed_stack_pop_discarding_caller_with_asm(&mut asm);
+
+    assert!(
+        caller.code.contains(&inline_call),
+        "a discarded `inline_int` call must still emit BC_INLINE_CALL; \
+         code={:?}",
+        caller.code
+    );
+    assert!(
+        residual_calls
+            .iter()
+            .all(|opcode| !caller.code.contains(opcode)),
+        "the discarded call must stay an inline splice, not fall back to a \
+         residual; code={:?}",
+        caller.code
+    );
+
+    // The value-position caller over the same helper is the control: if it
+    // ever stops emitting an inline_call, the assertion above is measuring the
+    // lowerer having changed rather than the discarded arm working.
+    let value_caller = __majit_inline_jitcode_inline_typed_stack_pop_caller_with_asm(&mut asm);
+    assert!(
+        value_caller.code.contains(&inline_call),
+        "control: the value-position caller over the same helper must splice \
+         it too; code={:?}",
+        value_caller.code
+    );
+}
+
+/// …and the concrete (non-JIT) path must perform the same mutation, so the two
+/// halves of the discarded call agree.
+#[test]
+fn a_discarded_inline_int_result_still_pops_on_the_concrete_path() {
+    let mut second = InlineTypedNode {
+        value: 22,
+        next: std::ptr::null_mut(),
+    };
+    let mut first = InlineTypedNode {
+        value: 11,
+        next: &mut second,
+    };
+    let mut stack = InlineTypedStack {
+        head: &mut first,
+        size: 2,
+    };
+    let stack_ptr = &mut stack as *mut InlineTypedStack as usize;
+
+    inline_typed_stack_pop_discarding_caller(stack_ptr);
+
+    assert_eq!(
+        stack.size, 1,
+        "the discarded pop must still shrink the stack"
+    );
+    assert_eq!(
+        unsafe { (*stack.head).value },
+        22,
+        "the discarded pop must still advance head past the popped node"
+    );
 }

--- a/majit/majit-metainterp/tests/jit_interp_pool_array_layout.rs
+++ b/majit/majit-metainterp/tests/jit_interp_pool_array_layout.rs
@@ -1,0 +1,209 @@
+//! A `pool_arrays` base whose items are not where the descr used to assume.
+//!
+//! `add_ptr_array_descr` hard-coded `base_size = size_of::<usize>()` and
+//! `len_offset = Some(0)` — a `{ len, items.. }` header the declaration never
+//! stated and the consumer's struct had to be built to match. Reordering that
+//! header, or dropping it, compiled clean on both sides and left the element
+//! read at `base + 8 + i*8`.
+//!
+//! Nothing could have caught it. The struct is the consumer's own, so the
+//! macro sees whatever it is handed; no `offset_of!` was emitted, so the
+//! assumption never met the layout. The two facts only ever met at run time,
+//! as a read of the wrong slot.
+//!
+//! This machine puts the items LAST, which is the arrangement the old
+//! hard-code gets wrong: with a `[i64; 2]` ahead of them, an assumed base of
+//! one word reads `items[i]` from inside that padding.
+
+use majit_metainterp::{Assembler, JitDriver};
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+static COMPILES: AtomicUsize = AtomicUsize::new(0);
+
+#[repr(C)]
+struct Slot {
+    value: i64,
+}
+
+/// Items last, and behind more than one word — so an assumed `base_size` of
+/// `size_of::<usize>()` lands inside `pad` rather than on an element.
+#[repr(C)]
+struct Pools {
+    len: usize,
+    pad: [i64; 2],
+    items: [*mut Slot; 4],
+}
+
+/// The marker call. Its concrete body is the fallback for a build with no
+/// `pool_arrays` declaration, and it is what the lowering replaces with a
+/// `getarrayitem_gc_r` when the declaration matches.
+fn pool_get(base: usize, index: i64) -> usize {
+    let pools = base as *const Pools;
+    unsafe { (*pools).items[index as usize] as usize }
+}
+
+struct PoolState {
+    pools: usize,
+    selected: usize,
+    total: i64,
+    /// The loop counter. The element read has to be inside a compiled trace to
+    /// be graded here at all, and a straight-line program never compiles one.
+    ticks: i64,
+}
+
+pub type Bytecode = [u8];
+
+const OP_SELECT: u8 = 1;
+const OP_READ: u8 = 2;
+const OP_TICK: u8 = 3;
+const OP_HALT: u8 = 4;
+
+#[majit_macros::jit_interp(
+    state = PoolState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        pools: ref(Pools),
+        selected: ref(Slot),
+        total: int,
+        ticks: int,
+    },
+    pool_arrays = { pools.items[len] => pool_get -> Slot },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_pool(program: &Bytecode, threshold: u32, pools: usize, ticks: i64) -> i64 {
+    let mut driver: JitDriver<PoolState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _b, _a, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = PoolState {
+        pools,
+        selected: 0,
+        total: 0,
+        ticks,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_SELECT => {
+                state.selected = pool_get(state.pools, 2i64);
+            }
+            OP_READ => {
+                state.total = state.total + state.selected.value;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_HALT => {
+                break;
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+fn build_pools(slots: &mut [Slot; 4]) -> Pools {
+    Pools {
+        len: 4,
+        pad: [-1, -1],
+        items: [
+            &mut slots[0] as *mut Slot,
+            &mut slots[1] as *mut Slot,
+            &mut slots[2] as *mut Slot,
+            &mut slots[3] as *mut Slot,
+        ],
+    }
+}
+
+/// The element read must resolve through the declaration, not through a
+/// header shape.
+///
+/// `items` sits behind `len` and a two-word `pad`, so the assumed one-word
+/// base lands on `pad[0]` and reads `-1` as a `*mut Slot`.
+///
+/// The concrete path indexes the real field whatever the descr says, so the
+/// sum alone does not grade the JIT — a program that never compiled a trace
+/// returns 30 under any layout the descr claims. The compile count is what
+/// makes the sum evidence, and it is asserted first for that reason: without
+/// it this test passes on the hard-coded build it exists to reject.
+#[test]
+fn the_element_read_follows_the_declared_items_offset() {
+    let mut slots = [
+        Slot { value: 10 },
+        Slot { value: 20 },
+        Slot { value: 30 },
+        Slot { value: 40 },
+    ];
+    let mut pools = build_pools(&mut slots);
+    const TICKS: i64 = 200;
+    let program = [OP_SELECT, OP_READ, OP_TICK, OP_HALT];
+
+    let before = COMPILES.load(Ordering::Relaxed);
+    let total = dispatch_pool(&program, 8, &mut pools as *mut Pools as usize, TICKS);
+    assert!(
+        COMPILES.load(Ordering::Relaxed) > before,
+        "no trace compiled, so the element read below never went through a \
+         descr and the assertion on it grades nothing",
+    );
+    assert_eq!(
+        total,
+        30 * TICKS,
+        "index 2 must reach `items[2]`, not a word two fields earlier",
+    );
+}
+
+/// …and the offsets the portal bakes in must be the struct's own.
+///
+/// Reading the jitcode rather than the run is what separates "the declaration
+/// was used" from "the concrete fallback ran and happened to agree". A machine
+/// whose trace never compiled would pass the test above unchanged.
+#[test]
+fn the_portal_bakes_in_the_structs_own_offsets() {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_pool(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    let dispatch_jc =
+        __dispatch_jitcode_dispatch_pool(&mut asm, 0i64).expect("dispatch lower must succeed");
+
+    let arrays: Vec<(usize, Option<usize>)> = dispatch_jc
+        .exec
+        .descrs
+        .iter()
+        .filter_map(|descr| descr.as_bh_descr())
+        .filter_map(|descr| match descr {
+            majit_metainterp::blackhole::BhDescr::Array {
+                base_size,
+                len_offset,
+                is_array_of_pointers: true,
+                ..
+            } => Some((*base_size, *len_offset)),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        arrays.contains(&(
+            core::mem::offset_of!(Pools, items),
+            Some(core::mem::offset_of!(Pools, len)),
+        )),
+        "the pool-array descr must carry this struct's offsets \
+         (items={}, len={}); found {arrays:?}",
+        core::mem::offset_of!(Pools, items),
+        core::mem::offset_of!(Pools, len),
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_ref_state_field.rs
+++ b/majit/majit-metainterp/tests/jit_interp_ref_state_field.rs
@@ -132,3 +132,28 @@ fn ref_state_field_live_value_types_tags_ref_slot() {
         "the appended ref scalar slot must be tagged Type::Ref"
     );
 }
+
+/// The success case for `assert_no_degraded_dispatch_arms`.
+///
+/// A gate that panicked unconditionally would satisfy the two failure cases
+/// pinned in `jit_interp_discarded_inline_result.rs`; this machine lowers every
+/// arm, so it is the one that says the gate can also pass. It also pins the
+/// census denominator against this fixture's own arm list.
+#[test]
+fn a_fully_lowered_machine_passes_the_degraded_arm_gate() {
+    let mut asm = Assembler::new();
+    let _ = build_ref_dispatch_jitcode(&mut asm);
+
+    let census = majit_metainterp::dispatch_arm_census();
+    let counted = census
+        .iter()
+        .find(|e| e.interp == "RefTestState")
+        .unwrap_or_else(|| panic!("the portal must record its arm count; census={census:?}"));
+    assert_eq!(
+        counted.arms, 3,
+        "OP_NOP, OP_INC_A and OP_TOUCH_SEL are counted; the `_` default is not; \
+         census={census:?}"
+    );
+
+    majit_metainterp::assert_no_degraded_dispatch_arms("RefTestState");
+}

--- a/majit/majit-metainterp/tests/jit_interp_unconsulted_field_declaration.rs
+++ b/majit/majit-metainterp/tests/jit_interp_unconsulted_field_declaration.rs
@@ -1,0 +1,233 @@
+//! A field declaration that describes nothing the machine reaches.
+//!
+//! `int_fields` and `ref_fields` are consulted by key — `"StructType::field"`,
+//! built from the *declared* type of the base an access goes through, not from
+//! the runtime object. A key naming a struct no access site is typed as
+//! therefore matches nothing, emits nothing, and is silently accepted.
+//!
+//! Both halves of that are the problem. The entry contributes no descr width,
+//! so it is dead; and `field_scalar_tokens`' `const _: fn(&S) -> T` witness is
+//! emitted only on a match, so the claim it makes about the field is never
+//! checked either. Measured on a real consumer: 36 entries declaring a `u32`
+//! field as `u8` compiled clean, while the same misdeclaration on a key that
+//! *is* consulted produced 13 `E0308`s. An unconsulted entry is not merely
+//! untidy — it is a false statement the build agrees to.
+//!
+//! `pool_arrays` already rejects a base name that resolves to no `ref(_)`
+//! state field. This is that check's missing sibling, reporting rather than
+//! rejecting for the reason the gate's own message gives.
+
+use majit_metainterp::{Assembler, JitDriver};
+
+#[repr(C)]
+struct Cell {
+    /// Consulted: the machine reads it through a `ref(Cell)` state field.
+    count: u32,
+}
+
+/// Never the declared type of any access base in this machine. A key naming it
+/// cannot match, whatever it claims about the field.
+#[repr(C)]
+#[allow(dead_code)]
+struct Unreached {
+    count: u32,
+}
+
+struct CellState {
+    cell: usize,
+    total: i64,
+    ticks: i64,
+}
+
+pub type Bytecode = [u8];
+
+const OP_READ: u8 = 1;
+const OP_TICK: u8 = 2;
+const OP_HALT: u8 = 3;
+
+#[majit_macros::jit_interp(
+    state = CellState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        cell: ref(Cell),
+        total: int,
+        ticks: int,
+    },
+    int_fields = {
+        // Consulted: `state.cell.count` is an access through `ref(Cell)`.
+        Cell::count => u32,
+        // Not consulted, and deliberately a lie about the width: `Unreached`
+        // is never an access base, so the key never matches and the witness
+        // that would reject `u8` is never emitted.
+        Unreached::count => u8,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_cell(program: &Bytecode, threshold: u32, cell: usize, ticks: i64) -> i64 {
+    let mut driver: JitDriver<CellState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = CellState {
+        cell,
+        total: 0,
+        ticks,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_READ => {
+                state.total = state.total + state.cell.count as i64;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_HALT => {
+                break;
+            }
+            _ => break,
+        }
+    }
+    state.total
+}
+
+fn install() {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    __prebuild_jitcode_liveness_dispatch_cell(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    let _ = __dispatch_jitcode_dispatch_cell(&mut asm, 0i64).expect("dispatch lower must succeed");
+}
+
+fn keys() -> Vec<String> {
+    install();
+    majit_metainterp::unconsulted_field_declarations()
+        .into_iter()
+        .filter(|e| e.interp == "CellState")
+        .map(|e| e.key.to_string())
+        .collect()
+}
+
+/// The subject, with its control beside it.
+///
+/// The control is not decoration: an empty report and a report of *everything*
+/// look the same from the subject alone, and a key set that listed `Cell::count`
+/// too would mean the consultation is never recorded rather than that this
+/// declaration is unused.
+#[test]
+fn a_declaration_no_access_site_consults_is_reported() {
+    let keys = keys();
+    assert!(
+        keys.iter().any(|key| key == "Unreached::count"),
+        "a key naming a struct no access is typed as matched nothing and \
+         emitted nothing, including the witness that would have caught its \
+         `u8`; keys={keys:?}",
+    );
+    assert!(
+        !keys.iter().any(|key| key == "Cell::count"),
+        "control: `state.cell.count` is a real access through `ref(Cell)`, so \
+         its declaration is consulted. If this fails the recording is firing \
+         for every key and the subject above means nothing; keys={keys:?}",
+    );
+}
+
+/// The gate must separate its two failures, and name the third possibility.
+///
+/// An unconsulted key is a stale declaration OR a live one whose only arm
+/// refused to lower. The message carries the degraded arms for that reason —
+/// a reader who cannot tell those apart will delete a declaration that is
+/// still needed.
+#[test]
+fn the_gate_reports_the_declaration_and_the_degraded_arms_together() {
+    install();
+
+    let failure = std::panic::catch_unwind(|| {
+        majit_metainterp::assert_no_unconsulted_field_declarations("CellState")
+    })
+    .expect_err("this fixture declares one unconsulted key on purpose");
+    let message = panic_message(&failure);
+    assert!(
+        message.contains("no access site consulted"),
+        "the gate must fail on the declaration; got {message:?}",
+    );
+    assert!(
+        message.contains("arms degraded"),
+        "…and must show the degraded arms beside it, since a key used only in \
+         a refused arm is unconsulted for a different reason; got {message:?}",
+    );
+
+    let uninstalled = std::panic::catch_unwind(|| {
+        majit_metainterp::assert_no_unconsulted_field_declarations("NoSuchState")
+    })
+    .expect_err("a machine that was never installed cannot be graded");
+    let uninstalled = panic_message(&uninstalled);
+    assert!(
+        uninstalled.contains("never installed"),
+        "an absent portal must fail on the denominator, not pass because its \
+         unconsulted list is empty; got {uninstalled:?}",
+    );
+}
+
+/// `#[jit_inline]` carries its own `int_fields` / `ref_fields`, and this is
+/// where the population is.
+///
+/// A machine declares a handful of keys; a consumer's helpers repeat theirs at
+/// every site, so a key matching nothing at one site matches nothing at dozens.
+/// The first version of this check covered only the `#[jit_interp]` portal and
+/// reported exactly one key on the consumer that motivated it, while the 36
+/// entries it was written for sat on the other surface untouched — the same
+/// asymmetry these two macros produce on every input.
+#[majit_macros::jit_inline(
+    ref_params = {
+        cell: ref(Cell),
+    },
+    int_fields = {
+        Cell::count => u32,
+        Unreached::count => u8,
+    },
+)]
+fn bump_cell(cell: usize) {
+    cell.count = cell.count + 1u32;
+}
+
+#[test]
+fn an_inline_helpers_own_declaration_is_reported_under_the_helper() {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![0], vec![]);
+    let _ = __majit_inline_jitcode_bump_cell_with_asm(&mut asm);
+
+    let keys: Vec<String> = majit_metainterp::unconsulted_field_declarations()
+        .into_iter()
+        .filter(|e| e.interp == "bump_cell")
+        .map(|e| e.key.to_string())
+        .collect();
+    assert!(
+        keys.iter().any(|key| key == "Unreached::count"),
+        "the helper's own unconsulted key must be reported under the helper's \
+         name, not the enclosing machine's; keys={keys:?}",
+    );
+    assert!(
+        !keys.iter().any(|key| key == "Cell::count"),
+        "control: `cell.count` is a real access through `ref(Cell)`; keys={keys:?}",
+    );
+}
+
+fn panic_message(payload: &Box<dyn std::any::Any + Send>) -> String {
+    payload
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| payload.downcast_ref::<&str>().map(|s| (*s).to_string()))
+        .unwrap_or_default()
+}

--- a/majit/majit-metainterp/tests/struct_layout_conflict.rs
+++ b/majit/majit-metainterp/tests/struct_layout_conflict.rs
@@ -1,0 +1,159 @@
+//! Two emit sites may describe one word differently, and nothing said so.
+//!
+//! `register_struct_layout` accumulates a struct's layout across the sites that
+//! touch it and dedups on the byte offset. An offset does not identify a field
+//! — a flattened inline aggregate and its first leaf share an address — so a
+//! second registration at a known offset is one of three things and only the
+//! first is benign: the same field again, a different field that happens to sit
+//! there, or the same field described differently.
+//!
+//! The first is the common case: every site re-registers what it accesses, so
+//! the same few type ids arrive hundreds of times. The other two were dropped
+//! on the floor, and both are silent in a way that outlives the build. A
+//! dropped sibling leaves the spec short an entry that `add_struct_field_descr`
+//! resolves `index_in_parent` and `name` against; a redescribed word gets the
+//! GC-pointer flag of whichever site emitted first, which is a property of
+//! emission order rather than of the struct.
+//!
+//! No compile-time witness can catch the second one. Stable Rust has no
+//! negative trait bound, so a declaration can state that a field it *names* is
+//! a pointer but not that a field it omits is not — `ref_field_witness_tokens`
+//! covers exactly the declared half. This is the mechanism for the other half,
+//! and it works by disagreement rather than by declaration.
+
+use majit_metainterp::{JitCodeBuilder, StructLayoutConflictKind};
+
+/// Distinct per test: the registry is process-global, so two tests sharing a
+/// type id would read each other's conflicts.
+const TID_AGREE: u64 = 0x4147_5245_4531;
+const TID_REDESCRIBED: u64 = 0x5245_4445_5343;
+const TID_SIBLING: u64 = 0x5349_424C_494E;
+
+fn conflicts_for(type_id: u64) -> Vec<majit_metainterp::StructLayoutConflict> {
+    majit_metainterp::struct_layout_conflicts()
+        .into_iter()
+        .filter(|c| c.type_id == type_id)
+        .collect()
+}
+
+/// The negative control, and it has to come with its own denominator.
+///
+/// "No conflict was reported" is what a check that never ran also produces, and
+/// a field at an offset nobody registered yet is appended without comparing
+/// anything. So this asserts the comparison count moved: the re-registration
+/// below really did meet the first one.
+#[test]
+fn a_site_re_registering_what_it_already_declared_is_not_a_conflict() {
+    let before = majit_metainterp::struct_layout_comparisons();
+    let mut builder = JitCodeBuilder::new();
+    let layout = &[(0, true, "head", 8, false), (8, false, "size", 8, true)][..];
+    // Two access sites on one struct, each re-declaring the whole layout —
+    // the shape `#[jit_interp]` emits, one call per getfield/setfield.
+    builder.register_struct_layout(16, TID_AGREE, false, false, layout);
+    builder.register_struct_layout(16, TID_AGREE, false, false, layout);
+    let _ = builder.finish();
+
+    assert!(
+        majit_metainterp::struct_layout_comparisons() >= before + 2,
+        "the second registration must have been compared against the first, or \
+         an empty conflict list below is vacuous",
+    );
+    assert_eq!(
+        conflicts_for(TID_AGREE),
+        vec![],
+        "identical re-registration is the common case and must stay silent",
+    );
+}
+
+/// A pointer word registered as a scalar by a second site.
+///
+/// This is what a field left out of one declaration's ref-field map produces.
+/// Both sites compile, both emit, and the collector traces through the word or
+/// does not depending on which site the assembler saw first.
+#[test]
+fn one_word_declared_a_pointer_and_a_scalar_is_a_conflict() {
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(
+        16,
+        TID_REDESCRIBED,
+        false,
+        false,
+        &[(0, true, "head", 8, false)],
+    );
+    builder.register_struct_layout(
+        16,
+        TID_REDESCRIBED,
+        false,
+        false,
+        &[(0, false, "head", 8, true)],
+    );
+    let _ = builder.finish();
+
+    let conflicts = conflicts_for(TID_REDESCRIBED);
+    assert_eq!(conflicts.len(), 1, "one disagreement: {conflicts:#?}");
+    let conflict = &conflicts[0];
+    assert_eq!(conflict.kind, StructLayoutConflictKind::Redescribed);
+    assert_eq!(conflict.offset, 0);
+    assert!(
+        conflict.kept.is_ref && !conflict.dropped.is_ref,
+        "the first registration is what the spec keeps: {conflict:#?}",
+    );
+}
+
+/// A real sibling at an occupied offset, which the offset-keyed dedup discards.
+///
+/// Registering both in ONE call keeps both — `field_specs_from_layout` does not
+/// dedup within a call, which is how a flattened aggregate and its first leaf
+/// both survive. Split across two calls, the second is dropped, and this is the
+/// only place that says so.
+#[test]
+fn a_sibling_at_an_occupied_offset_is_reported_as_dropped() {
+    let mut builder = JitCodeBuilder::new();
+    builder.register_struct_layout(24, TID_SIBLING, false, false, &[(8, false, "agg", 8, true)]);
+    builder.register_struct_layout(
+        24,
+        TID_SIBLING,
+        false,
+        false,
+        &[(8, true, "leaf", 8, false)],
+    );
+    let jitcode = builder.finish();
+    let _ = jitcode;
+
+    let conflicts = conflicts_for(TID_SIBLING);
+    assert_eq!(conflicts.len(), 1, "one dropped sibling: {conflicts:#?}");
+    let conflict = &conflicts[0];
+    assert_eq!(conflict.kind, StructLayoutConflictKind::DroppedSibling);
+    assert_eq!(conflict.kept.name, "agg");
+    assert_eq!(conflict.dropped.name, "leaf");
+}
+
+/// The gate's own two failures must read differently.
+///
+/// `assert_no_struct_layout_conflicts` is what a consumer calls, and it fails
+/// on an empty registry as well as on a populated one — an empty registry is
+/// also what a process that built no jitcodes produces. This test runs last in
+/// the file's order by name, but order is not what makes it correct: it asserts
+/// on the message, and the un-exercised message can only appear before any
+/// comparison has happened anywhere in the process.
+#[test]
+fn the_gate_reports_a_conflict_rather_than_passing_on_it() {
+    let mut builder = JitCodeBuilder::new();
+    const TID: u64 = 0x4741_5445_4441;
+    builder.register_struct_layout(16, TID, false, false, &[(0, true, "head", 8, false)]);
+    builder.register_struct_layout(16, TID, false, false, &[(0, false, "head", 8, true)]);
+    let _ = builder.finish();
+
+    let failure = std::panic::catch_unwind(majit_metainterp::assert_no_struct_layout_conflicts)
+        .expect_err("this fixture registers one word two ways on purpose");
+    let message = failure
+        .downcast_ref::<String>()
+        .cloned()
+        .or_else(|| failure.downcast_ref::<&str>().map(|s| (*s).to_string()))
+        .unwrap_or_default();
+    assert!(
+        message.contains("disagreed with the layout already recorded"),
+        "the gate must fail on the disagreement, not on its denominator; \
+         got {message:?}",
+    );
+}


### PR DESCRIPTION
Two gaps in the `#[jit_interp]` / `#[jit_inline]` macro surface, found by auditing what a consumer has to hand-write around.

## 1. `inline_int` / `inline_ref` / `inline_float` in statement position

Statement position and value position are lowered by two different functions. `lower_value.rs` has an arm for the three result-returning inline policies; `lower_stmt.rs` had one only for `inline_void`, so a helper registered `inline_int` and called for its effect reached the trailing `_ => return None`.

The two macro surfaces then diverge:

* `#[jit_inline]` reports `could not lower this helper into JitCode` and fails the build.
* `#[jit_interp]` degrades the enclosing dispatch arm to an abort stub, records it through `record_degraded_dispatch_arm`, and **builds clean** — every trace reaching that opcode aborts, once per threshold, forever, and the helper's stores never enter the trace.

`explicit_call_emits_post_live` already returns an answer for these three kinds, so the accounting said the policy was handled while the lowering did not handle it. The workaround is to bind the result to a `let _x` nothing reads, which makes the same source lower — so a machine that hit this looks like one that never did.

The new statement arm uses `alloc_reg()` for the destination the sub-jitcode's typed return needs, the way the discarded `ResidualInt` family below it already does; the rest is the value-position lowering.

## 2. A denominator for `degraded_dispatch_arms()`

`degraded_dispatch_arms()` is a numerator. An empty result reads as "no arm degraded" and as "no portal was ever built" at once, and only the first is a pass — the second is the same shape as the defect the registry exists to report, one level up. Every consumer gating on it therefore supplies its own proof that the portal was installed, and each supplies a different one.

`emit_dispatch_chain` now stages `record_dispatch_arm_census(state_type_name, n)` from the same admission test its emission loop uses, so an arm is counted exactly when a body is emitted for it. New API: `DispatchArmCensus`, `record_dispatch_arm_census`, `dispatch_arm_census`, and `assert_no_degraded_dispatch_arms(interp)`, which fails with one message when the portal was never installed and a different one when an arm degraded.

## Verification

* `jit_interp_discarded_inline_result.rs` — a `#[jit_interp]` machine with a discarding arm, a result-binding control arm, and a deliberately unlowerable arm as the registry's denominator. With the statement arm removed both subject assertions fail: `degraded=["OP_DISCARD_POP", "OP_ENCLOSED_BREAK"]`, and one helper splice instead of two.
* The splice count comes from the portal's sub-JitCode list, not from scanning bodies for `BC_INLINE_CALL`. Jitcode operands are bytes too, so a byte scan reports two inline calls even with the arm degraded to `[BC_ABORT]` — the first version of that assertion passed for exactly that reason.
* `jit_interp_inline_helper_typed_return.rs` — the `#[jit_inline]` half, where the same input previously failed the build.
* `jit_interp_ref_state_field.rs` — the success case for `assert_no_degraded_dispatch_arms`; a gate that panicked unconditionally would satisfy the two failure cases above.
* `cargo test -p majit-metainterp --features dynasm --no-fail-fast`: 29/29 binaries green. `cargo check --workspace --all-targets` RC=0. `cargo fmt --all --check` clean.

— *authored by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed discarded inline helper calls so they execute correctly in interpreted dispatch paths.
  * Improved validation for reference fields and pool-array declarations, including accurate item and length-field layouts.
  * Improved detection and reporting of degraded dispatch paths, unused declarations, and conflicting structure layouts.

* **Tests**
  * Added coverage for inline calls, stack mutations, field usage, pool-array layouts, dispatch tracking, and related diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->