### PR TITLE
jit: the exception-state leak behind test_pickle, plus three FOR_ITER/sub-walk fixes

### DIFF
--- a/pyre/extra_tests/parity_tests/exception_state_after_handler_return.py
+++ b/pyre/extra_tests/parity_tests/exception_state_after_handler_return.py
@@ -1,0 +1,32 @@
+# CPython-suite gap: `test_pickle` reaches this, but only as
+# `PyPicklingErrorTests.test_wrong_object_lookup_error` failing an
+# `assertIsNone(cm.exception.__context__)` several hundred tests after the load
+# that poisoned the state, so the suite reports it far from its cause.
+# parity-tests reason: `_Unpickler.load` returns from inside `except _Stop`, so
+# every load runs PUSH_EXC_INFO then POP_EXCEPT.  Once a bridge resumes into
+# that handler, PUSH_EXC_INFO's `prev` save read the exception the bridge was
+# resuming with instead of the execution context's slot, and the matching
+# POP_EXCEPT reinstated the just-handled `_Stop` as the thread's current
+# exception -- so the NEXT unrelated raise, anywhere, chained it as
+# `__context__`.
+
+import pickle
+
+
+def current_context():
+    """The exception a fresh raise would chain, i.e. the handled-exception slot."""
+    try:
+        raise ValueError("probe")
+    except ValueError as exc:
+        return exc.__context__
+
+
+payload = pickle._dumps(set(range(10)))
+
+for iteration in range(1, 3001):
+    loaded = pickle._loads(payload)
+    assert loaded == set(range(10)), (iteration, loaded)
+    context = current_context()
+    assert context is None, (iteration, repr(context))
+
+print("OK")

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1381,14 +1381,29 @@ pub(crate) fn reconstructed_all_ref_call_stack<Sym: WalkSym>(
             _ => return None,
         }
     }
-    for c in fresh {
+    // Only `null_or_self@1` may be null, and the layout above names it by
+    // index, so it is checked by position rather than by admitting a null
+    // anywhere.  Everything else here is a Python value the rewound `CALL`
+    // pops — an argument, or `kwnames` in the `call_kw` layout — and a null in
+    // one of those slots is an UNRESOLVED register, not a value: the concrete
+    // Ref bank holds `Ref(null)` for a box the walk never materialized, which
+    // is why `concrete_ref_for_color` tests for it and why the prefix loop
+    // above declines on it.  Publishing one lets the resumed interpreter pop a
+    // null where an object belongs.
+    for (index, c) in fresh.into_iter().enumerate() {
         match c {
-            ConcreteValue::Ref(r) => stack.push(r),
+            ConcreteValue::Ref(r) if index == NULL_OR_SELF_ARG_INDEX || !r.is_null() => {
+                stack.push(r)
+            }
             _ => return None,
         }
     }
     Some(stack)
 }
+
+/// `r_args` index of the `null_or_self` operand — the one slot of a residual
+/// call's Ref list whose correct value can be null.
+const NULL_OR_SELF_ARG_INDEX: usize = 1;
 
 /// Fold a keyword call's `kwnames`->parameter permutation at trace time so a
 /// `call_kw` reuses the positional inline path.  The constant `kwnames` tuple
@@ -3175,12 +3190,23 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 // that window resumes a frame whose callable slot was never
                 // written — `names(traceback)` in
                 // `synth/exception_reentry_guard_finally_residual` SIGSEGVs in
-                // `classify_callable` on a null callable.  No other deferred
-                // helper's result outlives the next op, so the loop header is
-                // only disqualifying together with that one residual.  The test
-                // is a superset of the failing shape: `names` also needs an
-                // in-window guard that actually fails, which a plain `self.attr`
-                // read folds away.
+                // `classify_callable` on a null callable.  The test is a
+                // superset of the failing shape: `names` also needs an in-window
+                // guard that actually fails, which a plain `self.attr` read
+                // folds away.
+                //
+                // ⚠️This pair is what disqualifies a CALLEE, and that is the
+                // whole of its licence — it is NOT that a method-load is the
+                // only deferred result outliving the next op, which this clause
+                // used to claim.  Measured counterexample: in
+                // `parity_tests/exception_handler_method_load_resume.py` the
+                // CALLER's `out.append(...)` leaves its `LOAD_ATTR name +
+                // NULL|self` pair on the stack across four opcodes, and the
+                // deopt did resume over the unwritten slot — the same SIGSEGV,
+                // through a caller this gate never examines.  What prevents it
+                // is the producer of the flush's operand image refusing to
+                // publish an unresolved null (`collect_call_stack_overrides`),
+                // not any admission test here.
                 let loop_header_admitted = !body_facts.owns_loop_header
                     || !fbw_callee_body_has_load_method_self_residual(body.code, callee_descr_refs);
                 foriter_deferred_admit = entry_is_call_boundary

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2470,7 +2470,11 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
     let saved_raw_descrs = ctx.raw_descrs;
     let saved_lookup = ctx.sub_jitcode_lookup;
     let saved_fbw_mode = ctx.fbw_mode;
-    let journal_before = fbw_store_journal_len();
+    // The odometer counts every journaled effect — a store, a list append/pop,
+    // a cell store — where the store journal counts only the first.  The
+    // rewind arm below reads it to decide whether this descent already applied
+    // something, the same question `latch_abort_call_resume` answers with it.
+    let effects_before = fbw_executed_effect_count();
     let unjournaled_before = fbw_has_unjournaled_effect();
     ctx.entry_py_pc = EntryPyPc::Jit(op.pc);
     ctx.outer_resume_marker_jit_pc = call_site_marker;
@@ -4269,7 +4273,13 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     // prologue's side effects a second time at trace time.  RPython's
     // `do_residual_call` runs the call exactly once (`pyjitpl.py`), so a
     // side-effecting prologue must decline the CA inline (see the arm).
-    let prologue_journal_before = fbw_store_journal_len();
+    //
+    // The odometer, not the store journal alone: a store, a list append/pop
+    // and a cell store each bump it, and the store journal counts only the
+    // first.  `latch_abort_call_resume` — the sibling that decides the same
+    // "did this sub-walk already run an effect" question for the abort latch —
+    // reads it for that reason.
+    let prologue_effects_before = fbw_executed_effect_count();
     // Compute fresh outer_active_boxes for the inline sub-walk when the
     // parent FBW walk carries an empty set (`dispatch_via_miframe`
     // initializes `outer_active_boxes: Vec::new()`; it is computed
@@ -5046,12 +5056,13 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
         }
         DispatchOutcome::SubLoopCalleeCallAssembler { token, target_pc } => {
             // CODEX1 parity: decline the CA inline when the prologue sub-walk
-            // mutated the heap (a journaled list store, or an unjournaled
+            // mutated the heap (any journaled effect the odometer counts — a
+            // store, a list append/pop, a cell store — or an unjournaled
             // effect newly set during the sub-walk).  Emitting the CA here
             // would re-run the whole call via the residual executor, applying
             // those side effects twice at trace time.  A side-effect-free
             // prologue (the common loop-setup-only case) still inlines.
-            if fbw_store_journal_len() > prologue_journal_before
+            if fbw_executed_effect_count() != prologue_effects_before
                 || (!unjournaled_before_subwalk && fbw_has_unjournaled_effect())
             {
                 return Err(DispatchError::callee_inline_unsupported(op.pc));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2523,7 +2523,7 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
         // the orthodox `w_list_append` descent does.  A descent that already
         // applied an effect cannot be rewound this way, so it keeps the abort.
         Err(DispatchError::OrthodoxSubWalkTraceUnsupported { pc, symbolic })
-            if fbw_store_journal_len() == journal_before
+            if fbw_executed_effect_count() == effects_before
                 && fbw_has_unjournaled_effect() == unjournaled_before =>
         {
             if fbw_inline_diag_enabled() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1294,13 +1294,21 @@ pub struct FbwWalkMode<Sym: WalkSym> {
     /// `CALL_ASSEMBLER` (`opimpl_recursive_call_assembler`) rather than
     /// re-unrolling the call tree to the multi-frame depth cap.
     pub carrier_resume: bool,
-    /// Bridge-entry view of `ExecutionContext.sys_exc_value` reconstructed
-    /// from the failing guard's pending setfield.  The walk is temporally
-    /// displaced from the guard failure, so live TLS is not a valid source
-    /// until a walked SETFIELD replaces this seed.
+    /// The exception a bridge resumes with, and after a walked
+    /// `set_current_exception` the value that store published.  Read by the
+    /// nullary bare-reraise folds, and by the PUSH_EXC_INFO `prev` save only
+    /// under [`FbwWalkMode::current_exception_seed_from_walk_store`].
     pub current_exception_seed: Option<OpRef>,
     /// Concrete shadow paired with [`FbwWalkMode::current_exception_seed`].
     pub current_exception_seed_concrete: pyre_object::PyObjectRef,
+    /// Whether [`FbwWalkMode::current_exception_seed`] names a value this walk
+    /// stored into `ExecutionContext.sys_exc_value`, as opposed to the
+    /// exception the bridge is resuming with.  Only the former answers "what
+    /// does that field hold": the bridge's in-flight exception is the one a
+    /// handler's `PUSH_EXC_INFO` is about to publish, so saving it as that
+    /// opcode's `prev` makes the matching `POP_EXCEPT` reinstate the exception
+    /// the handler just finished with.
+    pub current_exception_seed_from_walk_store: bool,
     /// Walker-carried mirror of
     /// `MetaInterp.class_of_last_exc_is_const` (`pyjitpl.py`).
     /// This is shared logically across recursive MIFrame walks; catch routing
@@ -1361,6 +1369,7 @@ impl<Sym: WalkSym> Default for FbwWalkMode<Sym> {
             carrier_resume: false,
             current_exception_seed: None,
             current_exception_seed_concrete: pyre_object::PY_NULL,
+            current_exception_seed_from_walk_store: false,
             class_of_last_exc_is_const: false,
             bridge_entry_merge_pc: None,
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -12042,11 +12042,28 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
         if !r_args.is_empty() || dst_bank != 'r' {
             return Ok(None);
         }
-        let (prev, prev_obj) = if let Some(seed) = ctx.fbw_mode.current_exception_seed {
-            // resume.py applies pending fields before resumed
-            // execution.  Bridge tracing does not mutate the live EC, so use
-            // the decoded fieldbox directly; a runtime GETFIELD here would
-            // read the pre-guard TLS value before the bridge applies anything.
+        // Two Python instructions lower to this helper, and they want
+        // different things from a bridge seed.  A bare `raise` / `RERAISE` wants
+        // the exception the bridge is resuming with — the compiled loop is free
+        // to elide its `sys_exc_value` store (a balanced save/store/restore
+        // DCEs), so the live slot is not a source there and only the seed
+        // names the exception to re-raise.  `PUSH_EXC_INFO`'s `prev` save wants
+        // the field itself, and at a bridge that resumes AT the handler the
+        // seed is the exception this opcode is two ops away from publishing:
+        // saving it as `prev` makes the matching `POP_EXCEPT` reinstate the
+        // exception the handler just finished with.  Read the live slot for
+        // that one — `_prepare_pendingfields` (state.rs, its `execute` block)
+        // runs every decoded pending write through `bh_setfield_gc_r` at bridge
+        // entry, so the slot is current.  A seed this walk stored itself is a
+        // view of the field either way, and reusing its OpRef keeps the
+        // save/store/restore triple balanced.
+        let seed_answers_this_read = ctx.fbw_mode.current_exception_seed_from_walk_store
+            || super::recording_instruction_is_bare_reraise(ctx, op.pc);
+        let (prev, prev_obj) = if let Some(seed) = ctx
+            .fbw_mode
+            .current_exception_seed
+            .filter(|_| seed_answers_this_read)
+        {
             (seed, ctx.fbw_mode.current_exception_seed_concrete)
         } else {
             let Some(ec) = walker_ensure_execution_context(ctx) else {
@@ -12159,6 +12176,7 @@ pub(crate) fn try_walker_lower_exc_info_residual<Sym: WalkSym>(
     pyre_interpreter::eval::set_current_exception(store_concrete);
     ctx.fbw_mode.current_exception_seed = Some(store_op);
     ctx.fbw_mode.current_exception_seed_concrete = store_concrete;
+    ctx.fbw_mode.current_exception_seed_from_walk_store = true;
     Ok(Some(()))
 }
 

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -474,8 +474,13 @@ pub(crate) fn range_foriter_demoted(key: u64) -> bool {
 /// re-failure).  `handle_fail` calls this only after confirming the failing
 /// descr carries the range marker (`Descr::range_foriter_green_key`), so an
 /// unrelated body guard at the same loop can never demote the site.
-pub fn range_foriter_demote_once(green_key: u64) -> bool {
-    RANGE_FORITER_DEMOTED.with(|s| s.borrow_mut().insert(green_key))
+///
+/// `site_key` is the key the marker carries — the FOR_ITER's own
+/// `make_green_key(w_code, foriter_start_pc)`, which is what
+/// [`range_foriter_demoted`] is later asked about before the site specializes
+/// again.  It is not the key the failing trace was entered at.
+pub fn range_foriter_demote_once(site_key: u64) -> bool {
+    RANGE_FORITER_DEMOTED.with(|s| s.borrow_mut().insert(site_key))
 }
 
 fn midbody_post_marker_is_effect_free(code: &CodeObject, start_pc: usize) -> bool {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9053,8 +9053,19 @@ fn handle_fail(
     // before `should_bridge` can spend another retrace-limit cycle trying to
     // close a bridge at the same failing loop header; blackhole resumes this
     // invocation without the invalidated compiled loop.
-    if descr_arc.range_foriter_green_key().is_some()
-        && pyre_jit_trace::trace::range_foriter_demote_once(green_key)
+    //
+    // The demotion registry is keyed on the FOR_ITER SITE, which is what the
+    // marker carries and what `walker_foriter_green_key` reads back before
+    // specializing again — `make_green_key(w_code, foriter_start_pc)` for the
+    // FOR_ITER the guard protects, not for the loop this trace was entered at.
+    // Those differ whenever the specialized FOR_ITER is not the entry header
+    // itself (an inner loop inside a trace entered at an outer one), and
+    // demoting under the entry key would leave the polymorphic site
+    // specialized — re-failing forever — while retiring an innocent one.  The
+    // token surgery below stays on `green_key`: the trace to discard is the
+    // one that just failed.
+    if let Some(site_key) = descr_arc.range_foriter_green_key()
+        && pyre_jit_trace::trace::range_foriter_demote_once(site_key)
     {
         let (driver, _) = driver_pair();
         driver.invalidate_loop(green_key);


### PR DESCRIPTION
## The exception-state leak

`test.test_pickle` was red on the `CPython suite (gate)` job:
`PyPicklingErrorTests.test_wrong_object_lookup_error` failing
`assertIsNone(cm.exception.__context__)` with `_Stop({0, ..., 9})` — an
exception left over from an unrelated `pickle._loads` several hundred tests
earlier.

`try_walker_lower_exc_info_residual`'s `GetCurrentException` arm answered every
`get_current_exception` from `fbw_mode.current_exception_seed`, which a bridge
walk seeds from `sym.last_exc_box` — the exception the bridge is resuming with,
not a view of `ExecutionContext.sys_exc_value`. Two Python instructions lower to
that helper and they want different things from it:

* a bare `raise` / `RERAISE` wants the resumed exception and **cannot** read the
  field — a balanced save/store/restore of `sys_exc_value` is dead-store
  eliminated, so a compiled loop need not have written it;
* `PUSH_EXC_INFO`'s `prev` save wants the field itself.

At a bridge that resumes at a handler, `prev` was therefore saved as the
exception `PUSH_EXC_INFO` publishes two ops later, and the matching `POP_EXCEPT`
reinstated it as the thread's current exception. From that point every later
raise anywhere in the thread chained the handled exception as `__context__`,
permanently: each subsequent handler faithfully saves and restores the poisoned
value.

The fix splits the two consumers on `recording_instruction_is_bare_reraise`,
which already maps a jitcode pc back to its containing Python instruction. The
bare-reraise lowering keeps the seed; `PUSH_EXC_INFO` reads the live slot unless
the seed is one this walk stored there. `_prepare_pendingfields` runs every
decoded pending write through `bh_setfield_gc_r` at bridge entry, so the live
slot is current on a bridge.

Gating the seed without that split keeps `synth/exception_bare_reraise_nested_outer`
correct but takes it from 0.09s to 34.6s (guard_failures 401 to 2 290 538,
loops_aborted 0 to 11451); with the split it stays at 0.11s.

`parity_tests/exception_state_after_handler_return.py` drives `pickle._loads`,
whose `_Unpickler.load` returns from inside `except _Stop`. It fails at
iteration 979 without the fix.

## The other three commits

* `admit a null only in the residual call's null_or_self slot` — the positional
  null guard in `reconstructed_all_ref_call_stack`; a null in any other slot is
  an unresolved register, not a value.
* `count every journaled effect in the two sub-walk rewind guards` — a list
  append/pop or a cell store bumps the executed-effect odometer without touching
  the store journal, so a sub-walk carrying one read as effect-free and its work
  was re-run.
* `demote the range FOR_ITER site under the key its marker carries` — the marker
  descr's site key, not the trace's entry key.

`restore the rewind arm's odometer read dropped in the rebase` repairs a hunk the
rebase onto `origin/main` lost.

## Verification

| gate | result |
| --- | --- |
| `pyre/check.py --backend dynasm` | 427/427 |
| `pyre/check.py --backend cranelift` | 427/427 |
| `pyre/extra_tests/parity_tests/run.py` | all pass |
| `cargo test -p pyre-jit-trace --features dynasm` | 0 failed |
| `test.test_pickle` (macOS, 3 runs) | 999 tests, OK — previously 1 failure |
| `test_copy`, `test_symtable` | OK, OK |

Base is `45d3ebaae6c`; `main` has moved on since.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q