### PR TITLE
jit: resume an aborted walk at the enclosing frame's own opcode boundary

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -3937,6 +3937,37 @@ mod tests {
             );
         }
 
+        /// `complex` arithmetic reaches the three interior-field loads in
+        /// generated helper JitCodes.  They already have orthodox
+        /// `bhimpl_getinteriorfield_gc_*` handlers; the production builder must
+        /// register their emitted bytes so `setup_insns` can bind them.
+        #[test]
+        fn production_bh_builder_wires_every_interior_field_load() {
+            use majit_translate::insns;
+            let builder = super::build_inline_call_only_bh_builder();
+            let placeholder = super::unwired_handler_placeholder as super::BhOpcodeHandler;
+            for (opname, byte) in [
+                (
+                    "getinteriorfield_gc_i/rid>i",
+                    insns::BC_GETINTERIORFIELD_GC_I,
+                ),
+                (
+                    "getinteriorfield_gc_r/rid>r",
+                    insns::BC_GETINTERIORFIELD_GC_R,
+                ),
+                (
+                    "getinteriorfield_gc_f/rid>f",
+                    insns::BC_GETINTERIORFIELD_GC_F,
+                ),
+            ] {
+                let slot = builder.dispatch_table[byte as usize];
+                assert_ne!(
+                    slot as usize, placeholder as usize,
+                    "`{opname}` (byte {byte}) is unwired in the production builder",
+                );
+            }
+        }
+
         /// The two `fnaddr` classifiers agree with the walker's gate.
         ///
         /// A symbolic hash carries the `SYMBOLIC_FNADDR_BASE` high-16-bit tag;
@@ -8752,6 +8783,18 @@ pub fn build_inline_call_only_bh_builder() -> BlackholeInterpBuilder {
     // / `new_with_vtable` read `bh.cpu`, which this builder sets above.
     for (key, byte) in [
         ("arraylen_gc/rd>i", majit_translate::insns::BC_ARRAYLEN_GC),
+        (
+            "getinteriorfield_gc_i/rid>i",
+            majit_translate::insns::BC_GETINTERIORFIELD_GC_I,
+        ),
+        (
+            "getinteriorfield_gc_r/rid>r",
+            majit_translate::insns::BC_GETINTERIORFIELD_GC_R,
+        ),
+        (
+            "getinteriorfield_gc_f/rid>f",
+            majit_translate::insns::BC_GETINTERIORFIELD_GC_F,
+        ),
         (
             "cast_float_to_int/f>i",
             majit_translate::insns::BC_CAST_FLOAT_TO_INT,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1505,6 +1505,24 @@ impl BlackholeInterpreter {
 
     fn run_inner(&mut self) -> Option<MergePointArgs> {
         let trace = crate::majit_log_enabled() || crate::bh_debug_enabled();
+        // blackhole.py:86-91:
+        //
+        // ```python
+        // if (not we_are_translated()
+        //     and self.jitcode._startpoints is not None):
+        //     assert position in self.jitcode._startpoints, (
+        //         "the current position %d is in the middle of "
+        //         "an instruction!" % position)
+        // ```
+        //
+        // The builder's `dispatch_loop` carries this check, but nothing
+        // production dispatches through it — this loop is the one that runs.
+        // Its subject is the resume coordinate somebody wrote into the frame,
+        // and without the check a coordinate pointing into an operand payload
+        // surfaces only as a bogus opcode byte, naming the dispatch table
+        // instead of the writer.  `jit_strict_mode` is the untranslated-build
+        // analog: debug builds plus `MAJIT_STRICT`.
+        let check_startpoints = crate::jit_strict_mode();
         loop {
             if self.finished() {
                 if trace {
@@ -1518,6 +1536,17 @@ impl BlackholeInterpreter {
             }
             let pos_before = self.position;
             self.last_opcode_position = pos_before;
+            if check_startpoints
+                && let Some(startpoints) = self.jitcode.startpoints.as_ref()
+            {
+                assert!(
+                    startpoints.contains(&pos_before),
+                    "run_inner: position {pos_before} is in the middle of an instruction \
+                     (jitcode {:?} index {:?})",
+                    self.jitcode.name,
+                    self.jitcode.try_index(),
+                );
+            }
             let opcode = self.next_u8();
             if trace {
                 eprintln!(
@@ -1602,13 +1631,21 @@ impl BlackholeInterpreter {
             // is `AttributeError` at builder-construction time.  pyre
             // hits this branch only when a builder has not registered
             // every BC_* it intends to emit.
+            // The jitcode NAME is not an identity — `__new__` names one jitcode
+            // per class — and a byte that is unwired here is just as likely to
+            // be an operand the frame was resumed in the middle of as an opname
+            // the builder forgot.  Report the index and whether the position is
+            // a recorded instruction boundary so the two read apart.
             panic!(
                 "dispatch_step: unwired opcode={opcode:#x} pos={} \
-                 table_len={} jitcode={:?} — extend the builder's \
-                 setup_insns to cover this opname",
+                 table_len={} jitcode={:?} index={:?} startpoint={} — extend the \
+                 builder's setup_insns to cover this opname",
                 self.last_opcode_position,
                 self.dispatch_table.len(),
                 self.jitcode.name,
+                self.jitcode.try_index(),
+                self.jitcode
+                    .is_valid_startpoint(self.last_opcode_position),
             );
         };
         // Clone the Arc to detach the `code` borrow from `self`, so the

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -1536,9 +1536,7 @@ impl BlackholeInterpreter {
             }
             let pos_before = self.position;
             self.last_opcode_position = pos_before;
-            if check_startpoints
-                && let Some(startpoints) = self.jitcode.startpoints.as_ref()
-            {
+            if check_startpoints && let Some(startpoints) = self.jitcode.startpoints.as_ref() {
                 assert!(
                     startpoints.contains(&pos_before),
                     "run_inner: position {pos_before} is in the middle of an instruction \
@@ -1644,8 +1642,7 @@ impl BlackholeInterpreter {
                 self.dispatch_table.len(),
                 self.jitcode.name,
                 self.jitcode.try_index(),
-                self.jitcode
-                    .is_valid_startpoint(self.last_opcode_position),
+                self.jitcode.is_valid_startpoint(self.last_opcode_position),
             );
         };
         // Clone the Arc to detach the `code` borrow from `self`, so the

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -3020,7 +3020,17 @@ pub fn walk<Sym: WalkSym>(
                     && !carrier_owned
                     && !abort_blackhole_latched()
                 {
-                    let _ = latch_abort_blackhole(ctx, error.stop_pc(), "mod2730");
+                    // The image belongs to THIS WalkContext's MIFrame, so its
+                    // resume coordinate must be this frame's opcode boundary.
+                    // A canonical helper is transparent: an error raised at
+                    // helper pc N propagates through `step`, but N indexes the
+                    // helper JitCode and is not a coordinate in this Python
+                    // frame's JitCode.  RPython keeps those as distinct
+                    // MIFrames; pairing the helper pc with the enclosing frame
+                    // lands `setposition` inside an operand payload.  Resume
+                    // the enclosing frame at the opcode whose step propagated
+                    // the abort instead.
+                    let _ = latch_abort_blackhole(ctx, opcode_position, "mod2730");
                 }
                 return Err(error);
             }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -152,6 +152,11 @@ pub(crate) struct LatchedSingleFrameBlackhole {
     /// `None` means the walk had no resolvable mirror, and the adopt then
     /// declines rather than publishing a partial stack.
     pub(crate) mirror_stack: Option<MirrorStackImage>,
+    /// Which latch published this image.  Every latch supplies the resume
+    /// coordinate from a different source, so an image that resumes at a
+    /// coordinate the jitcode cannot dispatch is only attributable once the
+    /// adopter can name its producer.
+    pub(crate) origin: &'static str,
 }
 
 pub(crate) struct LatchedMultiFrameBlackhole {
@@ -164,6 +169,8 @@ pub(crate) struct LatchedMultiFrameBlackhole {
     /// to the live red frame before the blackhole runs.  The vable-force path
     /// stops at a call resume marker and retains its existing handoff.
     pub(crate) publish_root_stack: bool,
+    /// Which latch published this image — see the single-frame counterpart.
+    pub(crate) origin: &'static str,
 }
 
 pub(crate) fn single_frame_blackhole_cell_ptr()
@@ -443,6 +450,7 @@ pub(crate) fn latch_abort_blackhole<Sym: WalkSym>(
                 last_exc_value,
                 raising_exception: false,
                 mirror_stack,
+                origin,
             });
         });
         true
@@ -468,6 +476,7 @@ pub(crate) fn latch_abort_blackhole<Sym: WalkSym>(
                 // caller image captured at the outermost inline push, exactly
                 // where RPython keeps that root MIFrame's register bank.
                 mirror_stack: capture_root_parent_resume_stack(ctx),
+                origin,
             });
         });
         true
@@ -3493,6 +3502,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                                 last_exc_value,
                                 raising_exception,
                                 mirror_stack,
+                                origin: "escape-flush",
                             });
                         });
                     }
@@ -3537,6 +3547,7 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                             raising_exception,
                             publish_root_stack: false,
                             mirror_stack: None,
+                            origin: "escape-flush",
                         });
                     });
                 }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -2298,6 +2298,17 @@ mod tests {
     /// handler but no opname→byte entry, so the blackhole took
     /// `dispatch_step: unwired opcode=0xd9` on the abort path.  Both are now
     /// registered.
+    ///
+    /// The three `getinteriorfield_gc_*` loads left without the emitted set
+    /// growing: they are registered pre-emptively, not in response to an
+    /// observed panic naming one of them.  Their
+    /// `bhimpl_getinteriorfield_gc_*` handlers already existed and only the
+    /// opname→byte entry was missing — the same shape `new_array/id>r` was in
+    /// when it did panic, and the shape that surfaces as `dispatch_step:
+    /// unwired opcode` rather than a decode.  `BUILD_EMITTED_INSNS` records
+    /// only what the assembler emitted while analyzing this build's source
+    /// set, so absence from it is not by itself proof that no jitcode carries
+    /// the byte.
     #[test]
     fn production_bh_builder_overlay_only_gap_snapshot() {
         let builder = build_pyre_production_bh_builder();
@@ -2326,9 +2337,6 @@ mod tests {
             "convert_longlong_bytes_to_float/i>f",
             "gc_load_indexed_f/riiii>f",
             "gc_load_indexed_i/riiii>i",
-            "getinteriorfield_gc_f/rid>f",
-            "getinteriorfield_gc_i/rid>i",
-            "getinteriorfield_gc_r/rid>r",
             "getlistitem_gc_f/ridd>f",
             "getlistitem_gc_i/ridd>i",
             "getlistitem_gc_r/ridd>r",

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2336,6 +2336,20 @@ fn try_adopt_single_frame_blackhole(
         );
         return false;
     };
+    // Name the image's producer alongside its resume coordinate.  Each latch
+    // derives that coordinate from a different source, and one that lands
+    // inside an operand payload stays invisible until the drive decodes the
+    // payload byte as an opcode — arbitrarily far from the latch that wrote it.
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() || majit_metainterp::bh_debug_enabled() {
+        eprintln!(
+            "[s1-adopt] origin={} leg={commit_leg:?} jitcode={} name={:?} pc={} boundary={}",
+            latched.origin,
+            latched.miframe.jitcode.index(),
+            latched.miframe.jitcode.name,
+            latched.miframe.pc,
+            latched.miframe.jitcode.is_valid_startpoint(latched.miframe.pc),
+        );
+    }
     let jitcode_index = match i32::try_from(latched.miframe.jitcode.index()) {
         Ok(index) => index,
         Err(_) => {
@@ -2745,6 +2759,23 @@ fn try_adopt_multi_frame_blackhole(
         mfdbg!("no latched multi-frame image; single-frame adopt follows");
         return false;
     };
+    // Per-frame counterpart of the single-frame `[s1-adopt]` line: name the
+    // producer and check each level's resume coordinate against its OWN
+    // jitcode's instruction boundaries.  A level built from one frame's pc and
+    // another's jitcode only shows up here.
+    if crate::jitcode_dispatch::fbw_debug_abort_enabled() || majit_metainterp::bh_debug_enabled() {
+        for (index, frame) in latched.framestack.frames.iter().enumerate() {
+            eprintln!(
+                "[mf-adopt] origin={} leg={commit_leg:?} frame={index} jitcode={} name={:?} \
+                 pc={} boundary={}",
+                latched.origin,
+                frame.jitcode.index(),
+                frame.jitcode.name,
+                frame.pc,
+                frame.jitcode.is_valid_startpoint(frame.pc),
+            );
+        }
+    }
     let depth = latched.framestack.len();
     if ctx.virtualizable_info().is_none() {
         mfdbg!("no virtualizable_info");

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -2347,7 +2347,10 @@ fn try_adopt_single_frame_blackhole(
             latched.miframe.jitcode.index(),
             latched.miframe.jitcode.name,
             latched.miframe.pc,
-            latched.miframe.jitcode.is_valid_startpoint(latched.miframe.pc),
+            latched
+                .miframe
+                .jitcode
+                .is_valid_startpoint(latched.miframe.pc),
         );
     }
     let jitcode_index = match i32::try_from(latched.miframe.jitcode.index()) {


### PR DESCRIPTION
`test_numeric_tower` and `test_long` crashed under dynasm on linux. Both are
`dynasm: PASS` in `baseline.json`, so both were live gate regressions. One root
cause.

## Root cause

`run_sub_jitcode_walk` (`inline_call.rs`) runs a canonical helper with
`walk(sub_body.code, 0, &mut sub_wc)?`. The `?` propagates the helper's
`DispatchError` upward unchanged, so `error.stop_pc()` is a byte offset into the
**helper's** JitCode. The helper sets `transparent_helper_subwalk`, so it does
not latch its own image — the enclosing Python frame's `walk()` does, and it was
pairing that foreign offset with its own JitCode. `latch_abort_blackhole` →
`MIFrame::new(jitcode, pc)` → `setposition` then lands inside an operand
payload, and the blackhole later decodes a payload byte as an opcode.

The fix is one argument: pass `opcode_position` — the coordinate of the opcode
whose step propagated the abort — instead of `error.stop_pc()`.

## Both panics named something other than the defect

| test | panic | what it actually was |
|---|---|---|
| `test_numeric_tower` | `dispatch_step: unwired opcode=0x5 pos=18 … jitcode="__new__"` | byte 5 is the register operand of an `int_copy/i>i`; `pos=18` is the `stop_pc` of an `OrthodoxSubWalkTraceUnsupported` raised inside the helper |
| `test_long` | `blackhole.rs:6675 index out of bounds: the len is 0 but the index is 65` | that line is `bhhandler_f_i!(handler_cast_float_to_int, …)` — a JitCode with **zero** float registers handed byte 65 as a float register |

The jitcode's own metadata is what settles it: `startpoints` contains 17 and 20
but not 18, and `resulttypes` agrees.

## Measurement

ubuntu24-arm64 container, dynasm, `MAJIT_STRICT=1`:

| tree | `test_numeric_tower` | `test_long` |
|---|---|---|
| without the fix | **5/5 rc=101** | **3/3 rc=101** |
| with the fix | 5/5 rc=0 | 3/3 rc=0 |
| with the fix, diagnostics removed | 5/5 rc=0 | 3/3 rc=0 |

The third row rules out the diagnostics in this PR as the cause of the green.

Re-verified after rebasing onto `04498478b2b`, on a binary rebuilt from the
rebased tree (markers confirmed present in it, so this is not a stale artefact):
3/3 rc=0 for each target module, and the full suite reports **`CRASH 0`**.
`cargo test -p majit-metainterp --features dynasm` is green, which exercises the
new assertion under `debug_assertions`.

## Measurement

### Evidence that the defect is real and this PR removes it

Taken at the earlier merge-base `04498478b2b`, where both sides ran the same
`CPython suite (gate)` job on the same runner — main run 31860244817, branch run
31862581203:

| | PASS | FAIL | CRASH | regressions |
|---|---|---|---|---|
| main | 211 | 2 | **3** | 6 |
| this branch | **213** | 2 | **1** | 4 |

Main reproduced both panics with the exact messages this PR opens with
(`blackhole.rs:6675 index out of bounds: the len is 0 but the index is 65` and
`dispatch_step: unwired opcode=0x5 pos=18 jitcode="__new__"`); on the branch both
rows were gone. **Fixed: `test_long`, `test_numeric_tower`. Introduced: none** —
`PASS` +2 and `CRASH` −2 are accounted for entirely by those two rows.

### After rebasing onto current main

The branch has since been rebased onto a main that includes #1237, which fixed
the exception-state leak behind `test_pickle`. Re-verified on a binary rebuilt
from the rebased tree (LLBC re-extracted first):

- `test_numeric_tower` 3/3 rc=0, `test_long` 3/3 rc=0, under `MAJIT_STRICT=1`
- full suite: `PASS 212  FAIL 1  **CRASH 0**  IMPORTERROR 1`
- `cargo test --all --no-default-features --features dynasm`: 130 test binaries,
  7958 passed, 0 failed
- `cargo fmt --check`: clean

The three remaining rows are not this PR's:

| row | verdict |
|---|---|
| `test_str` | main's; `test_raiseMemError` asserts exact `sys.getsizeof` arithmetic, a per-platform quantity, and it is compared against the darwin `baseline.json` |
| `test_interpreters` | main's; same darwin-baseline comparison |
| `test_urllib2` | environmental to my local container — reproduces under `--no-jit`, and neither CI run has it |

`baseline.linux-aarch64.json` carries only two module entries, so nearly every
row on this host is really a row compared against the darwin baseline. Note also
that the local runner and CI run different populations (`215 to run` locally vs
`217 to run` on CI, which does not apply the host overlay).

### One thing I have not measured

#1237 also changed sub-walk code paths. Its `mod.rs` changes are elsewhere — the
residual call's `null_or_self` slot, the rewind guards' odometer read, and the
range `FOR_ITER` demotion key — so by inspection it does not touch the resume
coordinate this PR fixes. **I have not built current main without these commits
to confirm the two crashes still reproduce on it**, so "this PR is still
necessary" rests on that inspection rather than on a control run. Main's own
gate at this base settles it if it runs.

## Commits

1. **`jit: resume an aborted walk at the enclosing frame's own opcode boundary`**
   — the fix.

2. **`majit: wire the interior-field loads in the production blackhole builder`**
   — `BC_GETINTERIORFIELD_GC_I/_R/_F` sat on the unwired placeholder while
   `bhimpl_getinteriorfield_gc_*` handlers already existed. Kept separate
   deliberately: the A/B above shows both crashes reproduce and clear
   identically whether or not these three bytes are wired, so this is not part
   of the fix even though `BC_GETINTERIORFIELD_GC_F` happens to be byte 5.

3. **`majit, jit: fail a mid-instruction blackhole resume at the coordinate's writer`**
   — `blackhole.py:86-91` asserts `position in jitcode._startpoints` every
   dispatch iteration. The port sits in `BlackholeInterpBuilder::dispatch_loop`,
   whose only callers are `#[cfg(test)]`; the loop production runs is
   `run_inner`, which had no check. So a bad resume coordinate failed far from
   its writer, as a bogus opcode byte that accused the dispatch table.
   - `run_inner` now carries the assertion under `jit_strict_mode()` (debug
     builds plus `MAJIT_STRICT`). `debug_assert!` would be compiled out of the
     release builds these appear in.
   - The `dispatch_step` panic reports the jitcode index and startpoint
     membership. The name is not an identity — jitcodes 2639, 2648, 2649 and
     2650 are all named `__new__`, which is why the original panic could not be
     resolved to a jitcode.
   - The two latch structs carry the latch that produced them, and both
     adopters print origin / jitcode / pc / startpoint per frame under
     `PYRE_FBW_DEBUG_ABORT` or `MAJIT_BH_DEBUG`. Four latches supply that
     coordinate from four different sources.

## Note for review

`bridge_subwalk.rs`'s `"bridge1361"` latch still passes `error.stop_pc()` raw,
and unlike the site fixed here it carries no `!abort_blackhole_latched()` guard,
so it can overwrite a correct image. It is the same class. I did not change it:
there is no repro for it, and its own doc argues a decline there is unsound
because the sub-walk is the callee's one real execution. The assert added in
commit 3 is live across the whole CPython suite gate (`run.py` sets
`MAJIT_STRICT=1`), so that run is a standing probe for this and every other
site that writes a resume coordinate.

— *authored by Claude*
