### PR TITLE
_io write path: run signal handlers between partial writes, retry raw writes on EINTR

### DIFF
--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -15426,7 +15426,12 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             {
                 #[cfg(not(feature = "sandbox"))]
                 if crt_call!(libc::lseek(fd, 0, libc::SEEK_END)) < 0 {
-                    return Err(fd_errno_err(crt_errno()));
+                    // A pipe has no end to seek to, and opening one for append
+                    // is legal; only a real seek failure is an error.
+                    let errno = crt_errno();
+                    if errno != libc::ESPIPE {
+                        return Err(fd_errno_err(errno));
+                    }
                 }
                 #[cfg(feature = "sandbox")]
                 crate::host_seam::ops::lseek(fd, 0, libc::SEEK_END)
@@ -16291,15 +16296,26 @@ fn file_method_write(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
         {
             #[cfg(not(feature = "sandbox"))]
-            let n = {
+            let n = loop {
                 // `count` is `size_t` on Unix but `c_uint` on Windows.
                 let (n, errno) = crate::module::thread::call_external_function(|| unsafe {
                     libc::write(fd, bytes.as_ptr() as *const libc::c_void, bytes.len() as _)
                 });
-                if n < 0 {
-                    return Err(fd_io_err(std::io::Error::from_raw_os_error(errno)));
+                if n >= 0 {
+                    break n as i64;
                 }
-                n as i64
+                // `interp_fileio.py:433-442` `write_w`: a non-blocking fd that
+                // accepted nothing reports "not now" as None, which is what
+                // `BufferedWriter._raw_write` turns into a BlockingIOError
+                // carrying the count actually written.
+                if errno == libc::EAGAIN {
+                    return Ok(w_none());
+                }
+                // The same lines wrap `os.write` in `eintr_retry=True`: a write
+                // cut short by a signal runs the handler and is re-issued, so
+                // the interruption surfaces as whatever the handler raised
+                // rather than as `InterruptedError`.
+                eintr_retry(std::io::Error::from_raw_os_error(errno))?;
             };
             #[cfg(feature = "sandbox")]
             let n = crate::host_seam::ops::write(fd, &bytes)

--- a/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_random.rs
@@ -241,6 +241,10 @@ impl W_BufferedRandom {
             };
             self.write_pos += written as i64;
             self.raw_pos = self.write_pos;
+            // Partial writes can return successfully when interrupted by a
+            // signal (see write(2)).  Run signal handlers before blocking
+            // another time, possibly indefinitely.
+            super::checksignals()?;
         }
         self.writer_reset_buf();
         Ok(())
@@ -337,6 +341,9 @@ impl W_BufferedRandom {
                     }
                     Err(error) => return Err(error),
                 }
+                // Same partial-write rule as `writer_flush_unlocked`: run the
+                // handlers before the next call can block indefinitely.
+                super::checksignals()?;
             }
 
             if this.readable {

--- a/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
+++ b/pyre/pyre-interpreter/src/module/_io/buffered_writer.rs
@@ -19,10 +19,14 @@ pub(super) fn make_write_blocking_error(written: usize) -> crate::PyError {
     let Some(blocking) = crate::builtins::lookup_exc_class("BlockingIOError") else {
         return crate::PyError::os_error("write could not complete without blocking");
     };
+    // `interp_bufferedio.py:26-38` reads the saved errno here.  It may be
+    // nonsense when the raw `write` is a Python method that simply returned
+    // None, but a caller that asked for a non-blocking fd needs EAGAIN, and
+    // the only place it survives is the errno the failed syscall left.
     match crate::call::call_function_impl_result(
         blocking,
         &[
-            w_int_new(0),
+            w_int_new(crate::builtins::crt_errno() as i64),
             w_str_new("write could not complete without blocking"),
             w_int_new(written as i64),
         ],
@@ -213,6 +217,10 @@ impl W_BufferedWriter {
             };
             self.write_pos += written as i64;
             self.raw_pos = self.write_pos;
+            // Partial writes can return successfully when interrupted by a
+            // signal (see write(2)).  Run signal handlers before blocking
+            // another time, possibly indefinitely.
+            super::checksignals()?;
         }
         self.writer_reset_buf();
         Ok(())
@@ -297,6 +305,9 @@ impl W_BufferedWriter {
                     }
                     Err(error) => return Err(error),
                 }
+                // Same partial-write rule as `writer_flush_unlocked`: run the
+                // handlers before the next call can block indefinitely.
+                super::checksignals()?;
             }
 
             let remaining = data.len() - written;

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -79,6 +79,21 @@ pub(crate) fn unsupported_operation_type() -> PyObjectRef {
         .map_or(std::ptr::null_mut(), |&addr| addr as PyObjectRef)
 }
 
+/// `space.getexecutioncontext().checksignals()` as the buffered writer's
+/// partial-write loops call it (`interp_bufferedio.py:429`, `:914`).
+///
+/// wasm32 carries no `signal` module (`module/mod.rs`), and with no handler to
+/// run the retry has nothing to check for.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn checksignals() -> Result<(), crate::PyError> {
+    crate::module::signal::interp_signal::checksignals_now()
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn checksignals() -> Result<(), crate::PyError> {
+    Ok(())
+}
+
 /// `interp_iobase.py:unsupported` — construct the module-local
 /// `UnsupportedOperation`, preserving its OSError + ValueError MRO.
 pub(crate) fn unsupported(message: &str) -> crate::PyError {

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2336,13 +2336,28 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     .map_err(|_| crate::PyError::type_error("write() arg 2 must be bytes-like"))?;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
-                    let (ret, errno) = crate::module::thread::call_external_function(|| unsafe {
-                        libc::write(fd, data.as_ptr() as *const libc::c_void, data.len() as _)
-                    });
-                    if ret < 0 {
-                        return Err(errno_err(errno, ""));
+                    // interp_posix.py:375-385 `write`: the syscall sits inside
+                    // the `eintr_retry=True` loop, so an interrupted write runs
+                    // the pending signal handlers and is re-issued rather than
+                    // surfacing as `InterruptedError`.  The blocking guard is
+                    // scoped to the syscall alone: `checksignals` runs Python.
+                    loop {
+                        let (ret, errno) =
+                            crate::module::thread::call_external_function(|| unsafe {
+                                libc::write(
+                                    fd,
+                                    data.as_ptr() as *const libc::c_void,
+                                    data.len() as _,
+                                )
+                            });
+                        if ret >= 0 {
+                            break ret as i64;
+                        }
+                        crate::builtins::eintr_retry_with(
+                            std::io::Error::from_raw_os_error(errno),
+                            |e| errno_err(e.raw_os_error().unwrap_or(0), ""),
+                        )?;
                     }
-                    ret as i64
                 };
                 #[cfg(feature = "sandbox")]
                 let ret = crate::host_seam::ops::write(fd, &data)


### PR DESCRIPTION
Five porting gaps in the write path, all reproduced and fixed against a Linux
container rather than inferred from CI.

## `_io` buffered writer layer

- `writer_flush_unlocked` and the large-write bypass loop in both
  `W_BufferedWriter` and `W_BufferedRandom` re-issued the raw write without
  calling `space.getexecutioncontext().checksignals()`, which
  `interp_bufferedio.py:429` and `:914` do after every partial write. A write to
  a pipe whose reader only starts from a signal handler blocked forever — this
  is why `test_io` never finished.
- `make_write_blocking_error` passed 0 as the BlockingIOError errno where
  `interp_bufferedio.py:26-38` passes `rposix.get_saved_errno()`.
- Adds `_io::checksignals`, forwarding to `interp_signal::checksignals_now` and
  a no-op on wasm32, where `module/mod.rs` gates the signal module off.

## raw write layer

- `interp_fileio.py:433-442` `write_w` and `interp_posix.py:375-385` `write`
  both wrap their `os.write` in `eintr_retry=True`; both sites returned the
  OSError directly. `interp_posix.rs` already had the loop on `read` and
  `readinto`.
- `write_w` also answers EAGAIN with None. `W_BufferedWriter::raw_write` turns
  that into a BlockingIOError carrying the count written, but the raw layer
  never returned None, so that arm was unreachable.
- `interp_fileio.py:258-264` ignores ESPIPE from the `lseek(0, SEEK_END)` an
  append open performs; a pipe opened for append raised it.

The C and pure-Python variants needed separate fixes: `_io` reaches
`file_method_write`, `_pyio` reaches `os.write`.

## Verification

| | |
|---|---|
| Linux `test_io` | did not finish (1800 s timeout) → 667 tests in 207 s, errors 27 → 20 |
| failing-test name-set diff | 3 closed, 0 new |
| `CSignalsTest`/`PySignalsTest` `test_interrupted_write_retry_*` | 4/4 ok |
| Linux `test_signal` | 57 tests, 3 failures — unchanged |
| macOS `cargo test --workspace --features dynasm` | rc=0 |
| macOS `check.py --backend dynasm` | ALL PASSED 427/427 |
| macOS `check.py --backend cranelift` | 1 failed, see below |

The cranelift red is `synth/str_fstring` jit-stats `guard_failures 657 -> 658`.
An in-place control arm built from the base commit reproduces it identically, so
it is pre-existing on this machine and not from this branch. The darwin overlay
records 657, which is what the macos-latest runner produces; this machine
produces 658 on both arms. No baseline was re-recorded.

Verification was done at the pre-rebase base; the rebased tree is what CI sees.

## Not addressed

- The remaining `test_io` failures (66 failures / 20 errors) are unrelated
  feature gaps: pickle error message wording, `ResourceWarning` not emitted,
  no `euc_jis_2004` codec, destructor/GC semantics.
- `test_posix` still stops at import on a missing `os.SCHED_DEADLINE`.
- Roughly twenty more posix functions that upstream wraps in `eintr_retry=True`
  (`fsync`, `pread`, `pwrite`, `ftruncate`, `waitpid`, `fchmod`, …) are still
  unported. `interp_posix.rs` already carries seventeen such sites, so this has
  been an incremental effort; these are outside the failing path here.
- `baseline.json` records `test_io`, `test_posix` and `test_signal` as
  `IMPORTERROR`, which leaves them ungated on every host, so the CPython suite
  gate never runs them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frxb5NtzofeEgMFCgbEBjU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file and pipe writing reliability, including support for interrupted and non-blocking writes.
  * Preserved accurate error information when writes cannot proceed.
  * Added more responsive signal handling during buffered and large data writes.
  * Improved append-mode handling for pipe-based streams.
  * Updated POSIX writes to retry safely when interrupted and report other failures correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->