### PR TITLE
jit: drop the dead exception-bridge prologue and the unread walk-sym exception getters

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11513,13 +11513,18 @@ impl<M: Clone> MetaInterp<M> {
             // compile.py:753-781: GUARD_VALUE per-value hash.
             let index = (status >> Self::ST_SHIFT) as u32;
             let typetag = status & Self::ST_TYPE_MASK;
-            let raw = fail_values.get(index as usize).copied().unwrap_or(0);
-            let intval: i64 = match typetag {
-                Self::TY_INT => raw,
-                Self::TY_REF => raw,
-                Self::TY_FLOAT => raw,
-                _ => raw,
-            };
+            // compile.py:772-773 `else: assert 0, typetag`.
+            debug_assert!(
+                matches!(typetag, Self::TY_INT | Self::TY_REF | Self::TY_FLOAT),
+                "compile.py:772-773 assert 0, typetag: unknown typetag {typetag:#x}"
+            );
+            // compile.py:761-771 turns each tag into an integer before hashing:
+            // `cast_ptr_to_int` for TY_REF, and `longlong.gethash_fast` for
+            // TY_FLOAT, which is `longlong2float.float2longlong` on a 64-bit
+            // host (codewriter/longlong.py:28) — the double's raw bit pattern.
+            // `fail_values` already holds every slot as that raw word, so all
+            // three tags hash the stored value unchanged.
+            let intval: i64 = fail_values.get(index as usize).copied().unwrap_or(0);
             // compile.py:780-781: current_object_addr_as_int(self) * 777767777
             //   + intval * 1442968193
             (descr_addr as u64)
@@ -13613,50 +13618,6 @@ impl<M: Clone> MetaInterp<M> {
 
     pub fn is_force_token_armed(&self, token: u64) -> bool {
         self.backend.is_force_token_armed(GcRef(token as usize))
-    }
-
-    /// RPython pyjitpl.py:3101 _prepare_exception_resumption +
-    /// pyjitpl.py:3132 prepare_resume_from_failure parity.
-    ///
-    /// Emit SAVE_EXC_CLASS + SAVE_EXCEPTION + RESTORE_EXCEPTION at
-    /// the bridge trace start for exception guard bridges, then emit
-    /// GUARD_EXCEPTION (pyjitpl.py:3140-3147
-    /// `handle_possible_exception`).
-    ///
-    /// When the three SAVE/RESTORE ops are consecutive (no resume-data
-    /// virtual-reconstruction ops between them — the current pyre
-    /// state), `rewrite.rs::remove_bridge_exception` strips them,
-    /// leaving only the GUARD_EXCEPTION.  When pyre gains
-    /// resume-data replay (emitting NEW_WITH_VTABLE etc. between
-    /// SAVE and RESTORE), this method must be split into two phases
-    /// matching RPython's `_prepare_exception_resumption` (phase 1,
-    /// trace start) and `prepare_resume_from_failure` (phase 2,
-    /// after resume ops).
-    ///
-    /// Not on the live path: the bridge walker emits this sequence itself at
-    /// the bridge-entry frame state, where the GUARD_EXCEPTION it ends with
-    /// carries a snapshot.  The guard emitted here carries none, so it could
-    /// only ever serve a trace that gets discarded.
-    pub fn emit_exception_bridge_prologue(&mut self, exc_class: i64, exc_value: i64) {
-        let Some(ref mut ctx) = self.tracing else {
-            return;
-        };
-        let class_const = ctx.const_int(exc_class);
-        let value_const = ctx.const_int(exc_value);
-        let class_op = ctx.record_op(OpCode::SaveExcClass, &[class_const]);
-        let value_op = ctx.record_op(OpCode::SaveException, &[value_const]);
-        ctx.record_op(OpCode::RestoreException, &[class_op, value_op]);
-        // pyjitpl.py:3140-3147: after RESTORE_EXCEPTION, RPython calls
-        // execute_ll_raised(exception_obj) which sets last_exc_value,
-        // then handle_possible_exception() which emits GUARD_EXCEPTION.
-        // The guard tells the optimizer "this bridge starts with a known
-        // exception of class exc_class" — without it, the optimizer may
-        // incorrectly remove a later GUARD_NO_EXCEPTION.
-        if exc_class != 0 {
-            ctx.guard_exception(class_const, 0);
-        } else {
-            ctx.guard_no_exception(0);
-        }
     }
 
     /// Handle a guard failure: recover interpreter state using resume data.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/bridge_subwalk.rs
@@ -443,6 +443,20 @@ pub fn dispatch_via_miframe<Sym: WalkSym>(
             //   pending exc cell at runtime) → RESTORE_EXCEPTION → GUARD_EXCEPTION
             //   (`handle_possible_exception`; deopts on a class mismatch, and
             //   consumes/clears the pending exception cell on match).
+            //
+            // RPython splits this across two calls because resume-data replay
+            // runs between them: `_prepare_exception_resumption` records the
+            // two SAVEs at the trace start (`pyjitpl.py:3148` asserts the trace
+            // is still empty), and `prepare_resume_from_failure` records
+            // RESTORE_EXCEPTION only after the resume operations. That gap is
+            // the whole point of the SAVE/RESTORE pair — a bare
+            // GUARD_NO_EXCEPTION at the bridge start is removable by the
+            // optimizer (`pyjitpl.py:3132-3138`). pyre emits nothing between
+            // them today, so `remove_bridge_exception`
+            // (`majit-gc/src/rewrite.rs`, rewrite.py:988-1001) strips the
+            // consecutive triple and leaves the guard. Once pyre replays
+            // resume data here, this must split into the same two phases
+            // rather than stay one block.
             let class_op = wc.trace_ctx.save_exc_class();
             let value_op = wc.trace_ctx.save_exception();
             wc.trace_ctx.restore_exception(class_op, value_op);

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -2886,9 +2886,7 @@ pub trait WalkSym {
     fn set_last_exc_box(&mut self, value: OpRef);
     fn class_of_last_exc_is_const(&self) -> bool;
     fn set_class_of_last_exc_is_const(&mut self, value: bool);
-    fn current_exc_value(&self) -> pyre_object::PyObjectRef;
     fn set_current_exc_value(&mut self, value: pyre_object::PyObjectRef);
-    fn current_exc_box(&self) -> OpRef;
     fn set_current_exc_box(&mut self, value: OpRef);
     fn trace_built_exc(&self) -> &indexmap::IndexMap<OpRef, pyre_object::PyObjectRef>;
     fn trace_built_exc_mut(&mut self) -> &mut indexmap::IndexMap<OpRef, pyre_object::PyObjectRef>;
@@ -3081,18 +3079,8 @@ impl WalkSym for PyreSym {
     }
 
     #[inline]
-    fn current_exc_value(&self) -> pyre_object::PyObjectRef {
-        self.current_exc_value
-    }
-
-    #[inline]
     fn set_current_exc_value(&mut self, value: pyre_object::PyObjectRef) {
         self.current_exc_value = value;
-    }
-
-    #[inline]
-    fn current_exc_box(&self) -> OpRef {
-        self.current_exc_box
     }
 
     #[inline]


### PR DESCRIPTION
Follow-up to #1232. This round re-read the bridge/retrace surface against the
vendored RPython sources looking for more of what #1222 and #1232 fixed. **It
found no wrong-code defect.** What it did find is dead code that had drifted
away from the live path it documents, so that is what this PR removes.

## `emit_exception_bridge_prologue` was dead, and no longer matched the live path

`MetaInterp::emit_exception_bridge_prologue` had no callers. The live
exception-edge bridge builds the sequence itself in `bridge_subwalk`, via
`trace_ctx.save_exc_class()` / `save_exception()` / `restore_exception()`, which
record0 the two SAVEs exactly as `pyjitpl.py:3148-3149` does. The dead copy
passed the class and value as operands instead — a shape the backends'
`genop_save_exc_class` (result-only, no arglocs) would not accept — and cited
`optimizeopt/rewrite.rs` for `remove_bridge_exception`, which lives in
`majit-gc/src/rewrite.rs` (rewrite.py:988-1001).

It did carry one thing worth keeping: that RPython splits the sequence across
`_prepare_exception_resumption` and `prepare_resume_from_failure` because
resume-data replay runs between the SAVEs and the RESTORE, and that collapsing
them into one block is sound only while pyre emits nothing in that gap. That
note moves onto the live emitter, where the next reader will be standing.

## Two `WalkSym` accessors had no callers

`current_exc_value()` / `current_exc_box()` are gone. The setters and the fields
stay — `walk_active_sym_exc_roots` reads `sym.current_exc_value` directly as a
GC carrier, so the state is live even though these two getters never were.

## A per-typetag match with four identical arms

`must_compile_with_values` decoded the GUARD_VALUE typetag and then returned the
same expression for TY_INT, TY_REF, TY_FLOAT and the fallthrough.
compile.py:761-771 really does convert — `cast_ptr_to_int` for TY_REF,
`longlong.gethash_fast` for TY_FLOAT — but `gethash_fast` is
`longlong2float.float2longlong` on a 64-bit host (codewriter/longlong.py:28),
i.e. the double's raw bit pattern, which is what `fail_values` already holds for
every slot. So no arm needs a conversion. Replaced with that reasoning plus
compile.py:772-773's `assert 0, typetag`, so the next reader does not have to
re-derive it from the RPython side.

## What was checked and came back faithful

Recording this so the next pass starts further along rather than re-walking it:
`bridgeopt.py` serialize/deserialize on both sides of the class bitfield and the
heap/loopinvariant sections; `serialize_optheap`'s three skip conditions
(`get_descr_index() == -1`, `_lazy_set`, `parent_descr.is_object()`) and the
array side's `index >= 2**15`; the `ST_BUSY_FLAG` / `ST_TYPE_MASK` status machine
and `make_a_counter_per_value` across all four backends; `store_hash` (pyre
assigns per compiled fail-descr layout rather than at optimizer-emit time, and
both bridge paths are covered); `_copy_resume_data_from` and the
`ResumeGuardCopiedDescr` `prev` chase, including the blackhole resume;
`propagate_original_jitcell_token` against the retrace path, where
`combined_ops = partial.ops + body_ops` puts the prior front's LABEL inside the
trace so the token set and the LABEL set coincide; all seven `optimize_bridge`
exits, the `vs`-survives-`InvalidLoop` fallthrough on the retrace-limit retry,
and the `retraced_count` read and write both landing on `cell_token_key`; and
`record_loop_or_bridge`'s quasi-immutable dependency publication on the bridge
path.

## Verification

`pyre/check.py`, darwin arm64, all three backends:

    ALL PASSED: dynasm 435/435
    ALL PASSED: cranelift 435/435
    ALL PASSED: wasm 428/428
    ALL PASSED: 3/3 backend run(s)

Neither touched crate is in the LLBC extraction set, and the change is dead-code
removal plus comments, so no jitstats row can move — the green run is a
regression check, not a measurement.

— *authored by Claude*
