### PR TITLE
majit: slim and harden the compiled-code entry path

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -381,6 +381,31 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         can_move: Some(can_move_via_active_runtime),
         supports_guard_gc_type,
     });
+    // No `set_active_gc_deadframe_hooks` call here, and the omission is the
+    // decision, not an oversight.
+    //
+    // That table exists because a backend whose jitframes are libc blocks
+    // outside both generations has no way to make a held deadframe's interior
+    // refs visible to the collector once the compiled epilogue has popped the
+    // frame off the JF shadow stack; it must publish the set and have the
+    // collector walk it (`majit_gc::ActiveGcDeadFrameHooks`, and note the
+    // walk goes through `trace_libc_jitframe`). This backend's frames are
+    // ordinary GC objects — `run_compiled_code_inner` allocates them from the
+    // nursery under the registered JITFRAME type id — and
+    // `JitFrameDeadFrame::register_roots` registers the `jf_gcref` SLOT with
+    // `add_root` for exactly the window the deadframe is held. The collector
+    // then reaches the frame as it reaches any rooted object, and gets the
+    // moving case for free: a walker yields an address and cannot update the
+    // holder if the frame is copied, whereas a registered slot is rewritten.
+    // Publishing a walker as well would root the same frames twice through
+    // two mechanisms with different invariants.
+    //
+    // `ACTIVE_LIVE_DEADFRAME_WALKER` is ONE process-global slot, so leaving it
+    // untouched is also what lets a dynasm backend compiled into the same
+    // process keep its walker installed across a cranelift GC install. A
+    // future cranelift walker would have to reckon with that: installing one
+    // here would silently drop dynasm's, and the frames it dropped would go
+    // untraced rather than fail loudly.
     majit_gc::set_active_alloc_nursery_typed(Some(alloc_nursery_typed_via_active_runtime));
     majit_gc::set_active_alloc_nursery_headerless_no_collect(Some(
         alloc_nursery_headerless_no_collect_via_active_runtime,
@@ -3012,17 +3037,29 @@ fn take_call_assembler_deadframe_from_outputs(outputs: &[i64]) -> DeadFrame {
         .copied()
         .unwrap_or_else(|| panic!("missing call_assembler deadframe handle slot"))
         as u64;
+    take_call_assembler_deadframe_from_handle(handle)
+}
+
+fn take_call_assembler_deadframe_from_handle(handle: u64) -> DeadFrame {
     assert!(handle != 0, "missing call_assembler deadframe handle");
     take_call_assembler_deadframe(handle)
         .unwrap_or_else(|| panic!("unknown call_assembler deadframe handle {handle}"))
 }
 
-fn maybe_take_call_assembler_deadframe(fail_index: u32, outputs: &[i64]) -> Option<DeadFrame> {
+/// Takes the run's `JitExecResult` rather than an extracted output vector: the
+/// handle lives in exit slot 0 and the slots are still in the frame the run
+/// returned, so `llmodel.py:240-250`'s read-through-the-frame answers this
+/// without materialising the other slots first. The dispatch loops that call
+/// this reach it on every exit, and all but the sentinel one discard the
+/// vector unread.
+fn maybe_take_call_assembler_deadframe(fail_index: u32, exec: &JitExecResult) -> Option<DeadFrame> {
     if fail_index != CALL_ASSEMBLER_DEADFRAME_SENTINEL {
         return None;
     }
 
-    Some(take_call_assembler_deadframe_from_outputs(outputs))
+    Some(take_call_assembler_deadframe_from_handle(
+        exec.get_jf_int(0) as u64,
+    ))
 }
 
 fn actual_call_assembler_result_kind(descr: &dyn FailDescr) -> Result<u64, BackendError> {
@@ -3194,15 +3231,14 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
             &cur_fail_descrs,
             cur_num_ref_roots,
             cur_max_output_slots,
-            &current_inputs,
+            &FrameInputs::Ints(&current_inputs),
             attachments,
             cur_dispatch_key,
         );
         let fail_index = exec.fail_index;
         let direct_descr = exec.direct_descr.clone();
-        let outputs = exec.extract_outputs(cur_max_output_slots.max(1));
 
-        if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &outputs) {
+        if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &exec) {
             // `RegisteredLoopTarget` is always a root-loop entry; root
             // registers never set `source_guard`, so pass `None` directly.
             // Bridges carry their own `BridgeData.source_guard` and never
@@ -3219,6 +3255,11 @@ fn execute_registered_loop_target(target: &RegisteredLoopTarget, inputs: &[i64])
         let fail_descr_fd = as_fd(fail_descr);
         maybe_increment_fail_count(fail_descr_fd);
         if let Some(bridge) = fail_descr_bridge_ref(fail_descr_fd) {
+            // Extracted here rather than beside `fail_index`: the exits that
+            // reach the two returns below never read a slot vector, and the
+            // frame the slots live in stays valid for the whole arm
+            // (`llmodel.py:240-250`).
+            let outputs = exec.extract_outputs(cur_max_output_slots.max(1));
             if bridge.loop_reentry {
                 // loop_reentry: use raw fail_args (same as run_compiled_code
                 // bridge dispatch). rebuild_state_after_failure transforms
@@ -7436,6 +7477,75 @@ fn find_fail_descr_by_ptr(
     Some(cell.descr.clone())
 }
 
+/// The entry arguments, in whichever form the caller already holds them.
+///
+/// `llmodel.py:306-315` writes each argument straight into the fresh jitframe,
+/// unwrapping it per its kind at the point of the store — there is no list
+/// standing between the caller's arguments and the frame slots. `Values` is
+/// that loop: the metainterp hands `execute_token` its live values, and
+/// unwrapping them into an owned `Vec<i64>` first is a copy of every argument
+/// that upstream never makes. `Ints` is the already-raw form — a bridge's
+/// parent outputs, an external JUMP's carried slots, the int-only entries —
+/// which is raw precisely because it was read out of a frame.
+/// `OwnedInts` exists for the re-entry step of the dispatch loops, which reads
+/// the carried slots out of the frame it is leaving and must keep them past
+/// that frame.
+enum FrameInputs<'a> {
+    Ints(&'a [i64]),
+    OwnedInts(Vec<i64>),
+    Values(&'a [Value]),
+}
+
+impl FrameInputs<'_> {
+    #[inline]
+    fn len(&self) -> usize {
+        match self {
+            FrameInputs::Ints(ints) => ints.len(),
+            FrameInputs::OwnedInts(ints) => ints.len(),
+            FrameInputs::Values(values) => values.len(),
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// The raw word argument `index` occupies in a frame slot.
+    #[inline]
+    fn raw(&self, index: usize) -> i64 {
+        match self {
+            FrameInputs::Ints(ints) => ints[index],
+            FrameInputs::OwnedInts(ints) => ints[index],
+            FrameInputs::Values(values) => match values[index] {
+                Value::Int(v) => v,
+                Value::Float(v) => v.to_bits() as i64,
+                Value::Ref(r) => r.0 as i64,
+                Value::Void => 0,
+            },
+        }
+    }
+
+    /// `llmodel.py:306-315` — store every argument into consecutive frame
+    /// slots starting at `dst`.
+    ///
+    /// # Safety
+    /// `dst` must be writable for `self.len()` words.
+    #[inline]
+    unsafe fn write_into(&self, dst: *mut i64) {
+        for i in 0..self.len() {
+            unsafe { *dst.add(i) = self.raw(i) };
+        }
+    }
+
+    /// Materialise the raw words. For the rare paths that keep the arguments
+    /// past the call — the CALL_ASSEMBLER caller context — rather than only
+    /// storing them into the frame.
+    fn to_ints(&self) -> Vec<i64> {
+        (0..self.len()).map(|i| self.raw(i)).collect()
+    }
+}
+
 /// Result of `run_compiled_code` — RPython llmodel.py:328 parity.
 ///
 /// Instead of copying values out of jf_frame into Vec<i64>,
@@ -7490,7 +7600,7 @@ fn run_compiled_code(
     fail_descrs: &[DescrRef],
     num_ref_roots: usize,
     max_output_slots: usize,
-    inputs: &[i64],
+    inputs: &FrameInputs<'_>,
     attachments: &CpuDescrAttachments,
     dispatch_key: u32,
 ) -> JitExecResult {
@@ -7516,7 +7626,7 @@ fn run_compiled_code_inner(
     fail_descrs: &[DescrRef],
     num_ref_roots: usize,
     max_output_slots: usize,
-    inputs: &[i64],
+    inputs: &FrameInputs<'_>,
     attachments: &CpuDescrAttachments,
     dispatch_key: u32,
 ) -> JitExecResult {
@@ -7602,16 +7712,14 @@ fn run_compiled_code_inner(
     let jf_ptr = jf_gcref.0 as *mut i64;
 
     // llmodel.py:306-315: set arguments in frame
-    for (i, &val) in inputs.iter().enumerate() {
-        unsafe { *jf_ptr.add(header_words + i) = val };
-    }
+    unsafe { inputs.write_into(jf_ptr.add(header_words)) };
     if majit_ir::debug::have_debug_prints() {
-        let preview: Vec<i64> = inputs.iter().copied().take(10).collect();
+        let preview: Vec<i64> = (0..inputs.len().min(10)).map(|i| inputs.raw(i)).collect();
         majit_ir::debug::log_one("jit-running", &format!("pre-call-inputs {preview:?}"));
     }
     // Debug: verify first input (frame ptr) is valid
     if majit_verify_enabled() && !inputs.is_empty() {
-        let frame_ptr = inputs[0];
+        let frame_ptr = inputs.raw(0);
         if frame_ptr != 0 && (frame_ptr < 0x1000 || (frame_ptr as usize & 0x7) != 0) {
             majit_ir::debug::log_one(
                 "jit-backend",
@@ -8603,7 +8711,7 @@ impl CraneliftBackend {
     /// fails with a bridge, switch to the bridge trace and continue.
     /// When a bridge FINISH with loop_reentry fires, switch back to the
     /// main loop.
-    fn execute_with_inputs(compiled: &CompiledLoop, inputs: &[i64]) -> DeadFrame {
+    fn execute_with_inputs(compiled: &CompiledLoop, inputs: FrameInputs<'_>) -> DeadFrame {
         Self::execute_with_inputs_at_dispatch_key(compiled, inputs, 0)
     }
 
@@ -8614,7 +8722,7 @@ impl CraneliftBackend {
     /// the jitframe slots and skips the preamble.
     fn execute_with_inputs_at_dispatch_key(
         compiled: &CompiledLoop,
-        inputs: &[i64],
+        inputs: FrameInputs<'_>,
         dispatch_key: u32,
     ) -> DeadFrame {
         slice_x2_probe::arm_reporter();
@@ -8629,13 +8737,14 @@ impl CraneliftBackend {
         let mut cur_fail_descrs: Cow<'_, [DescrRef]> = Cow::Borrowed(&compiled.fail_descrs);
         let mut cur_num_ref_roots = compiled.num_ref_roots;
         let mut cur_max_output_slots = compiled.max_output_slots;
-        // Borrowed for the same reason `cur_fail_descrs` is: the loop only
-        // READS the entry inputs, and the one writer is the external-JUMP
-        // re-entry below, which brings its own owned vector. `run_compiled_code`
-        // copies these into the jitframe (`llmodel.py:306-315 set arguments in
-        // frame`), which is the copy upstream makes; the caller's slice already
-        // is the argument list, so copying it first was a second one.
-        let mut cur_inputs: Cow<'_, [i64]> = Cow::Borrowed(inputs);
+        // Held in whatever form the caller already has, for the same reason
+        // `cur_fail_descrs` is borrowed: the loop only READS the entry inputs,
+        // and the one writer is the external-JUMP re-entry below, which brings
+        // its own owned words. `run_compiled_code` stores these into the
+        // jitframe (`llmodel.py:306-315 set arguments in frame`), which is the
+        // one copy upstream makes; unwrapping the caller's values into a raw
+        // vector on the way in was a second one.
+        let mut cur_inputs: FrameInputs<'_> = inputs;
         // External-JUMP re-entry LABEL selector (host_reentry_dispatch_key);
         // 0 only for the initial entry — every external-JUMP re-entry,
         // including the first LABEL, selects its loader (label_block_id + 1).
@@ -8660,12 +8769,11 @@ impl CraneliftBackend {
             );
             let fail_index = exec.fail_index;
             let direct_descr = exec.direct_descr.clone();
-            let outputs = exec.extract_outputs(cur_max_output_slots.max(1));
 
             // CALL_ASSEMBLER deadframe interception.
-            if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &outputs) {
+            if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &exec) {
                 let _caller_ctx_guard = CallAssemblerCallerContextGuard::push(
-                    CallAssemblerCallerContext::from_compiled_loop(compiled, &cur_inputs),
+                    CallAssemblerCallerContext::from_compiled_loop(compiled, &cur_inputs.to_ints()),
                 );
                 return wrap_call_assembler_deadframe_with_caller_prefix(frame);
             }
@@ -8714,8 +8822,14 @@ impl CraneliftBackend {
                 cur_code_ptr = target_entry.code_ptr;
                 cur_fail_descrs = Cow::Owned(target_entry.fail_descrs.into_vec());
                 cur_num_ref_roots = target_entry.num_ref_roots;
+                // Extracted here, on the one arm that consumes it. Every other
+                // exit out of this loop returns the frame itself as the
+                // deadframe and reads its slots through the accessors
+                // (`llmodel.py:240-250`), so a vector taken beside `fail_index`
+                // was built and dropped unread on each of them.
+                cur_inputs =
+                    FrameInputs::OwnedInts(exec.extract_outputs(cur_max_output_slots.max(1)));
                 cur_max_output_slots = target_entry.max_output_slots;
-                cur_inputs = Cow::Owned(outputs);
                 continue;
             }
             // llgraph/runner.py:1200-1201 execute_finish → ExecutionFinished.
@@ -8766,15 +8880,14 @@ impl CraneliftBackend {
             &bridge.fail_descrs,
             bridge.num_ref_roots,
             bridge.max_output_slots,
-            bridge_inputs,
+            &FrameInputs::Ints(bridge_inputs),
             attachments,
             0, // bridge entry (br_table preamble slot)
         );
         let fail_index = exec.fail_index;
         let direct_descr = exec.direct_descr.clone();
-        let outputs = exec.extract_outputs(bridge.max_output_slots.max(1));
 
-        if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &outputs) {
+        if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &exec) {
             let _caller_ctx_guard = CallAssemblerCallerContextGuard::push(
                 CallAssemblerCallerContext::from_bridge_data(bridge, bridge_inputs),
             );
@@ -8797,6 +8910,9 @@ impl CraneliftBackend {
         maybe_increment_fail_count(fail_descr_fd);
 
         if let Some(next_bridge) = fail_descr_bridge_ref(fail_descr_fd) {
+            // Extracted on the one arm that feeds it forward; the FINISH and
+            // no-bridge exits above and below return the frame itself.
+            let outputs = exec.extract_outputs(bridge.max_output_slots.max(1));
             return Self::execute_bridge(
                 &next_bridge,
                 &outputs,
@@ -16484,17 +16600,8 @@ impl majit_backend::Backend for CraneliftBackend {
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
-        let mut inputs: Vec<i64> = Vec::with_capacity(compiled.num_inputs);
-        for arg in args {
-            inputs.push(match arg {
-                Value::Int(v) => *v,
-                Value::Float(v) => v.to_bits() as i64,
-                Value::Ref(r) => r.0 as i64,
-                Value::Void => 0,
-            });
-        }
 
-        Self::execute_with_inputs(compiled, &inputs)
+        Self::execute_with_inputs(compiled, FrameInputs::Values(args))
     }
 
     fn execute_token_with_dispatch_key(
@@ -16509,17 +16616,12 @@ impl majit_backend::Backend for CraneliftBackend {
             .expect("token has no compiled code")
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
-        let mut inputs: Vec<i64> = Vec::with_capacity(compiled.num_inputs);
-        for arg in args {
-            inputs.push(match arg {
-                Value::Int(v) => *v,
-                Value::Float(v) => v.to_bits() as i64,
-                Value::Ref(r) => r.0 as i64,
-                Value::Void => 0,
-            });
-        }
 
-        Self::execute_with_inputs_at_dispatch_key(compiled, &inputs, dispatch_key)
+        // `llmodel.py:306-315` unwraps each argument at the store into the
+        // frame slot, so the values go from the caller's list to the frame in
+        // one step. Handing them down as-is keeps that: the unwrapping now
+        // happens in `FrameInputs::write_into`, against the frame.
+        Self::execute_with_inputs_at_dispatch_key(compiled, FrameInputs::Values(args), dispatch_key)
     }
 
     fn supports_dispatch_key_entry(&self) -> bool {
@@ -16534,7 +16636,7 @@ impl majit_backend::Backend for CraneliftBackend {
             .downcast_ref::<CompiledLoop>()
             .expect("compiled data is not CompiledLoop");
 
-        Self::execute_with_inputs(compiled, args)
+        Self::execute_with_inputs(compiled, FrameInputs::Ints(args))
     }
 
     fn execute_token_ints_raw(
@@ -16586,16 +16688,19 @@ impl majit_backend::Backend for CraneliftBackend {
                 &cur_fail_descrs,
                 cur_num_ref_roots,
                 cur_max_output_slots,
-                &cur_inputs,
+                &FrameInputs::Ints(&cur_inputs),
                 attachments,
                 cur_dispatch_key,
             );
             let fail_index = exec.fail_index;
             let direct_descr = exec.direct_descr.clone();
+            // Kept eager here, unlike the dispatch loops above: this entry's
+            // whole contract is to hand back the raw exit slots, so every exit
+            // out of it reads the vector.
             let mut outputs = exec.extract_outputs(cur_max_output_slots.max(1));
 
             // CALL_ASSEMBLER deadframe interception — exits raw dispatch.
-            if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &outputs) {
+            if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &exec) {
                 let _caller_ctx_guard = CallAssemblerCallerContextGuard::push(
                     CallAssemblerCallerContext::from_compiled_loop(compiled, &cur_inputs),
                 );

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -8629,7 +8629,13 @@ impl CraneliftBackend {
         let mut cur_fail_descrs: Cow<'_, [DescrRef]> = Cow::Borrowed(&compiled.fail_descrs);
         let mut cur_num_ref_roots = compiled.num_ref_roots;
         let mut cur_max_output_slots = compiled.max_output_slots;
-        let mut cur_inputs = inputs.to_vec();
+        // Borrowed for the same reason `cur_fail_descrs` is: the loop only
+        // READS the entry inputs, and the one writer is the external-JUMP
+        // re-entry below, which brings its own owned vector. `run_compiled_code`
+        // copies these into the jitframe (`llmodel.py:306-315 set arguments in
+        // frame`), which is the copy upstream makes; the caller's slice already
+        // is the argument list, so copying it first was a second one.
+        let mut cur_inputs: Cow<'_, [i64]> = Cow::Borrowed(inputs);
         // External-JUMP re-entry LABEL selector (host_reentry_dispatch_key);
         // 0 only for the initial entry — every external-JUMP re-entry,
         // including the first LABEL, selects its loader (label_block_id + 1).
@@ -8709,7 +8715,7 @@ impl CraneliftBackend {
                 cur_fail_descrs = Cow::Owned(target_entry.fail_descrs.into_vec());
                 cur_num_ref_roots = target_entry.num_ref_roots;
                 cur_max_output_slots = target_entry.max_output_slots;
-                cur_inputs = outputs;
+                cur_inputs = Cow::Owned(outputs);
                 continue;
             }
             // llgraph/runner.py:1200-1201 execute_finish → ExecutionFinished.

--- a/majit/majit-backend-dynasm/src/frame.rs
+++ b/majit/majit-backend-dynasm/src/frame.rs
@@ -1,39 +1,58 @@
-/// jitframe.py / assembler.py frame parity:
-/// Stores saved values and descriptor reference from guard failure.
+//! jitframe.py / assembler.py frame parity:
+//! the deadframe a compiled run hands back, and the values read out of it.
+use std::sync::{OnceLock, RwLock};
+
+use majit_backend::jitframe::JitFrame;
 use majit_ir::DescrRef;
 use majit_ir::GcRef;
 
 /// Concrete data stored in DeadFrame by the dynasm backend.
+///
+/// **THE DEADFRAME IS THE JITFRAME.** `llmodel.py:240-250` obtains it by
+/// `lltype.cast_opaque_ptr(jitframe.JITFRAMEPTR, deadframe)` and reads
+/// `jf_guard_exc` / `jf_savedata` straight off it; `llmodel.py:298` allocates
+/// exactly one `malloc_jitframe` per `execute_token`, and `:323` returns that
+/// same object as the deadframe. So there is nothing to copy out of the frame
+/// and no second structure to describe it: this type is the cast, and the
+/// accessors below are the reads.
 ///
 /// `fail_descr` carries the metainterp class-distinct Arc identity
 /// (ResumeGuardDescr family for guards, DoneWithThisFrame*/
 /// ExitFrameWithExceptionDescrRef for FINISH exits).  FailDescr-trait
 /// operations on the descr go through `DescrRef::as_fail_descr`.
 pub struct FrameData {
-    /// Raw exit slot values.
-    pub(crate) raw_values: Vec<i64>,
+    /// The frame compiled code returned — the tip of `head`'s `jf_forward`
+    /// chain whenever `_check_frame_depth` reallocated on the way.
+    tip: *mut JitFrame,
+    /// Head of the chain this deadframe OWNS and frees on drop, or `None`
+    /// when the frames belong to somebody else. `Backend::force` mints a
+    /// deadframe over the frame of a compiled run that is still executing
+    /// (`llmodel.py:280-284 force` likewise returns that frame rather than a
+    /// copy), and freeing it there would pull the ground out from under the
+    /// caller.
+    owned_head: Option<*mut JitFrame>,
+    /// Number of slots the frame carries. Bounds the index space the
+    /// accessors answer for; an index past it reads 0.
+    num_slots: usize,
     /// Backend-local fail descriptor used for slot decoding / bridge data.
     pub(crate) fail_descr: DescrRef,
     /// Original `jf_descr` object identity when the exit used an attached
     /// metainterp descr (`DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`).
     pub(crate) latest_descr: Option<DescrRef>,
-    /// `jf_guard_exc` captured off the deadframe tip before the libc jitframe
-    /// chain is freed.  `cpu.grab_exc_value(deadframe)` (llmodel.py:240) reads
-    /// it back; the jitframe is gone by then, so the value is staged here.
-    ///
-    /// Held as a bare `GcRef` (not a registered GC root): exception instances
-    /// are `malloc_typed` Box-immortal today (interp_exceptions.rs:843-844), so the
-    /// pointer can never dangle.  The whole exception channel
-    /// (`ExceptionState.exc_value`, threaded as a raw `i64`) shares this
-    /// assumption; future GC-managed exceptions must root all of it, not just
-    /// this slot.
-    pub(crate) exc_value: GcRef,
 }
+
+// SAFETY: `tip` / `owned_head` are libc allocations owned solely by this value
+// for its whole lifetime (`owned_head`), or borrowed from a compiled run on
+// the same thread (`None`). They are never aliased for mutation. `DeadFrame`
+// requires `Send` on its payload, and `JitCellToken` already carries the same
+// single-JIT-thread promise for the descrs held beside them here.
+unsafe impl Send for FrameData {}
 
 impl std::fmt::Debug for FrameData {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FrameData")
-            .field("num_values", &self.raw_values.len())
+            .field("num_values", &self.num_slots)
+            .field("owns_frame", &self.owned_head.is_some())
             .field("fail_descr", &self.fail_descr.repr())
             .field(
                 "latest_descr",
@@ -44,31 +63,147 @@ impl std::fmt::Debug for FrameData {
 }
 
 impl FrameData {
-    pub fn new(
-        raw_values: Vec<i64>,
+    /// Take ownership of the jitframe chain `head` and present its tip as the
+    /// deadframe.
+    ///
+    /// # Safety
+    /// `head` must be a live chain of `register_libc_jitframe`-tracked frames
+    /// that no one else frees, `tip` must be a node of that chain, and the
+    /// compiled epilogue must already have popped every node off the JF shadow
+    /// stack.
+    pub unsafe fn owning(
+        head: *mut JitFrame,
+        tip: *mut JitFrame,
+        num_slots: usize,
         fail_descr: DescrRef,
         latest_descr: Option<DescrRef>,
-        exc_value: GcRef,
     ) -> Self {
+        register_live_deadframe(tip as usize);
         FrameData {
-            raw_values,
+            tip,
+            owned_head: Some(head),
+            num_slots,
             fail_descr,
             latest_descr,
-            exc_value,
+        }
+    }
+
+    /// Present `frame` as a deadframe without taking ownership of it.
+    ///
+    /// # Safety
+    /// `frame` must outlive the returned value.
+    pub unsafe fn borrowing(
+        frame: *mut JitFrame,
+        num_slots: usize,
+        fail_descr: DescrRef,
+        latest_descr: Option<DescrRef>,
+    ) -> Self {
+        FrameData {
+            tip: frame,
+            owned_head: None,
+            num_slots,
+            fail_descr,
+            latest_descr,
+        }
+    }
+
+    /// `llmodel.py:422-424 _decode_pos` — the jitframe slot logical failarg
+    /// `index` lives in, or `None` when the descr maps it nowhere.
+    ///
+    /// Indices past `rd_locs` fall through to identity slot indexing, which is
+    /// what the synthetic and out-of-range descrs the runner mints rely on.
+    fn slot_of(&self, index: usize) -> Option<usize> {
+        if index >= self.num_slots {
+            return None;
+        }
+        let descr = self.fail_descr.as_fail_descr()?;
+        if index < descr.rd_locs().len() {
+            crate::guard::decode_rd_loc_slot(descr, index)
+        } else {
+            Some(index)
         }
     }
 
     pub fn get_int(&self, index: usize) -> i64 {
-        self.raw_values.get(index).copied().unwrap_or(0)
+        match self.slot_of(index) {
+            Some(slot) => unsafe { crate::llmodel::get_int_value_direct(self.tip, slot) as i64 },
+            None => 0,
+        }
     }
 
     pub fn get_float(&self, index: usize) -> f64 {
-        let bits = self.raw_values.get(index).copied().unwrap_or(0) as u64;
-        f64::from_bits(bits)
+        f64::from_bits(self.get_int(index) as u64)
     }
 
     pub fn get_ref(&self, index: usize) -> GcRef {
-        let raw = self.raw_values.get(index).copied().unwrap_or(0);
-        GcRef(raw as usize)
+        GcRef(self.get_int(index) as usize)
+    }
+
+    /// `cpu.grab_exc_value(deadframe)` (llmodel.py:240-242) — read
+    /// `jf_guard_exc` off the frame. The exc=True failure-recovery stub staged
+    /// `pos_exc_value` there for must_save_exception guards; other guards
+    /// leave it NULL.
+    pub fn exc_value(&self) -> GcRef {
+        GcRef(unsafe { (*self.tip).jf_guard_exc })
+    }
+}
+
+impl Drop for FrameData {
+    fn drop(&mut self) {
+        let Some(head) = self.owned_head else {
+            return;
+        };
+        unregister_live_deadframe(self.tip as usize);
+        // jitframe.py:139-145 — when `_check_frame_depth`'s realloc slowpath
+        // fires, the outgrown frame's `jf_forward` links to its replacement
+        // (`dynasm_realloc_frame`), and every node in that chain was
+        // `register_libc_jitframe`'d. Walk it, reading `jf_forward` before
+        // freeing each node, so every frame is unregistered and freed exactly
+        // once. In the common no-realloc case the chain is one node.
+        let mut cur = head;
+        while !cur.is_null() {
+            let next = unsafe { (*cur).jf_forward };
+            majit_gc::shadow_stack::unregister_libc_jitframe(cur as usize);
+            // Frees the block base, which sits one header word behind `cur`.
+            unsafe { majit_backend::jitframe::free_off_gc_jitframe(cur) };
+            cur = next;
+        }
+    }
+}
+
+// ── live deadframes as GC roots ────────────────────────────────────────────
+
+/// Payload addresses of the jitframes currently held as deadframes.
+///
+/// Between a compiled run returning and its `FrameData` dropping, the frame is
+/// off the JF shadow stack — `gen_footer_shadowstack` pops it in the epilogue —
+/// but its interior `Ref` slots are still live, because that is the window in
+/// which the frontend reads them. Nothing else in the collector's root phase
+/// can see them, and majit has no conservative stack scan to fall back on, so
+/// the set is published to `majit-gc` through
+/// [`majit_gc::ActiveGcDeadFrameHooks`] and walked there as a root source.
+///
+/// Process-global rather than thread-local, matching
+/// `shadow_stack::register_libc_jitframe`'s own registry: a collection can run
+/// on a thread other than the one holding the deadframe, and a thread-local set
+/// would be invisible to it.
+static LIVE_DEADFRAMES: OnceLock<RwLock<indexmap::IndexSet<usize>>> = OnceLock::new();
+
+fn live_deadframes() -> &'static RwLock<indexmap::IndexSet<usize>> {
+    LIVE_DEADFRAMES.get_or_init(|| RwLock::new(indexmap::IndexSet::new()))
+}
+
+fn register_live_deadframe(addr: usize) {
+    live_deadframes().write().unwrap().insert(addr);
+}
+
+fn unregister_live_deadframe(addr: usize) {
+    live_deadframes().write().unwrap().swap_remove(&addr);
+}
+
+/// [`majit_gc::LiveDeadFrameWalkerFn`] for this backend.
+pub fn walk_live_deadframes(visit: &mut dyn FnMut(usize)) {
+    for &addr in live_deadframes().read().unwrap().iter() {
+        visit(addr);
     }
 }

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -307,6 +307,13 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
         can_move: Some(dynasm_can_move),
         supports_guard_gc_type,
     });
+    // The jitframe a compiled run returns stays alive as the deadframe until
+    // the frontend has finished reading it, and is off the JF shadow stack for
+    // that whole window. Publishing the set is what keeps its interior refs
+    // rooted; see `frame::LIVE_DEADFRAMES`.
+    majit_gc::set_active_gc_deadframe_hooks(majit_gc::ActiveGcDeadFrameHooks {
+        walk_live_deadframes: Some(crate::frame::walk_live_deadframes),
+    });
     majit_gc::set_active_alloc_nursery_typed(Some(dynasm_alloc_nursery_typed));
     majit_gc::set_active_alloc_nursery_headerless_no_collect(Some(
         dynasm_alloc_nursery_headerless_no_collect,
@@ -2983,41 +2990,15 @@ impl Backend for DynasmBackend {
             );
         }
 
-        // PyPy `llmodel.py:422-424 _decode_pos` parity: remap jitframe
-        // values via `descr.rd_locs[i]`.  Synthetic / out-of-range
-        // descrs fall back to identity slot indexing.
-        let rd_locs_len = descr_fd.rd_locs().len();
-        let mut raw_values: Vec<i64> = Vec::with_capacity(num_slots);
-        for i in 0..num_slots {
-            if i < rd_locs_len {
-                match crate::guard::decode_rd_loc_slot(descr_fd, i) {
-                    Some(slot) => {
-                        let val =
-                            unsafe { crate::llmodel::get_int_value_direct(result_jf, slot) as i64 };
-                        raw_values.push(val);
-                    }
-                    None => raw_values.push(0),
-                }
-            } else {
-                raw_values
-                    .push(unsafe { crate::llmodel::get_int_value_direct(result_jf, i) as i64 });
-            }
-        }
-
-        // grab_exc_value (llmodel.py:240): read jf_guard_exc off the deadframe
-        // tip before the libc jitframe chain is freed.  The exc=True
-        // failure-recovery stub (generate_quick_failure) staged pos_exc_value
-        // here for must_save_exception guards; FrameData carries it to
-        // `grab_exc_value` since the frame is gone after the free below.
-        let exc_value = GcRef(unsafe { (*result_jf).jf_guard_exc });
-
-        // The deadframe `result_jf` is the tip of `jf_ptr`'s `jf_forward`
-        // chain whenever `_check_frame_depth` realloc'd; free every frame in
-        // the chain (jitframe.py:139-145), not just the original head.
-        unsafe { Self::free_jitframe_chain(jf_ptr) };
-
+        // `llmodel.py:323 return ll_frame` — the deadframe IS the frame the
+        // run returned. `result_jf` is the tip of `jf_ptr`'s `jf_forward`
+        // chain whenever `_check_frame_depth` realloc'd; the whole chain is
+        // handed to the deadframe, which frees it (jitframe.py:139-145) when
+        // it drops rather than here. Every slot read, and `grab_exc_value`,
+        // then goes straight into the frame the way `llmodel.py:240-250` does
+        // — nothing is decoded eagerly and no copy of the frame is made.
         DeadFrame {
-            data: Box::new(FrameData::new(raw_values, descr, None, exc_value)),
+            data: Box::new(unsafe { FrameData::owning(jf_ptr, result_jf, num_slots, descr, None) }),
         }
     }
 
@@ -3166,22 +3147,17 @@ impl Backend for DynasmBackend {
         unsafe { (*frame).jf_descr = force_descr };
 
         let descr = self.fail_descr_arc_from_addr(force_descr);
-        let fail_descr = descr
+        let num_slots = descr
             .as_fail_descr()
-            .expect("force descriptor must implement FailDescr");
-        let raw_values = fail_descr
+            .expect("force descriptor must implement FailDescr")
             .fail_arg_types()
-            .iter()
-            .enumerate()
-            .map(|(index, _)| {
-                crate::guard::decode_rd_loc_slot(fail_descr, index)
-                    .map(|slot| unsafe { crate::llmodel::get_int_value_direct(frame, slot) as i64 })
-                    .unwrap_or(0)
-            })
-            .collect();
-        let exc_value = GcRef(unsafe { (*frame).jf_guard_exc });
+            .len();
+        // `llmodel.py:280-284 force` casts the resolved frame to a GCREF and
+        // returns it — the forced frame IS the deadframe, and it belongs to
+        // the compiled run that is still executing, so this deadframe borrows
+        // it rather than taking the chain over.
         Some(DeadFrame {
-            data: Box::new(FrameData::new(raw_values, descr, None, exc_value)),
+            data: Box::new(unsafe { FrameData::borrowing(frame, num_slots, descr, None) }),
         })
     }
 
@@ -3210,7 +3186,7 @@ impl Backend for DynasmBackend {
     /// must_save_exception guards (GUARD_EXCEPTION / GUARD_NO_EXCEPTION /
     /// GUARD_NOT_FORCED); other guards leave it NULL.
     fn grab_exc_value(&self, frame: &DeadFrame) -> GcRef {
-        frame.data.downcast_ref::<FrameData>().unwrap().exc_value
+        frame.data.downcast_ref::<FrameData>().unwrap().exc_value()
     }
 
     fn clear_stored_exception(&self) {

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -2210,6 +2210,18 @@ impl MiniMarkGC {
         } else {
             crate::shadow_stack::walk_jf_roots(&mut visit_jf_root);
         }
+        // The jitframes the backend is still holding as DEADFRAMES. A frame
+        // reaches this walk exactly when it has left the shadow stack — the
+        // compiled epilogue pops it before returning — and has not yet been
+        // freed, which is the window in which the frontend reads its slots.
+        // `llmodel.py:240-250` reads those slots straight out of the frame, so
+        // the interior refs are live for the whole window and nothing else in
+        // this phase can see them. See `ActiveGcDeadFrameHooks`.
+        crate::walk_active_live_deadframes(&mut |addr| {
+            crate::shadow_stack::trace_libc_jitframe(addr, &mut |slot_ptr| {
+                libc_jf_slots.push(slot_ptr);
+            });
+        });
         for slot_ptr in libc_jf_slots {
             let field_ref = unsafe { &mut *slot_ptr };
             self.drag_out_root(field_ref);
@@ -3341,6 +3353,18 @@ impl MiniMarkGC {
         } else {
             crate::shadow_stack::walk_jf_roots(&mut visit_jf_root);
         }
+        // Same source the minor-collection root phase reads; enumerated here
+        // too, so a root that exists for the collector is also a root this
+        // listing reports. A listing that omitted it would say an object is
+        // unreachable while the collector keeps it.
+        crate::walk_active_live_deadframes(&mut |addr| {
+            crate::shadow_stack::trace_libc_jitframe(addr, &mut |slot_ptr| {
+                let field_ref = unsafe { *slot_ptr };
+                if !field_ref.is_null() {
+                    result.push((field_ref, "deadframe_slot"));
+                }
+            });
+        });
 
         let mut visit_bh_root = |gcref: &mut GcRef| {
             result.push((*gcref, "blackhole_register"));

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -1699,6 +1699,71 @@ pub fn walk_active_extra_roots(visitor: &mut dyn FnMut(&mut GcRef)) {
     }
 }
 
+/// Hand the collector the payload address of every jitframe that is currently
+/// a live DEADFRAME, for the visitor to trace.
+pub type LiveDeadFrameWalkerFn = fn(&mut dyn FnMut(usize));
+
+global_hook!(static ACTIVE_LIVE_DEADFRAME_WALKER: LiveDeadFrameWalkerFn);
+
+/// Backend callbacks that expose GC roots which exist only between a compiled
+/// run returning and the frontend finishing with its result.
+///
+/// `llmodel.py:240-250` (`grab_exc_value` / `get_savedata_ref`) and
+/// `llmodel.py:298` (`malloc_jitframe`) together say that the deadframe IS the
+/// jitframe: `execute_token` allocates one JITFRAME, compiled code returns it,
+/// and every `cpu.get_*_value(deadframe, i)` is a cast plus a read out of that
+/// same object. Nothing is copied out and nothing else is allocated.
+///
+/// Upstream can hold the deadframe across arbitrary frontend work because the
+/// jitframe is an ordinary GC object and `deadframe` is an ordinary local in
+/// RPython code, so the translated stack map roots it for free. **A STRUCTURAL
+/// ADAPTATION IS NEEDED HERE, AND THIS TABLE IS IT.** majit's jitframes for
+/// the dynasm backend are libc allocations outside both the nursery and the
+/// old generation; the collector reaches them only where they appear on the JF
+/// shadow stack, and the compiled epilogue pops them from it before returning.
+/// So between the run returning and the deadframe being dropped, the frame's
+/// interior `Ref` slots are visible to nobody — and any allocation the
+/// frontend makes in that window can move the objects they point at. There is
+/// no conservative stack scan to fall back on.
+///
+/// The backend therefore publishes the set of deadframes it is holding, and
+/// the collector walks it as a root source alongside the shadow stack. It is a
+/// fn-pointer table rather than a registry owned by this crate for the same
+/// reason [`ActiveGcGuardHooks`] is: majit-gc must not know what a deadframe
+/// is, and the backend already owns the lifetime.
+#[derive(Clone, Copy, Default)]
+pub struct ActiveGcDeadFrameHooks {
+    /// Yields each live deadframe's jitframe payload address. Interiors are
+    /// walked with the tracer `shadow_stack::register_libc_jitframe_tracer`
+    /// installed, the same one the shadow-stack walk uses, so a frame reached
+    /// through this table and one reached on the stack are traced identically.
+    pub walk_live_deadframes: Option<LiveDeadFrameWalkerFn>,
+}
+
+/// Install the active backend's deadframe-root callbacks. Pass a default
+/// [`ActiveGcDeadFrameHooks`] to clear.
+pub fn set_active_gc_deadframe_hooks(hooks: ActiveGcDeadFrameHooks) {
+    ACTIVE_LIVE_DEADFRAME_WALKER.set(hooks.walk_live_deadframes);
+}
+
+/// Snapshot of the installed deadframe-root callbacks.
+pub fn active_gc_deadframe_hooks() -> ActiveGcDeadFrameHooks {
+    ActiveGcDeadFrameHooks {
+        walk_live_deadframes: ACTIVE_LIVE_DEADFRAME_WALKER.get(),
+    }
+}
+
+/// Visit the payload address of every jitframe currently held as a deadframe.
+///
+/// A no-op when no backend has installed a walker — which is also the state a
+/// backend that frees its jitframe before returning leaves this in, and is
+/// correct for it: such a backend holds no frame for the collector to root.
+pub fn walk_active_live_deadframes(visitor: &mut dyn FnMut(usize)) {
+    if let Some(f) = ACTIVE_LIVE_DEADFRAME_WALKER.get() {
+        f(visitor);
+    }
+}
+
 /// llmodel.py:541-546 `cpu.check_is_object(gcptr)` shim. Returns whether
 /// `gcref` is a `T_IS_RPYTHON_INSTANCE` (has `typeptr` at offset 0). When
 /// no backend has installed a callback, returns `false`.

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1724,6 +1724,36 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             }
         })
         .collect();
+    // Pairs the two halves above straight into the driver's entry buffer.
+    // Emitted under the same condition as `live_value_types_into` — without
+    // that override the type half falls back to an allocating default, which
+    // would leave this one allocating anyway.
+    let extract_live_values_into_override: TokenStream =
+        if num_ref_scalars > 0 || num_virt_arrays > 0 || num_float_scalars > 0 {
+            quote! {
+                fn extract_live_values_into(
+                    &self,
+                    _meta: &#meta_ty,
+                    out: &mut ::std::vec::Vec<majit_ir::Value>,
+                    raw: &mut ::std::vec::Vec<i64>,
+                    types: &mut ::std::vec::Vec<majit_ir::Type>,
+                ) {
+                    self.extract_live_into(_meta, raw);
+                    self.live_value_types_into(_meta, types);
+                    out.extend(raw.iter().zip(types.iter()).map(|(&__v, &__t)| match __t {
+                        majit_ir::Type::Float => {
+                            majit_ir::Value::Float(f64::from_bits(__v as u64))
+                        }
+                        majit_ir::Type::Ref => {
+                            majit_ir::Value::Ref(majit_ir::GcRef(__v as usize))
+                        }
+                        _ => majit_ir::Value::Int(__v),
+                    }));
+                }
+            }
+        } else {
+            quote! {}
+        };
     let live_value_types_override: TokenStream =
         if num_ref_scalars > 0 || num_virt_arrays > 0 || num_float_scalars > 0 {
             quote! {
@@ -1732,7 +1762,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // and that lint is deny-by-default in every consumer of this
                 // macro, so a state of arrays only would not compile there.
                 #[allow(clippy::reversed_empty_ranges)]
-                fn live_value_types(&self, _meta: &#meta_ty) -> Vec<majit_ir::Type> {
+                fn live_value_types_into(
+                    &self,
+                    _meta: &#meta_ty,
+                    types: &mut ::std::vec::Vec<majit_ir::Type>,
+                ) {
                     // Value-routing types in `extract_live` order: int scalars,
                     // int array elements, then the ONE virtualizable identity
                     // (Ref), then appended ref scalars (Ref), then appended float
@@ -1741,7 +1775,6 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     // failarg (TAGBOX), which the resume reader decodes through
                     // `decode_ref` in both the vable section and the frame
                     // ref-liveness.
-                    let mut types: Vec<majit_ir::Type> = Vec::new();
                     for _ in 0..#num_scalars {
                         types.push(majit_ir::Type::Int);
                     }
@@ -1753,6 +1786,11 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     for _ in 0..#num_float_scalars {
                         types.push(majit_ir::Type::Float);
                     }
+                }
+
+                fn live_value_types(&self, _meta: &#meta_ty) -> Vec<majit_ir::Type> {
+                    let mut types: Vec<majit_ir::Type> = Vec::new();
+                    self.live_value_types_into(_meta, &mut types);
                     types
                 }
             }
@@ -2032,6 +2070,23 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 }
             })
             .collect();
+        // The same reads appended into a caller-owned slot rather than
+        // collected into a fresh `Vec`. Indexed by position so the two forms
+        // fill the outer list in the identical order.
+        let virt_array_export_into_parts: Vec<TokenStream> = virt_arrays
+            .iter()
+            .enumerate()
+            .map(|(i, (_, f))| {
+                let fname = &f.name;
+                let source = match &f.kind {
+                    StateFieldKind::VirtArray(tp) if tp == "float" => {
+                        quote! { self.#fname.iter().map(|&__x| __x.to_bits() as i64) }
+                    }
+                    _ => quote! { self.#fname.iter().map(|&__x| __x as i64) },
+                };
+                quote! { arrays[#i].extend(#source); }
+            })
+            .collect();
         // `extract_live` pushes int scalars, then every fixed array's items,
         // then the one identity slot. With no fixed arrays that position is a
         // constant — `num_scalars` — so the identity can be DECLARED the way
@@ -2139,6 +2194,23 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     #( #virt_array_export_parts ),*
                 ];
                 Some((__static_boxes, __array_boxes))
+            }
+
+            // Same export into buffers the driver reuses. Statics stays empty
+            // for the reason above, so only the arrays are written; the outer
+            // `Vec` is resized rather than rebuilt so the inner element
+            // storage survives across entries.
+            fn export_virtualizable_boxes_into(
+                &self,
+                _meta: &Self::Meta,
+                _virtualizable: &str,
+                _info: &majit_metainterp::virtualizable::VirtualizableInfo,
+                _statics: &mut ::std::vec::Vec<i64>,
+                arrays: &mut ::std::vec::Vec<::std::vec::Vec<i64>>,
+            ) -> bool {
+                arrays.resize_with(#num_virt_arrays, ::std::vec::Vec::new);
+                #( #virt_array_export_into_parts )*
+                true
             }
         }
     } else {
@@ -2583,17 +2655,28 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 }
             }
 
-            fn extract_live(&self, _meta: &#meta_ty) -> Vec<i64> {
-                let mut values = Vec::new();
+            // The buffer-filling form is the primary one and the owning form
+            // wraps it: `warmstate.py:503-511 maybe_compile_and_run` hands
+            // `execute_assembler` reds that are already unboxed locals, so the
+            // entry path allocates nothing to describe them. The driver keeps
+            // these buffers across calls, so a warm entry refills them.
+            fn extract_live_into(&self, _meta: &#meta_ty, values: &mut ::std::vec::Vec<i64>) {
                 #(#extract_scalar_parts)*
                 #(#extract_array_parts)*
                 #extract_vable_identity_part
                 #(#extract_ref_scalar_parts)*
                 #(#extract_float_scalar_parts)*
+            }
+
+            fn extract_live(&self, _meta: &#meta_ty) -> Vec<i64> {
+                let mut values = Vec::new();
+                self.extract_live_into(_meta, &mut values);
                 values
             }
 
             #live_value_types_override
+
+            #extract_live_values_into_override
 
             fn create_sym(meta: &#meta_ty, header_pc: usize) -> #sym_ty {
                 let mut __offset: usize = 0;

--- a/majit/majit-metainterp/Cargo.toml
+++ b/majit/majit-metainterp/Cargo.toml
@@ -44,3 +44,13 @@ majit-backend-wasm = { path = "../majit-backend-wasm", version = "0.0.2", defaul
 majit-macros = { workspace = true }
 majit-gc = { workspace = true }
 smallvec = { workspace = true }
+
+# A counting `#[global_allocator]` is process-wide, so this target must own its
+# process: libtest's default runner is multi-threaded and a second test running
+# beside it would land its allocations in the same counter. `--test-threads=1`
+# cannot be spelled in a manifest, so `harness = false` is the only way to get
+# a single owned `main`.
+[[test]]
+name = "allocs_per_compiled_entry"
+path = "tests/allocs_per_compiled_entry.rs"
+harness = false

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -154,7 +154,12 @@ pub struct CompileResult<M> {
     /// after the run would read whatever the compiled-loop index holds by
     /// then, and compiled code re-enters the driver through residual calls,
     /// so the entry can be recompiled or dropped mid-run.
-    pub meta: M,
+    ///
+    /// The hold is a shared reference, not a copy: upstream keeps the
+    /// `loop_token` object itself alive across `execute_assembler`, and an
+    /// `Arc` gives the same "this exact metadata, for the whole run" guarantee
+    /// without paying a struct copy per entry.
+    pub meta: std::sync::Arc<M>,
     pub fail_index: u32,
     pub trace_id: u64,
     /// `cpu.get_latest_descr(deadframe)` (`history.py:125`) — the
@@ -182,7 +187,7 @@ pub struct RawCompileResult<M> {
     pub values: Vec<i64>,
     pub typed_values: Vec<Value>,
     /// Pre-run metadata snapshot — see `CompileResult::meta`.
-    pub meta: M,
+    pub meta: std::sync::Arc<M>,
     pub fail_index: u32,
     pub trace_id: u64,
     /// `cpu.get_latest_descr(deadframe)` (`history.py:125`,

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -194,6 +194,47 @@ pub trait JitState: Sized {
         self.extract_live(meta).iter().map(|_| Type::Int).collect()
     }
 
+    /// Append this state's live values to `out` instead of returning a fresh
+    /// `Vec`.
+    ///
+    /// `warmstate.py:503-507 maybe_compile_and_run` builds the assembler's
+    /// arguments by unspecializing reds that are already unboxed locals, so
+    /// the upstream entry path allocates nothing to describe them. The
+    /// `Vec`-returning form above cannot express that: the caller entering
+    /// compiled code has a buffer whose shape the compiled artifact fixed, and
+    /// a return-by-value forces a new allocation per entry regardless.
+    ///
+    /// `raw` and `types` are the caller's scratch for the two halves the pair
+    /// is built from — cleared on arrival, unread on return, and reused across
+    /// entries. An implementation that needs neither may ignore them.
+    ///
+    /// The default defers to [`Self::extract_live_values`], so a state that
+    /// overrides neither — or that overrides only the `Vec`-returning form —
+    /// keeps exactly today's values and today's allocations. Overriding this
+    /// method is what removes them.
+    fn extract_live_values_into(
+        &self,
+        meta: &Self::Meta,
+        out: &mut Vec<Value>,
+        raw: &mut Vec<i64>,
+        types: &mut Vec<Type>,
+    ) {
+        let _ = (raw, types);
+        out.extend(self.extract_live_values(meta));
+    }
+
+    /// Append-to-buffer form of [`Self::extract_live`], for
+    /// [`Self::extract_live_values_into`] implementations.
+    fn extract_live_into(&self, meta: &Self::Meta, out: &mut Vec<i64>) {
+        out.extend(self.extract_live(meta));
+    }
+
+    /// Append-to-buffer form of [`Self::live_value_types`], for
+    /// [`Self::extract_live_values_into`] implementations.
+    fn live_value_types_into(&self, meta: &Self::Meta, out: &mut Vec<Type>) {
+        out.extend(self.live_value_types(meta));
+    }
+
     fn create_sym(meta: &Self::Meta, header_pc: usize) -> Self::Sym;
 
     /// Seed tracing-time concrete mirrors in the symbolic state.
@@ -652,6 +693,43 @@ pub trait JitState: Sized {
         _info: &VirtualizableInfo,
     ) -> Option<(Vec<i64>, Vec<Vec<i64>>)> {
         None
+    }
+
+    /// Buffer-filling form of [`Self::export_virtualizable_boxes`], for the
+    /// compiled-entry path that re-reads the virtualizable on every call.
+    ///
+    /// `warmstate.py:394-396 execute_assembler` passes the virtualizable to
+    /// the assembler as a single pointer argument and only clears its token;
+    /// it never copies the fields out, so upstream has no per-entry cost here
+    /// to mirror. majit's entry flattens the fields into scalar inputargs
+    /// instead, which is a real per-entry read — but the *storage* for that
+    /// read is fixed by the artifact's inputarg shape and so need not be
+    /// reallocated each time.
+    ///
+    /// `statics` arrives cleared with whatever capacity previous entries left
+    /// it. `arrays` arrives with each inner `Vec` cleared but the outer length
+    /// left as it was, so an implementation that resizes the outer to the
+    /// field count and extends each inner in place reuses both levels of
+    /// storage. Returns whether the export succeeded, matching the `Option` of
+    /// the owning form; on `false` the buffers' contents are unspecified and
+    /// the caller discards them.
+    ///
+    /// The default defers to [`Self::export_virtualizable_boxes`] so existing
+    /// implementations keep working unchanged.
+    fn export_virtualizable_boxes_into(
+        &self,
+        meta: &Self::Meta,
+        virtualizable: &str,
+        info: &VirtualizableInfo,
+        statics: &mut Vec<i64>,
+        arrays: &mut Vec<Vec<i64>>,
+    ) -> bool {
+        let Some((s, a)) = self.export_virtualizable_boxes(meta, virtualizable, info) else {
+            return false;
+        };
+        *statics = s;
+        *arrays = a;
+        true
     }
 
     fn collect_jump_args(sym: &Self::Sym) -> Vec<OpRef>;

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4628,9 +4628,17 @@ impl<S: JitState> JitDriver<S> {
                 // as the portal's own return value.
                 self.meta.back_edge_finish = Some(result.typed_values.clone());
                 let run_meta = result.meta.clone();
-                if !result.typed_values.is_empty() {
-                    state.restore_values(&run_meta, &result.typed_values);
-                }
+                // The FINISH arguments are NOT the loop-carried state, so they
+                // are not written back into it. `warmstate.py:405-419
+                // execute_assembler` takes the `DoneWithThisFrameDescr*` fast
+                // path straight to `fail_descr.get_result(cpu, deadframe)` and
+                // returns; the only thing it reads off the deadframe is the
+                // portal's own result, and it touches no interpreter state on
+                // the way out. A `restore_values` here decodes the FINISH
+                // descr's `fail_arg_types` — one word for an int-returning
+                // portal — into slots indexed by the state's live-value
+                // layout, so a state with more than one live field indexes
+                // past the end of the list it was handed.
                 let run_descriptor = self.driver_descriptor_for(state, &run_meta);
                 self.sync_after(state, &run_meta, run_descriptor.as_deref());
                 // Kept for callers that cannot consume the latch (a portal whose

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1819,7 +1819,10 @@ impl<S: JitState> JitDriver<S> {
     }
 
     /// Get compiled loop metadata for the given green key.
-    pub fn get_compiled_meta(&self, green_key: u64) -> Option<&S::Meta> {
+    ///
+    /// The `Arc` is the entry's own, not a copy: a caller that needs to hold
+    /// the metadata across a run clones the refcount.
+    pub fn get_compiled_meta(&self, green_key: u64) -> Option<&std::sync::Arc<S::Meta>> {
         self.meta.get_compiled_meta(green_key)
     }
 
@@ -4301,7 +4304,11 @@ impl<S: JitState> JitDriver<S> {
         if !state.can_trace() {
             return None;
         }
-        if self.meta.has_compiled_loop(green_key) {
+        // `warmstate.py:471-478`: a temporary token is not entered. Reporting
+        // `None` rather than an `Abort` outcome keeps the answer the same shape
+        // as the "no compiled code at all" case, which is what a tmp-only cell
+        // is from this path's point of view.
+        if self.has_runnable_compiled_loop(green_key) {
             return Some(self.run_compiled_detailed_keyed_with_dispatch_key(
                 green_key,
                 state,
@@ -4396,8 +4403,26 @@ impl<S: JitState> JitDriver<S> {
         if dispatch_key.is_none() && self.meta.is_cross_loop_cut_key(green_key) {
             return None;
         }
-        if self.meta.has_compiled_loop(green_key) {
-            let compiled_meta = self.meta.get_compiled_meta(green_key).unwrap().clone();
+        // `warmstate.py:471-478 maybe_compile_and_run`: a cell whose token was
+        // `attached by compile_tmp_callback()` is NOT entered — upstream falls
+        // straight to `jitcounter.tick(hash, increment_threshold)` and, on
+        // overflow, `bound_reached`. The pyre reading of "attached by
+        // compile_tmp_callback" is the absence of a `compiled_loops` meta
+        // (`has_runnable_compiled_loop`, which documents why): the temporary
+        // token has a body, so `has_compiled_loop` says yes, but MetaInterp
+        // never filed frontend meta for it. Binding the meta here rather than
+        // testing a predicate and unwrapping afterwards keeps the two in step —
+        // the fall-through below IS the counter processing upstream continues
+        // with. `has_compiled_loop` stays as the first conjunct: it is the
+        // `cell.get_procedure_token() is not None` half (code present and not
+        // invalidated), which the meta lookup alone does not imply, since
+        // `invalidate_loop` deliberately leaves the meta in place.
+        let runnable_meta = if self.entry_cell_has_compiled_code(green_key, structured_green_key) {
+            self.meta.get_compiled_meta(green_key).cloned()
+        } else {
+            None
+        };
+        if let Some(compiled_meta) = runnable_meta {
             let descriptor = self.driver_descriptor_for(state, &compiled_meta);
             if !state.is_compatible(&compiled_meta) {
                 self.meta.invalidate_loop(green_key);
@@ -5144,7 +5169,13 @@ impl<S: JitState> JitDriver<S> {
             return None;
         }
 
-        if self.meta.has_compiled_loop(green_key) {
+        // Same `warmstate.py:471-478` gate as `back_edge_internal`: a cell
+        // holding only a `compile_tmp_callback` token has no `compiled_loops`
+        // meta, and upstream counts it normally instead of entering it. Without
+        // the meta the runner below can only return `Abort`, which stops this
+        // route from ever reaching `maybe_start_tracing` — i.e. the counter
+        // stops ticking and the real loop is never traced.
+        if self.has_runnable_compiled_loop(green_key) {
             return Some(self.run_compiled_detailed_keyed_with_dispatch_key(
                 green_key,
                 state,
@@ -5369,6 +5400,35 @@ impl<S: JitState> JitDriver<S> {
             .map(std::sync::Arc::new);
         self.descriptor_cache = Some(resolved.clone());
         resolved
+    }
+
+    /// `warmstate.py:458-464`: the cell a back edge decides on is the one whose
+    /// `comparekey(*greenargs)` matches, not whichever cell heads the bucket.
+    ///
+    /// Upstream walks unconditionally because its comparison is against the
+    /// greens already sitting in the portal's arguments — it builds nothing.
+    /// Pyre's `GreenKey` is a heap object with its own `values` and `types`
+    /// vectors, and this is the entry path, so building one per warm entry to
+    /// re-confirm a single-candidate bucket would put back the per-entry
+    /// allocations this path exists to avoid. An unchained bucket HAS one
+    /// candidate: the head is what the walk would find, and the hash form is
+    /// exact. The key is therefore built only when the bucket is chained,
+    /// which is the only case in which the two answers can differ.
+    ///
+    /// A caller that reached here without a structured key (`back_edge`,
+    /// `back_edge_keyed`) cannot resolve the chain at all and keeps the hash
+    /// answer; `back_edge_structured` and `back_edge_declarative` carry one.
+    fn entry_cell_has_compiled_code(
+        &self,
+        green_key: u64,
+        structured_green_key: Option<&dyn Fn() -> GreenKey>,
+    ) -> bool {
+        match structured_green_key {
+            Some(make_key) if self.meta.green_key_bucket_is_chained(green_key) => {
+                self.meta.has_compiled_loop_for_key(&make_key())
+            }
+            _ => self.meta.has_compiled_loop(green_key),
+        }
     }
 
     fn live_values_match_descriptor(
@@ -6241,6 +6301,25 @@ impl<S: JitState> JitDriver<S> {
     #[inline]
     pub fn has_runnable_compiled_loop(&self, green_key: u64) -> bool {
         self.has_compiled_loop(green_key) && self.meta.get_compiled_meta(green_key).is_some()
+    }
+
+    /// Typed twin of [`Self::has_compiled_loop`]: `warmstate.py:458-464` walks
+    /// the bucket and tests `comparekey(*greenargs)` before deciding anything,
+    /// where the hash form can answer for whichever cell heads the bucket.
+    ///
+    /// The `compiled_loops` meta the runnable form additionally requires is
+    /// hash-keyed and has no chain, so only the JitCell half is resolved on
+    /// full key identity — see `MetaInterp::has_compiled_loop_for_key`.
+    #[inline]
+    pub fn has_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
+        self.meta.has_compiled_loop_for_key(key)
+    }
+
+    /// Typed twin of [`Self::has_runnable_compiled_loop`].
+    #[inline]
+    pub fn has_runnable_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
+        self.has_compiled_loop_for_key(key)
+            && self.meta.get_compiled_meta(key.get_uhash()).is_some()
     }
 
     /// Actual key the last compile_loop stored under.
@@ -8939,6 +9018,120 @@ mod tests {
         // return None from index().
         let driver = JitDriver::<TypedRestoreState>::new(1);
         assert_eq!(driver.index(), None);
+    }
+
+    /// Install the cell shape `warmstate.py:714-723 get_assembler_token` leaves
+    /// behind when it has to synthesise a token: a procedure token carrying a
+    /// backend body, flagged `JC_TEMPORARY`, and no `compiled_loops` entry —
+    /// MetaInterp never files frontend meta for a `compile_tmp_callback` stub
+    /// (`compile.py:1101-1150`).
+    fn attach_tmp_callback_cell<S: JitState>(driver: &mut JitDriver<S>, green_key: u64) {
+        let token = std::sync::Arc::new(majit_backend::JitCellToken::new(
+            driver.meta.warm_state_mut().alloc_token_number(),
+        ));
+        token.set_compiled(Box::new(()));
+        driver
+            .meta
+            .warm_state_mut()
+            .attach_tmp_callback_to_interp(green_key, token);
+    }
+
+    /// `warmstate.py:471-478 maybe_compile_and_run`: a cell whose token was
+    /// `attached by compile_tmp_callback()` is counted normally, never entered.
+    #[test]
+    fn a_tmp_callback_only_cell_is_counted_not_entered_at_the_back_edge() {
+        let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let key = 4413u64;
+        attach_tmp_callback_cell(&mut driver, key);
+
+        assert!(
+            driver.has_compiled_loop(key),
+            "the tmp callback token has a body, so the code-presence predicate says yes",
+        );
+        assert!(
+            !driver.has_runnable_compiled_loop(key),
+            "and it has no frontend meta, so the warm-entry runner cannot enter it",
+        );
+
+        // Before this fell through, the back edge unwrapped the absent meta and
+        // panicked at the loop header of any driver that can mint a tmp token.
+        let mut state = TypedRestoreState::default();
+        assert_eq!(
+            driver.back_edge_keyed(key, 0, &mut state, &(), || {}),
+            None,
+            "nothing ran and nothing was traced on the first tick",
+        );
+        assert!(
+            !driver.meta.is_tracing(),
+            "the first back edge only ticks the counter",
+        );
+
+        // The counter keeps ticking, so the real loop still gets traced — the
+        // tmp callback delays entry, it does not disable the key.
+        driver.back_edge_keyed(key, 0, &mut state, &(), || {});
+        assert!(
+            driver.meta.is_tracing(),
+            "the threshold is reached by counting, exactly as for a cell with no token",
+        );
+    }
+
+    /// `warmstate.py:458-464` resolves the cell by `comparekey(*greenargs)`
+    /// before reading a token off it. On a chained bucket the head is a
+    /// different cell, so the hash form and the typed form answer differently
+    /// — and the typed one is the one upstream asks.
+    #[test]
+    fn the_typed_entry_predicate_reads_the_keys_own_cell_not_the_bucket_head() {
+        let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let key = GreenKey::new(vec![1500, 1600]);
+        let hash = key.get_uhash();
+
+        // A hash-only writer squats the bucket with a comparator-less cell and
+        // gives it a code-bearing token; then a typed writer for the SAME key
+        // chains its own, token-less cell behind it.
+        let token = std::sync::Arc::new(majit_backend::JitCellToken::new(
+            driver.meta.warm_state_mut().alloc_token_number(),
+        ));
+        token.set_compiled(Box::new(()));
+        driver
+            .meta
+            .warm_state_mut()
+            .attach_tmp_callback_to_interp(hash, token);
+        driver.meta.warm_state_mut().mark_dont_trace_for_key(&key);
+
+        assert!(
+            driver.meta.green_key_bucket_is_chained(hash),
+            "fixture: two cells in one bucket is the only case in which the \
+             two forms can disagree",
+        );
+        assert!(
+            driver.has_compiled_loop(hash),
+            "fixture: the head cell holds the code-bearing token, so a \
+             head-reading predicate says this key has compiled code",
+        );
+        assert!(
+            !driver.has_compiled_loop_for_key(&key),
+            "but the cell this key owns holds no token at all, so the answer \
+             upstream would give is no",
+        );
+    }
+
+    /// The `run_compiled` sibling route makes the same decision.
+    #[test]
+    fn a_tmp_callback_only_cell_is_not_dispatched_by_back_edge_or_run_compiled() {
+        let mut driver = JitDriver::<TypedRestoreState>::new(2);
+        driver.meta.finish_setup_descrs_for_jitdrivers();
+        let key = 5161u64;
+        attach_tmp_callback_cell(&mut driver, key);
+
+        let mut state = TypedRestoreState::default();
+        assert!(
+            driver
+                .back_edge_or_run_compiled_keyed(key, 0, &mut state, &(), || {})
+                .is_none(),
+            "an unenterable cell reports the same `None` as a cell with no code at all",
+        );
     }
 }
 

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1313,6 +1313,45 @@ pub struct JitDriver<S: JitState> {
     /// This driver's payload for the per-thread `frame_value_count` store,
     /// built once by `register_dispatch_jitcode`. `None` until then.
     state_field_fvc: Option<StateFieldFvcData>,
+    /// Reusable buffers for the compiled-entry argument walk.
+    ///
+    /// `warmstate.py:387-398 execute_assembler` builds the entry arguments
+    /// with no allocation at all: the reds are already unboxed locals, and
+    /// `func_execute_token` writes them straight into the jitframe the backend
+    /// owns. Here the same walk minted a fresh `Vec` per entry — one for the
+    /// raw live values, one for their types, one for the typed pair, and one
+    /// more for each virtualizable box list — so a call-heavy program paid
+    /// several malloc/free pairs per entry for buffers whose shape is fixed by
+    /// the compiled artifact and therefore identical on every call.
+    ///
+    /// The driver outlives every entry through it, so the buffers are cleared
+    /// and refilled rather than reallocated; after the first entry their
+    /// capacity already covers the artifact's inputarg count. Same motivation
+    /// as [`Self::descriptor_cache`], one layer further in.
+    ///
+    /// One set is enough even though a compiled run can re-enter the driver:
+    /// the taker holds its buffers as a local for the whole entry, so a nested
+    /// entry finds this slot empty and starts from fresh ones. Nesting
+    /// therefore costs what it costs today and never aliases; only the
+    /// outermost entry's buffers survive to be reused.
+    entry_scratch: EntryScratch,
+}
+
+/// Per-entry scratch owned by [`JitDriver`]; see [`JitDriver::entry_scratch`].
+#[derive(Default)]
+struct EntryScratch {
+    /// The typed live values handed to the backend as the entry's inputargs.
+    live_values: Vec<Value>,
+    /// `JitState::extract_live` output, before it is paired with its types.
+    raw: Vec<i64>,
+    /// `JitState::live_value_types` output.
+    types: Vec<Type>,
+    /// `JitState::export_virtualizable_boxes_into` static-field output.
+    vable_static: Vec<i64>,
+    /// `JitState::export_virtualizable_boxes_into` array-field output. The
+    /// inner `Vec`s are retained across entries too, so a virtualizable whose
+    /// array lengths are stable reuses their storage as well.
+    vable_arrays: Vec<Vec<i64>>,
 }
 
 thread_local! {
@@ -1423,6 +1462,7 @@ impl<S: JitState> JitDriver<S> {
             portal_runner: None,
             portal_jd_index: None,
             state_field_fvc: None,
+            entry_scratch: EntryScratch::default(),
             #[expect(
                 clippy::arc_with_non_send_sync,
                 reason = "Arc preserves shared JitCode/descriptor identity across compiled artifacts; the non-Send translator payload is confined to the single-threaded build phase and is never transferred between threads"
@@ -4366,35 +4406,55 @@ impl<S: JitState> JitDriver<S> {
             if !self.sync_before(state, &compiled_meta, descriptor.as_deref()) {
                 return None;
             }
+            // The entry arguments are assembled in buffers the driver keeps
+            // across calls, so a warm entry reuses the capacity the artifact's
+            // inputarg shape fixed instead of minting one `Vec` per call —
+            // `warmstate.py:503-511 maybe_compile_and_run` reaches
+            // `execute_assembler` with the reds already in hand and allocates
+            // nothing to describe them. Taken out of `self` for the duration
+            // because assembling them calls back into `self`; every exit below
+            // hands it back, and `entry_scratch_out` names that.
+            let mut scratch = self.take_entry_scratch();
             // `direct_live_values` arrive already in the target LABEL's argument
             // order; state-extracted ones are in state-field order and have to be
             // mapped before a dispatch-key entry can use them.
             let values_are_label_ordered = direct_live_values.is_some();
-            let mut live_values = if let Some(values) = direct_live_values {
-                values
+            if let Some(values) = direct_live_values {
+                scratch.live_values.extend(values);
             } else {
-                let live_values = state.extract_live_values(&compiled_meta);
+                state.extract_live_values_into(
+                    &compiled_meta,
+                    &mut scratch.live_values,
+                    &mut scratch.raw,
+                    &mut scratch.types,
+                );
                 if !Self::live_values_match_descriptor(
                     descriptor.as_deref(),
-                    &live_values,
+                    &scratch.live_values,
                     state.state_field_layout().total_live_values(),
                 ) {
+                    self.entry_scratch_out(scratch);
                     return None;
                 }
 
-                self.extend_compiled_live_values(
+                if !self.extend_compiled_live_values_into(
                     green_key,
                     state,
                     &compiled_meta,
                     descriptor.as_deref(),
-                    live_values,
-                )?
-            };
+                    &mut scratch.live_values,
+                    &mut scratch.vable_static,
+                    &mut scratch.vable_arrays,
+                ) {
+                    self.entry_scratch_out(scratch);
+                    return None;
+                }
+            }
             if dispatch_key.is_some() && !values_are_label_ordered {
-                let full_len = live_values.len();
+                let full_len = scratch.live_values.len();
                 let Some(packed) = self
                     .meta
-                    .pack_front_target_live_values(green_key, &live_values)
+                    .pack_front_target_live_values(green_key, &scratch.live_values)
                 else {
                     if crate::callee_rca_enabled() {
                         eprintln!(
@@ -4404,6 +4464,7 @@ impl<S: JitState> JitDriver<S> {
                             dispatch_key,
                         );
                     }
+                    self.entry_scratch_out(scratch);
                     return None;
                 };
                 if crate::callee_rca_enabled() {
@@ -4415,17 +4476,21 @@ impl<S: JitState> JitDriver<S> {
                         packed.len()
                     );
                 }
-                live_values = packed;
+                scratch.live_values.clear();
+                scratch.live_values.extend(packed);
             }
             if dispatch_key.is_some() && values_are_label_ordered {
                 // The compact values are LABEL-ordered by construction, but the
                 // same unchecked Ref dereference is downstream of them, so the
                 // types are confirmed here as well.
-                let types = self.meta.front_target_inputarg_types(green_key)?;
-                if types.len() != live_values.len()
+                let Some(types) = self.meta.front_target_inputarg_types(green_key) else {
+                    self.entry_scratch_out(scratch);
+                    return None;
+                };
+                if types.len() != scratch.live_values.len()
                     || types
                         .iter()
-                        .zip(live_values.iter())
+                        .zip(scratch.live_values.iter())
                         .any(|(want, value)| value.get_type() != *want)
                 {
                     if crate::callee_rca_enabled() {
@@ -4434,12 +4499,18 @@ impl<S: JitState> JitDriver<S> {
                              dispatch_key={:?} source=compact-label label_types={types:?} \
                              value_types={:?} -> decline",
                             dispatch_key,
-                            live_values.iter().map(|v| v.get_type()).collect::<Vec<_>>(),
+                            scratch
+                                .live_values
+                                .iter()
+                                .map(|v| v.get_type())
+                                .collect::<Vec<_>>(),
                         );
                     }
+                    self.entry_scratch_out(scratch);
                     return None;
                 }
             }
+            let live_values = &scratch.live_values;
 
             if crate::callee_rca_enabled() {
                 let layout = state.state_field_layout();
@@ -4492,13 +4563,17 @@ impl<S: JitState> JitDriver<S> {
             let result = if let Some(dispatch_key) = dispatch_key {
                 self.meta.run_compiled_detailed_with_values_at_dispatch_key(
                     green_key,
-                    &live_values,
+                    live_values,
                     dispatch_key,
                 )
             } else {
                 self.meta
-                    .run_compiled_detailed_with_values(green_key, &live_values)
+                    .run_compiled_detailed_with_values(green_key, live_values)
             };
+            // The compiled body has run and nothing below reads the entry
+            // arguments, so the buffers go back before the first exit past
+            // this point.
+            self.entry_scratch_out(scratch);
             let result = result?;
             if portal_rca_enabled() {
                 eprintln!(
@@ -5246,6 +5321,33 @@ impl<S: JitState> JitDriver<S> {
         }
     }
 
+    /// Borrow [`Self::entry_scratch`] for the duration of one compiled entry.
+    ///
+    /// Handed out by value rather than by reference because assembling the
+    /// entry arguments calls back into `self`; every caller must return it
+    /// through [`Self::entry_scratch_out`] before leaving, or the next entry
+    /// starts from empty buffers (correct, just slower).
+    ///
+    /// The buffers arrive with their previous contents dropped and their
+    /// capacity kept. `vable_arrays` keeps its outer elements so the inner
+    /// buffers survive too — see `JitState::export_virtualizable_boxes_into`.
+    fn take_entry_scratch(&mut self) -> EntryScratch {
+        let mut scratch = std::mem::take(&mut self.entry_scratch);
+        scratch.live_values.clear();
+        scratch.raw.clear();
+        scratch.types.clear();
+        scratch.vable_static.clear();
+        for array in &mut scratch.vable_arrays {
+            array.clear();
+        }
+        scratch
+    }
+
+    /// Return the buffers [`Self::take_entry_scratch`] handed out.
+    fn entry_scratch_out(&mut self, scratch: EntryScratch) {
+        self.entry_scratch = scratch;
+    }
+
     /// The driver's static data, resolved once and then shared.
     ///
     /// See [`Self::descriptor_cache`] for why the answer is memoized rather
@@ -5311,16 +5413,15 @@ impl<S: JitState> JitDriver<S> {
             .all(|(var, value)| var.tp == value.get_type())
     }
 
-    fn flatten_virtualizable_values(
+    fn flatten_virtualizable_values_into(
         info: &VirtualizableInfo,
         static_boxes: &[i64],
         array_boxes: &[Vec<i64>],
-    ) -> Vec<Value> {
-        let mut values = Vec::with_capacity(
-            static_boxes.len() + array_boxes.iter().map(Vec::len).sum::<usize>(),
-        );
+        out: &mut Vec<Value>,
+    ) {
+        out.reserve(static_boxes.len() + array_boxes.iter().map(Vec::len).sum::<usize>());
         for (field, &raw) in info.static_fields.iter().zip(static_boxes.iter()) {
-            values.push(match field.field_type {
+            out.push(match field.field_type {
                 Type::Int => Value::Int(raw),
                 Type::Ref => Value::Ref(majit_ir::GcRef(raw as usize)),
                 Type::Float => Value::Float(f64::from_bits(raw as u64)),
@@ -5329,7 +5430,7 @@ impl<S: JitState> JitDriver<S> {
         }
         for (array, items) in info.array_fields.iter().zip(array_boxes.iter()) {
             for &raw in items {
-                values.push(match array.item_type {
+                out.push(match array.item_type {
                     Type::Int => Value::Int(raw),
                     Type::Ref => Value::Ref(majit_ir::GcRef(raw as usize)),
                     Type::Float => Value::Float(f64::from_bits(raw as u64)),
@@ -5337,7 +5438,6 @@ impl<S: JitState> JitDriver<S> {
                 });
             }
         }
-        values
     }
 
     /// warmstate.py:482-511: extend live values with virtualizable fields
@@ -5345,6 +5445,61 @@ impl<S: JitState> JitDriver<S> {
     /// RPython always has jitdriver_sd available; pyre may have descriptor=None
     /// when re-entering from guard failure, so fall back to virtualizable_info
     /// directly.
+    ///
+    /// Appends in place and reports success, so the compiled-entry path can
+    /// hand it a buffer that already has the artifact's capacity instead of a
+    /// freshly minted one. `statics` and `arrays` are scratch for the export;
+    /// they arrive cleared and their contents are not read on return. On
+    /// `false` `live_values` is restored to the length it arrived with, so a
+    /// declining caller sees the buffer it passed.
+    fn extend_compiled_live_values_into(
+        &self,
+        green_key: u64,
+        state: &S,
+        meta: &S::Meta,
+        descriptor: Option<&JitDriverStaticData>,
+        live_values: &mut Vec<Value>,
+        statics: &mut Vec<i64>,
+        arrays: &mut Vec<Vec<i64>>,
+    ) -> bool {
+        // `warmstate.py:188 cell.loop_token` is the single PyPy source of
+        // truth for the entry-path inputarg shape; route through
+        // `warm_state.get_compiled` so this site never consults pyre's
+        // `compiled_loops` side table (the F.7-orthodox retirement target).
+        let Some(compiled) = self.meta.warm_state_ref().get_compiled(green_key) else {
+            return false;
+        };
+        let compiled_inputs = compiled.inputarg_types().len();
+        if compiled_inputs <= live_values.len() {
+            return true;
+        }
+        // Fall back to virtualizable_info's default name if no descriptor.
+        let Some(info) = self.meta.virtualizable_info() else {
+            return false;
+        };
+        // Try descriptor path first (RPython jitdriver_sd.virtualizable), else
+        // jitdriver_sd.virtualizable_info.name (interp_jit.py:25). Borrowed
+        // rather than cloned: both spellings outlive this call, and the export
+        // below only reads the name.
+        let name: &str = match descriptor.and_then(|d| d.virtualizable()) {
+            Some(virtualizable) => &virtualizable.name,
+            None => &info.name,
+        };
+        if !state.export_virtualizable_boxes_into(meta, name, info, statics, arrays) {
+            return false;
+        }
+        let base = live_values.len();
+        Self::flatten_virtualizable_values_into(info, statics, arrays, live_values);
+        if live_values.len() != compiled_inputs {
+            live_values.truncate(base);
+            return false;
+        }
+        true
+    }
+
+    /// Owning form of [`Self::extend_compiled_live_values_into`], for the
+    /// bridge-setup and diagnostic paths that hold a `Vec` of their own and
+    /// run far from the steady entry path.
     fn extend_compiled_live_values(
         &self,
         green_key: u64,
@@ -5353,34 +5508,18 @@ impl<S: JitState> JitDriver<S> {
         descriptor: Option<&JitDriverStaticData>,
         mut live_values: Vec<Value>,
     ) -> Option<Vec<Value>> {
-        // `warmstate.py:188 cell.loop_token` is the single PyPy source of
-        // truth for the entry-path inputarg shape; route through
-        // `warm_state.get_compiled` so this site never consults pyre's
-        // `compiled_loops` side table (the F.7-orthodox retirement target).
-        let compiled_inputs = self
-            .meta
-            .warm_state_ref()
-            .get_compiled(green_key)?
-            .inputarg_types()
-            .len();
-        if compiled_inputs <= live_values.len() {
-            return Some(live_values);
-        }
-        // Try descriptor path first (RPython jitdriver_sd.virtualizable).
-        let vable_name = descriptor
-            .and_then(|d| d.virtualizable())
-            .map(|v| v.name.clone());
-        // Fall back to virtualizable_info's default name if no descriptor.
-        let info = self.meta.virtualizable_info()?;
-        // jitdriver_sd.virtualizable_info.name (interp_jit.py:25)
-        let name = vable_name.unwrap_or_else(|| info.name.clone());
-        let (static_boxes, array_boxes) = state.export_virtualizable_boxes(meta, &name, info)?;
-        let extra_values = Self::flatten_virtualizable_values(info, &static_boxes, &array_boxes);
-        if live_values.len() + extra_values.len() != compiled_inputs {
-            return None;
-        }
-        live_values.extend(extra_values);
-        Some(live_values)
+        let mut statics = Vec::new();
+        let mut arrays = Vec::new();
+        self.extend_compiled_live_values_into(
+            green_key,
+            state,
+            meta,
+            descriptor,
+            &mut live_values,
+            &mut statics,
+            &mut arrays,
+        )
+        .then_some(live_values)
     }
 
     fn sync_before(

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4481,6 +4481,13 @@ impl<S: JitState> JitDriver<S> {
                     format_rca_live_values(labels.as_deref(), &live_values)
                 );
             }
+            // Same point the RCA line above reports, but unconditional and
+            // counted: every decline has already returned, and the compiled
+            // body runs on the next statement, so one call here is one entry.
+            // Scoped so the borrow ends before `self.meta` is taken mutably.
+            if let Some(ref hook) = self.meta.hooks.on_compiled_entry {
+                hook(green_key, target_pc);
+            }
 
             let result = if let Some(dispatch_key) = dispatch_key {
                 self.meta.run_compiled_detailed_with_values_at_dispatch_key(
@@ -5522,6 +5529,18 @@ impl<S: JitState> JitDriver<S> {
     /// Set a callback for guard failure events.
     pub fn set_on_guard_failure(&mut self, f: impl Fn(u64, u32, u32) + Send + 'static) {
         self.meta.set_on_guard_failure(f);
+    }
+
+    /// Set a callback fired immediately before a call enters compiled code.
+    /// `f` receives `(green_key, target_pc)`.
+    ///
+    /// Scope: this driver reaches compiled code through `back_edge_internal`,
+    /// which is the site the hook is installed at.  The sibling entry paths in
+    /// this file serve other front ends and do not fire it yet, so a zero count
+    /// is evidence only for a consumer whose entries all go through the back
+    /// edge.
+    pub fn set_on_compiled_entry(&mut self, f: impl Fn(u64, usize) + Send + 'static) {
+        self.meta.set_on_compiled_entry(f);
     }
 
     /// Set a callback for trace abort events. `f` receives `(green_key, permanent)`

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -980,7 +980,12 @@ pub(crate) struct CompiledEntry<M> {
     /// (`warmstate.rs:77`), so Pyre has not yet reached PyPy's "alive_loops
     /// is the only long-lived strong owner" shape.
     pub(crate) token: std::sync::Weak<JitCellToken>,
-    pub(crate) meta: M,
+    /// Shared, never copied. `warmstate.py:398 get_procedure_token` hands the
+    /// caller the cell's own `loop_token` object; the entry runner then reads
+    /// its fields in place and passes the same object to the exit handling.
+    /// Behind an `Arc` the pyre entry path matches that: a warm entry clones a
+    /// refcount where it used to clone the whole struct, on every call.
+    pub(crate) meta: std::sync::Arc<M>,
     /// Front-end loop-version state, mirroring RPython's
     /// jitcell_token.target_tokens ownership across recompilations.
     pub(crate) front_target_tokens: Vec<crate::history::TargetToken>,
@@ -2442,7 +2447,7 @@ impl<M: Clone> MetaInterp<M> {
     fn run_result_for_jump_exit(
         fail_index: u32,
         values: Vec<i64>,
-        meta: M,
+        meta: std::sync::Arc<M>,
         savedata: Option<GcRef>,
     ) -> Option<RunResult<M>> {
         (fail_index == u32::MAX).then_some(RunResult::Jump {
@@ -7243,7 +7248,7 @@ impl<M: Clone> MetaInterp<M> {
                     green_key,
                     CompiledEntry {
                         token: Arc::downgrade(&token),
-                        meta,
+                        meta: Arc::new(meta),
                         front_target_tokens,
                         front_entry_index,
                         front_target_source_positions,
@@ -8508,7 +8513,7 @@ impl<M: Clone> MetaInterp<M> {
                     green_key,
                     CompiledEntry {
                         token: Arc::downgrade(&token),
-                        meta,
+                        meta: Arc::new(meta),
                         front_target_tokens,
                         front_entry_index,
                         front_target_source_positions: None,
@@ -9424,7 +9429,7 @@ impl<M: Clone> MetaInterp<M> {
                         green_key,
                         CompiledEntry {
                             token: Arc::downgrade(&token),
-                            meta,
+                            meta: Arc::new(meta),
                             front_target_tokens: ft,
                             front_entry_index,
                             front_target_source_positions: None,
@@ -9794,7 +9799,7 @@ impl<M: Clone> MetaInterp<M> {
                     green_key,
                     CompiledEntry {
                         token: Arc::downgrade(&token),
-                        meta,
+                        meta: Arc::new(meta),
                         front_target_tokens,
                         front_entry_index,
                         front_target_source_positions: None,
@@ -9854,7 +9859,7 @@ impl<M: Clone> MetaInterp<M> {
     /// Allows the interpreter to check preconditions (e.g., whether the
     /// current state matches the compiled loop's assumptions) before calling
     /// the run_compiled_* family.
-    pub fn get_compiled_meta(&self, green_key: u64) -> Option<&M> {
+    pub fn get_compiled_meta(&self, green_key: u64) -> Option<&std::sync::Arc<M>> {
         self.compiled_loops.get(&green_key).map(|e| &e.meta)
     }
 
@@ -11367,6 +11372,34 @@ impl<M: Clone> MetaInterp<M> {
             .is_some_and(|token| token.has_compiled_code())
     }
 
+    /// `warmstate.py:458-464` — the same code-presence gate as
+    /// [`Self::has_compiled_loop`], resolved on the full green key instead of
+    /// on the bucket head.
+    ///
+    /// Upstream never decides anything about a cell it has not first matched
+    /// with `comparekey(*greenargs)`; the hash form here can answer for a
+    /// different key that shares the bucket. Consumers that hold the typed key
+    /// at the decision point should ask this one.
+    ///
+    /// Scope: this resolves the JitCell half only. `compiled_loops` — the
+    /// frontend meta index that [`Self::get_compiled_meta`] reads — is keyed by
+    /// hash and has no chain to walk, so it stays hash-resolved. That is the
+    /// remaining collision surface on the entry path.
+    #[inline]
+    pub fn has_compiled_loop_for_key(&self, key: &majit_ir::GreenKey) -> bool {
+        self.warm_state
+            .get_procedure_token_for_key(key)
+            .is_some_and(|token| token.has_compiled_code())
+    }
+
+    /// Whether the hash and typed forms of a cell query can disagree at this
+    /// key's bucket. False means the head IS the match, so the caller can take
+    /// the hash path without building a `GreenKey` to prove it.
+    #[inline]
+    pub fn green_key_bucket_is_chained(&self, green_key: u64) -> bool {
+        self.warm_state.bucket_is_chained(green_key)
+    }
+
     /// Check if any guard in the compiled trace has Float-typed fail_args.
     /// Used to gate bridge compilation: traces with Float guards have
     /// type metadata issues that cause crashes on bridge guard failures.
@@ -12371,7 +12404,7 @@ impl<M: Clone> MetaInterp<M> {
                     original_green_key,
                     CompiledEntry {
                         token: Arc::downgrade(&token),
-                        meta,
+                        meta: Arc::new(meta),
                         front_target_tokens,
                         front_entry_index,
                         front_target_source_positions: None,
@@ -17017,19 +17050,19 @@ pub enum RunResult<M> {
     /// The loop finished normally.
     Finished {
         values: Vec<i64>,
-        meta: M,
+        meta: std::sync::Arc<M>,
         savedata: Option<GcRef>,
     },
     /// The trace exited via a normal back-edge jump.
     Jump {
         values: Vec<i64>,
-        meta: M,
+        meta: std::sync::Arc<M>,
         savedata: Option<GcRef>,
     },
     /// A guard failed.
     GuardFailure {
         values: Vec<i64>,
-        meta: M,
+        meta: std::sync::Arc<M>,
         trace_id: u64,
         fail_index: u32,
         savedata: Option<GcRef>,
@@ -22304,7 +22337,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: vec![start_token],
                 front_entry_index: Some(0),
                 front_target_source_positions: None,
@@ -22370,7 +22403,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: vec![start_token],
                 front_entry_index: Some(0),
                 front_target_source_positions: source_positions,
@@ -22693,7 +22726,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: Vec::new(),
                 front_entry_index: None,
                 front_target_source_positions: None,
@@ -22789,7 +22822,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: Vec::new(),
                 front_entry_index: None,
                 front_target_source_positions: None,
@@ -23101,7 +23134,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token_arc),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: Vec::new(),
                 front_entry_index: None,
                 front_target_source_positions: None,
@@ -23920,7 +23953,7 @@ mod tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Arc::downgrade(&token),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: Vec::new(),
                 front_entry_index: None,
                 front_target_source_positions: None,
@@ -24597,15 +24630,21 @@ mod tests {
 
     #[test]
     fn test_run_result_for_jump_exit_returns_jump() {
-        let result = MetaInterp::<()>::run_result_for_jump_exit(u32::MAX, vec![42], (), None)
-            .expect("jump exit should produce a direct Jump result");
+        let result = MetaInterp::<()>::run_result_for_jump_exit(
+            u32::MAX,
+            vec![42],
+            std::sync::Arc::new(()),
+            None,
+        )
+        .expect("jump exit should produce a direct Jump result");
         match result {
             RunResult::Jump { values, .. } => assert_eq!(values, vec![42]),
             other => panic!("expected Jump result, got {other:?}"),
         }
 
         assert!(
-            MetaInterp::<()>::run_result_for_jump_exit(3, vec![42], (), None).is_none(),
+            MetaInterp::<()>::run_result_for_jump_exit(3, vec![42], std::sync::Arc::new(()), None)
+                .is_none(),
             "guard failure exits must keep using recovery paths"
         );
     }
@@ -24674,7 +24713,7 @@ mod bridge_cell_token_tests {
             green_key,
             CompiledEntry {
                 token: std::sync::Weak::new(),
-                meta: (),
+                meta: std::sync::Arc::new(()),
                 front_target_tokens: Vec::new(),
                 front_entry_index: None,
                 front_target_source_positions: None,
@@ -24728,7 +24767,7 @@ mod loop_side_table_tests {
     fn compiled_entry(root_trace_id: u64) -> CompiledEntry<()> {
         CompiledEntry {
             token: std::sync::Weak::new(),
-            meta: (),
+            meta: std::sync::Arc::new(()),
             front_target_tokens: Vec::new(),
             front_entry_index: None,
             front_target_source_positions: None,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10454,7 +10454,15 @@ impl<M: Clone> MetaInterp<M> {
         let trace_id = descr.trace_id();
         let is_finish = descr.is_finish();
         let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
-        let exit_types = descr.fail_arg_types().to_vec();
+        // Borrowed, not copied. `warmstate.py:405-419 execute_assembler` reads
+        // the descr straight off the deadframe, and for a DoneWithThisFrame it
+        // goes to `fail_descr.get_result(cpu, deadframe)` without building any
+        // per-exit description; only the general `handle_fail` case needs one.
+        // Every reader below either only reads this list or says explicitly
+        // that it takes ownership, and this is the steady entry path, so the
+        // copy was paid on every call for the benefit of the guard-failure arm
+        // alone.
+        let exit_types: &[Type] = descr.fail_arg_types();
         let gc_ref_slots: Vec<usize> = exit_types
             .iter()
             .enumerate()
@@ -10492,11 +10500,13 @@ impl<M: Clone> MetaInterp<M> {
                 trace_id,
                 fail_index,
                 source_op_index: None,
-                exit_types: exit_types.clone(),
+                exit_types: exit_types.to_vec(),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
-                gc_ref_slots: gc_ref_slots.clone(),
-                force_token_slots: force_token_slots.clone(),
+                // Moved rather than cloned: the `else` arm below is the only
+                // other consumer and it is mutually exclusive with this one.
+                gc_ref_slots,
+                force_token_slots,
                 recovery_layout: None,
                 resume_layout: None,
                 storage: None,
@@ -10519,7 +10529,7 @@ impl<M: Clone> MetaInterp<M> {
                     trace_id,
                     fail_index,
                     source_op_index: None,
-                    exit_types: exit_types.clone(),
+                    exit_types: exit_types.to_vec(),
                     is_finish,
                     is_exception_exit: is_exit_frame_with_exception,
                     gc_ref_slots,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1887,6 +1887,22 @@ pub struct JitHooks {
     pub on_trace_abort: Option<Box<dyn Fn(u64, bool) + Send>>,
     /// Called when compilation (loop or bridge) fails. Args: (green_key, error_message).
     pub on_compile_error: Option<Box<dyn Fn(u64, &str) + Send>>,
+    /// Called when a call is about to ENTER compiled code. Args: (green_key, target_pc).
+    ///
+    /// The other hooks all describe the artifact POPULATION — what was traced,
+    /// compiled, or thrown away.  None of them says a call ran any of it, and
+    /// the two come apart: a loop that compiled and is then never entered
+    /// leaves `on_compile_loop` fired and every artifact assertion satisfied.
+    /// A consumer asking "did this run in compiled code?" had no answer but a
+    /// proxy, and each available proxy is unsound in one direction —
+    /// `guard_failures` stops being recorded once a bridge covers the exit
+    /// guard, so it reads zero on a loop that is still entered every call.
+    ///
+    /// Fires after every decline has passed and immediately before the
+    /// compiled body runs, so a count of these is a count of entries, not of
+    /// attempts.  It is a callback tally like the compile hooks, not a
+    /// population: it only rises.
+    pub on_compiled_entry: Option<Box<dyn Fn(u64, usize) + Send>>,
 }
 
 /// Runtime callback used to attach an application traceback while the
@@ -4401,6 +4417,12 @@ impl<M: Clone> MetaInterp<M> {
     /// Set a callback for guard failure events.
     pub fn set_on_guard_failure(&mut self, f: impl Fn(u64, u32, u32) + Send + 'static) {
         self.hooks.on_guard_failure = Some(Box::new(f));
+    }
+
+    /// Set a callback fired immediately before a call enters compiled code.
+    /// `f` receives `(green_key, target_pc)`.
+    pub fn set_on_compiled_entry(&mut self, f: impl Fn(u64, usize) + Send + 'static) {
+        self.hooks.on_compiled_entry = Some(Box::new(f));
     }
 
     /// Set a callback for trace start events.
@@ -24626,6 +24648,7 @@ mod tests {
         assert!(hooks.on_trace_start.is_none());
         assert!(hooks.on_trace_abort.is_none());
         assert!(hooks.on_compile_error.is_none());
+        assert!(hooks.on_compiled_entry.is_none());
     }
 }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -4533,10 +4533,27 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let guards_before = ctx.num_guards();
-                let (opref, value) = ctx.vable_getarrayitem_int_indexed(
+                let (opref, value) = ctx.vable_getarrayitem_int_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,
@@ -4568,10 +4585,27 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let guards_before = ctx.num_guards();
-                let (opref, value) = ctx.vable_getarrayitem_ref_indexed(
+                let (opref, value) = ctx.vable_getarrayitem_ref_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,
@@ -4603,10 +4637,27 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let guards_before = ctx.num_guards();
-                let (opref, value) = ctx.vable_getarrayitem_float_indexed(
+                let (opref, value) = ctx.vable_getarrayitem_float_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,
@@ -4638,11 +4689,28 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let (value, concrete) = self.read_int_reg(src);
                 let guards_before = ctx.num_guards();
-                let write = match ctx.vable_setarrayitem_indexed(
+                let write = match ctx.vable_setarrayitem_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,
@@ -4682,11 +4750,28 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let (value, concrete) = self.read_ref_reg(src);
                 let guards_before = ctx.num_guards();
-                let write = match ctx.vable_setarrayitem_indexed(
+                let write = match ctx.vable_setarrayitem_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,
@@ -4723,11 +4808,28 @@ where
                 // keeps that ownership: the guard gets a full-framestack,
                 // vable-carrying snapshot instead of the minimal one
                 // `TraceCtx::promote_int` can build without an `MIFrameStack`.
-                let index =
-                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc);
+                //
+                // The hoist moves the promote to the caller, NOT ahead of the
+                // branch that selects it. `_get_arrayitem_vable_index`
+                // (pyjitpl.py:1205) opens with the promote and is entered only
+                // from the standard leg (:1229, :1244); the non-standard leg
+                // reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with
+                // the index box as it stands. So the decision is taken first
+                // and handed to the `*_checked` leg, and a non-standard access
+                // with a non-constant index no longer mints a GUARD_VALUE that
+                // over-specializes an ordinary heap read.
+                let check_guards_before = ctx.num_guards();
+                let nonstandard = ctx.nonstandard_virtualizable(opcode_pc, vable_opref, &fdescr);
+                self.capture_vable_promote_guard(ctx, sym, opcode_pc, check_guards_before, None);
+                let index = if nonstandard {
+                    index
+                } else {
+                    self.implement_guard_value(ctx, sym, index_reg, index, index_value, opcode_pc)
+                };
                 let (value, concrete) = self.read_float_reg(src);
                 let guards_before = ctx.num_guards();
-                let write = match ctx.vable_setarrayitem_indexed(
+                let write = match ctx.vable_setarrayitem_checked(
+                    nonstandard,
                     opcode_pc,
                     vable_opref,
                     index,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3816,6 +3816,28 @@ impl TraceCtx {
         true
     }
 
+    /// pyjitpl.py:1120-1146 `_nonstandard_virtualizable(pc, box, fielddescr)`
+    /// as a standalone decision, for callers that must act between the check
+    /// and the branch it selects.
+    ///
+    /// `_opimpl_getarrayitem_vable` (pyjitpl.py:1220) and
+    /// `_opimpl_setarrayitem_vable` (:1239) take this decision FIRST and reach
+    /// `implement_guard_value` on the index only through
+    /// `_get_arrayitem_vable_index` (:1205), i.e. only on the standard branch.
+    /// A caller that owns an `MIFrameStack` promotes the index itself, so that
+    /// the GUARD_VALUE is built against its own framestack; it takes the
+    /// decision here and hands it to the matching `*_checked` leg rather than
+    /// letting the leg re-run a check that records ops.
+    pub fn nonstandard_virtualizable(
+        &mut self,
+        pc: usize,
+        vable_opref: OpRef,
+        fielddescr: &DescrRef,
+    ) -> bool {
+        let concrete = self.concrete_of_opref(vable_opref);
+        self.is_nonstandard_virtualizable(pc, vable_opref, fielddescr, concrete)
+    }
+
     /// Resolve a `setfield_vable`/`getfield_vable` static field descr (the
     /// `vable_static_field_descr(idx)` singleton, or the vinfo's own
     /// `SimpleFieldDescr`) to the parent-struct-layout `FieldDescr` for
@@ -4584,8 +4606,37 @@ impl TraceCtx {
         fdescr: DescrRef,
         adescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let nonstandard = self.nonstandard_virtualizable(pc, vable_opref, &fdescr);
+        self.vable_getarrayitem_int_checked(
+            nonstandard,
+            pc,
+            vable_opref,
+            index,
+            index_runtime_value,
+            fdescr,
+            adescr,
+        )
+    }
+
+    /// `_opimpl_getarrayitem_vable` body with the `_nonstandard_virtualizable`
+    /// decision already taken by the caller (see
+    /// [`Self::nonstandard_virtualizable`]).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter list mirrors the corresponding RPython metainterpreter routine plus the hoisted branch decision; grouping arguments into a Rust-only context object would obscure line-by-line parity"
+    )]
+    pub fn vable_getarrayitem_int_checked(
+        &mut self,
+        nonstandard: bool,
+        pc: usize,
+        vable_opref: OpRef,
+        index: OpRef,
+        index_runtime_value: i64,
+        fdescr: DescrRef,
+        adescr: DescrRef,
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
-        if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
+        if nonstandard {
             // arraybox = self.opimpl_getfield_gc_r(box, fdescr)
             // return self.opimpl_getarrayitem_gc_i(arraybox, indexbox, adescr)
             let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
@@ -4702,8 +4753,37 @@ impl TraceCtx {
         fdescr: DescrRef,
         adescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let nonstandard = self.nonstandard_virtualizable(pc, vable_opref, &fdescr);
+        self.vable_getarrayitem_ref_checked(
+            nonstandard,
+            pc,
+            vable_opref,
+            index,
+            index_runtime_value,
+            fdescr,
+            adescr,
+        )
+    }
+
+    /// `_opimpl_getarrayitem_vable` ref body with the
+    /// `_nonstandard_virtualizable` decision already taken by the caller (see
+    /// [`Self::nonstandard_virtualizable`]).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter list mirrors the corresponding RPython metainterpreter routine plus the hoisted branch decision; grouping arguments into a Rust-only context object would obscure line-by-line parity"
+    )]
+    pub fn vable_getarrayitem_ref_checked(
+        &mut self,
+        nonstandard: bool,
+        pc: usize,
+        vable_opref: OpRef,
+        index: OpRef,
+        index_runtime_value: i64,
+        fdescr: DescrRef,
+        adescr: DescrRef,
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
-        if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
+        if nonstandard {
             let fwd = self.nonstandard_vable_element_concrete(
                 vable_opref,
                 &fdescr,
@@ -4779,8 +4859,37 @@ impl TraceCtx {
         fdescr: DescrRef,
         adescr: DescrRef,
     ) -> (OpRef, Option<Value>) {
+        let nonstandard = self.nonstandard_virtualizable(pc, vable_opref, &fdescr);
+        self.vable_getarrayitem_float_checked(
+            nonstandard,
+            pc,
+            vable_opref,
+            index,
+            index_runtime_value,
+            fdescr,
+            adescr,
+        )
+    }
+
+    /// `_opimpl_getarrayitem_vable` float body with the
+    /// `_nonstandard_virtualizable` decision already taken by the caller (see
+    /// [`Self::nonstandard_virtualizable`]).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter list mirrors the corresponding RPython metainterpreter routine plus the hoisted branch decision; grouping arguments into a Rust-only context object would obscure line-by-line parity"
+    )]
+    pub fn vable_getarrayitem_float_checked(
+        &mut self,
+        nonstandard: bool,
+        pc: usize,
+        vable_opref: OpRef,
+        index: OpRef,
+        index_runtime_value: i64,
+        fdescr: DescrRef,
+        adescr: DescrRef,
+    ) -> (OpRef, Option<Value>) {
         let concrete = self.concrete_of_opref(vable_opref);
-        if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, concrete) {
+        if nonstandard {
             let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             return (
                 self.vable_getarrayitem_float_descr(array_opref, index, adescr),
@@ -4859,8 +4968,42 @@ impl TraceCtx {
         concrete: Value,
         live_null_push: bool,
     ) -> VableArrayStore {
-        let vable_concrete = self.concrete_of_opref(vable_opref);
-        if self.is_nonstandard_virtualizable(pc, vable_opref, &fdescr, vable_concrete) {
+        let nonstandard = self.nonstandard_virtualizable(pc, vable_opref, &fdescr);
+        self.vable_setarrayitem_checked(
+            nonstandard,
+            pc,
+            vable_opref,
+            index,
+            index_runtime_value,
+            fdescr,
+            adescr,
+            value,
+            concrete,
+            live_null_push,
+        )
+    }
+
+    /// `_opimpl_setarrayitem_vable` body with the `_nonstandard_virtualizable`
+    /// decision already taken by the caller (see
+    /// [`Self::nonstandard_virtualizable`]).
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The parameter order mirrors the corresponding RPython metainterpreter routine; grouping arguments into a Rust-only context object would obscure line-by-line parity and frame ownership"
+    )]
+    pub fn vable_setarrayitem_checked(
+        &mut self,
+        nonstandard: bool,
+        pc: usize,
+        vable_opref: OpRef,
+        index: OpRef,
+        index_runtime_value: i64,
+        fdescr: DescrRef,
+        adescr: DescrRef,
+        value: OpRef,
+        concrete: Value,
+        live_null_push: bool,
+    ) -> VableArrayStore {
+        if nonstandard {
             let array_opref = self.nonstandard_vable_array_base(vable_opref, &fdescr);
             self.profiler()
                 .count_ops(OpCode::SetarrayitemGc, crate::counters::OPS);

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1100,10 +1100,45 @@ impl WarmEnterState {
     }
 
     /// warmstate.py:191-196 `get_procedure_token`.
+    ///
+    /// Reads the cell that HEADS the bucket, which is the right cell only when
+    /// the bucket holds one. `maybe_compile_and_run` (warmstate.py:458-464)
+    /// walks `cell.next` and tests `cell.comparekey(*greenargs)` before it
+    /// looks at a token at all; [`Self::get_procedure_token_for_key`] is that
+    /// walk. Callers that hold the typed key should prefer it, and
+    /// [`Self::bucket_is_chained`] says when the two can differ.
     pub fn get_procedure_token(&self, green_key_hash: u64) -> Option<Arc<JitCellToken>> {
         self.cells
             .get(&green_key_hash)
             .and_then(|cell| cell.get_procedure_token().cloned())
+    }
+
+    /// `warmstate.py:458-464` — resolve the cell by `comparekey`, then read its
+    /// procedure token.
+    ///
+    /// The typed twin of [`Self::get_procedure_token`]. Upstream reaches a
+    /// token only through a cell it has already matched on the full green key;
+    /// this is that discipline. A bucket the key does not match anywhere is
+    /// upstream's `else:` arm — "not found" — and answers `None` rather than
+    /// handing back the head cell's unrelated token.
+    pub fn get_procedure_token_for_key(&self, key: &GreenKey) -> Option<Arc<JitCellToken>> {
+        self.lookup_chain_with_key(key)
+            .and_then(|cell| cell.get_procedure_token().cloned())
+    }
+
+    /// Whether this bucket holds more than one cell, i.e. whether the hash and
+    /// typed forms of a query can disagree at all.
+    ///
+    /// A chain needs no hash collision: one green key reached through a
+    /// hash-only writer and then a typed one produces two cells in one bucket
+    /// (see [`Self::clear_all_loop_tokens`]). An unchained bucket has exactly
+    /// one candidate, so the head IS what the walk would find, and a caller can
+    /// skip building a `GreenKey` it would only use to confirm that.
+    #[inline]
+    pub fn bucket_is_chained(&self, green_key_hash: u64) -> bool {
+        self.cells
+            .get(&green_key_hash)
+            .is_some_and(|cell| cell.next.is_some())
     }
 
     /// Allocate a new unique JitCellToken number.
@@ -4626,6 +4661,73 @@ mod tests {
             0,
             "and TRACING must be cleared on that same cell",
         );
+    }
+
+    /// `warmstate.py:458-464 maybe_compile_and_run` reads a procedure token
+    /// only off a cell whose `comparekey(*greenargs)` already matched. The
+    /// hash form reads the bucket head, which on a chained bucket is a
+    /// different cell.
+    ///
+    /// Same fixture discipline as the pair above: the hash-only writer takes
+    /// the bucket first, so the head is provably the comparator-less cell and
+    /// a head-reading lookup is looking at the wrong object.
+    #[test]
+    fn get_procedure_token_for_key_reads_the_keys_own_cell_not_the_bucket_head() {
+        let mut ws = WarmEnterState::new(100);
+        let key = GreenKey::new(vec![1100, 1200]);
+
+        ws.disable_noninlinable_function(key.get_uhash());
+        let token = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        ws.attach_procedure_to_interp_for_key(&key, Arc::clone(&token));
+
+        assert!(
+            ws.bucket_is_chained(key.get_uhash()),
+            "fixture: the hash-only writer and the typed one built a chain, \
+             which is the only case in which the two forms can disagree",
+        );
+        assert!(
+            ws.get_procedure_token(key.get_uhash()).is_none(),
+            "fixture: the head is the comparator-less cell and holds no token, \
+             so the hash form cannot see the one just installed",
+        );
+
+        let found = ws
+            .get_procedure_token_for_key(&key)
+            .expect("the typed form must find the token on the key's own cell");
+        assert!(
+            Arc::ptr_eq(&found, &token),
+            "and it must be the very token installed under this key",
+        );
+    }
+
+    /// An unchained bucket has one candidate, so the head IS the match and the
+    /// hash form is exact — this is what lets the entry path skip building a
+    /// `GreenKey` on every warm entry.
+    #[test]
+    fn an_unchained_bucket_answers_the_same_through_both_forms() {
+        let mut ws = WarmEnterState::new(100);
+        let key = GreenKey::new(vec![1300, 1400]);
+
+        let token = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        ws.attach_procedure_to_interp_for_key(&key, Arc::clone(&token));
+
+        assert!(
+            !ws.bucket_is_chained(key.get_uhash()),
+            "one typed writer and no hash-only squatter builds no chain",
+        );
+        assert!(
+            Arc::ptr_eq(
+                &ws.get_procedure_token(key.get_uhash())
+                    .expect("the hash form finds the only cell"),
+                &token,
+            ),
+            "both forms must name the same token when there is nothing to walk",
+        );
+        assert!(Arc::ptr_eq(
+            &ws.get_procedure_token_for_key(&key)
+                .expect("the typed form finds it too"),
+            &token,
+        ));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -4700,6 +4700,155 @@ mod tests {
         );
     }
 
+    /// The second green of a two-`Int` key beginning with `first` that makes it
+    /// hash to the same bucket as `other`.
+    ///
+    /// Constructed rather than searched. `get_uhash` folds
+    /// `x = (x ^ hash_whatever(tp, v)) * GREEN_UHASH_MULT` (warmstate.py:584-593)
+    /// and `hash_whatever(Int, v)` is `v` itself, so with the multiply the same
+    /// on both sides the two hashes agree exactly when the pre-multiply words
+    /// do — one xor away. A searched collision would pin the hash function; the
+    /// subject here is what a chained bucket does.
+    fn colliding_last_green(other: &GreenKey, first: i64) -> i64 {
+        use majit_ir::{GREEN_UHASH_SEED, GreenType, green_uhash_step};
+        assert_eq!(other.values.len(), 2, "written for two-green Int keys");
+        let other_prefix = green_uhash_step(GREEN_UHASH_SEED, GreenType::Int, other.values[0]);
+        let this_prefix = green_uhash_step(GREEN_UHASH_SEED, GreenType::Int, first);
+        (this_prefix ^ other_prefix ^ (other.values[1] as u64)) as i64
+    }
+
+    /// A token that answers `has_compiled_code()`, which is what both halves of
+    /// the entry gate test. The payload is never read — `has_compiled_code` is
+    /// `self.compiled.get().is_some()` — so its type only has to satisfy the
+    /// `Any + Send` bound.
+    fn token_with_compiled_code(ws: &mut WarmEnterState) -> Arc<JitCellToken> {
+        let token = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        token.set_compiled(Box::new(()));
+        assert!(token.has_compiled_code());
+        token
+    }
+
+    /// **The entry path decides on one cell and executes off another.**
+    ///
+    /// `jitdriver.rs entry_cell_has_compiled_code` resolves a chained bucket
+    /// through `comparekey` — `has_compiled_loop_for_key`, i.e.
+    /// `get_procedure_token_for_key` — but the runner it then calls,
+    /// `MetaInterp::run_compiled_detailed_with_values_at_dispatch_key`, reads
+    /// `warm_state.get_procedure_token(hash)`: the bucket HEAD.
+    ///
+    /// [`get_procedure_token_for_key_reads_the_keys_own_cell_not_the_bucket_head`]
+    /// above pins the reader in isolation, and its head cell holds no token at
+    /// all — so the entry it models DECLINES, which is safe. This one gives the
+    /// head a compiled token of its own, which is the shape a real collision
+    /// between two warm keys has, and then nothing declines: the decision is
+    /// about the chained cell's artifact and the execution is the head cell's.
+    ///
+    /// `warmstate.py:568-593` reaches a token only through the cell it has
+    /// already matched on greens + comparekey + `get_uhash` together, so the
+    /// two can never name different objects upstream. `warmstate.py:483/511`
+    /// then carries that resolved `procedure_token` to the executor
+    /// (`raise EnterJitAssembler(procedure_token, *execute_args)`) rather than
+    /// handing on the key for a second lookup — which is why upstream has no
+    /// second reader that could disagree.
+    ///
+    /// # Why this is `#[ignore]` and not a green test
+    ///
+    /// It FAILS, and the failure is the open defect, not a broken fixture. On
+    /// the tree that added it the assertion below reports `decided token #2,
+    /// executed token #1`.
+    ///
+    /// It is not fixed here because the fix is not the one this file could
+    /// make alone. The token half is small — thread the cell-resolved token to
+    /// the runner, which is upstream's own shape. But the runner reads TWO
+    /// things off the hash, and the second is
+    /// `MetaInterp::compiled_loops[hash]`, an `IndexMap<u64, CompiledEntry<M>>`
+    /// with ONE slot per hash and no chain to walk (`pyjitpl.rs` says so at
+    /// `has_compiled_loop_for_key`). Two colliding keys cannot both file a
+    /// meta there at all, so the second compile overwrites the first, and no
+    /// amount of walking on the cell side reaches a per-cell meta that does
+    /// not exist. Moving `meta` alone onto the cell would leave the rest of
+    /// `CompiledEntry` — traces, exit layouts, front target tokens, all read
+    /// across ~189 sites — indexed by hash while its `meta` was indexed by
+    /// cell: one artifact described through two index bases, which is a worse
+    /// state than this one, because it would look fixed.
+    ///
+    /// So the pin stays failing and named. Re-enabling it is the acceptance
+    /// test for moving the compiled meta onto the cell.
+    #[test]
+    #[ignore = "open defect: the entry decides on the comparekey-walked cell \
+                and executes off the bucket head; fixing it needs the compiled \
+                meta to move onto the cell, since compiled_loops holds one \
+                slot per hash"]
+    fn the_entry_decision_and_the_entry_execution_can_name_different_tokens() {
+        let mut ws = WarmEnterState::new(100);
+        let head_key = GreenKey::new(vec![2100, 2200]);
+        let chained_key = GreenKey::new(vec![2300, colliding_last_green(&head_key, 2300)]);
+        let bucket = head_key.get_uhash();
+        assert_eq!(
+            chained_key.get_uhash(),
+            bucket,
+            "fixture: the two keys must land in one bucket by their own hash, \
+             not by being installed there — `lookup_chain_with_key` starts \
+             from `key.get_uhash()`, so a hand-placed cell would simply be \
+             unreachable and the test would pass for the wrong reason",
+        );
+        assert_ne!(
+            head_key, chained_key,
+            "fixture: and they must be DIFFERENT keys, which is what makes \
+             one bucket two artifacts",
+        );
+
+        // Installed first, and keepable (a cell holding a procedure token is
+        // never `should_remove_jitcell`), so `install_new_cell` folds it in
+        // front of the second and it ends up HEADING the bucket.
+        let head_token = token_with_compiled_code(&mut ws);
+        let mut head_cell = BaseJitCell::new();
+        head_cell.set_comparekey(&head_key);
+        head_cell.set_procedure_token(Arc::clone(&head_token), false);
+        ws.install_new_cell(bucket, Some(head_cell));
+
+        let chained_token = token_with_compiled_code(&mut ws);
+        let mut chained_cell = BaseJitCell::new();
+        chained_cell.set_comparekey(&chained_key);
+        chained_cell.set_procedure_token(Arc::clone(&chained_token), false);
+        ws.install_new_cell(bucket, Some(chained_cell));
+
+        assert!(
+            ws.bucket_is_chained(bucket),
+            "fixture: both cells must share one bucket, which is the only \
+             case in which the two readers can disagree",
+        );
+        assert!(
+            !Arc::ptr_eq(&head_token, &chained_token),
+            "fixture: the two cells must hold DIFFERENT artifacts, or the \
+             defect has nothing to show",
+        );
+
+        // What the driver decides on for `chained_key`.
+        let decided = ws
+            .get_procedure_token_for_key(&chained_key)
+            .expect("the decision resolves the chain and finds the key's cell");
+        assert!(
+            Arc::ptr_eq(&decided, &chained_token),
+            "the decision is about the chained cell's artifact",
+        );
+
+        // What the runner then executes for that same key.
+        let executed = ws.get_procedure_token(chained_key.get_uhash()).expect(
+            "the runner reads the bucket head, which has a token here, \
+             so it does not decline",
+        );
+
+        assert!(
+            Arc::ptr_eq(&executed, &decided),
+            "the entry decided `chained_key` has compiled code and then ran a \
+             DIFFERENT key's artifact: decided token #{}, executed token #{}. \
+             The two must resolve through the same cell.",
+            decided.number,
+            executed.number,
+        );
+    }
+
     /// An unchained bucket has one candidate, so the head IS the match and the
     /// hash form is exact — this is what lets the entry path skip building a
     /// `GreenKey` on every warm entry.

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -1,0 +1,569 @@
+//! **Heap allocations per compiled-code entry** — the instrument for majit's
+//! warm entry path.
+//!
+//! ## Why this exists, and why it is not a `#[test]` in an ordinary file
+//!
+//! Reading the entry path statically has mispredicted this number twice. The
+//! only way to know what a warm entry costs is to count what the allocator is
+//! asked for while one is happening, so this file counts it.
+//!
+//! Three properties are load-bearing and each one is a separate failure mode:
+//!
+//! 1. **The driver must outlive the measured calls.** A fixture that builds its
+//!    `JitDriver` inside the annotated function measures a driver that never
+//!    gets warm: every call re-traces from zero and the figure it reports is
+//!    the cost of *compiling*, not of *entering*. The fixture below takes
+//!    `&mut JitDriver` as a parameter, so `main` binds one driver and calls the
+//!    interpreter many times against it — the bind-once/call-many regime the
+//!    steady-state cost lives in.
+//!
+//! 2. **The window must open at the compiled entry.** `MetaInterp`'s
+//!    `on_compiled_entry` hook fires at the one point in `back_edge_internal`
+//!    where every decline has already returned and the compiled body runs on
+//!    the next statement, so one call of the hook is exactly one entry. The
+//!    meter reads the allocation counter *in* the hook, which makes the
+//!    entry-to-entry delta a measurement of one whole round trip (assemble the
+//!    entry arguments, run the artifact, decode the exit, restore the state,
+//!    come back round to the next merge point) without needing a second probe
+//!    point in production code.
+//!
+//! 3. **libtest's thread pool races a process-global counter.** This target is
+//!    `harness = false` (see `Cargo.toml`), so there is no thread pool and no
+//!    second test running beside this one; and the counter that is *reported*
+//!    is thread-local, so an allocation made off-thread cannot land in it. A
+//!    second process-global counter is kept purely so the difference can be
+//!    reported as `off-thread` — evidence that the isolation did something,
+//!    rather than an assertion that it did.
+//!
+//! ## Per-site attribution
+//!
+//! The counter alone gives a number, not a diagnosis. For attribution the
+//! allocator captures a backtrace at each allocation made inside an armed
+//! window and buckets it by the innermost majit frame. Capturing a backtrace
+//! itself allocates, so a re-entrancy flag routes those straight to `System`
+//! uncounted and unattributed — without it the allocator recurses into itself.
+//!
+//! Attribution runs in its own short window, separate from the counting one:
+//! symbolizing a backtrace per allocation is orders of magnitude slower than
+//! the entry it describes, and a counted window that slow would be measuring
+//! the profiler.
+//!
+//! ## Running it
+//!
+//! ```text
+//! cargo test -p majit-metainterp --features dynasm --test allocs_per_compiled_entry
+//! cargo test -p majit-metainterp --features cranelift --test allocs_per_compiled_entry
+//! ```
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::{Cell, RefCell};
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use majit_metainterp::JitDriver;
+
+// ---------------------------------------------------------------------------
+// the meter
+// ---------------------------------------------------------------------------
+
+std::thread_local! {
+    /// Allocations made by THIS thread. `const`-initialised and holding a
+    /// destructor-free `Cell`, so the allocator can touch it without recursing
+    /// through lazy TLS setup or registering a TLS destructor.
+    static LOCAL_ALLOCS: Cell<u64> = const { Cell::new(0) };
+    /// Set while the allocator is capturing a backtrace. Allocations made by
+    /// the capture itself must not be counted, attributed, or recursed into.
+    static IN_PROBE: Cell<bool> = const { Cell::new(false) };
+    /// `innermost majit frame -> allocations charged to it`, filled only while
+    /// [`ATTRIBUTING`] is set.
+    static SITES: RefCell<BTreeMap<String, u64>> = RefCell::new(BTreeMap::new());
+}
+
+/// Allocations made by the whole process. Only ever read as `global - local`,
+/// which is the count that could NOT have been the subject.
+static GLOBAL_ALLOCS: AtomicU64 = AtomicU64::new(0);
+
+/// Whether the allocator should symbolize and bucket. Off for the counted
+/// window, on for the (much shorter) attribution window.
+static ATTRIBUTING: AtomicBool = AtomicBool::new(false);
+
+struct Counting;
+
+#[inline]
+fn bump() {
+    GLOBAL_ALLOCS.fetch_add(1, Ordering::Relaxed);
+    // `try_with`, not `with`: an allocation during thread teardown must not
+    // turn into a panic inside the allocator.
+    let _ = LOCAL_ALLOCS.try_with(|c| c.set(c.get() + 1));
+    if ATTRIBUTING.load(Ordering::Relaxed) {
+        attribute();
+    }
+}
+
+/// Charge this allocation to the innermost majit frame on the stack.
+#[inline(never)]
+fn attribute() {
+    let already = IN_PROBE.try_with(|c| c.replace(true)).unwrap_or(true);
+    if already {
+        return;
+    }
+    let site = innermost_majit_frame();
+    let _ = SITES.try_with(|sites| {
+        if let Ok(mut sites) = sites.try_borrow_mut() {
+            *sites.entry(site).or_insert(0) += 1;
+        }
+    });
+    let _ = IN_PROBE.try_with(|c| c.set(false));
+}
+
+/// The innermost frame that is neither the meter nor allocator plumbing, as a
+/// `symbol (file:line)` string.
+///
+/// Keyed on what to SKIP rather than on a `majit` prefix. A prefix filter reads
+/// as more precise and is in fact blinder: it buckets everything it does not
+/// recognise — a `std` collection growing inside a backend, a frame whose
+/// symbol the unwinder could not name — into one anonymous pile, and that pile
+/// was the largest row in the first run of this file. Skipping the containers
+/// instead names every site or says plainly that it could not.
+fn innermost_majit_frame() -> String {
+    let text = std::backtrace::Backtrace::force_capture().to_string();
+    let mut pending: Option<String> = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if let Some(rest) = line.strip_prefix("at ") {
+            if let Some(symbol) = pending.take() {
+                return format!("{symbol} ({})", trim_path(rest));
+            }
+            continue;
+        }
+        // Frame lines look like `  12: majit_metainterp::foo::bar`.
+        let Some((_, symbol)) = line.split_once(": ") else {
+            continue;
+        };
+        if is_plumbing(symbol) {
+            pending = None;
+        } else {
+            pending = Some(symbol.to_string());
+        }
+    }
+    match pending {
+        Some(symbol) => symbol,
+        None => String::from("<unnamed frame>"),
+    }
+}
+
+/// Frames that describe the CONTAINER an allocation went into, or the meter
+/// that observed it, rather than the code that asked for it.
+fn is_plumbing(symbol: &str) -> bool {
+    const CONTAINERS: &[&str] = &[
+        "__rust",
+        "_rjem_",
+        "alloc::",
+        "<alloc::",
+        "core::",
+        "<core::",
+        "std::",
+        "<std::",
+        "<fn(",
+        "hashbrown",
+        "<hashbrown",
+        "rustc_hash",
+        "indexmap",
+        "<indexmap",
+        "smallvec",
+        "<smallvec",
+        "vecset",
+        "<vecset",
+        "bit_set",
+        "<bit_set",
+    ];
+    // The meter's own frames, named ONE BY ONE rather than by the crate they
+    // live in. This file holds two very different kinds of code: the meter,
+    // which sits above every allocation and must never name itself; and the
+    // `#[jit_interp]` fixture, which IS entry-path code and whose expansion is
+    // one of the sites worth attributing. A `contains("allocs_per_compiled_
+    // entry")` filter cannot tell them apart, and swallowed 6 of the 11
+    // allocations per entry into an anonymous bucket when this was first run.
+    const METER: &[&str] = &[
+        "allocs_per_compiled_entry::bump",
+        "allocs_per_compiled_entry::attribute",
+        "allocs_per_compiled_entry::innermost_majit_frame",
+        "allocs_per_compiled_entry::is_plumbing",
+        "allocs_per_compiled_entry::trim_path",
+        "allocs_per_compiled_entry::Counting",
+        "<allocs_per_compiled_entry::Counting",
+    ];
+    METER.iter().any(|m| symbol.starts_with(m)) || CONTAINERS.iter().any(|c| symbol.starts_with(c))
+}
+
+/// Keep the last two path components, which is enough to identify a file
+/// without pinning the absolute build directory into the report.
+fn trim_path(at: &str) -> String {
+    let parts: Vec<&str> = at.rsplit('/').take(2).collect();
+    parts.into_iter().rev().collect::<Vec<_>>().join("/")
+}
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        bump();
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+
+    // Forwarded rather than left to the default (alloc + copy + dealloc) so
+    // `System.realloc`'s in-place growth survives; one realloc is one
+    // allocation event.
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        bump();
+        unsafe { System.realloc(ptr, layout, new_size) }
+    }
+}
+
+#[global_allocator]
+static ALLOC: Counting = Counting;
+
+#[inline]
+fn local_allocs() -> u64 {
+    LOCAL_ALLOCS.with(Cell::get)
+}
+
+// ---------------------------------------------------------------------------
+// what the entry hook records
+// ---------------------------------------------------------------------------
+
+/// Entries seen since the last [`reset_entries`].
+static ENTRIES: AtomicU64 = AtomicU64::new(0);
+/// The thread-local allocation counter as read at the FIRST entry of the
+/// current window, and at the LAST. Their difference over
+/// `ENTRIES - 1` gaps is the per-entry round-trip cost, measured entry
+/// boundary to entry boundary so no interpreter prologue or epilogue is
+/// half-counted.
+static FIRST_AT_ENTRY: AtomicU64 = AtomicU64::new(0);
+static LAST_AT_ENTRY: AtomicU64 = AtomicU64::new(0);
+
+fn reset_entries() {
+    ENTRIES.store(0, Ordering::Relaxed);
+    FIRST_AT_ENTRY.store(0, Ordering::Relaxed);
+    LAST_AT_ENTRY.store(0, Ordering::Relaxed);
+}
+
+/// Installed once on the persistent driver. Allocates nothing: two relaxed
+/// atomics and a `Cell` read.
+fn on_entry(_green_key: u64, _target_pc: usize) {
+    let now = local_allocs();
+    if ENTRIES.fetch_add(1, Ordering::Relaxed) == 0 {
+        FIRST_AT_ENTRY.store(now, Ordering::Relaxed);
+    }
+    LAST_AT_ENTRY.store(now, Ordering::Relaxed);
+}
+
+/// `(entries, allocations between the first and last entry of the window)`.
+fn window() -> (u64, u64) {
+    let entries = ENTRIES.load(Ordering::Relaxed);
+    let spanned = LAST_AT_ENTRY.load(Ordering::Relaxed) - FIRST_AT_ENTRY.load(Ordering::Relaxed);
+    (entries, spanned)
+}
+
+// ---------------------------------------------------------------------------
+// the fixture: one machine, one persistent driver
+// ---------------------------------------------------------------------------
+
+pub type Bytecode = [u8];
+
+const C_ADD: u8 = 1; // acc += n; n -= 1
+const C_BR_COND: u8 = 2; // [C_BR_COND, off]: if n != 0 jump
+const C_RETURN: u8 = 3;
+
+struct CounterState {
+    acc: i64,
+    n: i64,
+}
+
+/// `acc = n + (n-1) + ... + 1`.
+///
+/// THE DRIVER IS A PARAMETER, and that is the whole reason this fixture exists
+/// rather than reusing one of the `#[jit_interp]` fixtures next door. Every
+/// other machine in this crate spells `let mut driver = JitDriver::new(..)`
+/// inside the annotated function, which makes one call one driver: the artifact
+/// is compiled and thrown away within the call that paid for it, and no call
+/// ever *enters* an already-warm artifact. That fixture shape cannot express
+/// the regime this file measures no matter how it is driven.
+#[majit_macros::jit_interp(
+    state = CounterState,
+    env = Bytecode,
+    auto_calls = true,
+    greens = [pc, program],
+    state_fields = {
+        acc: int,
+        n: int,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(
+    mut driver: &mut JitDriver<CounterState>,
+    program: &Bytecode,
+    inputarg: i64,
+) -> i64 {
+    let mut pc: usize = 0;
+    let mut state = CounterState {
+        acc: 0,
+        n: inputarg,
+    };
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            C_ADD => {
+                state.acc = state.acc + state.n;
+                state.n = state.n - 1;
+            }
+            C_BR_COND => {
+                let offset = program[pc] as i8 as i64;
+                let target = ((pc as i64) + offset + 1) as usize;
+                pc += 1;
+                if state.n != 0 {
+                    if target <= pc {
+                        can_enter_jit!(driver, target, &mut state, program, || {});
+                    }
+                    pc = target;
+                    continue;
+                }
+            }
+            C_RETURN => break,
+            _ => {}
+        }
+    }
+
+    state.acc
+}
+
+fn counter_program() -> Vec<u8> {
+    vec![
+        C_ADD, // 0
+        C_BR_COND, 253,      // 1  (-3 -> back to 0)
+        C_RETURN, // 3
+    ]
+}
+
+/// Iterations per call. Small on purpose: the figure this file reports is a
+/// per-ENTRY cost, and a long inner loop amortizes the entry over iterations
+/// that never touch the entry path.
+const N: i64 = 8;
+
+/// Back edges before the merge point traces. Matches the in-tree fixtures.
+const THRESHOLD: u32 = 4;
+
+fn expected() -> i64 {
+    N * (N + 1) / 2
+}
+
+// ---------------------------------------------------------------------------
+// report
+// ---------------------------------------------------------------------------
+
+fn backend() -> &'static str {
+    if cfg!(feature = "cranelift") {
+        "cranelift"
+    } else if cfg!(feature = "dynasm") {
+        "dynasm"
+    } else {
+        "none"
+    }
+}
+
+fn profile() -> &'static str {
+    if cfg!(debug_assertions) {
+        "dev"
+    } else {
+        "release"
+    }
+}
+
+fn main() {
+    let program = counter_program();
+
+    // Bind ONCE. Everything below calls into this driver; nothing rebuilds it.
+    let mut driver: JitDriver<CounterState> = JitDriver::new(THRESHOLD);
+    {
+        use majit_metainterp::JitState as _;
+        // `MetaInterp::install_canonical_liveness` takes `Arc::get_mut` on the
+        // staticdata and so must run exactly once, before anything clones it.
+        // The per-call fixtures get away with calling it every call only
+        // because their driver is per-call too.
+        CounterState { acc: 0, n: 0 }
+            .build_meta(0, &program)
+            .install_canonical_liveness(&mut driver);
+    }
+    driver.set_on_compiled_entry(on_entry);
+
+    // Warm: trace, compile, and take every guard-failure bridge, so the window
+    // below sees an artifact that is already whole.
+    const WARMUP: usize = 512;
+    for _ in 0..WARMUP {
+        let got = mainloop(&mut driver, &program, N);
+        assert_eq!(
+            got,
+            expected(),
+            "the fixture must compute its own answer; a wrong result means the \
+             allocation figure below was taken off a broken run"
+        );
+    }
+    let warm_entries = ENTRIES.load(Ordering::Relaxed);
+    assert!(
+        warm_entries > 0,
+        "no compiled entry happened in {WARMUP} warm-up calls, so this run \
+         measures the INTERPRETER and not the entry path. Either the fixture \
+         stopped compiling or `on_compiled_entry` stopped firing; a number \
+         reported from here would be about neither."
+    );
+
+    // ---- the counted window -------------------------------------------
+    const CALLS: usize = 256;
+    reset_entries();
+    let before_local = local_allocs();
+    let before_global = GLOBAL_ALLOCS.load(Ordering::Relaxed);
+    for _ in 0..CALLS {
+        black_box(mainloop(&mut driver, &program, N));
+    }
+    let call_allocs = local_allocs() - before_local;
+    let off_thread =
+        (GLOBAL_ALLOCS.load(Ordering::Relaxed) - before_global).saturating_sub(call_allocs);
+    let (entries, spanned) = window();
+
+    // ---- the attribution window ---------------------------------------
+    // Separate and short: symbolizing a backtrace per allocation costs far
+    // more than the entry it describes, so a counted window run this way
+    // would be measuring the profiler.
+    const ATTRIBUTED_CALLS: usize = 8;
+    reset_entries();
+    SITES.with(|s| s.borrow_mut().clear());
+    ATTRIBUTING.store(true, Ordering::Relaxed);
+    for _ in 0..ATTRIBUTED_CALLS {
+        black_box(mainloop(&mut driver, &program, N));
+    }
+    ATTRIBUTING.store(false, Ordering::Relaxed);
+    let (attributed_entries, _) = window();
+    let sites: Vec<(String, u64)> = SITES.with(|s| {
+        let mut v: Vec<(String, u64)> = s.borrow().iter().map(|(k, n)| (k.clone(), *n)).collect();
+        v.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+        v
+    });
+
+    println!("allocations per compiled-code entry — majit warm entry path");
+    println!(
+        "backend={} profile={} threshold={THRESHOLD} n={N} warmup={WARMUP} calls={CALLS}",
+        backend(),
+        profile()
+    );
+    println!();
+    println!("  calls in window          {CALLS}");
+    println!("  compiled entries         {entries}");
+    println!("  allocations (thread)     {call_allocs}");
+    println!("  allocations (off-thread) {off_thread}");
+    println!(
+        "  per call                 {:.3}",
+        call_allocs as f64 / CALLS as f64
+    );
+    println!(
+        "  per entry, entry-to-entry {:.3}   ({spanned} allocations across {} gaps)",
+        spanned as f64 / (entries.saturating_sub(1)).max(1) as f64,
+        entries.saturating_sub(1)
+    );
+    println!();
+    println!("per-site attribution over {ATTRIBUTED_CALLS} calls / {attributed_entries} entries:");
+    let attributed: u64 = sites.iter().map(|(_, n)| *n).sum();
+    for (site, count) in &sites {
+        println!(
+            "  {count:>6}  {:>6.3}/entry  {site}",
+            *count as f64 / attributed_entries.max(1) as f64
+        );
+    }
+    println!("  {attributed:>6}  total attributed");
+
+    assert_eq!(
+        off_thread, 0,
+        "another thread allocated inside the measured window, so the \
+         thread-local isolation is not doing what the header claims"
+    );
+    assert_eq!(
+        entries as usize, CALLS,
+        "the window must be one compiled entry per call for the per-call and \
+         per-entry columns above to be the same measurement. {entries} entries \
+         over {CALLS} calls means the fixture changed shape and the two columns \
+         are no longer comparable."
+    );
+
+    // The number this file exists to pin. An EXACT equality, not a bound: a
+    // `<=` passes just as happily on a run that stopped entering compiled code
+    // altogether, and a `>=` cannot see the improvement it was written to
+    // protect. The per-site table above is the breakdown of this number, and
+    // the table is printed on every run precisely so that a failure here comes
+    // with its own diagnosis instead of a bare integer.
+    assert_eq!(
+        call_allocs as usize,
+        ALLOCS_PER_ENTRY * CALLS,
+        "warm entry allocated {:.3} times per entry; the pinned figure is \
+         {ALLOCS_PER_ENTRY}. Read the per-site table printed above: it names \
+         every allocation by symbol and file:line, so the row that moved says \
+         which site changed. Re-pin `ALLOCS_PER_ENTRY` only after deciding the \
+         move is intended.",
+        call_allocs as f64 / CALLS as f64
+    );
+}
+
+/// Heap allocations per warm compiled-code entry, as measured by this file.
+///
+/// **PER BACKEND, and the two disagree.** The backend is part of the key
+/// because it owns three of the rows below; pinning one number for both would
+/// make whichever leg ran second fail with a message about a regression that
+/// is really a configuration difference.
+///
+/// Eight of the allocations are shared by both backends:
+///
+/// | n | site |
+/// |---|------|
+/// | 2 | `CounterState::extract_live_into` — the `Vec<i64>` the macro's `extract_live` returns, and its one regrowth |
+/// | 1 | `JitState::extract_live_values` default body, `jit_state.rs:190` — the `Vec<Value>` it collects into |
+/// | 1 | `JitState::live_value_types` default body, `jit_state.rs:194` — the `Vec<Type>` it collects into |
+/// | 1 | `<[Type]>::to_vec` — `descr.fail_arg_types().to_vec()` |
+/// | 1 | `<[Value]>::to_vec` — the FINISH values copied out of the run result |
+/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key`, `pyjitpl.rs:10547` — `values` |
+/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key`, `pyjitpl.rs:10548` — `typed_values` |
+///
+/// ⚠ THE FIRST FOUR ARE A PROPERTY OF THIS FIXTURE'S STATE SHAPE, not of the
+/// entry path in general. `codegen_state.rs:1731` emits the non-allocating
+/// `extract_live_values_into` / `live_value_types_into` overrides only when the
+/// state has a ref scalar, a float scalar or a virt array; a state of int
+/// scalars only — which `CounterState` is — gets neither, and falls back to the
+/// allocating `JitState` defaults. A state that clears that gate pays 4 fewer.
+///
+/// `dynasm` adds two, for 10:
+///
+/// | n | site |
+/// |---|------|
+/// | 1 | `majit_backend::jitframe::alloc_off_gc_jitframe` — the JITFRAME itself (`llmodel.py:298 malloc_jitframe`, the ONE allocation upstream makes per entry) |
+/// | 1 | `DynasmBackend::execute_token`, `runner.rs:3001` — the `Box<FrameData>` inside `DeadFrame`. `DeadFrame` erases its payload behind `Box<dyn Any>`, so this box is the cast `llmodel.py:240` spells with `cast_opaque_ptr`; it holds the frame POINTER, not a copy of the frame |
+///
+/// It used to add three. The third was `raw_values` at `runner.rs:2990`, a copy
+/// of every jitframe slot taken because `execute_token` freed the frame before
+/// returning. `llmodel.py:240-250` reads those slots out of the frame itself,
+/// so the copy had no upstream counterpart; the frame now lives as long as the
+/// deadframe does and the accessors read it in place.
+///
+/// `cranelift` adds four, for 12:
+///
+/// | n | site |
+/// |---|------|
+/// | 1 | `<i64 as SpecFromElem>::from_elem` — `JitFrameDeadFrame::_heap_owner`, the jitframe's backing `Vec<i64>` |
+/// | 1 | `CraneliftBackend::execute_token_with_dispatch_key`, `compiler.rs:16512` |
+/// | 1 | `JitExecResult::extract_outputs`, `compiler.rs:7465` — the copy of the frame's output slots |
+/// | 1 | `deadframe_from_jitframe`, `compiler.rs:3073` — the `Box<JitFrameDeadFrame>` inside `DeadFrame` |
+const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 12 } else { 10 };

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -521,10 +521,12 @@ fn main() {
 
 /// Heap allocations per warm compiled-code entry, as measured by this file.
 ///
-/// **PER BACKEND, and the two disagree.** The backend is part of the key
-/// because it owns three of the rows below; pinning one number for both would
-/// make whichever leg ran second fail with a message about a regression that
-/// is really a configuration difference.
+/// The two backends now agree, so this is one number. It was two — `dynasm`
+/// 10, `cranelift` 12 — and the difference was the two cranelift-only rows
+/// named at the bottom, both since removed. The per-backend tables below stay
+/// split anyway: the backends reach 10 through rows that only *correspond*,
+/// and a table that pretended they were the same code would misname whichever
+/// row moved.
 ///
 /// Eight of the allocations are shared by both backends:
 ///
@@ -558,12 +560,24 @@ fn main() {
 /// so the copy had no upstream counterpart; the frame now lives as long as the
 /// deadframe does and the accessors read it in place.
 ///
-/// `cranelift` adds four, for 12:
+/// `cranelift` adds two, for 10 — the same two roles, in its own spelling:
 ///
 /// | n | site |
 /// |---|------|
-/// | 1 | `<i64 as SpecFromElem>::from_elem` — `JitFrameDeadFrame::_heap_owner`, the jitframe's backing `Vec<i64>` |
-/// | 1 | `CraneliftBackend::execute_token_with_dispatch_key`, `compiler.rs:16512` |
-/// | 1 | `JitExecResult::extract_outputs`, `compiler.rs:7465` — the copy of the frame's output slots |
-/// | 1 | `deadframe_from_jitframe`, `compiler.rs:3073` — the `Box<JitFrameDeadFrame>` inside `DeadFrame` |
-const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 12 } else { 10 };
+/// | 1 | `<i64 as SpecFromElem>::from_elem` — `JitFrameDeadFrame::_heap_owner`, the jitframe's backing `Vec<i64>` (`llmodel.py:298 malloc_jitframe`). This is the no-GC-registry branch of `run_compiled_code_inner`; with a JITFRAME type id registered the frame comes from the nursery and this row goes away |
+/// | 1 | `deadframe_from_jitframe` — the `Box<JitFrameDeadFrame>` inside `DeadFrame`, the `llmodel.py:240` `cast_opaque_ptr` |
+///
+/// It used to add four. The two that went:
+///
+/// - `CraneliftBackend::execute_token_with_dispatch_key` unwrapped the
+///   metainterp's `&[Value]` into an owned `Vec<i64>` before the frame
+///   existed. `llmodel.py:306-315` unwraps each argument *at* the store into
+///   its frame slot, so upstream never holds a second list; the arguments are
+///   now handed down as `FrameInputs::Values` and unwrapped against the frame.
+/// - `JitExecResult::extract_outputs` copied every exit slot out of the frame
+///   on every exit, and the only two consumers are branches — the
+///   CALL_ASSEMBLER sentinel, which reads slot 0, and external-JUMP re-entry.
+///   `llmodel.py:240-250` reads slots out of the frame through the accessors,
+///   so the copy is now taken only where it is consumed. This is the same
+///   removal `raw_values` got on dynasm.
+const ALLOCS_PER_ENTRY: usize = 10;

--- a/majit/majit-metainterp/tests/vable_array_promote_order.rs
+++ b/majit/majit-metainterp/tests/vable_array_promote_order.rs
@@ -1,0 +1,267 @@
+//! The six `BC_*ARRAYITEM_VABLE_*` dispatch arms must decide
+//! `_nonstandard_virtualizable` BEFORE promoting the index.
+//!
+//! `pyjitpl.py:1218-1230 _opimpl_getarrayitem_vable` (and `:1236-1247
+//! _opimpl_setarrayitem_vable`) open with the decision:
+//!
+//! ```python
+//! def _opimpl_getarrayitem_vable(self, pc, ..., arrayindex, index, ...):
+//!     if self.metainterp._nonstandard_virtualizable(pc, box, fdescr):
+//!         arraybox = self.opimpl_getfield_gc_r(box, fdescr)
+//!         return self.opimpl_getarrayitem_gc_i(arraybox, indexbox, adescr)
+//!     self.metainterp.check_synchronized_virtualizable()
+//!     index = self._get_arrayitem_vable_index(pc, arrayindex, indexbox)
+//! ```
+//!
+//! The promote lives on the first line of `_get_arrayitem_vable_index`
+//! (`pyjitpl.py:1205`), which only the STANDARD leg reaches. The non-standard
+//! leg goes to an ordinary `getfield_gc_r` + `getarrayitem_gc_*` with the index
+//! box exactly as it stands.
+//!
+//! majit's dispatch arms hoist the promote out of `TraceCtx` to the call site
+//! on purpose — the walker owns the `MIFrameStack`, so promoting here gives the
+//! guard a full-framestack snapshot, and `implement_guard_value`'s register-bank
+//! rewrite is something only the walker can do. The hazard the hoist creates is
+//! that it is easy to hoist it one step too far, above the branch that selects
+//! it, and a non-standard access with a non-constant index then mints a
+//! `GUARD_VALUE` that upstream does not — over-specializing the trace on what
+//! is an ordinary heap read.
+//!
+//! ## Two things had to be armed, because a `!` assertion cannot arm itself
+//!
+//! The subject here is which BOX a guard names, not how many guards there are:
+//! the non-standard branch mints a `GUARD_VALUE` of its own for the Step 4
+//! `PTR_EQ` promote inside `_nonstandard_virtualizable`. So "no guard named the
+//! index" is also what a walk that aborted before reaching the arm would
+//! report, and what a fixture whose vable box was never resolved would report.
+//! Each case therefore asserts that the arm ran and minted its own guard before
+//! asserting what was *not* promoted.
+//!
+//! That still only proves the arm ran. That the assertion can FAIL was checked
+//! by inverting the production decision by hand — see the note on the test
+//! itself for the exact inversion and what it produced.
+
+use std::sync::Arc;
+
+use majit_ir::{OpRef, Type, Value};
+use majit_metainterp::jitcode::JitCodeBuilder;
+use majit_metainterp::virtualizable::VirtualizableInfo;
+use majit_metainterp::{
+    ClosureRuntime, JitCode, JitCodeMachine, JitCodeSym, MIFrame, MIFrameStack, TraceCtx,
+};
+
+/// The minimum a `JitCodeSym` has to answer for the dispatcher to run one
+/// opcode. Every other member of the trait has a default.
+struct MinimalSym;
+
+impl JitCodeSym for MinimalSym {
+    fn total_slots(&self) -> usize {
+        0
+    }
+
+    fn loop_header_pc(&self) -> usize {
+        0
+    }
+
+    fn fail_args(&self) -> Option<Vec<OpRef>> {
+        None
+    }
+}
+
+/// A virtualizable with one int array, and nothing else — the smallest shape
+/// that makes `vable_array_descrs` resolve an `array_field_descrs[0]` and an
+/// `array_descrs[0]` for the arm to hand to the heap ops.
+fn one_int_array_vinfo() -> Arc<VirtualizableInfo> {
+    const TOKEN_OFFSET: usize = 0;
+    const ARRAY_FIELD_OFFSET: usize = 8;
+    const LENGTH_OFFSET: usize = 0;
+    const ITEMS_OFFSET: usize = 8;
+    const ITEM_SIZE: usize = 8;
+
+    let mut info = VirtualizableInfo::new(TOKEN_OFFSET);
+    info.add_array_field(
+        "items",
+        Type::Int,
+        ARRAY_FIELD_OFFSET,
+        LENGTH_OFFSET,
+        ITEMS_OFFSET,
+        majit_ir::make_array_descr(ITEMS_OFFSET, ITEM_SIZE, Type::Int),
+    );
+    // `virtualizable.py:293-301 finish()`. `_nonstandard_virtualizable` Step 3
+    // emits the force (`pyjitpl.py:1263 emit_force_virtualizable`) before it
+    // reaches the Step 4 `PTR_EQ`, and that emission reads `clear_vable_ptr`.
+    // Without it the fixture panics inside the arm — which would look like the
+    // arm never running.
+    info.set_clear_vable(
+        clear_vable_noop as *const (),
+        VirtualizableInfo::make_clear_vable_descr(),
+    );
+    info.finalize_arc(majit_ir::descr::make_size_descr(64))
+}
+
+/// Stands in for `virtualizable.py:294 clear_vable_token`. The emission under
+/// test only bakes its ADDRESS into a `COND_CALL`; nothing in a one-step
+/// dispatch calls it, so a body that clears nothing is the honest fixture.
+extern "C" fn clear_vable_noop(_vable: *mut u8) {}
+
+/// Which of the two arms under test to build a jitcode for.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Arm {
+    Get,
+    Set,
+}
+
+impl Arm {
+    fn name(self) -> &'static str {
+        match self {
+            Arm::Get => "BC_GETARRAYITEM_VABLE_I",
+            Arm::Set => "BC_SETARRAYITEM_VABLE_I",
+        }
+    }
+}
+
+/// Registers the fixture's jitcode uses. Named rather than spelled inline
+/// because the two arms read them in different orders.
+const VABLE_REG: u16 = 0;
+const INDEX_REG: u16 = 0;
+const VALUE_REG: u16 = 1;
+const DEST_REG: u16 = 1;
+const ARRAY_IDX: u16 = 0;
+
+fn build_jitcode(arm: Arm) -> (Arc<JitCode>, usize) {
+    let mut builder = JitCodeBuilder::new();
+    let pc = builder.current_pos();
+    match arm {
+        Arm::Get => {
+            builder.vable_getarrayitem_int_with_base(DEST_REG, VABLE_REG, ARRAY_IDX, INDEX_REG)
+        }
+        Arm::Set => {
+            builder.vable_setarrayitem_int_with_base(VABLE_REG, ARRAY_IDX, INDEX_REG, VALUE_REG)
+        }
+    }
+    let jitcode = Arc::new(builder.finish());
+    jitcode.set_index(0);
+    (jitcode, pc)
+}
+
+/// Run one dispatch step of `arm` against a NON-standard virtualizable whose
+/// index box is non-constant, and report `(guards minted, whether any guard
+/// names the index box)`.
+fn run_arm(arm: Arm) -> (usize, bool) {
+    let info = one_int_array_vinfo();
+    let mut ctx = TraceCtx::for_test_types(&[Type::Ref]);
+
+    // The STANDARD virtualizable, i.e. `virtualizable_boxes[-1]`
+    // (`pyjitpl.py:1195 virtualizable_boxes[-1]`).
+    const ARRAY_LEN: usize = 3;
+    let standard = ctx.const_ref(1);
+    let slot_count = info.num_static_extra_boxes + ARRAY_LEN;
+    let initial_boxes = vec![ctx.const_null(); slot_count];
+    let initial_values = vec![Value::Ref(majit_ir::GcRef::NULL); slot_count];
+    ctx.init_virtualizable_boxes(
+        &info,
+        standard,
+        Value::Ref(majit_ir::GcRef(1)),
+        &initial_boxes,
+        &initial_values,
+        &[ARRAY_LEN],
+    );
+
+    // A DIFFERENT object in the vable register: `_nonstandard_virtualizable`
+    // reaches its Step 4 `PTR_EQ`, reads unequal, and takes the non-standard
+    // branch. This is the whole point of the fixture — the standard branch
+    // promotes on purpose.
+    let other_vable = ctx.const_ref(2);
+
+    // A non-constant index carrying a recording-time concrete. Any other shape
+    // makes the promote a no-op, so the test would pass without measuring it.
+    let zero = ctx.const_int(0);
+    let index = ctx.record_op(majit_ir::OpCode::IntAdd, &[zero, zero]);
+    ctx.set_opref_concrete(index, Value::Int(0));
+    assert!(
+        !index.is_constant(),
+        "the index box must be promotable, or nothing here is being measured"
+    );
+    let stored = ctx.const_int(7);
+
+    let (jitcode, pc) = build_jitcode(arm);
+    let mut frame = MIFrame::new(jitcode, pc);
+    frame.ref_regs[VABLE_REG as usize] = Some(other_vable);
+    frame.ref_values[VABLE_REG as usize] = Some(2);
+    frame.int_regs[INDEX_REG as usize] = Some(index);
+    frame.int_values[INDEX_REG as usize] = Some(0);
+    if arm == Arm::Set {
+        frame.int_regs[VALUE_REG as usize] = Some(stored);
+        frame.int_values[VALUE_REG as usize] = Some(7);
+    }
+    let mut frames = MIFrameStack::empty();
+    frames.frames.push(frame);
+
+    let guards_before = ctx.num_guards();
+    let runtime = ClosureRuntime::new(|pc: usize| pc);
+    let mut sym = MinimalSym;
+    let mut machine = JitCodeMachine::<MinimalSym, _>::with_framestack(&mut frames, &[], &[]);
+    machine.run_one_step(&mut ctx, &mut sym, &runtime);
+    drop(machine);
+
+    let promoted_index = ctx.ops().iter().any(|recorded| {
+        recorded.opcode == majit_ir::OpCode::GuardValue
+            && recorded
+                .getarglist()
+                .first()
+                .is_some_and(|arg| arg.to_opref() == index)
+    });
+    (ctx.num_guards() - guards_before, promoted_index)
+}
+
+/// ## The negative control, and how it was taken
+///
+/// This assertion is a `!promoted_index`, which cannot arm itself. The `guards
+/// > 0` line below is what says the arm ran at all; that it fires on the
+/// pre-fix SHAPE was checked by hand rather than by a knob, because a
+/// production flag whose only caller is a test is a second code path to keep
+/// correct forever.
+///
+/// The inversion applied to each of the six arms in
+/// `pyjitpl/dispatch.rs` was to move the promote back above the branch, i.e.
+/// replace
+///
+/// ```text
+/// let nonstandard = ctx.nonstandard_virtualizable(..);
+/// let index = if nonstandard { index } else { self.implement_guard_value(..) };
+/// ```
+///
+/// with the pre-fix
+///
+/// ```text
+/// let index = self.implement_guard_value(..);
+/// let nonstandard = ctx.nonstandard_virtualizable(..);
+/// ```
+///
+/// Applied to all six arms, this test fails on the first case
+/// (`BC_GETARRAYITEM_VABLE_I`) with the `promoted_index` message below;
+/// restored, it passes. Anyone re-narrowing the decision has to reproduce that
+/// by the same route.
+#[test]
+fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
+    for arm in [Arm::Get, Arm::Set] {
+        let (guards, promoted_index) = run_arm(arm);
+        assert!(
+            guards > 0,
+            "{}: the arm must still mint the Step 4 PTR_EQ promote of \
+             `_nonstandard_virtualizable`. Zero guards means the walk never \
+             reached the branch, and the index assertion below would then be \
+             passing vacuously.",
+            arm.name()
+        );
+        assert!(
+            !promoted_index,
+            "{}: the index box was promoted on the NON-standard branch. \
+             `pyjitpl.py:1220` / `:1239` reach `getfield_gc_r` + \
+             `get|setarrayitem_gc_*` with the index box untouched; the promote \
+             belongs to `_get_arrayitem_vable_index` (`pyjitpl.py:1205`), which \
+             only the standard leg enters.",
+            arm.name()
+        );
+    }
+}


### PR DESCRIPTION
Slims and hardens the path a warm call takes into compiled code, and puts an in-tree meter on it so the cost is a pinned number rather than an estimate.

## Allocations per compiled-code entry

`majit/majit-metainterp/tests/allocs_per_compiled_entry.rs` is a `harness = false` test with a counting global allocator. One driver outlives 512 warmup calls plus 256 measured ones; the measurement window opens in the new `on_compiled_entry` hook, so it counts entries, not calls that might have declined. A second short window captures a backtrace per allocation and prints a per-site attribution table, so the pinned count names the sites it is made of.

The entry path allocated 19-20 times per call: `Vec`-returning `JitState` extraction, `extend_compiled_live_values` growth, virtualizable flattening buffers, a vable name clone, `fail_arg_types`/`exit_types` clones, and a defensive `inputs.to_vec` in the cranelift executor. Replacing those with an `EntryScratch` taken by value around entry assembly and `*_into` forms on `JitState` (whose defaults delegate to the existing `Vec`-returning forms, so existing impls are untouched) drops the steady one-row entry to 9 allocations on the cel rows. The meter then pins the fixture's own regime at 10 on dynasm and 12 on cranelift; removing the cranelift input/output copies brings that leg to 10 as well, so the pinned constant is now one number for both backends.

## FINISH write-back

`back_edge_internal`'s FINISH arm called `state.restore_values` with the FINISH descr's values. Those are the portal's return value — one word for an int portal — not the loop-carried state, so a state with more than one live field indexed past the end of that list and panicked. `warmstate.py:405-419`'s `execute_assembler` fast path reads only the result off the deadframe and touches no interpreter state on the way out; the arm now does the same. The `back_edge_finish` latch is still set for callers that consume it.

The panic is only reachable once a driver outlives its calls with warm bridges, which no per-call-driver fixture exercises — which is why the allocation meter's long-lived-driver fixture is what surfaced it.

## The deadframe is the jitframe

`execute_token` on dynasm copied every jitframe slot into a `Vec<i64>`, staged `jf_guard_exc` aside, and freed the frame chain before returning. Per `llmodel.py:240-250` and `:323` the deadframe **is** the jitframe. `FrameData` now holds the chain (owning) or borrows the still-executing run's frame in `force` (`llmodel.py:280-284`), decodes slots lazily through the descr's `rd_locs` (`_decode_pos`, `llmodel.py:422-424`), reads `jf_guard_exc` off the frame (`llmodel.py:240-242`), and frees the `jf_forward` chain on drop (`jitframe.py:139-145`).

That leaves the frame off the JF shadow stack for the whole window the frontend reads it in, and majit has no conservative stack scan. So `majit-gc` gains `ActiveGcDeadFrameHooks`, a fn-pointer table on the existing `ActiveGcGuardHooks` pattern through which a backend publishes its live deadframes; the collector walks them as a root source in the minor-collection root phase and in the debug root enumeration. This is a structural adaptation and is documented as one in-code.

Cranelift installs no deadframe walker, deliberately: its frames are GC objects whose `jf_gcref` slot `register_roots` already roots for the deadframe window, and a registered slot is rewritten when the frame moves, where a walker's address is not. The reasoning — including why the single-slot hook must stay untouched for a co-compiled dynasm — is documented at `register_active_hooks`.

On the cranelift side, `execute_token_with_dispatch_key` unwrapped the metainterp's `&[Value]` into an owned `Vec<i64>` before the frame existed; `llmodel.py:306-315` unwraps each argument at the store into its frame slot and holds no second list, so a `FrameInputs` source now writes arguments against the frame directly. `JitExecResult::extract_outputs` copied every exit slot on every exit; its only consumers are the `CALL_ASSEMBLER` sentinel (slot 0) and external-JUMP re-entry, so the copy is now taken only in those branches. `execute_token_ints_raw` keeps its eager copy — returning the raw slots is its contract.

## Vable array promote order

`TraceCtx` gains a public `nonstandard_virtualizable` wrapper and `*_checked` legs for the four `vable_get/setarrayitem_*_indexed` entry points, taking the branch decision as a parameter (existing callers unchanged). The six `BC_*ARRAYITEM_VABLE_*` arms in majit's dispatch now take that decision first and promote the index only on the standard leg, matching `pyjitpl.py:1205/:1229/:1244`: `_get_arrayitem_vable_index` opens with the promote and is entered only from the standard branch, while the non-standard branch reaches its `getfield_gc_r` + `get|setarrayitem_gc_*` with the index box as it stands. Promoting ahead of the decision minted a `GUARD_VALUE` upstream does not, over-specializing the trace on an ordinary heap read.

`majit/majit-metainterp/tests/vable_array_promote_order.rs` builds the metainterp `MIFrame` fixture that did not previously exist — `VirtualizableInfo`, a `TraceCtx` with `init_virtualizable_boxes`, a `JitCodeBuilder`-emitted jitcode, and `JitCodeMachine::run_one_step` — and asserts that no guard names the index box for `BC_GETARRAYITEM_VABLE_I` / `BC_SETARRAYITEM_VABLE_I`, with `guards > 0` arming the assertion so it cannot pass on a walk that never took the non-standard branch. Inverting the decision order in the six arms makes it fail naming the index box.

## Entry decisions on the key's own cell

`back_edge_internal` tested `has_compiled_loop` and then unwrapped `get_compiled_meta`; a `compile_tmp_callback` token has a body but no frontend meta, so a driver that can mint one panicked at its own loop header. The dispatch now binds the meta, which makes the fall-through to `maybe_start_tracing` — upstream's "attached by `compile_tmp_callback()`, count normally" arm (`warmstate.py:471-478`) — structural. `has_compiled_loop` stays as the first conjunct because `invalidate_loop` leaves the meta in place, so meta-presence alone would enter an invalidated loop.

Typed-key queries follow `warmstate.py:458-464`, which walks `cell.next` testing `comparekey` before reading a token: `get_procedure_token_for_key` walks the collision chain with the key comparator, with `has_compiled_loop_for_key` / `has_runnable_compiled_loop_for_key` on top. The entry branch goes through `entry_cell_has_compiled_code`, which takes the typed walk only when the bucket is actually chained — an unchained bucket's head *is* what the walk would find, and building the `GreenKey` eagerly would add two allocations to every warm entry.

### Known open defect, pinned but ignored

`majit: pin the entry deciding on one cell and executing off another` adds a deliberately-collided two-cell fixture (`get_uhash` folds `x = (x ^ hash_whatever(tp, v)) * MULT` per `warmstate.py:584-593`, so the collision is constructed with one xor rather than searched). Both cells carry their own compiled token; `entry_cell_has_compiled_code` decides through the `comparekey`-walked chained cell while the runner reads the bucket head's token — decided token #2, executed token #1. Upstream has no such second reader: `warmstate.py:568-593` reaches a token only through the cell already matched on greens + `comparekey` + `get_uhash`, and `:483/:511` carries the resolved `procedure_token` to the executor rather than re-looking-up by key.

The test is `#[ignore]`d because the fix is not in this PR: the runner also reads `compiled_loops`, an `IndexMap<u64, CompiledEntry<M>>` with one slot per hash and no chain, so two colliding keys cannot both file a meta there, and threading the token alone would split one artifact across two index bases. Re-enabling the test is the acceptance criterion for moving the compiled meta onto the cell.

## Commits dropped or reduced when carving this series

Two commits in the source series depended on work that is not on `main`, and were cut rather than pulling that work in:

- **`majit: triage MAJIT_DECLINE_LOG, MAJIT_FIELD_MINT_TRACE, MAJIT_STRUCT_LAYOUT_CENSUS` — dropped entirely.** It documents `MAJIT_DECLINE_LOG`, whose reader (`majit-translate/src/decline.rs`) is not on `main`. `pyrex`'s `every_live_triage_entry_still_has_a_reader` would go red on a triage entry with no reader. The commit's other two rows are prose refinements only.
- **`jit: promote the vable array index only on the standard branch; guard the array tid declarations` — reduced to its `trace_ctx.rs` half**, which is the `*_checked` legs and the public `nonstandard_virtualizable` wrapper described above. Its other two halves were resolved to `main`:
  - The `rlist.rs` half guards `set_gc_{int,float}_array_gc_type_id` against a conflicting re-declaration. `main` has no such setters — `GC_INT_ARRAY_GC_TYPE_ID` is a `pub const u32` literal there — so there is nothing to guard until the host-published-type-id work lands.
  - The `pyre-jit-trace/vable_ops.rs` half de-hoists `walker_promote_vable_array_index`. That function does not exist on `main`: `main`'s walker promotes inside `TraceCtx::get_arrayitem_vable_index`, which only the standard branch enters, so `main` already has the shape this half restores. The over-hoist it fixes was introduced on a branch not included here.

  The commit message is left intact and still describes all three halves; only the `trace_ctx.rs` change is present.

## Tests

Green on this branch:

- `cargo test -p majit-metainterp --features dynasm`
- `cargo test -p majit-metainterp --features cranelift`
- `cargo test -p majit-gc`
- `cargo test -p majit-backend-dynasm`
- `cargo test -p majit-backend-cranelift`
- `cargo fmt -p majit-metainterp -p majit-gc -p majit-backend-dynasm -p majit-backend-cranelift -- --check`

The allocation meter reads `per entry, entry-to-entry 10.000` on both backends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011capRVFH2W4gwGQNWYCxEx
