### PR TITLE
unpack, pyframe, gc, display: root four paths across the Python they run

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -207,6 +207,12 @@ pub fn request_deferred_major_collection() {
 pub struct GcConfig {
     /// Nursery size in bytes.
     pub nursery_size: usize,
+    /// incminimark.py:326/472 `debug_tiny_nursery` — the bytes
+    /// `collect_and_reserve` leaves free after each reservation, so a minor
+    /// collection runs roughly every `debug_tiny_nursery` bytes of allocation.
+    /// `None` is upstream's `-1` (off).  Set only by the `PYPY_GC_NURSERY`
+    /// clamp; an explicitly configured `nursery_size` is left alone.
+    pub debug_tiny_nursery: Option<usize>,
     /// Maximum object size that can be allocated in the nursery.
     /// Larger objects go directly to old gen.
     pub large_object_threshold: usize,
@@ -581,14 +587,42 @@ fn estimate_best_nursery_size() -> usize {
     best_nursery_size_for_l2cache(get_l2cache())
 }
 
-fn default_nursery_size() -> usize {
-    // incminimark.py:459-470:
-    //   newsize = env.read_from_env('PYPY_GC_NURSERY')
-    //   if newsize <= 0: newsize = env.estimate_best_nursery_size()
-    //   if newsize <= 0: newsize = defaultsize
+/// incminimark.py:453 `minsize = 2 * (self.nonlarge_max + 1)` — pyre stores
+/// `nonlarge_max + 1` directly as the large-object cutoff, so the doubling is
+/// of the cutoff itself.  A nursery below this cannot hold one non-large
+/// object, which is why upstream never lets the environment configure one.
+const LARGE_OBJECT_THRESHOLD: usize = (16384 + 512) * 8;
+
+/// incminimark.py:459-473 — the environment-configured nursery size, and the
+/// `debug_tiny_nursery` budget a request below `minsize` turns into.
+///
+/// ```python
+/// newsize = env.read_from_env('PYPY_GC_NURSERY')
+/// if newsize <= 0:
+///     newsize = env.estimate_best_nursery_size()
+///     if newsize <= 0:
+///         newsize = defaultsize
+/// if newsize < minsize:
+///     self.debug_tiny_nursery = newsize & ~(WORD-1)
+///     newsize = minsize
+/// ```
+///
+/// `PYPY_GC_NURSERY=1` means "collect on every malloc", not "a one-byte
+/// nursery": the arena stays at `minsize` so every non-large object still
+/// fits, and the requested size becomes the budget
+/// `collect_and_reserve` leaves free after each reservation.  Dropping the
+/// clamp and keeping the raw value instead hands out an arena smaller than a
+/// single object.
+fn default_nursery_size() -> (usize, Option<usize>) {
     // estimate_best_nursery_size never returns <= 0 (its floor is the 4MB
     // unknown-cache fallback), so the final `defaultsize` arm is unreachable.
-    read_uint_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size)
+    let newsize = read_uint_from_env("PYPY_GC_NURSERY").unwrap_or_else(estimate_best_nursery_size);
+    let minsize = 2 * LARGE_OBJECT_THRESHOLD;
+    if newsize < minsize {
+        (minsize, Some(newsize & !(std::mem::size_of::<usize>() - 1)))
+    } else {
+        (newsize, None)
+    }
 }
 
 /// env.py:67 `addressable_size = float(2**63)` for a 64-bit host: the most
@@ -675,9 +709,11 @@ fn get_total_memory() -> f64 {
 impl Default for GcConfig {
     fn default() -> Self {
         // large_object = (16384+512)*8 from incminimark for 64-bit
+        let (nursery_size, debug_tiny_nursery) = default_nursery_size();
         GcConfig {
-            nursery_size: default_nursery_size(),
-            large_object_threshold: (16384 + 512) * 8,
+            nursery_size,
+            debug_tiny_nursery,
+            large_object_threshold: LARGE_OBJECT_THRESHOLD,
             card_page_indices: 128,
             taggedpointers: false,
         }
@@ -1436,6 +1472,7 @@ impl MiniMarkGC {
             !ptr.is_null(),
             "collect_and_reserve could not find nursery space for a non-large object"
         );
+        self.apply_debug_tiny_nursery();
         self.finish_nursery_object(ptr, type_id)
     }
 
@@ -1579,7 +1616,32 @@ impl MiniMarkGC {
             !ptr.is_null(),
             "collect_and_reserve could not find nursery space for a non-large object"
         );
+        self.apply_debug_tiny_nursery();
         self.finish_nursery_object(ptr, type_id)
+    }
+
+    /// incminimark.py:946-948, the tail of `collect_and_reserve`:
+    ///
+    /// ```python
+    /// if self.debug_tiny_nursery >= 0:   # for debugging
+    ///     if self.nursery_top - self.nursery_free > self.debug_tiny_nursery:
+    ///         self.nursery_free = self.nursery_top - self.debug_tiny_nursery
+    /// ```
+    ///
+    /// Runs after the reservation, so the object just handed out kept the
+    /// whole arena and only what follows it is rationed.
+    #[inline]
+    fn apply_debug_tiny_nursery(&mut self) {
+        let Some(budget) = self.config.debug_tiny_nursery else {
+            return;
+        };
+        let free = self.nursery.free_ptr() as usize;
+        let top = self.nursery.top_ptr() as usize;
+        if top.saturating_sub(free) > budget {
+            // SAFETY: `top - budget` is above `free`, which the reservation
+            // just established is inside the nursery.
+            unsafe { self.nursery.set_free_ptr((top - budget) as *mut u8) };
+        }
     }
 
     /// The tail a successful nursery bump runs: `init_gc_object`, then

--- a/pyre/extra_tests/snippets/call_star_unpack_collecting_iterable.py
+++ b/pyre/extra_tests/snippets/call_star_unpack_collecting_iterable.py
@@ -1,0 +1,86 @@
+"""``f(*iterable)`` when producing each item runs a collection.
+
+The starred iterable of a ``CALL_FUNCTION_EX`` is unpacked by the call itself,
+through one of two drains: a generator runs its suspended frame per item, and
+anything else runs the iterator's ``__next__``.  Both keep producing while the
+items already pulled are held only by the drain, so an item has to survive
+every turn that follows it.
+"""
+
+import gc
+
+
+def f(*args):
+    return args
+
+
+def gen(n):
+    for i in range(n):
+        gc.collect()
+        yield [i]
+
+
+class CollectingIterator:
+    """Not a generator, so the ``next()`` drain runs instead of ``unpack_into``."""
+
+    def __init__(self, n):
+        self.i = 0
+        self.n = n
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self.i >= self.n:
+            raise StopIteration
+        i = self.i
+        self.i += 1
+        gc.collect()
+        return [i]
+
+
+class CollectingIterable:
+    """``__iter__`` itself collects, before a single item is produced."""
+
+    def __init__(self, n):
+        self.n = n
+
+    def __iter__(self):
+        gc.collect()
+        return iter([[i] for i in range(self.n)])
+
+
+for n in range(5):
+    expected = [[i] for i in range(n)]
+    for source in (gen(n), CollectingIterator(n), CollectingIterable(n)):
+        got = f(*source)
+        assert len(got) == n, (n, len(got))
+        assert [list(x) for x in got] == expected, (n, got)
+        # Each turn produced a fresh list; two slots holding one address means
+        # an item was dropped and its storage handed to a later one.
+        assert len({id(x) for x in got}) == n, (n, [id(x) for x in got])
+
+# The unpacked set also has to survive the callee's frame setup and whatever
+# collects after the call returns.
+r = f(*gen(4))
+gc.collect()
+assert [list(x) for x in r] == [[0], [1], [2], [3]], r
+
+# A `*` unpack alongside keywords reaches the same drain.
+def g(*args, **kwargs):
+    return args, sorted(kwargs.items())
+
+
+args, kwargs = g(*gen(3), x=1, **{"y": 2})
+assert [list(a) for a in args] == [[0], [1], [2]], args
+assert kwargs == [("x", 1), ("y", 2)], kwargs
+
+# An exhausted or empty producer still returns the empty unpack.
+assert f(*gen(0)) == ()
+assert f(*CollectingIterator(0)) == ()
+
+# A generator already drained by an earlier unpack yields nothing the second
+# time; `unpack_into` returns without appending.
+once = gen(2)
+assert [list(x) for x in f(*once)] == [[0], [1]]
+assert f(*once) == ()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12893,7 +12893,14 @@ pub fn unpackiterable(
     w_iterable: PyObjectRef,
     expected_length: isize,
 ) -> Result<Vec<PyObjectRef>, crate::PyError> {
-    let w_iterator = iter(w_iterable)?;
+    // `iter()` dispatches `__iter__`, which runs Python, and `w_iterable` is
+    // read again afterwards for the drain's length hint.  Publish it across
+    // that call so the hint reads the live object.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iterable);
+    let w_iterator = iter(pyre_object::gc_roots::shadow_stack_get(iterable_slot))?;
+    let w_iterable = || pyre_object::gc_roots::shadow_stack_get(iterable_slot);
     if expected_length == -1 {
         // baseobjspace.py:989-993 — generator fast path.  PyPy comments
         // (`generator.py:322 "This is a hack for performance"`) flag this
@@ -12911,7 +12918,7 @@ pub fn unpackiterable(
         // The drain returns the grown `W_List` ref (`Type::Ref`, RPython's
         // `return items`); read it back into the `Vec<PyObjectRef>` the Rust
         // signature promises here, outside the traced/blackholed drain body.
-        let w_list = _unpackiterable_unknown_length(w_iterator, w_iterable)?;
+        let w_list = _unpackiterable_unknown_length(w_iterator, w_iterable())?;
         // `warmspot.py:998-1005` re-raises `ExitFrameWithExceptionRef` out of
         // `ll_portal_runner`.  jd1 is entered from a merge-point hook that
         // returns unit, so a recording walk that ran the raising `next()` for
@@ -13015,32 +13022,44 @@ fn generator_unpack_driver_jit_merge_point(_pycode: PyObjectRef) {}
 /// null frame_ptr.  `_invoke_execute_frame(space.w_None)` corresponds to
 /// the frame's own `execute_frame(None, None)` resume — same routing as
 /// `generator_send_ex` for the `already_started=true, w_arg=None` path.
+///
+/// `results` is RPython's traced list; the `Vec` standing in for it here is
+/// native storage no root walker updates, and each resume runs the generator
+/// body, so an item already collected is unreachable across the next `yield`.
+/// Publish the generator and every produced item on the shadow stack and
+/// rebuild `results` from it once the drain ends.
 fn generator_unpack_into(
     gen_obj: PyObjectRef,
     results: &mut Vec<PyObjectRef>,
 ) -> Result<(), crate::PyError> {
     use pyre_object::generator::*;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let gen_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(gen_obj);
+    let gen_obj = || pyre_object::gc_roots::shadow_stack_get(gen_slot);
     unsafe {
         // generator.py:325-327 — `frame is None: return`.
-        if w_generator_is_running(gen_obj) {
+        if w_generator_is_running(gen_obj()) {
             // generator.py:112 `"%s already executing" % self.KIND`.
             return Err(PyError::value_error(format!(
                 "{} already executing",
-                generator_kind(gen_obj)
+                generator_kind(gen_obj())
             )));
         }
-        if w_generator_is_exhausted(gen_obj) {
+        if w_generator_is_exhausted(gen_obj()) {
             return Ok(());
         }
-        let frame_ptr = w_generator_get_frame(gen_obj) as *mut crate::pyframe::PyFrame;
+        let frame_ptr = w_generator_get_frame(gen_obj()) as *mut crate::pyframe::PyFrame;
         if frame_ptr.is_null() {
-            w_generator_set_exhausted(gen_obj);
+            w_generator_set_exhausted(gen_obj());
             return Ok(());
         }
         let frame = &mut *frame_ptr;
         // generator.py:328 `pycode = self.pycode` — pyre stashes pycode on
         // the suspended frame; expose it as the JitDriver greenkey.
         let pycode = frame.pycode as PyObjectRef;
+        let results_base = pyre_object::gc_roots::shadow_stack_len();
+        let mut produced = 0usize;
         loop {
             // generator.py:330 `jitdriver.jit_merge_point(pycode=pycode)`.
             generator_unpack_driver_jit_merge_point(pycode);
@@ -13060,9 +13079,9 @@ fn generator_unpack_into(
             // push entirely, so `yield`-expressions that bind the
             // resume value (e.g. `x = yield`) would observe stale
             // stack on the second iteration.
-            w_generator_set_started(gen_obj);
+            w_generator_set_started(gen_obj());
             let result = generator_invoke_execute_frame(
-                gen_obj,
+                gen_obj(),
                 frame,
                 Some(pyre_object::w_none()),
                 None,
@@ -13076,14 +13095,18 @@ fn generator_unpack_into(
                     // generator.py:339-341 — frame finished ⇒ RETURNed,
                     // mark exhausted and stop without appending.
                     if frame.frame_finished_execution() {
-                        generator_frame_is_finished(gen_obj, frame);
+                        generator_frame_is_finished(gen_obj(), frame);
                         break;
                     }
                     // generator.py:342 `results.append(w_result)`.
-                    results.push(w_result);
+                    pyre_object::gc_roots::pin_root(w_result);
+                    produced += 1;
                 }
             }
         }
+        results.extend(
+            (0..produced).map(|i| pyre_object::gc_roots::shadow_stack_get(results_base + i)),
+        );
         Ok(())
     }
 }
@@ -13109,24 +13132,65 @@ fn generator_unpack_into(
 ///         items.append(w_item)
 ///     return items
 /// ```
+/// Append `w_item` to the drained `W_List` published at shadow-stack slot
+/// `slot`, reading the list back inside the call.
+///
+/// The read has to happen here rather than in the drain's `Ok` arm.
+/// `try_fuse_drain_match` (`majit-translate front/result_exc.rs`) recognises
+/// that arm only when the `Result` payload read is the carrier's sole use and
+/// feeds the arm's single call directly; a shadow-stack read spelled in the arm
+/// ends the block around that read and forwards the carrier on a link instead.
+/// The fusion declines silently, leaving the `StopIteration` constructor and
+/// the `PyErrorKind::eq` in the drain — residuals with no host funcptr for the
+/// jd1 walk to invoke.
+///
+/// # Safety
+/// `slot` must be a live shadow-stack index holding a `W_List`.
+unsafe fn drain_append_at(slot: usize, w_item: PyObjectRef) {
+    unsafe {
+        pyre_object::listobject::drain_list_append(
+            pyre_object::gc_roots::shadow_stack_get(slot),
+            w_item,
+        )
+    }
+}
+
 fn _unpackiterable_unknown_length(
     w_iterator: PyObjectRef,
     w_iterable: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // `next()` runs the iterator's `__next__`, so both RPython livevars of the
+    // loop move under it.  Reload them from the shadow stack on every turn
+    // rather than reusing the addresses they had before the first resume.
+    // `w_iterator` is published ahead of the hint because that call reaches
+    // `__len__` / `__length_hint__`, which run Python too.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let root_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_iterator);
+    let w_iterator = || pyre_object::gc_roots::shadow_stack_get(root_base);
     // baseobjspace.py:1005-1008 — `try: items = newlist_hint(length_hint(...))
     // except MemoryError: items = []`.
     let _ = length_hint(w_iterable, 0)?;
-    let items = pyre_object::listobject::w_list_new_empty();
-    let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(items);
+    pyre_object::gc_roots::pin_root(pyre_object::listobject::w_list_new_empty());
+    // The slot index is computed once here, not at the append below.  Spelled
+    // `root_base + 1` inside the drain's `Ok` arm, the addition lands in the
+    // arm's own block ahead of the call, and the link out of that block then
+    // carries the `Result` alongside the element — the exact shape
+    // `try_fuse_drain_match` (`majit-translate front/result_exc.rs`) declines.
+    // Its decline is silent and leaves the `StopIteration` constructor and the
+    // `PyErrorKind::eq` in the drain, residuals with no host funcptr for the
+    // jd1 walk to invoke.  `test_result_exc_lowering.rs
+    // unpackiterable_drain_match_fuses_to_kind_test` is the guard.
+    let items_slot = root_base + 1;
+    let items = || pyre_object::gc_roots::shadow_stack_get(items_slot);
     // baseobjspace.py:1010 `greenkey = self.iterator_greenkey(w_iterator)`.
-    let greenkey = iterator_greenkey(w_iterator);
+    let greenkey = iterator_greenkey(w_iterator());
     loop {
         // baseobjspace.py:1012
         // `unpackiterable_driver.jit_merge_point(greenkey=greenkey)`.
-        unpackiterable_driver.jit_merge_point(greenkey, w_iterator, items);
-        match next(w_iterator) {
-            Ok(w_item) => unsafe { pyre_object::listobject::drain_list_append(items, w_item) },
+        unpackiterable_driver.jit_merge_point(greenkey, w_iterator(), items());
+        match next(w_iterator()) {
+            Ok(w_item) => unsafe { drain_append_at(items_slot, w_item) },
             // `except OperationError as e: if not e.match(space,
             // w_StopIteration): raise; break` — the StopIteration test rides
             // inside the handler (`e` is bound once, consumed only on the
@@ -13146,7 +13210,7 @@ fn _unpackiterable_unknown_length(
     // the blackhole epilogue is a plain `ref_return` rather than a
     // multi-word (`Vec`, sret-ABI) residual the single-register residual-call
     // handlers cannot invoke.
-    Ok(items)
+    Ok(items())
 }
 
 /// Copy the drained `W_List` back into a `Vec<PyObjectRef>` for the Rust

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4006,6 +4006,31 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         (args, None, None, None, false)
     };
 
+    // The values to print need the same treatment as the sink below, and they
+    // need it first: `resolve_default_print_target` reaches `sys.stdout`
+    // through the module dict, and every `emit` runs the argument's own
+    // `__str__` / `__repr__`.  `positional` is the caller's native slice and
+    // `sep` / `end` are native locals, so all of them name pre-collection
+    // addresses from the first of those calls onwards.
+    let arg_roots = pyre_object::gc_roots::push_roots();
+    let args_base = arg_roots.base();
+    for &arg in positional {
+        arg_roots.pin_root(arg);
+    }
+    let nargs = positional.len();
+    // `base()` is the bracket's fixed save point, so the two slots that follow
+    // the arguments are read off the live top instead.
+    let sep = sep.map(|s| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        arg_roots.pin_root(s);
+        slot
+    });
+    let end = end.map(|e| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        arg_roots.pin_root(e);
+        slot
+    });
+
     // With no explicit `file` (absent or `file=None`), the sink is the live
     // `sys.stdout`, resolved per call so a Python-level rebinding redirects
     // `print()`.  The unmodified default keeps the native path (`file = None`).
@@ -4092,17 +4117,19 @@ fn builtin_print(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         }
         Ok(())
     };
-    for (i, &obj) in positional.iter().enumerate() {
+    for i in 0..nargs {
         if i > 0 {
             match sep {
-                Some(s) => emit(s)?,
+                Some(slot) => emit(arg_roots.get(slot))?,
                 None => emit_literal(" ")?,
             }
         }
-        emit(obj)?;
+        // Read the value only here: the emits before it ran Python, and the
+        // rooted slot is what a move under them updated.
+        emit(arg_roots.get(args_base + i))?;
     }
     match end {
-        Some(e) => emit(e)?,
+        Some(slot) => emit(arg_roots.get(slot))?,
         None => emit_literal("\n")?,
     }
     if flush {

--- a/pyre/pyre-interpreter/src/display.rs
+++ b/pyre/pyre-interpreter/src/display.rs
@@ -39,16 +39,27 @@ pub(crate) unsafe fn try_call_dunder_obj(
         if !pyre_object::is_instance(obj) {
             return Ok(None);
         }
-        let Some(method) = crate::baseobjspace::lookup(obj, name) else {
+        // Resolving `name` walks the MRO, which allocates: an uncached type
+        // computes its `__mro__` on the spot and the namespace probe mints its
+        // key.  Publish the receiver first and read it back for the call —
+        // a copy taken before a collection addresses the pre-move object, and
+        // the descriptor rejects that as an instance of the wrong type.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
+        let Some(method) = crate::baseobjspace::lookup(obj(), name) else {
             return Ok(None);
         };
         if method.is_null() {
             return Ok(None);
         }
+        pyre_object::gc_roots::pin_root(method);
+        let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         // A raising `__repr__`/`__str__` propagates; a non-string return is a
         // TypeError (`object.c slot_tp_repr` / `slot_tp_str`).
-        let w_type = crate::typedef::r#type(obj).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
-        let result = crate::baseobjspace::get_and_call_function(method, obj, w_type, &[])?;
+        let w_type = crate::typedef::r#type(obj()).map_or(pyre_object::PY_NULL, |p| p.as_ptr());
+        let result = crate::baseobjspace::get_and_call_function(method(), obj(), w_type, &[])?;
         if pyre_object::is_str(result) {
             return Ok(Some(result));
         }
@@ -67,6 +78,11 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         let Some(w_type) = crate::typedef::r#type(obj) else {
             return Ok(None);
         };
+        // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_type.as_ptr(), name)
         else {
@@ -75,7 +91,10 @@ pub(crate) unsafe fn try_call_dunder_obj_above_object(
         if method.is_null() || std::ptr::eq(src, crate::typedef::w_object()) {
             return Ok(None);
         }
-        let result = crate::baseobjspace::get_and_call_function(method, obj, w_type.as_ptr(), &[])?;
+        pyre_object::gc_roots::pin_root(method);
+        let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        let result =
+            crate::baseobjspace::get_and_call_function(method(), obj(), w_type.as_ptr(), &[])?;
         if pyre_object::is_str(result) {
             return Ok(Some(result));
         }
@@ -259,13 +278,19 @@ pub unsafe fn list_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let Some(_guard) = ReprGuard::enter(obj) else {
         return Ok(Wtf8Buf::from_string("[...]".to_string()));
     };
-    let n = pyre_object::w_list_len(obj);
+    // Each item's `__repr__` runs Python, so the list itself moves under the
+    // walk; re-read it from the shadow stack before every element fetch.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let n = pyre_object::w_list_len(obj());
     let mut out = Wtf8Buf::new();
     out.push_str("[");
     for i in 0..n {
         // `listobject.py:217-221` stops rather than skipping when an item is
         // gone, since an item's `__repr__` may have shortened the list.
-        let Some(item) = pyre_object::w_list_getitem(obj, i as i64) else {
+        let Some(item) = pyre_object::w_list_getitem(obj(), i as i64) else {
             break;
         };
         // The separator goes by position, not by how much has been written:
@@ -289,11 +314,16 @@ pub unsafe fn tuple_repr(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> {
     let Some(_guard) = ReprGuard::enter(obj) else {
         return Ok(Wtf8Buf::from_string("(...)".to_string()));
     };
-    let n = pyre_object::w_tuple_len(obj);
+    // Same as `list_repr`: an item's `__repr__` moves the tuple under the walk.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
+    let obj = || pyre_object::gc_roots::shadow_stack_get(obj_slot);
+    let n = pyre_object::w_tuple_len(obj());
     let mut out = Wtf8Buf::new();
     out.push_str("(");
     for i in 0..n {
-        if let Some(item) = pyre_object::w_tuple_getitem(obj, i as i64) {
+        if let Some(item) = pyre_object::w_tuple_getitem(obj(), i as i64) {
             // `tupleobject.py:114` joins by position, so an item whose
             // `__repr__` answers `""` still gets its separator.
             if i != 0 {
@@ -417,6 +447,11 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         {
             return Ok(None);
         }
+        // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, found)) = crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
         else {
             return Ok(None);
@@ -431,8 +466,10 @@ pub(crate) unsafe fn builtin_subclass_dunder_obj(
         if std::ptr::eq(src, w_object) {
             return Ok(None);
         }
+        pyre_object::gc_roots::pin_root(found);
+        let found = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
         // A raising override propagates; a non-string return is a TypeError.
-        let r = crate::builtins::call_and_check(found, &[obj])?;
+        let r = crate::builtins::call_and_check(found(), &[obj()])?;
         if pyre_object::is_str(r) {
             return Ok(Some(r));
         }
@@ -460,6 +497,11 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
         if !pyre_object::is_type(metaclass.as_ptr()) {
             return Ok(None);
         }
+        // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(metaclass.as_ptr(), name)
         else {
@@ -470,7 +512,9 @@ pub(crate) unsafe fn type_metaclass_dunder_obj(
         {
             return Ok(None);
         }
-        let result = crate::builtins::call_and_check(method, &[obj])?;
+        pyre_object::gc_roots::pin_root(method);
+        let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        let result = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(result) {
             return Ok(Some(result));
         }
@@ -500,6 +544,11 @@ pub(crate) unsafe fn exc_user_dunder_obj(
         if w_class.is_null() || !pyre_object::is_type(w_class) {
             return Ok(None);
         }
+        // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
         else {
@@ -522,7 +571,9 @@ pub(crate) unsafe fn exc_user_dunder_obj(
         {
             return Ok(None);
         }
-        let r = crate::builtins::call_and_check(method, &[obj])?;
+        pyre_object::gc_roots::pin_root(method);
+        let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        let r = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(r) {
             return Ok(Some(r));
         }
@@ -550,6 +601,11 @@ unsafe fn module_user_dunder_obj(
         if std::ptr::eq(w_class, module_class) {
             return Ok(None);
         }
+        // Published across the allocating MRO walk, as in `try_call_dunder_obj`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let obj = || pyre_object::gc_roots::shadow_stack_get(root_base);
         let Some((src, method)) =
             crate::baseobjspace::lookup_where_with_method_cache(w_class, name)
         else {
@@ -561,7 +617,9 @@ unsafe fn module_user_dunder_obj(
         {
             return Ok(None);
         }
-        let r = crate::builtins::call_and_check(method, &[obj])?;
+        pyre_object::gc_roots::pin_root(method);
+        let method = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+        let r = crate::builtins::call_and_check(method(), &[obj()])?;
         if pyre_object::is_str(r) {
             return Ok(Some(r));
         }
@@ -599,6 +657,15 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
         return Ok(Wtf8Buf::from_string("NULL".to_string()));
     }
     unsafe {
+        // Each dispatch below resolves a dunder through an MRO walk and may
+        // run a Python override; both allocate, so the object this function
+        // goes on to format natively has to be re-read from the shadow stack
+        // rather than carried in a native local across them.  `ob_type` names
+        // a static type, so it survives the moves the object itself makes.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(obj);
+        let mut obj = obj;
         let tp = (*obj).ob_type;
         // A builtin leaf subclass keeps `ob_type` at the canonical storage
         // type but carries the Python class in `w_class`; dispatch its
@@ -606,6 +673,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
         if let Some(r) = builtin_subclass_dunder_obj(obj, tp, "__repr__")? {
             return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
         }
+        obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         // A class object is an instance of its metaclass.  PyPy's
         // `space.repr` therefore resolves `__repr__` on that metaclass before
         // `type`'s native `<class ...>` representation.  This is observable
@@ -613,6 +681,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
         if let Some(result) = type_metaclass_dunder_obj(obj, "__repr__")? {
             return Ok(pyre_object::w_str_get_wtf8(result).to_wtf8_buf());
         }
+        obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         let formatted = if let Some(s) = builtin_leaf_repr_string(obj, tp)? {
             s
         } else if pyre_object::interp_array::is_array(obj) {
@@ -652,6 +721,9 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                     && !std::ptr::eq(src, crate::typedef::w_object())
                     && !method.is_null()
                 {
+                    // The walk above allocates: re-read the receiver so the
+                    // descriptor is handed the object at its current home.
+                    obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                     // A raising override propagates; a non-string return is
                     // a TypeError like every other `__repr__` override.
                     let r = crate::builtins::call_and_check(method, &[obj])?;
@@ -791,6 +863,7 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             if let Some(r) = exc_user_dunder_obj(obj, "__repr__")? {
                 return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
             }
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             // `pypy/module/exceptions/interp_exceptions.py:135-147
             // W_BaseException.descr_repr` →
             //   lgt = len(self.args_w)
@@ -989,9 +1062,11 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
             if let Some(w) = try_call_dunder_wtf8(obj, "__repr__")? {
                 return Ok(w);
             }
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             if let Some(w) = try_call_dunder_wtf8(obj, "__str__")? {
                 return Ok(w);
             }
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {}>", repr_addr(obj as usize))
         } else {
@@ -1006,12 +1081,16 @@ pub unsafe fn py_repr_wtf8(obj: PyObjectRef) -> Result<Wtf8Buf, crate::PyError> 
                 && !std::ptr::eq(src, crate::typedef::w_object())
                 && !method.is_null()
             {
+                // The walk above allocates: re-read the receiver so the
+                // descriptor is handed the object at its current home.
+                obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
                 let r = crate::builtins::call_and_check(method, &[obj])?;
                 if pyre_object::is_str(r) {
                     return Ok(pyre_object::w_str_get_wtf8(r).to_wtf8_buf());
                 }
                 return Err(dunder_returned_non_string("__repr__", r));
             }
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             let name = crate::baseobjspace::getfulltypename(obj);
             format!("<{name} object at {}>", repr_addr(obj as usize))
         };

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3892,8 +3892,7 @@ impl PyFrame {
     /// / freevar from the mapping via `space.finditem_str` (KeyError →
     /// missing); a frame with no locals bound has nothing to copy.
     pub fn locals2fast(&mut self, skip_free_vars: bool) -> Result<(), crate::PyError> {
-        let w_locals = self.get_w_locals();
-        if w_locals.is_null() {
+        if self.get_w_locals().is_null() {
             return Ok(());
         }
         let code_ptr = unsafe { pyframe_get_pycode(self) };
@@ -3908,7 +3907,12 @@ impl PyFrame {
                 continue;
             }
             let name = &code.varnames[i];
-            let w_value = finditem_str_object(w_locals, name)?.unwrap_or(PY_NULL);
+            // `pyframe.py:576` reads `self.w_locals` per turn.  The lookup
+            // dispatches the mapping's `__getitem__`, so a hoisted copy names
+            // the address the mapping had before the previous turn ran.  The
+            // frame's own trace forwards the field, so re-reading it is the
+            // whole fix.
+            let w_value = finditem_str_object(self.get_w_locals(), name)?.unwrap_or(PY_NULL);
             let slot = locals_w!(self)[i];
             let is_cell_slot = i < code.localspluskinds.len()
                 && code.localspluskinds[i] & crate::bytecode::CO_FAST_CELL != 0;
@@ -3945,7 +3949,7 @@ impl PyFrame {
             };
             let idx = numlocals + i;
             if idx < locals_w!(self).len() {
-                let w_value = finditem_str_object(w_locals, name)?.unwrap_or(PY_NULL);
+                let w_value = finditem_str_object(self.get_w_locals(), name)?.unwrap_or(PY_NULL);
                 let slot = locals_w!(self)[idx];
                 if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
                     unsafe { pyre_object::w_cell_set(slot, w_value) };
@@ -4714,8 +4718,17 @@ fn finditem_str_object(
     w_obj: PyObjectRef,
     name: &str,
 ) -> Result<Option<PyObjectRef>, crate::PyError> {
-    let key = unsafe { pyre_object::w_str_new(name) };
-    match crate::baseobjspace::getitem(w_obj, key) {
+    // Minting the key allocates, so the mapping moves between entry and the
+    // lookup that uses it as the receiver.  A stale receiver reaches
+    // `dict.__getitem__` as a descriptor mismatch against its own type name,
+    // not as a crash, so publish it across the mint the way its `setitem` and
+    // `delitem` siblings do.
+    let roots = pyre_object::gc_roots::push_roots();
+    let object_slot = roots.base();
+    roots.pin_root(w_obj);
+    let key_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(unsafe { pyre_object::w_str_new(name) });
+    match crate::baseobjspace::getitem(roots.get(object_slot), roots.get(key_slot)) {
         Ok(v) if !v.is_null() => Ok(Some(v)),
         Ok(_) => Ok(None),
         Err(e) if e.kind == crate::PyErrorKind::KeyError => Ok(None),


### PR DESCRIPTION
Four defects, three of one shape and one of another. The shared shape: a value
is read into a Rust local, something between there and its use runs Python or
allocates, and the local keeps the address the object had before it moved.

## 1. The star-unpack drains

`f(*iterable)` compiles to a bare `CALL_FUNCTION_EX` carrying the iterable
itself — no `BUILD_LIST` / `LIST_EXTEND` — so the call performs the unpack.
Both drains held the items they had already pulled in storage no root walker
updates, so a producer that runs a collection per item loses them.

With `def gen(n): for i in range(n): gc.collect(); yield [i]`:

| form | before | CPython 3.14 |
| --- | --- | --- |
| `f(*gen(3))` | `[[2], [2], [2]]` | `[[0], [1], [2]]` |
| `f(*CollectingIterator(3))` | `()` | 3 items |
| `three(*CollectingIterator(3))` | `TypeError: three() missing 3 required positional arguments` | 3 items |
| `[*gen(3)]` `(*gen(3),)` `list(gen(3))` `a,b,c = gen(3)` | already correct | correct |

The last row is why only the call form breaks: every other shape appends into
a `W_List` the value stack roots.

- `generator_unpack_into` appended each yielded value to a native `Vec`.
  RPython's `results` is a traced list; the `Vec` standing in for it is not.
  It now pins the generator and every produced item, and rebuilds `results`
  from the shadow stack once the drain ends.
- `_unpackiterable_unknown_length` pinned its `W_List` but appended through
  the Rust local, which keeps the pre-collection address — the pin updates a
  shadow-stack slot, not the local. It now reloads both livevars every turn,
  and publishes `w_iterator` **before** `length_hint`, which reaches
  `__len__` / `__length_hint__`.
- `unpackiterable` publishes `w_iterable` across the `iter()` dispatch that
  precedes that hint read.

## 2. The frame-locals round trip

`finditem_str_object` mints the string key with `w_str_new` — an allocation —
and then uses the mapping as the lookup's receiver, so the mapping moved
between entry and the lookup. A stale mapping reaches `dict.__getitem__` as
`descriptor '__getitem__' for 'dict' objects doesn't apply to a 'dict'
object`, the same type name on both sides, rather than as a crash. Its
`setitem_str_object` / `delitem_str_object` siblings picked up the same
bracket on `main` while this branch was open; this is the third.

`locals2fast` hoisted `w_locals` out of its loop, so the copy named the
address the mapping had before the previous turn's `__getitem__` ran.
`pyframe.py:576` reads `self.w_locals` per turn and the frame's custom trace
forwards `debugdata.w_locals` (`pyre-jit/src/eval.rs:1329`), so re-reading the
field is the whole fix.

Reached from `build_class_inner` -> `locals2fast`, which is how the startup
`import site` was failing — the bare `except` printed `'import site' failed`
and swallowed the TypeError.

## 3. `PYPY_GC_NURSERY` below the minimum size

`incminimark.py:471-473` turns a request below `2 * (nonlarge_max + 1)` into a
nursery of exactly that minimum plus a `debug_tiny_nursery` budget; the
request itself is never the arena size. pyre used the raw value, so
`PYPY_GC_NURSERY=512` handed out an arena smaller than a single non-large
object and `print("hi")` SIGSEGV'd. `PYPY_GC_NURSERY=1` means "collect on
every malloc", not "a one-byte nursery".

The budget rides on `GcConfig` and is applied at both `collect_and_reserve`
tails (`incminimark.py:946-948`), after the reservation, so the object just
handed out keeps the whole arena and only what follows it is rationed.

## 4. The repr receiver

The eight dunder dispatches in `display.rs` each held the receiver in a native
local across the MRO walk that resolves the method, then handed that copy to
the call. The walk allocates, so the descriptor was handed a pre-move address
and rejected it — `descriptor '__repr__' requires a 'list' object but received
a 'list'`, the same signature as §2. The receiver and the resolved descriptor
are now published before the walk and read back at the call site;
`py_repr_wtf8` reloads its own `obj` after every dispatch it falls through,
`list_repr` / `tuple_repr` re-read the container before each element fetch,
and `builtin_print` publishes its arguments, `sep` and `end` before resolving
`sys.stdout`.

## Verification

- `extra_tests/snippets/call_star_unpack_collecting_iterable.py` (new) covers
  a generator, a non-generator iterator and a collecting `__iter__`; it fails
  on the pre-branch binary at n=1 and passes on CPython 3.14.6.
- A 14-case matrix over the call shapes (method / staticmethod / classmethod /
  lambda / `*args, **kwargs`) had 10 wrong answers before and 0 after.
- The `h(*gen(3))` `major_varsize_item` panic this started from is 0/5 instead
  of 101/5.
- For the frame-locals defect, `PYPY_GC_NURSERY=32768` fails 8/8 before and
  0/8 after; it still fails 8/8 with an unrelated env var also set, and a
  decoy env var alone fails 0/8, so the nursery value is what selects it and
  not the presence of an env var. Over 4 working directories x 25 nursery
  sizes: 4/68 before, 0/68 after.
- The nursery clamp: `PYPY_GC_NURSERY` at 1 / 512 / 4096 / 16384 / 24576 /
  32768 all exit 0 on `print("hi")`, where 16384 and below SIGSEGV'd before.
  At budget 1 a 20000-append benchmark takes 3657 ms against 134 ms
  unrationed, so the per-malloc collection it is meant to force does engage.
- `cargo test --all --no-default-features --features dynasm --no-fail-fast`:
  **exit 0, 134 suites**, with HEAD pinned for the whole run.
- `check.py`: dynasm **436/436**, cranelift **436/436**, wasm 428 passed +
  1 failed (see below).
- The drain rework in §1 initially regressed
  `majit-translate unpackiterable_drain_match_fuses_to_kind_test`. Spelling
  the shadow-stack slot as `root_base + 1` *inside* the `Ok` arm leaves the
  addition in that arm's block, which pushes the append into the next block
  and makes the link out of it carry the `Result` alongside the element —
  the shape `try_fuse_drain_match` declines, silently, reopening the jd1
  SIGBUS the fusion exists to close. The index is now computed once outside
  the loop (`items_slot`) so the arm holds only the payload read, and the
  reason is commented at the site.
- LLBC re-extracted in place; `--check` exit 0, `fingerprint matches the
  tree`, binaries built with no `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`.

## Left open

- `call.rs:pack_varargs` has no root bracket at all and `prepare_user_call`
  hands its native `final_args` to a frame allocation. Both are in the same
  call path but **neither reproduces**: 20000 iterations of
  `f(a, b, *args, **kw)` under a small nursery gives 0 wrong answers, and
  `MAJIT_GC_STRESS` cannot reach them (it fires only in `alloc_with_type`,
  while host-side pyre allocation goes through
  `try_alloc_nursery_no_collect_typed`). Left alone rather than bracketed on
  suspicion.
- The sibling stale receiver, `descriptor '__repr__' requires a 'list' object
  but received a 'list'`, is **base-owned and still open** — and §4 does not
  fix it. Over 33 nursery sizes `stdlib_ast.py` fails at 2 of them on `main`
  and at 1 on this branch, so this branch moves which size trips it rather
  than introducing it; default-nursery runs are 3/3 green.

  §4 is worth having on its own terms, but it is a **refutation** of the
  stale-local hypothesis for this symptom: with all eight dispatch sites
  publishing their receiver, the failure is bit-identical, and the
  disassembly confirms `bl shadow_stack_get` immediately precedes
  `bl call_and_check`. What the failure actually shows is an *internally
  inconsistent* object — the generic-fallback arm is only reached when
  `(*obj).ob_type` matches none of ~20 known types, yet `(*obj).w_class` read
  a few instructions later resolves `__repr__` to an owner named `list`. A
  moved object is consistent at its new address, so this is not a move; it
  reads like an old-gen object swept out from under a shadow-stack-only
  reference, which is the hazard `builtins.rs:4076` already names. Re-reading
  a slot cannot fix that — the slot still holds the freed address. Whoever
  picks this up should start at the `PYRE_GC_INTERP` safepoint sweep, not at
  more call-site rooting.
- §3 makes two further `stdlib_ast.py` symptoms reachable that used to
  SIGSEGV before reaching them, both uninvestigated: budget 1 gives
  `IndexError: list index out of range`, budget 4096 panics at
  `pyrex/src/lib.rs:490` with `called Result::unwrap() on an Err value`.
- `check.py`'s one wasm red, `synth/short_circuit_value_kept_stack` at 5.6x
  against its stated 3.7x ceiling, is **not this branch's**. This branch
  touches no bench fixture, no wasm backend and no `check.py`; the fixture is
  a pure-arithmetic 11M-iteration loop that never enters any changed
  function (its single `print` runs once). On the previous base the same
  commits measured wasm 428/428 green. The base this branch now sits on
  brought in two wasm-emission changes — #1251 "fold adjacent instructions
  while emitting", whose own message reports moving 7.2% of executed
  instructions across the five wasm-gated benches, this fixture among them,
  and #1254. The stated ceiling is left untouched: a perf gate is a target,
  not a number to refit.

— *commented by Claude*
