### PR TITLE
majit: verify the JITFRAME id contract and give each green key its own cell

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -293,71 +293,120 @@ const JF_FRAME_ITEM0_OFS: i32 = JF_FRAME_OFS as i32 + BASEITEMOFS as i32;
 /// W_FLOAT before JITFRAME, so the JITFRAME id depends on that ordering
 /// and cannot be hard-coded here).
 ///
-/// `u32::MAX` means "not yet registered"; the backend uses this in
-/// `ensure_jitframe_type_registered` to set it up lazily with its own
-/// custom trace hook, and in `alloc_nursery_no_collect_typed` to pass
-/// the correct id to the allocator.
+/// `u32::MAX` means "the frontend has published no id". Publishing is a
+/// precondition of installing a collector on this backend, not a hint the
+/// backend may supply for itself — see [`resolve_jitframe_heap`].
+///
+/// Published twice, to one value. The atomic is what a thread that never
+/// called [`set_jitframe_gc_type_id`] reads: pyre publishes once from
+/// `build_gc`, under a `Once`, and every later thread installs the singleton
+/// against that id. The thread-local is what the publishing thread itself
+/// reads, and it exists for the test binaries, where each thread builds its
+/// own collector and registers a different number of types ahead of JITFRAME:
+/// there the atomic holds whichever thread stored last, and a thread that read
+/// it would install an id naming some other collector's type.
 static JITFRAME_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(u32::MAX);
-static JITFRAME_GC_TYPE_ID_IS_EXPLICIT: AtomicBool = AtomicBool::new(false);
 
-/// Override the JITFRAME type id explicitly. Called from the frontend
-/// after it has registered its own types so that our nursery allocations
-/// (gc.alloc_nursery_no_collect_typed) use the same id that the frontend
-/// assigned to the JITFRAME TypeInfo (jitframe.py:48-52).
+thread_local! {
+    /// This thread's own publication (see [`JITFRAME_GC_TYPE_ID`]).
+    static JITFRAME_GC_TYPE_ID_LOCAL: Cell<Option<u32>> = const { Cell::new(None) };
+}
+
+/// Publish the JITFRAME type id. Called from the frontend after it has
+/// registered `jitframe_type_info()` on its collector, so that our nursery
+/// allocations (gc.alloc_nursery_no_collect_typed) use the same id the
+/// frontend assigned to the JITFRAME TypeInfo (jitframe.py:48-52).
+///
+/// Must precede the collector's install on this backend.
 pub fn set_jitframe_gc_type_id(id: u32) {
+    assert_ne!(
+        id,
+        u32::MAX,
+        "u32::MAX is the unpublished sentinel, not a type id"
+    );
+    JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.set(Some(id)));
     JITFRAME_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Release);
-    JITFRAME_GC_TYPE_ID_IS_EXPLICIT.store(true, std::sync::atomic::Ordering::Release);
 }
 
-fn jitframe_gc_type_id() -> u32 {
-    JITFRAME_GC_TYPE_ID.load(std::sync::atomic::Ordering::Acquire)
-}
-
-fn set_jitframe_gc_type_id_lazy(id: u32) {
-    JITFRAME_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Release);
-    JITFRAME_GC_TYPE_ID_IS_EXPLICIT.store(false, std::sync::atomic::Ordering::Release);
-}
-
-fn jitframe_gc_type_id_is_explicit() -> bool {
-    JITFRAME_GC_TYPE_ID_IS_EXPLICIT.load(std::sync::atomic::Ordering::Acquire)
-}
-
-// JitFrame layout registration for the GC rewriter
-/// Ensure the JITFRAME GC type is registered, and that
-/// `JITFRAME_GC_TYPE_ID` reflects the id the GC assigned to it.
-///
-/// RPython: rgc.register_custom_trace_hook(JITFRAME, jitframe_trace)
-/// called from jitframe_allocate (jitframe.py:49).
-///
-/// Lazy path (no frontend registration): register JITFRAME directly on
-/// each allocator and return the runtime-local type id. The `TypeInfo`
-/// comes from `majit_backend::jitframe::jitframe_type_info()` so the
-/// layout, item size, and custom-trace hook stay in sync with every
-/// other consumer of JITFRAME.
-fn ensure_jitframe_type_registered(gc: &mut dyn GcAllocator) -> Option<u32> {
-    if jitframe_gc_type_id_is_explicit() {
-        let id = jitframe_gc_type_id();
-        assert_ne!(id, u32::MAX, "explicit JITFRAME GC type id missing");
+fn published_jitframe_gc_type_id() -> Option<u32> {
+    if let Some(id) = JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.get()) {
         return Some(id);
     }
-    // The stub test is `did the registration take`, asked AFTER registering.
-    //
-    // `GcAllocator::register_type`'s default body returns 0 and records
-    // nothing, so an allocator with no type table accepts the call and still
-    // reports `type_count() == 0` afterwards. Asking BEFORE registering is a
-    // different question — whether some OTHER type was registered first — and
-    // it answers "no type table" for a collector whose registry is merely
-    // still empty. Every fixture in this file that wants a nursery-allocated
-    // jitframe had to register a throwaway type to get past that reading, and
-    // a frontend that registers the JITFRAME id before any of its own types
-    // would have silently fallen back to the off-GC frame.
-    let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
-    if gc.type_count() == 0 {
-        return None; // No type table (test-double allocators)
+    match JITFRAME_GC_TYPE_ID.load(std::sync::atomic::Ordering::Acquire) {
+        u32::MAX => None,
+        id => Some(id),
     }
-    set_jitframe_gc_type_id_lazy(id);
-    Some(id)
+}
+
+/// Unpublish, for the fixture that asks what an install does with no id.
+///
+/// Safe to run beside the other fixtures despite clearing process-global
+/// state: every fixture that publishes reads its own thread-local back, so
+/// the atomic has no reader but a thread that never published.
+#[cfg(test)]
+fn clear_published_jitframe_gc_type_id() {
+    JITFRAME_GC_TYPE_ID_LOCAL.with(|c| c.set(None));
+    JITFRAME_GC_TYPE_ID.store(u32::MAX, std::sync::atomic::Ordering::Release);
+}
+
+/// Where this thread's jitframes are allocated from, as decided once by
+/// `install_gc_box` / `install_gc_standalone`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum JitFrameHeap {
+    /// GC-managed under this type id — `jitframe.py:48`
+    /// `lltype.malloc(JITFRAME, ...)`, reached through
+    /// `llmodel.py:298 malloc_jitframe`.
+    Nursery(u32),
+    /// The installed allocator has no type table, so there is no shape to
+    /// allocate a frame under and the frame is a plain `Vec<i64>` block
+    /// outside both generations. Test-double allocators only; upstream has
+    /// no counterpart, because a translated backend always has a
+    /// `TypeLayoutBuilder`.
+    OffGc,
+}
+
+/// Decide, at install time, where this thread's jitframes come from.
+///
+/// RPython: rgc.register_custom_trace_hook(JITFRAME, jitframe_trace)
+/// called from jitframe_allocate (jitframe.py:49) — upstream registers the
+/// shape as part of translating the frontend, so the id is settled before any
+/// compiled code exists. This is the same ordering, made a precondition: a
+/// collector with a type table must arrive with its JITFRAME id already
+/// published, and one that arrives without it is a configuration error rather
+/// than a case to be recovered from.
+///
+/// There is no backend-side lazy registration any more, and its absence is the
+/// decision. Registering here means minting an id in whichever registry
+/// happens to be installed on the calling thread, which the frontend does not
+/// know about; it also means calling `register_type` on a registry the
+/// frontend may already have frozen (`gctypelayout.py:393-398` — after
+/// `encode_type_shapes_now` there are no new types), where the only outcomes
+/// are a panic or a shape the frontend cannot name.
+fn resolve_jitframe_heap(gc: &dyn GcAllocator) -> JitFrameHeap {
+    if !gc.has_type_registry() {
+        return JitFrameHeap::OffGc;
+    }
+    let Some(id) = published_jitframe_gc_type_id() else {
+        panic!(
+            "installing a collector with a type registry on the cranelift \
+             backend requires the JITFRAME type id: register \
+             majit_backend::jitframe::jitframe_type_info() on that collector \
+             and pass the id to set_jitframe_gc_type_id() BEFORE the install"
+        );
+    };
+    // The id is published process-wide but resolved against this collector, so
+    // an id minted in a different registry is caught here rather than at the
+    // first frame allocation, where it would name whatever type happens to sit
+    // at that index and the collector would copy jitframes under the wrong
+    // shape.
+    assert_eq!(
+        gc.type_size(id),
+        Some(majit_backend::jitframe::jitframe_type_info().size),
+        "published JITFRAME type id {id} does not name a JITFRAME in the \
+         collector being installed"
+    );
+    JitFrameHeap::Nursery(id)
 }
 
 /// Store a GC allocator in the cranelift backend thread-local and
@@ -369,11 +418,11 @@ fn install_gc_box(mut gc: Box<dyn GcAllocator>) {
     // Per-thread allocator: its nursery is not the singleton's, so the
     // process-wide published range can no longer answer `is_nursery_object`.
     majit_gc::disarm_published_nursery();
-    let jitframe_type_id = ensure_jitframe_type_registered(gc.as_mut());
+    let jitframe_heap = resolve_jitframe_heap(gc.as_ref());
     gc.freeze_types();
     let supports_guard_gc_type = gc.supports_guard_gc_type();
     set_cranelift_active_gc(Some(gc));
-    set_cranelift_jitframe_type_id(jitframe_type_id);
+    set_cranelift_jitframe_heap(Some(jitframe_heap));
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -469,13 +518,13 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
 /// the process-global `gc_sync` singleton (the per-thread GC box is the
 /// free-threading gap R4 removes).
 pub fn install_gc_standalone() {
-    let jitframe_type_id = majit_gc::gc_sync::gc_op(|gc| {
-        let id = ensure_jitframe_type_registered(gc);
+    let jitframe_heap = majit_gc::gc_sync::gc_op(|gc| {
+        let heap = resolve_jitframe_heap(gc);
         gc.freeze_types();
-        id
+        heap
     });
     let supports_guard_gc_type = majit_gc::gc_sync::gc_query(|gc| gc.supports_guard_gc_type());
-    set_cranelift_jitframe_type_id(jitframe_type_id);
+    set_cranelift_jitframe_heap(Some(jitframe_heap));
     register_active_hooks(supports_guard_gc_type);
 }
 
@@ -1470,10 +1519,13 @@ fn cranelift_type_for(tp: &Type) -> cranelift_codegen::ir::Type {
 }
 
 thread_local! {
-    /// JITFRAME `Type` id of the active GC runtime. Lazy-registered when
-    /// the GC sees its first JITFRAME, cleared when the active GC is
-    /// replaced or torn down.
-    static CRANELIFT_JITFRAME_TYPE_ID: Cell<Option<u32>> = const { Cell::new(None) };
+    /// What `install_gc_box` / `install_gc_standalone` decided about this
+    /// thread's jitframes, cleared when the active GC is torn down.
+    ///
+    /// `None` means no install ran ON THIS THREAD, which is not the same as
+    /// "no GC": the `gc_sync` singleton is process-global while this cell is
+    /// per-thread. [`cranelift_jitframe_type_id`] is what tells the two apart.
+    static CRANELIFT_JITFRAME_HEAP: Cell<Option<JitFrameHeap>> = const { Cell::new(None) };
 }
 
 /// The per-thread GC box, and the accessors every trampoline reaches it through.
@@ -1623,12 +1675,39 @@ fn set_cranelift_active_gc(gc: Option<Box<dyn GcAllocator>>) {
     gc_box::store(gc);
 }
 
+/// The type id to allocate this thread's jitframes under, or `None` for the
+/// off-GC `Vec` frame.
+///
+/// Three configurations, and the third is why this is not a plain cell read:
+///
+/// - an install ran on this thread: it already resolved the question, and its
+///   answer stands even if some other thread has since published a different
+///   id for its own collector;
+/// - no install ran anywhere reachable from here (`cranelift_gc_active()` is
+///   false): there is no collector, and the `Vec` frame is the configuration,
+///   not a fallback;
+/// - a collector is active but was installed on ANOTHER thread — the
+///   `gc_sync` singleton is process-global while the cell is per-thread. The
+///   published id is process-global too, so it answers; and if nothing
+///   published one, this fails rather than quietly handing back a `Vec` frame
+///   whose interior refs the collector would never trace.
 fn cranelift_jitframe_type_id() -> Option<u32> {
-    CRANELIFT_JITFRAME_TYPE_ID.with(|c| c.get())
+    match CRANELIFT_JITFRAME_HEAP.with(|c| c.get()) {
+        Some(JitFrameHeap::Nursery(id)) => Some(id),
+        Some(JitFrameHeap::OffGc) => None,
+        None if !cranelift_gc_active() => None,
+        None => Some(published_jitframe_gc_type_id().unwrap_or_else(|| {
+            panic!(
+                "reached compiled code with a collector installed but no \
+                 JITFRAME type id published; the frontend must call \
+                 set_jitframe_gc_type_id() before installing the collector"
+            )
+        })),
+    }
 }
 
-fn set_cranelift_jitframe_type_id(type_id: Option<u32>) {
-    CRANELIFT_JITFRAME_TYPE_ID.with(|c| c.set(type_id));
+fn set_cranelift_jitframe_heap(heap: Option<JitFrameHeap>) {
+    CRANELIFT_JITFRAME_HEAP.with(|c| c.set(heap));
 }
 
 fn cranelift_gc_active() -> bool {
@@ -3988,7 +4067,7 @@ extern "C" fn gc_alloc_varsize_shim(base_size: u64, item_size: u64, length: u64)
 ///   all live fail-args into `old_jf->jf_frame[...]` via `emit_guard_exit`
 ///   spills; this helper only needs to copy those words verbatim.
 /// - Must run on the JIT thread that owns `CRANELIFT_ACTIVE_GC` /
-///   `CRANELIFT_JITFRAME_TYPE_ID` thread-locals.
+///   `CRANELIFT_JITFRAME_HEAP` thread-locals.
 #[inline(never)]
 pub unsafe extern "C" fn cranelift_realloc_frame(old_jf: *mut i64, new_depth: usize) -> *mut i64 {
     let header_words = (JF_FRAME_ITEM0_OFS as usize) / 8;
@@ -7666,7 +7745,10 @@ fn run_compiled_code_inner(
     // When GC has a type registry (MiniMarkGC), allocate from nursery with
     // JITFRAME type_id so the GC can copy+trace it correctly. The shadow
     // stack holds a GcRef that the GC updates in place when copying.
-    // When GC is a stub (TrackingGc) or absent, fall back to Vec<i64>.
+    // With no collector at all, or one with no type table (TrackingGc), fall
+    // back to Vec<i64>. `cranelift_jitframe_type_id` is what draws that line;
+    // a collector that could trace a frame but has no shape to allocate it
+    // under fails there rather than reaching this branch.
     // jitframe_allocate (jitframe.py:48) allocates from the nursery
     // via rgc.malloc. Nursery::alloc syncs from NURSERY_FREE_ADDR
     // (incminimark.py:676 gc_adr_of_nursery_free parity) so JIT
@@ -7680,13 +7762,6 @@ fn run_compiled_code_inner(
     let use_gc_alloc = runtime_jitframe_tid.is_some();
     let (jf_gcref, heap_owner): (GcRef, Option<Vec<i64>>) = if use_gc_alloc {
         let type_id = runtime_jitframe_tid.unwrap();
-        assert_ne!(
-            type_id,
-            u32::MAX,
-            "JITFRAME GC type id not registered — frontend must call \
-             set_jitframe_gc_type_id() or ensure_jitframe_type_registered() \
-             before running compiled code"
-        );
         let gcref = with_cranelift_gc_required(|gc| {
             gc.alloc_nursery_no_collect_typed(type_id, payload_bytes)
         });
@@ -15100,7 +15175,7 @@ impl Drop for CraneliftBackend {
         // its own; matching dynasm's
         // `runner.rs DYNASM_ACTIVE_GC` reset on backend teardown.
         gc_box::clear_on_teardown();
-        let _ = CRANELIFT_JITFRAME_TYPE_ID.try_with(|c| c.set(None));
+        let _ = CRANELIFT_JITFRAME_HEAP.try_with(|c| c.set(None));
     }
 }
 
@@ -17823,6 +17898,7 @@ mod tests {
         let int_tid = gc.register_type(TypeInfo::simple(16));
         let int_vtable: usize = 0x1111_2200;
         majit_gc::GcAllocator::register_vtable_for_type(&mut gc, int_vtable, int_tid);
+        publish_jitframe_type(&mut gc);
 
         let mut backend = CraneliftBackend::new();
         backend.set_gc_allocator(Box::new(gc));
@@ -18098,20 +18174,86 @@ mod tests {
         return_ref
     }
 
+    /// Register JITFRAME on `gc` and publish its id, which is what a frontend
+    /// does before it installs its collector (`eval.rs build_gc` registers the
+    /// shape, then `set_jitframe_gc_type_id`, and only then
+    /// `install_gc_standalone`). `resolve_jitframe_heap` requires that
+    /// ordering of any collector that has a type registry.
+    ///
+    /// JITFRAME goes in AFTER whatever types the fixture registered for
+    /// itself, so it is never id 0: eval.rs registers OBJECT / W_INT / W_FLOAT
+    /// first, and a fixture that made JITFRAME the first type would be
+    /// exercising an id the shipped configuration cannot produce.
+    fn publish_jitframe_type(gc: &mut MiniMarkGC) -> u32 {
+        let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+        set_jitframe_gc_type_id(id);
+        id
+    }
+
+    /// [`publish_jitframe_type`] and the install, for the fixtures that build a
+    /// collector and hand it straight to a fresh backend.
+    fn backend_with_gc(mut gc: MiniMarkGC) -> CraneliftBackend {
+        publish_jitframe_type(&mut gc);
+        CraneliftBackend::with_gc_allocator(Box::new(gc))
+    }
+
+    /// A collector with a type registry may not be installed without its
+    /// JITFRAME id, and the refusal is a panic rather than a fall-through to
+    /// the off-GC `Vec` frame.
+    ///
+    /// The fall-through is what makes this worth a test: a `Vec` frame is not
+    /// wrong-looking at the allocation, it is wrong four collections later,
+    /// when the collector that was installed all along never traced the ref
+    /// slots of a frame it does not own.
+    ///
+    /// `expected` names only "JITFRAME" because two refusals reach it. With
+    /// nothing published the message is the missing-id one; if a sibling
+    /// fixture on another thread republishes the atomic between the clear and
+    /// the install, this collector — which has registered no type at all —
+    /// fails the id-names-a-JITFRAME check instead. Both are the contract.
+    #[test]
+    #[should_panic(expected = "JITFRAME")]
+    fn test_gc_install_without_published_jitframe_id_panics() {
+        clear_published_jitframe_gc_type_id();
+        let _backend = CraneliftBackend::with_gc_allocator(Box::new(MiniMarkGC::new()));
+    }
+
+    /// The published id is resolved against the collector being installed, so
+    /// an id minted in a DIFFERENT registry is refused at the install.
+    ///
+    /// Without the check it would be taken at face value and name whatever
+    /// type sits at that index — the collector would then copy jitframes under
+    /// some other shape's layout, which is the failure the hard-coded `2` in
+    /// eval.rs's comment describes.
+    #[test]
+    #[should_panic(expected = "does not name a JITFRAME")]
+    fn test_gc_install_with_a_foreign_jitframe_id_panics() {
+        let mut gc = MiniMarkGC::new();
+        let plain = gc.register_type(TypeInfo::simple(16));
+        set_jitframe_gc_type_id(plain);
+        let _backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+    }
+
+    /// An allocator with no type table keeps the off-GC `Vec` frame, and that
+    /// is the whole of the exemption: it is not "no id published", it is "no
+    /// registry to publish an id into". `TrackingGc` takes `GcAllocator`'s
+    /// default `has_type_registry`, as every test double does.
+    #[test]
+    fn test_stub_gc_install_keeps_the_off_gc_frame() {
+        let stub = TrackingGc::new(Arc::new(Mutex::new(TrackingGcState::default())));
+        assert!(!majit_gc::GcAllocator::has_type_registry(&stub));
+        let _backend = CraneliftBackend::with_gc_allocator(Box::new(stub));
+        assert_eq!(cranelift_jitframe_type_id(), None);
+    }
+
     fn make_gc_backend() -> CraneliftBackend {
         let mut gc = MiniMarkGC::with_config(GcConfig {
             nursery_size: 1 << 20,
             large_object_threshold: 1 << 20,
             ..GcConfig::default()
         });
-        // eval.rs registers regular GC types before installing the backend, so
-        // JITFRAME is never type id 0 in production. Keep this fixture on the
-        // same path: `install_call_assembler_test_layout` publishes whatever id
-        // the lazy registration assigns, and a fixture that made JITFRAME the
-        // first type would be exercising an id the shipped configuration
-        // cannot produce.
         gc.register_type(TypeInfo::simple(16));
-        CraneliftBackend::with_gc_allocator(Box::new(gc))
+        backend_with_gc(gc)
     }
 
     /// Publish the JitFrame layout descrs so the GC rewriter's
@@ -18119,12 +18261,13 @@ mod tests {
     /// GC_STORE against callee jitframes. Mirrors the dynasm test layout
     /// (runner.rs install_call_assembler_test_layout); the offsets match
     /// the production cranelift mapping in pyre-jit call_jit.rs
-    /// jitframe_layout_descrs. Reads jitframe_gc_type_id() after
-    /// set_gc_allocator has lazily registered JITFRAME.
+    /// jitframe_layout_descrs. Reads the type id the install resolved, so it
+    /// must run after `set_gc_allocator`.
     fn install_call_assembler_test_layout() {
         register_jitframe_layout(JitFrameLayoutInfo {
             jitframe_descrs: Some(majit_gc::rewrite::JitFrameDescrs {
-                jitframe_tid: jitframe_gc_type_id(),
+                jitframe_tid: cranelift_jitframe_type_id()
+                    .expect("call-assembler fixtures run on a GC-backed frame"),
                 jitframe_fixed_size: majit_backend::jitframe::JITFRAME_FIXED_SIZE,
                 jf_frame_info_ofs: majit_backend::jitframe::JF_FRAME_INFO_OFS,
                 jf_descr_ofs: JF_DESCR_OFS,
@@ -18143,8 +18286,8 @@ mod tests {
     /// GC-backed backend for CALL_ASSEMBLER tests:
     /// validate_call_assembler_rewrite_prereqs (compiler.rs) requires both a
     /// configured GC runtime and a registered JITFRAME layout. Build the GC
-    /// on the lazy path (like make_gc_backend), then install the layout once
-    /// set_gc_allocator has published the JITFRAME type id.
+    /// like make_gc_backend, then install the layout once the install has
+    /// resolved the JITFRAME type id.
     fn make_call_assembler_backend() -> CraneliftBackend {
         let mut gc = MiniMarkGC::with_config(GcConfig {
             nursery_size: 1 << 20,
@@ -18152,7 +18295,7 @@ mod tests {
             ..GcConfig::default()
         });
         gc.register_type(TypeInfo::simple(16));
-        let backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let backend = backend_with_gc(gc);
         install_call_assembler_test_layout();
         backend
     }
@@ -18181,7 +18324,7 @@ mod tests {
             ..GcConfig::default()
         });
         gc.register_type(TypeInfo::simple(16));
-        let _backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let _backend = backend_with_gc(gc);
 
         let type_id = cranelift_jitframe_type_id().expect("JITFRAME type id must be registered");
         let old = with_cranelift_gc_required(|gc| {
@@ -18485,7 +18628,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xD30F_0001;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let carried = OpRef::ref_op(1);
         let guard = mk_op(
             OpCode::GuardFalse,
@@ -18527,7 +18670,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xD30F_0003;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let carried = OpRef::ref_op(2);
         let next_count = OpRef::int_op(3);
         let guard = mk_op(OpCode::GuardTrue, &[OpRef::int_op(4)], OpRef::NONE.raw());
@@ -18573,7 +18716,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xD30F_0002;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let carried = OpRef::ref_op(1);
         let loop_descr = make_label_descr(1701);
         let guard = mk_op(
@@ -18626,7 +18769,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xD30F_0004;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let carried = OpRef::ref_op(2);
         let start_descr = make_label_descr(1704);
         let body_descr = make_label_descr(1705);
@@ -20402,7 +20545,7 @@ mod tests {
         set_test_exception_state(exception_ref.0 as i64);
         clear_test_exception_call_log();
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let descr = make_call_descr(vec![Type::Int], Type::Void);
 
         let inputargs = vec![InputArg::new_int(0)];
@@ -24377,7 +24520,7 @@ mod tests {
         });
         gc.register_type(TypeInfo::simple(16));
         let obj = majit_gc::GcAllocator::alloc_oldgen_typed(&mut gc, 0, 16);
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let inputargs = vec![InputArg::new_ref(0)];
         let ops = vec![
@@ -24438,7 +24581,7 @@ mod tests {
         });
         gc.register_type(TypeInfo::simple(payload_size));
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         // test_gc_integration.py:808-817:
         //   []
@@ -24503,7 +24646,7 @@ mod tests {
         });
         gc.register_type(TypeInfo::simple(16));
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let fd = make_field_descr(0, 8, Type::Int, true);
         let inputargs = vec![];
@@ -24574,7 +24717,7 @@ mod tests {
         let filler = gc.alloc_with_type(young_node_tid, 16);
         assert!(gc.is_in_nursery(filler.0));
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
         let ref_fd = make_field_descr(0, 8, Type::Ref, false);
         let int_fd = make_field_descr(0, 8, Type::Int, true);
         let inputargs = vec![InputArg::new_ref(0)];
@@ -24870,7 +25013,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xABCDEF01;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let descr = make_call_descr(vec![Type::Int], Type::Int);
         let inputargs = vec![InputArg::new_ref(0)];
@@ -24927,7 +25070,7 @@ mod tests {
             *(root.0 as *mut u64) = 0xFACEB00C;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let descr = make_call_descr(vec![Type::Int], Type::Void);
         let inputargs = vec![InputArg::new_ref(0)];
@@ -24982,7 +25125,7 @@ mod tests {
             *(root.0 as *mut u64) = 0x12345678;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let inputargs = vec![InputArg::new_ref(0)];
         let ops = vec![
@@ -25039,7 +25182,7 @@ mod tests {
             *(root.0 as *mut u64) = 0x5EED_5EED;
         }
 
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let inputargs = vec![InputArg::new_ref(0)];
         let ops = vec![
@@ -25100,7 +25243,7 @@ mod tests {
         gc.register_type(TypeInfo::simple(16));
 
         let root = gc.alloc_with_type(0, 16);
-        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+        let mut backend = backend_with_gc(gc);
 
         let inputargs = vec![InputArg::new_ref(0)];
         let ops = vec![

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -336,15 +336,26 @@ fn jitframe_gc_type_id_is_explicit() -> bool {
 /// layout, item size, and custom-trace hook stay in sync with every
 /// other consumer of JITFRAME.
 fn ensure_jitframe_type_registered(gc: &mut dyn GcAllocator) -> Option<u32> {
-    if gc.type_count() == 0 {
-        return None; // Stub GC (TrackingGc), no type registry
-    }
     if jitframe_gc_type_id_is_explicit() {
         let id = jitframe_gc_type_id();
         assert_ne!(id, u32::MAX, "explicit JITFRAME GC type id missing");
         return Some(id);
     }
+    // The stub test is `did the registration take`, asked AFTER registering.
+    //
+    // `GcAllocator::register_type`'s default body returns 0 and records
+    // nothing, so an allocator with no type table accepts the call and still
+    // reports `type_count() == 0` afterwards. Asking BEFORE registering is a
+    // different question — whether some OTHER type was registered first — and
+    // it answers "no type table" for a collector whose registry is merely
+    // still empty. Every fixture in this file that wants a nursery-allocated
+    // jitframe had to register a throwaway type to get past that reading, and
+    // a frontend that registers the JITFRAME id before any of its own types
+    // would have silently fallen back to the off-GC frame.
     let id = gc.register_type(majit_backend::jitframe::jitframe_type_info());
+    if gc.type_count() == 0 {
+        return None; // No type table (test-double allocators)
+    }
     set_jitframe_gc_type_id_lazy(id);
     Some(id)
 }
@@ -18093,10 +18104,12 @@ mod tests {
             large_object_threshold: 1 << 20,
             ..GcConfig::default()
         });
-        // eval.rs registers regular GC types before installing the backend.
-        // Keep this fixture on the same path so set_gc_allocator() can lazily
-        // register JITFRAME instead of tripping the "type id not registered"
-        // assertion that only exists for half-initialized test runtimes.
+        // eval.rs registers regular GC types before installing the backend, so
+        // JITFRAME is never type id 0 in production. Keep this fixture on the
+        // same path: `install_call_assembler_test_layout` publishes whatever id
+        // the lazy registration assigns, and a fixture that made JITFRAME the
+        // first type would be exercising an id the shipped configuration
+        // cannot produce.
         gc.register_type(TypeInfo::simple(16));
         CraneliftBackend::with_gc_allocator(Box::new(gc))
     }
@@ -24991,6 +25004,90 @@ mod tests {
         assert!(!moved_root.is_null());
         assert_ne!(moved_root, root);
         assert_eq!(unsafe { *(moved_root.0 as *const u64) }, 0x12345678);
+    }
+
+    /// A held deadframe whose JITFRAME is nursery-born survives a collection
+    /// that MOVES the frame.
+    ///
+    /// `test_deadframe_ref_survives_collection_after_execute_token` above runs
+    /// on a 160-byte nursery, which no jitframe fits in, so its frame is born
+    /// old-gen and never moves: what it checks is that a REF INSIDE the frame
+    /// was forwarded. `jitframe.py:33-60` makes JITFRAME an ordinary GcStruct
+    /// and `llmodel.py:298 malloc_jitframe` allocates it like any other object,
+    /// so the frame itself is nursery-born and a minor collection promotes it
+    /// to a different address — and every accessor on the deadframe reads
+    /// through `jf_gcref`, which is stale the moment that happens.
+    ///
+    /// What makes it not stale is that `register_roots` hands the collector the
+    /// ADDRESS OF THE SLOT (`add_root(&mut self.jf_gcref)`) rather than the
+    /// address of the frame, so the promotion rewrites the holder's pointer.
+    /// The assertion that the frame moved is therefore load-bearing: without
+    /// it a run where the frame happened to stay put would pass while proving
+    /// nothing, which is exactly what the old-gen fixture next door does.
+    #[test]
+    fn test_deadframe_nursery_jitframe_moves_across_collection() {
+        let mut gc = MiniMarkGC::with_config(GcConfig {
+            nursery_size: 1 << 20,
+            large_object_threshold: 1 << 20,
+            ..GcConfig::default()
+        });
+        gc.register_type(TypeInfo::simple(16));
+
+        let root = gc.alloc_with_type(0, 16);
+        assert!(gc.is_in_nursery(root.0));
+        unsafe {
+            *(root.0 as *mut u64) = 0x5EED_5EED;
+        }
+
+        let mut backend = CraneliftBackend::with_gc_allocator(Box::new(gc));
+
+        let inputargs = vec![InputArg::new_ref(0)];
+        let ops = vec![
+            mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
+            mk_op(
+                OpCode::Finish,
+                &[OpRef::input_arg_ref(0)],
+                OpRef::NONE.raw(),
+            ),
+        ];
+
+        let token = JitCellToken::new(1510);
+        backend.compile_loop(&inputargs, &ops, &token).unwrap();
+
+        let frame = backend.execute_token(&token, &[Value::Ref(root)]);
+
+        let frame_addr = |frame: &DeadFrame| {
+            frame
+                .data
+                .downcast_ref::<JitFrameDeadFrame>()
+                .expect("cranelift deadframes are JitFrameDeadFrame")
+                .jf_gcref
+        };
+        let before = frame_addr(&frame);
+        assert!(
+            with_cranelift_gc_required(|gc| gc.is_nursery_object(before.0)),
+            "the frame must be nursery-born, or the promotion this test is \
+             about cannot happen"
+        );
+
+        with_cranelift_gc_required(|gc| gc.collect_nursery());
+
+        let after = frame_addr(&frame);
+        assert_ne!(
+            after, before,
+            "a surviving nursery object is promoted, so the frame address must \
+             have changed; if it did not, this run cannot tell a rewritten \
+             root slot from an unmoved frame"
+        );
+        assert!(
+            !with_cranelift_gc_required(|gc| gc.is_nursery_object(after.0)),
+            "the promoted frame belongs to the old generation"
+        );
+
+        let moved_root = backend.get_ref_value(&frame, 0);
+        assert!(!moved_root.is_null());
+        assert_ne!(moved_root, root);
+        assert_eq!(unsafe { *(moved_root.0 as *const u64) }, 0x5EED_5EED);
     }
 
     #[test]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -6210,6 +6210,12 @@ impl GcAllocator for MiniMarkGC {
         self.types.freeze_types();
     }
 
+    /// Owns a `TypeRegistry`, so a shape id can always be resolved against
+    /// this allocator — including before anything has been registered in it.
+    fn has_type_registry(&self) -> bool {
+        true
+    }
+
     /// gc.py:318 `GcLLDescr_framework.supports_guard_gc_type = True`.
     /// MiniMarkGC owns a `TypeRegistry` that materializes a `TYPE_INFO`
     /// table on demand, so the framework-equivalent flag is always

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -986,6 +986,21 @@ pub trait GcAllocator: Send {
     /// Default no-op for stub allocators with no type table.
     fn freeze_types(&mut self) {}
 
+    /// Whether this allocator keeps a type table at all
+    /// (`gctypelayout.py` `TypeLayoutBuilder` — a collector translated
+    /// without one has no `type_info_group` to name a shape in).
+    ///
+    /// A capability, deliberately, rather than a reading of `type_count()`:
+    /// `register_type`'s default body returns 0 and records nothing, so an
+    /// allocator with no table and one whose table is merely still empty both
+    /// report zero, and the two want opposite answers from a caller deciding
+    /// whether a shape id can be resolved against this allocator. The default
+    /// `false` matches the same default-body allocators `freeze_types` and
+    /// `supports_guard_gc_type` are written for.
+    fn has_type_registry(&self) -> bool {
+        false
+    }
+
     /// llsupport/gc.py:162 / gc.py:318 `supports_guard_gc_type` flag.
     /// `GcLLDescr_boehm` sets it to `False`; `GcLLDescr_framework` sets
     /// it to `True`. Relayed to `cpu.supports_guard_gc_type` via
@@ -1423,6 +1438,9 @@ impl GcAllocator for GcHandle {
     }
     fn freeze_types(&mut self) {
         gc_sync::gc_op(|gc| gc.freeze_types())
+    }
+    fn has_type_registry(&self) -> bool {
+        gc_sync::gc_query_reentrant(|gc| gc.has_type_registry())
     }
     fn supports_guard_gc_type(&self) -> bool {
         gc_sync::gc_query_reentrant(|gc| gc.supports_guard_gc_type())

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4362,6 +4362,15 @@ impl<S: JitState> JitDriver<S> {
         if self.meta.is_tracing() {
             return None;
         }
+        // **Resolve once, then carry.** From here down `green_key` names ONE
+        // cell, not a celltable bucket — the decision below, the
+        // `compiled_loops` meta the runner executes, the invalidation on a
+        // shape mismatch and the front-target tables all read through this one
+        // number, so they cannot name different cells the way a bucket hash
+        // let them (`warmstate.py:458-464` resolves once and :483/:511 carries
+        // the resolved token onward for the same reason). Identity for every
+        // unchained bucket, so the collision-free path is unchanged.
+        let green_key = self.meta.resolve_cell_key(green_key, structured_green_key);
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         if !state.can_trace() {
@@ -4417,7 +4426,12 @@ impl<S: JitState> JitDriver<S> {
         // `cell.get_procedure_token() is not None` half (code present and not
         // invalidated), which the meta lookup alone does not imply, since
         // `invalidate_loop` deliberately leaves the meta in place.
-        let runnable_meta = if self.entry_cell_has_compiled_code(green_key, structured_green_key) {
+        // Both halves read through the resolved cell key, so the artifact the
+        // entry DECIDES on and the artifact it EXECUTES are the same object.
+        // They were not: the decision walked the bucket by `comparekey` while
+        // the runner read `compiled_loops[hash]`, so on a chained bucket the
+        // entry could decide about one cell's token and run another's.
+        let runnable_meta = if self.meta.has_compiled_loop(green_key) {
             self.meta.get_compiled_meta(green_key).cloned()
         } else {
             None
@@ -5410,35 +5424,6 @@ impl<S: JitState> JitDriver<S> {
         resolved
     }
 
-    /// `warmstate.py:458-464`: the cell a back edge decides on is the one whose
-    /// `comparekey(*greenargs)` matches, not whichever cell heads the bucket.
-    ///
-    /// Upstream walks unconditionally because its comparison is against the
-    /// greens already sitting in the portal's arguments — it builds nothing.
-    /// Pyre's `GreenKey` is a heap object with its own `values` and `types`
-    /// vectors, and this is the entry path, so building one per warm entry to
-    /// re-confirm a single-candidate bucket would put back the per-entry
-    /// allocations this path exists to avoid. An unchained bucket HAS one
-    /// candidate: the head is what the walk would find, and the hash form is
-    /// exact. The key is therefore built only when the bucket is chained,
-    /// which is the only case in which the two answers can differ.
-    ///
-    /// A caller that reached here without a structured key (`back_edge`,
-    /// `back_edge_keyed`) cannot resolve the chain at all and keeps the hash
-    /// answer; `back_edge_structured` and `back_edge_declarative` carry one.
-    fn entry_cell_has_compiled_code(
-        &self,
-        green_key: u64,
-        structured_green_key: Option<&dyn Fn() -> GreenKey>,
-    ) -> bool {
-        match structured_green_key {
-            Some(make_key) if self.meta.green_key_bucket_is_chained(green_key) => {
-                self.meta.has_compiled_loop_for_key(&make_key())
-            }
-            _ => self.meta.has_compiled_loop(green_key),
-        }
-    }
-
     fn live_values_match_descriptor(
         descriptor: Option<&JitDriverStaticData>,
         live_values: &[Value],
@@ -6313,21 +6298,24 @@ impl<S: JitState> JitDriver<S> {
 
     /// Typed twin of [`Self::has_compiled_loop`]: `warmstate.py:458-464` walks
     /// the bucket and tests `comparekey(*greenargs)` before deciding anything,
-    /// where the hash form can answer for whichever cell heads the bucket.
-    ///
-    /// The `compiled_loops` meta the runnable form additionally requires is
-    /// hash-keyed and has no chain, so only the JitCell half is resolved on
-    /// full key identity — see `MetaInterp::has_compiled_loop_for_key`.
+    /// where a bare bucket hash can answer for whichever cell holds it.
     #[inline]
     pub fn has_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
         self.meta.has_compiled_loop_for_key(key)
     }
 
     /// Typed twin of [`Self::has_runnable_compiled_loop`].
+    ///
+    /// Both conjuncts read through the SAME resolved cell key, so the JitCell
+    /// half and the `compiled_loops` half cannot answer about different cells.
+    /// They could: `compiled_loops` was consulted at the bare `key.get_uhash()`
+    /// while the token half walked the chain by `comparekey`.
     #[inline]
     pub fn has_runnable_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
-        self.has_compiled_loop_for_key(key)
-            && self.meta.get_compiled_meta(key.get_uhash()).is_some()
+        self.meta
+            .warm_state_ref()
+            .cell_key_for(key)
+            .is_some_and(|cell_key| self.has_runnable_compiled_loop(cell_key))
     }
 
     /// Actual key the last compile_loop stored under.
@@ -7253,7 +7241,14 @@ impl<S: JitState> JitDriver<S> {
             return None;
         }
 
-        let key_hash = crate::green_key_hash_typed(green_values, green_types);
+        // Resolve once (`warmstate.py:458-464`) and carry the cell key from
+        // here on, exactly as `back_edge_internal` does — the closure that
+        // builds the key runs only on a chained bucket, so the common entry
+        // still allocates nothing.
+        let key_hash = self.meta.resolve_cell_key(
+            crate::green_key_hash_typed(green_values, green_types),
+            Some(&|| GreenKey::with_types(green_values.to_vec(), green_types.to_vec())),
+        );
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(key_hash);
         if !state.can_trace() {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4743,6 +4743,18 @@ impl<M: Clone> MetaInterp<M> {
             HotResult::NotHot => BackEdgeAction::Interpret,
             HotResult::StartTracing => {
                 self.prepare_trace_start_runtime();
+                // `maybe_compile_with_key` has just installed (or found) this
+                // key's cell, so resolving now names it — and the trace, its
+                // `compiled_loops` entry, its `JitCellToken::green_key` and
+                // every `rd_loop_token` stamped off that token all inherit the
+                // CELL key rather than a bucket hash they would each have to
+                // re-resolve. `warmstate.py:483/:511` carries the resolved
+                // artifact on for the same reason.
+                let green_key = Self::with_typed_decision_key(green_key, green_key_raw, |key| {
+                    self.warm_state.cell_key_for(key)
+                })
+                .flatten()
+                .unwrap_or(green_key);
                 // The only reader of either value.  The key factory closes over
                 // `Copy` locals bound once at the back edge
                 // (`jit_interp/mod.rs` `__green_slotN`), and the descriptor
@@ -5029,7 +5041,15 @@ impl<M: Clone> MetaInterp<M> {
         let recursive_target =
             |jd_index: usize, green_values: &[i64]| -> Option<(Arc<JitCellToken>, u64)> {
                 let jd = staticdata.jitdrivers_sd.get(jd_index)?;
-                let green_key = crate::green_key_hash_typed(green_values, &jd.green_args_spec());
+                let spec = jd.green_args_spec();
+                // Resolve to the callee's CELL key before consulting either
+                // index: the token comes off the celltable and the key travels
+                // on to the `CALL_ASSEMBLER` descr, so both must name the cell
+                // the callee's greens own rather than whatever heads its bucket.
+                let green_key = warm_state
+                    .resolve_cell_key(crate::green_key_hash_typed(green_values, &spec), || {
+                        majit_ir::GreenKey::with_types(green_values.to_vec(), spec.clone())
+                    });
                 warm_state
                     .get_compiled(green_key)
                     .map(|arc| (Arc::clone(arc), green_key))
@@ -5050,7 +5070,15 @@ impl<M: Clone> MetaInterp<M> {
             let Some(jd) = staticdata.jitdrivers_sd.get(jd_index) else {
                 return InlineDecision::ResidualCall;
             };
-            let green_key = crate::green_key_hash_typed(green_values, &jd.green_args_spec());
+            let spec = jd.green_args_spec();
+            // Same resolve as `recursive_target` above, and it must be the same
+            // one: `decide_recursive_inline` exists to keep this decision and
+            // that resolver from drifting, which they would if one asked the
+            // celltable about a cell the other never looked at.
+            let green_key = warm_state
+                .resolve_cell_key(crate::green_key_hash_typed(green_values, &spec), || {
+                    majit_ir::GreenKey::with_types(green_values.to_vec(), spec.clone())
+                });
             // `callee_compiled` must recognise every token the sibling
             // `recursive_target` resolver can produce — `warm_state.get_compiled`
             // returns the cell's procedure token, including the tmp-callback
@@ -6146,7 +6174,7 @@ impl<M: Clone> MetaInterp<M> {
         // committing to a compile we mirror that by reading green_key
         // from the live trace ctx; only the "committed" exits below
         // take ownership of the ctx and drop the trace session.
-        let (green_key, cut_inner_green_key) = {
+        let (closed, cut_inner_green_key, outer_green_key) = {
             let ctx = self
                 .tracing
                 .as_ref()
@@ -6160,8 +6188,26 @@ impl<M: Clone> MetaInterp<M> {
             // so the origin key is only the fallback for traces that did not
             // close on a merge point.  If older traces lack typed close
             // greens, preserve the existing cross-loop-cut inner key path.
-            let closed = ctx.close_green_key_hash();
-            (closed.or(cut_inner).unwrap_or(outer), cut_inner)
+            let closed = ctx.close_green_key();
+            (closed, cut_inner, outer)
+        };
+        // File the loop under the CELL key, not the bucket hash: this is the
+        // key a later warm entry resolves and looks `compiled_loops` up by, and
+        // on a chained bucket a bucket hash names a different cell's slot. The
+        // resolve is the same one the entry does (`warmstate.py:458-464`), so
+        // compile and entry agree by construction.
+        let green_key = match closed {
+            Some(key) => self
+                .warm_state
+                .resolve_cell_key(key.get_uhash(), || key.clone()),
+            // `outer` is `ctx.green_key`, already resolved at trace start. The
+            // cross-loop-cut inner key is produced inside the trace walker,
+            // which holds no `WarmEnterState`, so it arrives as a bucket hash
+            // and can only be resolved for an unchained bucket — the same
+            // greens-less decline every hash-only producer takes.
+            None => cut_inner_green_key
+                .map(|inner| self.warm_state.sole_cell_key(inner).unwrap_or(inner))
+                .unwrap_or(outer_green_key),
         };
 
         // pyjitpl.py:3185-3189: has_compiled_targets(ptoken) →
@@ -11381,10 +11427,10 @@ impl<M: Clone> MetaInterp<M> {
     /// different key that shares the bucket. Consumers that hold the typed key
     /// at the decision point should ask this one.
     ///
-    /// Scope: this resolves the JitCell half only. `compiled_loops` — the
-    /// frontend meta index that [`Self::get_compiled_meta`] reads — is keyed by
-    /// hash and has no chain to walk, so it stays hash-resolved. That is the
-    /// remaining collision surface on the entry path.
+    /// Equivalent to `resolve_cell_key` followed by [`Self::has_compiled_loop`]:
+    /// `compiled_loops` and the celltable are indexed by the same cell key, so
+    /// the meta half and the JitCell half no longer answer about different
+    /// cells on a chained bucket.
     #[inline]
     pub fn has_compiled_loop_for_key(&self, key: &majit_ir::GreenKey) -> bool {
         self.warm_state
@@ -11398,6 +11444,47 @@ impl<M: Clone> MetaInterp<M> {
     #[inline]
     pub fn green_key_bucket_is_chained(&self, green_key: u64) -> bool {
         self.warm_state.bucket_is_chained(green_key)
+    }
+
+    /// **Resolve once.** Turn the raw green-key hash an entry arrives with into
+    /// the CELL key that names the one cell those greens own, and hand that key
+    /// back so the caller can carry it everywhere instead of re-deriving a cell
+    /// from the bucket at each consumer.
+    ///
+    /// `warmstate.py:458-464` resolves greens + `comparekey` + `get_uhash`
+    /// together, once, and `warmstate.py:483/:511` then carries the resolved
+    /// `procedure_token` to the executor (`raise
+    /// EnterJitAssembler(procedure_token, *execute_args)`) rather than handing
+    /// on a key for a second lookup — which is exactly why upstream has no
+    /// second reader that can disagree with the decision. This is that step,
+    /// spelled in the currency pyre carries across crates.
+    ///
+    /// Allocation discipline (the reason this is not simply
+    /// `cell_key_for(&make_key())`): upstream compares against greens already
+    /// sitting in the portal's arguments and builds nothing, while pyre's
+    /// `GreenKey` is a heap object with `values` and `types` vectors, and this
+    /// is the warm-entry path. An unchained bucket has ONE candidate, so
+    /// `sole_cell_key` is exact without a key; the key is built only when the
+    /// bucket is chained, which is the only shape in which the candidates
+    /// differ.
+    ///
+    /// A caller with no structured key on a chained bucket cannot resolve at
+    /// all, and gets the raw hash back. That names the bucket's original
+    /// occupant if it is still there and nothing otherwise — a miss, never a
+    /// guess at which sibling was meant.
+    #[inline]
+    pub fn resolve_cell_key(
+        &self,
+        green_key: u64,
+        structured_green_key: Option<&dyn Fn() -> majit_ir::GreenKey>,
+    ) -> u64 {
+        match structured_green_key {
+            Some(make_key) => self.warm_state.resolve_cell_key(green_key, make_key),
+            None => self
+                .warm_state
+                .sole_cell_key(green_key)
+                .unwrap_or(green_key),
+        }
     }
 
     /// Check if any guard in the compiled trace has Float-typed fail_args.
@@ -16018,7 +16105,13 @@ impl<M: Clone> MetaInterp<M> {
             "warmspot.py:663 _green_args_spec must agree with the \
              jitcode arg layout greenargs prefix",
         );
-        let green_key = crate::green_key_hash_typed(&green_values, &green_types);
+        // Resolve to the target's CELL key: the token this key selects is
+        // carried into the `CALL_ASSEMBLER` descr, so it has to be the token of
+        // the cell these greens own.
+        let green_key = self.warm_state.resolve_cell_key(
+            crate::green_key_hash_typed(&green_values, &green_types),
+            || majit_ir::GreenKey::with_types(green_values.clone(), green_types.clone()),
+        );
         // `compile.py:187` parity: `op.getdescr()` IS a `JitCellToken`.  Carry
         // the *same* Arc that `compiled_loops` / warm cell own through to the
         // descr so `record_loop_or_bridge` can downcast and push it directly,

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -2198,9 +2198,21 @@ impl TraceCtx {
     /// `original_boxes[:num_green_args]`, i.e. the greens captured at the
     /// merge point that closed the trace.
     pub fn close_green_key_hash(&self) -> Option<u64> {
+        Some(self.close_green_key()?.get_uhash())
+    }
+
+    /// The typed form of [`Self::close_green_key_hash`].
+    ///
+    /// A hash alone cannot say WHICH cell in a chained bucket the close
+    /// belongs to, and the loop this key files under is the one a later entry
+    /// has to find again. Callers with a `WarmEnterState` in hand resolve
+    /// through this (`WarmEnterState::resolve_cell_key`) and file under the
+    /// resolved cell key; the vectors it builds are the ones
+    /// `merge_point_green_key_hash` already built to hash.
+    pub fn close_green_key(&self) -> Option<GreenKey> {
         let greens = self.close_greens.as_ref()?;
         let pc = self.close_green_pc?;
-        self.merge_point_green_key_hash(pc, greens)
+        self.merge_point_green_key(pc, greens)
     }
 
     /// pyjitpl.py:1553 / :3005 `get_procedure_token(greenboxes)` analog: the
@@ -2212,6 +2224,16 @@ impl TraceCtx {
         pc: i64,
         greens: &(Vec<i64>, Vec<i64>, Vec<i64>),
     ) -> Option<u64> {
+        Some(self.merge_point_green_key(pc, greens)?.get_uhash())
+    }
+
+    /// The typed form of [`Self::merge_point_green_key_hash`], for callers
+    /// that must resolve the key to a cell rather than only hash it.
+    pub fn merge_point_green_key(
+        &self,
+        pc: i64,
+        greens: &(Vec<i64>, Vec<i64>, Vec<i64>),
+    ) -> Option<GreenKey> {
         let (ints, refs, floats) = greens;
         let spec = if let Some(key) = self.green_key_values.as_ref() {
             debug_assert_eq!(
@@ -2254,7 +2276,7 @@ impl TraceCtx {
             values.push(value);
         }
         types.extend(spec);
-        Some(crate::green_key_hash_typed(&values, &types))
+        Some(GreenKey::with_types(values, types))
     }
 
     /// Set the structured green key values.

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -101,6 +101,31 @@ pub struct BaseJitCell {
     /// counter.py:75 / warmstate.py BaseJitCell.next
     /// Linked list for per-bucket chain in the celltable.
     pub next: Option<Box<BaseJitCell>>,
+    /// This cell's own u64 identity — what every hash-form entry point on
+    /// [`WarmEnterState`] names it by, and what flows on through
+    /// `MetaInterp::compiled_loops`, `JitCellToken::green_key` and
+    /// `rd_loop_token`.
+    ///
+    /// Upstream needs no such field: `maybe_compile_and_run`
+    /// (warmstate.py:458-464) resolves greens + `comparekey` + `get_uhash`
+    /// *together* into a cell object and then carries **that object** to the
+    /// executor (`raise EnterJitAssembler(procedure_token, ...)`,
+    /// warmstate.py:483/:511), so nothing downstream re-derives which cell was
+    /// meant. Pyre carries a `u64` instead, and a bucket hash does not name a
+    /// cell when the bucket is chained — two cells, one number. The cell key
+    /// restores the missing half of the identity: it is
+    ///
+    /// * the bucket's raw `JitCell.get_uhash` when this cell is the only
+    ///   occupant, so the collision-free case is bit-for-bit what it always
+    ///   was, and
+    /// * a minted, live-set-unique u64 ([`WarmEnterState::mint_cell_key`])
+    ///   when this cell landed in a bucket whose raw hash another cell had
+    ///   already taken.
+    ///
+    /// `None` only between [`BaseJitCell::new`] and the
+    /// [`WarmEnterState::install_new_cell`] that files the cell — an
+    /// unassigned cell is in no chain and is reachable by nothing.
+    pub cell_key: Option<u64>,
     /// warmstate.py:568-582 — typed green-key carried per-cell so
     /// `JitCell.comparekey(*greenargs2)` can do per-green typed
     /// equality across hash collisions:
@@ -153,6 +178,7 @@ impl BaseJitCell {
             loop_token: None,
             abort_count: 0,
             next: None,
+            cell_key: None,
             comparekey: None,
             retained_greens: RetainedGreens::default(),
         }
@@ -366,13 +392,53 @@ pub struct JitStats {
     pub num_pinned_refs: usize,
 }
 
+/// # The `u64` this type is keyed by is a CELL key, not a bucket hash
+///
+/// Every `green_key_hash: u64` parameter below names one cell
+/// ([`BaseJitCell::cell_key`]), not a celltable bucket. The two are the same
+/// number whenever a bucket holds one cell — which is every collision-free
+/// workload, so nothing observable changes there — and differ only for a cell
+/// that had to be minted a key because a sibling already held the bucket's raw
+/// hash.
+///
+/// The distinction exists because pyre carries a `u64` where upstream carries
+/// the cell object. `maybe_compile_and_run` (warmstate.py:458-464) resolves
+/// greens + `comparekey` + `get_uhash` together into a cell and then hands
+/// *that cell's* procedure token to the executor (warmstate.py:483/:511:
+/// `raise EnterJitAssembler(procedure_token, *execute_args)`) rather than
+/// handing on a key for a second lookup — which is why upstream has no second
+/// reader that can disagree with the first. Pyre restores that property by
+/// resolving once, at the hash producer ([`WarmEnterState::cell_key_for`] /
+/// [`WarmEnterState::ensure_cell_key`] / [`WarmEnterState::sole_cell_key`]),
+/// and carrying the resolved cell key onward — through `MetaInterp`'s
+/// `compiled_loops`, `JitCellToken::green_key` and `rd_loop_token` alike.
+///
+/// The counter is the deliberate exception: `jitcounter.tick(hash, ...)`
+/// (warmstate.py:467) is indexed by the BUCKET upstream, so colliding keys
+/// share one back-edge counter. Every counter call here therefore goes through
+/// [`WarmEnterState::bucket_of`] first.
 pub struct WarmEnterState {
     /// counter.py JitCounter parity: single timetable shared by loop
     /// entry, guard failure, and function entry — each caller passes
     /// a different pre-computed increment to tick(hash, increment).
     pub counter: JitCounter,
-    /// Per-greenkey cells, keyed by the hash of the green key.
+    /// counter.py:227-256 celltable: per-bucket chains, keyed by the raw
+    /// `JitCell.get_uhash` of the green key. The map entry is the chain HEAD;
+    /// walk `BaseJitCell::next` for the rest. A cell inside a chain is named
+    /// by its own [`BaseJitCell::cell_key`], not by this map key.
     cells: indexmap::IndexMap<u64, BaseJitCell>,
+    /// Minted cell keys → the raw bucket hash the cell lives in.
+    ///
+    /// Only cells that could not take their bucket's raw hash appear here, so
+    /// this map is empty for every workload that never chains a bucket, and
+    /// [`WarmEnterState::bucket_of`] short-circuits on `is_empty()`. The
+    /// invariant it maintains is: **`bucket_of(cell_key)` is the bucket the
+    /// cell lives in** — trivially `cell_key` itself for an unminted key,
+    /// because an unminted key is only ever assigned inside the bucket whose
+    /// hash it equals.
+    minted: indexmap::IndexMap<u64, u64>,
+    /// Serial feeding [`WarmEnterState::mint_cell_key`]'s candidate sequence.
+    mint_serial: u64,
     /// Compilation threshold (copied from counter for easy access).
     threshold: u32,
     /// warmstate.py:254: increment_threshold = compute_threshold(threshold).
@@ -469,20 +535,18 @@ impl WarmEnterState {
             return false;
         }
         if flags & jc_flags::TRACING_OCCURRED != 0 {
-            self.counter.tick(green_key_hash, self.increment_threshold)
+            let bucket = self.bucket_of(green_key_hash);
+            self.counter.tick(bucket, self.increment_threshold)
         } else {
             true
         }
     }
 
     fn start_tracing_cell(&mut self, green_key_hash: u64) -> HotResult {
-        self.counter.reset(green_key_hash);
+        self.counter.reset(self.bucket_of(green_key_hash));
         self.tracing_generation += 1;
         let current_generation = self.tracing_generation;
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
         cell.flags |= jc_flags::TRACING | jc_flags::TRACING_OCCURRED;
         cell.state = BaseJitCellState::Tracing;
         cell.tracing_generation = current_generation;
@@ -507,6 +571,8 @@ impl WarmEnterState {
         WarmEnterState {
             counter,
             cells: indexmap::IndexMap::new(),
+            minted: indexmap::IndexMap::new(),
+            mint_serial: 0,
             threshold,
             increment_threshold,
             trace_eagerness: DEFAULT_TRACE_EAGERNESS,
@@ -541,7 +607,7 @@ impl WarmEnterState {
     /// Mark a green key as DONT_TRACE_HERE permanently.
     /// Clear the loop token for a cell, so is_compiled() returns false.
     pub fn clear_loop_token(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cells.get_mut(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
             cell.loop_token = None;
         }
     }
@@ -574,7 +640,7 @@ impl WarmEnterState {
     /// in jitdriver.rs for cold keys.
     #[inline]
     pub fn counter_would_fire(&self, green_key_hash: u64) -> bool {
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
@@ -586,12 +652,12 @@ impl WarmEnterState {
             }
         }
         self.counter
-            .would_tick_fire(green_key_hash, self.increment_threshold)
+            .would_tick_fire(self.bucket_of(green_key_hash), self.increment_threshold)
     }
 
     /// warmstate.py:467: jitcounter.tick(hash, increment_threshold).
     pub fn counter_tick(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
                 return;
             }
@@ -599,12 +665,13 @@ impl WarmEnterState {
                 return;
             }
         }
-        let _ = self.counter.tick(green_key_hash, self.increment_threshold);
+        let bucket = self.bucket_of(green_key_hash);
+        let _ = self.counter.tick(bucket, self.increment_threshold);
     }
 
     pub fn counter_tick_checked(&mut self, green_key_hash: u64) -> bool {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
@@ -625,15 +692,16 @@ impl WarmEnterState {
         if cleanup_dead_token_cell {
             // warmstate.py:483-500 — loop-header counter entry must also
             // remove invalidated token cells before it starts counting again.
-            self.cleanup_chain(green_key_hash);
+            self.cleanup_chain(self.bucket_of(green_key_hash));
             return false;
         }
-        self.counter.tick(green_key_hash, self.increment_threshold)
+        let bucket = self.bucket_of(green_key_hash);
+        self.counter.tick(bucket, self.increment_threshold)
     }
 
     pub fn maybe_compile(&mut self, green_key_hash: u64) -> HotResult {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             let has_procedure_token = cell.get_procedure_token().is_some();
             let is_compiled = cell.is_compiled();
             let is_tracing = cell.is_tracing();
@@ -668,11 +736,14 @@ impl WarmEnterState {
         if cleanup_dead_token_cell {
             // warmstate.py:483-500 — an invalidated/dead procedure token is
             // removed from the chain, resetting the hot counter so it re-arms.
-            self.cleanup_chain(green_key_hash);
+            self.cleanup_chain(self.bucket_of(green_key_hash));
             return HotResult::NotHot;
         }
 
-        if !self.counter.tick(green_key_hash, self.increment_threshold) {
+        if !self
+            .counter
+            .tick(self.bucket_of(green_key_hash), self.increment_threshold)
+        {
             return HotResult::NotHot;
         }
 
@@ -856,7 +927,7 @@ impl WarmEnterState {
     /// Used by function-entry tracing where the caller has already
     /// determined that tracing should begin.
     pub fn force_start_tracing(&mut self, green_key_hash: u64) -> HotResult {
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             if cell.is_compiled() {
                 return HotResult::RunCompiled;
             }
@@ -917,7 +988,7 @@ impl WarmEnterState {
     /// The caller is responsible for compiling the trace and calling
     /// `attach_procedure_to_interp` with the resulting JitCellToken.
     pub fn finish_tracing(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cells.get_mut(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
             cell.flags &= !jc_flags::TRACING;
             // State remains Tracing until attach_procedure_to_interp is called.
         }
@@ -928,7 +999,7 @@ impl WarmEnterState {
     /// Non-permanent aborts clear `JC_TRACING` and allow a future retry until
     /// pyre's abort ceiling marks the location `DONT_TRACE_HERE`.
     pub fn abort_tracing(&mut self, green_key_hash: u64, disable_noninlinable_function: bool) {
-        if let Some(cell) = self.cells.get_mut(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
             cell.flags &= !jc_flags::TRACING;
             cell.abort_count += 1;
             if disable_noninlinable_function || (cell.flags & jc_flags::DONT_TRACE_HERE != 0) {
@@ -971,10 +1042,7 @@ impl WarmEnterState {
         token: impl Into<Arc<JitCellToken>>,
     ) -> Option<Arc<JitCellToken>> {
         let token = token.into();
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
         cell.flags &= !jc_flags::TRACING;
         cell.set_procedure_token(token, false)
     }
@@ -1018,10 +1086,7 @@ impl WarmEnterState {
         token: impl Into<Arc<JitCellToken>>,
     ) {
         let token = token.into();
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
         let _old = cell.set_procedure_token(token, true);
     }
 
@@ -1033,7 +1098,7 @@ impl WarmEnterState {
     /// companion `attach_procedure_to_interp` / `abort_tracing` calls own
     /// the state transition for whichever cell they touch.
     pub fn clear_tracing_flag(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cells.get_mut(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
             cell.flags &= !jc_flags::TRACING;
         }
     }
@@ -1043,16 +1108,18 @@ impl WarmEnterState {
     ///
     /// `JC_TRACING` is *set* through [`Self::mark_as_being_traced_for_key`],
     /// which installs through [`Self::ensure_cell_for_key`] and therefore
-    /// writes the cell that matches the key. The hash form above clears
-    /// whichever cell happens to *head* the bucket. Once both spellings have
-    /// written one key those are two different cells
-    /// (`one_key_through_a_hash_and_a_typed_entry_point_builds_a_chain`), and
-    /// `install_new_cell` prepends survivors so the typed cell is the one that
-    /// is *not* the head. The set then lands on the tail and the clear on the
-    /// head, the flag is never cleared, and every gate that reads the head —
-    /// `counter_would_fire`, `counter_tick_checked`, `maybe_compile`,
-    /// `force_start_tracing`, `should_trace_function_entry` — refuses that key
-    /// from then on.
+    /// writes the cell that matches the key. The hash form above clears the
+    /// cell its CELL KEY names, which is the same cell whenever the caller's
+    /// u64 was resolved from these greens — but a caller holding a raw bucket
+    /// hash on a chained bucket names the bucket's first occupant instead.
+    /// Once a hash-only writer and a typed one have both written one key those
+    /// are two different cells
+    /// (`one_key_through_a_hash_and_a_typed_entry_point_builds_a_chain`) with
+    /// two different keys, so the set can land on one and the clear on the
+    /// other, the flag is never cleared, and every gate that reads the
+    /// unresolved key — `counter_would_fire`, `counter_tick_checked`,
+    /// `maybe_compile`, `force_start_tracing`, `should_trace_function_entry` —
+    /// refuses that key from then on.
     ///
     /// Deliberately does NOT route through `ensure_cell_for_key` the way the
     /// `_for_key` writers do: clearing a flag must not install a cell. A key
@@ -1077,8 +1144,7 @@ impl WarmEnterState {
     /// [`Self::attach_tmp_callback_to_interp`] got. Give it a typed form at
     /// the point a caller appears, not before.
     pub fn take_procedure_token(&mut self, green_key_hash: u64) -> Option<Arc<JitCellToken>> {
-        self.cells
-            .get_mut(&green_key_hash)
+        self.cell_by_key_mut(green_key_hash)
             .and_then(|cell| cell.loop_token.take())
     }
 
@@ -1094,22 +1160,20 @@ impl WarmEnterState {
     /// runner, the CALL_ASSEMBLER inline gate, or the bridge stitch
     /// surface.
     pub fn get_compiled(&self, green_key_hash: u64) -> Option<&Arc<JitCellToken>> {
-        self.cells
-            .get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
             .and_then(|cell| cell.get_procedure_token())
     }
 
     /// warmstate.py:191-196 `get_procedure_token`.
     ///
-    /// Reads the cell that HEADS the bucket, which is the right cell only when
-    /// the bucket holds one. `maybe_compile_and_run` (warmstate.py:458-464)
-    /// walks `cell.next` and tests `cell.comparekey(*greenargs)` before it
-    /// looks at a token at all; [`Self::get_procedure_token_for_key`] is that
-    /// walk. Callers that hold the typed key should prefer it, and
-    /// [`Self::bucket_is_chained`] says when the two can differ.
+    /// Reads the cell the CELL KEY names — one cell, whatever the bucket holds
+    /// — so this and [`Self::get_procedure_token_for_key`] answer about the
+    /// same object for any key that has been resolved
+    /// ([`Self::cell_key_for`]). Handing this a raw bucket hash instead is a
+    /// different question with a different answer: it names the bucket's first
+    /// occupant.
     pub fn get_procedure_token(&self, green_key_hash: u64) -> Option<Arc<JitCellToken>> {
-        self.cells
-            .get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
             .and_then(|cell| cell.get_procedure_token().cloned())
     }
 
@@ -1121,24 +1185,30 @@ impl WarmEnterState {
     /// this is that discipline. A bucket the key does not match anywhere is
     /// upstream's `else:` arm — "not found" — and answers `None` rather than
     /// handing back the head cell's unrelated token.
+    ///
+    /// Equivalent to [`Self::cell_key_for`] followed by
+    /// [`Self::get_procedure_token`], and callers that need the key as well as
+    /// the token should spell it that way so the key they carry onward is the
+    /// one this matched on.
     pub fn get_procedure_token_for_key(&self, key: &GreenKey) -> Option<Arc<JitCellToken>> {
         self.lookup_chain_with_key(key)
             .and_then(|cell| cell.get_procedure_token().cloned())
     }
 
-    /// Whether this bucket holds more than one cell, i.e. whether the hash and
-    /// typed forms of a query can disagree at all.
+    /// Whether this bucket holds more than one cell, i.e. whether a raw hash
+    /// leaves anything to choose between.
     ///
     /// A chain needs no hash collision: one green key reached through a
     /// hash-only writer and then a typed one produces two cells in one bucket
     /// (see [`Self::clear_all_loop_tokens`]). An unchained bucket has exactly
-    /// one candidate, so the head IS what the walk would find, and a caller can
-    /// skip building a `GreenKey` it would only use to confirm that.
+    /// one candidate, so [`Self::sole_cell_key`] is exact and a caller can skip
+    /// building a `GreenKey` it would only use to confirm that — which is what
+    /// keeps [`Self::resolve_cell_key`] allocation-free on the entry path.
     #[inline]
     pub fn bucket_is_chained(&self, green_key_hash: u64) -> bool {
         self.cells
-            .get(&green_key_hash)
-            .is_some_and(|cell| cell.next.is_some())
+            .get(&self.bucket_of(green_key_hash))
+            .is_some_and(|head| head.next.is_some())
     }
 
     /// Allocate a new unique JitCellToken number.
@@ -1164,7 +1234,7 @@ impl WarmEnterState {
 
     /// Reset the hot counter for a specific green key to zero.
     pub fn reset_counter(&mut self, green_key_hash: u64) {
-        self.counter.reset(green_key_hash);
+        self.counter.reset(self.bucket_of(green_key_hash));
     }
 
     /// Reset ALL counters to zero. Used after invalidation with incomplete
@@ -1177,29 +1247,26 @@ impl WarmEnterState {
 
     /// Check if a green key is marked DontTraceHere.
     pub fn is_dont_trace_here(&self, green_key_hash: u64) -> bool {
-        self.cells
-            .get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
             .is_some_and(|c| c.state == BaseJitCellState::DontTraceHere)
     }
 
     /// Get a reference to the BaseJitCell for a green key, if it exists.
     pub fn get_cell(&self, green_key_hash: u64) -> Option<&BaseJitCell> {
-        self.cells.get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
     }
 
     /// Typed-key variant of [`Self::get_cell`]:
     /// `warmstate.py:596-604 JitCell.get_jitcell(*greenargs)`.
     ///
     /// Walks the chain by `comparekey`, so it selects the cell belonging to
-    /// this key rather than whichever cell happens to head the bucket. That
-    /// distinction is load-bearing today, not once the table is bucketed: a
-    /// hash-only writer installs a cell with `comparekey: None`, which
-    /// `comparekey_matches` refuses unconditionally, so one key can already
-    /// own two cells in one bucket with no hash collision at all
-    /// (`one_key_through_a_hash_and_a_typed_entry_point_builds_a_chain`).
-    /// `install_new_cell` links survivors ahead of the new cell, so the
-    /// hash-installed one is the head and the typed one is *not* — reading
-    /// the head here returned the wrong cell.
+    /// this key rather than the cell that happens to hold the bucket's raw
+    /// hash as its key. Those differ whenever a bucket chains: a hash-only
+    /// writer installs a cell with `comparekey: None`, which
+    /// `comparekey_matches` refuses unconditionally, so one key can own two
+    /// cells in one bucket with no hash collision at all
+    /// (`one_key_through_a_hash_and_a_typed_entry_point_builds_a_chain`) — and
+    /// the hash-installed one took the raw hash, because it was there first.
     ///
     /// The reason to route through the key rather than the hash at all:
     /// every upstream cell lookup takes greenargs and compares them
@@ -1269,10 +1336,7 @@ impl WarmEnterState {
     where
         F: FnOnce() -> Result<Arc<JitCellToken>, E>,
     {
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
         if let Some(token) = cell.get_procedure_token() {
             return Ok(token.clone());
         }
@@ -1530,8 +1594,7 @@ impl WarmEnterState {
     /// `DONT_TRACE_HERE`, callers must stop inlining it and instead let it
     /// converge to a separate functrace / call_assembler path.
     pub fn can_inline_callable(&self, callee_key: u64) -> bool {
-        self.cells
-            .get(&callee_key)
+        self.cell_by_key(callee_key)
             .is_none_or(|cell| cell.flags & jc_flags::DONT_TRACE_HERE == 0)
     }
 
@@ -1540,10 +1603,7 @@ impl WarmEnterState {
     ///
     /// This is the warm-state equivalent of PyPy's `disable_noninlinable_function()`.
     pub fn disable_noninlinable_function(&mut self, callee_key: u64) {
-        let cell = self
-            .cells
-            .entry(callee_key)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(callee_key);
         cell.flags |= jc_flags::DONT_TRACE_HERE;
         if cell.flags & jc_flags::TRACING == 0 {
             cell.state = BaseJitCellState::DontTraceHere;
@@ -1554,14 +1614,12 @@ impl WarmEnterState {
     ///
     /// This is the warm-state equivalent of PyPy's `mark_as_being_traced()`.
     pub fn mark_as_being_traced(&mut self, callee_key: u64) {
-        let cell = self
-            .cells
-            .entry(callee_key)
-            .or_insert_with(BaseJitCell::new);
+        let tracing_generation = self.tracing_generation;
+        let cell = self.ensure_cell_by_key(callee_key);
         cell.flags |= jc_flags::TRACING;
         if cell.flags & jc_flags::TRACING_OCCURRED == 0 {
             cell.state = BaseJitCellState::Tracing;
-            cell.tracing_generation = self.tracing_generation;
+            cell.tracing_generation = tracing_generation;
         }
     }
 
@@ -1621,10 +1679,7 @@ impl WarmEnterState {
     /// `comparekey`. Prefer [`Self::mark_force_finish_tracing_for_key`]
     /// wherever the green key itself is in scope.
     pub fn mark_force_finish_tracing(&mut self, green_key_hash: u64) {
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
         cell.flags |= jc_flags::FORCE_FINISH;
     }
 
@@ -1647,8 +1702,7 @@ impl WarmEnterState {
     /// alive while it is set, and once set it persists until the cell itself
     /// is removed.
     pub fn should_force_finish_tracing(&self, green_key_hash: u64) -> bool {
-        self.cells
-            .get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
             .is_some_and(|cell| cell.flags & jc_flags::FORCE_FINISH != 0)
     }
 
@@ -1667,7 +1721,8 @@ impl WarmEnterState {
     /// The moment a cell read is added here, this needs a `&GreenKey` like
     /// [`Self::get_cell_for_key`]'s cohort.
     pub fn trace_next_iteration(&mut self, green_key_hash: u64) {
-        self.counter.change_current_fraction(green_key_hash, 0.98);
+        self.counter
+            .change_current_fraction(self.bucket_of(green_key_hash), 0.98);
     }
 
     /// warmstate.py:467 jitcounter.tick(hash, increment_threshold) parity.
@@ -1675,7 +1730,7 @@ impl WarmEnterState {
     /// warmstate.py:256-257: jitcounter.tick(hash, increment_function_threshold).
     pub fn should_trace_function_entry(&mut self, green_key_hash: u64) -> bool {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cells.get(&green_key_hash) {
+        if let Some(cell) = self.cell_by_key(green_key_hash) {
             // Slot 23 is the total; 64/65 are its two terms, evaluated
             // independently rather than short-circuited so a cell that is both
             // reaches both tallies. `is_compiled()` fires on every probe of
@@ -1749,12 +1804,14 @@ impl WarmEnterState {
             // warmstate.py:483-500 — function-entry warmup must see an
             // invalidated token as a removed cell and re-count from cold.
             crate::mc_diag_bump(24);
-            self.cleanup_chain(green_key_hash);
+            self.cleanup_chain(self.bucket_of(green_key_hash));
             return false;
         }
         crate::mc_diag_bump(25);
-        self.counter
-            .tick(green_key_hash, self.increment_function_threshold)
+        self.counter.tick(
+            self.bucket_of(green_key_hash),
+            self.increment_function_threshold,
+        )
     }
 
     /// Check if inlining is allowed at the given depth.
@@ -1816,7 +1873,7 @@ impl WarmEnterState {
 
         let mut invalidated = 0;
         for green_key_hash in &deps {
-            if let Some(cell) = self.cells.get_mut(green_key_hash)
+            if let Some(cell) = self.cell_by_key_mut(*green_key_hash)
                 && let Some(token) = &cell.loop_token
             {
                 token.invalidate();
@@ -1855,8 +1912,7 @@ impl WarmEnterState {
     /// Returns `NotHot` if no cell exists.
     #[inline]
     pub fn get_cell_state(&self, green_key_hash: u64) -> BaseJitCellState {
-        self.cells
-            .get(&green_key_hash)
+        self.cell_by_key(green_key_hash)
             .map(|c| c.state)
             .unwrap_or(BaseJitCellState::NotHot)
     }
@@ -1872,10 +1928,7 @@ impl WarmEnterState {
     /// makes it a way for a test to build the split-cell state deliberately.
     /// A twin becomes necessary if production ever calls this.
     pub fn transition_cell(&mut self, green_key_hash: u64, new_state: BaseJitCellState) {
-        let cell = self
-            .cells
-            .entry(green_key_hash)
-            .or_insert_with(BaseJitCell::new);
+        let cell = self.ensure_cell_by_key(green_key_hash);
 
         match new_state {
             BaseJitCellState::NotHot => {
@@ -2161,20 +2214,29 @@ impl WarmEnterState {
     pub fn gc_cells(&mut self) -> usize {
         let mut removed = 0;
         let keys: Vec<u64> = self.cells.keys().copied().collect();
+        let mut dropped: Vec<BaseJitCell> = Vec::new();
         for hash in keys {
             if let Some(head) = self.cells.swap_remove(&hash) {
-                let (kept, n) = Self::clean_chain(head);
+                let (kept, n) = Self::clean_chain(head, &mut dropped);
                 removed += n;
                 if let Some(k) = kept {
                     self.cells.insert(hash, k);
                 }
             }
         }
+        for cell in &dropped {
+            self.forget_cell_key(cell);
+        }
         removed
     }
 
     /// Walk a chain, removing cells where should_remove_jitcell() is true.
-    fn clean_chain(head: BaseJitCell) -> (Option<BaseJitCell>, usize) {
+    /// Removed cells are pushed to `dropped` so the caller can retire their
+    /// minted keys ([`Self::forget_cell_key`]).
+    fn clean_chain(
+        head: BaseJitCell,
+        dropped: &mut Vec<BaseJitCell>,
+    ) -> (Option<BaseJitCell>, usize) {
         let mut keep: Option<BaseJitCell> = None;
         let mut removed = 0;
         let mut cell_opt = Some(head);
@@ -2185,10 +2247,191 @@ impl WarmEnterState {
                 keep = Some(c);
             } else {
                 removed += 1;
+                dropped.push(c);
             }
             cell_opt = next;
         }
         (keep, removed)
+    }
+
+    /// The bucket a cell key lives in.
+    ///
+    /// An unminted cell key IS its bucket's raw hash (it is only ever handed
+    /// out inside that bucket), so the common path costs one `is_empty()`
+    /// test and no lookup at all.
+    #[inline]
+    pub(crate) fn bucket_of(&self, cell_key: u64) -> u64 {
+        if self.minted.is_empty() {
+            return cell_key;
+        }
+        self.minted.get(&cell_key).copied().unwrap_or(cell_key)
+    }
+
+    /// The cell named by `cell_key`, or `None` if no cell holds that key.
+    ///
+    /// This is what every hash-form entry point resolves through. Upstream's
+    /// equivalent is not a lookup at all: `maybe_compile_and_run` already
+    /// holds the cell object it matched (warmstate.py:458-464). Pyre's u64 is
+    /// carried across crate boundaries (`compiled_loops`,
+    /// `JitCellToken::green_key`, `rd_loop_token`), so it resolves back to the
+    /// cell here — and it resolves to exactly one, which is the property that
+    /// bucket-head reading did not have.
+    #[inline]
+    pub(crate) fn cell_by_key(&self, cell_key: u64) -> Option<&BaseJitCell> {
+        let mut cell = self.cells.get(&self.bucket_of(cell_key));
+        while let Some(c) = cell {
+            if c.cell_key == Some(cell_key) {
+                return Some(c);
+            }
+            cell = c.next.as_deref();
+        }
+        None
+    }
+
+    /// Mutable [`Self::cell_by_key`].
+    #[inline]
+    pub(crate) fn cell_by_key_mut(&mut self, cell_key: u64) -> Option<&mut BaseJitCell> {
+        let bucket = self.bucket_of(cell_key);
+        let mut cell = self.cells.get_mut(&bucket);
+        while let Some(c) = cell {
+            if c.cell_key == Some(cell_key) {
+                return Some(c);
+            }
+            cell = c.next.as_deref_mut();
+        }
+        None
+    }
+
+    /// The cell named by `cell_key`, installing a comparekey-less one if the
+    /// key names none — the hash-form analogue of
+    /// [`Self::ensure_cell_for_key`], and what `cells.entry(hash)` used to be.
+    ///
+    /// The cell it installs carries no `comparekey`, exactly as before: a
+    /// caller holding only a u64 has no greens to store. Such a cell is
+    /// reachable by its key and by nothing else — no typed walk will ever
+    /// match it (`comparekey_matches` refuses `None` unconditionally), which
+    /// is the pre-existing hazard this migration does not pretend to close.
+    /// What it does close is the other half: the cell is now named by a key
+    /// that means only this cell, so the writer and every later reader of that
+    /// u64 land on the same object even after the bucket chains.
+    fn ensure_cell_by_key(&mut self, cell_key: u64) -> &mut BaseJitCell {
+        if self.cell_by_key(cell_key).is_none() {
+            let mut newcell = BaseJitCell::new();
+            newcell.cell_key = Some(cell_key);
+            self.install_new_cell(self.bucket_of(cell_key), Some(newcell));
+        }
+        self.cell_by_key_mut(cell_key)
+            .expect("just installed a cell under this key")
+    }
+
+    /// Resolve greens to the cell key their cell is named by, WITHOUT
+    /// installing anything.
+    ///
+    /// This is the "resolve once" step. `warmstate.py:596-604
+    /// JitCell.get_jitcell` takes greens + `comparekey` + `get_uhash`
+    /// together and yields a cell; pyre yields that cell's key, and every
+    /// consumer downstream carries the key instead of re-deriving it from the
+    /// bucket hash (warmstate.py:483/:511 carries the resolved
+    /// `procedure_token` for the same reason).
+    ///
+    /// `None` means this key owns no cell AND its bucket's raw hash is already
+    /// taken by a different cell — the only state in which there is no u64
+    /// that names this key's (absent) cell. Readers must treat it as a miss;
+    /// writers call [`Self::ensure_cell_key`], which mints.
+    pub fn cell_key_for(&self, key: &GreenKey) -> Option<u64> {
+        if let Some(cell) = self.lookup_chain_with_key(key) {
+            return cell.cell_key;
+        }
+        let hash = key.get_uhash();
+        // Nothing holds the raw hash, so it is the key this green key's cell
+        // would be installed under, and it names no other cell meanwhile.
+        self.cell_by_key(hash).is_none().then_some(hash)
+    }
+
+    /// Resolve greens to their cell key, installing the cell (with its
+    /// `comparekey`) if the key owns none — `warmstate.py:626-641
+    /// _ensure_jit_cell_at_key`, reporting the identity of the cell it
+    /// ensured.
+    pub fn ensure_cell_key(&mut self, key: &GreenKey) -> u64 {
+        self.ensure_cell_for_key(key);
+        self.lookup_chain_with_key(key)
+            .and_then(|cell| cell.cell_key)
+            .expect("ensure_cell_for_key just installed a keyed cell for this key")
+    }
+
+    /// **Resolve once**: the cell key the greens behind `hash` name.
+    ///
+    /// `make_key` is called only when the bucket is chained — an unchained
+    /// bucket has one candidate, so [`Self::sole_cell_key`] is already exact
+    /// and no `GreenKey` has to be built to confirm it. Producers that cannot
+    /// build one on a chained bucket get `hash` back, which names the bucket's
+    /// original occupant or nothing: a miss, not a guess.
+    ///
+    /// See [`WarmEnterState`]'s type doc for why the resolve happens at the
+    /// producer and the result is carried, rather than each consumer
+    /// re-deriving a cell from the bucket.
+    #[inline]
+    pub fn resolve_cell_key(&self, hash: u64, make_key: impl FnOnce() -> GreenKey) -> u64 {
+        if self.bucket_is_chained(hash) {
+            self.cell_key_for(&make_key()).unwrap_or(hash)
+        } else {
+            self.sole_cell_key(hash).unwrap_or(hash)
+        }
+    }
+
+    /// The key the sole occupant of `hash`'s bucket is named by, if the bucket
+    /// holds exactly one cell.
+    ///
+    /// The entry path's allocation-free half. A one-cell bucket has one
+    /// candidate, so the walk `maybe_compile_and_run` would do can only find
+    /// that cell — no `GreenKey` has to be built to prove it. Normally the
+    /// answer is `hash` itself; it differs only when the cell that held the
+    /// raw hash has been evicted out from under a minted sibling.
+    #[inline]
+    pub fn sole_cell_key(&self, hash: u64) -> Option<u64> {
+        let head = self.cells.get(&hash)?;
+        if head.next.is_some() {
+            return None;
+        }
+        head.cell_key
+    }
+
+    /// Mint a cell key for a cell whose bucket's raw hash is already taken.
+    ///
+    /// **No sub-range of `u64` can be reserved for minted keys.**
+    /// `JitCell.get_uhash` (warmstate.py:584-593) is a full-width multiply-xor
+    /// fold over arbitrary greens, so every `u64` is a hash some green key can
+    /// produce; a reserved range would be a range real keys also land in.
+    /// Uniqueness is therefore enforced against the LIVE key set instead:
+    /// derive a candidate from the bucket and a monotone serial through the
+    /// same fold, then step until the candidate names no live cell and is not
+    /// already a minted key. Both tests are needed — `cell_by_key` would find
+    /// an unminted twin in its own bucket, and `bucket_of` would misroute a
+    /// duplicate mint.
+    ///
+    /// What is NOT guaranteed: that a green key compiled *later* cannot hash
+    /// to a live minted key. Nothing can guarantee that, and the consequence
+    /// is the pre-existing one — the later key resolves through
+    /// [`Self::cell_key_for`], sees its raw hash taken, and mints in turn, so
+    /// the two stay distinct cells. Only a caller that holds a bare hash and
+    /// no greens can land on the wrong one, which is the same class of miss a
+    /// raw hash collision already had.
+    fn mint_cell_key(&mut self, bucket: u64) -> u64 {
+        loop {
+            self.mint_serial = self.mint_serial.wrapping_add(1);
+            let candidate = majit_ir::green_uhash_step(
+                bucket ^ self.mint_serial,
+                majit_ir::GreenType::Int,
+                self.mint_serial as i64,
+            );
+            if candidate != bucket
+                && self.cell_by_key(candidate).is_none()
+                && !self.minted.contains_key(&candidate)
+            {
+                self.minted.insert(candidate, bucket);
+                return candidate;
+            }
+        }
     }
 
     /// counter.py:239-240 lookup_chain(hash)
@@ -2219,8 +2462,24 @@ impl WarmEnterState {
     ///          cell = nextcell
     ///      self.celltable[index] = keep
     /// ```
+    ///
+    /// Pyre addition: the cell being filed is given its [`BaseJitCell::cell_key`]
+    /// here if it does not already carry one — the bucket's raw hash when that
+    /// is free, a minted key when it is not. Filing is the moment the cell
+    /// acquires an identity because it is the moment it becomes reachable;
+    /// upstream needs no equivalent because it hands the cell object itself
+    /// on (warmstate.py:483/:511) and never re-derives it from a number.
     pub fn install_new_cell(&mut self, hash: u64, newcell: Option<BaseJitCell>) {
         let mut keep = newcell;
+        if let Some(cell) = &mut keep
+            && cell.cell_key.is_none()
+        {
+            cell.cell_key = Some(if self.cell_by_key(hash).is_none() {
+                hash
+            } else {
+                self.mint_cell_key(hash)
+            });
+        }
         let mut cell_opt = self.cells.swap_remove(&hash);
         // Walk the existing chain, unlink each node.
         while let Some(mut cell) = cell_opt {
@@ -2229,12 +2488,28 @@ impl WarmEnterState {
                 // counter.py:253-254: cell.next = keep; keep = cell
                 cell.next = keep.map(Box::new);
                 keep = Some(cell);
+            } else {
+                self.forget_cell_key(&cell);
             }
             cell_opt = next;
         }
         // counter.py:256: self.celltable[index] = keep
         if let Some(k) = keep {
             self.cells.insert(hash, k);
+        }
+    }
+
+    /// Retire a dropped cell's minted key so [`Self::mint_cell_key`] may reuse
+    /// the number and `bucket_of` stops answering for a cell that is gone.
+    ///
+    /// Unminted keys need no retiring: they equal their bucket hash, so they
+    /// are recomputable from greens and are re-taken by the next cell that
+    /// installs into an empty bucket.
+    fn forget_cell_key(&mut self, cell: &BaseJitCell) {
+        if let Some(key) = cell.cell_key
+            && !self.minted.is_empty()
+        {
+            self.minted.swap_remove(&key);
         }
     }
 
@@ -2273,25 +2548,19 @@ impl WarmEnterState {
     /// installs a cell that can carry no `comparekey`, the typed path then
     /// installs its own, and `install_new_cell` links the survivor ahead —
     /// so the bucket holds two cells for one key with no collision anywhere.
-    /// Reading `cells.get(&hash)` gets whichever happens to head the bucket.
     /// A full-width hash makes collisions impractical but says nothing about
     /// multiple cells linked under one hash. See
     /// `one_key_through_a_hash_and_a_typed_entry_point_builds_a_chain`.
     ///
-    /// The tracing lifecycle is migrated — `start_tracing_cell_for_key`,
-    /// `finish_tracing_for_key`, `abort_tracing_for_key` and their siblings
-    /// walk the chain through `lookup_chain_with_key_mut`. What still reads
-    /// the bucket HEAD is the `u64` API surface kept for callers that hold
-    /// only a hash: `clear_loop_token`, `counter_would_fire`, `counter_tick`,
-    /// `counter_tick_checked`, `maybe_compile`, `force_start_tracing`,
-    /// `finish_tracing`, `abort_tracing`, `clear_tracing_flag`, `get_cell`,
-    /// `should_trace_function_entry`, `invalidate_quasiimmut`. Those cannot
-    /// move until their callers carry a `GreenKey`, which is the same reason
-    /// `MetaInterp`'s `compiled_loops` / `cut_compiled_keys` are `u64`-keyed:
-    /// the hash, not the green tuple, is the identity currency across the
-    /// metainterp. (`loop_header_pcs` was a third such table; it now lives on
-    /// `CompiledEntry::loop_header_pc`, so it is reached through
-    /// `compiled_loops`' `u64` key rather than carrying one of its own.)
+    /// This is the resolve half of [`Self::cell_key_for`], which is how the
+    /// `u64` API surface reaches the same cell without holding the greens: the
+    /// walk happens ONCE, at the hash producer, and the cell key it yields is
+    /// what `clear_loop_token`, `counter_tick`, `maybe_compile`,
+    /// `finish_tracing`, `abort_tracing`, `get_cell` and the rest are handed —
+    /// along with `MetaInterp`'s `compiled_loops` / `cut_compiled_keys`, which
+    /// are indexed by the same key and so describe the same cell. That is the
+    /// property the `u64` currency previously lacked: it named a bucket, and a
+    /// bucket is not a cell.
     pub fn lookup_chain_with_key(&self, key: &GreenKey) -> Option<&BaseJitCell> {
         let hash = key.get_uhash();
         let mut cell = self.cells.get(&hash);
@@ -2320,13 +2589,9 @@ impl WarmEnterState {
     ///     return newcell
     /// ```
     ///
-    /// Returns the index into `self.cells[hash]`'s chain identifying
-    /// the matching cell — pyre stores chains as boxed linked lists
-    /// keyed by hash, so the simplest matching identifier is "head or
-    /// linked offset". For now the helper returns nothing and the
-    /// caller uses `lookup_chain_with_key` for read access; full
-    /// mutable-by-key access lands when the celltable migrates from
-    /// `HashMap<u64, BaseJitCell>` to a chain-aware container.
+    /// Returns nothing; the caller reads the ensured cell back through
+    /// `lookup_chain_with_key`, or through [`Self::ensure_cell_key`] when what
+    /// it needs is the cell's identity rather than the cell.
     ///
     /// On a miss (no chained cell matches the typed key) the helper
     /// allocates a new cell, stores the key through `set_comparekey` —
@@ -4751,35 +5016,54 @@ mod tests {
     /// handing on the key for a second lookup — which is why upstream has no
     /// second reader that could disagree.
     ///
-    /// # Why this is `#[ignore]` and not a green test
+    /// # What this used to pin, and what it pins now
     ///
-    /// It FAILS, and the failure is the open defect, not a broken fixture. On
-    /// the tree that added it the assertion below reports `decided token #2,
-    /// executed token #1`.
+    /// This is the rewritten body of the `#[ignore]`d pin
+    /// `the_entry_decision_and_the_entry_execution_can_name_different_tokens`,
+    /// rewritten with the repo owner's explicit approval. The fixture below —
+    /// two cells, one bucket, a compiled token each — is the original's,
+    /// unchanged. The assertion is inverted from "these two readers disagree,
+    /// and that is the open defect" to "these two readers resolve through one
+    /// cell key, so they cannot disagree", which is what the cell-unique-key
+    /// migration makes true.
     ///
-    /// It is not fixed here because the fix is not the one this file could
-    /// make alone. The token half is small — thread the cell-resolved token to
-    /// the runner, which is upstream's own shape. But the runner reads TWO
-    /// things off the hash, and the second is
-    /// `MetaInterp::compiled_loops[hash]`, an `IndexMap<u64, CompiledEntry<M>>`
-    /// with ONE slot per hash and no chain to walk (`pyjitpl.rs` says so at
-    /// `has_compiled_loop_for_key`). Two colliding keys cannot both file a
-    /// meta there at all, so the second compile overwrites the first, and no
-    /// amount of walking on the cell side reaches a per-cell meta that does
-    /// not exist. Moving `meta` alone onto the cell would leave the rest of
-    /// `CompiledEntry` — traces, exit layouts, front target tokens, all read
-    /// across ~189 sites — indexed by hash while its `meta` was indexed by
-    /// cell: one artifact described through two index bases, which is a worse
-    /// state than this one, because it would look fixed.
+    /// **Pre-migration failure, recorded from the run that authorised this
+    /// rewrite.** On `add4516a533` the same fixture and the same final
+    /// assertion, with the executed side reading `chained_key.get_uhash()` —
+    /// the raw bucket hash, which is the only u64 the runner had to carry
+    /// then — reports:
     ///
-    /// So the pin stays failing and named. Re-enabling it is the acceptance
-    /// test for moving the compiled meta onto the cell.
+    /// ```text
+    /// thread 'warmstate::tests::the_entry_decision_and_the_entry_execution_can_name_different_tokens'
+    /// panicked at majit/majit-metainterp/src/warmstate.rs:4842:9:
+    /// the entry decided `chained_key` has compiled code and then ran a DIFFERENT
+    /// key's artifact: decided token #2, executed token #1. The two must resolve
+    /// through the same cell.
+    /// ```
+    ///
+    /// The old pin's stated blocker — `MetaInterp::compiled_loops` is an
+    /// `IndexMap<u64, CompiledEntry<M>>` with one slot per hash, so two
+    /// colliding keys cannot both file a meta — is what the migration
+    /// dissolves rather than works around: the u64 those tables are keyed by
+    /// became cell-unique, so two colliding green keys file two entries and
+    /// nothing had to move onto the cell.
+    ///
+    /// **Measured again after the migration, by substitution.** Replacing
+    /// `carried` with `bucket` on the `executed` line below — the only
+    /// difference between this body and the pre-migration one — reproduces the
+    /// same failure on the migrated tree:
+    ///
+    /// ```text
+    /// panicked at majit/majit-metainterp/src/warmstate.rs:5127:9:
+    /// the entry decided `chained_key` has compiled code and then ran a DIFFERENT
+    /// key's artifact: decided token #2, executed token #1.
+    /// ```
+    ///
+    /// So the resolve is what carries this test, not a fixture that stopped
+    /// colliding. The last two assertions pin that in-test: the raw bucket
+    /// hash still names the HEAD cell's artifact.
     #[test]
-    #[ignore = "open defect: the entry decides on the comparekey-walked cell \
-                and executes off the bucket head; fixing it needs the compiled \
-                meta to move onto the cell, since compiled_loops holds one \
-                slot per hash"]
-    fn the_entry_decision_and_the_entry_execution_can_name_different_tokens() {
+    fn the_entry_decision_and_the_entry_execution_resolve_through_one_cell_key() {
         let mut ws = WarmEnterState::new(100);
         let head_key = GreenKey::new(vec![2100, 2200]);
         let chained_key = GreenKey::new(vec![2300, colliding_last_green(&head_key, 2300)]);
@@ -4824,7 +5108,19 @@ mod tests {
              defect has nothing to show",
         );
 
-        // What the driver decides on for `chained_key`.
+        // THE RESOLVE, once, at the entry — `jitdriver.rs back_edge_internal`
+        // calls `MetaInterp::resolve_cell_key` exactly here, with the bucket
+        // hash it arrived with and the greens behind it. Everything after this
+        // line carries `carried` and looks nothing up by bucket again.
+        let carried = ws.resolve_cell_key(bucket, || chained_key.clone());
+        assert_ne!(
+            carried, bucket,
+            "fixture: the chained cell had to be minted its own key, or the \
+             two halves below would agree for the trivial reason",
+        );
+
+        // What the driver decides on for `chained_key` — the `comparekey`
+        // walk, `has_compiled_loop_for_key`.
         let decided = ws
             .get_procedure_token_for_key(&chained_key)
             .expect("the decision resolves the chain and finds the key's cell");
@@ -4833,11 +5129,11 @@ mod tests {
             "the decision is about the chained cell's artifact",
         );
 
-        // What the runner then executes for that same key.
-        let executed = ws.get_procedure_token(chained_key.get_uhash()).expect(
-            "the runner reads the bucket head, which has a token here, \
-             so it does not decline",
-        );
+        // What the runner then executes: the u64 reader, handed the key the
+        // entry resolved rather than the bucket hash it arrived with.
+        let executed = ws
+            .get_procedure_token(carried)
+            .expect("the carried cell key names the cell the decision matched");
 
         assert!(
             Arc::ptr_eq(&executed, &decided),
@@ -4846,6 +5142,145 @@ mod tests {
              The two must resolve through the same cell.",
             decided.number,
             executed.number,
+        );
+
+        // Non-vacuity: the bucket hash has NOT stopped naming the head cell.
+        // Substituting it for `carried` above is the pre-migration reading and
+        // still fails the assertion, so the resolve is what carries this test.
+        let by_bucket_hash = ws
+            .get_procedure_token(bucket)
+            .expect("the head cell holds the bucket's raw hash as its key");
+        assert!(
+            Arc::ptr_eq(&by_bucket_hash, &head_token),
+            "the raw hash names the bucket's first occupant, as it always did",
+        );
+        assert!(
+            !Arc::ptr_eq(&by_bucket_hash, &decided),
+            "and that is a DIFFERENT artifact from the one the entry decided \
+             on, which is the whole reason the resolve has to happen",
+        );
+    }
+
+    /// A producer that reaches a chained bucket with no greens DECLINES rather
+    /// than guessing which sibling was meant.
+    ///
+    /// This is the answer to the hazard the hash-only cell creators leave
+    /// behind: they install cells with `comparekey: None`
+    /// (`attach_procedure_to_interp`, `attach_tmp_callback_to_interp`,
+    /// `disable_noninlinable_function`, `mark_as_being_traced`,
+    /// `mark_force_finish_tracing`, `transition_cell`), and a cell with no
+    /// comparator cannot be told from a colliding neighbour by any mechanism —
+    /// upstream cannot even express the state, since `JitCell.__init__`
+    /// (warmstate.py:610-616) always stores the greens.
+    ///
+    /// So the resolve does not try. With no greens it answers the raw bucket
+    /// hash, which names the bucket's ORIGINAL occupant — the cell that took
+    /// the hash as its key — and names nothing at all once that cell is gone.
+    /// That is a miss, and a miss is the honest port: a `None` from
+    /// `cell_key_for` and a raw hash naming no cell both dead-end in the same
+    /// "not found" arm `maybe_compile_and_run` has at warmstate.py:464.
+    #[test]
+    fn a_chained_bucket_reached_without_greens_answers_the_first_occupant() {
+        let mut ws = WarmEnterState::new(100);
+        let first = GreenKey::new(vec![3500, 3600]);
+        let second = GreenKey::new(vec![3700, colliding_last_green(&first, 3700)]);
+        let bucket = first.get_uhash();
+
+        // A procedure token keeps the first cell non-removable, so the second
+        // install chains it rather than pruning it (counter.py:246-256's
+        // `should_remove_jitcell` gate — a cold, tokenless cell is dropped).
+        let token = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        ws.attach_procedure_to_interp_for_key(&first, token);
+        let first_key = ws
+            .cell_key_for(&first)
+            .expect("the first key owns the cell it just installed");
+        let second_key = ws.ensure_cell_key(&second);
+        assert!(
+            ws.bucket_is_chained(bucket),
+            "fixture: the two keys must share a bucket",
+        );
+
+        assert_eq!(
+            first_key, bucket,
+            "the first occupant keeps the raw hash, so every workload that \
+             never collides is bit-for-bit unchanged",
+        );
+        assert_ne!(second_key, bucket, "the second had to be minted one");
+        assert_eq!(
+            ws.sole_cell_key(bucket),
+            None,
+            "and a greens-less producer gets no answer from the bucket: two \
+             candidates, nothing to choose between them",
+        );
+
+        // Which leaves the raw hash, and the raw hash names the first
+        // occupant — never the minted sibling.
+        assert_eq!(
+            ws.cell_by_key(bucket).and_then(|cell| cell.cell_key),
+            Some(first_key),
+        );
+    }
+
+    /// Two colliding green keys file two entries in a `u64`-keyed artifact
+    /// table — the precondition `MetaInterp::compiled_loops` and
+    /// `MemoryManager` eviction both need, and the one the old pin named as
+    /// its blocker.
+    ///
+    /// `compiled_loops` is an `IndexMap<u64, CompiledEntry<M>>` and
+    /// `try_to_free_some_loops` reaches an entry by
+    /// `token.green_key()` (`JitCellToken::green_key: Cell<u64>`). While that
+    /// u64 was a bucket hash, two colliding keys shared ONE slot: the second
+    /// compile overwrote the first, and the loser's token could not reach its
+    /// own entry to be freed. The stand-in table below is that shape — the
+    /// subject is the keys, not the payload, so the payload is the token
+    /// number.
+    #[test]
+    fn two_colliding_keys_file_two_entries_in_a_u64_keyed_artifact_table() {
+        let mut ws = WarmEnterState::new(100);
+        let key_a = GreenKey::new(vec![3100, 3200]);
+        let key_b = GreenKey::new(vec![3300, colliding_last_green(&key_a, 3300)]);
+        assert_eq!(
+            key_a.get_uhash(),
+            key_b.get_uhash(),
+            "fixture: one bucket, two keys",
+        );
+
+        let cell_a = ws.ensure_cell_key(&key_a);
+        let cell_b = ws.ensure_cell_key(&key_b);
+        assert_ne!(
+            cell_a, cell_b,
+            "colliding keys must be told apart by the u64 the artifact tables \
+             are indexed by, or one of them has no reachable entry at all",
+        );
+
+        // The two tokens each stamp their own cell key, which is what
+        // `compile.rs:2436 jitcell_token.green_key.set(green_key)` writes and
+        // what `try_to_free_some_loops` reads back.
+        let token_a = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        let token_b = Arc::new(JitCellToken::new(ws.alloc_token_number()));
+        token_a.green_key.set(cell_a);
+        token_b.green_key.set(cell_b);
+
+        let mut compiled_loops: indexmap::IndexMap<u64, u64> = indexmap::IndexMap::new();
+        compiled_loops.insert(token_a.green_key(), token_a.number);
+        compiled_loops.insert(token_b.green_key(), token_b.number);
+        assert_eq!(
+            compiled_loops.len(),
+            2,
+            "both compiles must file; a shared slot means the second erased \
+             the first",
+        );
+
+        // Eviction of B reaches B's entry and leaves A's alone.
+        assert_eq!(
+            compiled_loops.swap_remove(&token_b.green_key()),
+            Some(token_b.number),
+            "the evicted token's own key must name its own entry",
+        );
+        assert_eq!(
+            compiled_loops.get(&token_a.green_key()),
+            Some(&token_a.number),
+            "and the colliding sibling's artifact must survive it",
         );
     }
 

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -310,6 +310,23 @@ fn install_gc() {
     // this thread holds. The meter owns its process (`harness = false`), so it
     // holds the GIL for the whole run and never has to hand it back.
     majit_gc::gc_sync::register_thread();
+    // The cranelift backend requires the JITFRAME id before the install — its
+    // absence is what the doc above calls "with no GC at all it falls back to a
+    // `Vec<i64>`", now a refusal rather than a fallback. Registering the shape
+    // on the singleton and publishing its id is what `eval.rs build_gc` does.
+    // Only under this cfg: the dynasm backend's frame source is settled
+    // separately, and publishing for it would move the frame this file
+    // measures.
+    #[cfg(feature = "cranelift")]
+    {
+        let jitframe_tid = majit_gc::gc_sync::gc_op(|gc| {
+            majit_gc::GcAllocator::register_type(
+                gc,
+                majit_backend::jitframe::jitframe_type_info(),
+            )
+        });
+        majit_backend_cranelift::set_jitframe_gc_type_id(jitframe_tid);
+    }
     #[cfg(feature = "cranelift")]
     majit_backend_cranelift::install_gc_standalone();
     #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -7,7 +7,7 @@
 //! only way to know what a warm entry costs is to count what the allocator is
 //! asked for while one is happening, so this file counts it.
 //!
-//! Three properties are load-bearing and each one is a separate failure mode:
+//! Four properties are load-bearing and each one is a separate failure mode:
 //!
 //! 1. **The driver must outlive the measured calls.** A fixture that builds its
 //!    `JitDriver` inside the annotated function measures a driver that never
@@ -34,6 +34,13 @@
 //!    second process-global counter is kept purely so the difference can be
 //!    reported as `off-thread` — evidence that the isolation did something,
 //!    rather than an assertion that it did.
+//!
+//! 4. **A GC must be installed.** The entry path allocates its jitframe from
+//!    the nursery when there is a GC to allocate it from and out of the Rust
+//!    heap when there is not, and the two differ by a whole allocation per
+//!    entry. A fixture with no GC measures a frame shape that no shipped
+//!    configuration uses. [`install_gc`] puts the meter on the configuration
+//!    pyre and cel run.
 //!
 //! ## Per-site attribution
 //!
@@ -269,6 +276,47 @@ fn window() -> (u64, u64) {
 }
 
 // ---------------------------------------------------------------------------
+// the GC
+// ---------------------------------------------------------------------------
+
+/// Install the process GC, because WHERE the jitframe comes from is part of
+/// the configuration this file measures.
+///
+/// `llmodel.py:298 malloc_jitframe` allocates the frame through the GC, and
+/// `jitframe.py:33-60` makes JITFRAME an ordinary varsize GcStruct — so
+/// upstream's per-entry frame is a nursery bump, which no `#[global_allocator]`
+/// ever sees. The cranelift backend reproduces that only when a JITFRAME type
+/// id is registered; with no GC at all it falls back to a `Vec<i64>`, and a
+/// fixture that measured the fallback would be reporting a frame the shipped
+/// configuration never allocates. pyre and cel reach the nursery branch through
+/// `init_gc_subsystem` (pyre-jit `eval.rs`), which is the three calls below.
+///
+/// The nursery size is spelled out rather than left to `GcConfig::default`:
+/// the default is `estimate_best_nursery_size`, which reads the host's cache
+/// size, and a file whose whole point is an exact pinned integer must not take
+/// a host-dependent input. Nothing here ever collects — the entry path
+/// allocates its frames through the no-collect path and the fixture's state is
+/// int-only — so the nursery only ever fills, and 4 MB is two orders of
+/// magnitude more than the run needs. If a run ever did exhaust it, the spill
+/// to old-gen is a `rawmalloc` and the assertion at the bottom would fail with
+/// the spill named in the per-site table.
+fn install_gc() {
+    use majit_gc::collector::{GcConfig, MiniMarkGC};
+    majit_gc::gc_sync::store_singleton(Box::new(MiniMarkGC::with_config(GcConfig {
+        nursery_size: 1 << 22,
+        ..GcConfig::default()
+    })));
+    // Takes the GIL, which every `gc_sync::gc_op` under the entry path asserts
+    // this thread holds. The meter owns its process (`harness = false`), so it
+    // holds the GIL for the whole run and never has to hand it back.
+    majit_gc::gc_sync::register_thread();
+    #[cfg(feature = "cranelift")]
+    majit_backend_cranelift::install_gc_standalone();
+    #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]
+    majit_backend_dynasm::runner::install_gc_standalone();
+}
+
+// ---------------------------------------------------------------------------
 // the fixture: one machine, one persistent driver
 // ---------------------------------------------------------------------------
 
@@ -388,6 +436,7 @@ fn profile() -> &'static str {
 }
 
 fn main() {
+    install_gc();
     let program = counter_program();
 
     // Bind ONCE. Everything below calls into this driver; nothing rebuilds it.
@@ -521,12 +570,11 @@ fn main() {
 
 /// Heap allocations per warm compiled-code entry, as measured by this file.
 ///
-/// The two backends now agree, so this is one number. It was two — `dynasm`
-/// 10, `cranelift` 12 — and the difference was the two cranelift-only rows
-/// named at the bottom, both since removed. The per-backend tables below stay
-/// split anyway: the backends reach 10 through rows that only *correspond*,
-/// and a table that pretended they were the same code would misname whichever
-/// row moved.
+/// **PER BACKEND, and the two disagree.** The backend is part of the key
+/// because it owns the last rows below; pinning one number for both would make
+/// whichever leg ran second fail with a message about a regression that is
+/// really a configuration difference. The figure was briefly one number for
+/// both at 10, before cranelift's frame moved to the nursery.
 ///
 /// Eight of the allocations are shared by both backends:
 ///
@@ -560,14 +608,21 @@ fn main() {
 /// so the copy had no upstream counterpart; the frame now lives as long as the
 /// deadframe does and the accessors read it in place.
 ///
-/// `cranelift` adds two, for 10 — the same two roles, in its own spelling:
+/// `cranelift` adds ONE, for 9:
 ///
 /// | n | site |
 /// |---|------|
-/// | 1 | `<i64 as SpecFromElem>::from_elem` — `JitFrameDeadFrame::_heap_owner`, the jitframe's backing `Vec<i64>` (`llmodel.py:298 malloc_jitframe`). This is the no-GC-registry branch of `run_compiled_code_inner`; with a JITFRAME type id registered the frame comes from the nursery and this row goes away |
 /// | 1 | `deadframe_from_jitframe` — the `Box<JitFrameDeadFrame>` inside `DeadFrame`, the `llmodel.py:240` `cast_opaque_ptr` |
 ///
-/// It used to add four. The two that went:
+/// There is no cranelift row for the frame itself, and that is the difference
+/// between the two backends. `run_compiled_code_inner` takes the JITFRAME from
+/// the nursery under its registered type id, which is `jitframe.py:48-52`
+/// `jitframe_allocate` — a bump of `nursery_free`, so the frame costs the
+/// process allocator nothing. dynasm's `execute_token` (`runner.rs:2871`)
+/// allocates its entry frame off the GC unconditionally, so it keeps paying
+/// for one; installing a GC does not move its figure.
+///
+/// It used to add four. The three that went:
 ///
 /// - `CraneliftBackend::execute_token_with_dispatch_key` unwrapped the
 ///   metainterp's `&[Value]` into an owned `Vec<i64>` before the frame
@@ -580,4 +635,9 @@ fn main() {
 ///   `llmodel.py:240-250` reads slots out of the frame through the accessors,
 ///   so the copy is now taken only where it is consumed. This is the same
 ///   removal `raw_values` got on dynasm.
-const ALLOCS_PER_ENTRY: usize = 10;
+/// - `<i64 as SpecFromElem>::from_elem`, the `Vec<i64>` behind
+///   `JitFrameDeadFrame::_heap_owner`. That was the no-GC branch of
+///   `run_compiled_code_inner`, reached because this fixture had no GC at all;
+///   see [`install_gc`]. The branch itself remains for a backend running
+///   without a collector.
+const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 9 } else { 10 };

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -320,10 +320,7 @@ fn install_gc() {
     #[cfg(feature = "cranelift")]
     {
         let jitframe_tid = majit_gc::gc_sync::gc_op(|gc| {
-            majit_gc::GcAllocator::register_type(
-                gc,
-                majit_backend::jitframe::jitframe_type_info(),
-            )
+            majit_gc::GcAllocator::register_type(gc, majit_backend::jitframe::jitframe_type_info())
         });
         majit_backend_cranelift::set_jitframe_gc_type_id(jitframe_tid);
     }


### PR DESCRIPTION
Four follow-up commits on top of #1243 (squash-merged as `5df24b2062c`). They fall into two groups: making the JITFRAME type-id contract verifiable rather than guessed, and giving each green key its own cell.

## 1. `majit: ask whether the JITFRAME registration took, not whether a registry was already populated`

`ensure_jitframe_type_registered` opened with `type_count() == 0 => stub`, which asks whether *someone else* had registered a type first. A real `MiniMarkGC::new()` has an empty registry, so it was classified as a stub and silently took the off-GC `Vec` frame. Roughly fifteen fixtures carried a throwaway `register_type` whose only job was to get past that reading, one of them documenting the workaround as intended behaviour.

The stub test now registers JITFRAME and asks whether the registration *took*: `GcAllocator`'s default `register_type` returns 0 and records nothing, so a real stub still reports 0. The explicit-id check moves first, so a frontend that calls `set_jitframe_gc_type_id` before installing never registers a second JITFRAME.

New test: a 1 MB nursery makes the entry jitframe genuinely nursery-born, a collection while the deadframe is held moves the frame, and the slot accessor reads the forwarded copy. The pre-existing survives-collection test has a 160-byte nursery, so its frame is born old-gen and never moves — the moving case was uncovered. Negative control: stubbing `register_roots` fails the address-changed assertion.

## 2. `majit: meter the GC-present entry configuration`

The allocation meter fixture installed no GC, so cranelift took the off-GC branch of `run_compiled_code_inner` and the pinned 10 included the jitframe's backing `Vec<i64>` — an allocation neither pyre nor cel ever makes, since both install a GC and register types before compiling (the frame then comes from the nursery, `llmodel.py:298` `malloc_jitframe` / `jitframe.py:33-60`).

The fixture now installs a `MiniMarkGC` the way pyre's `install_gc_into_backend` does, with the nursery pinned at 4 MB because `GcConfig::default` reads the host's cache size and a pinned integer must not take a host-dependent input.

**The 10 → 9 is a meter-configuration correction, not a production change.** The number moved because the meter is now measuring the configuration production actually runs; no code on the entry path changed in this commit. The pin goes from a flat `const ALLOCS_PER_ENTRY: usize = 10` to `if cfg!(feature = "cranelift") { 9 } else { 10 }`: cranelift reads 9, and dynasm stays 10 since its entry frame is allocated off the GC unconditionally in `execute_token`, so the constant returns to the per-backend `cfg!` shape.

## 3. `majit: require the JITFRAME type id to be published before a cranelift GC install`

**This is an approved API contract change.** A collector with a type registry must now arrive with its JITFRAME id already published, or `install_gc_*` panics; the backend-side lazy registration is gone.

- **Capability query, not a count.** The exemption is drawn on the allocator's capability — new `GcAllocator::has_type_registry`, default `false`, `MiniMarkGC` `true` — not on `type_count()`, which cannot distinguish "no table" from "table still empty" (`register_type`'s default body returns 0 and records nothing).
- **Install-time verification.** Install also verifies the published id against the collector being installed (`type_size == jitframe_type_info().size`), so an id minted in a different registry is refused at install rather than naming an arbitrary type at the first frame allocation.
- **Thread-local / process-global split.** The TLS becomes `Cell<Option<JitFrameHeap>>` (`Nursery(u32)` | `OffGc`): `None` now means no install ran on this thread, distinct from installed-off-GC. A thread that reaches compiled code with a process-global collector but no thread-local install resolves through the process-published id, and panics if nothing published one — previously it silently took the `Vec` frame. `set_jitframe_gc_type_id` publishes to both the thread-local and the process atomic; the thread-local is what keeps parallel test threads, each with its own registry, from installing an id that names another collector's type.

pyre already satisfies the contract (`build_gc` registers and publishes under a `Once` before install). cel-jit installs no GC and stays on the `Vec` frame. Fixtures route through `backend_with_gc` / `publish_jitframe_type`; three negative-control tests pin the panic, the cross-registry refusal, and the stub exemption. The allocation meter registers and publishes on its singleton under `cfg(cranelift)` and still reads 9 / 10.

## 4. `majit: make the green-key u64 name one cell, resolved once at each producer`

**Defect.** On a chained bucket the entry decided through the comparekey-walked cell and then executed the bucket head's token and meta, because `get_procedure_token(hash)` and `compiled_loops.get(&hash)` read by raw hash — one slot per hash, so two colliding keys could not both file.

**Design.** `BaseJitCell` now carries `cell_key`: the bucket's raw `get_uhash` when the cell is the bucket's only occupant, a minted key otherwise (serial stepped through `green_uhash_step`, retried against the live set; no u64 sub-range is reserved, because every u64 is a hash some green key can produce). `WarmEnterState` keeps the `counter.py` celltable shape — cells still keyed by raw hash with next chains — and adds a minted side index; `bucket_of()` short-circuits on `minted.is_empty()` so the collision-free case pays one test.

Hash producers resolve raw hash + greens to the cell key once (greens + comparekey + `get_uhash` together, `warmstate.py:568-593`) and the resolved key flows onward (`warmstate.py:483` / `:511` carries the resolved procedure_token, never re-looking-up by key), so the ~34 dual-use `warm_state` call sites and the `compiled_loops` keying are unchanged. `entry_cell_has_compiled_code` is deleted — the decision and the runner read the same key by construction. A greens-less resolve on a chained bucket declines (answering the first occupant, `warmstate.py:464`'s not-found arm) rather than guessing. The back-edge counter stays bucket-keyed (`warmstate.py:467` ticks by bucket).

**Eviction by-product.** Tokens stamp the cell key, so `rd_loop_token` carries it and eviction by `token.green_key()` frees the right entry — a colliding sibling's entry was previously unreachable by its own token. Minted keys are retired when their cell is pruned.

**The formerly `#[ignore]`d pin is rewritten** (owner-approved) to assert the decided and executed artifacts are the same object, keeping the collision fixture; its doc records the pre-migration failure and a substitution control on the migrated tree. It now runs and passes as `warmstate::tests::the_entry_decision_and_the_entry_execution_resolve_through_one_cell_key`. Allocation meter unchanged at 9 (cranelift) / 10 (dynasm): resolve builds a `GreenKey` only on a chained bucket.

## 5. `majit: wrap the meter's register_type call the way rustfmt does`

Whitespace only. The `register_type` call added by commit 3 fits on one line at its indentation, so `cargo fmt --check` reported a diff on it. No behaviour change; both meters re-read 9 / 10 afterwards.

## Verification

All run on this branch, exit code 0 each:

- `cargo test -p majit-metainterp --features dynasm`
- `cargo test -p majit-metainterp --features cranelift`
- `cargo test -p majit-gc`
- `cargo test -p majit-backend-cranelift`
- `cargo test -p majit-backend-dynasm`
- `cargo test -p majit-metainterp --features cranelift --test allocs_per_compiled_entry` — 9.000/entry
- `cargo test -p majit-metainterp --features dynasm --test allocs_per_compiled_entry` — 10.000/entry
- `cargo fmt -p majit-metainterp -p majit-gc -p majit-backend-cranelift -- --check`

Follow-up to #1243.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011capRVFH2W4gwGQNWYCxEx
