### PR TITLE
majit: bound a virtualizable array index and the blackhole constant table; record test_interpreters as a known skip

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -659,7 +659,16 @@ impl BlackholeInterpreter {
     /// Set an integer register value.
     ///
     /// RPython: `BlackholeInterpreter.setarg_i(index, value)`
+    ///
+    /// The working registers occupy `0 .. num_regs_i`; everything above is the
+    /// jitcode's constant table, which no write may reach.
     pub fn setarg_i(&mut self, index: usize, value: i64) {
+        // `init_register_file_from_i64s` lays the jitcode's integer constants
+        // out at `num_regs_i ..`, so a write at or above that bound replaces a
+        // constant the instruction stream still reads as one.  The read side
+        // cannot tell the difference, and the value surfaces far away — as a
+        // bogus array index or callee address — so fail at the write.
+        debug_assert_constant_slot_untouched(index, self.jitcode.num_regs_i(), "setarg_i");
         self.registers_i[index] = value;
     }
 
@@ -7619,6 +7628,24 @@ fn check_residual_call_exception_after(
 /// it as a no-op returning `0`/null, a convention pyre relies on for host calls
 /// left unbound on purpose.
 #[inline]
+/// Refuse a register write that would land in the constant table.
+///
+/// `init_register_file_from_i64s` places the jitcode's constants at
+/// `num_regs_i ..` of the same bank the working registers live in, so the two
+/// are only separated by that bound.  Nothing distinguishes them at the read,
+/// which is why a clobbered constant is reported here rather than where its
+/// value is finally used.
+#[track_caller]
+fn debug_assert_constant_slot_untouched(index: usize, num_regs: usize, who: &str) {
+    if crate::jit_strict_mode() {
+        assert!(
+            index < num_regs,
+            "{who}: register index {index} is at or past num_regs {num_regs}, so it \
+             addresses the jitcode's constant table rather than a working register",
+        );
+    }
+}
+
 fn reject_symbolic_residual_call(bh: &mut BlackholeInterpreter, func: i64) -> DispatchError {
     if crate::majit_log_enabled() {
         eprintln!(

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -2996,6 +2996,23 @@ pub(crate) unsafe fn vable_read_array_item(
         if data_ptr.is_null() {
             0
         } else {
+            // An index past the end reads whatever follows the payload and
+            // hands it back as a value of `item_type` — for a `Ref` array that
+            // is a pointer the caller will dereference, so the fault lands in
+            // whatever consumes the result rather than here.  The operand is
+            // an interpreter register, so a stale or clobbered one is a defect
+            // in the producer; report it against this array instead of letting
+            // the poison value travel.
+            if crate::jit_strict_mode() {
+                let len = bhimpl_arraylen_vable(vable_ptr, array);
+                assert!(
+                    index < len,
+                    "vable_read_array_item: index {index} is past the end of \
+                     virtualizable array {:?} (len {len}, item_type {:?})",
+                    array.name,
+                    array.item_type,
+                );
+            }
             let src = data_ptr.add(index * item_size);
             if array.item_type == Type::Ref {
                 *(src as *const usize) as i64

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -631,8 +631,9 @@
       "dynasm": "PASS"
     },
     "test.test_interpreters": {
-      "cranelift": "PASS",
-      "dynasm": "PASS"
+      "cranelift": "SKIP",
+      "dynasm": "SKIP",
+      "reason": "package skips itself on a free-threaded build (Py_GIL_DISABLED)"
     },
     "test.test_io": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -110,6 +110,12 @@ KNOWN_SKIPS = {
     "test.test_embed": "needs embedded CPython",
     "test.test_xpickle": "spawns per-version pythonX.Y subprocesses (PATH-dependent, can deadlock)",
     "test.test_c_locale_coercion": "asserts child stderr is empty, but MAJIT_STATS=1 prints a [jit-stats] line to every process's stderr",
+    # `test/test_interpreters/__init__.py` raises SkipTest("GIL disabled")
+    # when `test.support.Py_GIL_DISABLED` is set, and pyre reports
+    # `Py_GIL_DISABLED = 1` (abiflags `t`) on every host. The package therefore
+    # opts out everywhere, which is a fact about the build rather than about
+    # one host.
+    "test.test_interpreters": "package skips itself on a free-threaded build (Py_GIL_DISABLED)",
 }
 
 # Whole modules that CPython skips at import on some platforms. Off-platform


### PR DESCRIPTION
Two independent changes, both small.

## `majit`: bound a virtualizable array index, and refuse a register write into the constant table

Two checks over the blackhole's register and virtualizable access, both under
`jit_strict_mode()` (debug builds plus `MAJIT_STRICT`), so a release build
without `MAJIT_STRICT` executes what it did before. The CPython suite gate sets
`MAJIT_STRICT=1`, so both are live there.

- `vable_read_array_item` checked only for a null base. An index past the end
  read whatever followed the payload and returned it as a value of the array's
  item type; for a `Ref` array that is a pointer the caller dereferences, which
  puts the fault in whatever consumes the result rather than at the bad access.
  It now compares the index against `bhimpl_arraylen_vable`.
- `init_register_file_from_i64s` lays a jitcode's integer constants out at
  `num_regs_i ..` of the same bank the working registers use, and `setarg_i`
  took any index. A write at or above that bound replaces a constant the
  instruction stream still reads as one, and the read side cannot tell the
  difference. The bound is now asserted at the write.

**Neither check fires on `test.test_dataclasses`.** They were added while
chasing its `test_classvar_module_level_import` segfault, and they refute two
explanations for it: the virtualizable array index that crash reads is in
bounds, and no write reached the constant table. That crash is red on `main`
at this base and is not addressed here; it is being tracked separately.

## `cpython_tests`: record `test_interpreters` as a known skip

`test/test_interpreters/__init__.py` raises `SkipTest("GIL disabled")` when
`test.support.Py_GIL_DISABLED` is set, and pyre reports
`sysconfig.get_config_var("Py_GIL_DISABLED") == 1` with abiflags `t` on every
host, so the package opts out everywhere. The shared baseline recorded it as
`PASS` on both backends, which made the linux gate report a `PASS -> SKIP`
regression.

It is a fact about the build rather than about one host, so it belongs in
`KNOWN_SKIPS`, whose entries `update_baseline` writes to the shared baseline as
`SKIP` with their reason. The baseline row is updated to match.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wapwfqfqNe7kFcxQRx85P

— *authored by Claude*
