### PR TITLE
wasm: fuse an overflow op's guard, and drop the dead fresh-entry home clear

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -3220,38 +3220,45 @@ fn build_function(
             }
 
             // Overflow variants: compute result + overflow flag
-            OpCode::IntAddOvf => {
-                ovf_flag_live = emit_ovf_binop(
+            OpCode::IntAddOvf | OpCode::IntSubOvf | OpCode::IntMulOvf => {
+                let binop = match op.opcode {
+                    OpCode::IntAddOvf => BinOp::I64Add,
+                    OpCode::IntSubOvf => BinOp::I64Sub,
+                    OpCode::IntMulOvf => BinOp::I64Mul,
+                    _ => unreachable!(),
+                };
+                let fused_guard = match binop {
+                    BinOp::I64Add | BinOp::I64Sub => next_ovf_guard(ops, op_idx),
+                    BinOp::I64Mul => None,
+                    _ => unreachable!(),
+                };
+                ovf_flag_live = match emit_ovf_binop(
                     &mut sink,
                     constants,
                     value_types,
                     op,
-                    BinOp::I64Add,
+                    binop,
                     value_types.count(),
                     ovf_flag_local,
-                );
-            }
-            OpCode::IntSubOvf => {
-                ovf_flag_live = emit_ovf_binop(
-                    &mut sink,
-                    constants,
-                    value_types,
-                    op,
-                    BinOp::I64Sub,
-                    value_types.count(),
-                    ovf_flag_local,
-                );
-            }
-            OpCode::IntMulOvf => {
-                ovf_flag_live = emit_ovf_binop(
-                    &mut sink,
-                    constants,
-                    value_types,
-                    op,
-                    BinOp::I64Mul,
-                    value_types.count(),
-                    ovf_flag_local,
-                );
+                    fused_guard.map(|guard| guard.opcode),
+                ) {
+                    OvfFlag::Absent => false,
+                    OvfFlag::InLocal => true,
+                    OvfFlag::FusedCond => {
+                        let guard = fused_guard.expect("fused overflow condition requires guard");
+                        emit_guard_if_exit(
+                            &mut sink,
+                            constants,
+                            value_types,
+                            guard_idx,
+                            guard,
+                            block_exit_depth,
+                        );
+                        guard_idx += 1;
+                        fused_guard_at = Some(op_idx + 1);
+                        false
+                    }
+                };
             }
 
             // ── Unary ops ──
@@ -5914,6 +5921,15 @@ fn next_op_can_accept_cc<'a>(
     Some(next_op)
 }
 
+/// The overflow guard immediately following an overflow op. The flag is not an
+/// SSA value — it has no local, no home slot, no LABEL capture, and can never be
+/// a fail argument — so unlike `next_op_can_accept_cc` this needs no liveness
+/// test: adjacency is the whole condition.
+fn next_ovf_guard(ops: &[Op], i: usize) -> Option<&Op> {
+    let next = ops.get(i + 1)?;
+    matches!(next.opcode, OpCode::GuardNoOverflow | OpCode::GuardOverflow).then_some(next)
+}
+
 /// Common guard exit: condition is on stack (i32), spill and branch on failure.
 ///
 /// The spill belongs in this arm rather than in one shared exit handler after
@@ -6140,8 +6156,6 @@ fn emit_umulhi_to_local(
     sink.local_set(output_local);
 }
 
-/// Overflow binary op: stores the wrapping result in pos and the signed
-/// overflow flag in the dedicated scratch local.
 /// The overflow condition for `a + c` / `a - c` against a constant `c`, as
 /// `(limit, greater_than)`: the operation overflows exactly when `a > limit`
 /// (`greater_than`) or when `a < limit`. `None` means it cannot overflow.
@@ -6189,6 +6203,36 @@ fn ovf_const_operand(
     }
 }
 
+/// What an overflow op left for the guard that follows it.
+enum OvfFlag {
+    /// The op was constant-folded and emitted nothing; there is no flag.
+    Absent,
+    /// `ovf_flag_local` holds the flag — nonzero means the op overflowed.
+    InLocal,
+    /// The following guard's failure condition is on the stack as an i32,
+    /// ready for `emit_guard_if_exit`.
+    FusedCond,
+}
+
+/// The comparison a fused guard makes on the overflow predicate.
+/// `GuardNoOverflow` exits when the op overflowed and so takes the predicate as
+/// it stands; `GuardOverflow` exits when it did not, and flipping the
+/// comparison costs nothing where negating its result would cost an
+/// instruction.
+fn overflow_failure_cmp(cmp: CmpOp, fused_guard: OpCode) -> CmpOp {
+    match fused_guard {
+        OpCode::GuardNoOverflow => cmp,
+        OpCode::GuardOverflow => match cmp {
+            CmpOp::I64GtS => CmpOp::I64LeS,
+            CmpOp::I64LtS => CmpOp::I64GeS,
+            _ => unreachable!("overflow comparison must be signed lt or gt"),
+        },
+        _ => unreachable!("overflow fusion requires an overflow guard"),
+    }
+}
+
+/// Overflow binary op: stores the wrapping result in pos and either leaves the
+/// overflow flag for a following guard or writes it to the scratch local.
 fn emit_ovf_binop(
     sink: &mut PeepSink<'_, '_>,
     constants: &indexmap::IndexMap<u32, i64>,
@@ -6197,14 +6241,16 @@ fn emit_ovf_binop(
     binop: BinOp,
     value_local_count: u32,
     ovf_flag_local: u32,
-) -> bool {
+    fused_guard: Option<OpCode>,
+) -> OvfFlag {
     let vi = op.pos.get().raw();
     if OpRef::raw_is_constant(vi) {
-        return false;
+        return OvfFlag::Absent;
     }
     let result_local = value_types.local(vi);
 
     if matches!(binop, BinOp::I64Mul) {
+        debug_assert!(fused_guard.is_none());
         // Keep both factors in the umulhi scratch bank. The hot signed-32
         // overflow check below reuses them without resolving the SSA operands
         // again; the slow 64-bit path is free to overwrite the same bank.
@@ -6222,28 +6268,35 @@ fn emit_ovf_binop(
     if let Some((var, c)) = ovf_const_operand(constants, op, binop) {
         match ovf_const_bound(binop, c) {
             Some((limit, greater_than)) => {
+                let cmp = if greater_than {
+                    CmpOp::I64GtS
+                } else {
+                    CmpOp::I64LtS
+                };
                 emit_resolve(sink, constants, value_types, var);
                 sink.i64_const(limit);
-                if greater_than {
-                    sink.i64_gt_s();
-                } else {
-                    sink.i64_lt_s();
+                if let Some(guard) = fused_guard {
+                    apply_cmp(sink, overflow_failure_cmp(cmp, guard));
+                    return OvfFlag::FusedCond;
                 }
+                apply_cmp(sink, cmp);
                 sink.i64_extend_i32_u();
             }
             // Adding or subtracting zero: the flag stays live so the paired
-            // guard still finds it, and folds against a constant zero.
+            // guard still finds it, and folds against a constant zero. There
+            // is no predicate to hand a fused guard, so this answers in the
+            // local whether or not one was offered.
             None => {
                 sink.i64_const(0);
             }
         }
         sink.local_set(ovf_flag_local);
-        return true;
+        return OvfFlag::InLocal;
     }
 
     match binop {
         BinOp::I64Add => {
-            // ((a ^ result) & (b ^ result)) >>s 63
+            // (a ^ result) & (b ^ result) — negative exactly when it overflowed
             emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
             sink.local_get(result_local);
             sink.i64_xor();
@@ -6251,12 +6304,9 @@ fn emit_ovf_binop(
             sink.local_get(result_local);
             sink.i64_xor();
             sink.i64_and();
-            sink.i64_const(63);
-            sink.i64_shr_s();
-            sink.local_set(ovf_flag_local);
         }
         BinOp::I64Sub => {
-            // ((a ^ b) & (a ^ result)) >>s 63
+            // (a ^ b) & (a ^ result) — negative exactly when it overflowed
             emit_resolve(sink, constants, value_types, op.arg(0).to_opref());
             emit_resolve(sink, constants, value_types, op.arg(1).to_opref());
             sink.i64_xor();
@@ -6264,9 +6314,6 @@ fn emit_ovf_binop(
             sink.local_get(result_local);
             sink.i64_xor();
             sink.i64_and();
-            sink.i64_const(63);
-            sink.i64_shr_s();
-            sink.local_set(ovf_flag_local);
         }
         BinOp::I64Mul => {
             // Multiplying two signed-32-bit integers cannot overflow i64: the
@@ -6320,10 +6367,23 @@ fn emit_ovf_binop(
             sink.i64_extend_i32_u();
             sink.local_set(ovf_flag_local);
             sink.end();
+            return OvfFlag::InLocal;
         }
         _ => unreachable!("overflow emitter requires add, sub, or mul"),
     }
-    true
+
+    // The sign bit of the word both arms left on the stack is the answer, so a
+    // fused guard reads it with the comparison it was going to make anyway.
+    if let Some(guard) = fused_guard {
+        sink.i64_const(0);
+        apply_cmp(sink, overflow_failure_cmp(CmpOp::I64LtS, guard));
+        OvfFlag::FusedCond
+    } else {
+        sink.i64_const(63);
+        sink.i64_shr_s();
+        sink.local_set(ovf_flag_local);
+        OvfFlag::InLocal
+    }
 }
 
 // ── Comparison ops ──

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2599,7 +2599,20 @@ fn build_function(
     // code, preserving captures written when the source loop first crossed
     // the LABEL.  Chained bridges have no capture plan and clear only their
     // own low ordinary-home prefix.
+    // A home the input loop fills below needs no null first: its store follows
+    // immediately and nothing between the two allocates, so no collection can
+    // read the slot while it is stale. Homes no input fills keep their clear
+    // because store-on-def writes them only later.
+    let mut input_filled_home = vec![false; ref_homes.len()];
+    for ia in inputargs {
+        if let Some(h) = ref_homes.home_id(ia.index) {
+            input_filled_home[h as usize] = true;
+        }
+    }
     for h in 0..ref_homes.len() as u64 {
+        if input_filled_home[h as usize] {
+            continue;
+        }
         sink.local_get(0);
         sink.i64_const(0);
         sink.i64_store(mem64(frame.home_slot_base + h * SLOT_SIZE));


### PR DESCRIPTION
Two wasm-backend codegen changes on the trace fast path. Both were measured
from `PYRE_WASM_DUMP_ALL_TRACES=1` WAT dumps; neither moves jit-stats.

## `wasm: fuse an overflow op's guard onto its own comparison`

An overflow op left its predicate in `ovf_flag_local` and the guard that
followed reloaded and re-tested it. The flag is not an SSA value — no local,
no home slot, no LABEL capture, and it can never be a fail argument — so
adjacency is the whole eligibility condition, and the op can hand the guard
the comparison it was going to make anyway. `GuardOverflow` exits on the
opposite sense, so the comparison is flipped rather than negated, which costs
nothing.

Fall-through path of the overflow test plus its guard: **108 -> 98**
instructions, both sides counted from WAT.

## `wasm: skip the fresh-entry home clear for homes an inputarg fills`

`build_function`'s fresh-entry prologue nulled every Ref home slot, and the
input loop directly below stores each Ref input into its home. Only the
`label_resume` capture clear separates the two, and that is straight-line
frame stores — nothing between a null and its overwrite can allocate, so no
collection can observe the slot while it is stale. Homes no inputarg fills
keep their clear, since store-on-def writes those only later.

On a nested-loop fixture (`while i < n: j = 0; while j < 4: j = j + 1; ...`)
the bridge that runs once per inner iteration carries 8 homes of which 7 are
input-filled: its emitted body drops **178 -> 163** instructions, and the
fixture's whole trace text 1242 -> 1215 WAT lines.

## Measurement

The nested-loop round trip is 270 wasm instructions across the loop and its
bridge, of which exactly one is the `i64.add` that does the work and ~158
(59%) are frame marshalling — the live set round-trips through linear memory
because a `return_call_indirect` cannot carry values in registers.

A/B with both arms built from the same commit, 21 reps, exec-only child CPU:

| fixture | emitted trace text | exec-only CPU | wall |
|---|---|---|---|
| nested loop | 1242 -> 1215 lines | **-5.3%** | -5.3% |
| `short_circuit_value_kept_stack` | — | -2.9% | -3.0% |
| `global_quasiimmut_invalidation` | unchanged (byte-identical) | +3.1% | +1.5% |

`global_quasiimmut_invalidation`'s traces are byte-identical between the two
arms, so its reading is the noise floor of the harness, not an effect.

Earlier a 17% cut of *arithmetic* fast-path instructions moved these fixtures
0%. This path is store-throughput-bound rather than ALU-bound, which is why a
7.8% cut of frame stores converts to 5.3% of time.

## jit-stats

Identical to the same commit built without these changes on `arith_int_bool`,
`short_circuit_value_kept_stack`, `if_else_jump_forward` and
`global_quasiimmut_invalidation`.

`cargo test -p majit-backend-wasm` passes (49 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved arithmetic overflow handling for addition and subtraction, including optimized guard checks.
  * Preserved input values correctly during WebAssembly execution.
  * Enhanced constant-bound overflow validation.
  * Added safeguards to prevent unsupported overflow-check fusion for multiplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->