### PR TITLE
jit: apply a SWAP to the vstack mirror only at the boundary that retires it

### DIFF
--- a/pyre/cpython_tests/baseline.linux-aarch64.json
+++ b/pyre/cpython_tests/baseline.linux-aarch64.json
@@ -1,10 +1,6 @@
 {
   "host": "linux-aarch64",
   "modules": {
-    "test.test_dataclasses": {
-      "dynasm": "FAIL",
-      "reason": "JIT wrong code, not a platform difference: _process_class raises a spurious 'dictionary changed size during iteration' over cls.__dict__ although the only delattr completes before the loop. PYRE_NO_JIT=1 passes and darwin-arm64 passes, so it is neither the arch nor the OS alone"
-    },
     "test.test_unittest": {
       "dynasm": "CRASH",
       "reason": "GC bug, not a platform difference: invalid type_id at minor_custom_trace_target under minor_remembered_set, aborting through pyre_jit::call_jit::bh_call_fn mid-run. Passes when the driver is run directly, so it needs run.py's process shape to show up"

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -427,7 +427,11 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
     // cannot report it.  Left out, an unwind to the handler read as a block
     // permutation and armed the reorder region over the whole handler body,
     // where `ShadowReseed` drops every operand box the shadow does not carry.
-    let cfg_successor = new_pypc as usize == prev_pypc
+    // One Python opcode's jitcode expansion can carry more than one boundary
+    // marker, so a boundary can report the py_pc it came from.  The walk has
+    // not left that opcode there, so the opcode has not retired.
+    let repeat_boundary = new_pypc as usize == prev_pypc;
+    let cfg_successor = repeat_boundary
         || (has_fallthrough && new_pypc as usize == fallthrough)
         || crate::liveness::target_pc(code, &instr, prev_pypc, op_arg) == Some(new_pypc as usize)
         || crate::liveness::exception_target_pc(code, prev_pypc) == Some(new_pypc as usize);
@@ -642,11 +646,25 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
             // A NONE in either slot is just permuted (the later hole-fill /
             // legacy-defer handles it); a malformed / out-of-range arg
             // declines (latch invalid).
+            //
+            // The exchange belongs to the boundary that RETIRES the opcode.  A
+            // repeat boundary has not left it, and SWAP is the one class whose
+            // replay is not idempotent: exchanging the same pair twice restores
+            // the pre-SWAP order, so the mirror ends up disagreeing with the
+            // `setarrayitem_vable_r` stores the walk executed for that SWAP,
+            // and the capture overlay then publishes the stale order into a
+            // branch guard's virtualizable resume section.  A repeat is invisible
+            // to `layout_only_boundary` here precisely because the net-zero
+            // depth matches the fallthrough successor.  The depth normalization
+            // still runs: it is what keeps mirror slot `s` naming operand-stack
+            // slot `s` at the observed depth.
             ctx.vstack_boxes.truncate(new_depth);
             if ctx.vstack_boxes.len() < new_depth {
                 ctx.vstack_boxes.resize(new_depth, OpRef::NONE);
             }
-            if new_depth >= 1 && i >= 1 && i <= new_depth {
+            if repeat_boundary {
+                // The retiring boundary performs the exchange.
+            } else if new_depth >= 1 && i >= 1 && i <= new_depth {
                 let top = new_depth - 1;
                 let other = new_depth - i;
                 ctx.vstack_boxes.swap(top, other);


### PR DESCRIPTION
Fixes the `test.test_dataclasses` SIGSEGV on linux-aarch64.

## The defect

One Python opcode's jitcode expansion can emit more than one boundary marker,
so `reconcile_vstack_at_boundary` can be called with `new_pypc == prev_pypc`.
The walk has not left that opcode there, but the previous opcode's class was
applied anyway.

`SWAP` is the one class whose replay is not idempotent — exchanging the same
pair twice restores the pre-SWAP order. The repeat escapes
`layout_only_boundary` precisely because `SWAP` is net-depth-0, so the observed
depth equals the fallthrough successor's.

## Where it bites

`dataclasses._process_class`, the inlined comprehension at
`lib-python/3/dataclasses.py:1125`:

```python
all_init_fields = [f for f in fields.values()
                   if f._field_type in (_FIELD, _FIELD_INITVAR)]
```

Its prologue is `930 LOAD_FAST_AND_CLEAR f · 931 SWAP 2 · 932 BUILD_LIST 0 ·
933 SWAP 2 · 934 FOR_ITER`, and 933 is what makes the frame carry
`[45]=old_f, [46]=list, [47]=iter`.

Measured on linux-aarch64, py 933 produced boundaries `933->933` and
`933->934`, both applying `Swap(2)`:

```
76: prev=933 new=933 d3->3 class=Swap(2) reorder=false   <- intra-opcode repeat
79: prev=933 new=934 d3->3 class=Swap(2) reorder=false   <- the retiring one
```

The mirror then held the pre-SWAP order while the executed
`setarrayitem_vable_r` stores had written the post-SWAP order to the
virtualizable shadow. At the branch guard for the comprehension's filter, the
capture overlay in `walker_capture_snapshot_for_last_guard_impl` writes the
mirror over the shadow, so the shadow being right did not save it:

```
[vsec] pc=10770 py_pc=964 bg=true vstack_valid=true seclen=67
  slot1(abs46) shadow=RefOp(153) mirror=RefOp(146) overlay=RefOp(146) section=RefOp(146)
  slot2(abs47) shadow=RefOp(146) mirror=RefOp(153) overlay=RefOp(153) section=RefOp(153)
```

The guard's virtualizable resume section therefore carried the comprehension's
list and iterator in each other's frame slots. `LIST_APPEND` resumed with the
iterator as `jit_list_append`'s receiver and `switch_to_object_strategy` read
`int_items` off a non-list.

The sibling guard `pc=10426` (FOR_ITER exhaustion) carries the same two boxes
in the correct order, which is what made the two comparable inside one run.

## The fix

Keep the depth normalization at a repeat boundary — it is what keeps mirror
slot `s` naming operand-stack slot `s` — and skip only the exchange. The 931
`SWAP` has a single boundary and is unaffected.

## Verification

Container `pyre-linux` (linux/arm64), `target-linux/release/pyre-dynasm`:

| | before | after |
|---|---|---|
| `test.test_dataclasses` driver | SIGSEGV | 276 tests OK |
| guard `pc=10770` capture | mirror transposed vs shadow | `mirror == shadow` |
| CPython suite gate | 214 run, 213 PASS | 215 run, 214 PASS |

The second commit drops the `test.test_dataclasses` FAIL row from
`baseline.linux-aarch64.json`. That row overrode the shared baseline's PASS, so
the gate never ran the module on linux; without it the gate runs and gates the
fix. `run.py` reports the transition itself as `test.test_dataclasses: FAIL ->
PASS`.

`cargo test -p pyre-jit-trace` green, `cargo fmt --check` clean.

## Not from this branch

The linux gate also reports `test.test_urllib2: PASS -> IMPORTERROR`. It
reproduces with `--no-jit` on the same binary, and this branch changes only the
JIT walker, which is unreachable with the JIT off. It is also full-run-only:
`--filter test_urllib2` passes on both the base and this branch. Root cause not
investigated here.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JIT trace handling for repeated bytecode positions, preserving correct execution boundaries.
  * Prevented stack-swapping operations from being applied twice during repeated-boundary processing.
  * Removed an outdated dataclass test failure baseline; the related tests are now expected to pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->