### PR TITLE
gh#346: rtyper two-phase coverage increments (type_object residualize + folds)

### DIFF
--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -46,6 +46,13 @@ const CONST_PREFIX_HINTS: &[(&str, &[&str])] = &[
 /// the marker consts present in `llbcs`.
 pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> {
     let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    // The `type_object` residual resolves through `PYRE_TYPE_OBJECT_FNADDRS`, a
+    // native-only link-time slice (empty on wasm32, which linkme rejects).
+    // Residualizing there would emit a call to an unpublished address, so keep
+    // those accessors on the legacy walker when building for wasm.
+    let residualize_type_object = !std::env::var("TARGET")
+        .unwrap_or_default()
+        .starts_with("wasm32");
     for llbc in llbcs {
         let function_paths: HashSet<String> = llbc
             .iter_local_fns()
@@ -131,6 +138,30 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
                         push_hint(&mut out, key.clone(), hint);
                     }
                     break;
+                }
+            }
+        }
+        // Residualize the `#[pyre_methods]`-generated `type_object()`
+        // accessors.  The body is the `OnceLock<usize>` type-object cache
+        // (`make_builtin_type_with_layout` building the class namespace dict) —
+        // unliftable host plumbing whose lift fails at the `CELL` read and
+        // poisons every caller.  Stamping `dont_look_inside` prefills a
+        // signature-only stub and lets the codewriter emit a residual call to
+        // the accessor's registered C ABI address (published through the
+        // `PYRE_TYPE_OBJECT_FNADDRS` link-time slice into `jit_trace_fnaddrs`).
+        // Gated on the exact accessor signature — leaf `type_object`, no inputs,
+        // `*mut PyObject` return — so the stamped set equals the funcptr set the
+        // macro registers, never a stray same-named function.  Skipped entirely
+        // on wasm, which has no funcptr slice to resolve the residual against.
+        if residualize_type_object {
+            for fd in llbc.iter_local_fns() {
+                let path = strip_crate_prefix(&fd.item_meta.name_path());
+                let leaf = path.rsplit("::").next().unwrap_or(path.as_str());
+                if leaf == "type_object"
+                    && fd.signature.inputs.is_empty()
+                    && crate::front::mir::output_type_is_objectptr(&fd.signature.output, llbc)
+                {
+                    push_hint(&mut out, path, "dont_look_inside");
                 }
             }
         }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -2452,6 +2452,11 @@ fn lower_unstructured_with_static_addrs_and_attrs(
         // the legacy walker and codewriter already handle, so it runs
         // unconditionally.
         let mut fmt_collapsed = collapse_fmt_chains(&mut lo.graph);
+        // Constant `format!("literal")` — a zero-placeholder format charon has
+        // already folded to the fully-rendered constant string, so the format
+        // op's argument is a bare `__str_const` with no pieces/args chain.
+        // Replace the op with that constant string in place.
+        fmt_collapsed += collapse_const_fmt(&mut lo.graph);
         // Multi-argument `format!("{a}…{b}", …)` chains build an N-field
         // argument tuple and N `Argument::new_display` ctors across several
         // blocks — a shape the single-argument collapser above does not
@@ -19404,6 +19409,76 @@ fn collapse_fmt_chains(graph: &mut FunctionGraph) -> usize {
             .splice(idx..idx + 1, expansion);
     }
     sites.len()
+}
+
+/// Collapse a constant `format!("literal")` — a zero-placeholder format whose
+/// `format_args!` charon has already folded to the fully-rendered constant
+/// string, so `alloc::fmt::format`'s single argument resolves to a
+/// `__str_const` rather than to an `Arguments::new(pieces, args)` chain.  The
+/// format of a constant string IS that string, so replace the `fmt::format` op
+/// in place with the same `__str_const`, keeping the result var; the now-unread
+/// producer is reclaimed by the dead-op sweep.  No pieces/args arrays exist
+/// (unlike the single/multi-arg Display collapsers), so no link re-threading is
+/// needed.  Retires the graph-less `alloc::fmt::format` extern with only the
+/// `__str_const` op the rtyper natively types `SomeString`.
+fn collapse_const_fmt(graph: &mut FunctionGraph) -> usize {
+    use crate::model::{CallTarget, OpKind, ValueType};
+    // `__str_const` carries its text as the second path segment (see
+    // `emit_str_const`), so a zero-arg `["__str_const", text]` producer is the
+    // whole rendered message.
+    let mut rewrites: Vec<(BlockId, usize, String)> = Vec::new();
+    for block in &graph.blocks {
+        for (fi, op) in block.operations.iter().enumerate() {
+            let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                ..
+            } = &op.kind
+            else {
+                continue;
+            };
+            if !fmt_path_ends_with(segments, &["fmt", "format"]) || op.result.is_none() {
+                continue;
+            }
+            let Some(arg) = args.first() else {
+                continue;
+            };
+            let Some((pbid, pidx)) = resolve_to_producer_op(graph, arg) else {
+                continue;
+            };
+            let text = match graph
+                .blocks
+                .iter()
+                .find(|b| b.id == pbid)
+                .and_then(|b| b.operations.get(pidx))
+                .map(|o| &o.kind)
+            {
+                Some(OpKind::Call {
+                    target: CallTarget::FunctionPath { segments: pseg },
+                    args: pargs,
+                    ..
+                }) if pargs.is_empty() && pseg.len() == 2 && pseg[0] == "__str_const" => {
+                    pseg[1].clone()
+                }
+                _ => continue,
+            };
+            rewrites.push((block.id, fi, text));
+        }
+    }
+    let n = rewrites.len();
+    // In-place kind replacement keeps every op index valid across the batch.
+    for (bid, fi, text) in rewrites {
+        if let Some(op) = graph.block_mut(bid).operations.get_mut(fi) {
+            op.kind = OpKind::Call {
+                target: CallTarget::FunctionPath {
+                    segments: vec!["__str_const".to_string(), text],
+                },
+                args: vec![],
+                result_ty: ValueType::Ref(None),
+            };
+        }
+    }
+    n
 }
 
 /// A recognized multi-argument `format!` chain ready to collapse.  Unlike

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7154,11 +7154,16 @@ impl<'a> Lowering<'a> {
                     self.graph.set_goto(bb_id, target_bb, link_args);
                     return Ok(());
                 }
-                // `<str|String as ToString>::to_string` on a string-family
-                // receiver — a `String` clone that is an identity in the
-                // lifted value model, so alias the destination to the
-                // receiver instead of emitting an unregistered `to_string`.
-                if args.len() == 1 && self.is_to_string_identity(&reg, first_arg_ty.as_ref()) {
+                // `<str|String as ToString>::to_string`, `Wtf8::to_wtf8_buf`,
+                // `<str>::to_owned`, and a string-family `Clone::clone` on a
+                // string-family receiver — each an owned copy of a value that
+                // is already the immutable rpy_string in the lifted model, so
+                // alias the destination to the receiver instead of emitting an
+                // unregistered clone/to_owned/to_string.
+                if args.len() == 1
+                    && (self.is_to_string_identity(&reg, first_arg_ty.as_ref())
+                        || self.is_string_clone_identity(&reg, first_arg_ty.as_ref()))
+                {
                     self.local_var[dest_local] = Some(args[0].clone());
                     let target_bb = self.block_id[target];
                     let link_args = self.edge_args(mir_bb, target)?;
@@ -10156,6 +10161,35 @@ impl<'a> Lowering<'a> {
         first_arg_ty.is_some_and(|ty| {
             tyref_is_string_adt(ty, self.llbc) || tyref_strips_to_str(ty, self.llbc)
         })
+    }
+
+    /// `Wtf8::to_wtf8_buf(&self) -> Wtf8Buf`, `<str as ToOwned>::to_owned
+    /// (&self) -> String`, and a string-family `<_ as Clone>::clone(&self)`
+    /// — an owned copy of a value that is already a string in the lifted
+    /// model (`String`/`&str`/`str`/`Wtf8`/`Wtf8Buf` all lower to the
+    /// immutable rpy_string), so it is an identity on the receiver, the same
+    /// alias shape as `to_string`.  `clone` / `to_owned` are generic leaves
+    /// shared by every `Clone` / `ToOwned` impl, so gate on the receiver
+    /// being a string value (`tyref_is_string_value`): a `Vec`/`BigInt`/`[T]`
+    /// (`<[T]>::to_owned -> Vec<T>`) receiver is outside the family and keeps
+    /// its ordinary lowering.  A receiver-string `clone`/`to_owned`/
+    /// `to_wtf8_buf` returns the same string family, so the receiver gate
+    /// alone fixes the result value model; no destination check is needed.
+    fn is_string_clone_identity(&self, reg: &RegularCall, first_arg_ty: Option<&TyRef>) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let Some(fd) = self.llbc.fn_by_id(*id) else {
+            return false;
+        };
+        let np = fd.item_meta.name_path();
+        let Some(leaf) = np.rsplit("::").next() else {
+            return false;
+        };
+        if !matches!(leaf, "to_wtf8_buf" | "to_owned" | "clone") {
+            return false;
+        }
+        first_arg_ty.is_some_and(|ty| tyref_is_string_value(ty, self.llbc))
     }
 
     /// `Option::<&T>::copied` / `Option::<T: Clone>::cloned` — reads the

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -16676,7 +16676,7 @@ fn ref_return_is_single_word(ast: &str) -> bool {
     false
 }
 
-fn output_type_is_objectptr(ty: &TyRef, llbc: &Llbc) -> bool {
+pub(crate) fn output_type_is_objectptr(ty: &TyRef, llbc: &Llbc) -> bool {
     tyref_node(ty, llbc)
         .and_then(|n| strip_ty_wrappers(n, llbc))
         .and_then(|n| raw_ptr_pointee_class_root(n, llbc))

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3306,8 +3306,8 @@ pub fn fuse_boxing_alloc(
         w_class: Option<Payload>,
     }
     let resolve_header_plan = |graph: &FunctionGraph, agg: &Variable| -> Option<HeaderPlan> {
-        let header = store_value(graph, agg, "ob_header")
-            .or_else(|| store_value(graph, agg, "ob"))?;
+        let header =
+            store_value(graph, agg, "ob_header").or_else(|| store_value(graph, agg, "ob"))?;
         let mut roots = Vec::new();
         if !store_roots(graph, &header, 8, &mut roots) {
             return None;

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -3032,6 +3032,18 @@ pub fn fuse_boxing_alloc(
     // so fall back to a leaf match when the exact key misses.  An unknown struct
     // yields `None` and is left unfused — the same fail-safe the old hardcoded
     // set applied to any struct outside the numeric four.
+    //
+    // The `PyObject` base field carries the type pointer, which
+    // `resolve_vtable_addr` lifts into `NewWithVtable.vtable`, so it is skipped
+    // here (the runtime stamps `ob_type`/`w_class` from the descriptor).  Two
+    // spellings reach this pass: the hand-written boxing structs
+    // (`W_FloatObject` etc.) name it `ob_header`, while `#[pyre_class]` injects
+    // it as `ob` (pyre-macros `expand_pyre_class`).  Both name the same base,
+    // so both are recognised as the header and neither is re-emitted as a
+    // payload setfield.
+    fn is_header_field(name: &str) -> bool {
+        name == "ob_header" || name == "ob"
+    }
     fn payload_fields(
         owner: &str,
         struct_field_attrs: &std::collections::HashMap<String, Vec<(String, ValueType)>>,
@@ -3053,7 +3065,7 @@ pub fn fuse_boxing_alloc(
         };
         Some(
             rows.iter()
-                .filter(|(name, _)| name != "ob_header")
+                .filter(|(name, _)| !is_header_field(name))
                 .cloned()
                 .collect(),
         )
@@ -3294,7 +3306,8 @@ pub fn fuse_boxing_alloc(
         w_class: Option<Payload>,
     }
     let resolve_header_plan = |graph: &FunctionGraph, agg: &Variable| -> Option<HeaderPlan> {
-        let header = store_value(graph, agg, "ob_header")?;
+        let header = store_value(graph, agg, "ob_header")
+            .or_else(|| store_value(graph, agg, "ob"))?;
         let mut roots = Vec::new();
         if !store_roots(graph, &header, 8, &mut roots) {
             return None;

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -371,8 +371,10 @@ pub fn allocate_lock() -> *mut Lock {
 }
 
 /// pypy/interpreter/baseobjspace.py `issubtype_w` — `cls` is in
-/// `w_type.mro_w`. Uses the cached MRO when present, otherwise
-/// recomputes via `compute_default_mro`.
+/// `w_type.mro_w`. Iterates the installed MRO (`typeobject.py:1640-1644
+/// _issubtype`: `w_type in w_sub.mro_w`); a type whose MRO is not yet
+/// installed (`mro_ptr` null / `not hasmro`) takes the
+/// [`issubtype_slow_and_wrong`] base-chain walk.
 pub(crate) unsafe fn issubtype_w(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
     if w_type.is_null() {
         return false;
@@ -387,9 +389,30 @@ pub(crate) unsafe fn issubtype_w(w_type: PyObjectRef, cls: PyObjectRef) -> bool 
     if !mro_ptr.is_null() {
         return (*mro_ptr).as_slice().iter().any(|&t| std::ptr::eq(t, cls));
     }
-    compute_default_mro(w_type)
-        .iter()
-        .any(|&t| std::ptr::eq(t, cls))
+    issubtype_slow_and_wrong(w_type, cls)
+}
+
+/// `typeobject.py:1646-1656 _issubtype_slow_and_wrong` — the subtype test
+/// for a partially-initialised `w_type` whose MRO is not yet installed
+/// (reached only from a custom `MetaCls.mro()`).  Walks the best-base chain
+/// rather than the MRO; deliberately broken wrt. multiple inheritance,
+/// matching CPython.
+///
+/// `dont_look_inside`: the cold walk bottoms out in `find_best_base`'s
+/// `w_tuple_items_copy_as_vec` `Vec` iteration, opaque to the annotator, and
+/// returns a single-word `bool`, so it residualises behind one boundary —
+/// keeping the hot cached-MRO branch of [`issubtype_w`] a pure typed-slice
+/// iteration instead of a `<slice> ∪ <opaque Vec>` phi merge.
+#[majit_macros::dont_look_inside]
+pub(crate) unsafe fn issubtype_slow_and_wrong(w_type: PyObjectRef, cls: PyObjectRef) -> bool {
+    let mut w_cls = w_type;
+    while !w_cls.is_null() {
+        if std::ptr::eq(w_cls, cls) {
+            return true;
+        }
+        w_cls = pyre_object::typeobject::w_type_get_best_base(w_cls);
+    }
+    false
 }
 
 /// pypy/interpreter/baseobjspace.py:1359 `exception_is_valid_obj_as_class_w`.

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -358,6 +358,24 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         push_fnaddr(&mut entries, wrapper.path, wrapper.func as *const ());
     }
 
+    // `#[pyre_methods]` `type_object()` accessors are `dont_look_inside`
+    // (`majit-translate` `front::llbc_hints` stamps them: the JIT residualizes
+    // the `OnceLock` body rather than lifting its unliftable `CELL` read), so
+    // each residual call needs the accessor's runtime address.  The macro
+    // registers every `(path, fn)` into this link-time slice; iterate it
+    // instead of hand-listing ~46 module-qualified paths (which mis-resolve
+    // inline-mod spellings and miss per-module `cfg` gates).  Register the
+    // crate-stripped alias too, mirroring `push_alias_pair`, so either
+    // spelling of the residual `FunctionPath` resolves.
+    #[cfg(not(target_arch = "wasm32"))]
+    for desc in pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS {
+        let fnptr = desc.func as *const ();
+        push_fnaddr(&mut entries, desc.path, fnptr);
+        if let Some((_crate_seg, rest)) = desc.path.split_once("::") {
+            push_fnaddr(&mut entries, rest, fnptr);
+        }
+    }
+
     push_alias_pair(
         &mut entries,
         "pyre_interpreter::runtime_ops::jit_make_function_from_globals",
@@ -3569,6 +3587,27 @@ mod tests {
             expected
         );
         assert_eq!(bindings["module::_random::Random::genrand32"], expected);
+    }
+
+    /// `PYRE_TYPE_OBJECT_FNADDRS` is a native-only `distributed_slice`, so the
+    /// `#[pyre_methods]` `type_object()` residual addresses are published only
+    /// off wasm32.  Both the crate-qualified path (the residual `FunctionPath`)
+    /// and the crate-stripped alias resolve to the accessor.
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn jit_trace_fnaddrs_covers_deque_iter_type_object_residual() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        let expected =
+            crate::module::_collections::deque_iter::type_object as *const () as usize as i64;
+
+        assert_eq!(
+            bindings["pyre_interpreter::module::_collections::deque_iter::type_object"],
+            expected
+        );
+        assert_eq!(
+            bindings["module::_collections::deque_iter::type_object"],
+            expected
+        );
     }
 
     /// `BUILTIN_WRAPPER_DESCRIPTORS` is only pushed into the binding table off

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -1014,6 +1014,18 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_interpreter::memoryview_gather_bytes",
         memoryview_gather_bytes as *const (),
     );
+    // #346: the `not hasmro` subtype fallback for a partially-initialised type
+    // (`_issubtype_slow_and_wrong`, typeobject.py:1646).  Its cold best-base
+    // walk bottoms out in an opaque `Vec` iteration and returns a single-word
+    // `bool`, so it is `#[dont_look_inside]` — keeping the hot cached-MRO
+    // branch of `issubtype_w` a pure typed-slice iteration.  Bind its `fn` by
+    // qualified path.
+    push_alias_pair(
+        &mut entries,
+        "pyre_interpreter::baseobjspace::issubtype_slow_and_wrong",
+        "pyre_interpreter::issubtype_slow_and_wrong",
+        crate::baseobjspace::issubtype_slow_and_wrong as *const (),
+    );
     // `gc_interp::enabled` reads (and lazily inits) the `STATE` atomic, and
     // `longobject::bigint_gc_type_id` /
     // `dictmultiobject::dict_view_iterator_gc_type_id` read the

--- a/pyre/pyre-macros/src/lib.rs
+++ b/pyre/pyre-macros/src/lib.rs
@@ -2425,6 +2425,20 @@ fn expand_pyre_methods(
                     tp as usize
                 }) as ::pyre_object::PyObjectRef
         }
+
+        // Publish this accessor's residual-call address.  `type_object` is
+        // `dont_look_inside` (the JIT never lifts the `OnceLock` body — its
+        // `CELL` read is unliftable host plumbing), so the codewriter emits a
+        // residual call the runtime resolves through `jit_trace_fnaddrs`, which
+        // iterates this slice.  Native only, matching the slice.
+        #[cfg(not(target_arch = "wasm32"))]
+        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
+        #[allow(non_upper_case_globals)]
+        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
+            ::pyre_object::lltype::TypeObjectFnDescriptor {
+                path: ::core::concat!(::core::module_path!(), "::type_object"),
+                func: type_object,
+            };
     };
 
     Ok(quote! {

--- a/pyre/pyre-object/src/lltype.rs
+++ b/pyre/pyre-object/src/lltype.rs
@@ -200,6 +200,35 @@ unsafe impl Sync for PyreClassDescriptor {}
 #[::linkme::distributed_slice]
 pub static PYRE_CLASS_DESCRIPTORS: [&'static PyreClassDescriptor] = [..];
 
+/// Link-time descriptor for a `#[pyre_methods]`-generated `type_object()`
+/// accessor.  The accessor's body is the `OnceLock<usize>` type-object cache;
+/// its `CELL` read is unliftable, so the JIT stamps the accessor
+/// `dont_look_inside` (`majit-translate` `front::llbc_hints`) and residualizes
+/// the call.  A residual call needs the callee's runtime address, so each
+/// accessor registers its census-visible path and pointer here, the same
+/// link-time census `PYRE_CLASS_DESCRIPTORS` uses for pytype statics.
+pub struct TypeObjectFnDescriptor {
+    /// `concat!(module_path!(), "::type_object")` — the `FunctionPath` the
+    /// residual call names, matched against `jit_trace_fnaddrs`.
+    pub path: &'static str,
+    /// The accessor.  `fn() -> PyObjectRef` is a single-word ref return with
+    /// no arguments — the plainest residual-call ABI the codewriter emits.
+    pub func: fn() -> crate::PyObjectRef,
+}
+
+// Safety: `path` is `'static` and `func` is a plain `fn` pointer to
+// process-global code; sharing across threads is sound.
+unsafe impl Sync for TypeObjectFnDescriptor {}
+
+/// Link-time registry of every `#[pyre_methods]` `type_object()` accessor,
+/// populated by the macro so `jit_trace_fnaddrs` publishes each residual-call
+/// address without a hand-maintained list (which would mis-resolve inline-mod
+/// paths and miss per-module `cfg` gates).  Native only, matching
+/// [`PYRE_CLASS_DESCRIPTORS`]: `distributed_slice` rejects `wasm32`.
+#[cfg(not(target_arch = "wasm32"))]
+#[::linkme::distributed_slice]
+pub static PYRE_TYPE_OBJECT_FNADDRS: [TypeObjectFnDescriptor] = [..];
+
 /// Compile-time bridge between a `#[pyre_class]` struct and its
 /// per-type static `PyType` / `PyreClassDescriptor`.  Implemented
 /// automatically by `#[pyre_class]`; consumed by `py_class_typed!`


### PR DESCRIPTION
gh#346 two-phase rtyper coverage increments, rebased onto `main`. Each commit is a
front-end recognizer/fold that lets a previously-residual JIT-traced graph lift
through the CodeWriter instead of falling back to the legacy walker; census-validated
via same-base phaseA A/B and, where they execute, the 3-backend (dynasm/cranelift/wasm)
bit-exact gate.

Commits:
- `issubtype_w` null-MRO fallback split into `issubtype_slow_and_wrong`.
- `fuse_boxing_alloc`: recognize the `ob` object-header field alongside `ob_header`.
- `collapse_const_fmt`: replace a constant `format!("literal")` with its `__str_const`.
- `is_string_clone_identity`: alias string `clone`/`to_owned`/`to_wtf8_buf` to the receiver.
- Residualize per-class `type_object()` accessors via `dont_look_inside`: a front
  recognizer stamps the accessor + a `linkme` slice publishes each accessor's funcptr
  for the residual call (native only). phaseA LIFTED +31, dynasm/cranelift 418/418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized constant-only string formatting and additional string operations.
  * Improved object allocation handling across supported runtime layouts.
  * Enhanced JIT optimization and method resolution for native builds.

* **Bug Fixes**
  * Improved subtype checks for partially initialized or incomplete type hierarchies.
  * Added safer handling for WebAssembly targets, preventing unsupported optimizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->