### PR TITLE
majit: streamline compiled entries and reload virtualizable arrays

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -452,11 +452,11 @@ fn register_active_hooks(supports_guard_gc_type: bool) {
     // walk goes through `trace_libc_jitframe`). This backend's frames are
     // ordinary GC objects — `run_compiled_code_inner` allocates them from the
     // nursery under the registered JITFRAME type id — and
-    // `JitFrameDeadFrame::register_roots` registers the `jf_gcref` SLOT with
-    // `add_root` for exactly the window the deadframe is held. The collector
-    // then reaches the frame as it reaches any rooted object, and gets the
-    // moving case for free: a walker yields an address and cannot update the
-    // holder if the frame is copied, whereas a registered slot is rewritten.
+    // `JitFrameDeadFrame` holds the frame in a root SLOT for exactly the window
+    // the deadframe is held. The collector then reaches the frame as it reaches
+    // any rooted object, and gets the moving case for free: a walker yields an
+    // address and cannot update the holder if the frame is copied, whereas a
+    // slot is rewritten in place by the walk that read it.
     // Publishing a walker as well would root the same frames twice through
     // two mechanisms with different invariants.
     //
@@ -800,7 +800,7 @@ fn lookup_loop_target(descr: &majit_ir::DescrRef) -> Option<LoopTargetEntry> {
 }
 
 fn deadframe_layout(frame: &DeadFrame) -> Option<FailDescrLayout> {
-    let jf = frame.data.downcast_ref::<JitFrameDeadFrame>()?;
+    let jf = frame.as_jitframe()?;
     let descr_ref: DescrRef = jf.fail_descr.clone();
     let fd = jf
         .fail_descr
@@ -906,7 +906,7 @@ fn wrap_call_assembler_deadframe_with_caller_prefix(mut frame: DeadFrame) -> Dea
     // the raw `jf_descr` slot still carries a `FailDescrCell` thin
     // pointer resolvable via `recover_fail_descr_cell`,
     // with no overlay descr needed.
-    let Some(jf) = frame.data.downcast_mut::<JitFrameDeadFrame>() else {
+    let Some(jf) = frame.as_jitframe_mut() else {
         // Fallback: return as-is (should not happen after FrameData removal).
         return frame;
     };
@@ -2073,34 +2073,6 @@ fn gc_is_nursery_object_via_active_runtime(addr: usize) -> bool {
         && majit_gc::gc_sync::gc_query_reentrant(|g| g.is_nursery_object(addr))
 }
 
-/// Returns true when the active GC was present and roots were
-/// registered; false when no GC is active and registration was a
-/// no-op. Callers pair the bool with `unregister_gc_roots` on Drop.
-pub(crate) fn register_gc_roots(roots: &mut [GcRef]) -> bool {
-    if roots.is_empty() {
-        return false;
-    }
-    with_cranelift_gc(|gc| {
-        for root in roots.iter_mut() {
-            unsafe {
-                gc.add_root(root as *mut GcRef);
-            }
-        }
-    })
-    .is_some()
-}
-
-pub(crate) fn unregister_gc_roots(roots: &mut [GcRef]) {
-    if roots.is_empty() {
-        return;
-    }
-    with_cranelift_gc(|gc| {
-        for root in roots.iter_mut() {
-            gc.remove_root(root as *mut GcRef);
-        }
-    });
-}
-
 struct GcRootSlotGuard {
     slots: Vec<*mut GcRef>,
     registered: bool,
@@ -3062,7 +3034,7 @@ fn finish_result_from_deadframe(frame: &mut DeadFrame) -> Result<i64, BackendErr
         [] => Ok(0),
         [Type::Int] => get_int_from_deadframe(frame, 0),
         [Type::Ref] => {
-            if let Some(jf) = frame.data.downcast_mut::<JitFrameDeadFrame>() {
+            if let Some(jf) = frame.as_jitframe_mut() {
                 return Ok(jf.take_ref_for_call_result(0).as_usize() as i64);
             }
             Err(BackendError::Unsupported(
@@ -3091,7 +3063,7 @@ fn call_assembler_finish_or_blackhole_deadframe(mut frame: DeadFrame) -> Option<
     // bumps the strong refcount before returning, so the local cell can
     // safely drop after BH completes.
     let (is_finish, fail_descr_arc, fail_arg_types) = {
-        let jf = frame.data.downcast_ref::<JitFrameDeadFrame>()?;
+        let jf = frame.as_jitframe()?;
         let fail_descr = jf.fail_descr.clone();
         let fd = as_fd(&fail_descr);
         let is_finish = fd.is_finish();
@@ -3197,11 +3169,9 @@ fn deadframe_from_jitframe(
     fail_descr: DescrRef,
     heap_owner: Option<Vec<i64>>,
 ) -> DeadFrame {
-    let mut frame = Box::new(JitFrameDeadFrame::new(
+    DeadFrame::JitFrame(JitFrameDeadFrame::new(
         jf_gcref, fail_descr, None, heap_owner,
-    ));
-    frame.register_roots();
-    DeadFrame { data: frame }
+    ))
 }
 
 pub fn set_savedata_ref_on_deadframe(
@@ -3209,8 +3179,7 @@ pub fn set_savedata_ref_on_deadframe(
     data: GcRef,
 ) -> Result<(), BackendError> {
     let jf = frame
-        .data
-        .downcast_mut::<JitFrameDeadFrame>()
+        .as_jitframe_mut()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     jf.set_savedata_ref(data);
     Ok(())
@@ -3220,8 +3189,7 @@ pub fn get_latest_descr_from_deadframe(frame: &DeadFrame) -> Result<&dyn FailDes
     // llmodel.py:411-419 get_latest_descr: cast deadframe → JITFRAMEPTR,
     // read jf_descr, show() → AbstractFailDescr.
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(as_fd(&jf.fail_descr))
 }
@@ -3237,48 +3205,42 @@ pub fn get_latest_descr_arc_from_deadframe(
     frame: &DeadFrame,
 ) -> Result<Arc<dyn majit_ir::Descr>, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.fail_descr.clone())
 }
 
 pub fn get_int_from_deadframe(frame: &DeadFrame, index: usize) -> Result<i64, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.get_int(index))
 }
 
 pub fn get_float_from_deadframe(frame: &DeadFrame, index: usize) -> Result<f64, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.get_float(index))
 }
 
 pub fn get_ref_from_deadframe(frame: &DeadFrame, index: usize) -> Result<GcRef, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.get_ref(index))
 }
 
 pub fn get_savedata_ref_from_deadframe(frame: &DeadFrame) -> Result<GcRef, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.get_savedata_ref())
 }
 
 pub fn grab_exc_value_from_deadframe(frame: &DeadFrame) -> Result<GcRef, BackendError> {
     let jf = frame
-        .data
-        .downcast_ref::<JitFrameDeadFrame>()
+        .as_jitframe()
         .ok_or_else(|| BackendError::Unsupported("expected JitFrameDeadFrame".to_string()))?;
     Ok(jf.grab_exc_value())
 }
@@ -25259,11 +25221,13 @@ mod tests {
     /// and `llmodel.py:298 malloc_jitframe` allocates it like any other object,
     /// so the frame itself is nursery-born and a minor collection promotes it
     /// to a different address — and every accessor on the deadframe reads
-    /// through `jf_gcref`, which is stale the moment that happens.
+    /// through `jf_gcref()`, which is stale the moment that happens.
     ///
-    /// What makes it not stale is that `register_roots` hands the collector the
-    /// ADDRESS OF THE SLOT (`add_root(&mut self.jf_gcref)`) rather than the
-    /// address of the frame, so the promotion rewrites the holder's pointer.
+    /// What makes it not stale is that the deadframe keeps the frame in a root
+    /// SLOT and reads it back by POSITION rather than holding a copy of the
+    /// address, so the walk that promoted the frame stored the new address into
+    /// the very slot the next read comes from
+    /// (`shadowstack.py:44-70 walk_stack_root`).
     /// The assertion that the frame moved is therefore load-bearing: without
     /// it a run where the frame happened to stay put would pass while proving
     /// nothing, which is exactly what the old-gen fixture next door does.
@@ -25301,10 +25265,9 @@ mod tests {
 
         let frame_addr = |frame: &DeadFrame| {
             frame
-                .data
-                .downcast_ref::<JitFrameDeadFrame>()
+                .as_jitframe()
                 .expect("cranelift deadframes are JitFrameDeadFrame")
-                .jf_gcref
+                .jf_gcref()
         };
         let before = frame_addr(&frame);
         assert!(
@@ -25331,6 +25294,82 @@ mod tests {
         assert!(!moved_root.is_null());
         assert_ne!(moved_root, root);
         assert_eq!(unsafe { *(moved_root.0 as *const u64) }, 0x5EED_5EED);
+    }
+
+    /// A deadframe that has MOVED still reads the frame the collector moved.
+    ///
+    /// The test above pins that the frame's address is rewritten while the
+    /// deadframe sits still. This one pins the other half, and it is the half
+    /// that decides how the deadframe may be stored: the deadframe is returned
+    /// by value and then moved again into a container, so its own address is
+    /// different at every step, and a collection between the last move and the
+    /// read still lands. Registering the address of the field that holds the
+    /// pointer cannot express this — that address stops being the frame's
+    /// holder the moment the holder moves, so the holder has to be pinned
+    /// first, which is what the per-exit heap allocation used to be for.
+    /// Addressing the root by its POSITION (`shadowstack.py:100-106`) is what
+    /// makes the holder's address irrelevant.
+    #[test]
+    fn test_moved_deadframe_still_reads_the_moved_jitframe() {
+        let mut gc = MiniMarkGC::with_config(GcConfig {
+            nursery_size: 1 << 20,
+            large_object_threshold: 1 << 20,
+            ..GcConfig::default()
+        });
+        gc.register_type(TypeInfo::simple(16));
+
+        let root = gc.alloc_with_type(0, 16);
+        assert!(gc.is_in_nursery(root.0));
+        unsafe {
+            *(root.0 as *mut u64) = 0xC0FF_EE00;
+        }
+
+        let mut backend = backend_with_gc(gc);
+
+        let inputargs = vec![InputArg::new_ref(0)];
+        let ops = vec![
+            mk_op(OpCode::Label, &[OpRef::input_arg_ref(0)], OpRef::NONE.raw()),
+            mk_op(
+                OpCode::Finish,
+                &[OpRef::input_arg_ref(0)],
+                OpRef::NONE.raw(),
+            ),
+        ];
+
+        let token = JitCellToken::new(1511);
+        backend.compile_loop(&inputargs, &ops, &token).unwrap();
+
+        // Returned by value, then moved into a Vec: two more addresses for the
+        // same deadframe, neither of them the one it was built at.
+        let frame = backend.execute_token(&token, &[Value::Ref(root)]);
+        let mut held = vec![frame];
+
+        let before = held[0]
+            .as_jitframe()
+            .expect("cranelift deadframes are JitFrameDeadFrame")
+            .jf_gcref();
+        assert!(
+            with_cranelift_gc_required(|gc| gc.is_nursery_object(before.0)),
+            "the frame must be nursery-born, or the promotion this test is \
+             about cannot happen"
+        );
+
+        with_cranelift_gc_required(|gc| gc.collect_nursery());
+
+        let after = held[0]
+            .as_jitframe()
+            .expect("cranelift deadframes are JitFrameDeadFrame")
+            .jf_gcref();
+        assert_ne!(
+            after, before,
+            "the frame must have been promoted, or a stale read would pass here"
+        );
+
+        let moved_root = backend.get_ref_value(&held[0], 0);
+        assert!(!moved_root.is_null());
+        assert_ne!(moved_root, root);
+        assert_eq!(unsafe { *(moved_root.0 as *const u64) }, 0xC0FF_EE00);
+        held.clear();
     }
 
     #[test]

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3011,7 +3011,7 @@ fn raw_values_from_deadframe_typed(
         .collect()
 }
 
-fn finish_result_from_deadframe(frame: &mut DeadFrame) -> Result<i64, BackendError> {
+fn finish_result_from_deadframe(frame: &DeadFrame) -> Result<i64, BackendError> {
     let (fail_arg_types, is_exit_frame_with_exception) = {
         let descr = get_latest_descr_from_deadframe(frame)?;
         assert!(descr.is_finish(), "expected finish deadframe");
@@ -3033,14 +3033,10 @@ fn finish_result_from_deadframe(frame: &mut DeadFrame) -> Result<i64, BackendErr
     match fail_arg_types.as_slice() {
         [] => Ok(0),
         [Type::Int] => get_int_from_deadframe(frame, 0),
-        [Type::Ref] => {
-            if let Some(jf) = frame.as_jitframe_mut() {
-                return Ok(jf.take_ref_for_call_result(0).as_usize() as i64);
-            }
-            Err(BackendError::Unsupported(
-                "unsupported dead frame type for Ref finish result".to_string(),
-            ))
-        }
+        // compile.py:640-642 DoneWithThisFrameDescrRef.get_result reads the
+        // slot through `cpu.get_ref_value(deadframe, 0)` and leaves it there —
+        // the same read the exception arm above makes.
+        [Type::Ref] => Ok(get_ref_from_deadframe(frame, 0)?.0 as i64),
         [Type::Float] => Ok(get_float_from_deadframe(frame, 0)?.to_bits() as i64),
         [Type::Void] => Ok(0),
         other => Err(BackendError::Unsupported(format!(
@@ -3049,7 +3045,7 @@ fn finish_result_from_deadframe(frame: &mut DeadFrame) -> Result<i64, BackendErr
     }
 }
 
-fn call_assembler_finish_or_blackhole_deadframe(mut frame: DeadFrame) -> Option<i64> {
+fn call_assembler_finish_or_blackhole_deadframe(frame: DeadFrame) -> Option<i64> {
     // `compile.py:710-716 resume_in_blackhole(descr, deadframe)` parity:
     // the descr is the sole identity carrier crossing the C-ABI; the
     // receiver derives green_key (memmgr-evicted JCT recovery via
@@ -3071,7 +3067,7 @@ fn call_assembler_finish_or_blackhole_deadframe(mut frame: DeadFrame) -> Option<
         (is_finish, fail_descr, fail_arg_types)
     };
     if is_finish {
-        return finish_result_from_deadframe(&mut frame).ok();
+        return finish_result_from_deadframe(&frame).ok();
     }
 
     let raw_values = raw_values_from_deadframe_typed(&frame, &fail_arg_types).ok()?;
@@ -3789,7 +3785,7 @@ fn call_assembler_shim_inner(
             target.trace_id, target.num_inputs, i0
         );
     }
-    let mut frame = execute_registered_loop_target(target, input_slice);
+    let frame = execute_registered_loop_target(target, input_slice);
     let descr =
         get_latest_descr_from_deadframe(&frame).expect("get_latest_descr_from_deadframe failed");
     if descr.is_finish() {
@@ -3797,7 +3793,7 @@ fn call_assembler_shim_inner(
             *outcome.add(0) = CALL_ASSEMBLER_OUTCOME_FINISH;
             *outcome.add(1) = 0;
         }
-        let result = finish_result_from_deadframe(&mut frame)
+        let result = finish_result_from_deadframe(&frame)
             .expect("finish_result_from_deadframe failed") as u64;
         return result;
     }

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -16,9 +16,8 @@
 // resume_guard_descr`.  PyPy `AbstractFailDescr._attrs_` (history.py:132)
 // carries none of these; Pyre's metainterp descr is the single source
 // of truth for both the `_attrs_` set and the backend-only cells.
-use crate::compiler::{register_gc_roots, unregister_gc_roots};
 use majit_backend::{ExitRecoveryLayout, TerminalExitLayout};
-use majit_ir::{DescrRef, GcRef, Type};
+use majit_ir::{DescrRef, Type};
 use std::cell::UnsafeCell;
 use std::sync::Arc;
 
@@ -161,118 +160,10 @@ pub(crate) unsafe fn drop_bridge_payload(ptr: *mut ()) {
 }
 
 // ── JitFrameDeadFrame (llmodel.py deadframe-as-jitframe parity) ─────
-
-/// RPython llmodel.py parity: the deadframe IS the JitFrame.
-///
-/// In RPython, `execute_token` returns the JitFrame GCREF directly as
-/// the deadframe. Values stay in `jf_frame[]` — no copying to `Vec<i64>`.
-/// `get_int_value(deadframe, index)` reads directly from `jf_frame[index]`.
-pub struct JitFrameDeadFrame {
-    /// GcRef pointing to the heap-allocated JitFrame.
-    pub jf_gcref: GcRef,
-    /// The fail descriptor for this exit.  Stored as `DescrRef`
-    /// (`Arc<dyn Descr>`) so the deadframe carries the same Arc identity
-    /// the metainterp stamps onto `op.descr` — matching PyPy's
-    /// `frame.jf_descr = descr` (llmodel.py:270) line-by-line.  The
-    /// backend wrapper `CraneliftFailDescr` is on its way out; this slot
-    /// already accepts the upcast forwarders so the eventual deletion
-    /// is a pure type substitution.
-    pub fail_descr: DescrRef,
-    /// Original attached `jf_descr` identity for finish exits emitted by
-    /// the metainterp (`DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`).
-    pub latest_descr: Option<DescrRef>,
-    /// Side-channel: caller-prefix layout assembled from the
-    /// `CALL_ASSEMBLER_CALLER_STACK` top at deadframe interception
-    /// (`wrap_call_assembler_deadframe_with_caller_prefix`).  When `Some`,
-    /// `compiler.rs::deadframe_layout` prefixes the descr's own recovery
-    /// layout by this value before returning.  Replaces the old overlay
-    /// descr synthesis (`overlay_deadframe_fail_descr` + overlay registry)
-    /// — the deadframe's `fail_descr` now keeps the callee's own Arc
-    /// identity rather than being swapped for a synthetic one.
-    pub call_assembler_caller_layout: Option<ExitRecoveryLayout>,
-    /// True when `register_roots` has registered `jf_gcref` with the
-    /// active cranelift GC, so `Drop` knows to remove it. Replaces the
-    /// pre-removal `gc_runtime_id` field that paired registration with
-    /// a per-trace runtime id; the active GC is now a single thread-local
-    /// (`compiler.rs CRANELIFT_ACTIVE_GC`, mirroring `llmodel.py:58`).
-    pub roots_registered: bool,
-    /// Keeps the frame memory alive for non-GC allocations.
-    pub _heap_owner: Option<Vec<i64>>,
-}
-
-/// Byte offset from JitFrame start to jf_frame[0].
-const JF_FRAME_ITEM0_BYTES: usize = 64;
-/// Byte offset to jf_savedata field.
-const JF_SAVEDATA_BYTES: usize = 32;
-/// Byte offset to jf_guard_exc field.
-const JF_GUARD_EXC_BYTES: usize = 40;
-
-impl JitFrameDeadFrame {
-    pub fn new(
-        jf_gcref: GcRef,
-        fail_descr: DescrRef,
-        latest_descr: Option<DescrRef>,
-        heap_owner: Option<Vec<i64>>,
-    ) -> Self {
-        JitFrameDeadFrame {
-            jf_gcref,
-            fail_descr,
-            latest_descr,
-            call_assembler_caller_layout: None,
-            roots_registered: false,
-            _heap_owner: heap_owner,
-        }
-    }
-
-    pub fn register_roots(&mut self) {
-        self.roots_registered = register_gc_roots(std::slice::from_mut(&mut self.jf_gcref));
-    }
-
-    #[inline]
-    pub fn get_int(&self, index: usize) -> i64 {
-        unsafe { *((self.jf_gcref.0 + JF_FRAME_ITEM0_BYTES + index * 8) as *const i64) }
-    }
-
-    #[inline]
-    pub fn get_float(&self, index: usize) -> f64 {
-        f64::from_bits(self.get_int(index) as u64)
-    }
-
-    #[inline]
-    pub fn get_ref(&self, index: usize) -> GcRef {
-        GcRef(self.get_int(index) as usize)
-    }
-
-    pub fn take_ref_for_call_result(&mut self, index: usize) -> GcRef {
-        GcRef(self.get_int(index) as usize)
-    }
-
-    #[inline]
-    pub fn get_savedata_ref(&self) -> GcRef {
-        GcRef(unsafe { *((self.jf_gcref.0 + JF_SAVEDATA_BYTES) as *const usize) })
-    }
-
-    #[inline]
-    pub fn try_get_savedata_ref(&self) -> Option<GcRef> {
-        let r = self.get_savedata_ref();
-        if r.is_null() { None } else { Some(r) }
-    }
-
-    #[inline]
-    pub fn set_savedata_ref(&mut self, data: GcRef) {
-        unsafe { *((self.jf_gcref.0 + JF_SAVEDATA_BYTES) as *mut usize) = data.0 };
-    }
-
-    #[inline]
-    pub fn grab_exc_value(&self) -> GcRef {
-        GcRef(unsafe { *((self.jf_gcref.0 + JF_GUARD_EXC_BYTES) as *const usize) })
-    }
-}
-
-impl Drop for JitFrameDeadFrame {
-    fn drop(&mut self) {
-        if self.roots_registered {
-            unregister_gc_roots(std::slice::from_mut(&mut self.jf_gcref));
-        }
-    }
-}
+//
+// The type itself lives in `majit-backend` because `DeadFrame` holds it by
+// value: `llmodel.py:323` returns the JITFRAMEPTR as the deadframe, so the
+// jitframe-shaped deadframe is the shared shape and not this backend's private
+// one. Re-exported here because every use site in this crate names it through
+// `crate::guard`.
+pub use majit_backend::deadframe::JitFrameDeadFrame;

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2997,9 +2997,7 @@ impl Backend for DynasmBackend {
         // it drops rather than here. Every slot read, and `grab_exc_value`,
         // then goes straight into the frame the way `llmodel.py:240-250` does
         // — nothing is decoded eagerly and no copy of the frame is made.
-        DeadFrame {
-            data: Box::new(unsafe { FrameData::owning(jf_ptr, result_jf, num_slots, descr, None) }),
-        }
+        DeadFrame::boxed(unsafe { FrameData::owning(jf_ptr, result_jf, num_slots, descr, None) })
     }
 
     /// Override execute_token_ints_raw to return the FULL jitframe
@@ -3131,7 +3129,10 @@ impl Backend for DynasmBackend {
     }
 
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr {
-        let data = frame.data.downcast_ref::<FrameData>().unwrap();
+        let data = frame
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
+            .unwrap();
         data.fail_descr
             .as_fail_descr()
             .expect("FrameData::fail_descr must implement FailDescr")
@@ -3156,9 +3157,9 @@ impl Backend for DynasmBackend {
         // returns it — the forced frame IS the deadframe, and it belongs to
         // the compiled run that is still executing, so this deadframe borrows
         // it rather than taking the chain over.
-        Some(DeadFrame {
-            data: Box::new(unsafe { FrameData::borrowing(frame, num_slots, descr, None) }),
-        })
+        Some(DeadFrame::boxed(unsafe {
+            FrameData::borrowing(frame, num_slots, descr, None)
+        }))
     }
 
     fn is_force_token_armed(&self, force_token: GcRef) -> bool {
@@ -3176,7 +3177,10 @@ impl Backend for DynasmBackend {
         // *is* the metainterp Arc (production codegen + synthetic exits
         // both stamp it via DescrRef directly), so we just clone the
         // shared identity.
-        let data = frame.data.downcast_ref::<FrameData>().unwrap();
+        let data = frame
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
+            .unwrap();
         Arc::clone(&data.fail_descr)
     }
 
@@ -3186,7 +3190,11 @@ impl Backend for DynasmBackend {
     /// must_save_exception guards (GUARD_EXCEPTION / GUARD_NO_EXCEPTION /
     /// GUARD_NOT_FORCED); other guards leave it NULL.
     fn grab_exc_value(&self, frame: &DeadFrame) -> GcRef {
-        frame.data.downcast_ref::<FrameData>().unwrap().exc_value()
+        frame
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
+            .unwrap()
+            .exc_value()
     }
 
     fn clear_stored_exception(&self) {
@@ -3224,24 +3232,24 @@ impl Backend for DynasmBackend {
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {
         frame
-            .data
-            .downcast_ref::<FrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
             .unwrap()
             .get_int(index)
     }
 
     fn get_float_value(&self, frame: &DeadFrame, index: usize) -> f64 {
         frame
-            .data
-            .downcast_ref::<FrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
             .unwrap()
             .get_float(index)
     }
 
     fn get_ref_value(&self, frame: &DeadFrame, index: usize) -> GcRef {
         frame
-            .data
-            .downcast_ref::<FrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<FrameData>())
             .unwrap()
             .get_ref(index)
     }

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -70,7 +70,7 @@ impl FailDescr for WasmFailDescr {
 
 /// Wasm-backend dead frame data.
 ///
-/// Stored inside `DeadFrame.data` after `execute_token` returns.
+/// Stored inside `DeadFrame::Boxed` after `execute_token` returns.
 pub struct WasmFrameData {
     pub raw_values: Vec<i64>,
     pub fail_descr: Arc<WasmFailDescr>,

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2060,9 +2060,7 @@ pub fn dead_frame_from_ran_frame(_compiled_ptr: usize, frame_ptr: usize) -> Dead
     let raw_values: Vec<i64> = (0..num_outputs)
         .map(|i| unsafe { *frame.add(1 + i) })
         .collect();
-    DeadFrame {
-        data: WasmFrameData::boxed(raw_values, fail_descr, exc_value),
-    }
+    DeadFrame::Boxed(WasmFrameData::boxed(raw_values, fail_descr, exc_value))
 }
 
 impl majit_backend::Backend for WasmBackend {
@@ -3354,9 +3352,7 @@ impl majit_backend::Backend for WasmBackend {
                 majit_gc::shadow_stack::pop_jf_to(saved);
                 drop(gcmap);
 
-                return DeadFrame {
-                    data: WasmFrameData::boxed(raw_values, fail_descr, exc_value),
-                };
+                return DeadFrame::Boxed(WasmFrameData::boxed(raw_values, fail_descr, exc_value));
             }
 
             // Legacy host-Vec frame path (default, PYRE_WASM_CA off): fail_index
@@ -3396,9 +3392,7 @@ impl majit_backend::Backend for WasmBackend {
                 global_fail_descr(fail_index).expect("invalid fail_index from compiled wasm");
             let num_outputs = fail_descr.fail_arg_types.len();
             let raw_values: Vec<i64> = (0..num_outputs).map(|i| frame[1 + i]).collect();
-            DeadFrame {
-                data: WasmFrameData::boxed(raw_values, fail_descr, exc_value),
-            }
+            DeadFrame::Boxed(WasmFrameData::boxed(raw_values, fail_descr, exc_value))
         }
     }
 
@@ -3409,8 +3403,8 @@ impl majit_backend::Backend for WasmBackend {
 
     fn get_latest_descr<'a>(&'a self, frame: &'a DeadFrame) -> &'a dyn FailDescr {
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         data.fail_descr.as_ref()
     }
@@ -3425,8 +3419,8 @@ impl majit_backend::Backend for WasmBackend {
         // fall back to the backend Arc upcast (synthetic backend-only
         // descrs).
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         if let Some(meta) = data.fail_descr.meta_descr.as_ref() {
             return Arc::clone(meta);
@@ -3436,24 +3430,24 @@ impl majit_backend::Backend for WasmBackend {
 
     fn get_int_value(&self, frame: &DeadFrame, index: usize) -> i64 {
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         data.raw_values[index]
     }
 
     fn get_float_value(&self, frame: &DeadFrame, index: usize) -> f64 {
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         f64::from_bits(data.raw_values[index] as u64)
     }
 
     fn get_ref_value(&self, frame: &DeadFrame, index: usize) -> GcRef {
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         GcRef(data.raw_values[index] as usize)
     }
@@ -3462,8 +3456,8 @@ impl majit_backend::Backend for WasmBackend {
     /// trace exited through a GuardNoException / GuardException.
     fn grab_exc_value(&self, frame: &DeadFrame) -> GcRef {
         let data = frame
-            .data
-            .downcast_ref::<WasmFrameData>()
+            .boxed_data()
+            .and_then(|d| d.downcast_ref::<WasmFrameData>())
             .expect("not WasmFrameData");
         GcRef(data.exc_value as usize)
     }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -10,7 +10,7 @@ use majit_gc::shadow_stack::OwnerRootGuard;
 use majit_ir::{DescrRef, GcRef};
 
 use crate::ExitRecoveryLayout;
-use crate::jitframe::{FIRST_ITEM_OFFSET, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS};
+use crate::jitframe::{FIRST_ITEM_OFFSET, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS, JitFrame};
 
 /// Where a held deadframe keeps its jitframe pointer.
 ///
@@ -36,6 +36,12 @@ enum JitFrameRoot {
     /// LIFO stack next to it: a deadframe's lifetime is the caller's, and two
     /// live deadframes are released in whatever order their owners drop, which
     /// a stack discipline cannot express.
+    ///
+    /// The vector is per-thread, so the position names a slot on the thread
+    /// that acquired it and the guard must be dropped there: releasing it
+    /// elsewhere would free a foreign thread's slot, or find none active. The
+    /// guard is `!Send` for that reason, which makes the whole deadframe
+    /// thread-confined.
     Slot(OwnerRootGuard),
     /// The frame is not a GC object — it was allocated out of the Rust heap
     /// because no type registry was available to allocate it under — so it
@@ -116,6 +122,16 @@ impl JitFrameDeadFrame {
 
     #[inline]
     pub fn get_int(&self, index: usize) -> i64 {
+        // A safe function that dereferences an index the caller chose, so the
+        // only thing between an index error and an out-of-bounds read is this
+        // check. The frame carries its own slot count in the length word ahead
+        // of `jf_frame`, which is the bound. `get_float` and `get_ref` read
+        // through here, so one check covers all three.
+        debug_assert!(
+            (index as isize)
+                < unsafe { JitFrame::frame_length(self.jf_gcref().0 as *const JitFrame) },
+            "jf_frame index {index} is past the frame's own length",
+        );
         unsafe { *((self.jf_gcref().0 + FIRST_ITEM_OFFSET + index * 8) as *const i64) }
     }
 
@@ -126,10 +142,6 @@ impl JitFrameDeadFrame {
 
     #[inline]
     pub fn get_ref(&self, index: usize) -> GcRef {
-        GcRef(self.get_int(index) as usize)
-    }
-
-    pub fn take_ref_for_call_result(&mut self, index: usize) -> GcRef {
         GcRef(self.get_int(index) as usize)
     }
 

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -1,0 +1,156 @@
+//! The deadframe a jitframe-backed backend returns from a compiled run.
+//!
+//! `llmodel.py:323 return ll_frame` — the deadframe IS the JitFrame. Values
+//! stay in `jf_frame[]` and are never copied out: `get_int_value(deadframe,
+//! index)` (`llmodel.py:437-451`) casts the opaque deadframe back to a
+//! JITFRAMEPTR and reads `jf_frame[index]` in place, and `get_latest_descr`
+//! (`llmodel.py:411-419`) does the same for `jf_descr`.
+
+use majit_gc::shadow_stack::OwnerRootGuard;
+use majit_ir::{DescrRef, GcRef};
+
+use crate::ExitRecoveryLayout;
+use crate::jitframe::{FIRST_ITEM_OFFSET, JF_GUARD_EXC_OFS, JF_SAVEDATA_OFS};
+
+/// Where a held deadframe keeps its jitframe pointer.
+///
+/// The frame is an ordinary GC object (`jitframe.py:33-60` makes JITFRAME a
+/// GcStruct and `llmodel.py:298 malloc_jitframe` allocates it like any other),
+/// so a collection during the window the deadframe is held promotes it to a
+/// different address while every accessor is still reading through the old
+/// one. The pointer therefore has to live somewhere the collector rewrites.
+///
+/// A root slot is that place. `shadowstack.py:100-106` (`push_stack` /
+/// `pop_stack`) names a root by its POSITION on a per-thread stack rather than
+/// by the address of the variable holding it, and `walk_stack_root`
+/// (`shadowstack.py:44-70`) reads each live slot and stores the forwarded
+/// address back into the slot it walked. Addressing by position is what makes
+/// the holder's own address irrelevant, so this frame can be returned by value
+/// instead of being pinned behind a per-exit heap allocation.
+enum JitFrameRoot {
+    /// The frame's position among this thread's root slots. Every read goes
+    /// back through the position, so a collection that moved the frame between
+    /// two reads is already accounted for by the second one.
+    ///
+    /// Slots are taken from the fixed-slot vector rather than the strictly
+    /// LIFO stack next to it: a deadframe's lifetime is the caller's, and two
+    /// live deadframes are released in whatever order their owners drop, which
+    /// a stack discipline cannot express.
+    Slot(OwnerRootGuard),
+    /// The frame is not a GC object — it was allocated out of the Rust heap
+    /// because no type registry was available to allocate it under — so it
+    /// cannot move and taking a slot would hand the collector an address
+    /// outside both generations.
+    Unrooted(GcRef),
+}
+
+impl JitFrameRoot {
+    #[inline]
+    fn get(&self) -> GcRef {
+        match self {
+            JitFrameRoot::Slot(guard) => guard.get(),
+            JitFrameRoot::Unrooted(gcref) => *gcref,
+        }
+    }
+}
+
+/// The deadframe of a backend whose frames are jitframes.
+pub struct JitFrameDeadFrame {
+    /// The JitFrame this deadframe reads through.
+    jf_root: JitFrameRoot,
+    /// The fail descriptor for this exit.  Stored as `DescrRef`
+    /// (`Arc<dyn Descr>`) so the deadframe carries the same Arc identity
+    /// the metainterp stamps onto `op.descr` — matching `frame.jf_descr =
+    /// descr` (llmodel.py:270) line-by-line.
+    pub fail_descr: DescrRef,
+    /// Original attached `jf_descr` identity for finish exits emitted by
+    /// the metainterp (`DoneWithThisFrame*` / `ExitFrameWithExceptionDescrRef`).
+    pub latest_descr: Option<DescrRef>,
+    /// Side-channel: caller-prefix layout assembled from the
+    /// `CALL_ASSEMBLER_CALLER_STACK` top at deadframe interception
+    /// (`wrap_call_assembler_deadframe_with_caller_prefix`).  When `Some`,
+    /// the exit's recovery layout is prefixed by this value.  Replaces the old
+    /// overlay descr synthesis — the deadframe's `fail_descr` keeps the
+    /// callee's own Arc identity rather than being swapped for a synthetic one.
+    pub call_assembler_caller_layout: Option<ExitRecoveryLayout>,
+    /// Keeps the frame memory alive for non-GC allocations.
+    _heap_owner: Option<Vec<i64>>,
+}
+
+impl JitFrameDeadFrame {
+    /// Take a root slot for `jf_gcref` and hold it for the deadframe's life.
+    ///
+    /// `heap_owner` decides whether the frame is rooted at all, because it is
+    /// the same condition: a frame handed a `Vec` owner was allocated out of
+    /// the Rust heap precisely because there was no type registry to allocate
+    /// it from the nursery under, and a frame allocated from the nursery is
+    /// always handed `None`.
+    pub fn new(
+        jf_gcref: GcRef,
+        fail_descr: DescrRef,
+        latest_descr: Option<DescrRef>,
+        heap_owner: Option<Vec<i64>>,
+    ) -> Self {
+        let jf_root = if heap_owner.is_some() {
+            JitFrameRoot::Unrooted(jf_gcref)
+        } else {
+            JitFrameRoot::Slot(OwnerRootGuard::new(jf_gcref))
+        };
+        JitFrameDeadFrame {
+            jf_root,
+            fail_descr,
+            latest_descr,
+            call_assembler_caller_layout: None,
+            _heap_owner: heap_owner,
+        }
+    }
+
+    /// The frame's CURRENT address, re-read through the root slot.
+    ///
+    /// Not cached anywhere: the slot is the only place the address is correct
+    /// after a collection, so every accessor below goes through here.
+    #[inline]
+    pub fn jf_gcref(&self) -> GcRef {
+        self.jf_root.get()
+    }
+
+    #[inline]
+    pub fn get_int(&self, index: usize) -> i64 {
+        unsafe { *((self.jf_gcref().0 + FIRST_ITEM_OFFSET + index * 8) as *const i64) }
+    }
+
+    #[inline]
+    pub fn get_float(&self, index: usize) -> f64 {
+        f64::from_bits(self.get_int(index) as u64)
+    }
+
+    #[inline]
+    pub fn get_ref(&self, index: usize) -> GcRef {
+        GcRef(self.get_int(index) as usize)
+    }
+
+    pub fn take_ref_for_call_result(&mut self, index: usize) -> GcRef {
+        GcRef(self.get_int(index) as usize)
+    }
+
+    #[inline]
+    pub fn get_savedata_ref(&self) -> GcRef {
+        GcRef(unsafe { *((self.jf_gcref().0 + JF_SAVEDATA_OFS as usize) as *const usize) })
+    }
+
+    #[inline]
+    pub fn try_get_savedata_ref(&self) -> Option<GcRef> {
+        let r = self.get_savedata_ref();
+        if r.is_null() { None } else { Some(r) }
+    }
+
+    #[inline]
+    pub fn set_savedata_ref(&mut self, data: GcRef) {
+        unsafe { *((self.jf_gcref().0 + JF_SAVEDATA_OFS as usize) as *mut usize) = data.0 };
+    }
+
+    #[inline]
+    pub fn grab_exc_value(&self) -> GcRef {
+        GcRef(unsafe { *((self.jf_gcref().0 + JF_GUARD_EXC_OFS as usize) as *const usize) })
+    }
+}

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1599,16 +1599,23 @@ unsafe impl Sync for JitCellToken {}
 ///
 /// [`DeadFrame::Boxed`] keeps the erasure for backends whose deadframe is not a
 /// jitframe, or is a jitframe held under a different ownership discipline.
+///
+/// **A deadframe is thread-confined**: it must be created and dropped on the
+/// same thread. The root slot [`DeadFrame::JitFrame`] holds names a position in
+/// the acquiring thread's root vector, so releasing it anywhere else would free
+/// a foreign thread's slot. That is what the guard's own thread-pinning
+/// enforces, and it is the rule for the enum as a whole — the erased variant
+/// states no weaker one, so its payload carries no `Send` bound either.
 pub enum DeadFrame {
     /// `llmodel.py:323` — the deadframe IS the jitframe the run returned.
     JitFrame(deadframe::JitFrameDeadFrame),
     /// Backend-specific frame data.
-    Boxed(Box<dyn std::any::Any + Send>),
+    Boxed(Box<dyn std::any::Any>),
 }
 
 impl DeadFrame {
     /// Wrap backend-specific frame data that is not a [`deadframe::JitFrameDeadFrame`].
-    pub fn boxed(data: impl std::any::Any + Send) -> Self {
+    pub fn boxed(data: impl std::any::Any) -> Self {
         DeadFrame::Boxed(Box::new(data))
     }
 
@@ -1632,7 +1639,7 @@ impl DeadFrame {
 
     /// The erased payload, for backends that still carry one.
     #[inline]
-    pub fn boxed_data(&self) -> Option<&(dyn std::any::Any + Send)> {
+    pub fn boxed_data(&self) -> Option<&dyn std::any::Any> {
         match self {
             DeadFrame::Boxed(data) => Some(&**data),
             DeadFrame::JitFrame(_) => None,

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -68,6 +68,7 @@ pub fn fallback_cpu_tracker() -> &'static CpuTotalTracker {
 }
 
 pub mod call_stub;
+pub mod deadframe;
 pub mod finish_descrs;
 pub mod jitframe;
 pub mod llmodel;
@@ -1588,9 +1589,55 @@ unsafe impl Sync for JitCellToken {}
 /// A "dead frame" — the state after JIT execution finishes or hits a guard.
 ///
 /// The backend stores register/stack values here so the frontend can read them.
-pub struct DeadFrame {
+///
+/// A backend whose frames are jitframes puts its frame in [`DeadFrame::JitFrame`]
+/// BY VALUE. `llmodel.py:323` hands back the JITFRAMEPTR the run returned and
+/// nothing wraps it, so an erased payload behind a per-exit heap allocation had
+/// no upstream counterpart; it existed only to give the frame pointer a fixed
+/// address to be registered at, which addressing the root by POSITION removes
+/// the need for (see [`deadframe::JitFrameDeadFrame`]).
+///
+/// [`DeadFrame::Boxed`] keeps the erasure for backends whose deadframe is not a
+/// jitframe, or is a jitframe held under a different ownership discipline.
+pub enum DeadFrame {
+    /// `llmodel.py:323` — the deadframe IS the jitframe the run returned.
+    JitFrame(deadframe::JitFrameDeadFrame),
     /// Backend-specific frame data.
-    pub data: Box<dyn std::any::Any + Send>,
+    Boxed(Box<dyn std::any::Any + Send>),
+}
+
+impl DeadFrame {
+    /// Wrap backend-specific frame data that is not a [`deadframe::JitFrameDeadFrame`].
+    pub fn boxed(data: impl std::any::Any + Send) -> Self {
+        DeadFrame::Boxed(Box::new(data))
+    }
+
+    /// The jitframe this deadframe reads through, if it has one.
+    #[inline]
+    pub fn as_jitframe(&self) -> Option<&deadframe::JitFrameDeadFrame> {
+        match self {
+            DeadFrame::JitFrame(jf) => Some(jf),
+            DeadFrame::Boxed(_) => None,
+        }
+    }
+
+    /// Mutable counterpart of [`DeadFrame::as_jitframe`].
+    #[inline]
+    pub fn as_jitframe_mut(&mut self) -> Option<&mut deadframe::JitFrameDeadFrame> {
+        match self {
+            DeadFrame::JitFrame(jf) => Some(jf),
+            DeadFrame::Boxed(_) => None,
+        }
+    }
+
+    /// The erased payload, for backends that still carry one.
+    #[inline]
+    pub fn boxed_data(&self) -> Option<&(dyn std::any::Any + Send)> {
+        match self {
+            DeadFrame::Boxed(data) => Some(&**data),
+            DeadFrame::JitFrame(_) => None,
+        }
+    }
 }
 
 /// `compile.py:665-674` `make_and_attach_done_descrs` + `pyjitpl.py:2283`

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -10880,6 +10880,71 @@ cache size\t: 8192 kB\n";
         }
     }
 
+    /// A minor collection rewrites the SLOT, so reading through the position
+    /// yields the promoted address.
+    ///
+    /// `walk_stack_root` (`shadowstack.py:44-70`) hands the collector the slot
+    /// itself — `invoke(..., addr)` where `addr` is the stack address, not the
+    /// value — which is what lets the forwarded address be stored back into it.
+    /// Every holder that addresses its root by position therefore sees the move
+    /// without being told about it.
+    #[test]
+    fn minor_collection_rewrites_an_owner_root_slot() {
+        let _guard = SHADOW_STACK_TEST_LOCK.lock().unwrap();
+        crate::shadow_stack::clear();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+
+        let obj = gc.alloc_with_type(tid, 16);
+        assert!(gc.is_in_nursery(obj.0));
+        unsafe {
+            *(obj.0 as *mut u64) = 0xD00D_D00D;
+        }
+        let root = crate::shadow_stack::OwnerRootGuard::new(obj);
+
+        gc.do_collect_nursery();
+
+        let moved = root.get();
+        assert_ne!(
+            moved, obj,
+            "a surviving nursery object is promoted, so this run cannot tell a \
+             rewritten slot from an unmoved object"
+        );
+        assert!(gc.oldgen.contains(moved.0));
+        assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xD00D_D00D);
+    }
+
+    /// The HOLDER may move. Addressing a root by position is what makes that
+    /// true, and it is the whole difference from registering the address of the
+    /// field that holds the pointer: a registered field address is only valid
+    /// while its owner stays put, so an owner that can be returned by value has
+    /// to be pinned behind a heap allocation first.
+    #[test]
+    fn an_owner_root_survives_its_holder_being_moved() {
+        let _guard = SHADOW_STACK_TEST_LOCK.lock().unwrap();
+        crate::shadow_stack::clear();
+        let mut gc = test_gc(4096);
+        let tid = gc.register_type(TypeInfo::simple(16));
+
+        let obj = gc.alloc_with_type(tid, 16);
+        assert!(gc.is_in_nursery(obj.0));
+        unsafe {
+            *(obj.0 as *mut u64) = 0xFEED_FEED;
+        }
+
+        // Three distinct addresses for the same guard, one of them the heap,
+        // with a collection between the last move and the read.
+        let root = crate::shadow_stack::OwnerRootGuard::new(obj);
+        let moved_once = root;
+        let mut holders = vec![moved_once];
+        gc.do_collect_nursery();
+
+        let moved = holders.pop().unwrap().get();
+        assert_ne!(moved, obj);
+        assert!(gc.oldgen.contains(moved.0));
+        assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xFEED_FEED);
+    }
+
     #[test]
     fn test_incremental_cycle_marks_jitframe_shadow_stack_roots() {
         let _guard = SHADOW_STACK_TEST_LOCK.lock().unwrap();

--- a/majit/majit-gc/src/shadow_stack.rs
+++ b/majit/majit-gc/src/shadow_stack.rs
@@ -1648,6 +1648,33 @@ mod tests {
         assert_eq!(root, GcRef(0x1100));
     }
 
+    /// A thread that unregisters leaves nothing behind for the all-mutator
+    /// walk to reach, and a later thread can take its place.
+    ///
+    /// `thread_die` (`shadowstack.py:168-187`) drops the dying thread's entry
+    /// from `gcdata.thread_stacks` before the last GIL release, so no
+    /// subsequent collection walks a stack whose owner is gone. The registry
+    /// here is that table; `register_mutator` asserts a thread is not present
+    /// twice, so a second registration succeeding is what proves the first
+    /// entry was actually removed rather than merely emptied.
+    #[test]
+    fn test_mutator_teardown_releases_its_registry_entry() {
+        let _lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());
+        std::thread::spawn(|| {
+            register_mutator();
+            {
+                let root = OwnerRootGuard::new(GcRef(0x4000));
+                assert_eq!(root.get(), GcRef(0x4000));
+            }
+            unregister_mutator();
+            // The entry is gone, so this thread can register again.
+            register_mutator();
+            unregister_mutator();
+        })
+        .join()
+        .expect("the registered thread must tear down without panicking");
+    }
+
     #[test]
     fn test_extern_c_interface() {
         let _lock = TEST_MUTEX.lock().unwrap_or_else(|p| p.into_inner());

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1922,6 +1922,29 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         }
     };
 
+    // Naming the virtualizable on the jitdriver static data
+    // (`warmspot.py:520-545 make_virtualizable_infos`) is what makes
+    // `compile.py:508-511`'s field-reload preamble run, which would retire the
+    // per-entry re-export of the virtualizable's array elements. Not declared
+    // here yet, and the missing piece is NOT the declaration: this state model
+    // backs its virtualizable arrays with `Vec`s embedded by value, and
+    // `compile.py:441-457`'s reconstruction needs to reach each array's data
+    // pointer with a load the trace IR can express. It cannot: a `Vec`'s data
+    // pointer is not at a specified offset within it, so there is no field
+    // load that portably finds it (see the `RustVec` arm of
+    // `patch_new_loop_to_load_virtualizable_fields`). Declaring the name
+    // without first giving that arm a reload it can emit turns every compile
+    // of such a driver into that arm's refusal.
+    //
+    // When it is declared, it must arrive through
+    // `JitDriver::declare_flat_entry_contract` together with the width of the
+    // entry it applies to: the flat live-value prefix, not the red count (the
+    // whole state is a single red in the merge-point payload). That prefix is
+    // `num_scalars + num_vable_identity_slots + num_ref_scalars +
+    // num_float_scalars` with the identity at flat index `num_scalars`, valid
+    // only while the state declares no fixed arrays — the same restriction
+    // `identity_live_index` below carries, and for the same reason.
+
     // pyjitpl.py:3443-3444 `rebuild_state_after_failure`:
     //     if vinfo is not None:
     //         self.virtualizable_boxes = virtualizable_boxes

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -647,8 +647,9 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
         .collect();
     // One value: the virtualizable identity (`&state` ==
     // `virtualizable_heap_ptr`), NOT any array's data pointer —
-    // `vable_getarrayitem_*` reaches every element through the RustVec storage
-    // from this base, and all `[.. ; virt]` arrays share it.  Emitting it once
+    // `vable_getarrayitem_*` reaches every element from this base through the
+    // storage each field registered, and all `[.. ; virt]` arrays share it.
+    // Emitting it once
     // is `virtualizable.py:139-144`; the lengths stay off the red vector
     // (`virtualizable.py:150-153` reads them off the live object).
     let extract_vable_identity_part: TokenStream = if has_vable_identity {
@@ -790,7 +791,15 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 StateFieldKind::VirtArray(tp) if tp == "float" => quote! { 0.0f64 },
                 _ => quote! { 0i64 },
             };
-            quote! { #fname: ::std::vec![#zero; self.#len_value_name as usize], }
+            // Constructed through the backing trait rather than as a `vec![]`,
+            // so the field keeps whatever container it was declared with. The
+            // target type comes from the field this initializer fills.
+            quote! {
+                #fname: majit_metainterp::virt_array::VirtArrayBacking::filled(
+                    #zero,
+                    self.#len_value_name as usize,
+                ),
+            }
         })
         .collect();
     // Reds in `extract_live` order: int scalars, then flattened fixed-array
@@ -1926,15 +1935,17 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     // (`warmspot.py:520-545 make_virtualizable_infos`) is what makes
     // `compile.py:508-511`'s field-reload preamble run, which would retire the
     // per-entry re-export of the virtualizable's array elements. Not declared
-    // here yet, and the missing piece is NOT the declaration: this state model
-    // backs its virtualizable arrays with `Vec`s embedded by value, and
-    // `compile.py:441-457`'s reconstruction needs to reach each array's data
-    // pointer with a load the trace IR can express. It cannot: a `Vec`'s data
-    // pointer is not at a specified offset within it, so there is no field
-    // load that portably finds it (see the `RustVec` arm of
-    // `patch_new_loop_to_load_virtualizable_fields`). Declaring the name
-    // without first giving that arm a reload it can emit turns every compile
-    // of such a driver into that arm's refusal.
+    // here yet, and whether it CAN be is the declared field type's answer, not
+    // this expansion's: `compile.py:441-457`'s reconstruction reaches each
+    // array's data pointer with a load the trace IR has to be able to express.
+    // A `Vec` embedded by value defeats that — its data pointer is not at a
+    // specified offset within it, so no field load portably finds it, and the
+    // `RustVec` arm of `patch_new_loop_to_load_virtualizable_fields` refuses
+    // rather than read a capacity as a base address. A field declared with
+    // `majit_metainterp::virt_array::VirtArray` holds a pointer to a block whose
+    // length and payload are at fixed offsets, which is the `Ptr(GcArray)` shape
+    // that arm's ordinary path already emits. So declaring the name is safe only
+    // once every `[.. ; virt]` field on the state is block-backed.
     //
     // When it is declared, it must arrive through
     // `JitDriver::declare_flat_entry_contract` together with the width of the
@@ -2031,13 +2042,20 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
     };
 
     // ── VirtualizableInfo / heap-ptr overrides for `[int; virt]` arrays ──
-    // Each virt array becomes a standard-virtualizable RustVec array field on
-    // a zero-static-field vinfo, so `state.<arr>[i]` lowers through the
+    // Each virt array becomes a standard-virtualizable array field on a
+    // zero-static-field vinfo, so `state.<arr>[i]` lowers through the
     // `virtualizable_boxes` devirt path. Scalars stay in the state-field
     // scalar resume mechanism (disjoint from the array restore).
+    //
+    // Which storage the field registers as is the declared field type's to say,
+    // not this expansion's: `register_virt_array_field` resolves it from the
+    // container the interpreter author wrote. That is the difference the
+    // compiled entry sees — only a field holding a pointer to a block with a
+    // fixed payload offset can be reloaded by `compile.py:441-457`, and a `Vec`
+    // embedded by value is not one.
     let build_vinfo_override: TokenStream = if num_virt_arrays > 0 {
-        // Per virt array: nested data-ptr/len extractor fns + an
-        // `add_rust_vec_array_field` call keyed on the field byte offset.
+        // Per virt array: nested data-ptr/len extractor fns + a registration
+        // keyed on the field byte offset.
         let virt_array_field_parts: Vec<TokenStream> = virt_arrays
             .iter()
             .map(|(_, f)| {
@@ -2062,18 +2080,15 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                     fn #len_fn(__p: *const u8) -> usize {
                         unsafe { (*(__p as *const #state_type)).#fname.len() }
                     }
-                    let __descr = majit_ir::descr::make_array_descr(
-                        0,
-                        #item_size,
-                        #item_type,
-                    );
-                    __info.add_rust_vec_array_field(
+                    majit_metainterp::virt_array::register_virt_array_field(
+                        &mut __info,
                         #fname_str,
                         #item_type,
+                        #item_size,
                         ::std::mem::offset_of!(#state_type, #fname),
                         #data_ptr_fn,
                         #len_fn,
-                        __descr,
+                        |__s: &#state_type| &__s.#fname,
                     );
                 }
             })

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -898,7 +898,13 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             extern "C" fn #fresh_alloc_fn(__cap: i64) -> i64 {
                 let __fresh: ::std::boxed::Box<#state_type> = ::std::boxed::Box::new(#state_type {
                     #(#fresh_entry_scalar_inits)*
-                    #virt_name: ::std::vec![#virt_zero; __cap as usize],
+                    // Same backing-trait construction the fresh-reds path uses:
+                    // the field keeps whatever container it was declared with,
+                    // and the target type comes from the field being filled.
+                    #virt_name: majit_metainterp::virt_array::VirtArrayBacking::filled(
+                        #virt_zero,
+                        __cap as usize,
+                    ),
                 });
                 ::std::boxed::Box::into_raw(__fresh) as i64
             }

--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -1933,28 +1933,60 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
 
     // Naming the virtualizable on the jitdriver static data
     // (`warmspot.py:520-545 make_virtualizable_infos`) is what makes
-    // `compile.py:508-511`'s field-reload preamble run, which would retire the
-    // per-entry re-export of the virtualizable's array elements. Not declared
-    // here yet, and whether it CAN be is the declared field type's answer, not
-    // this expansion's: `compile.py:441-457`'s reconstruction reaches each
-    // array's data pointer with a load the trace IR has to be able to express.
-    // A `Vec` embedded by value defeats that — its data pointer is not at a
-    // specified offset within it, so no field load portably finds it, and the
-    // `RustVec` arm of `patch_new_loop_to_load_virtualizable_fields` refuses
-    // rather than read a capacity as a base address. A field declared with
-    // `majit_metainterp::virt_array::VirtArray` holds a pointer to a block whose
-    // length and payload are at fixed offsets, which is the `Ptr(GcArray)` shape
-    // that arm's ordinary path already emits. So declaring the name is safe only
-    // once every `[.. ; virt]` field on the state is block-backed.
+    // `compile.py:508-511`'s field-reload preamble run, which retires the
+    // per-entry re-export of the virtualizable's array elements: the compiled
+    // entry reloads them from the virtualizable pointer instead of being handed
+    // one entry argument per element.
     //
-    // When it is declared, it must arrive through
-    // `JitDriver::declare_flat_entry_contract` together with the width of the
-    // entry it applies to: the flat live-value prefix, not the red count (the
-    // whole state is a single red in the merge-point payload). That prefix is
-    // `num_scalars + num_vable_identity_slots + num_ref_scalars +
-    // num_float_scalars` with the identity at flat index `num_scalars`, valid
-    // only while the state declares no fixed arrays — the same restriction
-    // `identity_live_index` below carries, and for the same reason.
+    // The name arrives through `JitDriver::declare_flat_entry_contract` together
+    // with the width of the entry it applies to, because the two halves are only
+    // meaningful together: the entry is the flat live-value prefix, not the red
+    // count (the whole state is a single red in the merge-point payload), and an
+    // index into one picks out a different value than the same index into the
+    // other. That prefix is `num_scalars + num_vable_identity_slots +
+    // num_ref_scalars + num_float_scalars` with the identity at flat index
+    // `num_scalars` — the order `extract_live` emits — valid only while the
+    // state declares no fixed arrays, the same restriction `identity_live_index`
+    // below carries and for the same reason: a fixed array contributes its
+    // runtime length to the prefix, and no constant here can name a length that
+    // is read off a state instance.
+    //
+    // Whether the contract CAN be declared at all is the declared field type's
+    // answer, not this expansion's: `compile.py:441-457`'s reconstruction
+    // reaches each array's data pointer with a load the trace IR has to be able
+    // to express, and a `Vec` embedded by value defeats that — its data pointer
+    // is not at a specified offset within it, so no field load portably finds
+    // it. `JitDriver::arm_flat_entry_contract` answers that off the vinfo this
+    // expansion already installed, and declines rather than declaring, so the
+    // width below is stated unconditionally and the structural gate stays where
+    // the storage is known. Left unarmed, a state keeps the per-entry re-export
+    // and behaves exactly as it did before.
+    //
+    // SOUNDNESS. Arming puts this driver on
+    // `patch_new_loop_to_load_virtualizable_fields`, which BAKES each array's
+    // trace-start length into the prologue as a fixed count of `GETARRAYITEM`
+    // ops (`compile.py:443`), and nothing re-reads it afterwards. The invariant
+    // stated on that helper is that the lengths are a function of the trace's
+    // GREENS, so a virtualizable with other lengths keys to a different trace
+    // and never reaches this entry. It is the interpreter author's to satisfy —
+    // a `[.. ; virt]` array whose length can vary while the greens stay fixed
+    // must not be block-backed — and it cannot be checked here: the lengths live
+    // on state instances that do not exist at install time.
+    let arm_flat_entry_contract: TokenStream = if num_virt_arrays > 0 && arrays.is_empty() {
+        let entry_len =
+            num_scalars + num_vable_identity_slots + num_ref_scalars + num_float_scalars;
+        let index_of_virtualizable = num_scalars;
+        quote! {
+            driver.arm_flat_entry_contract(
+                majit_metainterp::FlatEntryContract {
+                    len: #entry_len,
+                    index_of_virtualizable: #index_of_virtualizable,
+                },
+            );
+        }
+    } else {
+        quote! {}
+    };
 
     // pyjitpl.py:3443-3444 `rebuild_state_after_failure`:
     //     if vinfo is not None:
@@ -2353,6 +2385,14 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 // empty stub.  `green_kind_counts` / `red_kind_counts`
                 // then reflect the actual payload partition.
                 #declare_schema_fn_name(driver);
+                // `warmspot.py:520-545 make_virtualizable_infos` names the
+                // virtualizable on the jitdriver static data during setup, i.e.
+                // before the driver is registered. Order matters here for the
+                // same reason: `ensure_descriptor_registered` MOVES the
+                // descriptor into the `MetaInterpStaticData` table, so a
+                // contract declared after it would land on a descriptor no
+                // consumer reads.
+                #arm_flat_entry_contract
                 driver.ensure_descriptor_registered();
                 // Register canonical entry +
                 // canonical opcode ids into the driver-shared

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1909,30 +1909,22 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     index_of_virtualizable: usize,
     constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) {
-    // TODO (Rust language constraint, not a logic
-    // divergence): RPython `compile.py:425-461` calls
-    // `box.set_forwarded(extra_ops[-1])` to set Python-Box-attached
-    // forwarding pointers, which `emit_op`'s default `get_box_replacement`
-    // walks transitively when later body ops reference the original box.
-    // Pyre uses a flat-`OpRef` IR (no per-Box mutable forwarding cell),
-    // so the equivalent rewrite uses a function-local
-    // `forwarding: Vec<OpRef>` indexed by source `OpRef.0`. The Vec is
-    // discarded when the function returns; its lifetime mirrors the
-    // single in-place loop rewrite that RPython's `_forwarded` model
-    // accomplishes via Box mutation. No semantic divergence.
+    // `compile.py:425-461` redirects each entry inputarg at its own
+    // `_forwarded` slot — `box.set_forwarded(extra_ops[-1])` — and `emit_op`
+    // walks those slots through `get_box_replacement` as it copies the body.
+    // The rewrite below is that walk over a function-local table instead,
+    // keyed by source `OpRef`.
+    //
+    // Not for want of the slots: `InputArg` carries one and `Operand` walks it.
+    // They are unobservable HERE. The entry args this function rewrites against
+    // are fresh copies (`fresh_value_copy` deliberately clears the slot), the
+    // caller's own `Vec<InputArg>` is value-typed and truncated below, and the
+    // ops name their arguments by flat `OpRef` rather than by shared inputarg
+    // identity — so a chain rooted at any of them would have no reader. The
+    // table is dropped only after the rewrite is fully materialized into `ops`,
+    // which is what makes the two constructions equivalent.
     use majit_ir::{Op, OpCode, OpRef, descr::ArrayFlag};
 
-    // TODO (Rust language constraint, not a logic
-    // divergence): RPython `compile.py:425-461` calls
-    // `box.set_forwarded(extra_ops[-1])` to set Python-Box-attached
-    // forwarding pointers, which `emit_op`'s default `get_box_replacement`
-    // walks transitively when later body ops reference the original box.
-    // Pyre uses a flat-`OpRef` IR (no per-Box mutable forwarding cell),
-    // so the equivalent rewrite uses a function-local
-    // `forwarding: Vec<OpRef>` indexed by source `OpRef.0`. The Vec is
-    // discarded when the function returns; its lifetime mirrors the
-    // single in-place loop rewrite that RPython's `_forwarded` model
-    // accomplishes via Box mutation. No semantic divergence.
     fn set_local_forwarded(forwarding: &mut Vec<Option<Operand>>, source: OpRef, target: Operand) {
         if source.is_none() || source.is_constant() {
             return;
@@ -2553,9 +2545,14 @@ pub fn compile_tmp_callback(
     // `green_key` / `virtualizable_arg_index` are interior-mutable (`Cell`),
     // so they are written through the shared `Arc` directly.
     jitcell_token.green_key.set(green_key);
+    // Red-arg space, not entry space: this token's signature is `nb_red_args`
+    // wide (asserted below), and `direct_assembler_call` selects the vable out
+    // of a list of exactly that width. A driver whose compiled entry is a flat
+    // state-field prefix numbers its virtualizable in the entry instead, and
+    // that number would name the wrong red — or a red that is not there.
     jitcell_token
         .virtualizable_arg_index
-        .set(jitdriver_sd.virtualizable_arg_index());
+        .set(jitdriver_sd.red_arg_virtualizable_index());
     //
     // `compile.py:1110` `jl.tmp_callback(jitcell_token)` — JIT logger
     // marker.  TODO: `rpython/rlib/jit.py`'s `jl`

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -177,8 +177,22 @@ pub struct CompiledExitLayout {
     pub is_exception_exit: bool,
     pub gc_ref_slots: Vec<usize>,
     pub force_token_slots: Vec<usize>,
-    pub recovery_layout: Option<ExitRecoveryLayout>,
-    pub resume_layout: Option<ResumeLayoutSummary>,
+    /// Held behind a pointer, not inline. Both this and [`Self::resume_layout`]
+    /// describe how to REBUILD interpreter state after a guard failed, so both
+    /// are `None` on the two exits the steady path actually takes — a FINISH
+    /// and a loop-carried JUMP. Held inline they added 120 and 176 bytes to a
+    /// struct that is 120 bytes without them, and this layout is in turn a
+    /// field of the [`CompileResult`] every compiled entry returns by value,
+    /// so those 296 bytes were copied on every warm entry to carry two absent
+    /// values.
+    ///
+    /// The indirection costs an allocation only where the layout EXISTS, which
+    /// is the guard-failure arm — already several allocations deep building
+    /// the vectors these hold, and off the steady path by construction. A
+    /// FINISH or JUMP exit stores two null words and allocates nothing, so the
+    /// per-entry allocation count is unchanged.
+    pub recovery_layout: Option<Box<ExitRecoveryLayout>>,
+    pub resume_layout: Option<Box<ResumeLayoutSummary>>,
     /// compile.py:853 `ResumeGuardDescr` storage handle — shared
     /// pool with rd_numb / rd_consts / rd_virtuals / rd_pendingfields.
     pub storage: Option<std::sync::Arc<crate::resume::ResumeStorage>>,

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1856,18 +1856,56 @@ pub(crate) fn normalize_closing_jump_args(
 /// virtualizable's static and array fields ride through the optimizer as
 /// expanded trace inputargs; this function strips them and reconstructs
 /// each field at loop entry with a `GETFIELD_GC` / `GETARRAYITEM_GC` op
-/// so the compiled loop's `len(inputargs) == num_red_args` matches
+/// so the compiled loop's `len(inputargs) == entry_prefix_len` matches
 /// `execute_token`'s `clt._debug_nbargs` and CA's `op.args.len()`.
+///
+/// `entry_prefix_len` is `compile.py:431 i = jitdriver_sd.num_red_args`: the
+/// number of leading inputargs that survive the truncation, and the position
+/// the field reconstruction starts from. Upstream can spell it as the red-arg
+/// count because upstream's entry contract IS the red list — `warmstate.py:387
+/// execute_assembler` is called with the reds, and the virtualizable is one of
+/// them. A caller whose entry contract is not a red list (one flat slot per
+/// declared state field, with the virtualizable occupying a single slot among
+/// them) has a different width and must state it here rather than let this
+/// helper re-derive one from a red count that describes a different model. It
+/// is a hard error for the two to be confused: truncating at the wrong point
+/// silently reinterprets live entry values as virtualizable fields.
+///
+/// `index_of_virtualizable` is `compile.py:429` — an index INTO that entry
+/// prefix, so it is expressed in whichever of the two models the caller used.
 ///
 /// `vable_array_lengths` mirrors RPython's `vinfo.get_array_length(vable, i)`
 /// reads: one length per array field (in `vinfo.array_fields` order), taken
 /// from the concrete virtualizable at trace-start time.
+///
+/// SOUNDNESS INVARIANT — baking the lengths in.
+/// `compile.py:443` reads each array length off the concrete virtualizable at
+/// compile time and burns that many `GETARRAYITEM` ops into the prologue, so
+/// the compiled entry is only valid for a virtualizable whose arrays still
+/// have those lengths. Nothing re-checks it later: the entry's compatibility
+/// test covers the FIXED array fields only, and reads their length off the
+/// live object rather than comparing it against a recorded one. What makes
+/// the baking safe is that the array lengths are a function of the trace's
+/// GREEN key — upstream the frame's array sizes come from the code object,
+/// which is green — so a virtualizable with different lengths cannot reach
+/// this compiled entry in the first place; it keys to a different trace. A
+/// caller whose array lengths can vary while the greens stay fixed must NOT
+/// route through this helper: it would hand such an entry a prologue that
+/// reads a stale length.
+///
+/// The assertion at the baking site below is what that invariant buys in
+/// code: `compile.py:458 assert i == len(inputargs)` requires the baked
+/// lengths to account for EXACTLY the inputargs the tracer expanded, so a
+/// length that has moved since trace-start fails the compile instead of
+/// producing a prologue that reads the wrong number of elements. It cannot
+/// catch a length that changes AFTER the compile — no assertion here can,
+/// which is why the green-key argument above has to hold.
 pub fn patch_new_loop_to_load_virtualizable_fields(
     ops: &mut Vec<majit_ir::OpRc>,
     inputargs: &mut Vec<InputArg>,
     vinfo: &crate::virtualizable::VirtualizableInfo,
     vable_array_lengths: &[usize],
-    num_red_args: usize,
+    entry_prefix_len: usize,
     index_of_virtualizable: usize,
     constants: &mut majit_ir::ConstMap<majit_ir::Value>,
 ) {
@@ -1977,10 +2015,10 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     }
 
     assert!(
-        index_of_virtualizable < num_red_args,
-        "virtualizable must live inside the red args (pyjitpl.py:3589 index_of_virtualizable < num_red_args)"
+        index_of_virtualizable < entry_prefix_len,
+        "virtualizable must live inside the entry prefix (pyjitpl.py:3589 index_of_virtualizable < num_red_args)"
     );
-    if inputargs.len() <= num_red_args {
+    if inputargs.len() <= entry_prefix_len {
         // Already reduced or no virtualizable expansion in the trace.
         return;
     }
@@ -2026,10 +2064,14 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     let mut forwarding: Vec<Option<Operand>> =
         vec![None; (max_runtime_ref as usize).saturating_add(1)];
     let mut extra_ops: Vec<majit_ir::OpRc> = Vec::new();
-    let mut i = num_red_args;
+    let mut i = entry_prefix_len;
 
-    // compile.py:432 — loop.inputargs = inputargs[:i].
-    inputargs.truncate(num_red_args);
+    // compile.py:431-432 — i = jitdriver_sd.num_red_args; loop.inputargs =
+    // inputargs[:i].  `entry_prefix_len` is that `i`, stated by the caller
+    // because the two entry models it can be in disagree about the number;
+    // see the SOUNDNESS INVARIANT on this function for what the reconstruction
+    // below is allowed to assume about the array lengths it bakes in.
+    inputargs.truncate(entry_prefix_len);
 
     // compile.py:433-440 — GETFIELD_GC per static field.
     let static_descrs = vinfo.static_field_descrs();
@@ -2066,6 +2108,16 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
     // compile.py:441-457 — GETFIELD_GC_R (array ptr) + GETARRAYITEM_GC per element.
     let array_descrs_list = vinfo.array_field_descrs();
     for (ai, array_field_descr) in array_descrs_list.iter().enumerate() {
+        // compile.py:443 `arraylen = vinfo.get_array_length(vable, arrayindex)`
+        // — the length is BAKED into the compiled prologue here, as a fixed
+        // count of `GETARRAYITEM` ops. No later check re-reads it: the entry
+        // compatibility test is built from the fixed array fields and takes
+        // their length off the live object, so it cannot notice that a
+        // virtualizable array has grown or shrunk since this compile. The
+        // baking is sound only because the array lengths are a function of
+        // this trace's GREENS, so a virtualizable with other lengths keys to
+        // a different trace and never reaches this entry. See the SOUNDNESS
+        // INVARIANT on this function.
         let array_len = vable_array_lengths.get(ai).copied().unwrap_or(0);
         assert!(
             i + array_len <= expanded_inputargs.len(),
@@ -2197,6 +2249,12 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
         }
     }
 
+    // compile.py:458 `assert i == len(inputargs)`. This is also the only
+    // in-code check the baked array lengths get: the reconstruction consumed
+    // one expanded inputarg per baked element, so an equality here says the
+    // lengths passed in still describe the shape the tracer expanded at
+    // trace-start. A length that moves after this compile is outside its
+    // reach — see the SOUNDNESS INVARIANT on this function.
     assert!(
         i == expanded_inputargs.len(),
         "compile.py:458 assert i == len(inputargs) failed ({i} != {})",
@@ -2949,6 +3007,110 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![OpRef::input_arg_ref(0), ops[2].pos.get(), ops[3].pos.get()]
         );
+    }
+
+    /// The entry prefix is the caller's number, not `num_red_args`.
+    ///
+    /// A flat entry contract puts the virtualizable at some interior slot with
+    /// other live entry values around it — here one int scalar at slot 0, the
+    /// virtualizable at slot 1, and the array elements following from slot 2.
+    /// `compile.py:431-432` must truncate at 2 and start reconstructing there;
+    /// a helper that re-derived the point from a red count (this driver
+    /// declares one red, the whole state) would cut at 1 and reinterpret the
+    /// virtualizable itself as the first array element.
+    #[test]
+    fn test_patch_new_loop_truncates_at_the_callers_entry_prefix_not_a_red_count() {
+        let mut vinfo = crate::virtualizable::VirtualizableInfo::new(0);
+        vinfo.add_embedded_array_field(
+            "regs",
+            Type::Int,
+            8,
+            0,
+            8,
+            0,
+            majit_ir::descr::make_array_descr(0, 8, Type::Int),
+        );
+        vinfo.set_parent_descr(majit_ir::descr::make_size_descr(16));
+
+        let ops = vec![Op::new(
+            OpCode::Label,
+            &[
+                rooted_inputarg_operand(Type::Int, 0),
+                rooted_inputarg_operand(Type::Ref, 1),
+                rooted_inputarg_operand(Type::Int, 2),
+                rooted_inputarg_operand(Type::Int, 3),
+            ],
+        )];
+        let mut inputargs = vec![
+            InputArg::new_int(0),
+            InputArg::new_ref(1),
+            InputArg::new_int(2),
+            InputArg::new_int(3),
+        ];
+        let mut constants: majit_ir::ConstMap<majit_ir::Value> = majit_ir::ConstMap::new();
+        let mut ops: Vec<majit_ir::OpRc> = ops.into_iter().map(std::rc::Rc::new).collect();
+
+        patch_new_loop_to_load_virtualizable_fields(
+            &mut ops,
+            &mut inputargs,
+            &vinfo,
+            &[2],
+            2,
+            1,
+            &mut constants,
+        );
+
+        // The scalar at slot 0 survives the truncation alongside the
+        // virtualizable; only the two array elements are reconstructed.
+        assert_eq!(inputargs, vec![InputArg::new_int(0), InputArg::new_ref(1)]);
+        assert_eq!(ops[0].opcode, OpCode::GetfieldGcR);
+        // The array load reads through the virtualizable at slot 1, not the
+        // int scalar at slot 0.
+        assert_eq!(ops[0].arg(0).to_opref(), OpRef::input_arg_ref(1));
+        assert_eq!(ops[1].opcode, OpCode::GetfieldGcI);
+        assert_eq!(ops[2].opcode, OpCode::GetarrayitemRawI);
+        assert_eq!(ops[3].opcode, OpCode::GetarrayitemRawI);
+        assert_eq!(ops[4].opcode, OpCode::Label);
+        assert_eq!(
+            ops[4]
+                .getarglist()
+                .iter()
+                .map(|a| a.to_opref())
+                .collect::<Vec<_>>(),
+            vec![
+                OpRef::input_arg_int(0),
+                OpRef::input_arg_ref(1),
+                ops[2].pos.get(),
+                ops[3].pos.get()
+            ]
+        );
+    }
+
+    /// A declared flat contract is what every consumer of the entry shape must
+    /// see — both the width and the virtualizable's position inside it.
+    #[test]
+    fn test_flat_entry_contract_overrides_the_red_list_spelling() {
+        use crate::jitdriver::{FlatEntryContract, JitDriverStaticData};
+
+        // The merge-point payload schema: the whole state is a single red, so
+        // a red-list lookup would answer "slot 0" for the virtualizable.
+        let mut sd = JitDriverStaticData::with_virtualizable(
+            vec![("pc", Type::Int), ("program", Type::Ref)],
+            vec![("state", Type::Ref)],
+            Some("state"),
+        );
+        assert_eq!(sd.virtualizable_arg_index(), Some(0));
+        assert_eq!(sd.num_reds(), 1);
+
+        sd.flat_entry = Some(FlatEntryContract {
+            len: 2,
+            index_of_virtualizable: 1,
+        });
+        assert_eq!(sd.flat_entry_contract().map(|f| f.len), Some(2));
+        assert_eq!(sd.virtualizable_arg_index(), Some(1));
+        // The red count is untouched — it still describes the payload, which
+        // is why it cannot double as the entry width.
+        assert_eq!(sd.num_reds(), 1);
     }
 }
 /// Re-export the backend-owned resume payload under its historical

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -116,6 +116,17 @@ fn derive_slot_types(
         .collect()
 }
 
+/// Storage for one exit's type list.
+///
+/// Inline up to a width that costs nothing. `Type` is one byte, so sixteen of
+/// them occupy exactly the bytes a heap vector spends on its pointer and
+/// capacity anyway: both spellings are 24 bytes. What the inline storage buys
+/// is that the steady exit — a FINISH returning one word, or a guard with a
+/// handful of fail arguments — carries its types without asking the allocator,
+/// on a path taken once per entry into compiled code. A wider exit spills to
+/// the heap and pays exactly what it paid before.
+pub type ExitTypes = smallvec::SmallVec<[Type; 16]>;
+
 /// Static exit metadata for a compiled guard or finish point.
 #[derive(Debug, Clone)]
 pub struct CompiledExitLayout {
@@ -126,7 +137,7 @@ pub struct CompiledExitLayout {
     pub trace_id: u64,
     pub fail_index: u32,
     pub source_op_index: Option<usize>,
-    pub exit_types: Vec<Type>,
+    pub exit_types: ExitTypes,
     pub is_finish: bool,
     /// `compile.py:658-662 ExitFrameWithExceptionDescrRef`
     /// vs `compile.py:640-647 DoneWithThisFrameDescrRef`: distinguishes
@@ -1569,7 +1580,7 @@ pub(crate) fn infer_terminal_exit_layout<T: AsRef<majit_ir::Op>>(
     }
     let fail_index = find_fail_index_for_exit_op(ops, op_index).unwrap_or(u32::MAX);
     let type_index = majit_ir::OpTypeIndex::new(inputargs, ops);
-    let exit_types: Vec<Type> = op
+    let exit_types: ExitTypes = op
         .getarglist()
         .iter()
         .map(|opref| {
@@ -1644,7 +1655,7 @@ pub(crate) fn build_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
             // `ExitFrameWithExceptionDescrRef`, both of which expose
             // `fail_arg_types()` directly, so the cache stays `None`.
             let op_arg_types_for_jump =
-                (op.opcode == OpCode::Jump).then(|| layout.exit_types.clone());
+                (op.opcode == OpCode::Jump).then(|| layout.exit_types.to_vec());
             layouts.insert(
                 op_index,
                 StoredExitLayout {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -127,6 +127,36 @@ fn derive_slot_types(
 /// the heap and pays exactly what it paid before.
 pub type ExitTypes = smallvec::SmallVec<[Type; 16]>;
 
+/// Inline width of the two decoded-exit buffers below.
+///
+/// Chosen from the exit arities a compiled entry actually returns, not from
+/// the widest one possible. Two shapes account for the steady path: a FINISH
+/// handing back the traced function's single result, and a guard handing back
+/// a frame's worth of live values — a handful, not a frame's full extent,
+/// because the exit carries only what the guard's fail arguments name. Eight
+/// covers both.
+///
+/// The width is bounded from above by the exits that do *not* fit. They exist,
+/// but they sit far above eight rather than just past it, so nothing is gained
+/// by inching this number up: the next size that would capture them costs more
+/// per entry, on every entry, than the allocations it saves on the few.
+const EXIT_VALUE_INLINE: usize = 8;
+
+/// Storage for one exit's decoded values, as machine words.
+///
+/// Both this and [`ExitValues`] are written once per exit from a compiled
+/// entry and read by the guard, blackhole and finish arms downstream. Holding
+/// them inline keeps the ordinary entry from asking the allocator for a buffer
+/// it will free before the next one; an exit wider than [`EXIT_VALUE_INLINE`]
+/// spills to the heap and pays exactly what it paid before.
+pub type ExitRawValues = smallvec::SmallVec<[i64; EXIT_VALUE_INLINE]>;
+
+/// Storage for one exit's decoded values, typed — see [`ExitRawValues`].
+///
+/// A `Value` is two words, so this array is the more expensive half of the
+/// pair and is what bounds [`EXIT_VALUE_INLINE`] from above.
+pub type ExitValues = smallvec::SmallVec<[Value; EXIT_VALUE_INLINE]>;
+
 /// Static exit metadata for a compiled guard or finish point.
 #[derive(Debug, Clone)]
 pub struct CompiledExitLayout {
@@ -156,8 +186,8 @@ pub struct CompiledExitLayout {
 
 /// Typed result from running compiled code.
 pub struct CompileResult<M> {
-    pub values: Vec<i64>,
-    pub typed_values: Vec<Value>,
+    pub values: ExitRawValues,
+    pub typed_values: ExitValues,
     /// Snapshot of the compiled entry's metadata taken *before*
     /// `execute_token`, mirroring `warmstate.py:398`'s hold on the
     /// `loop_token` object across the run: the exit values being unpacked
@@ -195,8 +225,8 @@ pub struct CompileResult<M> {
 
 /// Raw (lightweight) result from running compiled code.
 pub struct RawCompileResult<M> {
-    pub values: Vec<i64>,
-    pub typed_values: Vec<Value>,
+    pub values: ExitRawValues,
+    pub typed_values: ExitValues,
     /// Pre-run metadata snapshot — see `CompileResult::meta`.
     pub meta: std::sync::Arc<M>,
     pub fail_index: u32,

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -2177,6 +2177,12 @@ pub fn patch_new_loop_to_load_virtualizable_fields(
                 // exactly this reason).  Fail loud rather than emit a
                 // `GetfieldGcR` at `field_offset` that would read `cap` as the
                 // base pointer and corrupt memory.
+                //
+                // The way out is the field's declared container, not this arm: a
+                // `virt_array::VirtArray` field holds a pointer to a block whose
+                // length and payload sit at fixed offsets, which registers as
+                // `DirectPointer` above and reloads through the ordinary
+                // `compile.py:441-457` pair.
                 panic!(
                     "patch_new_loop reload of a RustVec virtualizable array \
                      (array {ai}) is unsupported: the in-trace IR cannot locate \

--- a/majit/majit-metainterp/src/io_buffer.rs
+++ b/majit/majit-metainterp/src/io_buffer.rs
@@ -4,6 +4,7 @@
 use std::cell::RefCell;
 use std::fmt;
 use std::io::{self, Write};
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use majit_ir::{OpCode, Type};
 
@@ -20,8 +21,42 @@ thread_local! {
     static JIT_IO_BUFFER: RefCell<Vec<u8>> = RefCell::new(Vec::with_capacity(4096));
 }
 
+/// Set the first time anything is written to the buffer, and never cleared.
+///
+/// Every compiled run is bracketed by a discard on the way in and a commit on
+/// the way out, so a program whose traces emit no I/O still pays two
+/// thread-local lookups and two `RefCell` borrows per entry for a buffer that
+/// is empty at both ends. Clearing an empty buffer and flushing an empty
+/// buffer are both no-ops, so the bracket can be skipped outright as long as
+/// the buffer is known to be empty — which it is, on every thread, until some
+/// write has happened.
+///
+/// The flag is process-global while the buffer is per-thread, and monotone for
+/// exactly that reason. It carries no data between threads: a thread that
+/// reads `false` while another thread is mid-write is reading about *its own*
+/// buffer, which that other thread did not touch, so `Relaxed` is the whole
+/// requirement. Making the flag track emptiness instead (cleared on commit)
+/// would let one thread's clear cancel another thread's pending output, and
+/// making it per-thread would reintroduce the lookup it exists to avoid.
+static IO_BUFFER_USED: AtomicBool = AtomicBool::new(false);
+
+#[inline]
+fn mark_io_buffer_used() {
+    if !IO_BUFFER_USED.load(Ordering::Relaxed) {
+        IO_BUFFER_USED.store(true, Ordering::Relaxed);
+    }
+}
+
+/// True once any write has reached the buffer; while false, every thread's
+/// buffer is still empty.
+#[inline]
+fn io_buffer_possibly_nonempty() -> bool {
+    IO_BUFFER_USED.load(Ordering::Relaxed)
+}
+
 /// Write raw bytes to the JIT I/O buffer.
 pub fn io_buffer_write(data: &[u8]) {
+    mark_io_buffer_used();
     JIT_IO_BUFFER.with(|buf| {
         buf.borrow_mut().extend_from_slice(data);
     });
@@ -29,6 +64,7 @@ pub fn io_buffer_write(data: &[u8]) {
 
 /// Write formatted output to the JIT I/O buffer.
 pub fn io_buffer_write_fmt(args: fmt::Arguments<'_>) {
+    mark_io_buffer_used();
     JIT_IO_BUFFER.with(|buf| {
         let _ = buf.borrow_mut().write_fmt(args);
     });
@@ -36,6 +72,9 @@ pub fn io_buffer_write_fmt(args: fmt::Arguments<'_>) {
 
 /// Flush the JIT I/O buffer to stdout.
 pub fn io_buffer_commit() {
+    if !io_buffer_possibly_nonempty() {
+        return;
+    }
     JIT_IO_BUFFER.with(|buf| {
         let mut b = buf.borrow_mut();
         if !b.is_empty() {
@@ -50,6 +89,9 @@ pub fn io_buffer_commit() {
 
 /// Discard the JIT I/O buffer contents.
 pub fn io_buffer_discard() {
+    if !io_buffer_possibly_nonempty() {
+        return;
+    }
     JIT_IO_BUFFER.with(|buf| {
         buf.borrow_mut().clear();
     });

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4472,12 +4472,19 @@ impl<S: JitState> JitDriver<S> {
         // They were not: the decision walked the bucket by `comparekey` while
         // the runner read `compiled_loops[hash]`, so on a chained bucket the
         // entry could decide about one cell's token and run another's.
-        let runnable_meta = if self.meta.has_compiled_loop(green_key) {
-            self.meta.get_compiled_meta(green_key).cloned()
-        } else {
-            None
-        };
-        if let Some(compiled_meta) = runnable_meta {
+        //
+        // The token itself is bound here rather than only tested, and travels
+        // to the run below as an argument. `warmstate.py:483` reads
+        // `procedure_token = cell.get_procedure_token()` once per
+        // `maybe_compile_and_run` and `:509-511` carries it out through
+        // `raise EnterJitAssembler(procedure_token, *execute_args)`; the
+        // runner receives it and never asks the cell again. This is the same
+        // resolve-once discipline the cell key above already follows, one
+        // level in: the token the gate said yes about IS the token executed,
+        // and a warm entry pays for one cell lookup rather than two.
+        if let Some(procedure_token) = self.meta.entry_procedure_token(green_key)
+            && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
+        {
             let descriptor = self.driver_descriptor_for(state, &compiled_meta);
             if !state.is_compatible(&compiled_meta) {
                 self.meta.invalidate_loop(green_key);
@@ -4640,16 +4647,12 @@ impl<S: JitState> JitDriver<S> {
                 hook(green_key, target_pc);
             }
 
-            let result = if let Some(dispatch_key) = dispatch_key {
-                self.meta.run_compiled_detailed_with_values_at_dispatch_key(
-                    green_key,
-                    live_values,
-                    dispatch_key,
-                )
-            } else {
-                self.meta
-                    .run_compiled_detailed_with_values(green_key, live_values)
-            };
+            let result = self.meta.execute_assembler_at_dispatch_key(
+                &procedure_token,
+                green_key,
+                live_values,
+                selected_dispatch_key,
+            );
             // The compiled body has run and nothing below reads the entry
             // arguments, so the buffers go back before the first exit past
             // this point.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2521,6 +2521,7 @@ impl<S: JitState> JitDriver<S> {
         let r = self.back_edge_internal(
             key,
             None,
+            None,
             resume_pc,
             state,
             env,
@@ -4185,6 +4186,7 @@ impl<S: JitState> JitDriver<S> {
         self.back_edge_internal(
             target_pc as u64,
             None,
+            None,
             target_pc,
             state,
             env,
@@ -4202,7 +4204,9 @@ impl<S: JitState> JitDriver<S> {
         env: &S::Env,
         pre_run: impl FnOnce(),
     ) -> Option<usize> {
-        self.back_edge_internal(green_key, None, target_pc, state, env, None, None, pre_run)
+        self.back_edge_internal(
+            green_key, None, None, target_pc, state, env, None, None, pre_run,
+        )
     }
 
     /// Takes the green key's hash eagerly and the key itself lazily.
@@ -4233,6 +4237,50 @@ impl<S: JitState> JitDriver<S> {
         self.back_edge_internal(
             green_key_hash,
             Some(&make_green_key),
+            None,
+            target_pc,
+            state,
+            env,
+            None,
+            None,
+            pre_run,
+        )
+    }
+
+    /// [`Self::back_edge_structured`] for a caller that has already resolved
+    /// the cell and read its token — the resolve happens once, at that caller,
+    /// and its result travels here instead of being recomputed.
+    ///
+    /// `warmstate.py:509-511` is this shape: `maybe_compile_and_run` reads the
+    /// token at `:483`, decides on it, and passes that object to the executor
+    /// as an argument (`raise EnterJitAssembler(procedure_token,
+    /// *execute_args)`) rather than handing on a key for the executor to look
+    /// up again. A door that instead probes and then calls the hash-taking
+    /// entry point pays for two cell resolutions per warm call and, on a
+    /// chained bucket, can decide about one cell's token and enter another's.
+    ///
+    /// `cell_key` must be a [`Self::resolve_cell_key`] result and
+    /// `procedure_token` must be the token read from THAT key — normally
+    /// [`Self::runnable_procedure_token`] asked with this same `cell_key`.
+    /// Neither is re-derived here: the key is used as-is (re-resolving a
+    /// resolved key would also rebuild the caller's `GreenKey` on a chained
+    /// bucket, which is the allocation the carry exists to avoid), and the
+    /// token is entered as given.
+    #[cold]
+    #[inline(never)]
+    pub fn back_edge_resolved(
+        &mut self,
+        cell_key: u64,
+        procedure_token: std::sync::Arc<majit_backend::JitCellToken>,
+        target_pc: usize,
+        state: &mut S,
+        env: &S::Env,
+        pre_run: impl FnOnce(),
+    ) -> Option<usize> {
+        self.back_edge_internal(
+            cell_key,
+            None,
+            Some(procedure_token),
             target_pc,
             state,
             env,
@@ -4390,6 +4438,7 @@ impl<S: JitState> JitDriver<S> {
         &mut self,
         green_key_hash: u64,
         structured_green_key: Option<&dyn Fn() -> GreenKey>,
+        carried_procedure_token: Option<std::sync::Arc<majit_backend::JitCellToken>>,
         target_pc: usize,
         state: &mut S,
         env: &S::Env,
@@ -4409,9 +4458,19 @@ impl<S: JitState> JitDriver<S> {
         // let them (`warmstate.py:458-464` resolves once and :483/:511 carries
         // the resolved token onward for the same reason). Identity for every
         // unchained bucket, so the collision-free path is unchanged.
-        let green_key = self
-            .meta
-            .resolve_cell_key(green_key_hash, structured_green_key);
+        //
+        // A caller arriving with `carried_procedure_token` has already done
+        // this step and read its token from the result, so `green_key_hash` is
+        // that resolved key and is taken as-is: resolving a resolved key would
+        // rebuild the caller's `GreenKey` on a chained bucket, and the whole
+        // point of the carry is that the key, the token and the run come from
+        // one resolution.
+        let green_key = if carried_procedure_token.is_some() {
+            green_key_hash
+        } else {
+            self.meta
+                .resolve_cell_key(green_key_hash, structured_green_key)
+        };
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         if !state.can_trace() {
@@ -4482,7 +4541,15 @@ impl<S: JitState> JitDriver<S> {
         // resolve-once discipline the cell key above already follows, one
         // level in: the token the gate said yes about IS the token executed,
         // and a warm entry pays for one cell lookup rather than two.
-        if let Some(procedure_token) = self.meta.entry_procedure_token(green_key)
+        //
+        // A caller that already took its own decision on this cell's token
+        // hands that same object in, and it is entered unread — the carry
+        // reaches one level further out, to that caller, exactly as
+        // `EnterJitAssembler` carries `:483`'s read past `maybe_compile_and_run`
+        // and into the executor. The meta below is still fetched here because
+        // its VALUE is needed, not just its presence.
+        if let Some(procedure_token) =
+            carried_procedure_token.or_else(|| self.meta.entry_procedure_token(green_key))
             && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
         {
             let descriptor = self.driver_descriptor_for(state, &compiled_meta);
@@ -6349,9 +6416,69 @@ impl<S: JitState> JitDriver<S> {
     /// be expressed. `warmstate::tests::
     /// the_entry_decision_and_the_entry_execution_resolve_through_one_cell_key`
     /// is the pin for that.
+    ///
+    /// The boolean form of [`Self::runnable_procedure_token`] and defined in
+    /// terms of it, so a caller that decides through this predicate and a
+    /// caller that runs through the token cannot be answering about different
+    /// cells or different tokens.
     #[inline]
     pub fn has_runnable_compiled_loop(&self, green_key: u64) -> bool {
-        self.has_compiled_loop(green_key) && self.meta.get_compiled_meta(green_key).is_some()
+        self.runnable_procedure_token(green_key).is_some()
+    }
+
+    /// The token [`Self::has_runnable_compiled_loop`] says yes about, handed
+    /// back so a door can carry it into the run instead of resolving the cell a
+    /// second time.
+    ///
+    /// `warmstate.py:483` reads `procedure_token = cell.get_procedure_token()`
+    /// once and `:509-511` carries that object out through `raise
+    /// EnterJitAssembler(procedure_token, *execute_args)`; the executor never
+    /// asks the cell again. This is the reader that makes the same carry
+    /// expressible for a caller outside this crate.
+    ///
+    /// How the predicate's two conjuncts divide here: `entry_procedure_token`
+    /// IS the `has_compiled_loop` half — that predicate is defined as this
+    /// token being present, not merely as something equivalent to it — so
+    /// binding the token subsumes the first conjunct exactly. It does NOT
+    /// subsume the second: `get_compiled_meta` reads the frontend
+    /// `compiled_loops` table, which a `compile_tmp_callback` token is never
+    /// filed in, so that test stays here explicitly. Everything the comment
+    /// above says about why the second conjunct exists applies unchanged.
+    ///
+    /// `green_key` must already name one cell — see [`Self::resolve_cell_key`],
+    /// whose result is what a door should ask this with. A raw bucket hash
+    /// answers for whichever cell heads the bucket.
+    #[inline]
+    pub fn runnable_procedure_token(
+        &self,
+        green_key: u64,
+    ) -> Option<std::sync::Arc<majit_backend::JitCellToken>> {
+        self.meta
+            .entry_procedure_token(green_key)
+            .filter(|_| self.meta.get_compiled_meta(green_key).is_some())
+    }
+
+    /// Turn the raw green-key hash a door arrives with into the key that names
+    /// exactly one cell, so the door's decision, its token read and the run it
+    /// hands them to are all about that one cell.
+    ///
+    /// The producer-side half of `MetaInterp::resolve_cell_key`, exposed
+    /// because a door outside this crate carries the same obligation as the one
+    /// inside it: `warmstate.py:458-464` matches the greens with `comparekey`
+    /// before `:483` reads anything off the cell. A door that decides on a bare
+    /// hash and hands that hash on has matched nothing, and on a chained bucket
+    /// can decide about one cell and run another's code.
+    ///
+    /// `make_green_key` is called only when the bucket actually holds more than
+    /// one cell, so the common path builds no `GreenKey`.
+    #[inline]
+    pub fn resolve_cell_key(
+        &self,
+        green_key_hash: u64,
+        make_green_key: impl Fn() -> GreenKey,
+    ) -> u64 {
+        self.meta
+            .resolve_cell_key(green_key_hash, Some(&make_green_key))
     }
 
     /// Typed twin of [`Self::has_compiled_loop`], and the shape upstream

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4553,11 +4553,16 @@ impl<S: JitState> JitDriver<S> {
             && let Some(compiled_meta) = self.meta.get_compiled_meta(green_key).cloned()
         {
             let descriptor = self.driver_descriptor_for(state, &compiled_meta);
+            // Resolved here with the descriptor and carried to both ends of
+            // the run; see `sync_before` for why it is not asked for twice.
+            let vable = descriptor
+                .as_deref()
+                .and_then(JitDriverStaticData::virtualizable);
             if !state.is_compatible(&compiled_meta) {
                 self.meta.invalidate_loop(green_key);
                 return None;
             }
-            if !self.sync_before(state, &compiled_meta, descriptor.as_deref()) {
+            if !self.sync_before(state, &compiled_meta, vable) {
                 return None;
             }
             // The entry arguments are assembled in buffers the driver keeps
@@ -4595,7 +4600,7 @@ impl<S: JitState> JitDriver<S> {
                     green_key,
                     state,
                     &compiled_meta,
-                    descriptor.as_deref(),
+                    vable,
                     &mut scratch.live_values,
                     &mut scratch.vable_static,
                     &mut scratch.vable_arrays,
@@ -4766,8 +4771,16 @@ impl<S: JitState> JitDriver<S> {
                 // portal — into slots indexed by the state's live-value
                 // layout, so a state with more than one live field indexes
                 // past the end of the list it was handed.
-                let run_descriptor = self.driver_descriptor_for(state, &run_meta);
-                self.sync_after(state, &run_meta, run_descriptor.as_deref());
+                // The descriptor the entry decided on is the one the exit
+                // syncs through — resolved once above and carried here rather
+                // than asked for again. `warmstate.py:483/509-511` reads the
+                // cell once per `maybe_compile_and_run` and carries the read
+                // out to the executor for the same reason; the driver's static
+                // data is a configuration-time constant (see
+                // `descriptor_cache`), so a second consultation could only
+                // return the same object at the cost of one more refcount pair
+                // per compiled entry.
+                self.sync_after(state, &run_meta, vable);
                 // Kept for callers that cannot consume the latch (a portal whose
                 // return type the expansion cannot build from a `Value`). Those
                 // callers see today's behaviour unchanged; a caller that drains
@@ -4781,8 +4794,10 @@ impl<S: JitState> JitDriver<S> {
                 if !result.typed_values.is_empty() {
                     state.restore_values(&run_meta, &result.typed_values);
                 }
-                let run_descriptor = self.driver_descriptor_for(state, &run_meta);
-                self.sync_after(state, &run_meta, run_descriptor.as_deref());
+                // Carried from the entry decision above, not re-resolved; see
+                // the FINISH arm for why one resolution serves both ends of a
+                // compiled entry.
+                self.sync_after(state, &run_meta, vable);
                 return Some(target_pc);
             }
 
@@ -5344,7 +5359,12 @@ impl<S: JitState> JitDriver<S> {
         self.republish_state_field_fvc();
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_deref()) {
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
+        if !self.sync_before(state, &meta, vable) {
             return;
         }
         let live_values = state.extract_live_values(&meta);
@@ -5389,7 +5409,12 @@ impl<S: JitState> JitDriver<S> {
         self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_deref()) {
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
+        if !self.sync_before(state, &meta, vable) {
             return;
         }
         let live_values = state.extract_live_values(&meta);
@@ -5440,7 +5465,12 @@ impl<S: JitState> JitDriver<S> {
         crate::mc_diag_bump(61); // mst_entered
         let meta = state.build_meta(target_pc, env);
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_deref()) {
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
+        if !self.sync_before(state, &meta, vable) {
             crate::mc_diag_bump(62); // mst_sync_before_false
             return false;
         }
@@ -5623,7 +5653,7 @@ impl<S: JitState> JitDriver<S> {
         green_key: u64,
         state: &S,
         meta: &S::Meta,
-        descriptor: Option<&JitDriverStaticData>,
+        virtualizable: Option<&JitDriverVar>,
         live_values: &mut Vec<Value>,
         statics: &mut Vec<i64>,
         arrays: &mut Vec<Vec<i64>>,
@@ -5643,11 +5673,14 @@ impl<S: JitState> JitDriver<S> {
         let Some(info) = self.meta.virtualizable_info() else {
             return false;
         };
-        // Try descriptor path first (RPython jitdriver_sd.virtualizable), else
-        // jitdriver_sd.virtualizable_info.name (interp_jit.py:25). Borrowed
-        // rather than cloned: both spellings outlive this call, and the export
-        // below only reads the name.
-        let name: &str = match descriptor.and_then(|d| d.virtualizable()) {
+        // Try the driver's declared virtualizable first (RPython
+        // jitdriver_sd.virtualizable), else jitdriver_sd.virtualizable_info.name
+        // (interp_jit.py:25). Borrowed rather than cloned: both spellings
+        // outlive this call, and the export below only reads the name. Arrives
+        // pre-resolved for the reason given on `sync_before` — this is the
+        // third consultation on one compiled entry, and the caller already
+        // holds the answer.
+        let name: &str = match virtualizable {
             Some(virtualizable) => &virtualizable.name,
             None => &info.name,
         };
@@ -5671,7 +5704,7 @@ impl<S: JitState> JitDriver<S> {
         green_key: u64,
         state: &S,
         meta: &S::Meta,
-        descriptor: Option<&JitDriverStaticData>,
+        virtualizable: Option<&JitDriverVar>,
         mut live_values: Vec<Value>,
     ) -> Option<Vec<Value>> {
         let mut statics = Vec::new();
@@ -5680,7 +5713,7 @@ impl<S: JitState> JitDriver<S> {
             green_key,
             state,
             meta,
-            descriptor,
+            virtualizable,
             &mut live_values,
             &mut statics,
             &mut arrays,
@@ -5688,19 +5721,29 @@ impl<S: JitState> JitDriver<S> {
         .then_some(live_values)
     }
 
+    /// The declared virtualizable red of the driver this entry runs under,
+    /// or `None` for a driver that declares none.
+    ///
+    /// Taken pre-resolved rather than looked up here: the driver's static
+    /// data names its virtualizable by NAME, so asking it costs a scan of
+    /// the variable list with a string compare per variable, and both this
+    /// and [`Self::sync_after`] would pay it separately on one compiled
+    /// entry. `warmspot.py:529-538` resolves the virtualizable's position
+    /// once at driver setup (`jd.index_of_virtualizable`) and every runtime
+    /// reader indexes with it; the callers here resolve once at the entry
+    /// decision and carry the answer to both ends of the run for the same
+    /// reason.
     fn sync_before(
         &mut self,
         state: &mut S,
         meta: &S::Meta,
-        descriptor: Option<&JitDriverStaticData>,
+        virtualizable: Option<&JitDriverVar>,
     ) -> bool {
         // Descriptor-gated token-reset path — RPython
         // compile.py::sync_before_jit calls `vinfo.reset_vable_token(virt)`
         // when the JitDriver has a virtualizable declared.  Pyre routes
         // this through the interpreter's `sync_named_virtualizable_before_jit`.
-        if let Some(descriptor) = descriptor
-            && let Some(virtualizable) = descriptor.virtualizable()
-        {
+        if let Some(virtualizable) = virtualizable {
             let ok = state.sync_named_virtualizable_before_jit(
                 meta,
                 &virtualizable.name,
@@ -5737,11 +5780,10 @@ impl<S: JitState> JitDriver<S> {
         true
     }
 
-    fn sync_after(&self, state: &mut S, meta: &S::Meta, descriptor: Option<&JitDriverStaticData>) {
-        let Some(descriptor) = descriptor else {
-            return;
-        };
-        let Some(virtualizable) = descriptor.virtualizable() else {
+    /// Counterpart of [`Self::sync_before`]; takes the same pre-resolved
+    /// virtualizable red, and for the same reason.
+    fn sync_after(&self, state: &mut S, meta: &S::Meta, virtualizable: Option<&JitDriverVar>) {
+        let Some(virtualizable) = virtualizable else {
             return;
         };
         state.sync_named_virtualizable_after_jit(
@@ -5994,7 +6036,12 @@ impl<S: JitState> JitDriver<S> {
             };
         };
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !state.is_compatible(&meta) || !self.sync_before(state, &meta, descriptor.as_deref()) {
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
+        if !state.is_compatible(&meta) || !self.sync_before(state, &meta, vable) {
             return DetailedDriverRunOutcome::Abort {
                 restored: false,
                 via_blackhole: false,
@@ -6022,13 +6069,9 @@ impl<S: JitState> JitDriver<S> {
                 via_blackhole: false,
             };
         }
-        let Some(live_values) = self.extend_compiled_live_values(
-            green_key,
-            state,
-            &meta,
-            descriptor.as_deref(),
-            live_values,
-        ) else {
+        let Some(live_values) =
+            self.extend_compiled_live_values(green_key, state, &meta, vable, live_values)
+        else {
             return DetailedDriverRunOutcome::Abort {
                 restored: false,
                 via_blackhole: false,
@@ -6081,7 +6124,7 @@ impl<S: JitState> JitDriver<S> {
 
         let exit_meta = result.meta.clone();
         state.restore_values(&exit_meta, &result.typed_values);
-        self.sync_after(state, &exit_meta, descriptor.as_deref());
+        self.sync_after(state, &exit_meta, vable);
         DetailedDriverRunOutcome::Jump {
             via_blackhole: false,
             continue_running_normally_values: None,
@@ -6117,6 +6160,11 @@ impl<S: JitState> JitDriver<S> {
             };
         };
         let descriptor = self.driver_descriptor_for(state, &meta);
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
         // warmstate.py:482-511: RPython enters execute_token directly
         // when the green key matches — no is_compatible check.
         // pyre still needs this gate because compiled code reads
@@ -6136,7 +6184,7 @@ impl<S: JitState> JitDriver<S> {
                 via_blackhole: false,
             };
         }
-        if !self.sync_before(state, &meta, descriptor.as_deref()) {
+        if !self.sync_before(state, &meta, vable) {
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit][run-compiled-abort] key={} reason=sync-before target_pc={}",
@@ -6179,13 +6227,9 @@ impl<S: JitState> JitDriver<S> {
                 via_blackhole: false,
             };
         }
-        let Some(live_values) = self.extend_compiled_live_values(
-            green_key,
-            state,
-            &meta,
-            descriptor.as_deref(),
-            live_values,
-        ) else {
+        let Some(live_values) =
+            self.extend_compiled_live_values(green_key, state, &meta, vable, live_values)
+        else {
             if crate::majit_log_enabled() {
                 eprintln!(
                     "[jit][run-compiled-abort] key={} reason=extend-live-values target_pc={}",
@@ -6244,7 +6288,7 @@ impl<S: JitState> JitDriver<S> {
         // Normal loop back-edge JUMP, not a guard failure.
         if fail_index == u32::MAX {
             state.restore_values(&exit_meta, &typed_values);
-            self.sync_after(state, &exit_meta, descriptor.as_deref());
+            self.sync_after(state, &exit_meta, vable);
             return DetailedDriverRunOutcome::Jump {
                 via_blackhole: false,
                 continue_running_normally_values: None,
@@ -7462,7 +7506,12 @@ impl<S: JitState> JitDriver<S> {
         }
         let meta = meta.clone();
         let descriptor = self.driver_descriptor_for(state, &meta);
-        if !self.sync_before(state, &meta, descriptor.as_deref()) {
+        // Resolved here with the descriptor and carried to both ends of
+        // the run; see `sync_before` for why it is not asked for twice.
+        let vable = descriptor
+            .as_deref()
+            .and_then(JitDriverStaticData::virtualizable);
+        if !self.sync_before(state, &meta, vable) {
             return None;
         }
         let live_values = state.extract_live_values(&meta);
@@ -7473,13 +7522,8 @@ impl<S: JitState> JitDriver<S> {
         ) {
             return None;
         }
-        let live_values = self.extend_compiled_live_values(
-            key_hash,
-            state,
-            &meta,
-            descriptor.as_deref(),
-            live_values,
-        )?;
+        let live_values =
+            self.extend_compiled_live_values(key_hash, state, &meta, vable, live_values)?;
         let mut live_values = live_values;
         let mut dispatch_key = single_pass_dispatch_key;
         // `live_values` is in state-field order; a dispatch-key entry lands on a
@@ -7562,26 +7606,25 @@ impl<S: JitState> JitDriver<S> {
                     );
                 }
                 state.restore_values(&result_meta, &typed_values);
-                self.sync_after(state, &result_meta, descriptor.as_deref());
+                self.sync_after(state, &result_meta, vable);
                 // Re-enter compiled code if state is still compatible
                 if let Some(meta) = self.meta.get_compiled_meta(key_hash)
                     && state.is_compatible(meta)
                 {
                     let meta = meta.clone();
-                    let nd = self.driver_descriptor_for(state, &meta);
-                    if self.sync_before(state, &meta, nd.as_deref()) {
+                    // The re-entry runs under the same driver as the entry
+                    // this loop came in on, so it reuses that one resolution
+                    // instead of asking per iteration — the meta changes
+                    // between iterations, the driver's static data does not.
+                    if self.sync_before(state, &meta, vable) {
                         let nl = state.extract_live_values(&meta);
                         if Self::live_values_match_descriptor(
-                            nd.as_deref(),
+                            descriptor.as_deref(),
                             &nl,
                             state.state_field_layout().total_live_values(),
-                        ) && let Some(v) = self.extend_compiled_live_values(
-                            key_hash,
-                            state,
-                            &meta,
-                            nd.as_deref(),
-                            nl,
-                        ) {
+                        ) && let Some(v) =
+                            self.extend_compiled_live_values(key_hash, state, &meta, vable, nl)
+                        {
                             live_values = v;
                             continue;
                         }
@@ -7653,7 +7696,7 @@ impl<S: JitState> JitDriver<S> {
                 // Restore state for bridge tracing start point.
                 let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
                 let resume_pc = resume_pc.unwrap_or(guard_resume_pc);
-                self.sync_after(state, &result_meta, descriptor.as_deref());
+                self.sync_after(state, &result_meta, vable);
 
                 let bridge_ok =
                     self.start_bridge_tracing(&descr_arc, state, env, &raw_values, resume_pc);
@@ -7834,7 +7877,7 @@ impl<S: JitState> JitDriver<S> {
             self.prepare_exit_resume_heap_with_blackhole_allocator(&exit_layout, &raw_values);
             let resume_pc = on_guard_failure(state, &result_meta, &raw_values, &exit_layout);
             let resume_pc = resume_pc.unwrap_or(target_pc);
-            self.sync_after(state, &result_meta, descriptor.as_deref());
+            self.sync_after(state, &result_meta, vable);
             return Some(resume_pc);
         } // end loop { run_compiled ... }
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1234,20 +1234,32 @@ impl JitDriverStaticData {
 
     /// rewrite.py:684 `jd.index_of_virtualizable` parity.
     ///
-    /// Returns the index inside the entry arglist — the red-arg list /
-    /// original CALL_ASSEMBLER arglist — not the absolute index in `vars`.
+    /// Returns the index inside the ENTRY arglist — the values the compiled
+    /// entry is invoked with — not the absolute index in `vars`. When the reds
+    /// ARE the entry, that is a position among the reds and this agrees with
+    /// [`Self::red_arg_virtualizable_index`]. When the entry is a flat
+    /// state-field prefix the two part company: the reds describe the
+    /// merge-point payload, where the whole state is a single red, so the same
+    /// number picks out a different value in each list. The declared contract
+    /// takes precedence here; see [`FlatEntryContract`].
     ///
-    /// Every caller reads this as a position in the values the compiled entry
-    /// is invoked with, so a driver whose entry is a flat state-field prefix
-    /// must be answered in THAT list: its reds describe the merge-point
-    /// payload, where the whole state is a single red, and a position in the
-    /// reds picks out a different value than the same position in the entry.
-    /// The declared contract therefore takes precedence over the red-name
-    /// lookup; see [`FlatEntryContract`].
+    /// A consumer indexing an original CALL_ASSEMBLER red arglist wants the
+    /// other accessor, whichever driver it holds.
     pub fn virtualizable_arg_index(&self) -> Option<usize> {
         if let Some(flat) = self.flat_entry {
             return Some(flat.index_of_virtualizable);
         }
+        self.red_arg_virtualizable_index()
+    }
+
+    /// `warmspot.py:537 jd.index_of_virtualizable = jitdriver.reds.index(vname)`.
+    ///
+    /// The virtualizable's position among the REDS, and only that — a flat
+    /// entry contract does not override it, because the list this indexes is
+    /// the red arglist a CALL_ASSEMBLER carries rather than the compiled
+    /// entry's. Upstream has one coordinate system and spells it this way;
+    /// a consumer whose list is `num_red_args` wide has to as well.
+    pub fn red_arg_virtualizable_index(&self) -> Option<usize> {
         let name = self.virtualizable.as_deref()?;
         self.reds().iter().position(|var| var.name == name)
     }
@@ -1833,7 +1845,26 @@ impl<S: JitState> JitDriver<S> {
         // index, not a position in the reds, because the entry it describes is
         // not the red list.
         descriptor.index_of_virtualizable = contract.index_of_virtualizable as i32;
+        let registered_index = descriptor.index;
         self.descriptor_cache = None;
+        // Registration files a CLONE of the descriptor, so after it there are
+        // two copies and the consumers are split between them: a trace start
+        // reads the driver's, while `initialize_virtualizable` reads the
+        // registered one. Writing only the first is a silent disagreement
+        // about whether this driver has a virtualizable at all.
+        //
+        // Upstream has no such split to keep in step — `warmspot.py:259`
+        // builds the static data and `warmspot.py:537` stamps
+        // `jd.index_of_virtualizable` on the very object the table holds — so
+        // declaring after registration stays a supported order here too, and
+        // the registered copy is brought along rather than left behind.
+        if let Some(index) = registered_index
+            && let Some(registered) = self.meta.jitdriver_sd_mut(index)
+        {
+            registered.virtualizable = Some(virtualizable.to_string());
+            registered.flat_entry = Some(contract);
+            registered.index_of_virtualizable = contract.index_of_virtualizable as i32;
+        }
     }
 
     /// Declare `contract` if — and only if — this driver's virtualizable is one
@@ -2391,13 +2422,13 @@ impl<S: JitState> JitDriver<S> {
     /// resuming there re-runs the loop the compiled run already completed.
     pub fn take_back_edge_finish(&mut self) -> Option<Vec<Value>> {
         // The latch holds the exit values in their decoded storage, which is
-        // inline for the widths a finish actually returns. Handing them out
-        // as a vector copies them once, on a call no compiled entry makes on
-        // its own: the projecting siblings below are what the portal drains.
+        // inline for the widths a finish actually returns. Taken rather than
+        // copied: the buffer is owned here and has no reader left, so a width
+        // that did spill hands its allocation over instead of duplicating it.
         self.meta
             .back_edge_finish
             .take()
-            .map(|values| values.to_vec())
+            .map(smallvec::SmallVec::into_vec)
     }
 
     /// [`Self::take_back_edge_finish`] projected onto one integer word — the
@@ -6234,7 +6265,7 @@ impl<S: JitState> JitDriver<S> {
             self.meta
                 .run_compiled_detailed_with_values(green_key, &live_values)
         };
-        let Some(result) = result else {
+        let Some(mut result) = result else {
             return DetailedDriverRunOutcome::Abort {
                 restored: false,
                 via_blackhole: false,
@@ -6242,7 +6273,9 @@ impl<S: JitState> JitDriver<S> {
         };
 
         if result.is_finish {
-            let typed_values = result.typed_values.to_vec();
+            // Taken, not copied: this arm returns below, so the exit values in
+            // `result` have no reader past this point.
+            let typed_values = std::mem::take(&mut result.typed_values).into_vec();
             let is_exit_frame_with_exception = result.is_exit_frame_with_exception;
             drop(result);
             return DetailedDriverRunOutcome::Finished {
@@ -6373,7 +6406,7 @@ impl<S: JitState> JitDriver<S> {
             };
         };
         pre_run();
-        let Some(result) = self
+        let Some(mut result) = self
             .meta
             .run_compiled_detailed_with_values(green_key, &live_values)
         else {
@@ -6396,8 +6429,10 @@ impl<S: JitState> JitDriver<S> {
         let trace_id = result.trace_id;
         let descr_arc = std::sync::Arc::clone(&result.descr_arc);
         let exit_layout = result.exit_layout.clone();
-        let typed_values = result.typed_values.to_vec();
-        let raw_values = result.values.to_vec();
+        // Taken, not copied: every field this arm needs is read out here and
+        // `result` is dropped just below, so neither buffer has a reader left.
+        let typed_values = std::mem::take(&mut result.typed_values).into_vec();
+        let raw_values = std::mem::take(&mut result.values).into_vec();
         // llmodel.py:240 grab_exc_value: the pending exception captured at
         // guard failure travels with the GuardFailure outcome so the
         // blackhole resume can seed it (blackhole.py:1794).

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -768,6 +768,34 @@ fn build_jitcode_registry(
     (registry, dispatch_arc)
 }
 
+/// The width of a compiled loop's entry contract, and where the
+/// virtualizable sits inside it, for a driver whose entry is NOT a red list.
+///
+/// `compile.py:431` truncates `loop.inputargs` to `jitdriver_sd.num_red_args`
+/// and `compile.py:429` reads the virtualizable out of that prefix by
+/// `index_of_virtualizable`. Both spellings work upstream because the compiled
+/// entry is invoked with exactly the jitdriver's reds (`warmstate.py:387
+/// execute_assembler`) and the virtualizable is one of them
+/// (`warmspot.py:538 jd.index_of_virtualizable = jitdriver.reds.index(vname)`).
+///
+/// A driver that declares its runtime state as flat fields presents a
+/// different entry: one slot per declared field, in the order the state's live
+/// values are emitted, with the virtualizable occupying a single slot among
+/// them rather than being one of N reds. Its logical red list still exists —
+/// it is the merge-point payload schema, in which the whole state is one red —
+/// so the red count and the entry width are counts of different things and
+/// neither can be derived from the other. Such a driver states both numbers
+/// here instead.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FlatEntryContract {
+    /// Number of leading inputargs that form the entry contract — the
+    /// `compile.py:431 i` the loop's inputargs are truncated to.
+    pub len: usize,
+    /// Index, within that prefix, of the slot holding the virtualizable
+    /// pointer (`compile.py:429 inputargs[index_of_virtualizable]`).
+    pub index_of_virtualizable: usize,
+}
+
 /// Descriptor for a JitDriver's variable layout.
 ///
 /// Mirrors RPython's `JitDriver(greens=[...], reds=[...])`:
@@ -788,6 +816,10 @@ pub struct JitDriverStaticData {
     pub vars: Vec<JitDriverVar>,
     /// Optional name of the virtualizable red variable.
     pub virtualizable: Option<String>,
+    /// Set when this driver's compiled entry contract is a flat state-field
+    /// prefix rather than the red list. See [`FlatEntryContract`]; `None`
+    /// keeps the upstream red-list spelling.
+    pub flat_entry: Option<FlatEntryContract>,
     /// warmspot.py:449 jd.result_type — portal function return type.
     /// Determined once at driver setup from the portal's return signature.
     pub result_type: Type,
@@ -990,6 +1022,7 @@ impl JitDriverStaticData {
             index: None,
             vars,
             virtualizable: virtualizable.map(str::to_string),
+            flat_entry: None,
             result_type: Type::Ref,
             is_recursive: false,
             mainjitcode: None,
@@ -1201,11 +1234,34 @@ impl JitDriverStaticData {
 
     /// rewrite.py:684 `jd.index_of_virtualizable` parity.
     ///
-    /// Returns the index inside the red-arg list / original
-    /// CALL_ASSEMBLER arglist, not the absolute index in `vars`.
+    /// Returns the index inside the entry arglist — the red-arg list /
+    /// original CALL_ASSEMBLER arglist — not the absolute index in `vars`.
+    ///
+    /// Every caller reads this as a position in the values the compiled entry
+    /// is invoked with, so a driver whose entry is a flat state-field prefix
+    /// must be answered in THAT list: its reds describe the merge-point
+    /// payload, where the whole state is a single red, and a position in the
+    /// reds picks out a different value than the same position in the entry.
+    /// The declared contract therefore takes precedence over the red-name
+    /// lookup; see [`FlatEntryContract`].
     pub fn virtualizable_arg_index(&self) -> Option<usize> {
+        if let Some(flat) = self.flat_entry {
+            return Some(flat.index_of_virtualizable);
+        }
         let name = self.virtualizable.as_deref()?;
         self.reds().iter().position(|var| var.name == name)
+    }
+
+    /// The flat entry contract, when this driver declares one.
+    ///
+    /// A consumer that needs the compiled loop's entry WIDTH must consult this
+    /// rather than `num_reds()`: the two count different things, so a flat
+    /// driver answered with a red count gets a truncation point in the middle
+    /// of its live entry values. The virtualizable's position inside that
+    /// width is already served model-aware by
+    /// [`Self::virtualizable_arg_index`].
+    pub fn flat_entry_contract(&self) -> Option<FlatEntryContract> {
+        self.flat_entry
     }
 }
 
@@ -1748,6 +1804,35 @@ impl<S: JitState> JitDriver<S> {
             return;
         }
         self.descriptor = Some(JitDriverStaticData::with_green_types(greens, reds));
+        self.descriptor_cache = None;
+    }
+
+    /// Name the descriptor's virtualizable and state its flat entry contract.
+    ///
+    /// `warmspot.py:520-545 make_virtualizable_infos` names the virtualizable
+    /// on the jitdriver static data, which is what makes
+    /// `compile.py:508-511`'s field-reload preamble run at all. A driver whose
+    /// entry is a flat state-field prefix cannot say it through the reds — see
+    /// [`FlatEntryContract`] — so both halves arrive together here, after
+    /// [`Self::declare_schema_typed`] has built the descriptor from the
+    /// merge-point payload schema.
+    ///
+    /// No-op when no descriptor exists yet: a virtualizable declaration with
+    /// no green/red schema behind it has nothing to index into.
+    pub fn declare_flat_entry_contract(
+        &mut self,
+        virtualizable: &str,
+        contract: FlatEntryContract,
+    ) {
+        let Some(descriptor) = self.descriptor.as_mut() else {
+            return;
+        };
+        descriptor.virtualizable = Some(virtualizable.to_string());
+        descriptor.flat_entry = Some(contract);
+        // warmspot.py:538 `jd.index_of_virtualizable` — the flat contract's
+        // index, not a position in the reds, because the entry it describes is
+        // not the red list.
+        descriptor.index_of_virtualizable = contract.index_of_virtualizable as i32;
         self.descriptor_cache = None;
     }
 
@@ -8292,6 +8377,41 @@ mod tests {
             driver.meta.on_back_edge(key, &[]),
             BackEdgeAction::StartedTracing
         ));
+    }
+
+    /// `declare_flat_entry_contract` fills in the two things a flat entry
+    /// cannot say through the red list, on the descriptor the schema call just
+    /// built — and re-answers `virtualizable_arg_index` in that model, so the
+    /// consumers that read it as a position in the entry arglist see the
+    /// virtualizable's slot rather than its position among the reds.
+    #[test]
+    fn declare_flat_entry_contract_states_the_entry_shape_the_reds_cannot() {
+        let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.declare_schema_typed(
+            vec![("pc", GreenType::Int), ("program", GreenType::Ref)],
+            vec![("state", Type::Ref)],
+        );
+        let before = driver
+            .descriptor
+            .as_ref()
+            .expect("schema builds a descriptor");
+        assert_eq!(before.flat_entry_contract(), None);
+        assert_eq!(before.virtualizable_arg_index(), None);
+
+        driver.declare_flat_entry_contract(
+            "state",
+            FlatEntryContract {
+                len: 2,
+                index_of_virtualizable: 1,
+            },
+        );
+        let after = driver.descriptor.as_ref().expect("descriptor survives");
+        assert_eq!(after.virtualizable.as_deref(), Some("state"));
+        assert_eq!(after.flat_entry_contract().map(|f| f.len), Some(2));
+        assert_eq!(after.virtualizable_arg_index(), Some(1));
+        assert_eq!(after.index_of_virtualizable, 1);
+        // The reds still describe the merge-point payload, unchanged.
+        assert_eq!(after.num_reds(), 1);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4381,7 +4381,7 @@ impl<S: JitState> JitDriver<S> {
     )]
     fn back_edge_internal(
         &mut self,
-        green_key: u64,
+        green_key_hash: u64,
         structured_green_key: Option<&dyn Fn() -> GreenKey>,
         target_pc: usize,
         state: &mut S,
@@ -4393,15 +4393,16 @@ impl<S: JitState> JitDriver<S> {
         if self.meta.is_tracing() {
             return None;
         }
-        // **Resolve once, then carry.** From here down `green_key` names ONE
-        // cell, not a celltable bucket — the decision below, the
+        // **Resolve once, then carry.** The parameter is a raw bucket hash;
+        // from here down `green_key` names ONE cell, not a celltable bucket —
+        // the decision below, the
         // `compiled_loops` meta the runner executes, the invalidation on a
         // shape mismatch and the front-target tables all read through this one
         // number, so they cannot name different cells the way a bucket hash
         // let them (`warmstate.py:458-464` resolves once and :483/:511 carries
         // the resolved token onward for the same reason). Identity for every
         // unchained bucket, so the collision-free path is unchanged.
-        let green_key = self.meta.resolve_cell_key(green_key, structured_green_key);
+        let green_key = self.meta.resolve_cell_key(green_key_hash, structured_green_key);
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         if !state.can_trace() {
@@ -6322,31 +6323,38 @@ impl<S: JitState> JitDriver<S> {
     /// (`ResumeFromInterpDescr`, `compile.py:1079-1083`) DO get a
     /// `compiled_loops` entry despite carrying 0 target tokens, so they remain
     /// dispatchable — this predicate only excludes bare tmp callbacks.
+    ///
+    /// No typed twin, and unlike [`Self::has_compiled_loop_for_key`] that is
+    /// not a gap: the strengthening above is pyre-only, so there is no
+    /// warmstate.py reader for a twin to mirror. What a twin would add is a
+    /// `cell_key_for` resolve in front, and the entry path already resolves at
+    /// the producer (`back_edge_internal`, `resolve_cell_key`) — after which
+    /// both conjuncts here index by that one cell key, so the disagreement a
+    /// twin existed to prevent (`compiled_loops` read at the bare
+    /// `key.get_uhash()` while the token half walked the chain) can no longer
+    /// be expressed. `warmstate::tests::
+    /// the_entry_decision_and_the_entry_execution_resolve_through_one_cell_key`
+    /// is the pin for that.
     #[inline]
     pub fn has_runnable_compiled_loop(&self, green_key: u64) -> bool {
         self.has_compiled_loop(green_key) && self.meta.get_compiled_meta(green_key).is_some()
     }
 
-    /// Typed twin of [`Self::has_compiled_loop`]: `warmstate.py:458-464` walks
-    /// the bucket and tests `comparekey(*greenargs)` before deciding anything,
-    /// where a bare bucket hash can answer for whichever cell holds it.
+    /// Typed twin of [`Self::has_compiled_loop`], and the shape upstream
+    /// actually has: `warmstate.py:455-464` walks the bucket and tests
+    /// `comparekey(*greenargs)` before deciding anything, and only then
+    /// (`warmstate.py:482-483`) reads `cell.get_procedure_token()` and gates on
+    /// it. The hash form has no upstream counterpart at all — a bare bucket
+    /// hash can answer for whichever cell holds it — so this is the reader to
+    /// ask wherever the typed key is in scope at the decision point.
+    ///
+    /// Kept as the typed reader API even though its only callers today are
+    /// tests: `the_typed_entry_predicate_reads_the_keys_own_cell_not_the_bucket_head`
+    /// is what pins the hash/typed disagreement the entry path resolves away,
+    /// and a chained bucket is the only state in which the two can differ.
     #[inline]
     pub fn has_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
         self.meta.has_compiled_loop_for_key(key)
-    }
-
-    /// Typed twin of [`Self::has_runnable_compiled_loop`].
-    ///
-    /// Both conjuncts read through the SAME resolved cell key, so the JitCell
-    /// half and the `compiled_loops` half cannot answer about different cells.
-    /// They could: `compiled_loops` was consulted at the bare `key.get_uhash()`
-    /// while the token half walked the chain by `comparekey`.
-    #[inline]
-    pub fn has_runnable_compiled_loop_for_key(&self, key: &GreenKey) -> bool {
-        self.meta
-            .warm_state_ref()
-            .cell_key_for(key)
-            .is_some_and(|cell_key| self.has_runnable_compiled_loop(cell_key))
     }
 
     /// Actual key the last compile_loop stored under.

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4647,7 +4647,7 @@ impl<S: JitState> JitDriver<S> {
             // arguments, so the buffers go back before the first exit past
             // this point.
             self.entry_scratch_out(scratch);
-            let result = result?;
+            let mut result = result?;
             if portal_rca_enabled() {
                 eprintln!(
                     "[portal-rca][compiled-exit] green_key={green_key} \
@@ -4674,7 +4674,9 @@ impl<S: JitState> JitDriver<S> {
                 // no variant for "the function returned", so the `#[jit_interp]`
                 // expansion drains this latch right after the call and returns it
                 // as the portal's own return value.
-                self.meta.back_edge_finish = Some(result.typed_values.clone());
+                // Taken, not copied: this arm returns below, so the exit values
+                // in `result` have no reader past this point.
+                self.meta.back_edge_finish = Some(std::mem::take(&mut result.typed_values));
                 let run_meta = result.meta.clone();
                 // The FINISH arguments are NOT the loop-carried state, so they
                 // are not written back into it. `warmstate.py:405-419

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -4402,7 +4402,9 @@ impl<S: JitState> JitDriver<S> {
         // let them (`warmstate.py:458-464` resolves once and :483/:511 carries
         // the resolved token onward for the same reason). Identity for every
         // unchained bucket, so the collision-free path is unchanged.
-        let green_key = self.meta.resolve_cell_key(green_key_hash, structured_green_key);
+        let green_key = self
+            .meta
+            .resolve_cell_key(green_key_hash, structured_green_key);
         let single_pass_dispatch_key =
             self.take_single_pass_label_entry_dispatch_key_for_back_edge(green_key);
         if !state.can_trace() {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2259,7 +2259,14 @@ impl<S: JitState> JitDriver<S> {
     /// `Some(resume_pc)` the same call produced: that pc is the back edge, and
     /// resuming there re-runs the loop the compiled run already completed.
     pub fn take_back_edge_finish(&mut self) -> Option<Vec<Value>> {
-        self.meta.back_edge_finish.take()
+        // The latch holds the exit values in their decoded storage, which is
+        // inline for the widths a finish actually returns. Handing them out
+        // as a vector copies them once, on a call no compiled entry makes on
+        // its own: the projecting siblings below are what the portal drains.
+        self.meta
+            .back_edge_finish
+            .take()
+            .map(|values| values.to_vec())
     }
 
     /// [`Self::take_back_edge_finish`] projected onto one integer word — the
@@ -5991,7 +5998,7 @@ impl<S: JitState> JitDriver<S> {
         };
 
         if result.is_finish {
-            let typed_values = result.typed_values.clone();
+            let typed_values = result.typed_values.to_vec();
             let is_exit_frame_with_exception = result.is_exit_frame_with_exception;
             drop(result);
             return DetailedDriverRunOutcome::Finished {
@@ -6144,8 +6151,8 @@ impl<S: JitState> JitDriver<S> {
         let trace_id = result.trace_id;
         let descr_arc = std::sync::Arc::clone(&result.descr_arc);
         let exit_layout = result.exit_layout.clone();
-        let typed_values = result.typed_values.clone();
-        let raw_values = result.values.clone();
+        let typed_values = result.typed_values.to_vec();
+        let raw_values = result.values.to_vec();
         // llmodel.py:240 grab_exc_value: the pending exception captured at
         // guard failure travels with the GuardFailure outcome so the
         // blackhole resume can seed it (blackhole.py:1794).

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1836,6 +1836,52 @@ impl<S: JitState> JitDriver<S> {
         self.descriptor_cache = None;
     }
 
+    /// Declare `contract` if — and only if — this driver's virtualizable is one
+    /// the compiled entry's field-load preamble can serve. Reports whether it
+    /// was declared.
+    ///
+    /// Declaring the contract is what puts the driver on
+    /// `compile.py:508-511`'s preamble: the fields ride through the optimizer
+    /// as expanded inputargs and are reloaded from the virtualizable at entry
+    /// instead of being handed over one argument per element. That only works
+    /// for a virtualizable whose arrays the preamble can reach — see
+    /// [`crate::virtualizable::VirtualizableInfo::arrays_are_entry_reloadable`]
+    /// — and which array storage a state's fields register as is resolved from
+    /// the containers the interpreter author declared, at
+    /// `VirtualizableInfo`-build time. So the caller supplies the two numbers
+    /// only it can know (the width of its own entry and the virtualizable's
+    /// position in it) and the gate is answered here, off the vinfo already
+    /// installed on this driver.
+    ///
+    /// The name comes from the same vinfo (`interp_jit.py:25`
+    /// `jitdriver_sd.virtualizable_info.name`) rather than from the caller, so
+    /// the descriptor cannot end up naming a virtualizable other than the one
+    /// the gate was answered about.
+    ///
+    /// A driver with no virtualizable info, or one holding an array the
+    /// preamble cannot reload, is left exactly as it was: no contract, no name,
+    /// and the entry keeps whichever shape it already had.
+    pub fn arm_flat_entry_contract(&mut self, contract: FlatEntryContract) -> bool {
+        let Some(info) = self.meta.virtualizable_info() else {
+            return false;
+        };
+        if !info.arrays_are_entry_reloadable() {
+            return false;
+        }
+        let name = info.name.clone();
+        self.declare_flat_entry_contract(&name, contract);
+        true
+    }
+
+    /// The entry contract this driver's descriptor carries, if one was armed.
+    ///
+    /// Reads through the driver rather than the registered static data because
+    /// `register_descriptor` mirrors the stamped copy back onto the driver, so
+    /// this answer is the same before and after registration.
+    pub fn flat_entry_contract(&self) -> Option<FlatEntryContract> {
+        self.descriptor.as_ref()?.flat_entry_contract()
+    }
+
     pub fn with_descriptor(threshold: u32, descriptor: JitDriverStaticData) -> Self {
         let mut driver = Self::new(threshold);
         // warmstate.py:564 `_green_args_spec` carries lltype TYPE per
@@ -8412,6 +8458,112 @@ mod tests {
         assert_eq!(after.index_of_virtualizable, 1);
         // The reds still describe the merge-point payload, unchanged.
         assert_eq!(after.num_reds(), 1);
+    }
+
+    /// Build a driver whose virtualizable holds one array in `storage`.
+    fn driver_with_one_vable_array(
+        storage: crate::virtualizable::VableArrayStorage,
+    ) -> JitDriver<TypedRestoreState> {
+        let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.declare_schema_typed(vec![("pc", GreenType::Int)], vec![("state", Type::Ref)]);
+        let mut info = crate::virtualizable::VirtualizableInfo::without_vable_token();
+        info.name = "state".to_string();
+        match storage {
+            crate::virtualizable::VableArrayStorage::RustVec {
+                data_ptr_fn,
+                len_fn,
+            } => {
+                info.add_rust_vec_array_field(
+                    "regs",
+                    Type::Int,
+                    0,
+                    data_ptr_fn,
+                    len_fn,
+                    majit_ir::descr::make_array_descr(0, 8, Type::Int),
+                );
+            }
+            _ => {
+                info.add_array_field(
+                    "regs",
+                    Type::Int,
+                    0,
+                    0,
+                    8,
+                    majit_ir::descr::make_array_descr(8, 8, Type::Int),
+                );
+            }
+        }
+        driver
+            .meta
+            .set_virtualizable_info(info.finalize_arc(majit_ir::descr::make_size_descr(16)));
+        driver
+    }
+
+    /// A virtualizable whose arrays the entry preamble can reload gets armed:
+    /// `warmspot.py:520-545` names it on the static data, which is what makes
+    /// `compile.py:508-511` run.
+    #[test]
+    fn arming_declares_the_contract_for_a_reloadable_virtualizable() {
+        let mut driver =
+            driver_with_one_vable_array(crate::virtualizable::VableArrayStorage::DirectPointer);
+        assert!(driver.arm_flat_entry_contract(FlatEntryContract {
+            len: 2,
+            index_of_virtualizable: 1,
+        }));
+        assert_eq!(
+            driver.flat_entry_contract(),
+            Some(FlatEntryContract {
+                len: 2,
+                index_of_virtualizable: 1,
+            })
+        );
+        // The name comes from the vinfo the gate was answered about, so the
+        // descriptor cannot end up naming a different virtualizable.
+        assert_eq!(
+            driver.descriptor.as_ref().unwrap().virtualizable.as_deref(),
+            Some("state")
+        );
+    }
+
+    /// A `Vec` embedded by value has no offset a field load can reach its data
+    /// pointer at, so `patch_new_loop_to_load_virtualizable_fields` refuses that
+    /// storage. Arming must decline BEFORE the driver reaches that refusal, and
+    /// leave the descriptor exactly as it found it — no contract and no name, so
+    /// the entry keeps the shape it already had.
+    #[test]
+    fn arming_declines_a_virtualizable_the_entry_preamble_cannot_reload() {
+        fn data_ptr(_: *mut u8) -> *mut i64 {
+            std::ptr::null_mut()
+        }
+        fn len(_: *const u8) -> usize {
+            0
+        }
+        let mut driver =
+            driver_with_one_vable_array(crate::virtualizable::VableArrayStorage::RustVec {
+                data_ptr_fn: data_ptr,
+                len_fn: len,
+            });
+        assert!(!driver.arm_flat_entry_contract(FlatEntryContract {
+            len: 2,
+            index_of_virtualizable: 1,
+        }));
+        assert_eq!(driver.flat_entry_contract(), None);
+        let descriptor = driver.descriptor.as_ref().expect("descriptor survives");
+        assert_eq!(descriptor.virtualizable, None);
+        assert_eq!(descriptor.virtualizable_arg_index(), None);
+    }
+
+    /// With no virtualizable there is nothing for the preamble to reload from,
+    /// so there is no contract to declare either.
+    #[test]
+    fn arming_declines_a_driver_with_no_virtualizable_info() {
+        let mut driver = JitDriver::<TypedRestoreState>::new(1);
+        driver.declare_schema_typed(vec![("pc", GreenType::Int)], vec![("state", Type::Ref)]);
+        assert!(!driver.arm_flat_entry_contract(FlatEntryContract {
+            len: 2,
+            index_of_virtualizable: 1,
+        }));
+        assert_eq!(driver.flat_entry_contract(), None);
     }
 
     #[test]

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -96,6 +96,7 @@ pub mod resume_box_reader;
 pub(crate) mod ruleopt;
 pub mod support;
 mod trace_ctx;
+pub mod virt_array;
 pub mod virtualizable;
 pub mod virtualref;
 pub mod walkvirtual;

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -127,10 +127,10 @@ pub use jitcode::{
     RuntimeDescrTable, init_global_build_descr_pool, insns, live_slots_for_state_field_jit,
 };
 pub use jitdriver::{
-    DeclarativeJitDriver, JitDriver, JitDriverStaticData, MultiFrameBlackholeResult,
-    PendingAbortBlackhole, SingleFrameBlackholeResult, TraceContinuationSuspendGuard,
-    current_state_field_fvc_epoch, drive_multi_frame_blackhole, drive_single_frame_blackhole,
-    no_bridge_enabled, trace_continuation_suspended,
+    DeclarativeJitDriver, FlatEntryContract, JitDriver, JitDriverStaticData,
+    MultiFrameBlackholeResult, PendingAbortBlackhole, SingleFrameBlackholeResult,
+    TraceContinuationSuspendGuard, current_state_field_fvc_epoch, drive_multi_frame_blackhole,
+    drive_single_frame_blackhole, no_bridge_enabled, trace_continuation_suspended,
 };
 pub use majit_backend::CompiledTraceInfo;
 pub use pyjitpl::{eval_binop_f, eval_binop_i, eval_float_cmp, eval_unary_f, eval_unary_i};

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -16169,6 +16169,17 @@ impl<M: Clone> MetaInterp<M> {
             target_sd.num_reds(),
             "pyjitpl.py:3596 — direct_assembler_call args.len() must match num_red_args",
         );
+        // `args` is that red list, and the vable is picked out of it below by
+        // the index the target token carries, so the token's index has to be a
+        // position among the reds (`warmspot.py:537`). A driver whose compiled
+        // entry is a flat state-field prefix numbers its virtualizable in the
+        // entry instead; the two coordinate systems have never met because no
+        // such driver mints a CALL_ASSEMBLER token, and this says so.
+        debug_assert!(
+            target_sd.flat_entry_contract().is_none(),
+            "a flat-entry driver's virtualizable index is not a position in \
+             the reds, but direct_assembler_call selects out of the red list",
+        );
         // pyjitpl.py:3597-3599 token = warmrunnerstate.get_assembler_token(greenargs).
         //
         // Pull `arg_types` from `target_sd.red_args_types`

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11499,15 +11499,15 @@ impl<M: Clone> MetaInterp<M> {
     #[inline]
     pub fn resolve_cell_key(
         &self,
-        green_key: u64,
+        green_key_hash: u64,
         structured_green_key: Option<&dyn Fn() -> majit_ir::GreenKey>,
     ) -> u64 {
         match structured_green_key {
-            Some(make_key) => self.warm_state.resolve_cell_key(green_key, make_key),
+            Some(make_key) => self.warm_state.resolve_cell_key(green_key_hash, make_key),
             None => self
                 .warm_state
-                .sole_cell_key(green_key)
-                .unwrap_or(green_key),
+                .sole_cell_key(green_key_hash)
+                .unwrap_or(green_key_hash),
         }
     }
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10516,15 +10516,47 @@ impl<M: Clone> MetaInterp<M> {
         live_values: &[Value],
         dispatch_key: u32,
     ) -> Option<CompileResult<M>> {
-        let meta = self.compiled_loops.get(&green_key)?.meta.clone();
         // warmstate.py:398: execute the token returned by the JitCell, not
         // the compiled-metadata index's possibly retired predecessor.
+        //
+        // This is the resolving form, for callers that reach the run without
+        // having decided anything about the cell first. A caller that already
+        // gated on the token holds it and calls the run directly.
         let token = self.warm_state.get_procedure_token(green_key)?;
+        self.execute_assembler_at_dispatch_key(&token, green_key, live_values, dispatch_key)
+    }
+
+    /// `warmstate.py:405-419 execute_assembler(loop_token, *args)`: the run
+    /// RECEIVES the token whoever decided to enter already resolved, and never
+    /// looks the cell up again. Upstream hands it over the same way —
+    /// `warmstate.py:483` reads `procedure_token = cell.get_procedure_token()`
+    /// once per `maybe_compile_and_run` and `:509-511` carries it out through
+    /// `raise EnterJitAssembler(procedure_token, *execute_args)`.
+    ///
+    /// A caller that holds no token yet goes through
+    /// [`Self::run_compiled_detailed_with_values_at_dispatch_key`], which is
+    /// this one with the resolve in front.
+    ///
+    /// What is passed must be a token read off the JitCell — the artifact
+    /// `compiled_loops` indexes is metadata and can still name a predecessor a
+    /// recompile or redirect has already replaced, and entering that one
+    /// re-enters invalidated machine code and fails GUARD_NOT_INVALIDATED on
+    /// every iteration.
+    pub fn execute_assembler_at_dispatch_key(
+        &mut self,
+        procedure_token: &std::sync::Arc<JitCellToken>,
+        green_key: u64,
+        live_values: &[Value],
+        dispatch_key: u32,
+    ) -> Option<CompileResult<M>> {
+        let meta = self.compiled_loops.get(&green_key)?.meta.clone();
 
         Self::prepare_compiled_run_io();
-        let frame = self
-            .backend
-            .execute_token_with_dispatch_key(&token, live_values, dispatch_key);
+        let frame = self.backend.execute_token_with_dispatch_key(
+            procedure_token,
+            live_values,
+            dispatch_key,
+        );
         // RPython: bridge compilation happens synchronously inside
         // assembler_call_helper (called from compiled code). No deferred queue.
 
@@ -11436,17 +11468,35 @@ impl<M: Clone> MetaInterp<M> {
     /// `is_invalidated` AND here.
     #[inline]
     pub fn has_compiled_loop(&self, green_key: u64) -> bool {
-        // warmstate.py:482-511 maybe_compile_and_run gates execution entry on
-        // `cell.get_procedure_token() is not None` (code present), NOT on
-        // has_compiled_targets. An entry bridge (ResumeFromInterpDescr) has
-        // compiled code but may carry 0 target_tokens; gating on
-        // has_target_tokens() refused to dispatch it, so the interp re-ticked
-        // the green key every back-edge -> bound_reached -> decay_all_counters
-        // flood that starved the guard-failure bridge counter. Gate on
-        // has_compiled_code() so a code-present token is entered directly.
+        self.entry_procedure_token(green_key).is_some()
+    }
+
+    /// `warmstate.py:483` `procedure_token = cell.get_procedure_token()` — the
+    /// entry decision's single read of the cell's current token, handed back so
+    /// the caller can carry it into the run instead of resolving a second time.
+    /// Upstream carries it the same way: `warmstate.py:509-511 raise
+    /// EnterJitAssembler(procedure_token, *execute_args)` passes the resolved
+    /// token to `execute_assembler`, which never re-reads the cell.
+    ///
+    /// `None` is upstream's `procedure_token is None`, where the entry falls
+    /// through to the counter tick. [`Self::has_compiled_loop`] is the boolean
+    /// form of exactly this question and is defined in terms of it, so a
+    /// decision taken through the predicate and a run taken through the token
+    /// cannot be about different objects.
+    ///
+    /// warmstate.py:482-511 maybe_compile_and_run gates execution entry on
+    /// `cell.get_procedure_token() is not None` (code present), NOT on
+    /// has_compiled_targets. An entry bridge (ResumeFromInterpDescr) has
+    /// compiled code but may carry 0 target_tokens; gating on
+    /// has_target_tokens() refused to dispatch it, so the interp re-ticked
+    /// the green key every back-edge -> bound_reached -> decay_all_counters
+    /// flood that starved the guard-failure bridge counter. Gate on
+    /// has_compiled_code() so a code-present token is entered directly.
+    #[inline]
+    pub fn entry_procedure_token(&self, green_key: u64) -> Option<std::sync::Arc<JitCellToken>> {
         self.warm_state
             .get_procedure_token(green_key)
-            .is_some_and(|token| token.has_compiled_code())
+            .filter(|token| token.has_compiled_code())
     }
 
     /// `warmstate.py:458-464` — the same code-presence gate as

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -95,7 +95,7 @@ use crate::compile;
 use crate::compile::make_jitcell_token;
 pub use crate::compile::{
     CompileResult, CompiledExitLayout, CompiledTerminalExitLayout, CompiledTraceLayout,
-    DeadFrameArtifacts, RawCompileResult,
+    DeadFrameArtifacts, ExitTypes, RawCompileResult,
 };
 use crate::io_buffer;
 use crate::jitdriver::JitDriverStaticData;
@@ -358,7 +358,7 @@ impl StoredExitLayout {
             trace_id,
             fail_index,
             source_op_index: self.source_op_index,
-            exit_types: self.resolve_exit_types().to_vec(),
+            exit_types: ExitTypes::from_slice(self.resolve_exit_types()),
             is_finish: self.resolve_is_finish(),
             is_exception_exit: self.resolve_is_exception_exit(),
             gc_ref_slots: self.gc_ref_slots.clone(),
@@ -2616,7 +2616,7 @@ impl<M: Clone> MetaInterp<M> {
         let trace_id = descr.trace_id();
         let is_finish = descr.is_finish();
         let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
-        let exit_types = descr.fail_arg_types().to_vec();
+        let exit_types = ExitTypes::from_slice(descr.fail_arg_types());
         let gc_ref_slots: Vec<usize> = exit_types
             .iter()
             .enumerate()
@@ -2816,11 +2816,13 @@ impl<M: Clone> MetaInterp<M> {
                         layout.rd_pendingfields.clone().unwrap_or_default(),
                     )
                 });
-                let exit_types = if layout.fail_arg_types.is_empty() {
+                // `from_vec`, so whichever arm wins hands over the buffer it
+                // already owns instead of being copied into a fresh one.
+                let exit_types = ExitTypes::from_vec(if layout.fail_arg_types.is_empty() {
                     frontend_exit_types.unwrap_or_default()
                 } else {
                     layout.fail_arg_types
-                };
+                });
                 let gc_ref_slots = if layout.gc_ref_slots.is_empty() {
                     exit_types
                         .iter()
@@ -2860,7 +2862,7 @@ impl<M: Clone> MetaInterp<M> {
                 trace_id,
                 fail_index: layout.fail_index,
                 source_op_index: Some(layout.op_index),
-                exit_types: layout.exit_types,
+                exit_types: ExitTypes::from_vec(layout.exit_types),
                 is_finish: layout.is_finish,
                 is_exception_exit: layout.is_exception_exit,
                 gc_ref_slots: layout.gc_ref_slots,
@@ -2907,7 +2909,7 @@ impl<M: Clone> MetaInterp<M> {
                         trace_id,
                         fail_index: layout.fail_index,
                         source_op_index: layout.source_op_index,
-                        exit_types: layout.fail_arg_types,
+                        exit_types: ExitTypes::from_vec(layout.fail_arg_types),
                         is_finish: layout.is_finish,
                         is_exception_exit: layout.is_exception_exit,
                         gc_ref_slots: layout.gc_ref_slots,
@@ -2963,7 +2965,7 @@ impl<M: Clone> MetaInterp<M> {
                             trace_id,
                             fail_index: layout.fail_index,
                             source_op_index: Some(layout.op_index),
-                            exit_types: layout.exit_types,
+                            exit_types: ExitTypes::from_vec(layout.exit_types),
                             is_finish: layout.is_finish,
                             is_exception_exit: layout.is_exception_exit,
                             gc_ref_slots: layout.gc_ref_slots,
@@ -10230,7 +10232,7 @@ impl<M: Clone> MetaInterp<M> {
                     source_op_index: layout
                         .source_op_index
                         .or_else(|| trace_layout_ref.and_then(|layout| layout.source_op_index)),
-                    exit_types: layout.fail_arg_types,
+                    exit_types: ExitTypes::from_vec(layout.fail_arg_types),
                     is_finish: layout.is_finish,
                     is_exception_exit: layout.is_exception_exit,
                     gc_ref_slots: layout.gc_ref_slots,
@@ -10342,7 +10344,10 @@ impl<M: Clone> MetaInterp<M> {
         let trace_id = descr.trace_id();
         let is_finish = descr.is_finish();
         let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
-        let exit_types = descr.fail_arg_types().to_vec();
+        // Borrowed, not copied — see the sibling
+        // `run_compiled_detailed_with_values_at_dispatch_key` for why the copy
+        // does not belong on a path every entry takes.
+        let exit_types: &[Type] = descr.fail_arg_types();
         let gc_ref_slots: Vec<usize> = exit_types
             .iter()
             .enumerate()
@@ -10383,7 +10388,7 @@ impl<M: Clone> MetaInterp<M> {
                 trace_id,
                 fail_index,
                 source_op_index: None,
-                exit_types: exit_types.clone(),
+                exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
                 gc_ref_slots,
@@ -10412,7 +10417,7 @@ impl<M: Clone> MetaInterp<M> {
                     trace_id,
                     fail_index,
                     source_op_index: None,
-                    exit_types: exit_types.clone(),
+                    exit_types: ExitTypes::from_slice(exit_types),
                     is_finish,
                     is_exception_exit: is_exit_frame_with_exception,
                     gc_ref_slots,
@@ -10575,7 +10580,7 @@ impl<M: Clone> MetaInterp<M> {
                 trace_id,
                 fail_index,
                 source_op_index: None,
-                exit_types: exit_types.to_vec(),
+                exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
                 // Moved rather than cloned: the `else` arm below is the only
@@ -10604,7 +10609,7 @@ impl<M: Clone> MetaInterp<M> {
                     trace_id,
                     fail_index,
                     source_op_index: None,
-                    exit_types: exit_types.to_vec(),
+                    exit_types: ExitTypes::from_slice(exit_types),
                     is_finish,
                     is_exception_exit: is_exit_frame_with_exception,
                     gc_ref_slots,
@@ -12062,7 +12067,7 @@ impl<M: Clone> MetaInterp<M> {
     ) -> Option<Vec<Type>> {
         let exit_layout =
             self.get_compiled_exit_layout_in_trace(green_key, trace_id, fail_index)?;
-        Some(exit_layout.exit_types.clone())
+        Some(exit_layout.exit_types.to_vec())
     }
 
     /// resume.py:924-926 _prepare: get rd_virtuals + rd_pendingfields
@@ -23295,7 +23300,7 @@ mod tests {
         let layout = meta
             .get_compiled_exit_layout_in_trace(green_key, trace_id, fail_index)
             .expect("previous token backend layout should remain visible");
-        assert_eq!(layout.exit_types, vec![Type::Int]);
+        assert_eq!(layout.exit_types.as_slice(), [Type::Int]);
         assert!(!layout.is_finish);
         assert_eq!(
             meta.get_exit_types(green_key, trace_id, fail_index),
@@ -23407,7 +23412,10 @@ mod tests {
                 .map(|storage| storage.rd_numb.clone()),
             expected_rd_numb
         );
-        assert_eq!(recovery.exit_layout.exit_types, expected_exit_types);
+        assert_eq!(
+            recovery.exit_layout.exit_types.as_slice(),
+            expected_exit_types
+        );
     }
 
     #[cfg(all(feature = "dynasm", not(feature = "cranelift")))]

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -363,8 +363,8 @@ impl StoredExitLayout {
             is_exception_exit: self.resolve_is_exception_exit(),
             gc_ref_slots: self.gc_ref_slots.clone(),
             force_token_slots: self.force_token_slots.clone(),
-            recovery_layout: self.recovery_layout.clone(),
-            resume_layout: self.resume_layout.clone(),
+            recovery_layout: self.recovery_layout.clone().map(Box::new),
+            resume_layout: self.resume_layout.clone().map(Box::new),
             storage: self.storage.clone(),
         }
     }
@@ -2842,7 +2842,7 @@ impl<M: Clone> MetaInterp<M> {
                     is_exception_exit: layout.is_exception_exit,
                     gc_ref_slots,
                     force_token_slots: layout.force_token_slots,
-                    recovery_layout: layout.recovery_layout,
+                    recovery_layout: layout.recovery_layout.map(Box::new),
                     resume_layout: None,
                     storage,
                 }
@@ -2867,7 +2867,7 @@ impl<M: Clone> MetaInterp<M> {
                 is_exception_exit: layout.is_exception_exit,
                 gc_ref_slots: layout.gc_ref_slots,
                 force_token_slots: layout.force_token_slots,
-                recovery_layout: layout.recovery_layout,
+                recovery_layout: layout.recovery_layout.map(Box::new),
                 resume_layout: None,
                 storage: None,
             })
@@ -2914,7 +2914,7 @@ impl<M: Clone> MetaInterp<M> {
                         is_exception_exit: layout.is_exception_exit,
                         gc_ref_slots: layout.gc_ref_slots,
                         force_token_slots: layout.force_token_slots,
-                        recovery_layout: layout.recovery_layout,
+                        recovery_layout: layout.recovery_layout.map(Box::new),
                         resume_layout: merged
                             .get(&layout.fail_index)
                             .and_then(|existing| existing.resume_layout.clone()),
@@ -2970,7 +2970,7 @@ impl<M: Clone> MetaInterp<M> {
                             is_exception_exit: layout.is_exception_exit,
                             gc_ref_slots: layout.gc_ref_slots,
                             force_token_slots: layout.force_token_slots,
-                            recovery_layout: layout.recovery_layout,
+                            recovery_layout: layout.recovery_layout.map(Box::new),
                             resume_layout: merged
                                 .get(&layout.op_index)
                                 .and_then(|existing| existing.exit_layout.resume_layout.clone()),
@@ -10220,7 +10220,7 @@ impl<M: Clone> MetaInterp<M> {
                 let trace_layout_ref = trace_layout.as_ref();
                 let mut resume_layout = trace_layout
                     .as_ref()
-                    .and_then(|tl| tl.resume_layout.clone());
+                    .and_then(|tl| tl.resume_layout.as_deref().cloned());
                 compile::enrich_resume_layout_with_frame_stack(
                     &mut resume_layout,
                     layout.frame_stack.as_deref(),
@@ -10237,10 +10237,10 @@ impl<M: Clone> MetaInterp<M> {
                     is_exception_exit: layout.is_exception_exit,
                     gc_ref_slots: layout.gc_ref_slots,
                     force_token_slots: layout.force_token_slots,
-                    recovery_layout: layout.recovery_layout.or_else(|| {
+                    recovery_layout: layout.recovery_layout.map(Box::new).or_else(|| {
                         trace_layout_ref.and_then(|layout| layout.recovery_layout.clone())
                     }),
-                    resume_layout,
+                    resume_layout: resume_layout.map(Box::new),
                     storage: trace_layout_ref.and_then(|layout| layout.storage.clone()),
                 }
             })
@@ -12014,7 +12014,7 @@ impl<M: Clone> MetaInterp<M> {
             self.get_compiled_exit_layout_in_trace(green_key, trace_id, fail_index)?;
         Some(Self::recovery_slot_types_from_exit_types_and_layout(
             &exit_layout.exit_types,
-            exit_layout.recovery_layout.as_ref(),
+            exit_layout.recovery_layout.as_deref(),
         ))
     }
 
@@ -12105,7 +12105,7 @@ impl<M: Clone> MetaInterp<M> {
             storage,
             Self::recovery_slot_types_from_exit_types_and_layout(
                 &layout.exit_types,
-                layout.recovery_layout.as_ref(),
+                layout.recovery_layout.as_deref(),
             ),
         ))
     }
@@ -13988,7 +13988,7 @@ impl<M: Clone> MetaInterp<M> {
             .resume_layout
             .as_ref()
             .map(|layout| layout.reconstruct_state(fail_values));
-        let resume_layout = exit_layout.resume_layout.clone();
+        let resume_layout = exit_layout.resume_layout.as_deref().cloned();
         let reconstructed = reconstructed_state
             .as_ref()
             .map(|state| state.frames.clone());

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -4825,6 +4825,19 @@ impl<M: Clone> MetaInterp<M> {
         let Some(driver) = driver_descriptor else {
             return input_types;
         };
+        // A driver that declares a flat entry contract has no red list to
+        // synthesise the shape from — its entry slots ARE the leading
+        // inputargs, in the order `extract_live_values()` emits them, so the
+        // contract is the prefix of the types already in hand. Take it before
+        // the red-list path below, which would answer with a red count that
+        // describes a different model.
+        if let Some(flat) = driver.flat_entry_contract() {
+            let mut input_types = input_types;
+            if input_types.len() > flat.len {
+                input_types.truncate(flat.len);
+            }
+            return input_types;
+        }
         let Some(_) = driver.virtualizable_arg_index() else {
             return input_types;
         };
@@ -5801,8 +5814,21 @@ impl<M: Clone> MetaInterp<M> {
         let Some(index_of_vable) = driver.virtualizable_arg_index() else {
             return;
         };
-        let num_red_args = driver.num_reds();
-        if inputargs.len() <= num_red_args {
+        // compile.py:431 spells the entry contract's width as
+        // `jitdriver_sd.num_red_args`, because upstream's compiled entry is
+        // invoked with the jitdriver's reds (`warmstate.py:387
+        // execute_assembler`). A driver whose entry is a flat state-field
+        // prefix has a different width — its reds describe the merge-point
+        // payload, in which the whole state is a single red — and the red
+        // count is neither an upper bound on nor a scaled version of it, so
+        // using it there would truncate in the middle of the live entry values
+        // and reinterpret the rest as virtualizable fields. Ask the descriptor
+        // which model it is in.
+        let entry_prefix_len = match driver.flat_entry_contract() {
+            Some(flat) => flat.len,
+            None => driver.num_reds(),
+        };
+        if inputargs.len() <= entry_prefix_len {
             // Trace was never expanded (no virtualizable fields live at entry).
             return;
         }
@@ -5837,7 +5863,7 @@ impl<M: Clone> MetaInterp<M> {
             inputargs,
             vinfo,
             &array_lengths,
-            num_red_args,
+            entry_prefix_len,
             index_of_vable,
             constants,
         );
@@ -19167,6 +19193,7 @@ mod metainterp_static_data_tests {
             index: None,
             vars: vec![],
             virtualizable: None,
+            flat_entry: None,
             result_type: majit_ir::Type::Ref,
             is_recursive: false,
             mainjitcode: None,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -95,7 +95,7 @@ use crate::compile;
 use crate::compile::make_jitcell_token;
 pub use crate::compile::{
     CompileResult, CompiledExitLayout, CompiledTerminalExitLayout, CompiledTraceLayout,
-    DeadFrameArtifacts, ExitTypes, RawCompileResult,
+    DeadFrameArtifacts, ExitRawValues, ExitTypes, ExitValues, RawCompileResult,
 };
 use crate::io_buffer;
 use crate::jitdriver::JitDriverStaticData;
@@ -1392,7 +1392,7 @@ pub struct MetaInterp<M: Clone> {
     /// `Option<resume_pc>` back-edge signature cannot express the outcome —
     /// this carries the result value out of band instead. Set by
     /// `back_edge_internal`, `take`n by `JitDriver::take_back_edge_finish*`.
-    pub(crate) back_edge_finish: Option<Vec<Value>>,
+    pub(crate) back_edge_finish: Option<ExitValues>,
     /// Single-pass tracing: the walk-final scalar state-field values captured
     /// off the still-live sym at the CloseLoop point (scalar state-field index
     /// order, idx `0..num_scalars`), BEFORE the CloseLoop arm clears the sym.
@@ -10303,8 +10303,10 @@ impl<M: Clone> MetaInterp<M> {
         let descr_arc = result.descr_arc.clone();
 
         Some(RawCompileResult {
-            values: result.outputs,
-            typed_values: result.typed_outputs,
+            // The backend already owns these as heap vectors, so the inline
+            // spelling adopts the buffers rather than re-decoding into them.
+            values: ExitRawValues::from_vec(result.outputs),
+            typed_values: ExitValues::from_vec(result.typed_outputs),
             meta,
             fail_index,
             trace_id,
@@ -10438,8 +10440,8 @@ impl<M: Clone> MetaInterp<M> {
         if exit_types.len() > exit_layout.exit_types.len() {
             exit_layout.exit_types.resize(exit_types.len(), Type::Int);
         }
-        let mut values = Vec::with_capacity(exit_arity);
-        let mut typed_values = Vec::with_capacity(exit_arity);
+        let mut values = ExitRawValues::with_capacity(exit_arity);
+        let mut typed_values = ExitValues::with_capacity(exit_arity);
         for (i, &tp) in exit_types.iter().enumerate() {
             match tp {
                 Type::Int => {
@@ -10630,8 +10632,8 @@ impl<M: Clone> MetaInterp<M> {
         if exit_types.len() > exit_layout.exit_types.len() {
             exit_layout.exit_types.resize(exit_types.len(), Type::Int);
         }
-        let mut values = Vec::with_capacity(exit_arity);
-        let mut typed_values = Vec::with_capacity(exit_arity);
+        let mut values = ExitRawValues::with_capacity(exit_arity);
+        let mut typed_values = ExitValues::with_capacity(exit_arity);
         for (i, &tp) in exit_types.iter().enumerate() {
             match tp {
                 Type::Int => {
@@ -13975,7 +13977,7 @@ impl<M: Clone> MetaInterp<M> {
         let fail_index = result.fail_index;
         let trace_id = result.trace_id;
         let is_finish = result.is_finish;
-        let values = result.values.clone();
+        let values = result.values.to_vec();
         let typed_values = result.typed_values.clone();
         let savedata = result.savedata;
         let exception = result.exception.clone();

--- a/majit/majit-metainterp/src/virt_array.rs
+++ b/majit/majit-metainterp/src/virt_array.rs
@@ -36,9 +36,34 @@ use crate::virtualizable::VirtualizableInfo;
 const BLOCK_SIZE_SLOT: usize = majit_gc::header::GcHeader::SIZE;
 /// Bytes reserved for the zeroed header word in front of a block.
 const BLOCK_HEADER: usize = majit_gc::header::GcHeader::SIZE;
-/// Distance from the allocation base to the block pointer handed out.
+/// Distance from the block pointer back to the size slot.
+///
+/// The size slot and the header word sit immediately behind the block pointer,
+/// in that order, so a header-relative probe at a small negative offset lands
+/// inside the allocation.
 const BLOCK_PREFIX: usize = BLOCK_SIZE_SLOT + BLOCK_HEADER;
 const _: () = assert!(BLOCK_SIZE_SLOT >= std::mem::size_of::<u64>());
+
+/// Distance from the allocation base to the block pointer handed out, for an
+/// item type of `align`.
+///
+/// The allocation base carries the item's alignment, but the block pointer is
+/// the base advanced past the prefix, and the payload is the block pointer
+/// advanced by [`block_items_offset`]. Neither of those two steps can repair an
+/// alignment the first one broke, so the prefix — not the payload offset — is
+/// where an item needing more alignment than the size slot and header word
+/// provide is padded for. The padding goes in front of the size slot, leaving
+/// the header word adjacent to the block.
+///
+/// ```text
+///   base            block-16        block-8        block
+///   [ padding … ]   [ total size ]  [ header ]     [ length ][ payload … ]
+/// ```
+const fn block_base_offset(align: usize) -> usize {
+    let word = std::mem::align_of::<usize>();
+    let align = if align < word { word } else { align };
+    BLOCK_PREFIX.div_ceil(align) * align
+}
 
 /// Offset of the length word from the block pointer.
 ///
@@ -132,6 +157,14 @@ impl<T: Copy> VirtArray<T> {
     pub const LENGTH_OFFSET: usize = BLOCK_LENGTH_OFFSET;
     /// Offset of item 0 from the field's pointer value.
     pub const ITEMS_OFFSET: usize = block_items_offset(std::mem::align_of::<T>());
+    /// Distance from the allocation base to the field's pointer value.
+    const BASE_OFFSET: usize = block_base_offset(std::mem::align_of::<T>());
+
+    /// The payload lives at base + [`Self::BASE_OFFSET`] + [`Self::ITEMS_OFFSET`],
+    /// and the slice handed out over it is only sound when that address carries
+    /// the item's alignment. The base does, so the two offsets have to as well.
+    const _PAYLOAD_ALIGNED: () =
+        assert!((Self::BASE_OFFSET + Self::ITEMS_OFFSET).is_multiple_of(std::mem::align_of::<T>()));
 
     /// An empty array.
     pub fn new() -> Self {
@@ -195,7 +228,11 @@ impl<T: Copy> VirtArray<T> {
         *self = grown;
     }
 
-    /// Drop every item, keeping the array allocated as an empty one.
+    /// Discard every item, leaving a zero-length array.
+    ///
+    /// A block has no spare capacity, so this releases the old block and
+    /// allocates an empty one; a caller counting allocations sees both. An
+    /// array that is already zero-length keeps the block it has.
     pub fn clear(&mut self) {
         // `resize` needs an item to fill with and a shrink to zero never uses
         // one, so go straight to the empty block rather than invent a value.
@@ -207,6 +244,9 @@ impl<T: Copy> VirtArray<T> {
     /// Allocate a block for `len` items, off any collector, and write its
     /// length word. The items are left as the allocator returned them.
     fn alloc_block(len: usize) -> *mut u8 {
+        // An associated const is only evaluated where it is named, so naming it
+        // here is what makes the alignment assert run for this `T`.
+        let () = Self::_PAYLOAD_ALIGNED;
         let layout = Self::block_layout(len);
         // Zeroed rather than uninitialized: the header word in the prefix must
         // read as clear flags (see the module comment), and clearing the payload
@@ -217,8 +257,8 @@ impl<T: Copy> VirtArray<T> {
             std::alloc::handle_alloc_error(layout);
         }
         unsafe {
-            *(base as *mut u64) = layout.size() as u64;
-            let block = base.add(BLOCK_PREFIX);
+            let block = base.add(Self::BASE_OFFSET);
+            *(block.sub(BLOCK_PREFIX) as *mut u64) = layout.size() as u64;
             *(block.add(Self::LENGTH_OFFSET) as *mut usize) = len;
             block
         }
@@ -228,7 +268,7 @@ impl<T: Copy> VirtArray<T> {
         let items = std::mem::size_of::<T>()
             .checked_mul(len)
             .expect("virtualizable array payload size overflowed");
-        let total = BLOCK_PREFIX
+        let total = Self::BASE_OFFSET
             .checked_add(Self::ITEMS_OFFSET)
             .and_then(|prefix| prefix.checked_add(items))
             .expect("virtualizable array block size overflowed");
@@ -245,12 +285,14 @@ impl<T: Copy> VirtArray<T> {
 
 impl<T: Copy> Drop for VirtArray<T> {
     fn drop(&mut self) {
-        // The block pointer is not the allocation base — the size slot and the
-        // header word precede it — so the size slot is what says how much to
-        // release, exactly as `free_off_gc_jitframe` reads it.
+        // The block pointer is not the allocation base — the size slot, the
+        // header word and any alignment padding precede it — so the size slot
+        // is what says how much to release, exactly as `free_off_gc_jitframe`
+        // reads it, and the base is the block stepped back over the whole
+        // prefix rather than over the size slot alone.
         unsafe {
-            let base = self.block.sub(BLOCK_PREFIX);
-            let total = *(base as *const u64) as usize;
+            let base = self.block.sub(Self::BASE_OFFSET);
+            let total = *(self.block.sub(BLOCK_PREFIX) as *const u64) as usize;
             let align = std::mem::align_of::<T>()
                 .max(std::mem::align_of::<usize>())
                 .max(BLOCK_SIZE_SLOT);

--- a/majit/majit-metainterp/src/virt_array.rs
+++ b/majit/majit-metainterp/src/virt_array.rs
@@ -44,6 +44,26 @@ const BLOCK_HEADER: usize = majit_gc::header::GcHeader::SIZE;
 const BLOCK_PREFIX: usize = BLOCK_SIZE_SLOT + BLOCK_HEADER;
 const _: () = assert!(BLOCK_SIZE_SLOT >= std::mem::size_of::<u64>());
 
+/// Alignment of a block's allocation, for an item type of `align`.
+///
+/// The prefix holds a `u64` size slot and a `GcHeader`, and the block starts
+/// with a `usize` length word, so the allocation must carry their alignments
+/// alongside the item's — as alignments, not as sizes: a size is not required
+/// to be a power of two, and `Layout` rejects one that is not.
+const fn block_align(align: usize) -> usize {
+    let mut result = align;
+    if std::mem::align_of::<u64>() > result {
+        result = std::mem::align_of::<u64>();
+    }
+    if std::mem::align_of::<usize>() > result {
+        result = std::mem::align_of::<usize>();
+    }
+    if majit_gc::header::GcHeader::ALIGN > result {
+        result = majit_gc::header::GcHeader::ALIGN;
+    }
+    result
+}
+
 /// Distance from the allocation base to the block pointer handed out, for an
 /// item type of `align`.
 ///
@@ -272,9 +292,7 @@ impl<T: Copy> VirtArray<T> {
             .checked_add(Self::ITEMS_OFFSET)
             .and_then(|prefix| prefix.checked_add(items))
             .expect("virtualizable array block size overflowed");
-        let align = std::mem::align_of::<T>()
-            .max(std::mem::align_of::<usize>())
-            .max(BLOCK_SIZE_SLOT);
+        let align = block_align(std::mem::align_of::<T>());
         Layout::from_size_align(total, align).expect("virtualizable array block layout")
     }
 
@@ -293,9 +311,7 @@ impl<T: Copy> Drop for VirtArray<T> {
         unsafe {
             let base = self.block.sub(Self::BASE_OFFSET);
             let total = *(self.block.sub(BLOCK_PREFIX) as *const u64) as usize;
-            let align = std::mem::align_of::<T>()
-                .max(std::mem::align_of::<usize>())
-                .max(BLOCK_SIZE_SLOT);
+            let align = block_align(std::mem::align_of::<T>());
             let layout = Layout::from_size_align(total, align)
                 .expect("virtualizable array block size slot was corrupted");
             std::alloc::dealloc(base, layout);

--- a/majit/majit-metainterp/src/virt_array.rs
+++ b/majit/majit-metainterp/src/virt_array.rs
@@ -1,0 +1,603 @@
+//! GcArray-shaped backing for a virtualizable array field.
+//!
+//! `virtualizable.py:57-58` builds one `cpu.arraydescrof(...)` per virtualizable
+//! array, and the field those descrs address is a `Ptr(GcArray)`: a single
+//! pointer word in the virtualizable struct, aimed at a block whose length word
+//! and payload sit at fixed offsets from the block address. That shape is what
+//! lets `compile.py:441-457` rebuild every element of the array inside the
+//! compiled entry from the virtualizable alone — `GETFIELD_GC_R` for the
+//! pointer, then one `GETARRAYITEM_GC_*` per element, both expressible in trace
+//! IR with nothing but byte offsets.
+//!
+//! A Rust `Vec<T>` embedded by value cannot serve that entry. Its data pointer
+//! is one of three words in an order the language does not specify, so no field
+//! load portably finds it, and reading the wrong word yields a capacity as a
+//! base address. [`VirtArray`] is the same logical container with the upstream
+//! physical shape: one owned pointer to a `[length][payload…]` block.
+//!
+//! The block is deliberately allocated *outside* any collector. A state struct
+//! carrying these arrays is a stack-resident non-GC local — its identity as a
+//! virtualizable is its own address (`virtualizable_heap_ptr`) — so nothing
+//! traces it, and a block in a moving nursery reachable only from there would be
+//! collected or relocated behind the array's back. This mirrors the off-GC
+//! JITFRAME allocation in `majit_backend::jitframe::alloc_off_gc_jitframe`,
+//! including its prefix: a size slot so the block pointer alone can free it, and
+//! a zeroed header word in front so a header-relative write-barrier probe reads
+//! in-bounds and answers "no barrier".
+
+use std::alloc::Layout;
+use std::marker::PhantomData;
+
+use majit_ir::Type;
+
+use crate::virtualizable::VirtualizableInfo;
+
+/// Bytes reserved for the total-allocation-size slot in front of a block.
+const BLOCK_SIZE_SLOT: usize = majit_gc::header::GcHeader::SIZE;
+/// Bytes reserved for the zeroed header word in front of a block.
+const BLOCK_HEADER: usize = majit_gc::header::GcHeader::SIZE;
+/// Distance from the allocation base to the block pointer handed out.
+const BLOCK_PREFIX: usize = BLOCK_SIZE_SLOT + BLOCK_HEADER;
+const _: () = assert!(BLOCK_SIZE_SLOT >= std::mem::size_of::<u64>());
+
+/// Offset of the length word from the block pointer.
+///
+/// `rlist.py:251` puts the GcArray length first and the items straight after it;
+/// `majit_rlib::lltypesystem::rlist::TypedItemsBlock` is the same lowering for
+/// the list-strategy body.
+pub const BLOCK_LENGTH_OFFSET: usize = 0;
+
+/// Offset of item 0 from the block pointer, for an item type of `align`.
+///
+/// The length word is one machine word, but an item may need more alignment
+/// than that (an `f64` payload on a 32-bit target), so the payload starts at the
+/// length word's end rounded up to the item's alignment.
+const fn block_items_offset(align: usize) -> usize {
+    let word = std::mem::size_of::<usize>();
+    let align = if align < word { word } else { align };
+    word.div_ceil(align) * align
+}
+
+/// How a virtualizable array field is physically laid out in its owner.
+///
+/// The two arms are the two things a field can hold: the container itself, or a
+/// pointer to it. Only the second can be reloaded by the compiled entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VirtArrayBackingKind {
+    /// The field embeds a Rust `Vec<T>` by value.
+    RustVec,
+    /// The field holds a pointer to a `[length][payload…]` block, with both
+    /// offsets measured from that pointer.
+    GcArrayBlock {
+        length_offset: usize,
+        items_offset: usize,
+    },
+}
+
+/// A container a `[..; virt]` state field may be declared with.
+///
+/// The interpreter author picks the backing by choosing the field's Rust type;
+/// this trait is how the generated `VirtualizableInfo` builder and the
+/// fresh-entry state constructor stay written once for both. Every read and
+/// write of the elements goes through the slice the container derefs to, so the
+/// two backings present the same surface to interpreter code.
+pub trait VirtArrayBacking: std::ops::DerefMut<Target = [Self::Item]> {
+    /// Element type. Restricted to `Copy` so a block is released by freeing it,
+    /// with no element drop glue to run.
+    type Item: Copy;
+
+    /// Physical shape of this container, and where its length and payload sit
+    /// when the shape has fixed offsets.
+    const BACKING: VirtArrayBackingKind;
+
+    /// `len` copies of `value` — the fresh-entry constructor.
+    fn filled(value: Self::Item, len: usize) -> Self;
+}
+
+impl<T: Copy> VirtArrayBacking for Vec<T> {
+    type Item = T;
+    const BACKING: VirtArrayBackingKind = VirtArrayBackingKind::RustVec;
+
+    fn filled(value: T, len: usize) -> Self {
+        vec![value; len]
+    }
+}
+
+/// A `Vec`-like array whose storage is a single owned pointer to a
+/// `[length][payload…]` block.
+///
+/// Read and write the elements through the slice this derefs to; the pointer
+/// word is what makes the container addressable from compiled code, and nothing
+/// else about it is meant to be visible to interpreter code.
+///
+/// Empty is still a real block, so the pointer is never null and item-0
+/// addressing never offsets from null.
+#[repr(C)]
+pub struct VirtArray<T: Copy> {
+    /// Points past the size slot and header word at the length word.
+    block: *mut u8,
+    _item: PhantomData<T>,
+}
+
+// The block is owned exclusively by this handle: no other handle can reach it,
+// and dropping the handle frees it. So it may cross threads exactly when its
+// items may.
+unsafe impl<T: Copy + Send> Send for VirtArray<T> {}
+unsafe impl<T: Copy + Sync> Sync for VirtArray<T> {}
+
+const _: () = assert!(std::mem::size_of::<VirtArray<i64>>() == std::mem::size_of::<usize>());
+
+impl<T: Copy> VirtArray<T> {
+    /// Offset of the length word from the field's pointer value.
+    pub const LENGTH_OFFSET: usize = BLOCK_LENGTH_OFFSET;
+    /// Offset of item 0 from the field's pointer value.
+    pub const ITEMS_OFFSET: usize = block_items_offset(std::mem::align_of::<T>());
+
+    /// An empty array.
+    pub fn new() -> Self {
+        Self::with_len(0)
+    }
+
+    /// `len` items of whatever the allocation returned. Only useful when the
+    /// caller writes every slot before reading it; [`VirtArray::filled`] is the
+    /// initialized form.
+    fn with_len(len: usize) -> Self {
+        let block = Self::alloc_block(len);
+        Self {
+            block,
+            _item: PhantomData,
+        }
+    }
+
+    /// `len` copies of `value`.
+    pub fn filled(value: T, len: usize) -> Self {
+        let mut this = Self::with_len(len);
+        this.fill(value);
+        this
+    }
+
+    /// A copy of `items`.
+    pub fn from_slice(items: &[T]) -> Self {
+        let mut this = Self::with_len(items.len());
+        this.copy_from_slice(items);
+        this
+    }
+
+    /// Number of items.
+    pub fn len(&self) -> usize {
+        unsafe { *(self.block.add(Self::LENGTH_OFFSET) as *const usize) }
+    }
+
+    /// Whether the array holds no items.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Grow or shrink to `new_len`, filling any new slot with `value` and
+    /// keeping every slot both lengths have.
+    ///
+    /// A block has no spare capacity — its length word is the allocation's
+    /// length, which is what makes the length readable from the block address
+    /// alone — so a length change is a reallocation. A length that does not
+    /// change is not, which is the case a caller reusing one array across calls
+    /// is in.
+    pub fn resize(&mut self, new_len: usize, value: T) {
+        let old_len = self.len();
+        if new_len == old_len {
+            return;
+        }
+        let mut grown = Self::with_len(new_len);
+        let kept = old_len.min(new_len);
+        grown[..kept].copy_from_slice(&self[..kept]);
+        for slot in &mut grown[kept..] {
+            *slot = value;
+        }
+        *self = grown;
+    }
+
+    /// Drop every item, keeping the array allocated as an empty one.
+    pub fn clear(&mut self) {
+        // `resize` needs an item to fill with and a shrink to zero never uses
+        // one, so go straight to the empty block rather than invent a value.
+        if self.len() != 0 {
+            *self = Self::with_len(0);
+        }
+    }
+
+    /// Allocate a block for `len` items, off any collector, and write its
+    /// length word. The items are left as the allocator returned them.
+    fn alloc_block(len: usize) -> *mut u8 {
+        let layout = Self::block_layout(len);
+        // Zeroed rather than uninitialized: the header word in the prefix must
+        // read as clear flags (see the module comment), and clearing the payload
+        // too means a caller that reads before writing sees zeros rather than
+        // whatever the allocator held.
+        let base = unsafe { std::alloc::alloc_zeroed(layout) };
+        if base.is_null() {
+            std::alloc::handle_alloc_error(layout);
+        }
+        unsafe {
+            *(base as *mut u64) = layout.size() as u64;
+            let block = base.add(BLOCK_PREFIX);
+            *(block.add(Self::LENGTH_OFFSET) as *mut usize) = len;
+            block
+        }
+    }
+
+    fn block_layout(len: usize) -> Layout {
+        let items = std::mem::size_of::<T>()
+            .checked_mul(len)
+            .expect("virtualizable array payload size overflowed");
+        let total = BLOCK_PREFIX
+            .checked_add(Self::ITEMS_OFFSET)
+            .and_then(|prefix| prefix.checked_add(items))
+            .expect("virtualizable array block size overflowed");
+        let align = std::mem::align_of::<T>()
+            .max(std::mem::align_of::<usize>())
+            .max(BLOCK_SIZE_SLOT);
+        Layout::from_size_align(total, align).expect("virtualizable array block layout")
+    }
+
+    fn items_ptr(&self) -> *mut T {
+        unsafe { self.block.add(Self::ITEMS_OFFSET) as *mut T }
+    }
+}
+
+impl<T: Copy> Drop for VirtArray<T> {
+    fn drop(&mut self) {
+        // The block pointer is not the allocation base — the size slot and the
+        // header word precede it — so the size slot is what says how much to
+        // release, exactly as `free_off_gc_jitframe` reads it.
+        unsafe {
+            let base = self.block.sub(BLOCK_PREFIX);
+            let total = *(base as *const u64) as usize;
+            let align = std::mem::align_of::<T>()
+                .max(std::mem::align_of::<usize>())
+                .max(BLOCK_SIZE_SLOT);
+            let layout = Layout::from_size_align(total, align)
+                .expect("virtualizable array block size slot was corrupted");
+            std::alloc::dealloc(base, layout);
+        }
+    }
+}
+
+impl<T: Copy> std::ops::Deref for VirtArray<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        unsafe { std::slice::from_raw_parts(self.items_ptr(), self.len()) }
+    }
+}
+
+impl<T: Copy> std::ops::DerefMut for VirtArray<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        unsafe { std::slice::from_raw_parts_mut(self.items_ptr(), self.len()) }
+    }
+}
+
+impl<T: Copy> Default for VirtArray<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T: Copy> Clone for VirtArray<T> {
+    fn clone(&self) -> Self {
+        Self::from_slice(self)
+    }
+}
+
+impl<T: Copy + std::fmt::Debug> std::fmt::Debug for VirtArray<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+impl<T: Copy> From<&[T]> for VirtArray<T> {
+    fn from(items: &[T]) -> Self {
+        Self::from_slice(items)
+    }
+}
+
+impl<T: Copy> FromIterator<T> for VirtArray<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let items: Vec<T> = iter.into_iter().collect();
+        Self::from_slice(&items)
+    }
+}
+
+impl<T: Copy> VirtArrayBacking for VirtArray<T> {
+    type Item = T;
+    const BACKING: VirtArrayBackingKind = VirtArrayBackingKind::GcArrayBlock {
+        length_offset: Self::LENGTH_OFFSET,
+        items_offset: Self::ITEMS_OFFSET,
+    };
+
+    fn filled(value: T, len: usize) -> Self {
+        VirtArray::filled(value, len)
+    }
+}
+
+/// Register one `[..; virt]` state field on `info`, in the shape its declared
+/// container has.
+///
+/// `witness` names the field's Rust type and is not called: a generated builder
+/// runs before any state instance exists, so the backing has to be resolved from
+/// the type rather than from a value.
+///
+/// `data_ptr_fn` and `len_fn` reach a `Vec` backing's items through `Vec`'s own
+/// methods, because there are no offsets that can. A block backing has offsets,
+/// so it registers as an ordinary array-pointer field and the extractors go
+/// unused — which is the whole difference the compiled entry sees.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "One call per declared field carries the field's whole description; splitting it into a context object would separate the offsets from the container they describe"
+)]
+pub fn register_virt_array_field<S, B: VirtArrayBacking>(
+    info: &mut VirtualizableInfo,
+    name: &str,
+    item_type: Type,
+    item_size: usize,
+    field_offset: usize,
+    data_ptr_fn: fn(*mut u8) -> *mut i64,
+    len_fn: fn(*const u8) -> usize,
+    witness: impl Fn(&S) -> &B,
+) {
+    let _ = witness;
+    match B::BACKING {
+        VirtArrayBackingKind::RustVec => {
+            info.add_rust_vec_array_field(
+                name,
+                item_type,
+                field_offset,
+                data_ptr_fn,
+                len_fn,
+                majit_ir::descr::make_array_descr(0, item_size, item_type),
+            );
+        }
+        VirtArrayBackingKind::GcArrayBlock {
+            length_offset,
+            items_offset,
+        } => {
+            // `virtualizable.py:58 cpu.arraydescrof(ARRAY)` — the descr an
+            // element access is emitted with. Its base is the payload offset, so
+            // `GETARRAYITEM_GC_*` against the pointer the field holds addresses
+            // item `i` directly, with no step in between for the entry to
+            // express.
+            info.add_array_field(
+                name,
+                item_type,
+                field_offset,
+                length_offset,
+                items_offset,
+                majit_ir::descr::make_array_descr(items_offset, item_size, item_type),
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_block_is_one_pointer_word_with_its_length_and_payload_at_fixed_offsets() {
+        let array = VirtArray::filled(7i64, 3);
+        // What the state field holds, i.e. what `GETFIELD_GC_R` would load.
+        let field: usize = unsafe { *(&array as *const VirtArray<i64> as *const usize) };
+        assert_ne!(field, 0, "an empty-or-not block is never null");
+
+        let length = unsafe { *((field + VirtArray::<i64>::LENGTH_OFFSET) as *const usize) };
+        assert_eq!(length, 3);
+
+        for index in 0..3 {
+            let item =
+                unsafe { *((field + VirtArray::<i64>::ITEMS_OFFSET + index * 8) as *const i64) };
+            assert_eq!(item, 7, "item {index} read through the block offsets");
+        }
+    }
+
+    #[test]
+    fn the_header_word_in_front_of_a_block_reads_as_clear_flags() {
+        let array = VirtArray::filled(0i64, 1);
+        let field = unsafe { *(&array as *const VirtArray<i64> as *const usize) };
+        // The word a header-relative probe would land on. In-bounds because the
+        // prefix reserves it, and zero because the block is allocated zeroed.
+        let header = unsafe { *((field - BLOCK_HEADER) as *const u64) };
+        assert_eq!(header, 0);
+    }
+
+    #[test]
+    fn resize_keeps_the_overlap_and_fills_the_rest() {
+        let mut array = VirtArray::from_slice(&[1i64, 2, 3]);
+        array.resize(5, 9);
+        assert_eq!(&array[..], &[1, 2, 3, 9, 9]);
+        array.resize(2, 0);
+        assert_eq!(&array[..], &[1, 2]);
+    }
+
+    #[test]
+    fn a_resize_to_the_same_length_keeps_the_block() {
+        let mut array = VirtArray::from_slice(&[1i64, 2, 3]);
+        let before = array.as_ptr();
+        array.resize(3, 0);
+        assert_eq!(
+            array.as_ptr(),
+            before,
+            "an unchanged length reallocates nothing"
+        );
+        assert_eq!(&array[..], &[1, 2, 3]);
+    }
+
+    #[test]
+    fn an_empty_array_still_has_a_block_to_address_item_zero_from() {
+        let array: VirtArray<i64> = VirtArray::new();
+        assert_eq!(array.len(), 0);
+        assert!(array.is_empty());
+        // The field's own word, not the slice's data pointer: the slice reports
+        // a dangling non-null address for an empty length either way, and it is
+        // the field the item-0 arithmetic starts from.
+        let field: usize = unsafe { *(&array as *const VirtArray<i64> as *const usize) };
+        assert_ne!(field, 0);
+    }
+
+    #[test]
+    fn a_float_payload_is_eight_byte_aligned_wherever_the_word_size_lands() {
+        let array = VirtArray::filled(1.5f64, 2);
+        assert_eq!(array.as_ptr() as usize % 8, 0);
+        assert_eq!(&array[..], &[1.5, 1.5]);
+        assert!(VirtArray::<f64>::ITEMS_OFFSET >= std::mem::size_of::<usize>());
+        assert_eq!(VirtArray::<f64>::ITEMS_OFFSET % 8, 0);
+    }
+
+    #[test]
+    fn the_slice_surface_is_the_one_a_vec_presents() {
+        let mut array = VirtArray::filled(0i64, 4);
+        array.copy_from_slice(&[4, 3, 2, 1]);
+        array[0] = 40;
+        assert_eq!(array.len(), 4);
+        assert_eq!(array.iter().copied().sum::<i64>(), 46);
+        assert_eq!(array.to_vec(), vec![40, 3, 2, 1]);
+        array.clear();
+        assert_eq!(array.len(), 0);
+    }
+
+    #[test]
+    fn the_two_backings_declare_different_shapes() {
+        assert_eq!(
+            <Vec<i64> as VirtArrayBacking>::BACKING,
+            VirtArrayBackingKind::RustVec
+        );
+        assert_eq!(
+            <VirtArray<i64> as VirtArrayBacking>::BACKING,
+            VirtArrayBackingKind::GcArrayBlock {
+                length_offset: 0,
+                items_offset: VirtArray::<i64>::ITEMS_OFFSET,
+            }
+        );
+    }
+
+    /// A field holding the block pointer registers as an ordinary array-pointer
+    /// field, which is the storage `compile.py:441-457` can rebuild from.
+    #[test]
+    fn a_block_backed_field_registers_as_an_array_pointer_field() {
+        #[repr(C)]
+        struct State {
+            regs: VirtArray<i64>,
+        }
+        fn data_ptr(p: *mut u8) -> *mut i64 {
+            unsafe { (*(p as *mut State)).regs.as_mut_ptr() }
+        }
+        fn len(p: *const u8) -> usize {
+            unsafe { (*(p as *const State)).regs.len() }
+        }
+
+        let mut info = VirtualizableInfo::without_vable_token();
+        register_virt_array_field(
+            &mut info,
+            "regs",
+            Type::Int,
+            8,
+            std::mem::offset_of!(State, regs),
+            data_ptr,
+            len,
+            |s: &State| &s.regs,
+        );
+
+        let field = &info.array_fields[0];
+        assert_eq!(
+            field.storage,
+            crate::virtualizable::VableArrayStorage::DirectPointer
+        );
+        assert_eq!(field.length_offset, VirtArray::<i64>::LENGTH_OFFSET);
+        assert_eq!(field.items_offset, VirtArray::<i64>::ITEMS_OFFSET);
+        assert!(field.can_read_length_from_heap());
+
+        // The element descr addresses the payload from the pointer the field
+        // holds, so an entry needs no step between the two loads.
+        let descr = info.array_item_descr(0);
+        let descr = descr.as_array_descr().expect("an array descr");
+        assert_eq!(descr.base_size(), VirtArray::<i64>::ITEMS_OFFSET);
+        assert_eq!(descr.item_size(), 8);
+    }
+
+    /// The same declaration on a `Vec` field keeps the storage that reads the
+    /// items through `Vec`'s own methods.
+    #[test]
+    fn a_vec_backed_field_registers_as_rust_vec_storage() {
+        #[repr(C)]
+        struct State {
+            regs: Vec<i64>,
+        }
+        fn data_ptr(p: *mut u8) -> *mut i64 {
+            unsafe { (*(p as *mut State)).regs.as_mut_ptr() }
+        }
+        fn len(p: *const u8) -> usize {
+            unsafe { (*(p as *const State)).regs.len() }
+        }
+
+        let mut info = VirtualizableInfo::without_vable_token();
+        register_virt_array_field(
+            &mut info,
+            "regs",
+            Type::Int,
+            8,
+            std::mem::offset_of!(State, regs),
+            data_ptr,
+            len,
+            |s: &State| &s.regs,
+        );
+
+        assert!(matches!(
+            info.array_fields[0].storage,
+            crate::virtualizable::VableArrayStorage::RustVec { .. }
+        ));
+    }
+
+    /// The heap-side readers the blackhole and the resume writer use reach the
+    /// items of a block-backed field through its registered offsets.
+    #[test]
+    fn the_vable_item_readers_reach_a_block_through_its_registered_offsets() {
+        #[repr(C)]
+        struct State {
+            regs: VirtArray<i64>,
+        }
+        fn data_ptr(p: *mut u8) -> *mut i64 {
+            unsafe { (*(p as *mut State)).regs.as_mut_ptr() }
+        }
+        fn len(p: *const u8) -> usize {
+            unsafe { (*(p as *const State)).regs.len() }
+        }
+
+        let mut info = VirtualizableInfo::without_vable_token();
+        register_virt_array_field(
+            &mut info,
+            "regs",
+            Type::Int,
+            8,
+            std::mem::offset_of!(State, regs),
+            data_ptr,
+            len,
+            |s: &State| &s.regs,
+        );
+
+        let mut state = State {
+            regs: VirtArray::from_slice(&[10i64, 20, 30]),
+        };
+        let vable = &mut state as *mut State as *mut u8;
+        let array = &info.array_fields[0];
+
+        assert_eq!(
+            unsafe { crate::virtualizable::bhimpl_arraylen_vable(vable, array) },
+            3
+        );
+        for (index, expected) in [10i64, 20, 30].into_iter().enumerate() {
+            assert_eq!(
+                unsafe { crate::virtualizable::vable_read_array_item(vable, array, index) },
+                expected
+            );
+        }
+        unsafe { crate::virtualizable::vable_write_array_item(vable, array, 1, 99) };
+        assert_eq!(state.regs.to_vec(), vec![10, 99, 30]);
+    }
+}

--- a/majit/majit-metainterp/src/virtualizable.rs
+++ b/majit/majit-metainterp/src/virtualizable.rs
@@ -1461,9 +1461,42 @@ impl VirtualizableInfo {
             self.reset_vable_token(obj_ptr);
         }
     }
+
+    /// Whether every array field can be rebuilt by the compiled entry's
+    /// field-load preamble — see [`VableArrayInfo::is_entry_reloadable`].
+    ///
+    /// `compile.py:508-511` runs that preamble for any driver whose
+    /// `virtualizable_info` is set, with no per-array escape, so the decision
+    /// is all-or-nothing per virtualizable: one array the preamble cannot
+    /// reload disqualifies the whole entry contract, not just that array.
+    pub fn arrays_are_entry_reloadable(&self) -> bool {
+        self.array_fields
+            .iter()
+            .all(VableArrayInfo::is_entry_reloadable)
+    }
 }
 
 impl VableArrayInfo {
+    /// Whether the compiled entry's field-load preamble can rebuild this
+    /// array's elements from the virtualizable pointer alone.
+    ///
+    /// `compile.py:441-457` reaches every element with `GETFIELD_GC_R` for the
+    /// array's data pointer followed by one `GETARRAYITEM_GC_*` per element —
+    /// two loads expressible in trace IR with nothing but byte offsets. A
+    /// storage whose data pointer sits at a fixed offset (from the field, or
+    /// from a container the field points at) answers that; a `Vec` embedded by
+    /// value does not, because its data pointer is one of three words in an
+    /// order the language does not specify, so no field load portably finds it.
+    /// `patch_new_loop_to_load_virtualizable_fields` panics rather than read a
+    /// capacity as a base address, which makes this the predicate a caller must
+    /// consult BEFORE putting a virtualizable on the preamble's path.
+    pub fn is_entry_reloadable(&self) -> bool {
+        match self.storage {
+            VableArrayStorage::DirectPointer | VableArrayStorage::EmbeddedArray { .. } => true,
+            VableArrayStorage::RustVec { .. } => false,
+        }
+    }
+
     pub fn can_read_length_from_heap(&self) -> bool {
         match self.storage {
             VableArrayStorage::EmbeddedArray { .. } => true,

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1839,6 +1839,9 @@ impl WarmEnterState {
     /// to fail and forcing a retrace.
     ///
     /// `qmut_key` should be a hash of (object_id, field_index) or similar.
+    /// `cell_key` is a resolved cell identity, not a raw green-key hash: it is
+    /// what names one cell among a bucket's occupants, so it is what the
+    /// invalidation below can resolve back to the dependent it was recorded for.
     pub fn register_quasiimmut_dependency(&mut self, qmut_key: u64, cell_key: u64) {
         let deps = self.quasiimmut_deps.entry(qmut_key).or_default();
         if !deps.contains(&cell_key) {
@@ -1855,19 +1858,19 @@ impl WarmEnterState {
     ///
     /// Returns the number of loops invalidated.
     ///
-    /// No typed twin, and unlike the other two abstainers this one is not a
-    /// choice. Its green keys arrive as the *values* of `quasiimmut_deps`,
-    /// which stores them as `u64` hashes, so there is no caller that holds a
-    /// `GreenKey` to hand one down: a twin cannot be given a key to take until
-    /// that table is widened. Dead in production today — its only registrar,
+    /// No typed twin, and this one needs none. Its dependents arrive as the
+    /// *values* of `quasiimmut_deps`, which records a `cell_key` each — the
+    /// identity [`Self::cell_by_key_mut`] resolves, and that resolve walks the
+    /// whole chain rather than answering with the bucket head. So a colliding
+    /// neighbour cannot be invalidated in a dependent's place, and a dependent
+    /// sitting behind a chained head cannot be skipped: the property
+    /// [`Self::invalidate_all`] below is written for — *skipping a cell is a
+    /// WRONG ANSWER rather than a leak* — holds here for the same reason,
+    /// without a `GreenKey` having to reach this far.
+    ///
+    /// Dead in production today: its only registrar,
     /// `register_quasiimmut_dependency`, has no production caller either, so
     /// `quasiimmut_deps` is empty and this returns 0 at the first line.
-    ///
-    /// That is what makes it a trap rather than a bug: [`Self::invalidate_all`]
-    /// below was fixed to walk chains because *"skipping a cell is a WRONG
-    /// ANSWER rather than a leak"*, and this targeted sibling still reads the
-    /// bucket head. Whoever wires the registrar inherits that, and a sweep
-    /// selecting whole-map `.values()` walks will not see it.
     pub fn invalidate_quasiimmut(&mut self, qmut_key: u64) -> usize {
         let deps = match self.quasiimmut_deps.swap_remove(&qmut_key) {
             Some(deps) => deps,
@@ -2390,6 +2393,27 @@ impl WarmEnterState {
     /// that cell — no `GreenKey` has to be built to prove it. Normally the
     /// answer is `hash` itself; it differs only when the cell that held the
     /// raw hash has been evicted out from under a minted sibling.
+    ///
+    /// **Why no comparator is consulted.** `warmstate.py:458-464` accepts a
+    /// cell only after `comparekey` matches, because upstream buckets are
+    /// indexed slots of a sized table (`counter.py:239-240`) and genuinely mix
+    /// unrelated green keys. This table is keyed by the FULL `get_uhash`, so
+    /// short of a 64-bit collision a bucket holds one green key's cells and
+    /// nothing else — the several occupants of a chained bucket are that one
+    /// key's hash-written cell and its typed twin, which a comparator would
+    /// only tell apart from each other. Two consequences:
+    ///
+    /// * the sole occupant of an unchained bucket IS this key's cell, and
+    /// * where it is not — an occupant a hash-written creator installed with no
+    ///   comparator — the full typed resolve reaches the same key anyway:
+    ///   [`Self::cell_key_for`] misses the chain, finds `hash` taken, and
+    ///   `unwrap_or(hash)` lands back on that same cell. So the shortcut is not
+    ///   trading a typed miss for a wrong cell; there is no typed miss to take.
+    ///
+    /// A 64-bit `get_uhash` collision breaks the invariant, and then this can
+    /// answer with a neighbour's cell. That is the condition under which a
+    /// comparator-less cell is unresolvable rather than resolvable-but-unsound
+    /// (see [`BaseJitCell::comparekey`]) — no accept rule fixes it here.
     #[inline]
     pub fn sole_cell_key(&self, hash: u64) -> Option<u64> {
         let head = self.cells.get(&hash)?;

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -5019,6 +5019,14 @@ mod tests {
     /// handing on the key for a second lookup — which is why upstream has no
     /// second reader that could disagree.
     ///
+    /// The entry path now carries the token the same way: `back_edge_internal`
+    /// binds it at the decision and hands it to
+    /// `MetaInterp::execute_assembler_at_dispatch_key` as an argument, so on
+    /// that route there is no longer a second reader for the resolved key to
+    /// keep honest — only the one modelled below. The u64 reader survives for
+    /// callers that reach a run without having decided anything about the cell
+    /// first, which is what the `executed` line stands in for.
+    ///
     /// # What this used to pin, and what it pins now
     ///
     /// This is the rewritten body of the `#[ignore]`d pin

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -721,11 +721,8 @@ impl WarmEnterState {
             if is_tracing {
                 return HotResult::AlreadyTracing;
             }
-            if self.should_start_dont_trace_here_trace(
-                cell_key,
-                flags,
-                has_seen_a_procedure_token,
-            ) {
+            if self.should_start_dont_trace_here_trace(cell_key, flags, has_seen_a_procedure_token)
+            {
                 return self.start_tracing_cell(cell_key);
             }
             // A JC_DONT_TRACE_HERE cell declines here, except when it once saw a
@@ -1816,10 +1813,8 @@ impl WarmEnterState {
             return false;
         }
         crate::mc_diag_bump(25);
-        self.counter.tick(
-            self.bucket_of(cell_key),
-            self.increment_function_threshold,
-        )
+        self.counter
+            .tick(self.bucket_of(cell_key), self.increment_function_threshold)
     }
 
     /// Check if inlining is allowed at the given depth.

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -394,12 +394,20 @@ pub struct JitStats {
 
 /// # The `u64` this type is keyed by is a CELL key, not a bucket hash
 ///
-/// Every `green_key_hash: u64` parameter below names one cell
+/// Every `cell_key: u64` parameter below names one cell
 /// ([`BaseJitCell::cell_key`]), not a celltable bucket. The two are the same
 /// number whenever a bucket holds one cell — which is every collision-free
 /// workload, so nothing observable changes there — and differ only for a cell
 /// that had to be minted a key because a sibling already held the bucket's raw
 /// hash.
+///
+/// The parameter name says which side of the resolve the value sits on, so the
+/// two entry points that genuinely take a PRE-resolve raw bucket hash keep the
+/// `green_key_hash` spelling: [`WarmEnterState::bucket_is_chained`] (the test
+/// [`WarmEnterState::resolve_cell_key`] asks before it decides whether a
+/// `GreenKey` has to be built at all) and
+/// [`WarmEnterState::trace_next_iteration`] (whose whole identity is the hash,
+/// see its own doc).
 ///
 /// The distinction exists because pyre carries a `u64` where upstream carries
 /// the cell object. `maybe_compile_and_run` (warmstate.py:458-464) resolves
@@ -465,7 +473,7 @@ pub struct WarmEnterState {
     /// Quasi-immutable field invalidation registry.
     ///
     /// Maps a quasi-immutable field key (hash of object_id + field_index)
-    /// to the set of green_key_hashes whose compiled loops depend on that field.
+    /// to the set of cell keys whose compiled loops depend on that field.
     /// When a quasi-immutable field is mutated, all dependent loops are invalidated.
     quasiimmut_deps: indexmap::IndexMap<u64, Vec<u64>>,
     // Function-entry hotness rides on the shared `counter: JitCounter`
@@ -527,7 +535,7 @@ impl WarmEnterState {
     /// so neither does this.
     fn should_start_dont_trace_here_trace(
         &mut self,
-        green_key_hash: u64,
+        cell_key: u64,
         flags: u8,
         has_seen_a_procedure_token: bool,
     ) -> bool {
@@ -535,18 +543,18 @@ impl WarmEnterState {
             return false;
         }
         if flags & jc_flags::TRACING_OCCURRED != 0 {
-            let bucket = self.bucket_of(green_key_hash);
+            let bucket = self.bucket_of(cell_key);
             self.counter.tick(bucket, self.increment_threshold)
         } else {
             true
         }
     }
 
-    fn start_tracing_cell(&mut self, green_key_hash: u64) -> HotResult {
-        self.counter.reset(self.bucket_of(green_key_hash));
+    fn start_tracing_cell(&mut self, cell_key: u64) -> HotResult {
+        self.counter.reset(self.bucket_of(cell_key));
         self.tracing_generation += 1;
         let current_generation = self.tracing_generation;
-        let cell = self.ensure_cell_by_key(green_key_hash);
+        let cell = self.ensure_cell_by_key(cell_key);
         cell.flags |= jc_flags::TRACING | jc_flags::TRACING_OCCURRED;
         cell.state = BaseJitCellState::Tracing;
         cell.tracing_generation = current_generation;
@@ -606,8 +614,8 @@ impl WarmEnterState {
     /// Returns a `HotResult` telling the interpreter what to do next.
     /// Mark a green key as DONT_TRACE_HERE permanently.
     /// Clear the loop token for a cell, so is_compiled() returns false.
-    pub fn clear_loop_token(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
+    pub fn clear_loop_token(&mut self, cell_key: u64) {
+        if let Some(cell) = self.cell_by_key_mut(cell_key) {
             cell.loop_token = None;
         }
     }
@@ -630,8 +638,8 @@ impl WarmEnterState {
         }
     }
 
-    pub fn mark_dont_trace(&mut self, green_key_hash: u64) {
-        self.disable_noninlinable_function(green_key_hash);
+    pub fn mark_dont_trace(&mut self, cell_key: u64) {
+        self.disable_noninlinable_function(cell_key);
     }
 
     /// TODO: pyre-only cold fast path check. RPython
@@ -639,8 +647,8 @@ impl WarmEnterState {
     /// directly; this read-only peek exists to skip GreenKey allocation
     /// in jitdriver.rs for cold keys.
     #[inline]
-    pub fn counter_would_fire(&self, green_key_hash: u64) -> bool {
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+    pub fn counter_would_fire(&self, cell_key: u64) -> bool {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
@@ -652,12 +660,12 @@ impl WarmEnterState {
             }
         }
         self.counter
-            .would_tick_fire(self.bucket_of(green_key_hash), self.increment_threshold)
+            .would_tick_fire(self.bucket_of(cell_key), self.increment_threshold)
     }
 
     /// warmstate.py:467: jitcounter.tick(hash, increment_threshold).
-    pub fn counter_tick(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+    pub fn counter_tick(&mut self, cell_key: u64) {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             if cell.flags & jc_flags::DONT_TRACE_HERE != 0 {
                 return;
             }
@@ -665,13 +673,13 @@ impl WarmEnterState {
                 return;
             }
         }
-        let bucket = self.bucket_of(green_key_hash);
+        let bucket = self.bucket_of(cell_key);
         let _ = self.counter.tick(bucket, self.increment_threshold);
     }
 
-    pub fn counter_tick_checked(&mut self, green_key_hash: u64) -> bool {
+    pub fn counter_tick_checked(&mut self, cell_key: u64) -> bool {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             if cell.is_compiled() || cell.is_tracing() {
                 return true;
             }
@@ -692,16 +700,16 @@ impl WarmEnterState {
         if cleanup_dead_token_cell {
             // warmstate.py:483-500 — loop-header counter entry must also
             // remove invalidated token cells before it starts counting again.
-            self.cleanup_chain(self.bucket_of(green_key_hash));
+            self.cleanup_chain(self.bucket_of(cell_key));
             return false;
         }
-        let bucket = self.bucket_of(green_key_hash);
+        let bucket = self.bucket_of(cell_key);
         self.counter.tick(bucket, self.increment_threshold)
     }
 
-    pub fn maybe_compile(&mut self, green_key_hash: u64) -> HotResult {
+    pub fn maybe_compile(&mut self, cell_key: u64) -> HotResult {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             let has_procedure_token = cell.get_procedure_token().is_some();
             let is_compiled = cell.is_compiled();
             let is_tracing = cell.is_tracing();
@@ -714,11 +722,11 @@ impl WarmEnterState {
                 return HotResult::AlreadyTracing;
             }
             if self.should_start_dont_trace_here_trace(
-                green_key_hash,
+                cell_key,
                 flags,
                 has_seen_a_procedure_token,
             ) {
-                return self.start_tracing_cell(green_key_hash);
+                return self.start_tracing_cell(cell_key);
             }
             // A JC_DONT_TRACE_HERE cell declines here, except when it once saw a
             // procedure token that has since been invalidated — that dead entry
@@ -736,18 +744,18 @@ impl WarmEnterState {
         if cleanup_dead_token_cell {
             // warmstate.py:483-500 — an invalidated/dead procedure token is
             // removed from the chain, resetting the hot counter so it re-arms.
-            self.cleanup_chain(self.bucket_of(green_key_hash));
+            self.cleanup_chain(self.bucket_of(cell_key));
             return HotResult::NotHot;
         }
 
         if !self
             .counter
-            .tick(self.bucket_of(green_key_hash), self.increment_threshold)
+            .tick(self.bucket_of(cell_key), self.increment_threshold)
         {
             return HotResult::NotHot;
         }
 
-        self.start_tracing_cell(green_key_hash)
+        self.start_tracing_cell(cell_key)
     }
 
     /// warmstate.py:446-511 `WarmEnterState.maybe_compile_and_run` —
@@ -926,8 +934,8 @@ impl WarmEnterState {
     ///
     /// Used by function-entry tracing where the caller has already
     /// determined that tracing should begin.
-    pub fn force_start_tracing(&mut self, green_key_hash: u64) -> HotResult {
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+    pub fn force_start_tracing(&mut self, cell_key: u64) -> HotResult {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             if cell.is_compiled() {
                 return HotResult::RunCompiled;
             }
@@ -944,7 +952,7 @@ impl WarmEnterState {
             }
         }
 
-        self.start_tracing_cell(green_key_hash)
+        self.start_tracing_cell(cell_key)
     }
 
     /// Typed-key variant of [`Self::force_start_tracing`]: reads the
@@ -987,8 +995,8 @@ impl WarmEnterState {
     /// Mark that tracing is done for a green key. Clears the TRACING flag.
     /// The caller is responsible for compiling the trace and calling
     /// `attach_procedure_to_interp` with the resulting JitCellToken.
-    pub fn finish_tracing(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
+    pub fn finish_tracing(&mut self, cell_key: u64) {
+        if let Some(cell) = self.cell_by_key_mut(cell_key) {
             cell.flags &= !jc_flags::TRACING;
             // State remains Tracing until attach_procedure_to_interp is called.
         }
@@ -998,8 +1006,8 @@ impl WarmEnterState {
     ///
     /// Non-permanent aborts clear `JC_TRACING` and allow a future retry until
     /// pyre's abort ceiling marks the location `DONT_TRACE_HERE`.
-    pub fn abort_tracing(&mut self, green_key_hash: u64, disable_noninlinable_function: bool) {
-        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
+    pub fn abort_tracing(&mut self, cell_key: u64, disable_noninlinable_function: bool) {
+        if let Some(cell) = self.cell_by_key_mut(cell_key) {
             cell.flags &= !jc_flags::TRACING;
             cell.abort_count += 1;
             if disable_noninlinable_function || (cell.flags & jc_flags::DONT_TRACE_HERE != 0) {
@@ -1015,7 +1023,7 @@ impl WarmEnterState {
         }
 
         if disable_noninlinable_function {
-            self.disable_noninlinable_function(green_key_hash);
+            self.disable_noninlinable_function(cell_key);
         }
         if let Some(log) = &mut self.jitlog {
             log.log_abort();
@@ -1038,11 +1046,11 @@ impl WarmEnterState {
     /// itself is in scope.
     pub fn attach_procedure_to_interp(
         &mut self,
-        green_key_hash: u64,
+        cell_key: u64,
         token: impl Into<Arc<JitCellToken>>,
     ) -> Option<Arc<JitCellToken>> {
         let token = token.into();
-        let cell = self.ensure_cell_by_key(green_key_hash);
+        let cell = self.ensure_cell_by_key(cell_key);
         cell.flags &= !jc_flags::TRACING;
         cell.set_procedure_token(token, false)
     }
@@ -1082,11 +1090,11 @@ impl WarmEnterState {
     /// the point a caller appears, not before.
     pub fn attach_tmp_callback_to_interp(
         &mut self,
-        green_key_hash: u64,
+        cell_key: u64,
         token: impl Into<Arc<JitCellToken>>,
     ) {
         let token = token.into();
-        let cell = self.ensure_cell_by_key(green_key_hash);
+        let cell = self.ensure_cell_by_key(cell_key);
         let _old = cell.set_procedure_token(token, true);
     }
 
@@ -1097,8 +1105,8 @@ impl WarmEnterState {
     /// installed under a different inner cell. Does not alter state: the
     /// companion `attach_procedure_to_interp` / `abort_tracing` calls own
     /// the state transition for whichever cell they touch.
-    pub fn clear_tracing_flag(&mut self, green_key_hash: u64) {
-        if let Some(cell) = self.cell_by_key_mut(green_key_hash) {
+    pub fn clear_tracing_flag(&mut self, cell_key: u64) {
+        if let Some(cell) = self.cell_by_key_mut(cell_key) {
             cell.flags &= !jc_flags::TRACING;
         }
     }
@@ -1143,8 +1151,8 @@ impl WarmEnterState {
     /// second uncalled entry point, so it gets a reason instead, the same call
     /// [`Self::attach_tmp_callback_to_interp`] got. Give it a typed form at
     /// the point a caller appears, not before.
-    pub fn take_procedure_token(&mut self, green_key_hash: u64) -> Option<Arc<JitCellToken>> {
-        self.cell_by_key_mut(green_key_hash)
+    pub fn take_procedure_token(&mut self, cell_key: u64) -> Option<Arc<JitCellToken>> {
+        self.cell_by_key_mut(cell_key)
             .and_then(|cell| cell.loop_token.take())
     }
 
@@ -1159,8 +1167,8 @@ impl WarmEnterState {
     /// PyPy provides — invalidated tokens never reach the warm-entry
     /// runner, the CALL_ASSEMBLER inline gate, or the bridge stitch
     /// surface.
-    pub fn get_compiled(&self, green_key_hash: u64) -> Option<&Arc<JitCellToken>> {
-        self.cell_by_key(green_key_hash)
+    pub fn get_compiled(&self, cell_key: u64) -> Option<&Arc<JitCellToken>> {
+        self.cell_by_key(cell_key)
             .and_then(|cell| cell.get_procedure_token())
     }
 
@@ -1172,8 +1180,8 @@ impl WarmEnterState {
     /// ([`Self::cell_key_for`]). Handing this a raw bucket hash instead is a
     /// different question with a different answer: it names the bucket's first
     /// occupant.
-    pub fn get_procedure_token(&self, green_key_hash: u64) -> Option<Arc<JitCellToken>> {
-        self.cell_by_key(green_key_hash)
+    pub fn get_procedure_token(&self, cell_key: u64) -> Option<Arc<JitCellToken>> {
+        self.cell_by_key(cell_key)
             .and_then(|cell| cell.get_procedure_token().cloned())
     }
 
@@ -1233,8 +1241,8 @@ impl WarmEnterState {
     }
 
     /// Reset the hot counter for a specific green key to zero.
-    pub fn reset_counter(&mut self, green_key_hash: u64) {
-        self.counter.reset(self.bucket_of(green_key_hash));
+    pub fn reset_counter(&mut self, cell_key: u64) {
+        self.counter.reset(self.bucket_of(cell_key));
     }
 
     /// Reset ALL counters to zero. Used after invalidation with incomplete
@@ -1246,14 +1254,14 @@ impl WarmEnterState {
     }
 
     /// Check if a green key is marked DontTraceHere.
-    pub fn is_dont_trace_here(&self, green_key_hash: u64) -> bool {
-        self.cell_by_key(green_key_hash)
+    pub fn is_dont_trace_here(&self, cell_key: u64) -> bool {
+        self.cell_by_key(cell_key)
             .is_some_and(|c| c.state == BaseJitCellState::DontTraceHere)
     }
 
     /// Get a reference to the BaseJitCell for a green key, if it exists.
-    pub fn get_cell(&self, green_key_hash: u64) -> Option<&BaseJitCell> {
-        self.cell_by_key(green_key_hash)
+    pub fn get_cell(&self, cell_key: u64) -> Option<&BaseJitCell> {
+        self.cell_by_key(cell_key)
     }
 
     /// Typed-key variant of [`Self::get_cell`]:
@@ -1330,13 +1338,13 @@ impl WarmEnterState {
     /// / `greenboxes` bundle without threading them through WarmEnterState.
     pub fn get_assembler_token<E, F>(
         &mut self,
-        green_key_hash: u64,
+        cell_key: u64,
         make_token: F,
     ) -> Result<Arc<JitCellToken>, E>
     where
         F: FnOnce() -> Result<Arc<JitCellToken>, E>,
     {
-        let cell = self.ensure_cell_by_key(green_key_hash);
+        let cell = self.ensure_cell_by_key(cell_key);
         if let Some(token) = cell.get_procedure_token() {
             return Ok(token.clone());
         }
@@ -1678,8 +1686,8 @@ impl WarmEnterState {
     /// Installs under the bare hash, so the cell it creates carries no
     /// `comparekey`. Prefer [`Self::mark_force_finish_tracing_for_key`]
     /// wherever the green key itself is in scope.
-    pub fn mark_force_finish_tracing(&mut self, green_key_hash: u64) {
-        let cell = self.ensure_cell_by_key(green_key_hash);
+    pub fn mark_force_finish_tracing(&mut self, cell_key: u64) {
+        let cell = self.ensure_cell_by_key(cell_key);
         cell.flags |= jc_flags::FORCE_FINISH;
     }
 
@@ -1701,8 +1709,8 @@ impl WarmEnterState {
     /// explicitly: `should_remove_jitcell` (warmstate.py:222) keeps the cell
     /// alive while it is set, and once set it persists until the cell itself
     /// is removed.
-    pub fn should_force_finish_tracing(&self, green_key_hash: u64) -> bool {
-        self.cell_by_key(green_key_hash)
+    pub fn should_force_finish_tracing(&self, cell_key: u64) -> bool {
+        self.cell_by_key(cell_key)
             .is_some_and(|cell| cell.flags & jc_flags::FORCE_FINISH != 0)
     }
 
@@ -1728,9 +1736,9 @@ impl WarmEnterState {
     /// warmstate.py:467 jitcounter.tick(hash, increment_threshold) parity.
     ///
     /// warmstate.py:256-257: jitcounter.tick(hash, increment_function_threshold).
-    pub fn should_trace_function_entry(&mut self, green_key_hash: u64) -> bool {
+    pub fn should_trace_function_entry(&mut self, cell_key: u64) -> bool {
         let mut cleanup_dead_token_cell = false;
-        if let Some(cell) = self.cell_by_key(green_key_hash) {
+        if let Some(cell) = self.cell_by_key(cell_key) {
             // Slot 23 is the total; 64/65 are its two terms, evaluated
             // independently rather than short-circuited so a cell that is both
             // reaches both tallies. `is_compiled()` fires on every probe of
@@ -1804,12 +1812,12 @@ impl WarmEnterState {
             // warmstate.py:483-500 — function-entry warmup must see an
             // invalidated token as a removed cell and re-count from cold.
             crate::mc_diag_bump(24);
-            self.cleanup_chain(self.bucket_of(green_key_hash));
+            self.cleanup_chain(self.bucket_of(cell_key));
             return false;
         }
         crate::mc_diag_bump(25);
         self.counter.tick(
-            self.bucket_of(green_key_hash),
+            self.bucket_of(cell_key),
             self.increment_function_threshold,
         )
     }
@@ -1828,7 +1836,7 @@ impl WarmEnterState {
 
     // ── Quasi-immutable field invalidation ──
 
-    /// Register that the compiled loop at `green_key_hash` depends on the
+    /// Register that the compiled loop at `cell_key` depends on the
     /// quasi-immutable field identified by `qmut_key`.
     ///
     /// When `invalidate_quasiimmut(qmut_key)` is called later, the compiled
@@ -1836,10 +1844,10 @@ impl WarmEnterState {
     /// to fail and forcing a retrace.
     ///
     /// `qmut_key` should be a hash of (object_id, field_index) or similar.
-    pub fn register_quasiimmut_dependency(&mut self, qmut_key: u64, green_key_hash: u64) {
+    pub fn register_quasiimmut_dependency(&mut self, qmut_key: u64, cell_key: u64) {
         let deps = self.quasiimmut_deps.entry(qmut_key).or_default();
-        if !deps.contains(&green_key_hash) {
-            deps.push(green_key_hash);
+        if !deps.contains(&cell_key) {
+            deps.push(cell_key);
         }
     }
 
@@ -1872,8 +1880,8 @@ impl WarmEnterState {
         };
 
         let mut invalidated = 0;
-        for green_key_hash in &deps {
-            if let Some(cell) = self.cell_by_key_mut(*green_key_hash)
+        for cell_key in &deps {
+            if let Some(cell) = self.cell_by_key_mut(*cell_key)
                 && let Some(token) = &cell.loop_token
             {
                 token.invalidate();
@@ -1911,8 +1919,8 @@ impl WarmEnterState {
     /// Get the explicit state of a BaseJitCell for a green key.
     /// Returns `NotHot` if no cell exists.
     #[inline]
-    pub fn get_cell_state(&self, green_key_hash: u64) -> BaseJitCellState {
-        self.cell_by_key(green_key_hash)
+    pub fn get_cell_state(&self, cell_key: u64) -> BaseJitCellState {
+        self.cell_by_key(cell_key)
             .map(|c| c.state)
             .unwrap_or(BaseJitCellState::NotHot)
     }
@@ -1927,8 +1935,8 @@ impl WarmEnterState {
     /// comparator-less cells it installs exist only in fixtures. That also
     /// makes it a way for a test to build the split-cell state deliberately.
     /// A twin becomes necessary if production ever calls this.
-    pub fn transition_cell(&mut self, green_key_hash: u64, new_state: BaseJitCellState) {
-        let cell = self.ensure_cell_by_key(green_key_hash);
+    pub fn transition_cell(&mut self, cell_key: u64, new_state: BaseJitCellState) {
+        let cell = self.ensure_cell_by_key(cell_key);
 
         match new_state {
             BaseJitCellState::NotHot => {

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -636,11 +636,7 @@ fn main() {
 /// so the copy had no upstream counterpart; the frame now lives as long as the
 /// deadframe does and the accessors read it in place.
 ///
-/// `cranelift` adds ONE, for 5:
-///
-/// | n | site |
-/// |---|------|
-/// | 1 | `deadframe_from_jitframe` — the `Box<JitFrameDeadFrame>` inside `DeadFrame`, the `llmodel.py:240` `cast_opaque_ptr` |
+/// `cranelift` adds NOTHING, and its four are the four shared rows above.
 ///
 /// There is no cranelift row for the frame itself, and that is the difference
 /// between the two backends. `run_compiled_code_inner` takes the JITFRAME from
@@ -650,8 +646,17 @@ fn main() {
 /// allocates its entry frame off the GC unconditionally, so it keeps paying
 /// for one; installing a GC does not move its figure.
 ///
-/// It used to add four. The three that went:
+/// It used to add four. The four that went:
 ///
+/// - `deadframe_from_jitframe` — the `Box<JitFrameDeadFrame>` inside
+///   `DeadFrame`. The box was not the `llmodel.py:240` `cast_opaque_ptr` it was
+///   annotated as; it was a PIN. The deadframe's frame pointer was rooted by
+///   registering the address of the field holding it, and a field address is
+///   only a valid root while its owner stays put, so the owner had to be given
+///   a fixed address before it could be returned. The pointer now lives in a
+///   root slot addressed by POSITION (`shadowstack.py:100-106`), which the
+///   collector rewrites in place, so the holder may move and `DeadFrame` holds
+///   the frame by value.
 /// - `CraneliftBackend::execute_token_with_dispatch_key` unwrapped the
 ///   metainterp's `&[Value]` into an owned `Vec<i64>` before the frame
 ///   existed. `llmodel.py:306-315` unwraps each argument *at* the store into
@@ -668,4 +673,4 @@ fn main() {
 ///   `run_compiled_code_inner`, reached because this fixture had no GC at all;
 ///   see [`install_gc`]. The branch itself remains for a backend running
 ///   without a collector.
-const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 5 } else { 6 };
+const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 4 } else { 6 };

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -588,19 +588,27 @@ fn main() {
 /// because it owns the last rows below; pinning one number for both would make
 /// whichever leg ran second fail with a message about a regression that is
 /// really a configuration difference. The figure was briefly one number for
-/// both at 10, before cranelift's frame moved to the nursery.
+/// both, before cranelift's frame moved to the nursery.
 ///
-/// Eight of the allocations are shared by both backends:
+/// Six of the allocations are shared by both backends:
 ///
 /// | n | site |
 /// |---|------|
 /// | 2 | `CounterState::extract_live_into` — TWO separate `extract_live()` calls, one `Vec<i64>` each: `extract_live_values`'s default (`jit_state.rs:186-187`) calls it and then `live_value_types`, whose default (`jit_state.rs:194`) calls it AGAIN. A two-int-scalar state builds each Vec in one allocation (capacity 0→4, no regrowth); the 2 is a doubled traversal, not a regrowth |
 /// | 1 | `JitState::extract_live_values` default body, `jit_state.rs:190` — the `Vec<Value>` it collects into |
 /// | 1 | `JitState::live_value_types` default body, `jit_state.rs:194` — the `Vec<Type>` it collects into |
-/// | 1 | `<[Type]>::to_vec` — `descr.fail_arg_types().to_vec()` |
-/// | 1 | `<[Value]>::to_vec` — the FINISH values copied out of the run result |
 /// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `values` (the run result's own output vector; find it by symbol, the line drifts) |
 /// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `typed_values` (ditto) |
+///
+/// Two shared rows have gone since:
+///
+/// - `<[Type]>::to_vec`, the exit's type list copied out of the failing descr
+///   into the exit layout. `CompiledExitLayout::exit_types` is now inline
+///   storage wide enough for the exits a steady entry produces, so the copy
+///   costs the allocator nothing until an exit is wider than that.
+/// - `<[Value]>::to_vec`, the FINISH values copied out of the run result. The
+///   FINISH arm returns immediately after publishing them, so nothing reads
+///   the source and the values are moved instead.
 ///
 /// ⚠ THE FIRST FOUR ARE A PROPERTY OF THIS FIXTURE'S STATE SHAPE, not of the
 /// entry path in general. `codegen_state.rs:1731` emits the non-allocating
@@ -609,7 +617,7 @@ fn main() {
 /// scalars only — which `CounterState` is — gets neither, and falls back to the
 /// allocating `JitState` defaults. A state that clears that gate pays 4 fewer.
 ///
-/// `dynasm` adds two, for 10:
+/// `dynasm` adds two, for 8:
 ///
 /// | n | site |
 /// |---|------|
@@ -622,7 +630,7 @@ fn main() {
 /// so the copy had no upstream counterpart; the frame now lives as long as the
 /// deadframe does and the accessors read it in place.
 ///
-/// `cranelift` adds ONE, for 9:
+/// `cranelift` adds ONE, for 7:
 ///
 /// | n | site |
 /// |---|------|
@@ -654,4 +662,4 @@ fn main() {
 ///   `run_compiled_code_inner`, reached because this fixture had no GC at all;
 ///   see [`install_gc`]. The branch itself remains for a backend running
 ///   without a collector.
-const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 9 } else { 10 };
+const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 7 } else { 8 };

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -594,13 +594,13 @@ fn main() {
 ///
 /// | n | site |
 /// |---|------|
-/// | 2 | `CounterState::extract_live_into` — the `Vec<i64>` the macro's `extract_live` returns, and its one regrowth |
+/// | 2 | `CounterState::extract_live_into` — TWO separate `extract_live()` calls, one `Vec<i64>` each: `extract_live_values`'s default (`jit_state.rs:186-187`) calls it and then `live_value_types`, whose default (`jit_state.rs:194`) calls it AGAIN. A two-int-scalar state builds each Vec in one allocation (capacity 0→4, no regrowth); the 2 is a doubled traversal, not a regrowth |
 /// | 1 | `JitState::extract_live_values` default body, `jit_state.rs:190` — the `Vec<Value>` it collects into |
 /// | 1 | `JitState::live_value_types` default body, `jit_state.rs:194` — the `Vec<Type>` it collects into |
 /// | 1 | `<[Type]>::to_vec` — `descr.fail_arg_types().to_vec()` |
 /// | 1 | `<[Value]>::to_vec` — the FINISH values copied out of the run result |
-/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key`, `pyjitpl.rs:10547` — `values` |
-/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key`, `pyjitpl.rs:10548` — `typed_values` |
+/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `values` (the run result's own output vector; find it by symbol, the line drifts) |
+/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `typed_values` (ditto) |
 ///
 /// ⚠ THE FIRST FOUR ARE A PROPERTY OF THIS FIXTURE'S STATE SHAPE, not of the
 /// entry path in general. `codegen_state.rs:1731` emits the non-allocating

--- a/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
+++ b/majit/majit-metainterp/tests/allocs_per_compiled_entry.rs
@@ -590,17 +590,15 @@ fn main() {
 /// really a configuration difference. The figure was briefly one number for
 /// both, before cranelift's frame moved to the nursery.
 ///
-/// Six of the allocations are shared by both backends:
+/// Four of the allocations are shared by both backends:
 ///
 /// | n | site |
 /// |---|------|
 /// | 2 | `CounterState::extract_live_into` — TWO separate `extract_live()` calls, one `Vec<i64>` each: `extract_live_values`'s default (`jit_state.rs:186-187`) calls it and then `live_value_types`, whose default (`jit_state.rs:194`) calls it AGAIN. A two-int-scalar state builds each Vec in one allocation (capacity 0→4, no regrowth); the 2 is a doubled traversal, not a regrowth |
 /// | 1 | `JitState::extract_live_values` default body, `jit_state.rs:190` — the `Vec<Value>` it collects into |
 /// | 1 | `JitState::live_value_types` default body, `jit_state.rs:194` — the `Vec<Type>` it collects into |
-/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `values` (the run result's own output vector; find it by symbol, the line drifts) |
-/// | 1 | `run_compiled_detailed_with_values_at_dispatch_key` — `typed_values` (ditto) |
 ///
-/// Two shared rows have gone since:
+/// Four shared rows have gone since:
 ///
 /// - `<[Type]>::to_vec`, the exit's type list copied out of the failing descr
 ///   into the exit layout. `CompiledExitLayout::exit_types` is now inline
@@ -609,15 +607,23 @@ fn main() {
 /// - `<[Value]>::to_vec`, the FINISH values copied out of the run result. The
 ///   FINISH arm returns immediately after publishing them, so nothing reads
 ///   the source and the values are moved instead.
+/// - `run_compiled_detailed_with_values_at_dispatch_key` — `values`, the run
+///   result's own machine-word output buffer.
+/// - the same function's `typed_values`, its typed twin. Both are now inline
+///   storage on the result, sized to the exit widths a steady entry returns,
+///   so decoding an exit asks the allocator for nothing. The buffers could not
+///   be pooled and reused instead: each one leaves the function owned — into
+///   the finish latch, into the public run outcome, into the guard arm's own
+///   copy — so there is nothing to hand back.
 ///
-/// ⚠ THE FIRST FOUR ARE A PROPERTY OF THIS FIXTURE'S STATE SHAPE, not of the
+/// ⚠ ALL FOUR ARE A PROPERTY OF THIS FIXTURE'S STATE SHAPE, not of the
 /// entry path in general. `codegen_state.rs:1731` emits the non-allocating
 /// `extract_live_values_into` / `live_value_types_into` overrides only when the
 /// state has a ref scalar, a float scalar or a virt array; a state of int
 /// scalars only — which `CounterState` is — gets neither, and falls back to the
 /// allocating `JitState` defaults. A state that clears that gate pays 4 fewer.
 ///
-/// `dynasm` adds two, for 8:
+/// `dynasm` adds two, for 6:
 ///
 /// | n | site |
 /// |---|------|
@@ -630,7 +636,7 @@ fn main() {
 /// so the copy had no upstream counterpart; the frame now lives as long as the
 /// deadframe does and the accessors read it in place.
 ///
-/// `cranelift` adds ONE, for 7:
+/// `cranelift` adds ONE, for 5:
 ///
 /// | n | site |
 /// |---|------|
@@ -662,4 +668,4 @@ fn main() {
 ///   `run_compiled_code_inner`, reached because this fixture had no GC at all;
 ///   see [`install_gc`]. The branch itself remains for a backend running
 ///   without a collector.
-const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 7 } else { 8 };
+const ALLOCS_PER_ENTRY: usize = if cfg!(feature = "cranelift") { 5 } else { 6 };

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
@@ -157,3 +157,35 @@ fn the_live_arrays_are_reachable_from_the_state_pointer_by_the_registered_offset
         0.5
     );
 }
+
+/// Because the storage is reloadable, installing the machine ARMS the flat
+/// entry contract: `warmspot.py:520-545` names the virtualizable on the
+/// jitdriver static data, which is what makes `compile.py:508-511`'s reload
+/// preamble run.
+///
+/// The width is the flat live-value prefix, not the red count — this state has
+/// no scalars, so the whole prefix is the one virtualizable identity slot at
+/// index 0, and `virtualizable_arg_index` answers in that model rather than
+/// with a position among the reds.
+#[test]
+fn installing_a_block_backed_machine_arms_the_flat_entry_contract() {
+    let program = count_program();
+    let mut driver: majit_metainterp::JitDriver<Machine> =
+        majit_metainterp::JitDriver::new(u32::MAX);
+    let state = Machine {
+        regs: VirtArray::from_slice(&[0i64, 1]),
+        fregs: VirtArray::filled(0.0f64, 1),
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, &program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    let contract = driver
+        .flat_entry_contract()
+        .expect("a reloadable virtualizable arms the contract");
+    assert_eq!(contract.len, 1);
+    assert_eq!(contract.index_of_virtualizable, 0);
+}

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
@@ -1,0 +1,159 @@
+//! A `[.. ; virt]` state field declared with a block-backed container.
+//!
+//! `virtualizable.py:57-58` describes each virtualizable array as a
+//! `Ptr(GcArray)` — one pointer word in the virtualizable, aimed at a block
+//! whose length and payload sit at fixed offsets. That is what lets
+//! `compile.py:441-457` rebuild the array inside a compiled entry from the
+//! virtualizable alone: `GETFIELD_GC_R` for the pointer, then one
+//! `GETARRAYITEM_GC_*` per element.
+//!
+//! A `Vec` embedded by value cannot present that, because its data pointer is
+//! one of three words in an unspecified order. This fixture declares the same
+//! machine with `VirtArray` instead and checks two things: the interpretation is
+//! unchanged, and the field registers as the array-pointer storage whose two
+//! offsets the entry can be emitted from.
+
+use majit_metainterp::virt_array::VirtArray;
+use majit_metainterp::virtualizable::VableArrayStorage;
+
+pub type Bytecode = [u8];
+
+const OP_ACC: u8 = 1; // fregs[0] += 1.25
+const OP_INC: u8 = 2; // regs[0] += 1
+const OP_JUMP_BACK: u8 = 3; // [OP_JUMP_BACK, target]: loop while regs[0] < regs[1]
+const OP_RETURN: u8 = 4; // yield regs[0]
+
+fn count_program() -> Vec<u8> {
+    vec![OP_ACC, OP_INC, OP_JUMP_BACK, 0, OP_RETURN]
+}
+
+struct Machine {
+    regs: VirtArray<i64>,
+    fregs: VirtArray<f64>,
+}
+
+#[majit_macros::jit_interp(
+    state = Machine,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        regs: [int; virt],
+        fregs: [float; virt],
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn mainloop(program: &Bytecode, limit: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<Machine> =
+        majit_metainterp::JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = Machine {
+        regs: VirtArray::from_slice(&[0i64, limit]),
+        fregs: VirtArray::filled(0.0f64, 1),
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_ACC => state.fregs[0] = state.fregs[0] + 1.25,
+            OP_INC => state.regs[0] = state.regs[0] + 1,
+            OP_JUMP_BACK => {
+                let target = program[pc] as usize;
+                pc += 1;
+                if state.regs[0] < state.regs[1] {
+                    if target < pc {
+                        can_enter_jit!(driver, target, &mut state, program, || {});
+                    }
+                    pc = target;
+                }
+            }
+            OP_RETURN => return state.regs[0],
+            _ => unreachable!(),
+        }
+    }
+    state.regs[0]
+}
+
+/// The machine computes what it computed with a `Vec` backing, warm and cold.
+#[test]
+fn a_block_backed_state_interprets_the_same_program_to_the_same_answer() {
+    let program = count_program();
+    assert_eq!(mainloop(&program, 7, u32::MAX), 7, "never-warm run");
+    assert_eq!(mainloop(&program, 200, 3), 200, "warm run");
+}
+
+/// The registration the generated `VirtualizableInfo` builder produces is the
+/// array-pointer storage, with the block's length and payload offsets. Those
+/// two offsets are exactly what `patch_new_loop_to_load_virtualizable_fields`
+/// needs to emit the reload preamble; the `RustVec` storage a `Vec` field
+/// registers has neither and that arm refuses.
+#[test]
+fn a_block_backed_field_registers_the_storage_a_compiled_entry_can_reload() {
+    let info = <Machine as majit_metainterp::JitState>::__build_virtualizable_info()
+        .expect("a state with virt arrays builds a vinfo");
+
+    assert_eq!(info.array_fields.len(), 2);
+    for (index, field) in info.array_fields.iter().enumerate() {
+        assert_eq!(
+            field.storage,
+            VableArrayStorage::DirectPointer,
+            "array field {index} ({}) must be reachable through its pointer",
+            field.name,
+        );
+        assert_eq!(field.length_offset, VirtArray::<i64>::LENGTH_OFFSET);
+        assert_eq!(field.items_offset, VirtArray::<i64>::ITEMS_OFFSET);
+        assert!(field.can_read_length_from_heap());
+    }
+
+    // The element descr addresses the payload straight off the pointer the
+    // field holds, so nothing sits between the two loads the entry emits.
+    for index in 0..info.array_fields.len() {
+        let descr = info.array_item_descr(index);
+        let descr = descr.as_array_descr().expect("an array descr");
+        assert_eq!(descr.base_size(), VirtArray::<i64>::ITEMS_OFFSET);
+        assert_eq!(descr.item_size(), 8);
+    }
+}
+
+/// The container the field is declared with is what the array reads and writes
+/// through, so a live state's arrays are addressable from the state pointer by
+/// those same offsets.
+#[test]
+fn the_live_arrays_are_reachable_from_the_state_pointer_by_the_registered_offsets() {
+    let info = <Machine as majit_metainterp::JitState>::__build_virtualizable_info()
+        .expect("a state with virt arrays builds a vinfo");
+    let mut state = Machine {
+        regs: VirtArray::from_slice(&[11i64, 22, 33]),
+        fregs: VirtArray::filled(0.5f64, 2),
+    };
+    let vable = &mut state as *mut Machine as *mut u8;
+
+    let regs = &info.array_fields[0];
+    let block = unsafe { *(vable.add(regs.field_offset) as *const *const u8) };
+    let length = unsafe { *(block.add(regs.length_offset) as *const usize) };
+    assert_eq!(length, 3);
+    for (index, expected) in [11i64, 22, 33].into_iter().enumerate() {
+        let item = unsafe { *(block.add(regs.items_offset + index * 8) as *const i64) };
+        assert_eq!(item, expected);
+    }
+
+    let fregs = &info.array_fields[1];
+    let block = unsafe { *(vable.add(fregs.field_offset) as *const *const u8) };
+    assert_eq!(
+        unsafe { *(block.add(fregs.length_offset) as *const usize) },
+        2
+    );
+    assert_eq!(
+        unsafe { *(block.add(fregs.items_offset) as *const f64) },
+        0.5
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_gc_block_backing.rs
@@ -101,26 +101,44 @@ fn a_block_backed_field_registers_the_storage_a_compiled_entry_can_reload() {
     let info = <Machine as majit_metainterp::JitState>::__build_virtualizable_info()
         .expect("a state with virt arrays builds a vinfo");
 
-    assert_eq!(info.array_fields.len(), 2);
-    for (index, field) in info.array_fields.iter().enumerate() {
+    // Each field is graded against the offsets of the container ITS OWN item
+    // type produces, so a divergence between the two item types is a failure
+    // rather than a coincidence, and the name is checked so a reordering of
+    // `array_fields` fails here instead of silently swapping the expectations.
+    let expected = [
+        (
+            "regs",
+            VirtArray::<i64>::LENGTH_OFFSET,
+            VirtArray::<i64>::ITEMS_OFFSET,
+            size_of::<i64>(),
+        ),
+        (
+            "fregs",
+            VirtArray::<f64>::LENGTH_OFFSET,
+            VirtArray::<f64>::ITEMS_OFFSET,
+            size_of::<f64>(),
+        ),
+    ];
+    assert_eq!(info.array_fields.len(), expected.len());
+    for (index, (field, (name, length_offset, items_offset, item_size))) in
+        info.array_fields.iter().zip(expected).enumerate()
+    {
+        assert_eq!(field.name, name, "array field {index} is out of order");
         assert_eq!(
             field.storage,
             VableArrayStorage::DirectPointer,
-            "array field {index} ({}) must be reachable through its pointer",
-            field.name,
+            "array field {index} ({name}) must be reachable through its pointer",
         );
-        assert_eq!(field.length_offset, VirtArray::<i64>::LENGTH_OFFSET);
-        assert_eq!(field.items_offset, VirtArray::<i64>::ITEMS_OFFSET);
+        assert_eq!(field.length_offset, length_offset, "{name} length offset");
+        assert_eq!(field.items_offset, items_offset, "{name} items offset");
         assert!(field.can_read_length_from_heap());
-    }
 
-    // The element descr addresses the payload straight off the pointer the
-    // field holds, so nothing sits between the two loads the entry emits.
-    for index in 0..info.array_fields.len() {
+        // The element descr addresses the payload straight off the pointer the
+        // field holds, so nothing sits between the two loads the entry emits.
         let descr = info.array_item_descr(index);
         let descr = descr.as_array_descr().expect("an array descr");
-        assert_eq!(descr.base_size(), VirtArray::<i64>::ITEMS_OFFSET);
-        assert_eq!(descr.item_size(), 8);
+        assert_eq!(descr.base_size(), items_offset, "{name} descr base size");
+        assert_eq!(descr.item_size(), item_size, "{name} descr item size");
     }
 }
 

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_recursive_fresh_alloc.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_recursive_fresh_alloc.rs
@@ -1,0 +1,170 @@
+//! A recursive-portal-capable state whose `[.. ; virt]` field is block-backed.
+//!
+//! The recursive `CALL_ASSEMBLER` portal cannot `New` a host state through the
+//! IR, so the generated interpreter emits a pair of host helpers the compiled
+//! caller calls residually: one allocates a fresh state sized at the caller's
+//! live capacity, the other drops it. That allocator is generated only for the
+//! single-virt-array shape declared here — no ref scalars, no float scalars, no
+//! opaque carriers and no fixed arrays.
+//!
+//! The fixture exists because that allocator builds the whole state by struct
+//! literal, so each field's initializer has to be spelled in the container the
+//! field was declared with. A `[.. ; virt]` field may be declared with either a
+//! `Vec` or a block-backed `VirtArray`, and only the block-backed spelling
+//! catches an initializer that hardcodes one of the two: with a `Vec` field a
+//! `vec![]` initializer compiles whether or not it consulted the declaration.
+
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+const OP_PUSH: u8 = 1; // regs[top] = top as i64; top += 1
+const OP_ADD: u8 = 2; // top -= 2; regs[top] += regs[top + 1]; top += 1
+const OP_JUMP_BACK: u8 = 3; // [OP_JUMP_BACK, target]: loop while regs[0] < limit
+const OP_RETURN: u8 = 4; // yield regs[top - 1]
+
+fn accumulate_program() -> Vec<u8> {
+    vec![OP_PUSH, OP_ADD, OP_JUMP_BACK, 0, OP_RETURN]
+}
+
+struct Machine {
+    top: i64,
+    regs: VirtArray<i64>,
+}
+
+#[majit_macros::jit_interp(
+    state = Machine,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        top: int,
+        regs: [int; virt],
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn mainloop(program: &Bytecode, limit: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<Machine> =
+        majit_metainterp::JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = Machine {
+        top: 1,
+        regs: VirtArray::filled(0i64, 8),
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH => {
+                state.regs[state.top as usize] = 1;
+                state.top += 1;
+            }
+            OP_ADD => {
+                state.top -= 2;
+                let rhs = state.regs[(state.top + 1) as usize];
+                state.regs[state.top as usize] = state.regs[state.top as usize] + rhs;
+                state.top += 1;
+            }
+            OP_JUMP_BACK => {
+                let target = program[pc] as usize;
+                pc += 1;
+                if state.regs[0] < limit {
+                    if target < pc {
+                        can_enter_jit!(driver, target, &mut state, program, || {});
+                    }
+                    pc = target;
+                }
+            }
+            OP_RETURN => return state.regs[(state.top - 1) as usize],
+            _ => unreachable!(),
+        }
+    }
+    state.regs[0]
+}
+
+/// The machine answers the same warm and cold, so the fixture is not vacuous:
+/// the generated interpreter it compiles is the one under test.
+#[test]
+fn a_block_backed_recursive_capable_machine_interprets_the_same_program() {
+    let program = accumulate_program();
+    assert_eq!(mainloop(&program, 5, u32::MAX), 5, "never-warm run");
+    assert_eq!(mainloop(&program, 120, 3), 120, "warm run");
+}
+
+/// The host allocator builds a fresh state at a requested capacity and the
+/// matching free reclaims it. Reaching the pair at all is the regression: the
+/// allocator is generated for this state shape, so if its array initializer
+/// were spelled as a `Vec` the fixture would not compile.
+#[test]
+fn the_generated_fresh_allocator_sizes_a_block_backed_array() {
+    use majit_metainterp::{JitCodeSym as _, JitState as _};
+    let program = accumulate_program();
+    let caller = Machine {
+        top: 3,
+        regs: VirtArray::from_slice(&[9i64, 8, 7, 0, 0, 0]),
+    };
+    let meta = caller.build_meta(0, program.as_slice());
+    let mut sym = <Machine as majit_metainterp::JitState>::create_sym(&meta, 0);
+    caller.initialize_sym(&mut sym, &meta);
+    let (alloc_fp, free_fp) = sym
+        .recursive_fresh_alloc_free_targets()
+        .expect("a single-virt-array state supports portal alloc/free");
+    let alloc: extern "C" fn(i64) -> i64 = unsafe { core::mem::transmute(alloc_fp) };
+    let free: extern "C" fn(i64) = unsafe { core::mem::transmute(free_fp) };
+
+    let cap: i64 = 12;
+    let raw = alloc(cap);
+    assert_ne!(raw, 0, "fresh alloc must return a non-null pointer");
+    unsafe {
+        let fresh = &*(raw as *const Machine);
+        assert_eq!(fresh.top, 0, "fresh scalars are zeroed");
+        assert_eq!(
+            fresh.regs.len(),
+            cap as usize,
+            "fresh array sized at the requested capacity",
+        );
+        assert!(
+            fresh.regs.iter().all(|&x| x == 0),
+            "fresh array zero-initialised",
+        );
+    }
+    free(raw);
+    // The compiled guard-fail path may reach the free with nothing allocated.
+    free(0);
+}
+
+/// The fresh reds path builds the same state through the same declared backing,
+/// at the capacity the caller's array carries.
+#[test]
+fn the_fresh_reds_path_reallocates_at_the_callers_capacity() {
+    use majit_metainterp::{JitCodeSym as _, JitState as _};
+    let program = accumulate_program();
+    let caller = Machine {
+        top: 3,
+        regs: VirtArray::from_slice(&[9i64, 8, 7, 0, 0, 0]),
+    };
+    let meta = caller.build_meta(0, program.as_slice());
+    let mut sym = <Machine as majit_metainterp::JitState>::create_sym(&meta, 0);
+    caller.initialize_sym(&mut sym, &meta);
+    let (_values, owner) = sym
+        .recursive_fresh_entry_reds()
+        .expect("a state with no ref scalars and no opaque carriers has fresh reds");
+    let fresh = owner
+        .downcast_ref::<Machine>()
+        .expect("the owner is the fresh state the reds name");
+    assert_eq!(fresh.top, 0, "fresh frame starts empty");
+    assert_eq!(
+        fresh.regs.len(),
+        caller.regs.len(),
+        "fresh array re-allocated at the caller's captured capacity",
+    );
+}


### PR DESCRIPTION
This PR contains the generic majit work extracted from the ongoing CEL integration. It intentionally includes no CEL interpreter, example, or test code.

## What changes

- Reduces compiled-entry allocation and copying: exit types stay inline where possible, finish values are moved, failure-argument types are borrowed, and an untouched I/O buffer no longer creates a bracket.
- Resolves the procedure token once and threads the token, descriptor, and virtualizable through the compiled-entry path.
- Stores exit recovery/resume descriptions behind stable owned pointers and roots backend deadframes through explicit owner slots.
- Backs virtualizable arrays with GC-managed length-prefixed blocks.
- Defines an explicit entry-prefix contract and enables flat compiled entries only after the virtualizable state has registered reloadable storage.
- Keeps the generic DynASM, Cranelift, and Wasm entry/failguard paths consistent with the new ownership and state contracts.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- Forced LLBC re-extraction and freshness check for `majit-rlib`, `pyre-object`, `pyre-interpreter`, and `pyre-jit`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test -p majit-metainterp --features dynasm` (1,563 tests passed)
- `cargo test -p majit-metainterp --features cranelift` (1,561 tests passed)
- `python3 pyre/check.py --backend dynasm --no-synthetic` (17/17 passed)