### PR TITLE
majit dynasm: give a JUMP's surplus argument slot the frame base every other slot uses

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2897,7 +2897,15 @@ impl<'a> AssemblerARM64<'a> {
                     let dst_loc = if i < target_arglocs.len() {
                         target_arglocs[i]
                     } else {
-                        let dst_ofs = crate::regalloc::get_ebp_ofs(0, i);
+                        // The canonical base for a frame position, the
+                        // one `FrameManager` was built with
+                        // (`get_baseofs_of_frame_field`). Passing 0 here named
+                        // a slot `FIRST_ITEM_OFFSET` bytes below the one the
+                        // regalloc means by the same position, so a source and
+                        // this destination could denote the same value and
+                        // different storage.
+                        let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
+                        let dst_ofs = crate::regalloc::get_ebp_ofs(base_ofs, i);
                         Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, false))
                     };
                     let arg_tp = op

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2894,6 +2894,20 @@ impl<'a> AssemblerARM64<'a> {
                     target_arglocs.len()
                 };
                 for (i, src_loc) in arglocs[..remap_count].iter().enumerate() {
+                    // One classification, two consumers. It picks the location
+                    // set the pair rides — set 2 carries the floats and gets
+                    // the float scratch — and, when the destination has to be
+                    // synthesized below, the kind of the slot itself.
+                    // Hard-coding the slot's kind instead described a slot the
+                    // value never lands in: `regalloc_push` / `regalloc_pop`
+                    // read exactly this field to choose their scratch
+                    // register, and `loc_width` reads it for the width.
+                    let arg_tp = op
+                        .getarglist()
+                        .get(i)
+                        .and_then(|arg| self.opref_type_at(arg.to_opref(), Some(op_index)))
+                        .unwrap_or(Type::Int);
+                    let is_float = arg_tp == Type::Float;
                     let dst_loc = if i < target_arglocs.len() {
                         target_arglocs[i]
                     } else {
@@ -2906,20 +2920,15 @@ impl<'a> AssemblerARM64<'a> {
                         // different storage.
                         let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
                         let dst_ofs = crate::regalloc::get_ebp_ofs(base_ofs, i);
-                        Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, false))
+                        Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, is_float))
                     };
-                    let arg_tp = op
-                        .getarglist()
-                        .get(i)
-                        .and_then(|arg| self.opref_type_at(arg.to_opref(), Some(op_index)))
-                        .unwrap_or(Type::Int);
-                    if arg_tp == Type::Float {
-                        src_locations2.push(*src_loc);
-                        dst_locations2.push(dst_loc);
+                    let (srcs, dsts) = if is_float {
+                        (&mut src_locations2, &mut dst_locations2)
                     } else {
-                        src_locations1.push(*src_loc);
-                        dst_locations1.push(dst_loc);
-                    }
+                        (&mut src_locations1, &mut dst_locations1)
+                    };
+                    srcs.push(*src_loc);
+                    dsts.push(dst_loc);
                 }
                 let tmpreg1 = Loc::Reg(crate::regloc::RegLoc::new(16, false));
                 let tmpreg2 = Loc::Reg(crate::regloc::RegLoc::new(15, true));

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3878,7 +3878,15 @@ impl<'a> Assembler386<'a> {
                     let dst_loc = if i < target_arglocs.len() {
                         target_arglocs[i]
                     } else {
-                        let dst_ofs = crate::regalloc::get_ebp_ofs(0, i);
+                        // The canonical base for a frame position, the
+                        // one `FrameManager` was built with
+                        // (`get_baseofs_of_frame_field`). Passing 0 here named
+                        // a slot `FIRST_ITEM_OFFSET` bytes below the one the
+                        // regalloc means by the same position, so a source and
+                        // this destination could denote the same value and
+                        // different storage.
+                        let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
+                        let dst_ofs = crate::regalloc::get_ebp_ofs(base_ofs, i);
                         Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, false))
                     };
                     match src_loc {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -3875,6 +3875,27 @@ impl<'a> Assembler386<'a> {
                     target_arglocs.len()
                 };
                 for (i, src_loc) in arglocs[..remap_count].iter().enumerate() {
+                    // One classification, two consumers. It picks the location
+                    // set the pair rides — set 2 carries the floats and gets
+                    // the float scratch — and, when the destination has to be
+                    // synthesized below, the kind of the slot itself.
+                    // Hard-coding the slot's kind instead described a slot the
+                    // value never lands in: `regalloc_push` / `regalloc_pop`
+                    // read exactly this field to choose their scratch
+                    // register, and `loc_width` reads it for the width.
+                    //
+                    // `ebp_loc_pat!` rather than `Loc::Frame` alone because a
+                    // frame-pointer location has two spellings and both carry
+                    // `is_float` (`regloc.py:113 class FrameLoc(RawEbpLoc)`);
+                    // naming one sent the other to the integer set.
+                    let is_float = match src_loc {
+                        Loc::Reg(r) => r.is_xmm,
+                        ebp_loc_pat!(e) => e.is_float,
+                        // An immediate is re-materialized into whichever set
+                        // its destination is in, and an address is not a legal
+                        // parallel-move operand at all.
+                        _ => false,
+                    };
                     let dst_loc = if i < target_arglocs.len() {
                         target_arglocs[i]
                     } else {
@@ -3887,22 +3908,15 @@ impl<'a> Assembler386<'a> {
                         // different storage.
                         let base_ofs = crate::jitframe::FIRST_ITEM_OFFSET as i32;
                         let dst_ofs = crate::regalloc::get_ebp_ofs(base_ofs, i);
-                        Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, false))
+                        Loc::Frame(crate::regloc::FrameLoc::new(i, dst_ofs, is_float))
                     };
-                    match src_loc {
-                        Loc::Reg(r) if r.is_xmm => {
-                            src_locations2.push(*src_loc);
-                            dst_locations2.push(dst_loc);
-                        }
-                        Loc::Frame(f) if f.ebp_loc.is_float => {
-                            src_locations2.push(*src_loc);
-                            dst_locations2.push(dst_loc);
-                        }
-                        _ => {
-                            src_locations1.push(*src_loc);
-                            dst_locations1.push(dst_loc);
-                        }
-                    }
+                    let (srcs, dsts) = if is_float {
+                        (&mut src_locations2, &mut dst_locations2)
+                    } else {
+                        (&mut src_locations1, &mut dst_locations1)
+                    };
+                    srcs.push(*src_loc);
+                    dsts.push(dst_loc);
                 }
                 let tmpreg1 = Loc::Reg(crate::regloc::X86_64_SCRATCH_REG);
                 let tmpreg2 = Loc::Reg(crate::regloc::XMM15);

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -147,6 +147,10 @@ impl RuntimeDescrTable for EmbeddedJitCodeTable {
     fn len(&self) -> usize {
         self.descrs.len()
     }
+
+    fn jitcodes(&self) -> &'static [Arc<JitCode>] {
+        self.jitcodes
+    }
 }
 
 #[cfg(test)]

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -1,0 +1,218 @@
+//! A build-time jitcode table and the one descr pool its bodies index.
+//!
+//! `CodeWriter.make_jitcodes()` (codewriter.py:89) produces two lists that
+//! only mean anything together: `all_jitcodes`, and the single shared
+//! `Assembler.descrs` (assembler.py:23) that every `d`/`j` argcode in every
+//! body indexes. A host that runs the codewriter at build time and embeds the
+//! two serialized lists in its binary has to join them back into the runtime
+//! shapes — `Arc<JitCode>` shells and a `RuntimeBhDescr` pool. This type is
+//! that join, and it is the only place the two lists meet.
+//!
+//! **What the join has to preserve.** A `BhDescr::JitCode` slot names its
+//! callee by an `all_jitcodes` index, and the object that index resolves to
+//! must be *the* object the table holds at it — `codewriter.py:80
+//! all_jitcodes[jitcode.index] is jitcode`, an identity, not an equality.
+//! Minting a second shell per pool slot satisfies every read that only wants a
+//! body and breaks every read that asks whether two references name the same
+//! jitcode: an `Arc::ptr_eq` dedup while flattening a registry sees one callee
+//! twice, and an index stamped on one shell is read back off the other.
+//!
+//! **Why there is no cycle to break.** The shells carry an EMPTY per-jitcode
+//! `exec.descrs` and resolve every operand through this pool as the
+//! process-global fallback ([`JitCode::descr_at`],
+//! [`init_global_build_descr_pool`]). So the pool holds jitcodes and the
+//! jitcodes hold nothing — a `BC_INLINE_CALL` chain of any depth resolves
+//! against one table. Copying the pool into each shell instead makes the depth
+//! the copy was taken at the depth that resolves: the callees inside a copied
+//! pool are shells of their own, and whatever pool they were given is the one
+//! their own operands read.
+
+use std::sync::Arc;
+
+use super::{CanonicalBhDescr, CanonicalJitCode, JitCode, RuntimeBhDescr, RuntimeDescrTable};
+
+/// A materialized build-time `all_jitcodes` + `Assembler.descrs` pair.
+///
+/// Process-lifetime by construction: [`Self::materialize`] leaks both lists,
+/// because the pool is installed as the global `descr_at` fallback, whose
+/// entries are handed out as `&'static`.
+pub struct EmbeddedJitCodeTable {
+    jitcodes: &'static [Arc<JitCode>],
+    descrs: &'static [RuntimeBhDescr],
+}
+
+// SAFETY: `materialize` builds only the `Descr` and `JitCode` variants. The
+// two variants that carry raw pointers — `Call`'s `JitCallTarget` and
+// `AssemblerToken` — are never constructed here, so nothing in either list is
+// a pointer this type could hand across a thread. A future arm that mints one
+// invalidates this, which is why the constructor is the only writer.
+unsafe impl Send for EmbeddedJitCodeTable {}
+unsafe impl Sync for EmbeddedJitCodeTable {}
+
+impl EmbeddedJitCodeTable {
+    /// Join the two serialized lists into runtime shells and their pool.
+    ///
+    /// `canonical` must be `all_jitcodes` in allocation order, which
+    /// `codewriter.py:68 jitcode.index = index` makes the same thing as
+    /// "indexed by `jitcode.index`" — asserted here, since every `j` operand
+    /// in the pool is an index into it and a list that drifted from its own
+    /// indices resolves silently to the wrong callee.
+    pub fn materialize(
+        canonical: &[Arc<CanonicalJitCode>],
+        descrs: Vec<CanonicalBhDescr>,
+    ) -> &'static Self {
+        let jitcodes: &'static [Arc<JitCode>] = Box::leak(
+            canonical
+                .iter()
+                .enumerate()
+                .map(|(index, core)| {
+                    assert_eq!(
+                        core.try_index(),
+                        Some(index),
+                        "jitcode {:?} sits at position {index} but names index {:?}; \
+                         every `j` operand indexes this list",
+                        core.name,
+                        core.try_index(),
+                    );
+                    Arc::new(JitCode::from_canonical((**core).clone()))
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        );
+        let pool: &'static [RuntimeBhDescr] = Box::leak(
+            descrs
+                .into_iter()
+                .map(|descr| match descr {
+                    // The callee is the table's own entry, cloned — an
+                    // `Arc::clone`, so `ptr_eq` against the table holds.
+                    CanonicalBhDescr::JitCode { jitcode_index, .. } => {
+                        RuntimeBhDescr::JitCode(Arc::clone(&jitcodes[jitcode_index]))
+                    }
+                    // Every other variant is an ordinary `d` descr and carries
+                    // through unchanged: the runtime pool element and the
+                    // build-time one are the same type.
+                    other => RuntimeBhDescr::Descr(Box::new(other)),
+                })
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+        );
+        Box::leak(Box::new(Self {
+            jitcodes,
+            descrs: pool,
+        }))
+    }
+
+    /// `metainterp_sd.jitcodes` (warmspot.py:281-282) — the flat registry
+    /// `resume.py:1338-1340` indexes by a frame's `jitcode_pos`.
+    pub fn jitcodes(&self) -> &'static [Arc<JitCode>] {
+        self.jitcodes
+    }
+
+    /// The shared pool, in `Assembler.descrs` order.
+    pub fn descrs(&self) -> &'static [RuntimeBhDescr] {
+        self.descrs
+    }
+
+    /// The jitcode an `all_jitcodes` index names.
+    pub fn by_index(&self, index: usize) -> Option<&'static Arc<JitCode>> {
+        self.jitcodes.get(index)
+    }
+
+    /// The jitcode a graph leaf name names, or `None`.
+    ///
+    /// A name is not unique — the codewriter derives it from the graph leaf,
+    /// and two distinct graphs can end on the same one — so this returns the
+    /// first match and is only a lookup for callers that hold a name and
+    /// nothing better. Anything that can carry an index should use
+    /// [`Self::by_index`], which is what the operands themselves do.
+    pub fn by_name(&self, name: &str) -> Option<&'static Arc<JitCode>> {
+        self.jitcodes.iter().find(|jitcode| jitcode.name() == name)
+    }
+
+    /// Install this pool as the process-global `descr_at` fallback.
+    ///
+    /// Idempotent through [`init_global_build_descr_pool`]: the first table
+    /// wins. Until this runs, a shell's operands resolve against its own empty
+    /// `exec.descrs` and every lookup returns `None`.
+    pub fn install_as_global_pool(&'static self) {
+        super::init_global_build_descr_pool(self);
+    }
+}
+
+impl RuntimeDescrTable for EmbeddedJitCodeTable {
+    fn get(&self, index: usize) -> Option<&'static RuntimeBhDescr> {
+        self.descrs.get(index)
+    }
+
+    fn len(&self) -> usize {
+        self.descrs.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Two jitcodes, the second reachable from the first through a `j` slot.
+    fn fixture() -> (Vec<Arc<CanonicalJitCode>>, Vec<CanonicalBhDescr>) {
+        let caller = Arc::new(CanonicalJitCode::new("caller"));
+        caller.set_index(0);
+        caller.set_body(Default::default());
+        let callee = Arc::new(CanonicalJitCode::new("callee"));
+        callee.set_index(1);
+        callee.set_body(Default::default());
+        (
+            vec![caller, callee],
+            vec![CanonicalBhDescr::JitCode {
+                jitcode_index: 1,
+                fnaddr: 0,
+                calldescr: Default::default(),
+            }],
+        )
+    }
+
+    /// The subject: a `j` slot resolves to the table's own entry, not to a
+    /// second shell that merely carries the same body.
+    #[test]
+    fn a_jitcode_slot_resolves_to_the_table_entry_itself() {
+        let (canonical, descrs) = fixture();
+        let table = EmbeddedJitCodeTable::materialize(&canonical, descrs);
+        let from_slot = table.descrs()[0]
+            .as_jitcode()
+            .expect("the `j` slot must resolve to a jitcode");
+        let from_table = table.by_index(1).expect("index 1 is in the table");
+        assert!(
+            Arc::ptr_eq(from_slot, from_table),
+            "`all_jitcodes[jitcode.index] is jitcode` (codewriter.py:80) is an \
+             identity: a second shell with the same body passes every read of \
+             the body and fails every `Arc::ptr_eq`",
+        );
+    }
+
+    /// The shells hold no pool of their own, so nothing is stored twice and
+    /// depth cannot decide what resolves.
+    #[test]
+    fn a_shell_carries_no_pool_of_its_own() {
+        let (canonical, descrs) = fixture();
+        let table = EmbeddedJitCodeTable::materialize(&canonical, descrs);
+        for jitcode in table.jitcodes() {
+            assert!(
+                jitcode.exec.descrs.is_empty(),
+                "a build-time shell resolves through the global pool; a \
+                 per-shell copy makes its callees' operands read whichever \
+                 pool those callees were handed",
+            );
+        }
+    }
+
+    /// A list whose positions disagree with its own `jitcode.index` stamps
+    /// cannot be indexed by a `j` operand, and says so at materialization
+    /// rather than resolving to the wrong callee.
+    #[test]
+    #[should_panic(expected = "names index")]
+    fn a_table_out_of_order_with_its_indices_is_refused() {
+        let (mut canonical, descrs) = fixture();
+        canonical.swap(0, 1);
+        let _ = EmbeddedJitCodeTable::materialize(&canonical, descrs);
+    }
+}

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -1,7 +1,9 @@
 mod assembler;
+mod embedded;
 
 pub(crate) use assembler::scalar_size;
 pub use assembler::{JitCodeBuilder, live_slots_for_state_field_jit};
+pub use embedded::EmbeddedJitCodeTable;
 pub use majit_translate::jitcode::{
     BhCallDescr as CanonicalBhCallDescr, BhDescr as CanonicalBhDescr, BhInteriorFieldSpec,
     JitCode as CanonicalJitCode,

--- a/majit/majit-metainterp/src/jitcode/mod.rs
+++ b/majit/majit-metainterp/src/jitcode/mod.rs
@@ -299,6 +299,19 @@ pub trait RuntimeDescrTable: Sync {
     fn get(&self, index: usize) -> Option<&'static RuntimeBhDescr>;
     fn len(&self) -> usize;
 
+    /// The build-time `all_jitcodes` list this pool's `j` operands index
+    /// (`codewriter.py:89 make_jitcodes`), positioned by `jitcode.index`.
+    ///
+    /// Empty by default: a host that decodes its jitcodes on demand has no
+    /// such list to hand over, and nothing here requires one. A host that
+    /// does return it is stating that those indices are already assigned, so
+    /// a second numbering must continue above them rather than restart —
+    /// `resume.py:1338-1340` indexes one list by a frame's `jitcode_pos`, and
+    /// two numberings over the same slots make that lookup ambiguous.
+    fn jitcodes(&self) -> &'static [std::sync::Arc<JitCode>] {
+        &[]
+    }
+
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
@@ -329,6 +342,14 @@ pub fn init_global_build_descr_pool(table: &'static dyn RuntimeDescrTable) {
 /// only exercises runtime-built jitcodes).
 pub(crate) fn global_build_descr_pool() -> Option<&'static dyn RuntimeDescrTable> {
     GLOBAL_BUILD_DESCR_POOL.get().copied()
+}
+
+/// The build-time `all_jitcodes` the installed pool numbers against, or empty.
+///
+/// See [`RuntimeDescrTable::jitcodes`]: this is the prefix of the flat registry
+/// that is already assigned, so any numbering done at run time starts above it.
+pub(crate) fn global_build_jitcodes() -> &'static [std::sync::Arc<JitCode>] {
+    global_build_descr_pool().map_or(&[], |pool| pool.jitcodes())
 }
 
 /// Per-`JitCode` descrs.  Pyre's analog of

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -716,6 +716,58 @@ where
     }
 }
 
+/// Flatten a dispatch JitCode and everything it can inline-call into the one
+/// flat `all_jitcodes` registry, returning it with the dispatch JitCode's
+/// `Arc`.
+///
+/// `codewriter.py:89 make_jitcodes` numbers a single list — `jitcode.index =
+/// index` as each is appended — and `resume.py:1338-1340 jitcode =
+/// jitcodes[jitcode_pos]` reads that same list back. So the registry has one
+/// property to keep: `registry[jitcode.index()]` is that jitcode.
+///
+/// `seed` is the part of the list a host already numbered at build time, which
+/// its own `j` operands are written against. Those indices are not this
+/// function's to assign — `JitCode::set_index` is set-once and asserts on a
+/// second value, so overwriting one is not even a silent renumbering, it is a
+/// panic. Numbering therefore CONTINUES above the seed rather than restarting,
+/// which is the same thing upstream does by appending to `all_jitcodes` in one
+/// pass.
+///
+/// The walk starts at the dispatch JitCode, not at the seed: every seeded entry
+/// is already present, so its callees are too. It is depth-agnostic, so a
+/// nested inline helper stays correctly indexed without a parent-relative walk.
+fn build_jitcode_registry(
+    seed: &[std::sync::Arc<crate::jitcode::JitCode>],
+    dispatch: crate::jitcode::JitCode,
+) -> (
+    Vec<std::sync::Arc<crate::jitcode::JitCode>>,
+    std::sync::Arc<crate::jitcode::JitCode>,
+) {
+    let mut registry = seed.to_vec();
+    let dispatch_position = registry.len();
+    dispatch.set_index(dispatch_position);
+    let dispatch_arc = std::sync::Arc::new(dispatch);
+    registry.push(dispatch_arc.clone());
+    let mut cursor = dispatch_position;
+    while cursor < registry.len() {
+        let current = registry[cursor].clone();
+        cursor += 1;
+        for descr in &current.exec.descrs {
+            if let Some(sub) = descr.as_jitcode() {
+                if registry.iter().any(|j| std::sync::Arc::ptr_eq(j, sub)) {
+                    continue;
+                }
+                // Reached here only if the seed does not already hold it, so
+                // it is a jitcode built at run time and has no index yet.
+                let idx = registry.len();
+                sub.set_index(idx);
+                registry.push(sub.clone());
+            }
+        }
+    }
+    (registry, dispatch_arc)
+}
+
 /// Descriptor for a JitDriver's variable layout.
 ///
 /// Mirrors RPython's `JitDriver(greens=[...], reds=[...])`:
@@ -1554,29 +1606,8 @@ impl<S: JitState> JitDriver<S> {
         // Production-active — `warmspot.py:660-666
         // make_args_specification` translation-time assert parity.
         validate_dispatch_jitcode_payload(self, &jitcode);
-        // Assign the dispatch JitCode the root global index 0, then flatten
-        // every reachable sub-JitCode into one flat registry, assigning each
-        // its own absolute index (resume.py:1050 `metainterp_sd.jitcodes`).
-        // The worklist enumeration is depth-agnostic, so a future nested
-        // inline helper stays correctly indexed without a parent-relative walk.
-        jitcode.set_index(0);
-        let dispatch_arc = std::sync::Arc::new(jitcode);
-        let mut registry: Vec<std::sync::Arc<crate::jitcode::JitCode>> = vec![dispatch_arc.clone()];
-        let mut cursor = 0;
-        while cursor < registry.len() {
-            let current = registry[cursor].clone();
-            cursor += 1;
-            for descr in &current.exec.descrs {
-                if let Some(sub) = descr.as_jitcode() {
-                    if registry.iter().any(|j| std::sync::Arc::ptr_eq(j, sub)) {
-                        continue;
-                    }
-                    let idx = registry.len();
-                    sub.set_index(idx);
-                    registry.push(sub.clone());
-                }
-            }
-        }
+        let (registry, dispatch_arc) =
+            build_jitcode_registry(crate::jitcode::global_build_jitcodes(), jitcode);
         // call.py:147-148 `grab_initial_jitcodes`:
         //
         //     jd.mainjitcode = self.get_jitcode(jd.portal_graph)
@@ -9464,5 +9495,117 @@ mod cross_loop_cut_close_tests {
             !driver.meta.is_cross_loop_cut_key(inner_key),
             "the cut mark must not outlive the loop it describes",
         );
+    }
+}
+
+#[cfg(test)]
+mod jitcode_registry_tests {
+    use super::*;
+    use crate::jitcode::{JitCode, RuntimeBhDescr};
+    use std::sync::Arc;
+
+    /// A jitcode with a committed body, optionally already numbered the way a
+    /// build-time table numbers its entries.
+    fn jitcode(name: &str, prenumbered: Option<usize>) -> Arc<JitCode> {
+        let core = majit_translate::jitcode::JitCode::new(name);
+        core.set_body(Default::default());
+        if let Some(index) = prenumbered {
+            core.set_index(index);
+        }
+        Arc::new(JitCode::from_canonical(core))
+    }
+
+    /// A dispatch jitcode that inline-calls each of `callees`.
+    fn dispatch_calling(callees: &[Arc<JitCode>]) -> JitCode {
+        let core = majit_translate::jitcode::JitCode::new("dispatch");
+        core.set_body(Default::default());
+        let mut dispatch = JitCode::from_canonical(core);
+        dispatch.exec.descrs = callees
+            .iter()
+            .map(|callee| RuntimeBhDescr::JitCode(Arc::clone(callee)))
+            .collect();
+        dispatch
+    }
+
+    /// Every entry sits at the index it names — the property
+    /// `resume.py:1338-1340` reads the registry with.
+    fn assert_self_indexed(registry: &[Arc<JitCode>]) {
+        for (position, jitcode) in registry.iter().enumerate() {
+            assert_eq!(
+                jitcode.try_index(),
+                Some(position),
+                "`{}` sits at {position} but names {:?}",
+                jitcode.name(),
+                jitcode.try_index(),
+            );
+        }
+    }
+
+    /// With no build-time table the dispatch jitcode is the root of the list,
+    /// exactly as before a seed existed.
+    #[test]
+    fn an_unseeded_registry_numbers_the_dispatch_jitcode_first() {
+        let helper = jitcode("helper", None);
+        let (registry, dispatch) = build_jitcode_registry(&[], dispatch_calling(&[helper]));
+        assert_eq!(dispatch.index(), 0);
+        assert_eq!(registry.len(), 2);
+        assert_self_indexed(&registry);
+    }
+
+    /// The subject: a callee that a build-time table already numbered keeps
+    /// that number.
+    ///
+    /// Renumbering it is not a silent drift — `set_index` is set-once and
+    /// asserts — so before the seed existed, inline-calling a build-time
+    /// jitcode panicked here rather than tracing.
+    /// A seed whose inline-called entry sits at an index the run-time
+    /// numbering would otherwise hand to something else. `add` at 2 rather
+    /// than at the first free slot is the point: a seed one entry long would
+    /// pass this test by coincidence.
+    fn seed() -> Vec<Arc<JitCode>> {
+        vec![
+            jitcode("mainloop", Some(0)),
+            jitcode("val_add", Some(1)),
+            jitcode("add", Some(2)),
+        ]
+    }
+
+    #[test]
+    fn a_prenumbered_callee_keeps_the_index_its_own_operands_use() {
+        let seed = seed();
+        let (registry, dispatch) = build_jitcode_registry(&seed, dispatch_calling(&seed[2..]));
+        assert_eq!(
+            seed[2].index(),
+            2,
+            "the seed's own `j` operands are written against this index",
+        );
+        assert_eq!(
+            dispatch.index(),
+            3,
+            "the run-time numbering continues above the seed rather than \
+             restarting over slots the build already assigned",
+        );
+        assert_eq!(
+            registry.len(),
+            4,
+            "the callee is seeded, not appended twice"
+        );
+        assert_self_indexed(&registry);
+    }
+
+    /// A seed and a run-time helper in one registry: both numbering authorities
+    /// land in one list with no collision and no hole.
+    #[test]
+    fn a_runtime_helper_is_numbered_above_a_seeded_callee() {
+        let seed = seed();
+        let helper = jitcode("helper", None);
+        let (registry, dispatch) = build_jitcode_registry(
+            &seed,
+            dispatch_calling(&[Arc::clone(&seed[2]), Arc::clone(&helper)]),
+        );
+        assert_eq!(dispatch.index(), 3);
+        assert_eq!(helper.index(), 4);
+        assert_eq!(registry.len(), 5);
+        assert_self_indexed(&registry);
     }
 }

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -123,8 +123,8 @@ pub use jit_state::{
     bridge_decode_red,
 };
 pub use jitcode::{
-    BC_GOTO, JitArgKind, JitCallArg, JitCode, JitCodeBuilder, RuntimeBhDescr, RuntimeDescrTable,
-    init_global_build_descr_pool, insns, live_slots_for_state_field_jit,
+    BC_GOTO, EmbeddedJitCodeTable, JitArgKind, JitCallArg, JitCode, JitCodeBuilder, RuntimeBhDescr,
+    RuntimeDescrTable, init_global_build_descr_pool, insns, live_slots_for_state_field_jit,
 };
 pub use jitdriver::{
     DeclarativeJitDriver, JitDriver, JitDriverStaticData, MultiFrameBlackholeResult,

--- a/majit/majit-metainterp/tests/jit_interp_inline_pipeline_build_time_callee.rs
+++ b/majit/majit-metainterp/tests/jit_interp_inline_pipeline_build_time_callee.rs
@@ -1,0 +1,206 @@
+//! An `inline_pipeline_*` call resolves a callee a build-time table already
+//! numbered.
+//!
+//! The three `inline_pipeline_*` call policies name their callee by the call's
+//! last path segment and ask the host for it through `__majit_pipeline_jitcode`
+//! (`jitcode_lower/lower_value.rs`). Unlike the `inline_*` policies, the
+//! returned jitcode is not built here: it comes out of a table the host
+//! serialized after running the codewriter, so it already carries the
+//! `jitcode.index` its own operands are written against (`codewriter.py:68`).
+//!
+//! That index is the whole point of this fixture. Installing the dispatch
+//! JitCode flattens everything it can inline-call into the flat registry
+//! `resume.py:1338-1340` indexes, and the numbering there used to start at 0
+//! and stamp every jitcode it discovered. `JitCode::set_index` is set-once and
+//! asserts, so the first `inline_pipeline_*` call over a build-time callee
+//! aborted the install with `index already set to N, cannot reassign to 1`
+//! rather than tracing. Nothing else covers this: the other inline policies
+//! build their callee on the spot, so it reaches the walk unnumbered.
+//!
+//! `greens = []` is deliberate and the macro's empty-green-set report is the
+//! expected line for it: what is under test is what the install path does with
+//! the callee's index, and no trace is recorded here.
+
+use std::sync::{Arc, OnceLock};
+
+use majit_metainterp::{Assembler, EmbeddedJitCodeTable, JitDriver};
+
+pub type Bytecode = [u8];
+
+const OP_NOP: u8 = 0;
+const OP_DOUBLE: u8 = 1;
+
+/// The callee the fixture inline-calls. Its body is what the host would have
+/// deserialized, so it is spelled here the way the blob spells it: a committed
+/// body ending in a typed return, and an index assigned at build time.
+fn build_time_table() -> &'static EmbeddedJitCodeTable {
+    static TABLE: OnceLock<&'static EmbeddedJitCodeTable> = OnceLock::new();
+    TABLE.get_or_init(|| {
+        // Two entries so the callee does NOT sit at the slot a fresh numbering
+        // would hand it. With the callee at index 0 the collision cannot show:
+        // the old walk numbered the dispatch jitcode 0 and would have written
+        // 1, which happens to be free.
+        let filler = canonical_jitcode("pipeline_filler", 0);
+        let callee = canonical_jitcode("pipeline_double", 1);
+        let table = EmbeddedJitCodeTable::materialize(&[filler, callee], Vec::new());
+        table.install_as_global_pool();
+        table
+    })
+}
+
+/// `int_return/i` reading int register 0 — the minimum
+/// `trailing_return_info()` accepts, which the `inline_pipeline_*` lowering
+/// requires of its callee.
+fn canonical_jitcode(name: &str, index: usize) -> Arc<majit_translate::jitcode::JitCode> {
+    let core = majit_translate::jitcode::JitCode::new(name);
+    core.set_body(majit_translate::jitcode::JitCodeBody {
+        code: vec![majit_metainterp::jitcode::insns::BC_INT_RETURN, 0],
+        c_num_regs_i: 1,
+        ..Default::default()
+    });
+    core.set_index(index);
+    Arc::new(core)
+}
+
+/// The hook the `inline_pipeline_*` lowering emits a call to. The host owns
+/// both the table and this resolution; nothing below it knows the names.
+#[allow(non_snake_case)]
+fn __majit_pipeline_jitcode(name: &str) -> Arc<majit_metainterp::JitCode> {
+    build_time_table()
+        .by_name(name)
+        .unwrap_or_else(|| panic!("no build-time jitcode named {name}"))
+        .clone()
+}
+
+/// The concrete (non-tracing) path. The jitcode above stands in for its traced
+/// form, exactly as a pipeline-built callee stands in for the real function.
+fn pipeline_double(value: i64) -> i64 {
+    value * 2
+}
+
+struct DoublingState {
+    a: i64,
+}
+
+#[majit_macros::jit_interp(
+    state = DoublingState,
+    env = Bytecode,
+    state_fields = { a: int },
+    greens = [],
+    calls = { pipeline_double => inline_pipeline_int },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn doubling_interp(program: &Bytecode, threshold: u32) -> i64 {
+    let mut driver: JitDriver<DoublingState> = JitDriver::new(threshold);
+    let mut pc: usize = 0;
+    let mut state = DoublingState { a: 1 };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+    while pc < program.len() {
+        jit_merge_point!();
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_NOP => {}
+            OP_DOUBLE => state.a = pipeline_double(state.a),
+            _ => break,
+        }
+    }
+    state.a
+}
+
+/// The subject: installing the driver over a dispatch JitCode that
+/// inline-calls a build-time callee completes, and every jitcode in the flat
+/// registry sits at the index it names.
+///
+/// A threshold above the program's length keeps the tracer out of it — the
+/// registry is built at install time, which is where the numbering happened.
+#[test]
+fn a_build_time_callee_survives_the_dispatch_registry_numbering() {
+    let program = [OP_DOUBLE, OP_DOUBLE, OP_NOP];
+    assert_eq!(
+        doubling_interp(&program, 1_000_000),
+        4,
+        "the concrete path must still double twice",
+    );
+
+    let table = build_time_table();
+    assert_eq!(
+        table.by_name("pipeline_double").map(|jc| jc.index()),
+        Some(1),
+        "the callee keeps the index its own operands are written against; \
+         the registry numbering must not have reassigned it",
+    );
+}
+
+/// Every jitcode reachable from `root` through `j` slots, `root` included, in
+/// the order the registry walk finds them.
+fn reachable(root: &Arc<majit_metainterp::JitCode>) -> Vec<Arc<majit_metainterp::JitCode>> {
+    let mut found = vec![Arc::clone(root)];
+    let mut cursor = 0;
+    while cursor < found.len() {
+        let current = Arc::clone(&found[cursor]);
+        cursor += 1;
+        for descr in &current.exec.descrs {
+            if let Some(sub) = descr.as_jitcode() {
+                if !found.iter().any(|j| Arc::ptr_eq(j, sub)) {
+                    found.push(Arc::clone(sub));
+                }
+            }
+        }
+    }
+    found
+}
+
+/// The control: the build-time callee really is spliced, and really does reach
+/// the registry walk.
+///
+/// Without this the test above passes for a fixture whose call was lowered as
+/// a residual — the callee would never reach the walk, and the numbering it is
+/// meant to exercise would never run.
+///
+/// The splice is one level down: the dispatch JitCode inline-calls the
+/// per-opcode arm, and the arm inline-calls the callee. Asserting on the
+/// dispatch's own descrs would look only at the arms and find nothing, which
+/// is not the same fact.
+#[test]
+fn the_dispatch_jitcode_inline_calls_the_build_time_callee() {
+    let mut asm = Assembler::new();
+    asm.set_canonical_liveness_triple(vec![0], vec![], vec![]);
+    __prebuild_jitcode_liveness_doubling_interp(&mut asm);
+    let _ = asm.ensure_canonical_liveness_offset();
+    let dispatch = Arc::new(
+        __dispatch_jitcode_doubling_interp(&mut asm, 0i64)
+            .expect("dispatch lower must succeed for the pipeline fixture"),
+    );
+    let reached = reachable(&dispatch);
+    let names: Vec<&str> = reached.iter().map(|jc| jc.name()).collect();
+    assert!(
+        names.contains(&"pipeline_double"),
+        "`inline_pipeline_int` must splice the host-resolved callee somewhere \
+         the registry walk reaches; reached {names:?}",
+    );
+    assert!(
+        reached.iter().any(|jc| jc
+            .code
+            .contains(&majit_metainterp::jitcode::insns::BC_INLINE_CALL)),
+        "the callee must arrive through BC_INLINE_CALL, not a residual call",
+    );
+    // The callee is reached at depth 2, so this fixture also pins that the
+    // walk does not stop at the dispatch's own slots.
+    assert!(
+        !dispatch
+            .exec
+            .descrs
+            .iter()
+            .filter_map(majit_metainterp::RuntimeBhDescr::as_jitcode)
+            .any(|callee| callee.name() == "pipeline_double"),
+        "the callee is expected one level below the dispatch (inside the \
+         per-opcode arm); if it moved up, this fixture stopped covering the \
+         depth it was written for",
+    );
+}


### PR DESCRIPTION
Root cause of the `synth/generator_tree_recursion` jit-stats split that #1256 exposed: `guard_failures` 2951 -> 2955 on both x86 runners, unchanged at 2951 on aarch64.

## What is wrong

`get_ebp_ofs(base_ofs, position)` is `base_ofs + WORD * (position + JITFRAME_FIXED_SIZE)`. A position names a slot only together with the base it is resolved against. The canonical base is `get_baseofs_of_frame_field()` = `FIRST_ITEM_OFFSET`; it is what `FrameManager::new` is built with (`regalloc.rs`) and what every other frame-slot construction in both assemblers passes.

The JUMP path passed `0` when it synthesised a destination for an argument the target LABEL had recorded no argloc for. For the same position that names a slot `FIRST_ITEM_OFFSET` bytes below the one the regalloc means — same value, different storage.

## Why it surfaced only now

`regalloc_mov`'s frame-to-frame identity arm compared `FrameLoc::position`. Those two locations share a position, so they compared **equal** and the move was skipped entirely: the wrong address was never written and the defect stayed masked.

#1256 changed that arm to compare offsets — the identity upstream's `_getregkey()` uses, and correct, since two positions can only be told apart by the storage they resolve to. The move stopped being skipped and began landing at the wrong slot. The `else` branch is reached only when the target LABEL recorded no arglocs, which is why one architecture moved and the other did not.

So this is not a counter to re-record. `check.py`'s own note on per-platform baselines says it: a counter that splits per host "is not a host disagreement, it is a boundary the harness has not pinned yet", and it asks for the fixture's dependence on the host input to be removed rather than the host recorded. Here the unpinned boundary was the frame base.

## Verification

- `synth/generator_tree_recursion` still passes on aarch64 — the branch is not reached there, so the baseline must not move, and it does not.
- `cargo test -p majit-backend-dynasm --features dynasm`: 0 failed.
- `cargo fmt --all --check`: clean.
- Prediction this PR's CI settles: the two x86 runners return to 2951 and no baseline changes.

## Adjacent, deliberately not touched

The same synthesised destination hardcodes `is_float: false`, while the match immediately below routes a float source into the float location set. A float argument reaching this branch would be given an integer slot as its destination. Left alone to keep this change single-variable; worth a follow-up.

— *opened by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for embedding and accessing build-time JIT code registries at runtime.
  * Preserved JIT code identities and indexes when combining embedded code with dynamically generated code.
  * Improved inline-call handling for build-time callees.

* **Bug Fixes**
  * Fixed jump handling on AArch64 and x86 to use the correct frame layout.
  * Resolved inconsistencies that could produce incorrect register or frame destinations during generated code execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->