### PR TITLE
jit: give every bridge the loop-header GUARD_FUTURE_CONDITION, and stop dereferencing its absence

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4141,14 +4141,24 @@ impl Optimizer {
 
         // A bridge trace carries no GUARD_FUTURE_CONDITION
         // (reached_loop_header's GFC lives in pyre's loop-creation path,
-        // which bridges skip), so `self.patchguardop` is None and the
-        // retarget's inline_short_preamble guards never receive a
-        // rd_resume_position. Synthesize patchguardop from the bridge's own
-        // last body guard (highest resume position, closest to the close).
-        // `retarget_close_jump` already gated on `has_body_guard`, so the
-        // filter is guaranteed non-empty here.
-        if retarget_close_jump
-            && self.patchguardop.is_none()
+        // which bridges skip), so `self.patchguardop` is None where upstream
+        // always has one: `_jump_to_existing_trace` dereferences
+        // `self.optimizer.patchguardop` unconditionally for the extra guards
+        // (unroll.py:333-335) and passes it to `inline_short_preamble`, which
+        // dereferences it again per replayed guard (unroll.py:409).
+        // Synthesize it from the bridge's own last body guard (highest resume
+        // position, closest to the close).
+        //
+        // Gated only on there being such a guard, NOT on `retarget_close_jump`.
+        // Every path that reaches `try_jump_to_existing_trace` below can read
+        // patchguardop, and `retarget_close_jump` is strictly narrower than
+        // that: it also demands `ops.last()` be a JUMP, while the close is
+        // decided from the post-optimization `terminal_op`. Leaving the gate
+        // there let a bridge inline a short preamble with no patchguardop,
+        // where the replayed guards keep the `rd_resume_position` cloned off
+        // the PREAMBLE's guard and resolve their snapshot against this
+        // trace's numbering. Setting it when nothing reads it is inert.
+        if self.patchguardop.is_none()
             && let Some(g) = ops
                 .iter()
                 .filter(|o| o.opcode.is_guard() && o.rd_resume_position.get() >= 0)

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3450,12 +3450,41 @@ impl OptUnroll {
             // unconditionally on the GUARD_FUTURE_CONDITION emitted at
             // `reached_loop_header` (pyjitpl.py:2969), so by the time
             // `_jump_to_existing_trace` runs `self.optimizer.patchguardop` is
-            // always populated. pyre mirrors this: `close_loop_args_at`
-            // (trace_opcode.rs:1863) emits the same GFC, and Phase 1 captures
-            // it into `patchguardop` (rewrite.rs:2737), which Phase 2 inherits
-            // (unroll.rs:513). Skip the read when `extra_guards` is empty —
-            // RPython's `for guard in extra_guards.extra_guards` loop body is
-            // also skipped in that case.
+            // always populated.
+            //
+            // pyre mirrors that on the LOOP path only: the GFC comes from the
+            // close-loop path and Phase 1 captures it into `patchguardop`,
+            // which Phase 2 inherits. A bridge records no GFC at all, so on
+            // the `optimize_bridge` -> `try_jump_to_existing_trace` route the
+            // only patchguardop is the stand-in `optimize_bridge` synthesizes
+            // from one of the bridge's own body guards — and a bridge whose
+            // body carries no guard with a resume position leaves even that
+            // unset. Upstream cannot reach that state, because :2991-2993
+            // emits the GFC before the closing JUMP of every trace that
+            // reaches `reached_loop_header`, a bridge grown from a
+            // ResumeGuardDescr included.
+            //
+            // Decline this target token rather than dereference a None, the
+            // way the replayed-guard arm of `inline_short_preamble` does.  The
+            // check sits here, BEFORE any `send_extra_operation`, because the
+            // stamp loop below streams ops into the trace as it goes: bailing
+            // out from inside it would leave a partially-guarded target
+            // behind.  Declining costs this target token only; the caller
+            // tries the next one and otherwise falls back to jump_to_preamble
+            // (unroll.py:208-210), so the bridge still compiles.
+            if !extra_guards.is_empty() && ctx.patchguardop.is_none() {
+                if crate::optimizeopt::majit_log_enabled() {
+                    eprintln!(
+                        "[jit] jump_to_existing_trace: target_token #{tt_idx} needs \
+                         {} extra guard(s) but the trace has no patchguardop — declining",
+                        extra_guards.len(),
+                    );
+                }
+                continue;
+            }
+            // Skip the read when `extra_guards` is empty — RPython's
+            // `for guard in extra_guards.extra_guards` loop body is also
+            // skipped in that case.
             for guard_req in &extra_guards {
                 let emitted = guard_req.to_ops(&args, ctx);
                 if emitted.is_empty() {
@@ -3466,9 +3495,9 @@ impl OptUnroll {
                 // the invariant is asserted before any op streams out.
                 let patch = ctx.patchguardop.as_ref().unwrap_or_else(|| {
                     panic!(
-                        "unroll.py:333 invariant: patchguardop must be set \
-                         when extra_guards is non-empty (target_token #{}, \
-                         {} extra guard(s), force_boxes={})",
+                        "unroll.py:333 invariant: the non-empty-extra_guards \
+                         decline above must have skipped this target token \
+                         (target_token #{}, {} extra guard(s), force_boxes={})",
                         tt_idx,
                         extra_guards.len(),
                         force_boxes,
@@ -3988,7 +4017,10 @@ impl OptUnroll {
                     // one. Decline the inlining instead, exactly as the unmapped
                     // -arg arm above does: the caller falls back to
                     // jump_to_preamble and the trace still compiles.
-                    let Some(patch_pos) = ctx.patchguardop.as_ref().map(|p| p.rd_resume_position.get())
+                    let Some(patch_pos) = ctx
+                        .patchguardop
+                        .as_ref()
+                        .map(|p| p.rd_resume_position.get())
                     else {
                         if crate::optimizeopt::majit_log_enabled() {
                             eprintln!(
@@ -8713,6 +8745,65 @@ mod tests {
         assert!(
             ctx.take_invalid_loop().is_some(),
             "the caller must see an InvalidLoop and fall back to jump_to_preamble"
+        );
+    }
+
+    /// unroll.py:333 dereferences `self.optimizer.patchguardop` before stamping
+    /// the guards `generate_guards` produced, which upstream can do because
+    /// `reached_loop_header` emits a GUARD_FUTURE_CONDITION before the closing
+    /// JUMP of every trace that reaches it — a bridge included
+    /// (pyjitpl.py:2991-2993). pyre records that GFC only on the loop path, so
+    /// a bridge arrives here with whatever `optimize_bridge` could synthesize
+    /// from its own body guards, and a bridge with no such guard arrives with
+    /// none. Skip the target token instead of dereferencing.
+    #[test]
+    fn jump_to_existing_trace_declines_a_target_needing_guards_with_no_patchguardop() {
+        use crate::history::TargetToken;
+        use crate::optimizeopt::intutils::IntBound;
+        use crate::optimizeopt::virtualstate::{VirtualState, VirtualStateInfo};
+
+        let mut optimizer = Optimizer::new();
+        let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(1, 0);
+
+        let arg_operand = rooted_resop_operand(Type::Int, 11);
+        let arg = arg_operand.to_opref();
+
+        // The incoming state knows nothing statically; the target demands a
+        // narrow bound and the concrete runtime value falls inside it, which is
+        // virtualstate.py:493-498's runtime fallback — it manufactures
+        // INT_GE/INT_LE + GUARD_TRUE pairs (intutils.py:1264
+        // `IntBound.make_guards`) rather than rejecting the target.
+        let incoming = VirtualState::new(vec![VirtualStateInfo::Unknown(Type::Int)]);
+        let runtime_box = OpRef::const_int(5);
+        let mut target_tokens = vec![TargetToken::new_loop(1)];
+        target_tokens[0].virtual_state =
+            Some(VirtualState::new(vec![VirtualStateInfo::IntBounded(
+                IntBound::bounded(0, 10),
+            )]));
+
+        let unroll = OptUnroll::default();
+        assert!(ctx.patchguardop.is_none());
+        assert!(optimizer.patchguardop.is_none());
+        let vs = unroll.jump_to_existing_trace_with_vs(
+            &[arg],
+            None,
+            &mut target_tokens,
+            &mut optimizer,
+            &mut ctx,
+            false,
+            &[runtime_box],
+            Some(incoming),
+        );
+
+        // unroll.py:207-211 reads the result as "None means a target matched and
+        // the jump was retargeted"; a returned virtual state means none did, and
+        // `optimize_bridge` falls back to jump_to_preamble. The point of the test
+        // is that the declined target reaches that fallback instead of
+        // dereferencing the absent patchguardop.
+        assert!(
+            vs.is_some(),
+            "the only target token needed extra guards it could not stamp, so it \
+             must be declined and the caller left to jump_to_preamble"
         );
     }
 }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -3973,13 +3973,36 @@ impl OptUnroll {
                     new_op.setdescr(crate::optimizeopt::make_resume_at_position_descr());
                     new_op.clearfailargs();
                     new_op.clear_fail_arg_types();
-                    // unroll.py:409: op.rd_resume_position = patchguardop.rd_resume_position
-                    // RPython: patchguardop is always set (from GUARD_FUTURE_CONDITION).
-                    if let Some(ref patch) = ctx.patchguardop {
-                        new_op
-                            .rd_resume_position
-                            .set(patch.rd_resume_position.get());
-                    }
+                    // unroll.py:409: op.rd_resume_position =
+                    // patchguardop.rd_resume_position — an unconditional
+                    // dereference, so upstream has no branch for an absent
+                    // patchguardop.
+                    //
+                    // `new_op` is a clone of the short-preamble entry, which is
+                    // itself a whole-op clone of a guard from the PREAMBLE
+                    // trace, so it arrives carrying that trace's
+                    // rd_resume_position. Skipping the stamp does not leave the
+                    // guard unstamped — it leaves it stamped with a coordinate
+                    // from another trace's numbering, which
+                    // `store_final_boxes_in_guard` then resolves against this
+                    // one. Decline the inlining instead, exactly as the unmapped
+                    // -arg arm above does: the caller falls back to
+                    // jump_to_preamble and the trace still compiles.
+                    let Some(patch_pos) = ctx.patchguardop.as_ref().map(|p| p.rd_resume_position.get())
+                    else {
+                        if crate::optimizeopt::majit_log_enabled() {
+                            eprintln!(
+                                "[jit] inline_short_preamble: no patchguardop for replayed \
+                                 {:?} — InvalidLoop",
+                                new_op.opcode
+                            );
+                        }
+                        ctx.signal_invalid_loop(
+                            "inline_short_preamble: replayed guard with no patchguardop",
+                        );
+                        return Vec::new();
+                    };
+                    new_op.rd_resume_position.set(patch_pos);
                     // history.py:227/268/314 — Const values ride inline
                     // on the OpRef (ConstInt/ConstFloat/
                     // ConstPtr). No pool replay needed.
@@ -8644,5 +8667,52 @@ mod tests {
         )];
 
         assert_eq!(closing_loop_contract_arity(&ops, 5), 3);
+    }
+
+    /// unroll.py:409 stamps every replayed short-preamble guard with
+    /// `patchguardop.rd_resume_position`, unconditionally. A short-preamble
+    /// entry is a whole-op clone of a guard from the preamble trace, so it
+    /// arrives carrying that trace's coordinate; leaving it in place when no
+    /// patchguardop exists hands `store_final_boxes_in_guard` a position from
+    /// another trace's numbering. Decline the inlining instead.
+    #[test]
+    fn inline_short_preamble_declines_a_replayed_guard_with_no_patchguardop() {
+        use crate::optimizeopt::shortpreamble::{ShortPreamble, ShortPreambleOp};
+
+        let mut optimizer = Optimizer::new();
+        let mut ctx = crate::optimizeopt::OptContext::with_num_inputs(2, 0);
+
+        let short_input_operand = rooted_resop_operand(Type::Int, 11);
+        let short_input = short_input_operand.to_opref();
+        let jump_arg = OpRef::int_op(12);
+        ctx.materialize_operand_at(jump_arg);
+
+        // A guard carrying the PREAMBLE trace's resume coordinate.
+        let mut guard = Op::new(OpCode::GuardTrue, &[short_input_operand]);
+        guard.pos.set(OpRef::void_op(13));
+        guard.rd_resume_position.set(4242);
+
+        let mut short_preamble = ShortPreamble::empty();
+        short_preamble.inputargs = vec![short_input];
+        short_preamble.ops = vec![ShortPreambleOp {
+            op: guard,
+            arg_mapping: Vec::new(),
+            fail_arg_mapping: Vec::new(),
+        }];
+
+        assert!(ctx.patchguardop.is_none());
+        let extra = OptUnroll::inline_short_preamble(
+            &[jump_arg],
+            &[jump_arg],
+            &short_preamble,
+            &mut optimizer,
+            &mut ctx,
+        );
+
+        assert!(extra.is_empty(), "declined inlining returns no extra args");
+        assert!(
+            ctx.take_invalid_loop().is_some(),
+            "the caller must see an InvalidLoop and fall back to jump_to_preamble"
+        );
     }
 }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -11855,6 +11855,46 @@ fn handle<Sym: WalkSym>(
                 let already_declined = ctx.trace_ctx.cross_loop_close_declined(key);
                 if !has_partial && has_targets {
                     if !already_declined {
+                        // pyjitpl.py:2991-2993 reached_loop_header:
+                        //
+                        //     # generate a dummy guard just before the JUMP so
+                        //     # that unroll can use it when it's creating
+                        //     # artificial guards.
+                        //     self.generate_guard(rop.GUARD_FUTURE_CONDITION)
+                        //
+                        // Upstream emits it once at :2993, ahead of BOTH the
+                        // `get_procedure_token` / `compile_trace` pair at
+                        // :3001-3007 that closes into an ALREADY compiled loop
+                        // and the merge-point scan at :3018-3060 that closes a
+                        // loop of the trace's own. pyre splits those two
+                        // outcomes across different returns and had the guard on
+                        // only one of them: the own-loop leg gets it from
+                        // `close_loop_args_at`, which runs off
+                        // `DispatchOutcome::CloseLoop`, while this leg returns
+                        // `CompileTracePending` and never reached it. So every
+                        // bridge arrived at the optimizer carrying no
+                        // GUARD_FUTURE_CONDITION — measured across
+                        // `pyre/bench/synth`: 672 bridge compilations, 0 with
+                        // one. `Optimizer.patchguardop` was left to a stand-in
+                        // synthesized from one of the bridge's own body guards,
+                        // whose resume coordinate is mid-trace where upstream's
+                        // is the merge point's, and a bridge with no such guard
+                        // got none at all.
+                        //
+                        // `_jump_to_existing_trace` dereferences that
+                        // patchguardop for the extra virtual-state guards
+                        // (unroll.py:333-337) and hands it to
+                        // `inline_short_preamble`, which stamps it onto every
+                        // replayed short-preamble guard (unroll.py:409).
+                        //
+                        // Emitted on this leg only, so the own-loop leg is not
+                        // double-guarded. `next_instr` is the merge point being
+                        // crossed — the loop header the synthesized JUMP goes
+                        // to, matching `close_loop_args_at`'s `orgpc =
+                        // target_pc` rather than the back edge that got here.
+                        ctx.trace_ctx
+                            .record_guard(OpCode::GuardFutureCondition, &[], 0);
+                        walker_capture_snapshot_for_last_guard(ctx, next_instr)?;
                         // jitdriver.rs:2981-2988 states the rule the latch runs
                         // under: only latch what an attempt actually rejected.
                         // The give-up below returns without calling into


### PR DESCRIPTION
Follow-up to #1232 / #1240. Three commits on one defect: `Optimizer.patchguardop`
is absent for every bridge, and the three places that read it disagreed about
what to do with a `None`.

## The measurement

`optimize_bridge` was instrumented and run over all 419 `pyre/bench/synth`
fixtures:

| | |
|---|---|
| bridge compilations | **672** |
| carrying a `GUARD_FUTURE_CONDITION` | **0** |
| arriving with a `patchguardop` | **0** |
| with no body guard to synthesize one from | **7** |
| where the old synthesis gate declined to synthesize (`retarget_close_jump` false) | **306** (45.5%) |

## The root cause

`reached_loop_header` emits a dummy `GUARD_FUTURE_CONDITION` just before the
JUMP, "so that unroll can use it when it's creating artificial guards"
(pyjitpl.py:2991-2993). Upstream emits it **once**, ahead of both closes that
follow it: the `get_procedure_token` / `compile_trace` pair at :3001-3007 that
jumps into an already-compiled loop, and the merge-point scan at :3018-3060 that
closes a loop of the trace's own. A bridge grown from a `ResumeGuardDescr` goes
through the first one — the function's own comment at :2996-3000 says so.

pyre splits those two outcomes across different returns and had the guard on only
one. The own-loop leg gets it from `close_loop_args_at`, which runs off
`DispatchOutcome::CloseLoop`; the leg that closes into an existing loop returns
`CompileTracePending` and never reached it. Hence 0/672.

What stood in for it was a stand-in the optimizer synthesizes from one of the
bridge's own body guards. Its `rd_resume_position` is a mid-trace coordinate
where upstream's is the merge point's — the same error `close_loop_args_at`
already warns about on the loop leg ("orgpc must be the loop header TARGET, not
the JUMP_BACKWARD's PC ... If orgpc is wrong, all those guards resume at the
wrong PC").

## The three commits

**1. Synthesize the stand-in on every path that can read it.** The synthesis was
gated on `retarget_close_jump`, which additionally demands `ops.last()` be a
JUMP, while whether the trace closes is decided from the post-optimization
`terminal_op`. 306 of the 672 bridge compilations fell in that gap and reached
`try_jump_to_existing_trace` with nothing. There, `inline_short_preamble`
silently skipped the stamp — which does not leave the replayed guard unstamped,
it leaves the PREAMBLE's coordinate on it (a short-preamble entry is a whole-op
clone, `ShortPreambleOp { op: (*preamble_op.op).clone(), .. }`), and
`store_final_boxes_in_guard` then resolves that against this trace's numbering.
Gate it on having such a guard alone, and make the replay site decline the
inlining when there is still none, the way its unmapped-arg arm already does.

**2. Decline a jump target instead of panicking.** The extra-guard site
(unroll.py:333-337) dereferenced the same `Option` and panicked on `None` — where
the replay site had silently skipped. Commit 1 does not reach the 7 bridges with
no body guard, so that panic was live. Decline the target token instead. The
check runs before the stamp loop, because that loop streams ops into the trace as
it goes and bailing from inside it would leave a target half-guarded; the caller
tries the remaining tokens and otherwise falls back to `jump_to_preamble`
(unroll.py:208-210).

**3. Record the guard where upstream records it.** Emit the
`GUARD_FUTURE_CONDITION` on the leg that closes into an existing loop, at
upstream's position relative to the `compile_trace` call, with `next_instr` — the
merge point the synthesized JUMP targets — as the resume coordinate. That leg
only, so the own-loop close is not double-guarded.

Commits 1 and 2 stay after commit 3: the legs it does not cover — a close already
latched as declined, a first-visit merge point that registers and keeps tracing, a
crossing reached with `partial_trace` armed — still reach the optimizer with no
patchguardop.

## Verification

`short_circuit_value_kept_stack` goes from 2 recorded `GUARD_FUTURE_CONDITION`s
(both the loop's) to 14 — one per compiled bridge, 12 of them — with jit-stats
unchanged at `loops_compiled=1 bridges_compiled=12 guard_failures=2510`.

`pyre/check.py`, darwin arm64:

    ALL PASSED: dynasm 436/436
    ALL PASSED: cranelift 436/436
    FAILED: wasm 1 failed, 428 passed

No jit-stats row moved on any backend. The one wasm row is
`short_circuit_value_kept_stack`'s wasm/dynasm execution ratio (5.0x against a
3.7x gate), which fails on main itself — main's own ubuntu leg reports it at 5.5x,
alongside `if_else_jump_forward` at 3.9x.

Two regression tests, each verified to fail against the code it fixes:

  * `inline_short_preamble_declines_a_replayed_guard_with_no_patchguardop` —
    panics in `store_final_boxes_in_guard` with `resume_pos=4242`, the preamble
    coordinate the clone carried in.
  * `jump_to_existing_trace_declines_a_target_needing_guards_with_no_patchguardop`
    — panics at the extra-guard site with `1 extra guard(s), force_boxes=false`.

## Checked and left alone

`heap.rs`'s virtualizable-Ref null guard has the same silent `patchguardop` skip,
and its comment is stale (it says the guard "would be silently dropped", but that
fallback panics now). It fires 0 times across all 419 fixtures, so there is
nothing to demonstrate and nothing was changed there.

— *authored by Claude*
