### PR TITLE
check.py: raise the wasm/dynasm ratio ceiling to 4x

### DIFF
--- a/pyre/bench/fannkuch.py
+++ b/pyre/bench/fannkuch.py
@@ -1,6 +1,3 @@
-# pyre-check: max-wasm-ratio=3.6
-# Reported 2.9x here idle and 3.1x here under load, and under the gate on
-# ubuntu-24.04 twice.
 # Fannkuch-Redux benchmark (The Computer Language Benchmarks Game)
 # Ported for pyre: while-loop only, no range/list/enumerate
 

--- a/pyre/bench/fib_recursive.py
+++ b/pyre/bench/fib_recursive.py
@@ -1,6 +1,3 @@
-# pyre-check: max-wasm-ratio=3.6
-# Reported 3.1x on ubuntu-24.04, and under the gate on the run before it.
-
 def fib(n):
     if n < 2:
         return n

--- a/pyre/bench/raise_catch_loop.py
+++ b/pyre/bench/raise_catch_loop.py
@@ -1,6 +1,3 @@
-# pyre-check: max-wasm-ratio=3.8
-# Reported 3.2x and 3.3x on ubuntu-24.04.
-
 def main():
     s = 0
     i = 0

--- a/pyre/bench/synth/const_arg_call_resume.py
+++ b/pyre/bench/synth/const_arg_call_resume.py
@@ -13,6 +13,43 @@
 # and int / object element strategies each exercise the same caller-frame
 # resume; every form must reach `n` (never a dropped element or an unbound
 # local).
+#
+# `bridges_compiled` and `guard_failures` here do not reproduce, so a move in
+# either is not evidence about a diff until one configuration has been repeated.
+# The same binary on the same source with the same argv, the same child
+# environment and PYTHONHASHSEED all held fixed reads six bridges / 1204 or
+# seven / 1404, run to run -- 1 of 6 runs, then 2 of 6, then 0 of 8 an hour
+# later. CI has seen it too: `dynasm/synth/const_arg_call_resume` came up
+# `jit-stats unstable (not gated)` on the windows runner. A machine settles on
+# one value and repeats it many times over, which is what the stability re-runs
+# cannot see through -- they ask whether a reading reproduces itself, and this
+# one does, until it does not. Whichever way it is settled locally, it will
+# stay that way long enough to look like a property of the tree.
+#
+# The two readings are one bridge generation apart. Each of the three resume
+# guards keeps failing after its first bridge is attached, so another is
+# compiled every `trace_eagerness` (200) failures. Under MAJIT_GUARDLOG both
+# readings show the same three guard sites and differ only in their failure
+# totals: 402/402/400 sums to 1204 and floors to 2+2+2 = six bridges,
+# 602/402/400 to 1404 and 3+2+2 = seven.
+#
+# Two things that do not settle it, both measured, so neither is worth trying
+# again:
+#
+# * The trip count. 220, 240, 260, 280, 300, 320, 360 and 400 read the same
+#   counters, so there is no value that lands away from the boundary; only at
+#   200 does a guard stop reaching the threshold at all, and that alternates
+#   too (1199 / 1397). Halving the file is what settled `str_fstring`, whose
+#   counters moved with a major-collection crossing -- `back_edge_polls` reads
+#   0 in every run here at every trip count, which is what says this is not
+#   that class.
+# * Re-recording. It pins whichever side the recording machine was on, and
+#   everything moves it: adding these comment lines alone -- text the parser
+#   drops, changing nothing the JIT can see -- moved a wasm reading from 1404
+#   to 1204 for eight runs in a row.
+#
+# What the fixture is actually gated on is its printed sum against cpython and
+# pypy, which is what catches the bug described above.
 
 
 def comp(n):

--- a/pyre/bench/synth/short_circuit_value_kept_stack.py
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.py
@@ -1,6 +1,4 @@
 # pyre-check: max-pypy-ratio=19
-# pyre-check: max-wasm-ratio=3.7
-# Reported 3.2x twice on ubuntu-24.04.
 # Exercises short-circuit `and` / `or` in VALUE context inside a hot loop.
 #
 # `x = (i % 7) and (i + 3)` lowers to `BINARY_OP %; COPY 1; TO_BOOL;

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -144,7 +144,19 @@ WASM_TIMEOUT_SCALE = 4.0
 # in this run and its execution-only time clears FLOOR_GATE_MIN_BASELINE_S;
 # below that the denominator is startup noise, and the comparison table marks
 # the ratio `~` the way the pypy gates already do.
-WASM_MAX_DYNASM_RATIO = 3.0
+#
+# 4x rather than the 3x this started at, because 3x was not where the backend
+# is. Four fixtures had already been carved out of it one at a time -- fannkuch
+# 3.6, fib_recursive 3.6, raise_catch_loop 3.8, short_circuit_value_kept_stack
+# 3.7 -- every one for the same structural reason (`wasm_ratio_gate` below
+# spells it out), and more kept arriving: one main run failed
+# `if_else_jump_forward` at 3.9x and `loop_callee_shared_mutation` at 3.3x with
+# no allowance written for either. A ceiling that the fixtures above it are
+# exempted from individually is collecting exemptions rather than measuring the
+# backend. At 4x the gate means what it says, all four of those allowances come
+# out, and one stays genuinely above it
+# (`global_quasiimmut_invalidation`, 6).
+WASM_MAX_DYNASM_RATIO = 4.0
 # Native Windows CI can spend substantially more wall time than reported
 # process user-CPU while antivirus and concurrent matrix jobs contend for the
 # runner.  Keep the timeout as a hang guard by granting native backends 2x


### PR DESCRIPTION
Two commits: the wasm/dynasm ratio ceiling, and a note on a fixture's counters.

## `WASM_MAX_DYNASM_RATIO` 3x → 4x

3x was not where the backend is. Four fixtures had already been carved out of it one at a time, each for the reason `wasm_ratio_gate` documents — the wasm backend reaches CPython-level objects through interpreter round-trips and allocates each on a Rust heap the wasm path does not yet collect, so a loop dominated by that work runs several times dynasm's execution time with no regression behind it:

| fixture | allowance |
| --- | --- |
| `fannkuch` | 3.6 |
| `fib_recursive` | 3.6 |
| `raise_catch_loop` | 3.8 |
| `synth/short_circuit_value_kept_stack` | 3.7 |

And more kept arriving without one. On main's ubuntu runner, `if_else_jump_forward` fails at 3.9x and `loop_callee_shared_mutation` at 3.3x today, neither carrying an allowance.

A ceiling that the fixtures above it are exempted from individually is collecting exemptions rather than measuring the backend. This sets it to 4x and removes the four allowances now under it. `synth/global_quasiimmut_invalidation` keeps its 6, the only one still above the gate.

**What this does not fix:** `short_circuit_value_kept_stack` reads 5.2x on main's ubuntu runner and 5.7x here. It was already over its own 3.7 allowance and is over 4x too, so it stays exactly as red as it is on main. Removing its line moves its ceiling from 3.7 to 4x and changes nothing else — what that fixture should be fitted to is a separate question from where the shared gate sits, and raising a ceiling to cover it is the move that was refused before.

## A note on `const_arg_call_resume`

Comment only — no gate change, no baseline change.

Its `bridges_compiled` and `guard_failures` do not reproduce. The same binary on the same source with the same argv, the same child environment and `PYTHONHASHSEED` pinned reads six bridges / 1204 or seven / 1404, run to run — 1 of 6 runs, then 2 of 6, then 0 of 8 an hour later. CI has seen it as well: the windows runner reported `dynasm/synth/const_arg_call_resume` as `jit-stats unstable (not gated)`.

A machine settles on one value and repeats it many times over, so a local red on either counter looks like a property of the tree and is not one. The note also records the two things that do not settle it, so neither is tried again:

- the trip count reads the same counters at 220, 240, 260, 280, 300, 320, 360 and 400
- re-recording pins whichever side the recording machine was on — adding this very comment, text the parser drops, moved a wasm reading from 1404 to 1204 for eight runs in a row

`JITSTATS_STABILITY_RUNS` already excuses the fixture whenever its repeats disagree, and across six recent main runs on three hosts its counters were never gated against it, so nothing here changes the gate.

## Verification

Being re-measured on the current branch tip; the numbers will be posted here when the run finishes. (An earlier full run was discarded: the branch was rebased while it was in flight, so its source and its binaries did not come from one tree.)

Assisted-by: Claude


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Updated WebAssembly performance validation to allow a higher execution-time variance threshold, reducing unnecessary benchmark failures.

- **Documentation**
  - Added context around benchmark measurements, including JIT behavior, test conditions, and output validation.
  - Removed outdated benchmark ratio notes and configuration comments where they no longer apply.

- **Tests**
  - Confirmed benchmark logic, outputs, and runtime behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->