### PR TITLE
wasm: skip reloads for a call that cannot collect; optimizeopt: constant-pointer aliasing

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -1378,6 +1378,45 @@ impl HomeLiveness {
     }
 }
 
+/// Whether a call has to be followed by the frame and home reloads.
+///
+/// callbuilder.py:29-43 splits this in two: `emit_no_collect` prepares the
+/// arguments and calls, while `emit` additionally pushes a gcmap and reloads a
+/// possibly-forwarded frame afterwards. Without a gcmap the collector cannot
+/// reach the home slots, so a callee that cannot collect leaves the JitFrame
+/// and every home exactly where they were and the reload only re-reads what
+/// the locals already hold. `x86/assembler.py:2205-2209` takes the same
+/// decision from the same bit, as does the cranelift residual call emission.
+///
+/// Two families keep their reloads whatever the effect info says, because
+/// upstream pushes their gcmap without ever consulting it:
+///
+/// - `CALL_RELEASE_GIL` — `x86/assembler.py:2200-2203` dispatches to
+///   `emit_call_release_gil` before the `check_can_collect()` test, and
+///   `push_gcmap_for_call_release_gil` is unconditional; `emit`'s own
+///   docstring reads "not for CALL_RELEASE_GIL". The bit describes the callee,
+///   while another thread may collect for the span the GIL is released.
+/// - `COND_CALL_VALUE` — `x86/regalloc.py:952-1011` builds the gcmap with
+///   `get_gcmap()` and reads no effect info at all.
+///
+/// A call carrying no call descr also keeps its reloads: this narrows a
+/// conservative answer where the effect info is there to narrow it, and never
+/// widens one.
+fn call_can_collect(op: &Op) -> bool {
+    if matches!(
+        op.opcode,
+        OpCode::CallReleaseGilI
+            | OpCode::CallReleaseGilN
+            | OpCode::CallReleaseGilF
+            | OpCode::CondCallValueI
+            | OpCode::CondCallValueR
+    ) {
+        return true;
+    }
+    op.with_call_descr(|descr| descr.get_extra_info().check_can_collect())
+        .unwrap_or(true)
+}
+
 /// Static collecting-call positions whose gcmap-visible homes may be forwarded.
 /// Every `is_malloc` op (the whole `New..=Newunicode` range, string allocations
 /// included) routes through a collecting allocator; conservatively include
@@ -4927,6 +4966,7 @@ fn build_function(
             | OpCode::CallAssemblerF
             | OpCode::CallReleaseGilF => {
                 let vi = op.pos.get().raw();
+                let can_collect = call_can_collect(op);
 
                 // Direct in-module residual call: skip the `jit_call` host hop and
                 // `call_indirect` the callee's table slot with a static
@@ -4951,21 +4991,23 @@ fn build_function(
                     } else {
                         sink.drop(); // value-producing call whose result is unused
                     }
-                    emit_reload_frame_if_necessary(
-                        &mut sink,
-                        residual_type_base,
-                        ca.ca_reload_fn_ptr,
-                        ca.jf_top_addr,
-                    );
-                    emit_reload_refs_from_homes(
-                        &mut sink,
-                        value_types,
-                        ref_homes,
-                        &liveness,
-                        op_idx,
-                        (!OpRef::raw_is_constant(vi)).then_some(vi),
-                        frame,
-                    );
+                    if can_collect {
+                        emit_reload_frame_if_necessary(
+                            &mut sink,
+                            residual_type_base,
+                            ca.ca_reload_fn_ptr,
+                            ca.jf_top_addr,
+                        );
+                        emit_reload_refs_from_homes(
+                            &mut sink,
+                            value_types,
+                            ref_homes,
+                            &liveness,
+                            op_idx,
+                            (!OpRef::raw_is_constant(vi)).then_some(vi),
+                            frame,
+                        );
+                    }
                     // store-on-def (end of loop) homes a Ref result, so the
                     // direct path must NOT `continue` past it.
                 } else if let (Some(base), Some(nargs)) =
@@ -4982,21 +5024,23 @@ fn build_function(
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, base + nargs as u32);
                     sink.drop();
-                    emit_reload_frame_if_necessary(
-                        &mut sink,
-                        residual_type_base,
-                        ca.ca_reload_fn_ptr,
-                        ca.jf_top_addr,
-                    );
-                    emit_reload_refs_from_homes(
-                        &mut sink,
-                        value_types,
-                        ref_homes,
-                        &liveness,
-                        op_idx,
-                        None,
-                        frame,
-                    );
+                    if can_collect {
+                        emit_reload_frame_if_necessary(
+                            &mut sink,
+                            residual_type_base,
+                            ca.ca_reload_fn_ptr,
+                            ca.jf_top_addr,
+                        );
+                        emit_reload_refs_from_homes(
+                            &mut sink,
+                            value_types,
+                            ref_homes,
+                            &liveness,
+                            op_idx,
+                            None,
+                            frame,
+                        );
+                    }
                 } else if let Some((sig, &type_idx)) = residual_call_float_sig(op).and_then(|sig| {
                     float_residual_type_indices
                         .get(&sig)
@@ -5022,21 +5066,23 @@ fn build_function(
                     } else {
                         sink.drop(); // value-producing call whose result is unused
                     }
-                    emit_reload_frame_if_necessary(
-                        &mut sink,
-                        residual_type_base,
-                        ca.ca_reload_fn_ptr,
-                        ca.jf_top_addr,
-                    );
-                    emit_reload_refs_from_homes(
-                        &mut sink,
-                        value_types,
-                        ref_homes,
-                        &liveness,
-                        op_idx,
-                        (!OpRef::raw_is_constant(vi)).then_some(vi),
-                        frame,
-                    );
+                    if can_collect {
+                        emit_reload_frame_if_necessary(
+                            &mut sink,
+                            residual_type_base,
+                            ca.ca_reload_fn_ptr,
+                            ca.jf_top_addr,
+                        );
+                        emit_reload_refs_from_homes(
+                            &mut sink,
+                            value_types,
+                            ref_homes,
+                            &liveness,
+                            op_idx,
+                            (!OpRef::raw_is_constant(vi)).then_some(vi),
+                            frame,
+                        );
+                    }
                 } else if let (Some(base), Some(nargs)) = (
                     true_void_residual_type_base,
                     residual_call_void_true_arity(op),
@@ -5051,21 +5097,23 @@ fn build_function(
                     emit_resolve(&mut sink, constants, value_types, op.arg(0).to_opref());
                     sink.i32_wrap_i64();
                     sink.call_indirect(0, base + nargs as u32);
-                    emit_reload_frame_if_necessary(
-                        &mut sink,
-                        residual_type_base,
-                        ca.ca_reload_fn_ptr,
-                        ca.jf_top_addr,
-                    );
-                    emit_reload_refs_from_homes(
-                        &mut sink,
-                        value_types,
-                        ref_homes,
-                        &liveness,
-                        op_idx,
-                        None,
-                        frame,
-                    );
+                    if can_collect {
+                        emit_reload_frame_if_necessary(
+                            &mut sink,
+                            residual_type_base,
+                            ca.ca_reload_fn_ptr,
+                            ca.jf_top_addr,
+                        );
+                        emit_reload_refs_from_homes(
+                            &mut sink,
+                            value_types,
+                            ref_homes,
+                            &liveness,
+                            op_idx,
+                            None,
+                            frame,
+                        );
+                    }
                 } else {
                     let jit_call = jit_call_idx.expect("CALL op present but jit_call not imported");
 
@@ -5112,21 +5160,23 @@ fn build_function(
                         sink.local_set(value_types.local(vi));
                     }
                     // Mirror the direct path: a trampoline residual call may force and collect.
-                    emit_reload_frame_if_necessary(
-                        &mut sink,
-                        residual_type_base,
-                        ca.ca_reload_fn_ptr,
-                        ca.jf_top_addr,
-                    );
-                    emit_reload_refs_from_homes(
-                        &mut sink,
-                        value_types,
-                        ref_homes,
-                        &liveness,
-                        op_idx,
-                        (!is_void && !OpRef::raw_is_constant(vi)).then_some(vi),
-                        frame,
-                    );
+                    if can_collect {
+                        emit_reload_frame_if_necessary(
+                            &mut sink,
+                            residual_type_base,
+                            ca.ca_reload_fn_ptr,
+                            ca.jf_top_addr,
+                        );
+                        emit_reload_refs_from_homes(
+                            &mut sink,
+                            value_types,
+                            ref_homes,
+                            &liveness,
+                            op_idx,
+                            (!is_void && !OpRef::raw_is_constant(vi)).then_some(vi),
+                            frame,
+                        );
+                    }
                 }
             }
 

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -72,6 +72,33 @@ fn same_ptr_info(ctx: &OptContext, left: OpRef, right: OpRef) -> bool {
     }
 }
 
+/// heap.py:79-91 AbstractCachedEntry._cannot_alias_via_constants
+///
+/// Two constant pointers are two addresses fixed at trace time, so unless they
+/// are the same constant they name different objects. Lives beside
+/// [`same_ptr_info`] rather than on `CachedField` / `ArrayCachedItem` because,
+/// like its upstream counterpart on the base class, it reads nothing about
+/// what is cached and so is shared by fields and array items.
+///
+/// Upstream asks only whether both sides are `ConstPtrInfo`, since
+/// `same_info` has already returned MUST_ALIAS for the equal case by then;
+/// comparing the two constants here answers the same question without
+/// depending on that ordering.
+fn cannot_alias_via_constants(ctx: &mut OptContext, left: OpRef, right: OpRef) -> bool {
+    fn const_ref(ctx: &mut OptContext, opref: OpRef) -> Option<majit_ir::GcRef> {
+        match ctx
+            .get_box_replacement_operand_opt(opref)
+            .and_then(|b| b.const_value())
+        {
+            Some(Value::Ref(gcref)) => Some(gcref),
+            _ => None,
+        }
+    }
+    let left = const_ref(ctx, left);
+    let right = const_ref(ctx, right);
+    matches!((left, right), (Some(a), Some(b)) if a != b)
+}
+
 #[inline]
 fn make_nonnull_box(ctx: &mut OptContext, arg: &Operand) {
     if let Some(box_ref) = ctx.resolve_operand_operand_opt(arg) {
@@ -2166,14 +2193,15 @@ impl OptHeap {
                     ctx.make_equal_to(&b_old, &b_cached);
                     return OptimizationResult::Remove;
                 }
-                // heap.py:67-75 possible_aliasing_two_infos:
+                // heap.py:67-77 possible_aliasing_two_infos:
                 //     if opinfo1.same_info(opinfo2): return MUST_ALIAS
+                //     if self._cannot_alias_via_constants(...): return CANNOT_ALIAS
                 //     if cf._cannot_alias_via_classes_or_lengths(...): return CANNOT_ALIAS
                 //     if cf._cannot_alias_via_content(...): return CANNOT_ALIAS
                 //     return UNKNOWN_ALIAS
-                let cannot_alias =
-                    CachedField::_cannot_alias_via_classes_or_lengths(lazy_struct, obj, ctx)
-                        || CachedField::_cannot_alias_via_content(lazy_struct, obj, ctx);
+                let cannot_alias = cannot_alias_via_constants(ctx, lazy_struct, obj)
+                    || CachedField::_cannot_alias_via_classes_or_lengths(lazy_struct, obj, ctx)
+                    || CachedField::_cannot_alias_via_content(lazy_struct, obj, ctx);
                 if !cannot_alias {
                     // UNKNOWN_ALIAS → force_lazy_set, return None (cache miss)
                     force_lazy = true;
@@ -2732,15 +2760,17 @@ impl OptHeap {
                     }
                     // heap.py:108 possible_aliasing_two_infos
                     let lazy_obj_resolved = ctx.get_replacement_opref(lazy_struct);
-                    let cannot_alias = ArrayCachedItem::_cannot_alias_via_classes_or_lengths(
-                        lazy_obj_resolved,
-                        array,
-                        ctx,
-                    ) || ArrayCachedItem::_cannot_alias_via_content(
-                        lazy_obj_resolved,
-                        array,
-                        ctx,
-                    );
+                    let cannot_alias = cannot_alias_via_constants(ctx, lazy_obj_resolved, array)
+                        || ArrayCachedItem::_cannot_alias_via_classes_or_lengths(
+                            lazy_obj_resolved,
+                            array,
+                            ctx,
+                        )
+                        || ArrayCachedItem::_cannot_alias_via_content(
+                            lazy_obj_resolved,
+                            array,
+                            ctx,
+                        );
                     if !cannot_alias {
                         // UNKNOWN_ALIAS → force_lazy_set
                         force_lazy_arr = true;
@@ -7512,6 +7542,32 @@ mod tests {
         assert_eq!(
             len_count, 1,
             "duplicate ARRAYLEN_GC should be cached by OptPure"
+        );
+    }
+
+    /// heap.py:79-91 AbstractCachedEntry._cannot_alias_via_constants — two
+    /// different constant pointers name two different objects, while a
+    /// non-constant operand on either side leaves the question open.
+    #[test]
+    fn test_cannot_alias_via_constants() {
+        use crate::optimizeopt::OptContext;
+
+        let mut ctx = OptContext::with_inputarg_types(64, &[Type::Ref]);
+        let first = ctx.emit_constant_ref(majit_ir::GcRef(0x1000));
+        let second = ctx.emit_constant_ref(majit_ir::GcRef(0x2000));
+        let unknown = OpRef::input_arg_typed(0, Type::Ref);
+
+        assert!(
+            super::cannot_alias_via_constants(&mut ctx, first, second),
+            "two different constant pointers cannot alias"
+        );
+        assert!(
+            !super::cannot_alias_via_constants(&mut ctx, first, first),
+            "the same constant pointer is the same object, not a disproof"
+        );
+        assert!(
+            !super::cannot_alias_via_constants(&mut ctx, first, unknown),
+            "a non-constant operand leaves aliasing unknown"
         );
     }
 

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.cranelift.jitstats
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=812
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.dynasm.jitstats
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=812
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/inline_multiframe_branchy_carrier.wasm.jitstats
+++ b/pyre/bench/synth/inline_multiframe_branchy_carrier.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=2
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=812
+guard_failures=402
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=4
+loops_compiled=2
+retraces_compiled=0

--- a/rpython/jit/metainterp/optimizeopt/heap.py
+++ b/rpython/jit/metainterp/optimizeopt/heap.py
@@ -68,11 +68,26 @@ class AbstractCachedEntry(object):
         """returns MUST_ALIAS, CANNOT_ALIAS, UNKNOWN_ALIAS """
         if opinfo1.same_info(opinfo2):
             return MUST_ALIAS
+        if self._cannot_alias_via_constants(opinfo1, opinfo2) == CANNOT_ALIAS:
+            return CANNOT_ALIAS
         if self._cannot_alias_via_classes_or_lengths(optheap, opinfo1, opinfo2) == CANNOT_ALIAS:
             return CANNOT_ALIAS
         if self._cannot_alias_via_content(optheap, opinfo1, opinfo2) == CANNOT_ALIAS:
             return CANNOT_ALIAS
         return UNKNOWN_ALIAS
+
+    def _cannot_alias_via_constants(self, opinfo1, opinfo2):
+        # Two constant pointers are two addresses fixed at trace time, so
+        # unless they are the same constant they are different objects.
+        # same_info() has already answered MUST_ALIAS for the equal case by
+        # the time we get here, so being constant on both sides is enough.
+        # Unlike the two helpers below this one does not depend on what is
+        # cached, so it is shared by fields and array items alike.
+        if not isinstance(opinfo1, info.ConstPtrInfo):
+            return UNKNOWN_ALIAS
+        if not isinstance(opinfo2, info.ConstPtrInfo):
+            return UNKNOWN_ALIAS
+        return CANNOT_ALIAS
 
     def do_setfield(self, optheap, op):
         # Update the state with the SETFIELD_GC/SETARRAYITEM_GC operation 'op'.


### PR DESCRIPTION
Three commits on top of `main`: one wasm backend change to call frame traffic,
one optimizeopt change, one jit-stats baseline re-record.

Rebased onto `629e8e355a5`. Four commits that were in earlier revisions of this
PR have been dropped — see **Dropped** below.

## wasm backend

- **`wasm: skip the post-call frame and home reloads for a call that cannot
  collect`** — a call that cannot collect cannot move an object, so the frame
  pointer and the Ref homes reloaded after it are reloads of values that did not
  change. The predicate is the descr's `check_can_collect()`, with
  `CALL_RELEASE_GIL` and `COND_CALL_VALUE` excluded: at the x86 backend the
  gcmap push is gated on `check_can_collect()` (`x86/assembler.py:2205-2209`),
  but `CALL_RELEASE_GIL` dispatches before that test (`:2200-2203` →
  `emit_call_release_gil` → unconditional `push_gcmap_for_call_release_gil`) and
  `COND_CALL_VALUE` never consults effect info at all
  (`x86/regalloc.py:952-1011`); the rewrite pass uses opcode-level
  `rop.can_malloc()` rather than the descr bit (`rewrite.py:379-380`).

  ⚠️ **Its commit message's emitted-instruction figures no longer hold on this
  rebase, and the effect is far smaller than they suggest.** They were taken in
  mid-August; the tree has moved several times since.

  Controlled here by building `pyre-wasm` twice from one tree — arm A at this
  head, arm B with only this commit's hunks reverted — and running both under
  the same `pyre-wasm-runner` via `$PYRE_WASM_MODULE`. Graded by wasmtime fuel
  (`PYRE_WASM_JIT_STATS=1` → `wasm_ops`), an exact count of executed guest
  instructions, with two trip counts to cancel bootstrap, compiles and warmup.
  Wall clock was not used: the same slope script on the same binaries a day
  apart moved every fixture by up to 1.7x here, so it cannot grade codegen.

  | fixture | emitted, A → reverted | executed ops/iter, A → reverted |
  |---|---|---|
  | `bench/raise_catch_loop` | 2694 → 2743 B | 113.1 → 115.8 (**−2.3%** with the commit) |
  | `synth/loop_callee_shared_mutation` | 7748 → 7748 B | 3737.3 → 3737.3 |
  | `synth/global_quasiimmut_invalidation` | 4839 → 4839 B | 218.0 → 218.0 |
  | `synth/short_circuit_value_kept_stack` | 31460 → 31460 B | 766.0 → 766.0 |
  | `attr_cache` / `inline_multiframe` / `nested_loop` | — | equal to the last decimal |

  So the commit changes the emitted module of exactly one fixture in this set.
  In particular `short_circuit_value_kept_stack`, for which the message claims
  `210 -> 159` in its largest module, is now **byte-identical across the arms**
  in all 12 of its modules. Every fixture was checked to compile traces at the
  reduced trip counts (`short_circuit` reports `compiles=12 executes=2201`), so
  the zeros are zeros and not a JIT that never ran.

  The change itself stands on parity, not on this number: it takes
  `check_can_collect()` where the x86 backend takes it. But on this tree the
  predicate is false for almost nothing.

## optimizeopt

- **`optimizeopt: two different constant pointers cannot alias`** — adds
  `_cannot_alias_via_constants` on `AbstractCachedEntry`, consulted first from
  both the field and the array-item path. Previously a pending setfield on one
  constant cell forced the lazy set and invalidated the cache for every struct
  sharing the descr. Ported to `rpython/jit/metainterp/optimizeopt/heap.py`.

## Dropped

- **`optimizeopt: widen an IntBound before it becomes a short-preamble guard`**
  (and its `cargo fmt` follow-up) — withdrawn. The change edited the **vendored**
  `rpython/jit/metainterp/optimizeopt/shortpreamble.py`, adding a
  `make_entry_guards` helper that upstream does not have; pristine upstream is
  `info.make_guards(arg, self.short, optimizer)`. Widening at `use_box` is a
  deviation from the vendored tree, not a port of it, and upstream widening
  elsewhere does not license it here. Status quo is the PyPy-faithful code.

- **`wasm: read a guard's Ref fail arguments from their frame homes`** and
  **`wasm: spill a never-redefined input from its own frame slot`** — both rested
  on ending a fail argument's live range at its guard. #1274 makes that
  unreachable: `bridge_param_arities` is built from the guards' own fail arities,
  so `param_type_indices` is non-empty for every guarded trace and
  `emit_guard_exit` always takes the parameter arm, where
  `emit_guard_param_tail_call` resolves each fail argument from its local at that
  same guard. The `is_empty()` arm survives only for a trace with no guards —
  nothing to emit — or under `PYRE_WASM_BRIDGE_PARAMS=0`. What remained was a
  frame load where a local read would do.

- **`optimizeopt: keep a foreign target token out of a loop's closing walk`** —
  withdrawn in favour of the producer-side fix in #1287, which empties the seed
  at a token-minting compile and subsumes this narrowing of the consumer walk.
  It was parity-motivated only in any case; the trace it moved is not on the hot
  path.

## Measurement notes

- Local wasm/dynasm ratios on darwin-arm64 do not predict the gate: ubuntu-24.04
  is the only runner that builds wasm, so the wasm commit is graded by CI, not
  locally.
- **Do not read this branch's CI ratio movement as this branch's doing** without
  a control. A `pull_request` run tests the **merge ref**, so a run of this
  branch also contains whatever landed on `main` since its base.
- `bench: re-record inline_multiframe_branchy_carrier jit-stats baselines` — all
  three backends read `loops_compiled` 2, `bridges_compiled` 2 and
  `guard_failures` 402 where the committed baselines held 4, 4 and 812. The
  re-recorded snapshot also carries `retraces_compiled`, a field the runs print
  and the committed baseline predates. These are the values the runs produce on
  this rebase; CI grades them here.

Note for reviewers: `generator_tree_recursion`'s `guard_failures 2951 -> 2955`
SNAPDIFF, if it appears, is `main`'s and not this branch's — it reproduces on
both x86 hosts independently of these commits.

— *commented by Claude*

