### PR TITLE
posix, fcntl: take a bytes-like fcntl() argument and warn on a bool file descriptor

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -8458,6 +8458,13 @@ pub fn c_uid_t_w(obj: PyObjectRef) -> Result<u32, PyError> {
 /// non-negative C int.  `isinstance_w(w_fd, w_int)` accepts a long or an
 /// int subclass as well, so the membership test is `is_int_or_long`.
 pub fn c_filedescriptor_w(obj: PyObjectRef) -> Result<i32, PyError> {
+    // A bool passes the int test below and names descriptor 0 or 1, which is
+    // almost always a mistake at a descriptor argument.  Only the object the
+    // caller named is reported: a `fileno()` that answers with a bool is the
+    // object's own doing, not the caller's.
+    if unsafe { pyre_object::is_bool(obj) } {
+        crate::warn::warn_category("bool is used as a file descriptor", "RuntimeWarning", 1)?;
+    }
     let w_fd = if unsafe { pyre_object::pyobject::is_int_or_long(obj) } {
         obj
     } else {

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1766,7 +1766,21 @@ fn path_or_fd_w(
             // raising `__index__` and a working `__fspath__` reports that
             // exception rather than being statted. The parity suite's oracle
             // is CPython.
-            let fd = crate::baseobjspace::c_int_w(obj)?;
+            //
+            // A bool is an integer, so it reaches this arm and names
+            // descriptor 0 or 1; the warning says so before it is used.
+            if pyre_object::is_bool(obj) {
+                crate::warn::warn_category(
+                    "bool is used as a file descriptor",
+                    "RuntimeWarning",
+                    1,
+                )?;
+            }
+            // The warning runs the installed filters, which are Python, so the
+            // argument is read back off the shadow stack the same way the
+            // `__fspath__` arm reads it after its call.
+            let fd =
+                crate::baseobjspace::c_int_w(pyre_object::gc_roots::shadow_stack_get(obj_slot))?;
             // interp_posix.py:269-271 `unwrap_fd` — `-1` is the sentinel for
             // "not a descriptor", so a caller naming it has to be turned away
             // here rather than silently read as a path.

--- a/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
+++ b/pyre/pyre-interpreter/src/module/fcntl/interp_fcntl.rs
@@ -7,8 +7,9 @@
 ///
 /// fcntl(fd, cmd, arg=0) / ioctl(fd, request, arg=0) / flock(fd, op) /
 /// lockf(fd, cmd, len=0, start=0, whence=0).  Backed by
-/// `rustpython_host_env::fcntl`.  Only the integer-argument forms are
-/// implemented; bytes-buffer (out-arg) variants are out of scope.
+/// `rustpython_host_env::fcntl`.  `ioctl` is still limited to the
+/// integer-argument form; its buffer form needs writable-buffer acquisition
+/// and `mutate_flag` handling from `interp_fcntl.py:252-300`.
 pub fn register_module(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(
         ns,
@@ -21,9 +22,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "fcntl() takes 2 or 3 arguments",
                     ));
                 }
-                if !unsafe { pyre_object::is_int(args[1]) }
-                    || (args.len() >= 3 && !unsafe { pyre_object::is_int(args[2]) })
-                {
+                if !unsafe { pyre_object::is_int(args[1]) } {
                     return Err(crate::PyError::type_error(
                         "fcntl() arguments must be integers",
                     ));
@@ -33,7 +32,39 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // number it wraps.
                 let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                 let cmd = (unsafe { pyre_object::w_int_get_value(args[1]) }) as i32;
+                if args.len() >= 3 && unsafe { pyre_object::bytesobject::is_bytes_like(args[2]) } {
+                    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[2]) };
+                    let mut buf = data.to_vec();
+                    buf.push(0);
+                    // `interp_fcntl.py:118-138 fcntl` tries the string-buffer
+                    // path before falling back to the integer path, and
+                    // returns exactly the original buffer length.
+                    loop {
+                        let outcome = {
+                            let _blocked = crate::module::thread::before_external_block();
+                            rustpython_host_env::fcntl::fcntl_with_bytes(fd, cmd, &mut buf)
+                        };
+                        match outcome {
+                            Ok(_) => {
+                                return Ok(pyre_object::bytesobject::w_bytes_from_bytes(
+                                    &buf[..data.len()],
+                                ));
+                            }
+                            Err(e) => crate::builtins::eintr_retry_with(e, |e| {
+                                crate::PyError::os_error_with_errno(
+                                    e.raw_os_error().unwrap_or(0),
+                                    format!("fcntl: {e}"),
+                                )
+                            })?,
+                        }
+                    }
+                }
                 let arg = if args.len() >= 3 {
+                    if !unsafe { pyre_object::is_int(args[2]) } {
+                        return Err(crate::PyError::type_error(
+                            "fcntl() arguments must be integers",
+                        ));
+                    }
                     unsafe { pyre_object::w_int_get_value(args[2]) as i32 }
                 } else {
                     0

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -8770,8 +8770,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     if args.len() < 2 {
                         return Err(crate::PyError::type_error("fpathconf() requires fd, name"));
                     }
-                    // interp_posix.py:2411 `@unwrap_spec(fd=c_int)`.
-                    let fd = crate::baseobjspace::c_int_w(args[0])?;
+                    // interp_posix.py:2411 descriptor argument: accept an int
+                    // or a `fileno()` object through `space.c_filedescriptor_w`;
+                    // that boundary also raises the bool file descriptor warning.
+                    let fd = crate::baseobjspace::c_filedescriptor_w(args[0])?;
                     let name = confname_arg(args[1], PATHCONF_NAMES)?;
                     let limit = host_posix::fpathconf(fd, name).map_err(|e| io_err(e, ""))?;
                     Ok(pyre_object::w_int_new(indeterminate_limit(limit)))

--- a/pyre/pyre-wasm/src/lib.rs
+++ b/pyre/pyre-wasm/src/lib.rs
@@ -461,10 +461,16 @@ pub extern "C" fn pyre_jit_internal_compile_panics() -> u64 {
 }
 
 /// The rest of the native `[jit-stats]` line. These are not sign-stable, so
-/// each is gated on its own terms rather than against zero: `loops_compiled`
-/// fails on any FALL, `guard_failures` on a rise past a band, and
-/// `bridges_compiled` on neither direction, since it moves both ways under
-/// ordinary tuning.
+/// each is gated on its own terms rather than against zero, and the comparison
+/// is exact in both directions — a baseline that stopped describing the tree
+/// has to be re-recorded whichever way it moved. `loops_compiled` and
+/// `retraces_compiled` name a FALL as the regression and a rise as the gain;
+/// `guard_failures` is the other way round, with no band around it.
+/// `bridges_compiled` has no gain direction at all: a rise and a fall are both
+/// reported as regressions, because a fall is the dead-bridge class — guards
+/// that stop earning a bridge re-enter the metainterp forever, and a collapse
+/// to zero stayed invisible for as long as this counter was left ungated on
+/// the grounds that it moves both ways under ordinary tuning.
 ///
 /// They come out of the same `JitStats` the fields above read, and were simply
 /// never exported. Their absence was not neutral: a count-valued field missing


### PR DESCRIPTION
Three independent changes.

### `fcntl.fcntl(fd, op, arg)` accepts a bytes-like `arg`

`interp_fcntl.py:118-129` tries `space.getarg_w('s#', w_arg)` **before** the
integer path, and on success calls `fcntl` with the buffer and returns
`space.newbytes` of the *original* length holding whatever the OS wrote back.
Only a `TypeError` from that attempt falls through to the integer path. pyre
rejected any non-integer third argument up front, so the buffer form was
unreachable. `ioctl`'s buffer form is still out of scope — it needs the
writable-buffer acquisition and `mutate_flag` handling of
`interp_fcntl.py:252-300` — and the module doc comment now says so.

### `RuntimeWarning("bool is used as a file descriptor")`

It was raised only by the `FileIO` constructor, so `True`/`False` silently named
descriptor 1 or 0 everywhere else. Both general descriptor converters now raise
it: `c_filedescriptor_w` (the int-or-`fileno()` converter) and `path_or_fd_w`'s
descriptor arm (what a `path_t(allow_fd=True)` argument takes). Only the object
the caller named is reported — a `fileno()` that answers with a bool is the
object's own doing.

The warning runs the installed filters, which are Python and may move objects,
so `path_or_fd_w` reads its argument back off the shadow stack afterwards, the
way its `__fspath__` arm already does.

`os.fpathconf` read its descriptor with the generic integer converter, which
cannot warn (ordinary integer arguments — modes, flags, signal numbers — are
allowed to be bools). It now takes `c_filedescriptor_w`, which also accepts a
`fileno()` object. `os.dup`'s argument is a plain integer and is left alone.

### A stale comment in `pyre-wasm`

The comment on the exported structural counters described a band around
`guard_failures` and left `bridges_compiled` ungated in both directions.
`check.py` compares `JITSTATS_SNAPSHOT_FIELDS` exactly, with no band, and
`bridges_compiled` is in neither `JITSTATS_REGRESSION_ON_RISE` nor
`JITSTATS_REGRESSION_ON_FALL`, so both of its directions are reported as
regressions — deliberately, because a fall is the dead-bridge class.

## Testing

Measured in the linux/arm64 container:

| suite | before | after |
|---|---|---|
| `test.test_fcntl` | 8 errors | **12 tests, OK** (3 skipped) |
| `test.test_os` `TestInvalidFD` | 4 errors, 2 failures | 1 failure |
| `test.test_os` (whole module) | 8 errors, 15 failures | 4 errors, 14 failures |

No new failures. The 4 remaining `test_os` errors are `Pep383Tests` — the
container filesystem rejects surrogate-escape names, which is the environment,
not pyre.

**Caveat:** those runs predate several rebases of this branch. Re-checked on the
current base: `cargo check -p pyre-interpreter --features dynasm` is clean.

## Known gap, deliberately not fixed here

`test_pathconf_negative_fd_uses_fd_semantics` still fails. `os.pathconf(-1, …)`
raises an errno-less `OSError` because `path_or_fd_w` overloads `-1` as its
"not a descriptor" sentinel; separating those needs an explicit is-a-descriptor
flag, which is a wider change than this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Frxb5NtzofeEgMFCgbEBjU