### PR TITLE
check: gate a schedule-sensitive jit-stats counter with a declared band

### DIFF
--- a/pyre/bench/synth/generator_tree_recursion.py
+++ b/pyre/bench/synth/generator_tree_recursion.py
@@ -1,4 +1,13 @@
 # pyre-check: max-pypy-ratio=7.6
+# pyre-check: jitstats-band=guard_failures=8
+# Jitcounter decay is 0.96 every 32 minor collections
+# (majit-trace/src/counter.rs), so guard_failures tracks collection count during
+# each guard's warm-up rather than a compile decision. One host measured
+# 2951..2958 across nursery sizes; PYRE_JIT=decay=0 pinned 2999 everywhere,
+# while loops_compiled=3 and bridges_compiled=26 stayed invariant and remain
+# gated exactly. Width 8 adds one count of margin (0.27%); real regressions this
+# gate caught moved by hundreds to thousands (828 -> 4923, 404 -> 812,
+# 937 -> 7408).
 # Generator-driven accumulation over recursive tree/linear results. The
 # tree_sum recursion once silently miscompiled on cranelift (first checksum
 # already wrong) and recovered a regalloc panic on dynasm. Deterministic;

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1202,13 +1202,18 @@ JITSTATS_STABILITY_RUNS = 2
 # regressions, so the ambiguous case is the one a human is asked to look at.
 
 
-def _jit_stats_change(saved, current):
+def _jit_stats_change(saved, current, bands=None):
     """Return `(regressions, improvements)`, each a list of "field a -> b".
 
     Both directions gate: a rise means the JIT started aborting traces, hitting
     internal compile panics or failing guards it did not before, and a fall
     means it stopped compiling something it used to compile. Neither may pass
     unrecorded — see the surface comment above.
+
+    A band suppresses an integer-valued move at or below its symmetric width,
+    whether that move is a regression or an improvement. It cannot suppress a
+    non-integer value or a move outside the band, and the fixture parser rejects
+    bands on badness counters whose healthy value must remain exactly zero.
 
     A field missing from either side reads as "0", so a baseline recorded before
     a counter existed still matches a run that reports it as 0, and adding an
@@ -1218,6 +1223,7 @@ def _jit_stats_change(saved, current):
     one of its baselines, silently. Whenever a backend's line changes shape,
     re-record its whole baseline surface rather than trusting the run that
     follows."""
+    bands = bands or {}
     old_fields = _parse_jit_stats(saved)
     new_fields = _parse_jit_stats(current)
     regressions, improvements = [], []
@@ -1226,10 +1232,14 @@ def _jit_stats_change(saved, current):
         if old == new:
             continue
         try:
-            rose = int(new) > int(old)
+            old_int, new_int = int(old), int(new)
         except ValueError:
             # A counter that stopped being an integer is not a gain.
             rose = None
+        else:
+            if field in bands and abs(new_int - old_int) <= bands[field]:
+                continue
+            rose = new_int > old_int
         if rose is not None and (
             (rose and field in JITSTATS_REGRESSION_ON_FALL)
             or (not rose and field in JITSTATS_REGRESSION_ON_RISE)
@@ -1469,6 +1479,61 @@ def synth_skip_backends(path):
                 )
             return tuple(names)
     return ()
+
+
+def synth_jitstats_bands(path):
+    """Read an optional per-fixture jit-stats band from its header:
+        # pyre-check: jitstats-band=guard_failures=8
+
+    The band is symmetric around the recorded baseline and absorbs moves in
+    both directions: a delta smaller than the band is not signal either way.
+    It is only for schedule-sensitive counters; badness counters must remain
+    exactly zero. The directive must be followed by a comment describing the
+    measured variance, so the allowance is reviewable next to the workload.
+    Unknown or duplicate fields and non-positive or non-integer widths are
+    errors rather than silent no-ops. A directive below the 20-line window is
+    simply not read, so the fixture gates normally in that case.
+    """
+    prefix = "# pyre-check: jitstats-band="
+    with open(path, encoding="utf-8") as source:
+        for _ in range(20):
+            line = source.readline()
+            if not line:
+                break
+            if not line.startswith(prefix):
+                continue
+            bands = {}
+            entries = line[len(prefix):].strip().split(",")
+            for entry in entries:
+                parts = entry.split("=")
+                if len(parts) != 2 or not all(part.strip() for part in parts):
+                    raise ValueError(f"invalid jit-stats band in {path}: {line.strip()}")
+                field, raw_width = (part.strip() for part in parts)
+                if field not in JITSTATS_SNAPSHOT_FIELDS:
+                    raise ValueError(
+                        f"unknown jit-stats band field {field!r} in {path}: {line.strip()}"
+                    )
+                if field in JITSTATS_BADNESS_FIELDS:
+                    raise ValueError(
+                        f"badness counter cannot be banded in {path}: {line.strip()}"
+                    )
+                if field in bands:
+                    raise ValueError(
+                        f"duplicate jit-stats band field {field!r} in {path}: {line.strip()}"
+                    )
+                try:
+                    width = int(raw_width)
+                except ValueError as e:
+                    raise ValueError(
+                        f"invalid jit-stats band width in {path}: {line.strip()}"
+                    ) from e
+                if width <= 0:
+                    raise ValueError(
+                        f"jit-stats band width must be positive in {path}: {line.strip()}"
+                    )
+                bands[field] = width
+            return bands
+    return {}
 
 
 def _synth_header_flag(path, directive, malformed):
@@ -1927,6 +1992,7 @@ class Check:
         time_path = self._snapshot_path(backend, name, "time")
         jitstats_path = self._jitstats_baseline_path(backend, script)
         jitstats = _jit_stats_snapshot(stderr)
+        jitstats_bands = synth_jitstats_bands(script)
 
         # The jit-stats gate — enforced on EVERY run, so a structural JIT change
         # reddens the default `pyre/check.py` (locally, and in the bare CI
@@ -1974,7 +2040,7 @@ class Check:
                 self.jitstats_vacuous.append(f"{backend}/{name}")
                 return "fail", vacuous
             regressions, improvements = _jit_stats_change(
-                jitstats_path.read_text(encoding="utf-8"), jitstats
+                jitstats_path.read_text(encoding="utf-8"), jitstats, jitstats_bands
             )
             if regressions or improvements:
                 repeats = self._jitstats_repeats(backend, script, timeout)
@@ -1982,16 +2048,19 @@ class Check:
                     (s for s in repeats or () if s != jitstats), None
                 )
                 if drifted is not None:
-                    moved = _jit_stats_change(jitstats, drifted)
-                    self.jitstats_unstable.append(f"{backend}/{name}")
-                    return "unstable", (
-                        "jit-stats unstable — re-running the same binary moved "
-                        + ", ".join(moved[0] + moved[1])
-                        + ", so this run's counters are not a property of the "
-                        "tree and the baseline comparison ("
-                        + ", ".join(regressions + improvements)
-                        + ") is not gated"
-                    )
+                    moved = _jit_stats_change(jitstats, drifted, jitstats_bands)
+                    # Snapshot text can drift inside a band without making any
+                    # gated counter unstable.
+                    if moved[0] or moved[1]:
+                        self.jitstats_unstable.append(f"{backend}/{name}")
+                        return "unstable", (
+                            "jit-stats unstable — re-running the same binary moved "
+                            + ", ".join(moved[0] + moved[1])
+                            + ", so this run's counters are not a property of the "
+                            "tree and the baseline comparison ("
+                            + ", ".join(regressions + improvements)
+                            + ") is not gated"
+                        )
                 parts = []
                 if regressions:
                     parts.append("regressed: " + ", ".join(regressions))

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1203,15 +1203,16 @@ JITSTATS_STABILITY_RUNS = 2
 
 
 def _jit_stats_change(saved, current, bands=None):
-    """Return `(regressions, improvements)`, each a list of "field a -> b".
+    """Return `(regressions, improvements, banded)` change descriptions.
 
     Both directions gate: a rise means the JIT started aborting traces, hitting
     internal compile panics or failing guards it did not before, and a fall
     means it stopped compiling something it used to compile. Neither may pass
     unrecorded — see the surface comment above.
 
-    A band suppresses an integer-valued move at or below its symmetric width,
-    whether that move is a regression or an improvement. It cannot suppress a
+    A band reclassifies an integer-valued move at or below its symmetric width,
+    whether that move would be a regression or an improvement. The move is
+    reported in `banded` rather than hidden. A band cannot reclassify a
     non-integer value or a move outside the band, and the fixture parser rejects
     bands on badness counters whose healthy value must remain exactly zero.
 
@@ -1226,7 +1227,7 @@ def _jit_stats_change(saved, current, bands=None):
     bands = bands or {}
     old_fields = _parse_jit_stats(saved)
     new_fields = _parse_jit_stats(current)
-    regressions, improvements = [], []
+    regressions, improvements, banded = [], [], []
     for field in JITSTATS_SNAPSHOT_FIELDS:
         old, new = old_fields.get(field, "0"), new_fields.get(field, "0")
         if old == new:
@@ -1238,6 +1239,9 @@ def _jit_stats_change(saved, current, bands=None):
             rose = None
         else:
             if field in bands and abs(new_int - old_int) <= bands[field]:
+                banded.append(
+                    f"{field} {old} -> {new} (within band {bands[field]})"
+                )
                 continue
             rose = new_int > old_int
         if rose is not None and (
@@ -1247,7 +1251,7 @@ def _jit_stats_change(saved, current, bands=None):
             improvements.append(f"{field} {old} -> {new}")
         else:
             regressions.append(f"{field} {old} -> {new}")
-    return regressions, improvements
+    return regressions, improvements, banded
 
 
 def _jit_stats_vacuous(stderr):
@@ -1486,10 +1490,12 @@ def synth_jitstats_bands(path):
         # pyre-check: jitstats-band=guard_failures=8
 
     The band is symmetric around the recorded baseline and absorbs moves in
-    both directions: a delta smaller than the band is not signal either way.
-    It is only for schedule-sensitive counters; badness counters must remain
-    exactly zero. The directive must be followed by a comment describing the
-    measured variance, so the allowance is reviewable next to the workload.
+    both directions: a delta within the band is not signal either way. An
+    absorbed move is reported on that run rather than swallowed, so the
+    allowance is visible whenever it is used and not only in the fixture
+    header. It is only for schedule-sensitive counters; badness counters must
+    remain exactly zero. The directive must be followed by a comment describing
+    the measured variance, so the allowance is reviewable next to the workload.
     Unknown or duplicate fields and non-positive or non-integer widths are
     errors rather than silent no-ops. A directive below the 20-line window is
     simply not read, so the fixture gates normally in that case.
@@ -1755,6 +1761,9 @@ class Check:
         # Benches whose counters did not reproduce across repeats in this same
         # invocation. Reported, never failed — see JITSTATS_STABILITY_RUNS.
         self.jitstats_unstable = []
+        # Benches whose gated counters moved only inside a declared per-fixture
+        # band. Reported, never failed.
+        self.jitstats_banded = []
         self.jitstats_missing = []
         # Benches whose run printed no `[jit-stats]` line at all. Tracked apart
         # from `jitstats_missing` because the two say opposite things: a missing
@@ -2039,7 +2048,7 @@ class Check:
             if vacuous:
                 self.jitstats_vacuous.append(f"{backend}/{name}")
                 return "fail", vacuous
-            regressions, improvements = _jit_stats_change(
+            regressions, improvements, banded = _jit_stats_change(
                 jitstats_path.read_text(encoding="utf-8"), jitstats, jitstats_bands
             )
             if regressions or improvements:
@@ -2066,6 +2075,8 @@ class Check:
                     parts.append("regressed: " + ", ".join(regressions))
                 if improvements:
                     parts.append("improved: " + ", ".join(improvements))
+                if banded:
+                    parts.append("within band: " + ", ".join(banded))
                 reason = (
                     "jit-stats change — " + "; ".join(parts)
                     + _jit_stats_context(jitstats)
@@ -2077,6 +2088,12 @@ class Check:
                     return "regressed", reason
                 self.jitstats_improvements.append(f"{backend}/{name}")
                 return "improved", reason
+            if banded:
+                self.jitstats_banded.append(f"{backend}/{name}")
+                return "banded", (
+                    "jit-stats within band — " + ", ".join(banded)
+                    + _jit_stats_context(jitstats)
+                )
 
         if self.args.snapshot_mode == "record":
             out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2750,10 +2767,11 @@ class Check:
             backend, name, script, output, stderr, elapsed, timeout,
         )
         if snap_status != "ok":
-            if snap_status == "unstable":
-                # Warned, not failed: the counter did not reproduce itself in
-                # this invocation, so there is nothing to gate on.
-                unstable_line = f"{yellow('UNSTABLE')}  {snap_reason}"
+            if snap_status in ("unstable", "banded"):
+                # Warned, not failed: unstable counters cannot be gated, while
+                # banded counters stayed inside their declared allowance.
+                note_label = snap_status.upper()
+                note_line = f"{yellow(note_label)}  {snap_reason}"
             else:
                 # `improved` is still a failure; the label only tells the
                 # reader whether to investigate or just re-record.
@@ -2762,9 +2780,9 @@ class Check:
                 failures.append(
                     (f"{paint(label)}  {snap_reason}", snap_reason, label, None)
                 )
-                unstable_line = None
+                note_line = None
         else:
-            unstable_line = None
+            note_line = None
 
         if failures:
             self._record(
@@ -2773,8 +2791,8 @@ class Check:
             )
             for index, (line, _, _, _) in enumerate(failures):
                 print(f"{' ' * 14 if index else ''}{line}")
-            if unstable_line is not None:
-                print(f"{' ' * 14}{unstable_line}")
+            if note_line is not None:
+                print(f"{' ' * 14}{note_line}")
             _, _, comparison_cell, comparison_note = failures[0]
             self._append_comparison(
                 backend, name, t_cpython, t_pypy,
@@ -2782,10 +2800,10 @@ class Check:
             )
             return
 
-        if unstable_line is not None:
+        if note_line is not None:
             self._record(backend, True, name, f"{elapsed:.2f}s")
-            print(unstable_line)
-            self._append_comparison(backend, name, t_cpython, t_pypy, "UNSTABLE")
+            print(note_line)
+            self._append_comparison(backend, name, t_cpython, t_pypy, note_label)
             return
 
         self._record(backend, True, name, f"{elapsed:.2f}s")
@@ -3257,6 +3275,7 @@ class Check:
                 (red, "jit-stats regressed", self.jitstats_diffs),
                 (yellow, "jit-stats improved (re-record)", self.jitstats_improvements),
                 (yellow, "jit-stats unstable (not gated)", self.jitstats_unstable),
+                (yellow, "jit-stats within band (not gated)", self.jitstats_banded),
                 (red, "jit-stats baseline missing", self.jitstats_missing),
                 (red, "jit-stats line absent", self.jitstats_absent),
                 (red, "jit-stats census vacuous", self.jitstats_vacuous),

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1496,11 +1496,13 @@ def synth_jitstats_bands(path):
     header. It is only for schedule-sensitive counters; badness counters must
     remain exactly zero. The directive must be followed by a comment describing
     the measured variance, so the allowance is reviewable next to the workload.
-    Unknown or duplicate fields and non-positive or non-integer widths are
-    errors rather than silent no-ops. A directive below the 20-line window is
-    simply not read, so the fixture gates normally in that case.
+    Unknown or duplicate fields, repeated directives, and non-positive or
+    non-integer widths are errors rather than silent no-ops. A directive below
+    the 20-line window is simply not read, so the fixture gates normally in
+    that case.
     """
     prefix = "# pyre-check: jitstats-band="
+    bands = None
     with open(path, encoding="utf-8") as source:
         for _ in range(20):
             line = source.readline()
@@ -1508,6 +1510,8 @@ def synth_jitstats_bands(path):
                 break
             if not line.startswith(prefix):
                 continue
+            if bands is not None:
+                raise ValueError(f"duplicate jit-stats band directive in {path}: {line.strip()}")
             bands = {}
             entries = line[len(prefix):].strip().split(",")
             for entry in entries:
@@ -1538,8 +1542,7 @@ def synth_jitstats_bands(path):
                         f"jit-stats band width must be positive in {path}: {line.strip()}"
                     )
                 bands[field] = width
-            return bands
-    return {}
+    return bands if bands is not None else {}
 
 
 def _synth_header_flag(path, directive, malformed):
@@ -2057,19 +2060,17 @@ class Check:
                     (s for s in repeats or () if s != jitstats), None
                 )
                 if drifted is not None:
-                    moved = _jit_stats_change(jitstats, drifted, jitstats_bands)
-                    # Snapshot text can drift inside a band without making any
-                    # gated counter unstable.
-                    if moved[0] or moved[1]:
-                        self.jitstats_unstable.append(f"{backend}/{name}")
-                        return "unstable", (
-                            "jit-stats unstable — re-running the same binary moved "
-                            + ", ".join(moved[0] + moved[1])
-                            + ", so this run's counters are not a property of the "
-                            "tree and the baseline comparison ("
-                            + ", ".join(regressions + improvements)
-                            + ") is not gated"
-                        )
+                    # Drift compares two samples directly and is deliberately unbanded.
+                    moved = _jit_stats_change(jitstats, drifted)
+                    self.jitstats_unstable.append(f"{backend}/{name}")
+                    return "unstable", (
+                        "jit-stats unstable — re-running the same binary moved "
+                        + ", ".join(moved[0] + moved[1])
+                        + ", so this run's counters are not a property of the "
+                        "tree and the baseline comparison ("
+                        + ", ".join(regressions + improvements)
+                        + ") is not gated"
+                    )
                 parts = []
                 if regressions:
                     parts.append("regressed: " + ", ".join(regressions))
@@ -2089,8 +2090,13 @@ class Check:
                 self.jitstats_improvements.append(f"{backend}/{name}")
                 return "improved", reason
             if banded:
+                # Assigned, not returned: every other verdict above is a
+                # failure, so leaving early costs those nothing. A band means
+                # the run is fine, and returning here would carry the fixture
+                # past the `--snapshot-diff` and `--threshold` gates below on
+                # every run of a host that sits inside its band.
                 self.jitstats_banded.append(f"{backend}/{name}")
-                return "banded", (
+                status, reason = "banded", (
                     "jit-stats within band — " + ", ".join(banded)
                     + _jit_stats_context(jitstats)
                 )


### PR DESCRIPTION
`synth/generator_tree_recursion` reds CI with `guard_failures 2951 -> 2955`,
identically on ubuntu-x86_64 and windows-x86_64, against a baseline recorded on
darwin-arm64. It is not a regression.

## What the counter actually follows

`JitCounter::new` registers `invoke_after_minor_collection`, which bumps a decay
generation every **32 minor collections**, and `warmstate` calls
`set_decay(40)` — so `tick` multiplies every guard counter by `0.96 **
generations` before using it (`majit-trace/src/counter.rs`). With
`trace_eagerness = 200`, a guard whose warm-up window straddles a decay
generation needs a different number of failures before its bridge attaches, and
`guard_failures` counts exactly the deopts taken before that bridge lands. The
counter therefore follows the minor-collection count during warm-up, which moves
with allocation volume and layout — including target architecture.

Measured on one machine, one binary, one arch (darwin arm64), with `check.py`'s
own pins otherwise:

| nursery | minor collections | `guard_failures` |
|---|---|---|
| 512KB | 316 | 2957 |
| 768KB | 226 | 2958 |
| 1MB | 180 | 2954 |
| 1.5MB | 135 | 2952 |
| 2MB / 4MB / 8MB | 112 / 78 / 61 | 2951 |

`loops_compiled=3 bridges_compiled=26` on every row. CI's 2955 sits inside the
band one host produces by itself.

The falsifying test: `PYRE_JIT=decay=0` reads **2999 at every one of those
nursery sizes**. Turning the decay off removes the entire variance. A decay sweep
at a fixed 4MB nursery reads `0 -> 2999`, `20 -> 3002`, `40 -> 2951`,
`80 -> 2955` — non-monotone, with `loops_compiled=3 bridges_compiled=26
FIRED=26` on all four.

This is upstream-faithful: `rpython/jit/metainterp/counter.py` decays its
counters from the same GC hook. Nothing in the JIT is changed here.

## Why the existing devices do not reach it

`JITSTATS_STABILITY_RUNS` re-runs the same binary in the same invocation and
un-gates a fixture that fails to reproduce itself. This fixture reproduces
exactly — five consecutive runs gave byte-identical snapshots — so that device
provably never fires. The variance is across hosts, and `check.py` runs on one
host at a time.

Trip-count reduction (the `str_fstring` precedent) does not apply either:
startup allocation alone costs ~49 minor collections, so no shortening reaches
zero decay generations, and cutting 9000 -> 3600 drops `bridges_compiled`
26 -> 18, deleting the mechanism the fixture exists to cover. A
`.<platform>.jitstats` overlay cannot express arch. Re-recording to 2955 moves
the red to macOS.

## What this adds

`# pyre-check: jitstats-band=<field>=<width>` — a per-fixture, per-counter
allowance, symmetric around the recorded baseline, read from the first 20 lines
like the other `# pyre-check:` headers.

* Unknown fields, duplicates, non-integer and non-positive widths are errors
  rather than silent no-ops, following `skip-backends`.
* A badness counter cannot be banded: its healthy value is exactly zero, so an
  allowance there would let a real defect through.
* An absorbed move is **reported, not swallowed**. `_jit_stats_change` returns a
  third list, and a run whose only movement was absorbed gets the new
  non-failing `banded` status — a yellow line naming the field, both values and
  the width, plus an end-of-run summary row. When the row is already failing for
  another counter, the absorbed move is appended to the same reason. This keeps
  the band as accountable as the `unstable` arm it is modelled on.

Only `generator_tree_recursion` opts in, at `guard_failures=8`: one unit of
margin over the measured 2951..2958 span, 0.27% of the counter. The regressions
this gate exists for move by hundreds to thousands (`828 -> 4923`, `404 -> 812`,
`937 -> 7408`), and `loops_compiled` / `bridges_compiled` — invariant under every
perturbation above — stay gated exactly.

## Verification

Against the real committed baseline and the real fixture header:

| change | result |
|---|---|
| `guard_failures` 2951 -> 2958 | banded only |
| 2951 -> 2959 (delta 8, boundary) | banded only |
| 2951 -> 2942 (delta 9) | gated |
| 2951 -> 4923 | gated |
| 2955 **and** `bridges_compiled` 26 -> 0 | bridges gated, guard move listed as banded |
| same inputs, no bands | identical to pre-change behaviour |

Fed through the real pipeline (`_jit_stats_snapshot` on measured stderr), the
4MB run (2951) passes either way and the 768KB run (2958) fails without the band
and passes with it. Parser validation covers unknown / badness / duplicate /
zero / negative / non-integer / empty and the 20-line boundary. `ruff` reports
the same two pre-existing findings as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-fixture tolerance bands when evaluating JIT statistics.
  * Changes within declared tolerance bands are reported as warnings without failing checks.
  * Stability retries now ignore expected in-band variation while continuing to detect genuine counter drift.

* **Bug Fixes**
  * Improved validation for JIT statistics configuration, including malformed, duplicate, or unsupported fields.

* **Documentation**
  * Added explanations of guard-failure measurements, decay behavior, benchmark observations, and threshold selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->