### PR TITLE
majit-macros: sync a flat virtualizable by resetting its token, not by copying

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -2249,6 +2249,50 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
                 Some(self as *const Self as *mut u8)
             }
 
+            // warmstate.py:387-396 `execute_assembler`: all a compiled entry
+            // does to its virtualizable is `vinfo.clear_vable_token(virt)` —
+            // one store, before the call, and nothing after it. There is no
+            // copy in and no copy out, because the virtualizable IS the
+            // storage the compiled code reads and writes.
+            //
+            // The default hooks copy in and copy out instead, which is what a
+            // host needs when its interpreter-side storage is a separate
+            // mirror of the virtualizable object. This state is not such a
+            // host: `virtualizable_heap_ptr` above hands out its own address,
+            // and every array field is registered at its byte offset within
+            // it, so the boxes the default reads and the boxes it writes back
+            // address the same memory. The copy in is discarded outright —
+            // nothing here overrides `import_virtualizable_boxes`, whose
+            // default drops the boxes it is handed — and the copy out reads
+            // each element and writes it back unchanged. Both are no-ops that
+            // cost a pass over every array, plus the vectors to hold it, on
+            // every entry into compiled code.
+            //
+            // So keep the token store and drop the copies. The store is itself
+            // inert while the info carries no token field, which is the case
+            // for a state whose offset 0 is a live user field; it is written
+            // rather than omitted so that a state which later declares one
+            // gets the upstream behaviour without this having to be revisited.
+            fn sync_virtualizable_before_jit(
+                &mut self,
+                meta: &Self::Meta,
+                virtualizable: &str,
+                info: &majit_metainterp::virtualizable::VirtualizableInfo,
+            ) -> bool {
+                if let Some(__obj) = self.virtualizable_heap_ptr(meta, virtualizable, info) {
+                    unsafe { info.reset_vable_token(__obj) };
+                }
+                true
+            }
+
+            fn sync_virtualizable_after_jit(
+                &mut self,
+                _meta: &Self::Meta,
+                _virtualizable: &str,
+                _info: &majit_metainterp::virtualizable::VirtualizableInfo,
+            ) {
+            }
+
             fn export_virtualizable_boxes(
                 &self,
                 _meta: &Self::Meta,


### PR DESCRIPTION
Follow-up to #1261, resolving the per-call regression flagged in https://github.com/youknowone/pyre/pull/1261#issuecomment-5308789098.

## Root cause

The macro-generated state's `virtualizable_heap_ptr` hands out the state's own address, and every array field is registered at its byte offset within it — so compiled code already reads and writes the interpreter's storage directly. Yet the default `sync_virtualizable_before_jit`/`sync_virtualizable_after_jit` hooks still copied every array element in and out around each compiled entry. Over the same memory both passes are no-ops that cost a full-array walk plus the holding vectors per entry. This is what turned #1261's armed entry contract (compiled inputs 16–42 → 2, −14 allocs/eval — both real) into a net per-call loss.

## Fix

Generate overrides in the state-field macro:

- `sync_virtualizable_before_jit`: reset the vable token through `virtualizable_heap_ptr` and return true — `warmstate.py:387-396` `execute_assembler` does only `vinfo.clear_vable_token(virt)`, one store, before the call.
- `sync_virtualizable_after_jit`: nothing — upstream does nothing after the call either.

The token store is inert while the descriptor carries no token field; it is written so a state that later declares one gets the upstream behaviour unchanged.

## Measurements (interleaved A/B, stashed binaries, min-of-4, load 5–8)

- vs the armed HEAD (#1261 as merged): faster on every percall case; `list_filter` 442→189 ns/call.
- vs the pre-arming baseline (cycle-17): 25/28 cases equal or faster (flat cases −4…−29 ns/call, `list_filter` −101 ns = −35%).
- Remaining known gap, not caused by this change (control with unarmed Vec banks matches baseline): `comprehension_scaling/100` +7.6%, `/500` +14.4% vs baseline — attributable to the armed configuration's bank-growth path, under separate investigation.

Verified: majit-metainterp + majit-macros suites green (cranelift and dynasm), allocation meters unchanged at 4.000/6.000, fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011capRVFH2W4gwGQNWYCxEx