### PR TITLE
jit: expand `%` and `//` by a constant on a backend with no mul-high

### DIFF
--- a/majit/majit-ir/src/intbound.rs
+++ b/majit/majit-ir/src/intbound.rs
@@ -731,6 +731,53 @@ impl IntBound {
         IntBound::bounded(lower, upper)
     }
 
+    /// Bound for the truncating `int_floordiv` primitive.
+    ///
+    /// [`Self::py_div_bound`] is the floor form and belongs to `int_py_div`;
+    /// this one rounds toward zero, so the two disagree for a negative
+    /// quotient.
+    pub fn trunc_div_bound(&self, other: &IntBound) -> IntBound {
+        if other.contains(0) || other.lower < 0 && 0 < other.upper {
+            return IntBound::unbounded();
+        }
+        // `i64::MIN / -1` overflows, so leave the corners unevaluated there.
+        if other.contains(-1) && (self.lower == i64::MIN || self.upper == i64::MIN) {
+            return IntBound::unbounded();
+        }
+        let a = self.upper / other.upper;
+        let b = self.upper / other.lower;
+        let c = self.lower / other.upper;
+        let d = self.lower / other.lower;
+        IntBound::bounded(a.min(b).min(c).min(d), a.max(b).max(c).max(d))
+    }
+
+    /// Bound for the truncating `int_mod` primitive.
+    ///
+    /// The remainder is smaller in magnitude than the divisor and carries the
+    /// *dividend's* sign, where [`Self::mod_bound`] — the `int_py_mod` form —
+    /// carries the divisor's.
+    pub fn trunc_mod_bound(&self, other: &IntBound) -> IntBound {
+        let (Some(lo_abs), Some(hi_abs)) = (other.lower.checked_abs(), other.upper.checked_abs())
+        else {
+            return IntBound::unbounded();
+        };
+        let magnitude = lo_abs.max(hi_abs);
+        if magnitude == 0 {
+            return IntBound::unbounded();
+        }
+        let lower = if self.known_nonnegative() {
+            0
+        } else {
+            -(magnitude - 1)
+        };
+        let upper = if self.known_le_const(0) {
+            0
+        } else {
+            magnitude - 1
+        };
+        IntBound::bounded(lower, upper)
+    }
+
     /// Bound after left shift.
     pub fn lshift_bound(&self, other: &IntBound) -> IntBound {
         let (mut tvalue, mut tmask) = (0u64, u64::MAX); // TNUM_UNKNOWN

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -1855,6 +1855,13 @@ pub enum OpCode {
     IntSub,
     IntMul,
     UintMulHigh,
+    /// `int_floordiv` / `int_mod`: the C-truncating division primitives, as
+    /// `support.py:255-271 _ll_2_int_floordiv` / `_ll_2_int_mod` define them —
+    /// the quotient rounds toward zero and the remainder carries the
+    /// dividend's sign. Python's floor forms are separate: they reach the
+    /// optimizer as the `int_py_div` / `int_py_mod` oopspec calls that
+    /// `OptRewrite::optimize_call_int_py_div` / `_mod` expand, and those
+    /// expansions build the floor correction on top of these two.
     IntFloorDiv,
     IntMod,
     IntAnd,

--- a/majit/majit-metainterp/src/executor.rs
+++ b/majit/majit-metainterp/src/executor.rs
@@ -423,14 +423,12 @@ pub fn execute_binary_int_const(opcode: OpCode, a: i64, b: i64) -> Option<i64> {
         OpCode::UintLe => ((a as u64) <= (b as u64)) as i64,
         OpCode::UintGe => ((a as u64) >= (b as u64)) as i64,
         OpCode::UintGt => ((a as u64) > (b as u64)) as i64,
-        OpCode::IntFloorDiv if b != 0 => {
-            let (q, r) = (a / b, a % b);
-            if (r != 0) && ((r ^ b) < 0) { q - 1 } else { q }
-        }
-        OpCode::IntMod if b != 0 => {
-            let r = a % b;
-            if (r != 0) && ((r ^ b) < 0) { r + b } else { r }
-        }
+        // Truncating, as `_ll_2_int_floordiv` / `_ll_2_int_mod` are and as the
+        // blackhole and every backend execute them. Wrapping keeps
+        // `i64::MIN / -1` off the panic path; the trace guards that corner out
+        // before it reaches either op.
+        OpCode::IntFloorDiv if b != 0 => a.wrapping_div(b),
+        OpCode::IntMod if b != 0 => a.wrapping_rem(b),
         OpCode::IntSignext if (1..=8).contains(&b) => {
             // `blackhole.bhimpl_int_signext` delegates to `support.int_signext`.
             crate::support::int_signext(a, b)

--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -520,14 +520,17 @@ impl OptIntBounds {
     fn postprocess_int_floordiv(&mut self, op: &Op, ctx: &mut OptContext) {
         let b0 = self.getintbound_arg(&op.arg(0), ctx);
         let b1 = self.getintbound_arg(&op.arg(1), ctx);
-        let b = b0.py_div_bound(&b1);
+        let b = b0.trunc_div_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 
     fn postprocess_int_mod(&mut self, op: &Op, ctx: &mut OptContext) {
         let b0 = self.getintbound_arg(&op.arg(0), ctx);
         let b1 = self.getintbound_arg(&op.arg(1), ctx);
-        let b = b0.mod_bound(&b1);
+        // `IntMod` truncates, so `mod_bound`'s `0 <= x % pos < pos` does not
+        // hold for a negative dividend; that one belongs to the `int_py_mod`
+        // call, which `postprocess_call` still attaches it to.
+        let b = b0.trunc_mod_bound(&b1);
         self.intersect_bound(op.pos.get(), &b, ctx);
     }
 

--- a/majit/majit-metainterp/src/optimizeopt/intdiv.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intdiv.rs
@@ -203,6 +203,139 @@ pub fn modulo_operations(
     )
 }
 
+/// Generate `n // m` for a positive constant `m` from the truncating
+/// `IntFloorDiv` primitive, for a backend that has no efficient
+/// `UintMulHigh`.
+///
+/// [`division_operations`] above is upstream's expansion and the better one
+/// wherever a 64x64->128 multiply is a single instruction. A backend that has
+/// to emulate one answers `supports_efficient_uint_mul_high = false`, and
+/// upstream has nothing to offer it: RPython expands unconditionally because
+/// every backend it targets has the multiply. Left alone, such a backend keeps
+/// the residual `int_py_div` call, which costs it an indirect call in the
+/// middle of the loop it was tracing.
+///
+/// `IntFloorDiv` truncates, so the quotient is one too high exactly when the
+/// dividend is negative and the division is inexact — which for `m > 0` is
+/// exactly when the truncating remainder is negative:
+///
+/// ```text
+///   q = IntFloorDiv(n, m)
+///   t = IntMod(n, m)          sign of n, zero iff m divides n
+///   s = t >> 63               -1 when t < 0, else 0
+///   result = q + s
+/// ```
+///
+/// A non-negative dividend cannot need the correction, so `known_nonneg`
+/// returns `q` itself.
+pub fn trunc_division_operations(
+    n_ref: OpRef,
+    m: i64,
+    known_nonneg: bool,
+    pass_idx: usize,
+    ctx: &mut OptContext,
+) -> OpRef {
+    debug_assert!(m > 0);
+    let m_ref = emit_constant_int(ctx, m);
+
+    let arg_n = ctx.materialize_operand_at(n_ref);
+    let arg_m = ctx.materialize_operand_at(m_ref);
+    let q_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntFloorDiv, &[arg_n.clone(), arg_m.clone()]),
+    );
+    if known_nonneg {
+        return q_ref;
+    }
+
+    let s_ref = emit_remainder_sign(n_ref, m_ref, pass_idx, ctx);
+    let arg_q = ctx.materialize_operand_at(q_ref);
+    let arg_s = ctx.materialize_operand_at(s_ref);
+    emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntAdd, &[arg_q.clone(), arg_s.clone()]),
+    )
+}
+
+/// Generate `n % m` for a positive constant `m` from the truncating `IntMod`
+/// primitive; the modulo counterpart of [`trunc_division_operations`], and
+/// used under the same condition.
+///
+/// The truncating remainder carries the dividend's sign, so it is exactly `m`
+/// short of Python's whenever it is negative:
+///
+/// ```text
+///   t = IntMod(n, m)          -(m-1) <= t <= m-1
+///   s = t >> 63               -1 when t < 0, else 0
+///   result = t + (s & m)      0 <= result < m
+/// ```
+pub fn trunc_modulo_operations(
+    n_ref: OpRef,
+    m: i64,
+    known_nonneg: bool,
+    pass_idx: usize,
+    ctx: &mut OptContext,
+) -> OpRef {
+    debug_assert!(m > 0);
+    let m_ref = emit_constant_int(ctx, m);
+
+    let arg_n = ctx.materialize_operand_at(n_ref);
+    let arg_m = ctx.materialize_operand_at(m_ref);
+    let t_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntMod, &[arg_n.clone(), arg_m.clone()]),
+    );
+    if known_nonneg {
+        return t_ref;
+    }
+
+    // s is 0 or -1, so `s & m` is m on exactly the negative side and 0 elsewhere.
+    let arg_t = ctx.materialize_operand_at(t_ref);
+    let shift63_ref = emit_constant_int(ctx, 63);
+    let arg_shift63 = ctx.materialize_operand_at(shift63_ref);
+    let s_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntRshift, &[arg_t.clone(), arg_shift63.clone()]),
+    );
+    let arg_s = ctx.materialize_operand_at(s_ref);
+    let arg_m = ctx.materialize_operand_at(m_ref);
+    let masked_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntAnd, &[arg_s.clone(), arg_m.clone()]),
+    );
+    let arg_t = ctx.materialize_operand_at(t_ref);
+    let arg_masked = ctx.materialize_operand_at(masked_ref);
+    emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntAdd, &[arg_t.clone(), arg_masked.clone()]),
+    )
+}
+
+/// `IntMod(n, m) >> 63`: -1 when the truncating remainder is negative, else 0.
+fn emit_remainder_sign(n_ref: OpRef, m_ref: OpRef, pass_idx: usize, ctx: &mut OptContext) -> OpRef {
+    let arg_n = ctx.materialize_operand_at(n_ref);
+    let arg_m = ctx.materialize_operand_at(m_ref);
+    let t_ref = emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntMod, &[arg_n.clone(), arg_m.clone()]),
+    );
+    let arg_t = ctx.materialize_operand_at(t_ref);
+    let shift63_ref = emit_constant_int(ctx, 63);
+    let arg_shift63 = ctx.materialize_operand_at(shift63_ref);
+    emit_op(
+        ctx,
+        pass_idx,
+        Op::new(OpCode::IntRshift, &[arg_t.clone(), arg_shift63.clone()]),
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -384,6 +517,120 @@ mod tests {
 
         let final_op = &ctx.new_operations[result_ref.raw() as usize];
         assert_eq!(final_op.opcode, OpCode::IntSub);
+    }
+
+    // ── truncating expansions (backends without an efficient UintMulHigh) ──
+
+    /// What `trunc_modulo_operations` emits, evaluated on i64 with Rust's `%`
+    /// standing in for `IntMod` (both truncate).
+    fn apply_trunc_mod(n: i64, m: i64) -> i64 {
+        let t = n % m;
+        t + ((t >> 63) & m)
+    }
+
+    /// The same for `trunc_division_operations`.
+    fn apply_trunc_div(n: i64, m: i64) -> i64 {
+        (n / m) + ((n % m) >> 63)
+    }
+
+    #[test]
+    fn test_trunc_expansions_match_python_semantics() {
+        for m in [3i64, 5, 7, 10, 13, 100, 127, 1000] {
+            for n in [
+                0i64,
+                1,
+                m - 1,
+                m,
+                m + 1,
+                -1,
+                -(m - 1),
+                -m,
+                -(m + 1),
+                999,
+                -999,
+                i64::MAX,
+                i64::MIN,
+            ] {
+                assert_eq!(
+                    apply_trunc_mod(n, m),
+                    n.rem_euclid(m),
+                    "modulo failed: {n} % {m}"
+                );
+                assert_eq!(
+                    apply_trunc_div(n, m),
+                    floor_div(n, m),
+                    "division failed: {n} // {m}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_trunc_modulo_ops_emits_correct_sequence() {
+        let mut ctx = OptContext::new(12);
+        let n_ref = ctx.emit(Op::new(OpCode::SameAsI, &[]));
+
+        let result_ref = trunc_modulo_operations(n_ref, 7, false, 0, &mut ctx);
+        drain_extra_ops(&mut ctx);
+
+        // IntMod + IntRshift + IntAnd + IntAdd after the input.
+        assert_eq!(ctx.new_operations.len(), 5);
+        assert_eq!(
+            ctx.new_operations[result_ref.raw() as usize].opcode,
+            OpCode::IntAdd
+        );
+        assert!(
+            ctx.new_operations
+                .iter()
+                .all(|op| op.opcode != OpCode::UintMulHigh),
+            "the truncating expansion exists to avoid UintMulHigh"
+        );
+    }
+
+    #[test]
+    fn test_trunc_modulo_ops_known_nonneg_is_the_bare_remainder() {
+        let mut ctx = OptContext::new(8);
+        let n_ref = ctx.emit(Op::new(OpCode::SameAsI, &[]));
+
+        let result_ref = trunc_modulo_operations(n_ref, 7, true, 0, &mut ctx);
+        drain_extra_ops(&mut ctx);
+
+        assert_eq!(ctx.new_operations.len(), 2);
+        assert_eq!(
+            ctx.new_operations[result_ref.raw() as usize].opcode,
+            OpCode::IntMod
+        );
+    }
+
+    #[test]
+    fn test_trunc_division_ops_emits_correct_sequence() {
+        let mut ctx = OptContext::new(12);
+        let n_ref = ctx.emit(Op::new(OpCode::SameAsI, &[]));
+
+        let result_ref = trunc_division_operations(n_ref, 7, false, 0, &mut ctx);
+        drain_extra_ops(&mut ctx);
+
+        // IntFloorDiv + IntMod + IntRshift + IntAdd after the input.
+        assert_eq!(ctx.new_operations.len(), 5);
+        assert_eq!(
+            ctx.new_operations[result_ref.raw() as usize].opcode,
+            OpCode::IntAdd
+        );
+    }
+
+    #[test]
+    fn test_trunc_division_ops_known_nonneg_is_the_bare_quotient() {
+        let mut ctx = OptContext::new(8);
+        let n_ref = ctx.emit(Op::new(OpCode::SameAsI, &[]));
+
+        let result_ref = trunc_division_operations(n_ref, 7, true, 0, &mut ctx);
+        drain_extra_ops(&mut ctx);
+
+        assert_eq!(ctx.new_operations.len(), 2);
+        assert_eq!(
+            ctx.new_operations[result_ref.raw() as usize].opcode,
+            OpCode::IntFloorDiv
+        );
     }
 
     // ── Edge cases ──

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -195,14 +195,22 @@ impl OptRewrite {
             return OptimizationResult::Remove;
         }
 
-        // Strength reduction for constant divisor >= 2
+        // Strength reduction for constant divisor >= 2.
+        //
+        // Both arms below compute a FLOOR quotient, which `IntFloorDiv` is
+        // not: they are only equal to it for a non-negative dividend, so both
+        // are gated on that.
+        let known_nonneg = ctx
+            .resolve_operand_operand_opt(&arg0)
+            .and_then(|b| ctx.peek_intbound_box(&b))
+            .is_some_and(|bound| bound.known_nonnegative());
         if let Some(divisor) = ctx
             .resolve_operand_operand_opt(&arg1)
             .and_then(|b| ctx.get_constant_int_box(&b))
+            && known_nonneg
         {
             if divisor > 1 && divisor.count_ones() == 1 {
-                // Power-of-2 floor division: x // (2^n) = x >> n
-                // Arithmetic right shift IS floor division for positive divisors.
+                // Power-of-2 division: x // (2^n) = x >> n
                 let shift = divisor.trailing_zeros();
                 let shift_ref = self.emit_constant_int(ctx, shift as i64);
                 let arg_shift = ctx.materialize_operand_at(shift_ref);
@@ -217,10 +225,6 @@ impl OptRewrite {
             if divisor >= 3 && ctx.supports_efficient_uint_mul_high {
                 // rewrite.py:770 `known_nonneg = b1.known_nonnegative()`:
                 // a non-negative dividend skips the sign-correction ops.
-                let known_nonneg = ctx
-                    .resolve_operand_operand_opt(&arg0)
-                    .and_then(|b| ctx.peek_intbound_box(&b))
-                    .is_some_and(|bound| bound.known_nonnegative());
                 let result = intdiv::division_operations(
                     arg0.to_opref(),
                     divisor,
@@ -303,20 +307,25 @@ impl OptRewrite {
             return OptimizationResult::Remove;
         }
 
-        // Strength reduction for constant divisor >= 3 (non-power-of-2)
+        // Strength reduction for constant divisor >= 3 (non-power-of-2).
+        //
+        // `modulo_operations` computes a FLOOR remainder, which `IntMod` is
+        // not, so the rewrite holds only for a non-negative dividend — the
+        // case where the two agree.  rewrite.py:809
+        // `known_nonneg = b1.known_nonnegative()` reads the same bound to
+        // decide whether the expansion needs its sign-correction ops.
+        let known_nonneg = ctx
+            .resolve_operand_operand_opt(&arg0)
+            .and_then(|b| ctx.peek_intbound_box(&b))
+            .is_some_and(|bound| bound.known_nonnegative());
         if let Some(divisor) = ctx
             .resolve_operand_operand_opt(&arg1)
             .and_then(|b| ctx.get_constant_int_box(&b))
             && divisor >= 3
             && divisor.count_ones() != 1
+            && known_nonneg
             && ctx.supports_efficient_uint_mul_high
         {
-            // rewrite.py:809 `known_nonneg = b1.known_nonnegative()`:
-            // a non-negative dividend skips the sign-correction ops.
-            let known_nonneg = ctx
-                .resolve_operand_operand_opt(&arg0)
-                .and_then(|b| ctx.peek_intbound_box(&b))
-                .is_some_and(|bound| bound.known_nonnegative());
             let result = intdiv::modulo_operations(
                 arg0.to_opref(),
                 divisor,
@@ -1137,13 +1146,16 @@ impl OptRewrite {
             return Some(OptimizationResult::Remove);
         }
         // rewrite.py:797-805: intdiv.modulo_operations fallback, which emits
-        // UINT_MUL_HIGH.  A backend without one leaves the residual call in
-        // place, the same answer the IntMod arm gives.
-        if !ctx.supports_efficient_uint_mul_high {
-            return None;
-        }
+        // UINT_MUL_HIGH.  A backend that has to emulate that multiply expands
+        // through the native truncating remainder instead; either way the
+        // residual call goes away.
         let known_nonneg = b1.known_nonnegative();
-        let result_ref = crate::optimizeopt::intdiv::modulo_operations(
+        let expand = if ctx.supports_efficient_uint_mul_high {
+            crate::optimizeopt::intdiv::modulo_operations
+        } else {
+            crate::optimizeopt::intdiv::trunc_modulo_operations
+        };
+        let result_ref = expand(
             arg1.to_opref(),
             val,
             known_nonneg,
@@ -1245,13 +1257,16 @@ impl OptRewrite {
             return Some(OptimizationResult::Remove);
         }
         // rewrite.py:758-766: intdiv.division_operations fallback, which emits
-        // UINT_MUL_HIGH.  A backend without one leaves the residual call in
-        // place, the same answer the IntFloorDiv arm gives.
-        if !ctx.supports_efficient_uint_mul_high {
-            return None;
-        }
+        // UINT_MUL_HIGH.  A backend that has to emulate that multiply expands
+        // through the native truncating quotient instead; either way the
+        // residual call goes away.
         let known_nonneg = b1.known_nonnegative();
-        let result_ref = crate::optimizeopt::intdiv::division_operations(
+        let expand = if ctx.supports_efficient_uint_mul_high {
+            crate::optimizeopt::intdiv::division_operations
+        } else {
+            crate::optimizeopt::intdiv::trunc_division_operations
+        };
+        let result_ref = expand(
             arg1.to_opref(),
             val,
             known_nonneg,
@@ -2550,13 +2565,14 @@ mod tests {
         target: usize,
         constants: &[(OpRef, Value)],
     ) -> (OptimizationResult, OptContext) {
-        run_one_rewrite_only_with_mul_high(specs, target, constants, true)
+        run_one_rewrite_only_with_mul_high(specs, target, constants, &[], true)
     }
 
     fn run_one_rewrite_only_with_mul_high(
         specs: Vec<OpSpec>,
         target: usize,
         constants: &[(OpRef, Value)],
+        nonneg: &[OpRef],
         supports_efficient_uint_mul_high: bool,
     ) -> (OptimizationResult, OptContext) {
         let ops = build_specs(&specs);
@@ -2568,6 +2584,14 @@ mod tests {
         for &(opref, value) in constants {
             let b = ctx.materialize_operand_at(opref);
             ctx.make_constant_box(&b, value);
+        }
+        for &opref in nonneg {
+            let b = ctx.materialize_operand_at(opref);
+            let _ = ctx
+                .getintbound_handle(&b)
+                .borrow_mut()
+                .expect("a materialized int operand has a live bound cell")
+                .make_ge_const(0);
         }
         let mut pass = OptRewrite::new();
         let mut op = (*ops[target]).clone();
@@ -2795,15 +2819,20 @@ mod tests {
         assert_binop_self(OpCode::IntMod, Some(0));
     }
 
-    /// Whether the magic-number expansion ran.  `intdiv` queues its sequence
+    /// Whether the pass emitted `opcode`.  `intdiv` queues its sequence
     /// through `emit_extra`, so it is still in `extra_operations_after` when
     /// the pass returns.
-    fn emitted_uint_mul_high(ctx: &OptContext) -> bool {
+    fn emitted_opcode(ctx: &OptContext, opcode: OpCode) -> bool {
         ctx.new_operations
             .iter()
             .map(|op| op.opcode)
             .chain(ctx.extra_operations_after.iter().map(|(_, op)| op.opcode))
-            .any(|opcode| opcode == OpCode::UintMulHigh)
+            .any(|emitted| emitted == opcode)
+    }
+
+    /// Whether the magic-number expansion ran.
+    fn emitted_uint_mul_high(ctx: &OptContext) -> bool {
+        emitted_opcode(ctx, OpCode::UintMulHigh)
     }
 
     /// A `CALL_PURE_I` carrying one of the Python division oopspecs, with the
@@ -2848,6 +2877,31 @@ mod tests {
         (result, ctx)
     }
 
+    /// `IntFloorDiv` and `IntMod` truncate, while both strength reductions
+    /// below them compute a floor.  The two agree only for a non-negative
+    /// dividend, so an unknown-sign one keeps the native op no matter what
+    /// the backend can multiply.
+    #[test]
+    fn constant_division_and_modulo_keep_the_native_op_for_an_unknown_sign_dividend() {
+        for opcode in [OpCode::IntFloorDiv, OpCode::IntMod] {
+            for mul_high in [false, true] {
+                let (result, ctx) = run_one_rewrite_only_with_mul_high(
+                    vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
+                    2,
+                    &[(OpRef::int_op(1), Value::Int(100))],
+                    &[],
+                    mul_high,
+                );
+                assert_pass_on(&result);
+                assert!(
+                    !emitted_uint_mul_high(&ctx),
+                    "{opcode:?} took the floor expansion for a possibly-negative \
+                     dividend (mul_high={mul_high})"
+                );
+            }
+        }
+    }
+
     #[test]
     fn backend_without_mul_high_keeps_native_constant_division_and_modulo() {
         for opcode in [OpCode::IntFloorDiv, OpCode::IntMod] {
@@ -2855,6 +2909,7 @@ mod tests {
                 vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
                 2,
                 &[(OpRef::int_op(1), Value::Int(100))],
+                &[OpRef::int_op(0)],
                 false,
             );
             assert_pass_on(&result);
@@ -2872,6 +2927,7 @@ mod tests {
                 vec![same_i(), same_i(), bin_i(opcode, 0, 1)],
                 2,
                 &[(OpRef::int_op(1), Value::Int(100))],
+                &[OpRef::int_op(0)],
                 true,
             );
             assert!(
@@ -2881,22 +2937,31 @@ mod tests {
         }
     }
 
-    /// The call-based helpers share the magic-number expansion with the
-    /// native opcodes, so they answer to the same capability.
+    /// The `int_py_div` / `int_py_mod` calls carry Python's floor semantics,
+    /// which no backend has an instruction for, so the call always goes away.
+    /// The capability picks the expansion: the magic-number sequence where
+    /// `UintMulHigh` is cheap, `intdiv::trunc_division_operations` /
+    /// `trunc_modulo_operations` — the native truncating primitive plus a
+    /// sign correction — where it is not.
     #[test]
-    fn call_int_py_div_and_mod_follow_the_mul_high_capability() {
-        for oopspecindex in [
-            majit_ir::OopSpecIndex::IntPyDiv,
-            majit_ir::OopSpecIndex::IntPyMod,
+    fn call_int_py_div_and_mod_expand_on_either_mul_high_setting() {
+        for (oopspecindex, primitive) in [
+            (majit_ir::OopSpecIndex::IntPyDiv, OpCode::IntFloorDiv),
+            (majit_ir::OopSpecIndex::IntPyMod, OpCode::IntMod),
         ] {
             let (result, ctx) = run_int_py_call(oopspecindex, 100, false);
-            assert_pass_on(&result);
+            assert_remove(&result);
             assert!(
                 !emitted_uint_mul_high(&ctx),
                 "{oopspecindex:?} expanded through UintMulHigh on a backend that lacks it"
             );
+            assert!(
+                emitted_opcode(&ctx, primitive),
+                "{oopspecindex:?} reached neither expansion on a backend without UintMulHigh"
+            );
 
-            let (_result, ctx) = run_int_py_call(oopspecindex, 100, true);
+            let (result, ctx) = run_int_py_call(oopspecindex, 100, true);
+            assert_remove(&result);
             assert!(
                 emitted_uint_mul_high(&ctx),
                 "{oopspecindex:?} left the residual call on a backend that has UintMulHigh"

--- a/pyre/bench/synth/arith_int_bool.wasm.jitstats
+++ b/pyre/bench/synth/arith_int_bool.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=11
+bridges_compiled=10
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2307
+guard_failures=2211
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=7

--- a/pyre/bench/synth/int_divmod_negative_dividend.cranelift.jitstats
+++ b/pyre/bench/synth/int_divmod_negative_dividend.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/synth/int_divmod_negative_dividend.dynasm.jitstats
+++ b/pyre/bench/synth/int_divmod_negative_dividend.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/synth/int_divmod_negative_dividend.py
+++ b/pyre/bench/synth/int_divmod_negative_dividend.py
@@ -1,0 +1,27 @@
+# `%` and `//` by a small positive constant over a dividend that crosses zero.
+#
+# Both operators reach the optimizer as the `int_py_mod` / `int_py_div` oopspec
+# calls and are expanded against the constant divisor, by magic-number
+# multiplication where the backend has a cheap 64x64->128 multiply and through
+# the truncating `IntMod` / `IntFloorDiv` primitives plus a sign correction
+# where it does not. The two expansions have to agree with each other and with
+# Python, and they only differ on a negative dividend -- the correction is
+# exactly what a non-negative one lets both of them drop.
+#
+# The divisors are 7, 3 and 5: positive, none a power of two, so neither the
+# `x & (2**k - 1)` nor the `x >> k` arm claims them. Weighted so a sign error
+# in any one term moves the checksum.
+N = 400000
+
+
+def main():
+    total = 0
+    i = -N
+    while i < N:
+        total = total + (i % 7) + (i % 3) * 2 + (i % 5) * 3
+        total = total + (i // 7) + (i // 3) * 2 + (i // 5) * 3
+        i = i + 1
+    print(total)
+
+
+main()

--- a/pyre/bench/synth/int_divmod_negative_dividend.wasm.jitstats
+++ b/pyre/bench/synth/int_divmod_negative_dividend.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=0
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=1
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/pyre-jit/src/jit/executor.rs
+++ b/pyre/pyre-jit/src/jit/executor.rs
@@ -66,6 +66,7 @@ pub fn bhimpl_int_mul_ovf(a: ConcreteValue, b: ConcreteValue) -> (ConcreteValue,
     }
 }
 
+/// The `int_py_div` residual call's target: Python's floor quotient.
 pub fn bhimpl_int_floordiv(a: ConcreteValue, b: ConcreteValue) -> ConcreteValue {
     match (a.getint(), b.getint()) {
         (Some(x), Some(y)) if y != 0 => {
@@ -76,9 +77,28 @@ pub fn bhimpl_int_floordiv(a: ConcreteValue, b: ConcreteValue) -> ConcreteValue 
     }
 }
 
+/// The `int_py_mod` residual call's target: Python's floor remainder.
 pub fn bhimpl_int_mod(a: ConcreteValue, b: ConcreteValue) -> ConcreteValue {
     match (a.getint(), b.getint()) {
         (Some(x), Some(y)) if y != 0 => ConcreteValue::Int(((x % y) + y) % y),
+        _ => ConcreteValue::Null,
+    }
+}
+
+/// `support.py:255-265 _ll_2_int_floordiv` — the truncating primitive the
+/// `IntFloorDiv` opcode is, as distinct from the floor helper above that the
+/// `int_py_div` call reaches.
+pub fn _ll_2_int_floordiv(a: ConcreteValue, b: ConcreteValue) -> ConcreteValue {
+    match (a.getint(), b.getint()) {
+        (Some(x), Some(y)) if y != 0 => ConcreteValue::Int(x.wrapping_div(y)),
+        _ => ConcreteValue::Null,
+    }
+}
+
+/// `support.py:266-271 _ll_2_int_mod` — see [`_ll_2_int_floordiv`].
+pub fn _ll_2_int_mod(a: ConcreteValue, b: ConcreteValue) -> ConcreteValue {
+    match (a.getint(), b.getint()) {
+        (Some(x), Some(y)) if y != 0 => ConcreteValue::Int(x.wrapping_rem(y)),
         _ => ConcreteValue::Null,
     }
 }
@@ -318,9 +338,11 @@ pub fn execute_opcode(opcode: majit_ir::OpCode, args: &[ConcreteValue]) -> (Conc
                 (ConcreteValue::Null, false)
             }
         }
+        // The truncating primitives, not the floor helpers the `int_py_div` /
+        // `int_py_mod` calls reach.
         OpCode::IntFloorDiv => {
             let v = if args.len() >= 2 {
-                bhimpl_int_floordiv(args[0], args[1])
+                _ll_2_int_floordiv(args[0], args[1])
             } else {
                 ConcreteValue::Null
             };
@@ -328,7 +350,7 @@ pub fn execute_opcode(opcode: majit_ir::OpCode, args: &[ConcreteValue]) -> (Conc
         }
         OpCode::IntMod => {
             let v = if args.len() >= 2 {
-                bhimpl_int_mod(args[0], args[1])
+                _ll_2_int_mod(args[0], args[1])
             } else {
                 ConcreteValue::Null
             };


### PR DESCRIPTION
> **Superseded in part by #1296.** On the Codex parity review below, the
> `supports_efficient_uint_mul_high` fork this PR kept was dropped: both call
> handlers now reach `intdiv.modulo_operations` / `division_operations`
> unconditionally, as `rewrite.py:797-805` and `:758-766` do, and the truncating
> expansion described under "The change" is gone. The residual call still goes
> away on every backend and the recorded `.jitstats` are unchanged; wasm pays
> 403.80 executed ops per iteration rather than 303.96, against the residual
> call's 857.91. Everything else here — the `IntMod` / `IntFloorDiv` semantics,
> the bounds, the `known_nonneg` gate, the fixture — still stands.

`synth/short_circuit_value_kept_stack` was the last fixture over the wasm/dynasm
ratio ceiling that #1272 set to 4x — ubuntu read 5.2x.

## The cost

`_optimize_CALL_INT_PY_MOD` / `_DIV` expand a constant divisor through
`intdiv.modulo_operations` / `division_operations`, which emit `UintMulHigh`. A
backend that has to emulate the 64x64->128 multiply answers
`supports_efficient_uint_mul_high = false` — wasm is the only one, and its
`emit_umulhi` is a ~30-instruction 32-bit-split software multiply — and the
expansion was declined there, leaving the residual `int_py_mod` call behind.
This fixture does `i % 7`, `i % 3`, `i % 5` per iteration, so that is three
`call_indirect` inside the traced loop against seven inline ops on dynasm.

## The change

The wasm backend already lowers `IntMod` to `i64.rem_s` and `IntFloorDiv` to
`i64.div_s` — which the capability answer's own comment names ("i64.div/rem are
native Wasm operations"). Expand through those plus the floor correction they
need, for a positive constant divisor:

```
t = IntMod(n, m);      s = t >> 63;   r = t + (s & m)
q = IntFloorDiv(n, m);                r = q + (IntMod(n, m) >> 63)
```

A non-negative dividend takes neither correction. Backends with the multiply
keep upstream's magic-number sequence, so dynasm and cranelift emit exactly what
they emitted before. No backend code changes.

## `IntMod` had no producer and two readings

This is the first production emitter of `IntMod` / `IntFloorDiv`, and the tree
disagreed about what they mean. `resoperation.rs` declared both as bare variants
with no doc comment, and the users split — truncating in the blackhole (whose
comment already cites `support.py:255-271`), in `eval_binop_i`, in the cranelift
and wasm lowerings and in `try_fold_binary_int`; Python-floor in
`execute_binary_int_const`, in `postprocess_int_floordiv` / `postprocess_int_mod`
and in the two strength-reduction arms. Both front-ends route Rust's `/` and `%`
to the `int_py_div` / `int_py_mod` residual calls instead, so nothing emitted
either op and neither reading was ever exercised.

This states the upstream one — these are the `int_floordiv` / `int_mod` llops,
both truncating — and moves the four floor-reading sites onto it:

- the const fold truncates (`wrapping_div` / `wrapping_rem`);
- the postprocess bounds come from new `trunc_div_bound` / `trunc_mod_bound`,
  since `mod_bound`'s `0 <= x % pos < pos` is false for a negative dividend and
  belongs to the `int_py_mod` call that `postprocess_call` still attaches it to;
- the two strength reductions produce floor results, so they are gated on a
  non-negative dividend, where floor and truncation agree;
- `pyre-jit`'s `execute_opcode` went through the same `bhimpl_int_floordiv` /
  `bhimpl_int_mod` the `int_py_*` calls reach (correctly floor in *that* role);
  it now goes through `_ll_2_int_floordiv` / `_ll_2_int_mod` beside them.

## Measured

Executed-wasm-op differencing (two trip counts, warm `.cwasm`, `PYRE_WASM_MODULE`
swapped between two prebuilt modules so both arms share one LLBC):

| fixture | before | after | |
|---|---:|---:|---|
| `short_circuit_value_kept_stack` (3 mods/iter) | 857.91 | 303.96 | **−64.6%** |
| `raise_catch_loop` shape (1 mod/iter) | 108.57 | 74.86 | −31.1% |
| 3 mods + 3 divs, negative dividend | 830.48 | 518.00 | −37.6% |
| `global_quasiimmut_invalidation` (no `%`) | 566.00 | 566.00 | **+0.00%** |
| flat loop (no `%`) | 42.00 | 42.00 | **+0.00%** |

The two exact zeros are the control: the arms differ only in `%` / `//`, and no
build drift leaked in. Wall-clock on the gate, darwin/aarch64:

| | dynasm | wasm | ratio gate |
|---|---:|---:|---|
| before | 0.12s | 0.56s | `FAIL … ratio 5.7x > gate 4x` |
| after | 0.10s | 0.20s | **2.0x PASS** |

## jit-stats

A whole-corpus three-backend sweep moves **zero** dynasm and **zero** cranelift
rows — the change is wasm-only — and exactly two wasm rows, each onto the value
its own dynasm *and* cranelift baselines already hold:

| fixture | wasm before | wasm after | dynasm / cranelift |
|---|---|---|---|
| `short_circuit_value_kept_stack` | 11 bridges / 2201 guards | 12 / 2510 | 12 / 2510 |
| `arith_int_bool` | 11 / 2307 | 10 / 2211 | 10 / 2211 |

Both directions occur; converging on the native value is the invariant, not
rising. The `guard_failures` rise is a lost bound — with the call in place
`postprocess_call` attached `mod_bound = [0, m-1]` to its result and neither
expansion reproduces it, which is why dynasm was already at 2510. Upstream runs
`intbounds` before `rewrite` (`__init__.py:15-16`) precisely so that bound can
land on the expansion. Fixing it would move all three backends' baselines, so it
is left as a separate change.

> **Correction (2026-08-17).** This paragraph originally guessed that pyre loses
> the bound through "a parity gap in `make_equal_to`". That is wrong, and anyone
> following it would dig in the wrong place. `make_equal_to`
> (`optimizeopt/mod.rs:4565-4569`) ports `optimizer.py:395-396` faithfully,
> `OpInfo::IntBound` included, so the transfer works; the postprocess that would
> produce the bound never runs at all. The actual site is the `Remove` arm of the
> pass-chain walk, `optimizeopt/optimizer.rs:4736-4746`, which returns
> immediately and discards the `postprocess_passes` it has already collected.
> Upstream `send_extra_operation` (`optimizer.py:600-616`) breaks the *walk* on a
> removal but still runs every collected callback, in reverse order — and the
> sibling `Restart` arm twelve lines above already does exactly that. The
> `optimizer.py:573-575` the `Remove` arm cites is the `log_operations_intbounds`
> comment, not a rule.

## Test

`synth/int_divmod_negative_dividend` sweeps a dividend across zero through both
operators — where the two expansions and Python disagree if either correction is
wrong. All three backends compile one loop and print the same sum; truncating
semantics would print a different one.

Two existing unit tests pinned the old contract and are rewritten as contract
statements: one fed an unknown-sign dividend to the strength reduction it
asserted, the other asserted the residual call this change removes. A third
covers the unknown-sign dividend keeping the native op.

---

⚠️ The branch was rebased onto a base seven PRs newer than the one every number
above was measured on. The three recorded `.jitstats` files are the part most
exposed to that — #1274 in particular touches wasm bridge plumbing — so treat
CI's jit-stats verdict, not this table, as the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected integer division and remainder behavior for negative values to consistently use truncating semantics.
  - Prevented incorrect optimizer transformations when the dividend’s sign is unknown or negative.
  - Improved handling of division edge cases, including overflow scenarios.

- **Performance**
  - Added optimized division and modulo paths for supported constant divisors and backends.
  - Removed unnecessary residual calls while preserving correct sign behavior.

- **Tests**
  - Added coverage for negative dividends, boundary values, backend-specific execution paths, and optimized operation sequences.
  - Added benchmark coverage and updated JIT performance statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
