### PR TITLE
jit: note that an empty-mask reorder restore can replace a Ref with NULL

### DIFF
--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vstack_mirror.rs
@@ -540,6 +540,17 @@ pub(crate) fn reconcile_vstack_at_boundary<Sym: WalkSym>(
         // and the shadow-backed hole-fill declines any slot the virtualizable
         // does not carry, and those holes are exactly what the snapshot
         // restores.
+        //
+        // Such a restore can replace a live-looking Ref with a NULL const-ptr,
+        // and that is the intended outcome rather than a lost box.  A `with`
+        // block keeps the resolved `__exit__` and its `self_or_null` NULL side
+        // by side at the base of the block's stack for the whole body, and the
+        // NULL's slot is the one the callable's own push wrote last, so a
+        // reseed inside the region refills it from the shadow with the
+        // callable.  The snapshot is what puts the NULL back.  Extending the
+        // mask over these slots would keep the callable instead — the shape a
+        // blackhole resuming into WITH_EXCEPT_START calls with the receiver
+        // twice.
         if mask.iter().all(|&w| !w) {
             ctx.vstack_boxes = saved;
         } else {


### PR DESCRIPTION
Closes the last open question from the #1268 reorder-restore census: the residual
conflicting slots at `exception_with_exit_self_null_slot`, which #1268's mask
widening left at 28→20 and 118→89 captures. The verdict is **not a defect**, and
this records it in the file so the next census does not re-open it.

## What the residue is

Settled statically, no build. The coordinate translation is the whole trick:
pyre's `py_pc` counts **code units** (`byte offset / 2`), so it indexes the
instruction stream *including* inline caches — `dis`'s own instruction index does
not match it and decodes the wrong opcode (36 is `LOAD_SPECIAL __enter__`, not
`LOAD_SMALL_INT`).

With that, the `<module>` stack of the fixture is unambiguous:

```
LOAD_NAME context / COPY 1
LOAD_SPECIAL __exit__   -> pops the copy, pushes the callable at slot 1, NULL at slot 2
SWAP 2 / SWAP 3         -> [__exit__, NULL, ctx]
LOAD_SPECIAL __enter__  -> [__exit__, NULL, enter, NULL]   (depth 4 - the audited boundary)
```

**Slot 1 is the `self_or_null` NULL for the whole block body; slot 0 is the
callable.** So at the audited `36->37` boundary `restored=ConstPtr(NULL)` is
correct and `mirror=shadow=RefOp(46)` — the callable — is the wrong side. The
capture-audit coordinates (py_pc 42, 43, 51, 52, 60) are all inside the body and
give the same answer, and `context_manager.py` shows the identical shape at the
same slot and depth. Neither reading depends on `nlocals`.

The mirror acquires the callable because `ShadowReseed` inside the region refills
slot 1 from the shadow, whose last store into that slot was the callable's own
push. The pc-derived snapshot is what puts the NULL back.

## Why it must not be "fixed"

Extending the mask over these slots keeps the callable instead. That is exactly
the regression the fixture was written to witness — a blackhole resuming into
`WITH_EXCEPT_START` reads the bound `__exit__` one slot below and calls it with
the receiver twice (`__exit__() takes 4 positional arguments but 5 were given`).
The fixture currently passes with its expected `180060000 20000`.

## Refuted on the way

- *"SWAP never updates the virtualizable shadow"* — `trace_opcode.rs`'s
  `swap_stack_slots` swaps the `(OpRef, Value)` pair atomically.
- *"the jitcode carries no vable traffic for SWAP"* — `vstack_mirror.rs`'s own
  `Swap` arm names "the `setarrayitem_vable_r` stores the walk executed for that
  SWAP".

## Change

Comment only, 11 lines, at the `mask.iter().all(|&w| !w)` branch in
`reconcile_vstack_at_boundary`. `cargo fmt -p pyre-jit-trace -- --check` clean;
no code path is touched, so the published tables and the walk are unchanged.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified snapshot restoration behavior during stack reordering recovery.
  * Documented preservation of `NULL` and callable slots when resuming `with` blocks and exception-handling flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->