### PR TITLE
majit: stop inheriting a previous compile's target tokens

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -4364,7 +4364,7 @@ thread_local! {
 }
 
 fn opref_is_op_result_var(opref: OpRef) -> bool {
-    // history.py:213 `Const.is_constant()` returns True; inline-Const
+    // history.py:220 `Const.is_constant()` returns True; inline-Const
     // variants are constants, never op results — short-circuit before
     // `.raw()` (which panics on inline variants).
     if opref.inline_const_bits().is_some() {
@@ -4706,7 +4706,7 @@ fn validate_oprefs_for_compile(
         }
         if op_dereferences_first_arg(op.opcode) {
             let arg = op.arg(0);
-            // history.py:213 `Const.is_constant()` — Const operands are
+            // history.py:220 `Const.is_constant()` — Const operands are
             // always "bound" by the value carried inline.
             let bound = arg.is_none()
                 || arg.is_constant()

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -3683,7 +3683,7 @@ impl<'a> RegAlloc<'a> {
         ) {
             return false;
         }
-        // history.py:213 `Const.is_constant()` — Const operands are not
+        // history.py:220 `Const.is_constant()` — Const operands are not
         // op-result identities; comparison via raw position is invalid.
         if next_op.num_args() == 0
             || next_op.arg(0).is_constant()

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -50,7 +50,7 @@ struct DynasmCaTarget {
     /// `model.py:292-338` `CompiledLoopToken` — Arc-shared with the
     /// owning `JitCellToken` once the real target registers.
     compiled_loop_token: Arc<majit_backend::CompiledLoopToken>,
-    /// `pyjitpl.py:3605` `outermost_jitdriver_sd.index_of_virtualizable`.
+    /// `pyjitpl.py:3629` `outermost_jitdriver_sd.index_of_virtualizable`.
     /// Captured from `JitCellToken.virtualizable_arg_index` when the compiled
     /// target registers.
     index_of_virtualizable: i32,

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -6425,7 +6425,7 @@ fn next_op_can_accept_cc<'a>(
     if !matches!(next_op.opcode, OpCode::GuardTrue | OpCode::GuardFalse) {
         return None;
     }
-    // history.py:213 `Const.is_constant()` — a Const operand is not an
+    // history.py:220 `Const.is_constant()` — a Const operand is not an
     // op-result identity, so comparing raw positions against it is invalid.
     if next_op.num_args() == 0 || next_op.arg(0).is_constant() {
         return None;

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1291,9 +1291,12 @@ pub struct JitCellToken {
     /// use the accessors (not `.get()` / `.set()` directly) to keep
     /// the bit-packing invariant.
     pub retraced_count: Cell<u32>,
-    /// `history.py:433` `JitCellToken.target_tokens = None` (lazily
-    /// populated to a `list[TargetToken]` in `compile.py:286-296` /
-    /// `:312-323` once the loop is compiled).  `pyjitpl.py:3898`
+    /// `history.py:440` `JitCellToken.target_tokens = None`, the class
+    /// default, assigned a `list[TargetToken]` at exactly two sites:
+    /// `compile.py:245` in `compile_simple_loop` and `:290` in
+    /// `compile_loop`.  Those are the only writers, so a token minted
+    /// anywhere else — `compile_retrace`'s no-resumekey arm mints at
+    /// `:1013` — keeps the `None` default.  `pyjitpl.py:3922-3923`
     /// `has_compiled_targets(token)` reads this list — `bool(token)
     /// and bool(token.target_tokens)`.
     ///
@@ -1301,8 +1304,12 @@ pub struct JitCellToken {
     /// (`LoopTargetDescr` Arc; `TargetToken IS-A AbstractDescr` in
     /// PyPy, so a `DescrRef` is the matching identity).  Each
     /// successful loop / retrace populates this through
-    /// `record_target_token` so `has_compiled_loop` reads the same
-    /// signal PyPy's `has_compiled_targets` does.  The metainterp-side
+    /// `record_target_token`.  Its one reader is
+    /// [`Self::first_target_token`], the descr a bridge closes onto:
+    /// neither `has_compiled_loop` (token presence) nor pyre's
+    /// `has_compiled_targets` (the `compiled_loops` side table) reads
+    /// this list, so it is not pyre's `has_compiled_targets` signal
+    /// despite mirroring what upstream's reads.  The metainterp-side
     /// `TargetToken` value (with `virtual_state` / `short_preamble`)
     /// stays on the `CompiledEntry::front_target_tokens` list per
     /// the F.6 retirement plan — the per-target descr identity is the
@@ -1544,31 +1551,42 @@ impl JitCellToken {
         self.bridge_invalidation_flags.lock().last().cloned()
     }
 
-    /// `pyjitpl.py:3898` `has_compiled_targets(token)` —
+    /// `pyjitpl.py:3922-3923` `has_compiled_targets(token)` —
     /// `bool(token) and bool(token.target_tokens)`.  PyPy reads
-    /// `token.target_tokens` (a `list[TargetToken]` populated at
-    /// `compile.py:286-296`) and treats a non-empty list as the signal
-    /// that the loop has been compiled.
+    /// `token.target_tokens` (a `list[TargetToken]` assigned at
+    /// `compile.py:245` / `:290`) and treats a non-empty list as the
+    /// signal that the loop has been compiled.
     #[inline]
     pub fn has_target_tokens(&self) -> bool {
         !self.target_tokens.lock().is_empty()
     }
 
     /// The head of `token.target_tokens` — the descr `compile.py:290`
-    /// seeds the list with, and the one `pyjitpl.py:3007` closes a bridge
-    /// onto once `has_compiled_targets` has admitted the token.  Reading it
-    /// from the token rather than from a side table keeps the target and the
-    /// gate that admitted it the same object, which is what makes the
-    /// `warmstate.py:191-196` invalidation filter cover both.
+    /// seeds the list with.  Reading it from the token rather than from a
+    /// side table keeps the target and the gate that admitted it the same
+    /// object, which is what makes the `warmstate.py:191-196` invalidation
+    /// filter cover both.
+    ///
+    /// Upstream resolves the close target later and differently:
+    /// `pyjitpl.py:3007` hands `compile_trace` the JitCellToken itself, the
+    /// JUMP carries that token as its descr, and `unroll.py:320-340` picks
+    /// among `target_tokens` by matching each one's `virtual_state`,
+    /// skipping `VirtualStatesCantMatch`.  Taking the head here is
+    /// unconditional, so a list longer than one is a list of one for
+    /// close-target purposes.
     #[inline]
     pub fn first_target_token(&self) -> Option<majit_ir::DescrRef> {
         self.target_tokens.lock().first().cloned()
     }
 
-    /// `compile.py:286-296` / `:312-323` — append a freshly minted
-    /// TargetToken's descr to `token.target_tokens`.  Idempotent on
-    /// `Arc::ptr_eq` so retrace paths that reuse `prior_front_target_tokens`
-    /// across `compile_loop` and `compile_retrace` do not duplicate.
+    /// Append a freshly minted TargetToken's descr to
+    /// `token.target_tokens`.  Idempotent on `Arc::ptr_eq` so retrace
+    /// paths that reuse `prior_front_target_tokens` do not duplicate.
+    ///
+    /// This has no single upstream counterpart: `compile.py:245` /
+    /// `:290` assign the list outright, and both are in
+    /// `compile_simple_loop` / `compile_loop`, so neither describes
+    /// what happens on the retrace path this method also serves.
     pub fn record_target_token(&self, descr: majit_ir::DescrRef) {
         let mut guard = self.target_tokens.lock();
         if !guard.iter().any(|existing| Arc::ptr_eq(existing, &descr)) {

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -1183,12 +1183,12 @@ pub struct JitCellToken {
     bridge_invalidation_flags: parking_lot::Mutex<Vec<Arc<AtomicBool>>>,
     /// Alternative loop versions to compile immediately after the main loop.
     pub version_info: Option<LoopVersionInfo>,
-    /// history.py:449: _keepalive_jitcell_tokens — set of other tokens
+    /// history.py:455: _keepalive_jitcell_tokens — set of other tokens
     /// that this loop can jump to (via CALL_ASSEMBLER or JUMP).
     /// Upstream prevents the target from being evicted while this loop
     /// is alive by holding the actual `JitCellToken` object reference
-    /// (`history.py:441 _keepalive_jitcell_tokens = {}` keyed on the
-    /// token object itself, with `:451 record_jump_to` writing
+    /// (`history.py:455 _keepalive_jitcell_tokens = {}` keyed on the
+    /// token object itself, with `:457 record_jump_to` writing
     /// `self._keepalive_jitcell_tokens[target] = None`).  Pyre keeps the
     /// same shape: an `Arc<JitCellToken>` set keyed on token number.
     ///
@@ -1248,7 +1248,7 @@ pub struct JitCellToken {
     /// covered by the existing `unsafe impl Sync for JitCellToken`
     /// at line 1130 — single-threaded JIT scheduler invariant.
     pub generation: Cell<i64>,
-    /// `history.py:431-435 JitCellToken.retraced_count` parity slot.
+    /// `history.py:442 JitCellToken.retraced_count` parity slot.
     ///
     /// RPython packs two pieces of state into this u-int:
     ///   * bit 0 = `FORCE_BRIDGE_SEGMENTING` flag.
@@ -1318,7 +1318,7 @@ pub struct JitCellToken {
 }
 
 impl JitCellToken {
-    /// `history.py:431` `FORCE_BRIDGE_SEGMENTING = 1` — bit packed
+    /// `history.py:438` `FORCE_BRIDGE_SEGMENTING = 1` — bit packed
     /// into `retraced_count`.  Set at `pyjitpl.py:2833` (pyre:
     /// `MetaInterp::blackhole_trace_too_long_slow`) when a bridge
     /// trace aborts without an inlinable function; read at
@@ -1364,9 +1364,9 @@ impl JitCellToken {
             _ll_function_addr: AtomicUsize::new(0),
             // memmgr.py:38 default; first keep_loop_alive overwrites this.
             generation: Cell::new(0),
-            // history.py:435 `retraced_count = 0` (class attribute default).
+            // history.py:442 `retraced_count = 0` (class attribute default).
             retraced_count: Cell::new(0),
-            // history.py:433 `target_tokens = None` — pyre uses the
+            // history.py:440 `target_tokens = None` — pyre uses the
             // empty-Vec equivalent so `has_target_tokens` is one
             // `is_empty()` check away.
             target_tokens: parking_lot::Mutex::new(Vec::new()),

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -550,7 +550,7 @@ impl FailDescr for ResumeGuardDescr {
         self.external_jump_target.get().is_some()
     }
 
-    /// `history.py:470` `TargetToken._ll_loop_code` parity: when this
+    /// `history.py:478` `TargetToken._ll_loop_code` parity: when this
     /// descr is the synthesised cross-loop JUMP exit, surface the target
     /// `DescrRef` the dispatcher re-enters via.  `None` for regular
     /// guard descrs.

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3108,7 +3108,7 @@ struct BasicLoopTargetDescrState {
 struct BasicLoopTargetDescr {
     token_id: u64,
     is_preamble_target: bool,
-    /// `history.py:470` `TargetToken._ll_loop_code` parity: a single
+    /// `history.py:478` `TargetToken._ll_loop_code` parity: a single
     /// integer recording the address of the loop's compiled entry
     /// point.  RPython sets this with a plain `setattr` (atomic w.r.t.
     /// the GIL); pyre uses `AtomicUsize` so cranelift-emitted in-code
@@ -3406,7 +3406,7 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
         false
     }
 
-    /// compile.py:919-920: `invent_fail_descr_for_op` mints
+    /// compile.py:924-927: `invent_fail_descr_for_op` mints
     /// `ResumeGuardForcedDescr` for `GUARD_NOT_FORCED` /
     /// `GUARD_NOT_FORCED_2`.  Allows descr-level dispatch in places
     /// that today switch on opcode (e.g. `handle_fail` for forced

--- a/majit/majit-ir/src/resoperation.rs
+++ b/majit/majit-ir/src/resoperation.rs
@@ -252,7 +252,7 @@ impl OpRef {
     }
 
     /// resoperation.py:47 `AbstractValue.is_constant()` returns False;
-    /// history.py:213 `Const.is_constant()` returns True. The
+    /// history.py:220 `Const.is_constant()` returns True. The
     /// dispatch is class-based — typed body variants
     /// (`IntOp/RefOp/FloatOp/VoidOp/InputArg*`) correspond to
     /// `AbstractValue` subclasses and are NOT constants.

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -5393,27 +5393,27 @@ fn bhimpl_int_ne(a: i64, b: i64) -> i64 {
     (a != b) as i64
 }
 
-/// blackhole.py:551 `bhimpl_int_gt(a, b): return int(a > b)`.
+/// blackhole.py:548 `bhimpl_int_gt(a, b): return int(a > b)`.
 fn bhimpl_int_gt(a: i64, b: i64) -> i64 {
     (a > b) as i64
 }
 
-/// blackhole.py:555 `bhimpl_int_ge(a, b): return int(a >= b)`.
+/// blackhole.py:551 `bhimpl_int_ge(a, b): return int(a >= b)`.
 fn bhimpl_int_ge(a: i64, b: i64) -> i64 {
     (a >= b) as i64
 }
 
-/// blackhole.py:559 `bhimpl_int_is_true(a): return int(bool(a))`.
+/// blackhole.py:557 `bhimpl_int_is_true(a): return int(bool(a))`.
 fn bhimpl_int_is_true(a: i64) -> i64 {
     (a != 0) as i64
 }
 
-/// blackhole.py:563 `bhimpl_int_is_zero(a): return int(not a)`.
+/// blackhole.py:554 `bhimpl_int_is_zero(a): return int(not a)`.
 fn bhimpl_int_is_zero(a: i64) -> i64 {
     (a == 0) as i64
 }
 
-/// blackhole.py:567 `bhimpl_int_force_ge_zero(a): if a < 0: return 0; return a`.
+/// blackhole.py:563 `bhimpl_int_force_ge_zero(a): if a < 0: return 0; return a`.
 fn bhimpl_int_force_ge_zero(a: i64) -> i64 {
     if a < 0 { 0 } else { a }
 }
@@ -9688,7 +9688,7 @@ fn handler_copystrcontent(
     }
     Ok(p + 5)
 }
-/// RPython `blackhole.py:1580-1583` `bhimpl_copyunicodecontent`.
+/// RPython `blackhole.py:1593-1595` `bhimpl_copyunicodecontent`.
 fn handler_copyunicodecontent(
     bh: &mut BlackholeInterpreter,
     code: &[u8],

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -4423,7 +4423,7 @@ impl FailDescr for ResumeGuardCopiedDescr {
              copied descrs share their donor's type vector via prev"
         );
     }
-    /// history.py:143 `AbstractFailDescr.attach_vector_info`: writes
+    /// history.py:150 `AbstractFailDescr.attach_vector_info`: writes
     /// `self.rd_vector_info`, never `self.prev`.  `prev` is for resume
     /// storage only (compile.py:849 `get_resumestorage`); vector info
     /// lives on the copied descr itself.

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -117,7 +117,7 @@ struct LoopTargetDescrState {
 struct LoopTargetDescr {
     token_id: u64,
     is_preamble_target: bool,
-    /// `history.py:470` `TargetToken._ll_loop_code` parity (PyPy stores
+    /// `history.py:478` `TargetToken._ll_loop_code` parity (PyPy stores
     /// a plain integer GIL-atomic; pyre uses `AtomicUsize` so the
     /// cranelift backend's in-code `closing_jump` dispatch can read
     /// the slot via a baked address without taking a Mutex).

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -53,10 +53,6 @@ pub struct TargetToken {
     pub virtual_state: Option<crate::optimizeopt::virtualstate::VirtualState>,
     /// Short preamble: ops to replay when entering from a bridge.
     pub short_preamble: Option<crate::optimizeopt::shortpreamble::ShortPreamble>,
-    /// RPython unroll.py: active ExtendedShortPreambleBuilder for the target
-    /// token currently being finalized.
-    pub short_preamble_producer:
-        Option<crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder>,
     jump_target_descr: Arc<LoopTargetDescr>,
 }
 
@@ -73,7 +69,6 @@ impl TargetToken {
             is_preamble_target: false,
             virtual_state: None,
             short_preamble: None,
-            short_preamble_producer: None,
             jump_target_descr: Arc::new(LoopTargetDescr::new(0, false)),
         }
     }

--- a/majit/majit-metainterp/src/jitcode/assembler.rs
+++ b/majit/majit-metainterp/src/jitcode/assembler.rs
@@ -6077,7 +6077,7 @@ impl JitCodeBuilder {
     }
 }
 
-/// pyjitpl.py:3675 `effectinfo.call_release_gil_target` parity.
+/// pyjitpl.py:3699 `effectinfo.call_release_gil_target` parity.
 ///
 /// PyPy populates `(realfuncaddr, saveerr)` at descr creation time:
 /// `codewriter/call.py:252-258` reads `_call_aroundstate_target_` off

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -755,7 +755,7 @@ pub struct OptContext {
     /// info.py:788-790 `ConstPtrInfo._unpack_str(mode)` — runtime hook for
     /// extracting character data from a constant string GcRef.
     pub string_content_resolver: Option<StringContentResolver>,
-    /// history.py:377 `get_const_ptr_for_string(s)` — runtime hook for
+    /// history.py:384 `get_const_ptr_for_string(s)` — runtime hook for
     /// creating a constant string GcRef from char values (used by
     /// force_box constant-folding path, vstring.py:79-90).
     pub string_constant_alloc: Option<StringConstantAllocator>,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -399,6 +399,15 @@ pub struct Optimizer {
     /// producer for the target token currently being compiled.
     pub imported_short_preamble_builder:
         Option<crate::optimizeopt::shortpreamble::ShortPreambleBuilder>,
+    /// RPython `unroll.py:298` `self.short_preamble_producer = ...`.
+    ///
+    /// `imported_short_preamble_builder` above ports `unroll.py:507`.
+    /// Upstream stage-switches one slot in time, overwriting the imported
+    /// plain builder with this extended builder. Pyre keeps both stages live
+    /// as distinct Rust types; relocating this field to `Optimizer` changes
+    /// the extended builder's home without merging those stages.
+    pub short_preamble_producer:
+        Option<crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder>,
     /// RPython unroll.py: `label_args = import_state(...)`.
     /// The peeled loop's LABEL must use these args, not the phase-1 end_args.
     pub imported_label_args: Option<Vec<OpRef>>,
@@ -1480,6 +1489,7 @@ impl Optimizer {
             imported_short_aliases: Vec::new(),
             imported_short_preamble: None,
             imported_short_preamble_builder: None,
+            short_preamble_producer: None,
             imported_label_args: None,
             patchguardop: None,
             skip_flush: false,

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2376,7 +2376,7 @@ mod tests {
     }
 
     /// pure.py:62 / :72-74 same_box semantics for constant args.
-    /// history.py:204-205 / :244 — `same_box(a, b) == same_constant(a, b)`
+    /// history.py:211-212 / :251 — `same_box(a, b) == same_constant(a, b)`
     /// for Const subclasses, so cache hits are value-equality. With
     /// inline `ConstInt.value`, two `make_constant_int(5)` calls return
     /// the same `OpRef::ConstInt(5)` and the cache hit is by

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -397,13 +397,13 @@ impl OptRewrite {
     // ── Unary operations ──
 
     /// Constant fold INT_IS_ZERO.
-    /// rewrite.py:512-513 `optimize_INT_IS_ZERO`:
+    /// rewrite.py:522-523 `optimize_INT_IS_ZERO`:
     ///     return self._optimize_nullness(op, op.getarg(0), False)
     fn optimize_int_is_zero(&self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
         self.optimize_nullness(op, op.arg(0).to_opref(), false, ctx)
     }
 
-    /// rewrite.py:505-510 `optimize_INT_IS_TRUE`:
+    /// rewrite.py:515-520 `optimize_INT_IS_TRUE`:
     ///     if (not self.is_raw_ptr(op.getarg(0)) and
     ///         self.getintbound(op.getarg(0)).is_bool()):
     ///         self.make_equal_to(op, op.getarg(0))

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2538,7 +2538,7 @@ pub struct ExtendedShortPreambleBuilder {
     label_args: Vec<OpRef>,
     used_boxes: Vec<OpRef>,
     short_jump_args: Vec<OpRef>,
-    pub target_token: u64,
+    pub target_token: majit_ir::DescrRef,
     /// RPython parity: remap Phase 1 preamble OpRefs → current inputargs.
     /// Values are the current-namespace boxes, bound to their producers at
     /// `setup()` insertion (the mapping values in unroll.py:396 are the
@@ -2611,7 +2611,7 @@ impl ExtendedShortPreambleBuilder {
         // positions, never Const) — nothing to walk.
     }
 
-    pub fn new(target_token: u64, sb: &ShortPreambleBuilder) -> Self {
+    pub fn new(target_token: majit_ir::DescrRef, sb: &ShortPreambleBuilder) -> Self {
         ExtendedShortPreambleBuilder {
             // The live builder now keys `produced_short_boxes` by the short-box
             // res Box (#146/S8); this builder keys by `preamble_op.pos` (the
@@ -4478,7 +4478,10 @@ mod tests {
     #[test]
     fn test_extended_short_preamble_builder_fallback_keeps_invented_name_alias_identity() {
         let sb = ShortPreambleBuilder::new(&[OpRef::int_op(7)], &[], &[OpRef::int_op(7)]);
-        let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
+        let mut builder = ExtendedShortPreambleBuilder::new(
+            crate::history::TargetToken::new_loop(0).as_jump_target_descr(),
+            &sb,
+        );
         let mut replay_op = Op::new(OpCode::GetfieldGcI, &[rop(Type::Int, 30)]);
         replay_op.pos.set(OpRef::int_op(14));
         let pop = crate::optimizeopt::info::PreambleOp {
@@ -4514,7 +4517,10 @@ mod tests {
         let original = OpRef::input_arg_typed(8, Type::Ref);
         let current = OpRef::ref_op(80);
         let sb = ShortPreambleBuilder::new(&[original], &[], &[renamed]);
-        let mut builder = ExtendedShortPreambleBuilder::new(0, &sb);
+        let mut builder = ExtendedShortPreambleBuilder::new(
+            crate::history::TargetToken::new_loop(0).as_jump_target_descr(),
+            &sb,
+        );
         let initial = ShortPreamble {
             ops: vec![ShortPreambleOp {
                 op: Op::new(OpCode::GetfieldGcR, &[Operand::bound_from_opref(renamed)]),
@@ -4537,7 +4543,10 @@ mod tests {
         assert_eq!(rebuilt.ops[0].op.arg(0).to_opref(), original);
         assert!(rebuilt.ops[0].arg_mapping.is_empty());
 
-        let mut retrace_builder = ExtendedShortPreambleBuilder::new(0, &sb);
+        let mut retrace_builder = ExtendedShortPreambleBuilder::new(
+            crate::history::TargetToken::new_loop(0).as_jump_target_descr(),
+            &sb,
+        );
         assert!(retrace_builder.setup(&rebuilt, &[current], &mut ctx));
         assert_eq!(
             retrace_builder.short_op(0).unwrap().arg(0).to_opref(),

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -1570,7 +1570,7 @@ impl ProducedShortOp {
         // `result_opref` is a typed synthetic alias minted by
         // `add_op_to_short` via `ctx.alloc_op_position_typed(arg_type)`
         // — its variant carries `Box.type` from the chosen producer
-        // (history.py:802 `record_same_as` parity). Downstream type
+        // (history.py:809 `record_same_as` parity). Downstream type
         // lookups read it directly via `OpRef::ty()` or the producing
         // SAME_AS body op's `op.type_` once it lands in
         // `new_operations`.

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2182,7 +2182,7 @@ pub struct ExportedState {
     /// This preserves the original preamble ops so the active path can build
     /// short preambles without re-extracting them from the peeled trace.
     pub exported_short_boxes: Vec<crate::optimizeopt::shortpreamble::PreambleOp>,
-    /// RPython unroll.py:466-477 `short_boxes = sb.create_short_boxes(...)`
+    /// RPython unroll.py:478-479 `short_boxes = sb.create_short_boxes(...)`
     /// stored directly on ExportedState. Consumer sites
     /// (`build_imported_short_preamble`, `import_short_preamble_state`)
     /// iterate this list verbatim. Pyre derives this eagerly from
@@ -2313,7 +2313,7 @@ impl ExportedState {
         short_inputargs: Vec<OpRef>,
         short_inputarg_refs: Vec<majit_ir::InputArgRc>,
     ) -> Self {
-        // unroll.py:466-477 `sb.create_short_boxes(...)` parity: pyre
+        // unroll.py:478-479 `sb.create_short_boxes(...)` parity: pyre
         // pre-derives the per-OpRef ProducedShortOp view and stores it
         // directly, matching RPython's `ExportedState.short_boxes`. The
         // label-arg → short-inputarg rename already happened at export time
@@ -3424,7 +3424,7 @@ impl OptUnroll {
         runtime_boxes: &[OpRef],
         pre_vs: Option<crate::optimizeopt::virtualstate::VirtualState>,
     ) -> Option<crate::optimizeopt::virtualstate::VirtualState> {
-        // optimizer.py:317 `with self.optimizer.cant_replace_guards():`
+        // unroll.py:317 `with self.optimizer.cant_replace_guards():`
         // line-by-line — save current `can_replace_guards`, set False
         // for the guarded section, restore on exit. Nested scopes
         // preserve the outer False via the saved token. An InvalidLoop is

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -377,6 +377,9 @@ pub struct UnrollOptimizer {
     /// because the unroll optimizer owns the inner phase optimizers while the
     /// registered GC walker enters through MetaInterp.
     pub compile_snapshot_root_slots: Option<usize>,
+    /// MetaInterp-owned slot that publishes the in-flight phase-2
+    /// `Optimizer.short_preamble_producer` to the registered GC walker.
+    pub compile_short_preamble_producer_slot: Option<usize>,
     /// Snapshot-root slots that must stay rooted across every phase's
     /// `replace_compile_snapshot_roots`. pyjitpl installs the caller-owned
     /// original snapshot maps here so a moving GC during unroll forwards their
@@ -386,28 +389,41 @@ pub struct UnrollOptimizer {
     pub persistent_snapshot_root_slots: Vec<usize>,
 }
 
+/// Withdraws the address `publish_short_preamble_producer` installed in
+/// `MetaInterp.compile_short_preamble_producer`.
+pub(crate) struct PublishedShortPreambleProducer {
+    slot: Option<usize>,
+}
+
+impl Drop for PublishedShortPreambleProducer {
+    fn drop(&mut self) {
+        if let Some(addr) = self.slot {
+            // SAFETY: the same address pyjitpl installed for this compile, on
+            // the same thread as the registered root walker. Writing `None`
+            // here is what keeps the walker from reading the optimizer local
+            // after it is dropped.
+            unsafe {
+                *(addr as *mut Option<usize>) = None;
+            }
+        }
+    }
+}
+
 impl UnrollOptimizer {
     /// Supply the target tokens an earlier compile of this green key left
-    /// behind, stripped of their short-preamble producers.
+    /// behind.
     ///
-    /// unroll.py:250 declares `short_preamble_producer = None` on `OptUnroll`
-    /// and only `finalize_short_preamble` (unroll.py:298) ever sets it, so
-    /// upstream enters every compile with exactly one producer: the one for
-    /// the target token that compile is minting. That is what lets
-    /// `inline_short_preamble` decide by identity — `sb.target_token is
-    /// target_token` (unroll.py:376-385) — whether it may set the builder up
-    /// in place against the current label args.
+    /// `unroll.py:250` declares `short_preamble_producer = None`;
+    /// `import_state` sets its plain builder at `unroll.py:507`, and
+    /// `finalize_short_preamble` replaces it with the extended builder at
+    /// `unroll.py:298`. Thus one extended producer is live for an optimizer
+    /// run, which is what `unroll.py:378`'s
+    /// `assert isinstance(sb, ExtendedShortPreambleBuilder)` relies on.
     ///
-    /// pyre parks the producer on the `TargetToken` instead, and the tokens
-    /// resupplied here are clones of a previous compile's. Left intact, the
-    /// first one whose virtual state matches would hand out that compile's
-    /// builder, which would then be set up against this trace's label args and
-    /// have its stored short preamble overwritten with one naming this
-    /// compile's boxes.
-    pub fn seed_prior_target_tokens(&mut self, mut tokens: Vec<TargetToken>) {
-        for token in &mut tokens {
-            token.short_preamble_producer = None;
-        }
+    /// `inline_short_preamble` retains the `sb.target_token is target_token`
+    /// discrimination at `unroll.py:376-385`; its descriptor-identity gate
+    /// prevents an in-place setup against every matching candidate.
+    pub fn seed_prior_target_tokens(&mut self, tokens: Vec<TargetToken>) {
         self.target_tokens = tokens;
     }
 
@@ -450,6 +466,7 @@ impl UnrollOptimizer {
             cpu: crate::cpu::default_cpu(),
             phase2_input_ops_seed: None,
             compile_snapshot_root_slots: None,
+            compile_short_preamble_producer_slot: None,
             persistent_snapshot_root_slots: Vec::new(),
         }
     }
@@ -486,6 +503,39 @@ impl UnrollOptimizer {
 
     fn clear_compile_snapshot_roots(&self) {
         self.replace_compile_snapshot_roots(Vec::new());
+    }
+
+    /// Publish the address of `optimizer.short_preamble_producer` to the
+    /// registered root walker, and withdraw it when the returned guard drops.
+    ///
+    /// The guard is not optional. The published address points into the
+    /// caller's `Optimizer` local, which dies when the unroll call returns;
+    /// `CompileSnapshotRootsGuard` clears the slot only when the enclosing
+    /// compile entry returns, which is later. Between those two points a root
+    /// walk would read the address of a dropped local. Bind the guard after
+    /// the optimizer so it withdraws the address first.
+    #[must_use]
+    fn publish_short_preamble_producer(
+        &self,
+        optimizer: &mut crate::optimizeopt::optimizer::Optimizer,
+    ) -> PublishedShortPreambleProducer {
+        if let Some(addr) = self.compile_short_preamble_producer_slot {
+            // SAFETY: pyjitpl installs this address from
+            // `MetaInterp.compile_short_preamble_producer` for the duration
+            // of one compile. Unroll phases run on the same thread as the
+            // registered root walker.
+            unsafe {
+                *(addr as *mut Option<usize>) = Some(
+                    (&mut optimizer.short_preamble_producer
+                        as *mut Option<
+                            crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder,
+                        >) as usize,
+                );
+            }
+        }
+        PublishedShortPreambleProducer {
+            slot: self.compile_short_preamble_producer_slot,
+        }
     }
 
     /// Optimize the preamble (first iteration) of a loop trace.
@@ -975,6 +1025,9 @@ impl UnrollOptimizer {
             }
             None => crate::optimizeopt::optimizer::Optimizer::default_pipeline(),
         };
+        // Bound after `opt_p2` so it drops first and withdraws the published
+        // address while the optimizer it names is still alive.
+        let _published_short_preamble_producer = self.publish_short_preamble_producer(&mut opt_p2);
         opt_p2.all_descrs = std::mem::take(&mut self.all_descrs);
         opt_p2.callinfocollection = self.callinfocollection.clone();
         opt_p2.cpu = self.cpu.clone();
@@ -1558,13 +1611,14 @@ impl UnrollOptimizer {
             }
         }
         let opt_unroll = OptUnroll::new();
-        let target_token = opt_unroll.finalize_short_preamble(
+        let (target_token, short_preamble_producer) = opt_unroll.finalize_short_preamble(
             self.target_tokens.len() as u64,
             exported_vs,
             initial_sp.clone(),
             imported_short_preamble_builder.as_ref(),
         );
         self.target_tokens.push(target_token);
+        opt_p2.short_preamble_producer = short_preamble_producer;
 
         if crate::majit_log_enabled() {
             eprintln!(
@@ -3296,14 +3350,20 @@ impl OptUnroll {
         virtual_state: crate::optimizeopt::virtualstate::VirtualState,
         short_preamble: crate::optimizeopt::shortpreamble::ShortPreamble,
         short_preamble_builder: Option<&crate::optimizeopt::shortpreamble::ShortPreambleBuilder>,
-    ) -> TargetToken {
+    ) -> (
+        TargetToken,
+        Option<crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder>,
+    ) {
         let mut target_token = TargetToken::new_loop(token_id);
         target_token.virtual_state = Some(virtual_state);
         target_token.short_preamble = Some(short_preamble);
-        target_token.short_preamble_producer = short_preamble_builder.map(|builder| {
-            crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder::new(token_id, builder)
+        let short_preamble_producer = short_preamble_builder.map(|builder| {
+            crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder::new(
+                target_token.as_jump_target_descr(),
+                builder,
+            )
         });
-        target_token
+        (target_token, short_preamble_producer)
     }
 
     /// unroll.py:320-362: _jump_to_existing_trace — check if any existing
@@ -3613,62 +3673,62 @@ impl OptUnroll {
             // unroll.py:353-356: inline short preamble
             let mut extra = Vec::new();
             if let Some(sp) = target_token.short_preamble.clone() {
-                if let Some(mut builder) = target_token.short_preamble_producer.take() {
-                    // unroll.py:376-385 inline_short_preamble sets a builder up
-                    // in place only when `sb.target_token is target_token`.
-                    // pyre needs no such test here: a producer exists only on
-                    // the token this compile minted, because
-                    // `seed_prior_target_tokens` strips the ones an earlier
-                    // compile left behind.
-                    if let Some(label_args) = current_label_args {
-                        // shortpreamble.py:283-296 / 311-341 parity:
-                        // setup() returns false when an op references an
-                        // unresolvable Phase 1 OpRef. Treat this exactly
-                        // like RPython's "produce_arg returned None →
-                        // add_op_to_short returned None" path: drop the
-                        // peeled trace and let the unroll caller raise
-                        // InvalidLoop, falling back to jump_to_preamble.
-                        if !builder.setup(&sp, label_args, ctx) {
-                            target_token.short_preamble_producer = Some(builder);
-                            // Drop the peeled trace and let the caller fall back
-                            // to jump_to_preamble. Recorded as a deferred
-                            // InvalidLoop signal (checked right after this
-                            // returns) so no unwinding is needed.
-                            ctx.signal_invalid_loop("short preamble has unresolvable Phase 1 args");
-                            return None;
-                        }
-                        ctx.activate_short_preamble_producer(builder);
-                        extra = Self::inline_short_preamble(
-                            &short_jump_args,
-                            &target_args,
-                            &sp,
-                            optimizer,
-                            ctx,
-                        );
-                        if let Some(builder) = ctx.take_active_short_preamble_producer() {
-                            // history.py:227/268/314 — `Const{Int,Float,Ptr}.value`
-                            // rides inline on the OpRef. Production no longer
-                            // seeds `ctx.const_pool`
-                            // (`merge_backend_constants_from_ctx` asserts the
-                            // pool is empty at export), so the cross-compile
-                            // `loop_constants` snapshot is no longer built:
-                            // short-preamble ops embed the Const value
-                            // directly in `op.args`, mirroring RPython's
-                            // `shortpreamble.py` which has no parallel side
-                            // table.
-                            target_token.short_preamble =
-                                Some(builder.build_short_preamble_struct());
-                            target_token.short_preamble_producer = Some(builder);
-                        }
-                    } else {
-                        extra = Self::inline_short_preamble(
-                            &short_jump_args,
-                            &target_args,
-                            &sp,
-                            optimizer,
-                            ctx,
-                        );
-                        target_token.short_preamble_producer = Some(builder);
+                let is_mine = optimizer
+                    .short_preamble_producer
+                    .as_ref()
+                    .is_some_and(|sb| {
+                        majit_ir::descr_identity(&sb.target_token)
+                            == majit_ir::descr_identity(&target_token.as_jump_target_descr())
+                    });
+                // `descr_identity` identifies a descriptor allocation, not
+                // Python `is`: same descr allocation means the same clone
+                // family. That is sufficient here because TargetToken clones
+                // share one Arc, `finalize_short_preamble` mints a fresh
+                // LoopTargetDescr Arc per compile, and TargetToken carries no
+                // producer; `unroll.py:376-385` performs the corresponding
+                // identity discrimination.
+                if is_mine && let Some(label_args) = current_label_args {
+                    let mut builder = optimizer
+                        .short_preamble_producer
+                        .take()
+                        .expect("identity gate requires a short-preamble producer");
+                    // shortpreamble.py:283-296 / 311-341 parity:
+                    // setup() returns false when an op references an
+                    // unresolvable Phase 1 OpRef. Treat this exactly
+                    // like RPython's "produce_arg returned None →
+                    // add_op_to_short returned None" path: drop the
+                    // peeled trace and let the unroll caller raise
+                    // InvalidLoop, falling back to jump_to_preamble.
+                    if !builder.setup(&sp, label_args, ctx) {
+                        optimizer.short_preamble_producer = Some(builder);
+                        // Drop the peeled trace and let the caller fall back
+                        // to jump_to_preamble. Recorded as a deferred
+                        // InvalidLoop signal (checked right after this
+                        // returns) so no unwinding is needed.
+                        ctx.signal_invalid_loop("short preamble has unresolvable Phase 1 args");
+                        return None;
+                    }
+                    ctx.activate_short_preamble_producer(builder);
+                    extra = Self::inline_short_preamble(
+                        &short_jump_args,
+                        &target_args,
+                        &sp,
+                        optimizer,
+                        ctx,
+                    );
+                    if let Some(builder) = ctx.take_active_short_preamble_producer() {
+                        // history.py:227/268/314 — `Const{Int,Float,Ptr}.value`
+                        // rides inline on the OpRef. Production no longer
+                        // seeds `ctx.const_pool`
+                        // (`merge_backend_constants_from_ctx` asserts the
+                        // pool is empty at export), so the cross-compile
+                        // `loop_constants` snapshot is no longer built:
+                        // short-preamble ops embed the Const value
+                        // directly in `op.args`, mirroring RPython's
+                        // `shortpreamble.py` which has no parallel side
+                        // table.
+                        target_token.short_preamble = Some(builder.build_short_preamble_struct());
+                        optimizer.short_preamble_producer = Some(builder);
                     }
                 } else {
                     extra = Self::inline_short_preamble(

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -968,13 +968,15 @@ impl UnrollOptimizer {
                     }
                     // `compile.py:245` `jitcell_token.target_tokens = [target_token]`
                     // / `:290` `jitcell_token.target_tokens = [start_descr]` —
-                    // PyPy unconditionally publishes one preamble target token
-                    // for any successful compile path (compile_simple_loop +
-                    // compile_loop both).  Phase 2 is bypassed here (no
-                    // exported_loop_state) but the loop still compiles, so
-                    // mirror the unconditional preamble registration so that
+                    // one preamble target token published unconditionally on
+                    // whichever of the two paths ran. Those are the only two
+                    // assignments of `target_tokens` upstream, and both are
+                    // inside `compile_simple_loop` / `compile_loop`, so this
+                    // says nothing about `compile_retrace`. Phase 2 is bypassed
+                    // here (no exported_loop_state) but the loop still
+                    // compiles, so mirror the registration so that
                     // `JitCellToken.target_tokens` is non-empty at the
-                    // `has_compiled_targets` (`pyjitpl.py:3898`) read site.
+                    // `has_compiled_targets` (`pyjitpl.py:3922-3923`) read site.
                     self.ensure_preamble_target_token();
                     let loop_arity = closing_loop_contract_arity(&ops, p1_ni);
                     self.clear_compile_snapshot_roots();

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7731,6 +7731,26 @@ impl<M: Clone> MetaInterp<M> {
             // `jitdriver.rs:6288` keeps an invalidated loop's target tokens on
             // purpose. Reading both halves off the token is what makes the
             // filter cover the target as well as the gate.
+            //
+            // Resolving to a TargetToken descr here, where `pyjitpl.py:3213-3214`
+            // records the JitCellToken itself, is early binding rather than a
+            // different answer. Upstream's cell-token descr is a placeholder the
+            // optimizer always consumes, in one of two ways: `unroll.py:196-199`
+            // takes `jump_to_preamble` when the target list holds one entry, and
+            // `:238-241` rewrites the descr to `cell_token.target_tokens[0]` —
+            // element zero, unconditionally, exactly what `first_target_token`
+            // answers; otherwise `:320-359` virtual-state matches and rewrites to
+            // the token it picked. Both consumers exist here:
+            // `jump_to_existing_trace_impl` (`unroll.rs`) iterates every
+            // candidate, and its `unroll.py:357-359` arm re-points this JUMP's
+            // descr at whichever token matched. So the ladder is not bypassed by
+            // binding early; only the preamble arm keeps what is recorded here.
+            //
+            // The equivalence needs the list to be unchanged between the two
+            // points, and it is: recording and optimizing are one synchronous
+            // sequence in this function (cut → record → snapshot → optimize) on
+            // the single JIT thread, and `optimize_bridge` mints no target
+            // tokens.
             let jump_descr = self
                 .warm_state
                 .get_procedure_token(green_key)
@@ -7748,6 +7768,25 @@ impl<M: Clone> MetaInterp<M> {
                 crate::mc_diag_bump(29); // compile_trace: no front target token
                 return CompileOutcome::Cancelled;
             };
+            // The descr list on the token and the value list in
+            // `compiled_loops` are two projections of one thing, written by
+            // separate statements, and nothing else checks that they agree.
+            // Upstream cannot drift because `token.target_tokens` holds the
+            // TargetTokens themselves; the split here is forced by the crate
+            // layering (`JitCellToken` lives in majit-backend, which cannot
+            // name a `VirtualState`). This asserts what that layering costs us
+            // the ability to guarantee: the head the optimizer will see is the
+            // head whose value the ladder reads.
+            debug_assert!(
+                self.compiled_loops
+                    .get(&green_key)
+                    .and_then(|compiled| compiled.front_target_tokens.first())
+                    .is_none_or(|front| majit_ir::descr_identity(
+                        &front.as_jump_target_descr()
+                    ) == majit_ir::descr_identity(&jump_descr)),
+                "compile_trace: token target-descr head disagrees with \
+                 front_target_tokens head for key={green_key}"
+            );
             ctx.recorder
                 .close_loop_with_descr(finish_args, Some(jump_descr));
         }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6493,6 +6493,23 @@ impl<M: Clone> MetaInterp<M> {
             .map(|compiled| compiled.front_target_tokens.clone())
             .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
             .unwrap_or_default();
+        // `compile.py:245` / `:290` assign `jitcell_token.target_tokens` a fresh
+        // single-element list, so a token-minting compile carries only its own
+        // labels; only `compile.py:341`'s retrace, which appends to the *same*
+        // token, accumulates labels across compiles. This path mints a new
+        // token, and carrying the prior loop's labels into it is what lets a
+        // close resolve into that loop after it has been invalidated: the
+        // `warmstate.py:191-196` filter guards the token, and the labels arrive
+        // on a fresh one that the filter admits. Apply the same filter here, so
+        // a prior loop lends its labels only while it is still enterable.
+        // Carrying them across a *valid* recompile is the standing adaptation
+        // for a backend that cannot patch a jump in place.
+        let prior_front_target_tokens = if self.warm_state.get_procedure_token(green_key).is_some()
+        {
+            prior_front_target_tokens
+        } else {
+            Vec::new()
+        };
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
         unroll_opt.supports_efficient_uint_mul_high =
             self.backend.supports_efficient_uint_mul_high();

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7781,9 +7781,10 @@ impl<M: Clone> MetaInterp<M> {
                 self.compiled_loops
                     .get(&green_key)
                     .and_then(|compiled| compiled.front_target_tokens.first())
-                    .is_none_or(|front| majit_ir::descr_identity(
-                        &front.as_jump_target_descr()
-                    ) == majit_ir::descr_identity(&jump_descr)),
+                    .is_none_or(
+                        |front| majit_ir::descr_identity(&front.as_jump_target_descr())
+                            == majit_ir::descr_identity(&jump_descr)
+                    ),
                 "compile_trace: token target-descr head disagrees with \
                  front_target_tokens head for key={green_key}"
             );
@@ -11590,12 +11591,13 @@ impl<M: Clone> MetaInterp<M> {
     /// reads `cell.loop_token.as_ref()` directly per F.1 audit
     /// (`tfinal_f0_f1_landed_2026_05_07`).
     ///
-    /// `pyjitpl.py:3922-3923` `has_compiled_targets(token)` parity:
-    /// `bool(token) and bool(token.target_tokens)`.  pyre stores the
-    /// per-target descr identity on `JitCellToken.target_tokens`
-    /// (`backend/src/lib.rs`); each successful `compile_loop` /
-    /// `compile_retrace` populates it through `record_target_token` so
-    /// `has_target_tokens` returns the same signal PyPy reads.
+    /// `pyjitpl.py:3922-3923` `has_compiled_targets(token)` is
+    /// `bool(token) and bool(token.target_tokens)`. pyre answers that
+    /// question from the `compiled_loops` side table instead
+    /// ([`Self::has_compiled_targets`]); the per-target descr identity
+    /// mirrored onto `JitCellToken.target_tokens` (`backend/src/lib.rs`) is
+    /// read only by `first_target_token`, and `has_target_tokens` has no
+    /// callers at all.
     /// Invalidation in PyPy is `quasiimmut.py:99 looptoken.invalidated = True`
     /// — a single boolean flag, not a clear of `target_tokens`. Pyre
     /// routes the `bool(token)` half through `WarmEnterState::

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6482,34 +6482,18 @@ impl<M: Clone> MetaInterp<M> {
 
         // Use UnrollOptimizer for preamble peeling when available.
         // compile.py: compile_loop → PreambleCompileData + LoopCompileData.
-        // NOTE: the `prior_retraced_count == u32::MAX` early Cancelled
-        // path fires above (before ctx take) so we only reach this point
-        // when a recompile is actually attempted. `pending_preamble_tokens`
-        // must be consumed here because the tokens from a previous
-        // InvalidLoop attempt are now being resupplied to the unroller.
-        let prior_front_target_tokens = self
-            .compiled_loops
-            .get(&green_key)
-            .map(|compiled| compiled.front_target_tokens.clone())
-            .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
-            .unwrap_or_default();
-        // `compile.py:245` / `:290` assign `jitcell_token.target_tokens` a fresh
-        // single-element list, so a token-minting compile carries only its own
-        // labels; only `compile.py:341`'s retrace, which appends to the *same*
-        // token, accumulates labels across compiles. This path mints a new
-        // token, and carrying the prior loop's labels into it is what lets a
-        // close resolve into that loop after it has been invalidated: the
-        // `warmstate.py:191-196` filter guards the token, and the labels arrive
-        // on a fresh one that the filter admits. Apply the same filter here, so
-        // a prior loop lends its labels only while it is still enterable.
-        // Carrying them across a *valid* recompile is the standing adaptation
-        // for a backend that cannot patch a jump in place.
-        let prior_front_target_tokens = if self.warm_state.get_procedure_token(green_key).is_some()
-        {
-            prior_front_target_tokens
-        } else {
-            Vec::new()
-        };
+        // `compile.py:245` and `:290` assign `jitcell_token.target_tokens` a
+        // fresh single-element list, so a token-minting compile carries only
+        // its own labels. `ensure_preamble_target_token`
+        // (`optimizeopt/unroll.rs`) inserts that one element, so an empty list
+        // here is `[start_descr]`, not an absent label.
+        //
+        // The drain stays: the `prior_retraced_count == u32::MAX` early
+        // Cancelled path returns above, so reaching this point means a
+        // recompile is under way and the tokens a previous InvalidLoop attempt
+        // parked for this green key are spent either way.
+        self.pending_preamble_tokens.swap_remove(&green_key);
+        let prior_front_target_tokens: Vec<crate::history::TargetToken> = Vec::new();
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
         unroll_opt.supports_efficient_uint_mul_high =
             self.backend.supports_efficient_uint_mul_high();

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -158,7 +158,7 @@ pub struct BridgeRetraceResult {
 }
 
 /// Result of checking a back-edge.
-/// pyjitpl.py:2807 `raise SwitchToBlackhole(Counters.ABORT_TOO_LONG)` —
+/// pyjitpl.py:2831 `raise SwitchToBlackhole(Counters.ABORT_TOO_LONG)` —
 /// reason attached to an abort.  RPython uses `Counters.ABORT_*` ints
 /// (`resoperation.Counters.ABORT_TOO_LONG`, `ABORT_BRIDGE`, ...); pyre
 /// tracks only the variants that propagate through the blackhole flow.
@@ -1520,7 +1520,7 @@ pub struct MetaInterp<M: Clone> {
     pub(crate) string_length_resolver: Option<crate::optimizeopt::info::StringLengthResolver>,
     /// info.py:788-790 `ConstPtrInfo._unpack_str(mode)` runtime hook.
     pub(crate) string_content_resolver: Option<crate::optimizeopt::info::StringContentResolver>,
-    /// history.py:377 `get_const_ptr_for_string(s)` runtime hook.
+    /// history.py:384 `get_const_ptr_for_string(s)` runtime hook.
     pub(crate) string_constant_alloc: Option<crate::optimizeopt::info::StringConstantAllocator>,
     /// pyjitpl.py:2389: partial trace from a failed bridge compilation attempt.
     /// When bridge optimization returns "not final" (retrace needed), the
@@ -5685,7 +5685,7 @@ impl<M: Clone> MetaInterp<M> {
                 green_key
             );
         }
-        // pyjitpl.py:2807 `raise SwitchToBlackhole(ABORT_TOO_LONG)`.
+        // pyjitpl.py:2831 `raise SwitchToBlackhole(ABORT_TOO_LONG)`.
         // Return the reason; caller unwinds with abort_trace_live +
         // aborted_tracing(reason) exactly once.
         Some(AbortReason::TooLong)
@@ -5715,7 +5715,7 @@ impl<M: Clone> MetaInterp<M> {
         if let Some(outer_key) = outermost_merge_key {
             // pyjitpl.py:2819 `JitCell.trace_next_iteration(greenkey)`.
             self.warm_state.trace_next_iteration(outer_key);
-            // pyjitpl.py:2820 `warmstate.mark_force_finish_tracing(greenkey)`.
+            // pyjitpl.py:2844 `warmstate.mark_force_finish_tracing(greenkey)`.
             self.warm_state.mark_force_finish_tracing(outer_key);
             // pyjitpl.py:2822 `warmstate.dont_trace_here(greenkey)`.
             self.warm_state.disable_noninlinable_function(outer_key);
@@ -8930,7 +8930,7 @@ impl<M: Clone> MetaInterp<M> {
                 // `compile_and_attach` just set to the SOURCE loop's token.
                 // `unroll.py:290-297` separately appended the freshly minted
                 // one to `loop_jitcell_token.target_tokens`
-                // (`compile.py:356`'s `get_procedure_token(greenkey)`), which
+                // (`compile.py:355`'s `get_procedure_token(greenkey)`), which
                 // is what `pyjitpl.py:3923 has_compiled_targets` reads.
                 for target_token in &unroll_opt.target_tokens {
                     target_token.set_original_jitcell_token_number(source_jct.number);
@@ -11210,7 +11210,7 @@ impl<M: Clone> MetaInterp<M> {
             let _ = self
                 .backend
                 .redirect_call_assembler(&old_token, &attach_token);
-            // `warmstate.py:347` `old_token.record_jump_to(procedure_token)`.
+            // `warmstate.py:348` `old_token.record_jump_to(procedure_token)`.
             old_token.record_jump_to(attach_token);
         }
     }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8497,7 +8497,14 @@ impl<M: Clone> MetaInterp<M> {
             .set_callinfocollection(self.callinfocollection.clone());
 
         let token_num = self.warm_state.alloc_token_number();
-        // `compile.py:266 jitcell_token = make_jitcell_token(jitdriver_sd)`.
+        // `compile.py:1013` — `ResumeFromInterpDescr.compile_and_attach` does
+        // `new_loop.original_jitcell_token = jitcell_token =
+        // make_jitcell_token(jitdriver_sd)`. `compile.py:392-393` dispatches
+        // `compile_and_attach` on the resumekey's class, and this is the arm
+        // without a guard resumekey, so a fresh token is the identity the
+        // trace is installed under. The token `compile.py:355-356` resolves is
+        // the optimization-time one — it carries the closing JUMP descr and
+        // the retrace budget, not the installation identity.
         let mut token =
             make_jitcell_token(token_num, driver_descriptor.as_ref().and_then(|d| d.index));
         self.configure_loop_token_for_driver(
@@ -8543,28 +8550,17 @@ impl<M: Clone> MetaInterp<M> {
             Ok(_) => {
                 self.last_compiled_artifact_invalidation_flag = Some(token.invalidation_flag());
                 self.assign_guard_hashes(token.as_ref());
-                // `compile.py:237` / `compile.py:289` — every TargetToken
-                // whose LABEL or JUMP appears in `combined_ops` carries
-                // `original_jitcell_token = jitcell_token`.  In the retrace
-                // path, `combined_ops = old_front + new_body`, so the old
-                // front's TargetTokens (created under the previous
-                // jitcell_token) still point at the old number.  RPython
-                // avoids this entirely by reusing the same
-                // `loop_jitcell_token` for retrace (`compile.py:356`); pyre
-                // allocates a new `token_num` for cranelift bridge
-                // migration, so we rebind the prior tokens to the new
-                // number here.  Without this, `record_loop_or_bridge`'s
-                // JUMP arm sees `target_owner_num == old_num !=
-                // new_token.number` and records a false self-loop keepalive.
-                // `compile.py:286-296` / `:312-323` retrace path —
-                // both prior + freshly produced TargetTokens are owned
-                // by the new JCT.  Mirror their descrs onto
-                // `JitCellToken.target_tokens` for `has_compiled_targets`
-                // parity (`pyjitpl.py:3898`).
-                for target_token in &prior_front_target_tokens {
-                    target_token.set_original_jitcell_token_number(token_num);
-                    token.record_target_token(target_token.as_jump_target_descr());
-                }
+                // `compile.py:1014` `propagate_original_jitcell_token(new_loop)`,
+                // whose body at `:463-468` walks the trace's LABELs and sets
+                // each `TargetToken.original_jitcell_token` to the token this
+                // compile installs under. Both `compile_and_attach` arms run
+                // it (`:806` and `:1014`), so re-stamping is upstream's own
+                // step on this path, not a consequence of minting.
+                //
+                // Their descrs are mirrored onto `JitCellToken.target_tokens`
+                // for `has_compiled_targets` (`pyjitpl.py:3922-3923`); see the
+                // note there about upstream leaving the minted token's list
+                // empty on this arm.
                 for target_token in &unroll_opt.target_tokens {
                     target_token.set_original_jitcell_token_number(token_num);
                     token.record_target_token(target_token.as_jump_target_descr());

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7112,9 +7112,11 @@ impl<M: Clone> MetaInterp<M> {
         // exists, so `record_loop_or_bridge`'s JUMP branch
         // (`compile.py:197-199`) can read it.
         //
-        // `compile.py:286-296` `jitcell_token.target_tokens = [start_descr]
-        // + ...` — populate the JCT-side descr list for
-        // `has_compiled_targets` parity (`pyjitpl.py:3898`).
+        // `compile.py:290` `jitcell_token.target_tokens = [start_descr]` —
+        // populate the JCT-side descr list for `has_compiled_targets` parity
+        // (`pyjitpl.py:3922-3923`). The assignment is a single element, not
+        // an append; this loop reaches the same state because the seed on
+        // this path holds only the tokens this compile produced.
         for target_token in &front_target_tokens {
             target_token.set_original_jitcell_token_number(token_num);
             token.record_target_token(target_token.as_jump_target_descr());
@@ -8220,10 +8222,16 @@ impl<M: Clone> MetaInterp<M> {
         // `get_procedure_token(greenkey)` and asserts it, so a retrace runs
         // against a token that already owns the accumulated target tokens and
         // carrying them is that token's own state. The arm below without a
-        // resumekey has no such token: it mints one, and `compile.py:245` /
-        // `:290` give a minted token a fresh single-element list. Drain the
-        // parked tokens on both arms — `swap_remove` is what spends them — and
-        // hand them on only where a token already owns them.
+        // resumekey has no such token: it mints one at `compile.py:1013`, and
+        // `ResumeFromInterpDescr.compile_and_attach` (`:1006-1022`) never
+        // assigns that token's `target_tokens` at all — `target_tokens` has
+        // exactly three writers upstream, the `history.py:440` class default
+        // `None` and the two assignments at `compile.py:245` and `:290`, both
+        // of which are inside `compile_simple_loop` / `compile_loop` and so
+        // are not on this route. The minted token therefore starts owning
+        // nothing. Drain the parked tokens on both arms — `swap_remove` is
+        // what spends them — and hand them on only where a token already owns
+        // them.
         //
         // The binding, not the seed argument, is emptied: on the minting arm
         // it also feeds the ownership rebind and the republication fallback
@@ -9571,7 +9579,7 @@ impl<M: Clone> MetaInterp<M> {
                     // never builds a `TargetToken`/LABEL and never adds to
                     // `jitcell_token.target_tokens`.  So a FINISH-only trace
                     // leaves `front_target_tokens` empty: `has_compiled_targets`
-                    // (`pyjitpl.py:3898` = `bool(token.target_tokens)`) is
+                    // (`pyjitpl.py:3922-3923` = `bool(token.target_tokens)`) is
                     // false, while the trace stays enterable through
                     // `has_compiled_loop`
                     // (`get_procedure_token().has_compiled_code()`, mod.rs:8273
@@ -9818,7 +9826,7 @@ impl<M: Clone> MetaInterp<M> {
         // `compile.py:237 target_token.original_jitcell_token = jitcell_token`.
         target_token.set_original_jitcell_token_number(token_num);
         // `compile.py:245 jitcell_token.target_tokens = [target_token]` —
-        // mirror onto JCT for `has_compiled_targets` (`pyjitpl.py:3898`).
+        // mirror onto JCT for `has_compiled_targets` (`pyjitpl.py:3922-3923`).
         token.record_target_token(target_token.as_jump_target_descr());
         let mut compiled_ops = optimized_ops.clone();
         if let Some(jump_op) = compiled_ops.last().filter(|op| op.opcode == OpCode::Jump) {
@@ -11543,7 +11551,7 @@ impl<M: Clone> MetaInterp<M> {
     /// reads `cell.loop_token.as_ref()` directly per F.1 audit
     /// (`tfinal_f0_f1_landed_2026_05_07`).
     ///
-    /// `pyjitpl.py:3898` `has_compiled_targets(token)` parity:
+    /// `pyjitpl.py:3922-3923` `has_compiled_targets(token)` parity:
     /// `bool(token) and bool(token.target_tokens)`.  pyre stores the
     /// per-target descr identity on `JitCellToken.target_tokens`
     /// (`backend/src/lib.rs`); each successful `compile_loop` /

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -489,8 +489,9 @@ fn collect_snapshot_const_ptr_slots(maps: &mut [&mut SnapshotBoxes]) -> Vec<usiz
     slots
 }
 
-/// RAII guard that empties `MetaInterp.compile_snapshot_refs` when
-/// dropped. Every compile entry point that calls
+/// RAII guard that empties `MetaInterp.compile_snapshot_refs` and unpublishes
+/// `MetaInterp.compile_short_preamble_producer` when dropped. Every compile
+/// entry point that calls
 /// `collect_snapshot_const_ptr_slots` stores raw `*mut OpRef`
 /// pointers into local `SnapshotBoxes` storage; once the enclosing
 /// compile returns, those locals are dropped and the raw pointers
@@ -500,12 +501,14 @@ fn collect_snapshot_const_ptr_slots(maps: &mut [&mut SnapshotBoxes]) -> Vec<usiz
 /// stale pointers.
 pub(crate) struct CompileSnapshotRootsGuard {
     refs: *mut Vec<usize>,
+    short_preamble_producer: *mut Option<usize>,
 }
 
 impl CompileSnapshotRootsGuard {
-    pub(crate) fn new(refs: &mut Vec<usize>) -> Self {
+    pub(crate) fn new(refs: &mut Vec<usize>, short_preamble_producer: &mut Option<usize>) -> Self {
         Self {
             refs: refs as *mut _,
+            short_preamble_producer: short_preamble_producer as *mut _,
         }
     }
 }
@@ -520,6 +523,7 @@ impl Drop for CompileSnapshotRootsGuard {
         // observed the original `&mut` at construction.
         unsafe {
             (*self.refs).clear();
+            *self.short_preamble_producer = None;
         }
     }
 }
@@ -1564,6 +1568,10 @@ pub struct MetaInterp<M: Clone> {
     /// slots directly so a moving GC updates the snapshot boxes the
     /// optimizer will read.
     pub(crate) compile_snapshot_refs: Vec<usize>,
+    /// Address of the in-flight phase-2 optimizer's extended short-preamble
+    /// producer. Installed only while that optimizer is alive so the
+    /// registered root walker can forward its inline ConstPtr fields.
+    pub(crate) compile_short_preamble_producer: Option<usize>,
     /// Set by compile_bridge when optimizer returns retrace_requested=true.
     /// Checked by compile_bridge_trace to return RetraceNeeded.
     pub(crate) retrace_after_bridge: bool,
@@ -2172,9 +2180,19 @@ impl<M: Clone> MetaInterp<M> {
                 if let Some(sp) = tt.short_preamble.as_mut() {
                     sp.walk_const_ptr_refs_mut(&mut visitor);
                 }
-                if let Some(builder) = tt.short_preamble_producer.as_mut() {
-                    builder.walk_const_ptr_refs_mut(&mut visitor);
-                }
+            }
+        }
+        if let Some(slot_addr) = self.compile_short_preamble_producer {
+            // SAFETY: UnrollOptimizer publishes the address of the in-flight
+            // `Optimizer.short_preamble_producer` for one compile, and
+            // `CompileSnapshotRootsGuard` clears it before that optimizer is
+            // dropped. Phases run on the same thread as this root walker.
+            let producer = unsafe {
+                &mut *(slot_addr
+                    as *mut Option<crate::optimizeopt::shortpreamble::ExtendedShortPreambleBuilder>)
+            };
+            if let Some(builder) = producer.as_mut() {
+                builder.walk_const_ptr_refs_mut(&mut visitor);
             }
         }
     }
@@ -3038,6 +3056,7 @@ impl<M: Clone> MetaInterp<M> {
             potential_retrace_position: None,
             last_quasi_immutable_deps: Vec::new(),
             compile_snapshot_refs: Vec::new(),
+            compile_short_preamble_producer: None,
             retrace_after_bridge: false,
             keep_tracing_after_close: false,
             declined_bridge_guards: std::collections::HashSet::new(),
@@ -6048,7 +6067,10 @@ impl<M: Clone> MetaInterp<M> {
     }
 
     fn compile_loop_body(&mut self, jump_args: &[OpRef], meta: M) -> CompileOutcome {
-        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(
+            &mut self.compile_snapshot_refs,
+            &mut self.compile_short_preamble_producer,
+        );
         // Only this call's own give-up decides the reason the caller accounts.
         self.pending_abort_reason = None;
         self.single_pass_compact_label_values = None;
@@ -6499,6 +6521,8 @@ impl<M: Clone> MetaInterp<M> {
             self.backend.supports_efficient_uint_mul_high();
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
+        unroll_opt.compile_short_preamble_producer_slot =
+            Some((&mut self.compile_short_preamble_producer as *mut Option<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
         unroll_opt.retraced_count = prior_retraced_count_early;
@@ -7674,7 +7698,10 @@ impl<M: Clone> MetaInterp<M> {
         finish_descr: Option<majit_ir::DescrRef>,
         entry_bridge: Option<(u64, M)>,
     ) -> CompileOutcome {
-        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(
+            &mut self.compile_snapshot_refs,
+            &mut self.compile_short_preamble_producer,
+        );
         let ends_with_jump = finish_descr.is_none();
         let ctx = match self.tracing.as_mut() {
             Some(ctx) => ctx,
@@ -7995,7 +8022,10 @@ impl<M: Clone> MetaInterp<M> {
     ///
     /// Returns true if compilation succeeded.
     pub fn compile_retrace(&mut self, jump_args: &[OpRef], meta: M) -> bool {
-        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(
+            &mut self.compile_snapshot_refs,
+            &mut self.compile_short_preamble_producer,
+        );
         // compile.py:355-359: resolve `loop_jitcell_token` before recording
         // the closing JUMP.  Keep this lookup before any state is consumed so
         // the rare missing-token path does not drain the active retrace.
@@ -8217,6 +8247,8 @@ impl<M: Clone> MetaInterp<M> {
             self.backend.supports_efficient_uint_mul_high();
         unroll_opt.compile_snapshot_root_slots =
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
+        unroll_opt.compile_short_preamble_producer_slot =
+            Some((&mut self.compile_short_preamble_producer as *mut Option<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
         // `AbstractResumeGuardDescr.compile_and_attach`, `compile.py:797-811`,
@@ -9143,7 +9175,10 @@ impl<M: Clone> MetaInterp<M> {
         meta: M,
         exit_with_exception: bool,
     ) -> Result<(), SwitchToBlackhole> {
-        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(
+            &mut self.compile_snapshot_refs,
+            &mut self.compile_short_preamble_producer,
+        );
         // Cache vable_config before take() clears self.tracing.
         let vable_config = self.current_virtualizable_optimizer_config();
         // Cache driver descriptor before ctx is partially consumed below.
@@ -9621,7 +9656,10 @@ impl<M: Clone> MetaInterp<M> {
     /// Returns the green_key on success (caller must call
     /// attach_procedure_to_interp), None on failure.
     pub fn compile_simple_loop(&mut self, meta: M) -> Option<u64> {
-        let _snapshot_guard = CompileSnapshotRootsGuard::new(&mut self.compile_snapshot_refs);
+        let _snapshot_guard = CompileSnapshotRootsGuard::new(
+            &mut self.compile_snapshot_refs,
+            &mut self.compile_short_preamble_producer,
+        );
         let vable_config = self.current_virtualizable_optimizer_config();
         self.force_finish_trace = false;
         let mut ctx = self.tracing.take()?;

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -8185,12 +8185,33 @@ impl<M: Clone> MetaInterp<M> {
         }
 
         // compile.py:362-367: optimize using UnrolledLoopData with start_state.
-        let prior_front_target_tokens = self
-            .compiled_loops
-            .get(&green_key)
-            .map(|compiled| compiled.front_target_tokens.clone())
-            .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
-            .unwrap_or_default();
+        //
+        // `compile.py:355-356` resolves the retrace's token with
+        // `get_procedure_token(greenkey)` and asserts it, so a retrace runs
+        // against a token that already owns the accumulated target tokens and
+        // carrying them is that token's own state. The arm below without a
+        // resumekey has no such token: it mints one, and `compile.py:245` /
+        // `:290` give a minted token a fresh single-element list. Drain the
+        // parked tokens on both arms — `swap_remove` is what spends them — and
+        // hand them on only where a token already owns them.
+        //
+        // The binding, not the seed argument, is emptied: on the minting arm
+        // it also feeds the ownership rebind and the republication fallback
+        // further down, and that fallback fires precisely when the optimizer
+        // produced no tokens of its own.
+        let prior_front_target_tokens = {
+            let prior_front_target_tokens = self
+                .compiled_loops
+                .get(&green_key)
+                .map(|compiled| compiled.front_target_tokens.clone())
+                .or_else(|| self.pending_preamble_tokens.swap_remove(&green_key))
+                .unwrap_or_default();
+            if retrace_resumekey.is_some() {
+                prior_front_target_tokens
+            } else {
+                Vec::new()
+            }
+        };
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
         unroll_opt.supports_efficient_uint_mul_high =
             self.backend.supports_efficient_uint_mul_high();
@@ -8198,13 +8219,12 @@ impl<M: Clone> MetaInterp<M> {
             Some((&mut self.compile_snapshot_refs as *mut Vec<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
-        // `compile.py:797-811` — a retrace grown from a guard failure is
-        // installed under the source guard's own loop token, so a close onto
-        // one of that token's target tokens stays inside a single live code
-        // buffer and may be admitted. Without a resumekey the retrace mints a
-        // fresh JitCellToken below and re-stamps the prior tokens onto it, so
-        // every seeded candidate is foreign at the moment the close is chosen
-        // and none may be admitted.
+        // `AbstractResumeGuardDescr.compile_and_attach`, `compile.py:797-811`,
+        // installs a retrace grown from a guard failure under
+        // `resumekey_original_loop_token`, so a close onto one of that token's
+        // target tokens stays inside a single live code buffer and may be
+        // admitted. The arm without a resumekey seeds nothing, so it has no
+        // candidate to admit.
         unroll_opt.attach_jitcell_token_number = retrace_resumekey
             .as_ref()
             .and_then(|bridge| bridge.source_descr.as_fail_descr())

--- a/majit/majit-translate/src/codewriter/insns.rs
+++ b/majit/majit-translate/src/codewriter/insns.rs
@@ -34,7 +34,7 @@ use indexmap::IndexMap;
 // 1:1 invariant that `pyjitpl.py:2230 setup_insns` enforces.
 pub const BC_CAST_FLOAT_TO_INT: u8 = 0;
 pub const BC_ARRAYLEN_GC: u8 = 1;
-/// RPython `blackhole.py:531-533` `bhimpl_int_is_true(a) -> !!a` — the
+/// RPython `blackhole.py:556-558` `bhimpl_int_is_true(a) -> !!a` — the
 /// boolean-coercion of an int, produced by a `Bool` exitswitch source
 /// that is read before the branch rather than fused into
 /// `goto_if_not_int_is_true`. Takes slot 2 (was free; `BC_ARRAYLEN_VABLE`

--- a/pyre/bench/synth/attr_cache_invalidation.cranelift.jitstats
+++ b/pyre/bench/synth/attr_cache_invalidation.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1002
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/attr_cache_invalidation.dynasm.jitstats
+++ b/pyre/bench/synth/attr_cache_invalidation.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1002
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/attr_cache_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/attr_cache_invalidation.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1002
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/global_quasiimmut_invalidation.cranelift.jitstats
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1003
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/global_quasiimmut_invalidation.dynasm.jitstats
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1003
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/global_quasiimmut_invalidation.py
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.py
@@ -1,7 +1,10 @@
 # pyre-check: max-pypy-ratio=26
 # pyre-check: skip-cpython
-# pyre-check: max-wasm-ratio=6
-# Reported 5.2x and 5.1x on ubuntu-24.04.
+# The wasm allowance this carried (`max-wasm-ratio=6`, for the 5.2x and 5.1x
+# reported on ubuntu-24.04) is gone because the ratio came down, not because
+# the ceiling went up: the steady state no longer re-enters the invalidated
+# loop, halving the executed wasm ops, and the ratio reads 2.9x here against
+# 7.8x before.
 # The pypy ceiling is twice the slowest ratio observed, 12.6x on the macos
 # runner; the gate it replaces sat inside the run-to-run spread.
 # cpython 0.21s vs pyre 0.07s (3.0x), and it is not gated on — only pypy is.

--- a/pyre/bench/synth/global_quasiimmut_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=5
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1003
+guard_failures=602
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=2
+retraces_compiled=0

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -6158,7 +6158,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
         original_call_descr.arg_types(),
     );
 
-    // pyjitpl.py:1105-1120 `opimpl_jit_force_quasi_immutable` must run before
+    // pyjitpl.py:1094-1118 `opimpl_jit_force_quasi_immutable` must run before
     // any fold or residual applies the opcode. In particular,
     // `try_walker_specialize_store_attr` mutates `?` fields while resolving,
     // so moving this below the STORE_ATTR fold would hide the force. The abort

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -1664,7 +1664,7 @@ fn pyre_p_payload_len(opname: &str, code: &[u8], cursor: usize) -> Option<usize>
 /// ```
 ///
 /// `live/` is special-cased to advance by `liveness::OFFSET_SIZE` per
-/// `blackhole.py:1603-1605` (`bhimpl_live(pc): return pc + OFFSET_SIZE`).
+/// `blackhole.py:1605-1607` (`bhimpl_live(pc): return pc + OFFSET_SIZE`).
 pub fn decode_op_at(code: &[u8], pc: usize) -> Option<DecodedOp> {
     let opcode_byte = *code.get(pc)?;
     let key: &'static str = INSNS_BYTE_TO_OPNAME.get(&opcode_byte)?.as_str();
@@ -3092,7 +3092,7 @@ mod tests {
         //   PC=3:  float_add r0, r1 → r2
         //   PC=7:  void_return
         //
-        // RPython parity: blackhole.py:574-577 `bhimpl_float_add` +
+        // RPython parity: blackhole.py:696-700 `bhimpl_float_add` +
         // :859-862 `bhimpl_void_return`. Pyre's `registers_f` stores
         // `f64::to_bits() as i64`; the `bhhandler_ff_f!` macro decodes
         // via `f64::from_bits` on read and `to_bits()` on write, so

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5668,7 +5668,7 @@ pub(crate) fn can_flush_walk_end_state_after_outer_call(
     // statement, and a nested CALL therefore legitimately carries that NULL
     // through this post-CALL handoff.  The carrier has already proved every
     // slot before it becomes a raw `PyObjectRef`: NULL is admitted only from
-    // an inline `ConstPtr(NULL)` (RPython history.py:361 `CONST_NULL`) or the
+    // an inline `ConstPtr(NULL)` (RPython history.py:368 `CONST_NULL`) or the
     // CALL layout's named null-or-self slot.  Rejecting it here collapses that
     // distinction again and forces the effectful callee prologue to replay.
     let base = info.num_static_extra_boxes;


### PR DESCRIPTION
A token-minting compile inherited the previous compile's target tokens. Ten commits: the
measured fix, the deviation that made it possible, and the citations that hid it.

Rebased onto `origin/main` (`81e8a2d`); `git range-diff` reports the nine pre-rebase commits
unchanged.

| commit | change |
|---|---|
| `9fb952f` | drop an invalidated loop's targets at the mint seed |
| `30cd766` | remove `global_quasiimmut_invalidation`'s `max-wasm-ratio` allowance |
| `20ffefb` | seed a token-minting compile with **no** prior target tokens |
| `1b303ab` | same for the retrace's minting arm |
| `634da99` | keep the short-preamble producer on the optimizer, not the target token |
| `de4f9b2` | correct the retrace mint citation, drop a loop the commit above made dead |
| `4e96b65` | reroute four `target_tokens` citations off `compile_loop`, correct two claims |
| `c2f90ea` | cite the close-descr equivalence, assert the descr list and value list agree |
| `f926f64` | fix seven stale `JitCellToken` citations and one invented reader |
| `857c0bc` | fix 37 further stale upstream citations found by a tree-wide audit |

## The defect

`compile.py:245` and `:290` assign `jitcell_token.target_tokens` a **fresh single-element
list**, so a token-minting compile carries only its own labels. Only `compile.py:341`'s
`compile_retrace`, which appends to the *same* token, accumulates. That is why
`warmstate.py:191-196`'s invalidation filter covers the whole list: the list lives on the object
that was invalidated.

`compile_trace_inner` seeded the prior entry's `front_target_tokens` into the unroll optimizer
unconditionally. Instrumenting each compile's token list:

```
compile_loop (62 ops)  token=1  fronts=[837680, 837552]
compile_loop (32 ops)  token=3  fronts=[837680, 837552, 837664]
```

Token 3 is the loop compiled after the store invalidates the first one, and it carries the dead
loop's two labels ahead of its own.

The damage is **not** at the mint's own close — that is already refused by the ownership gate in
`jump_to_existing_trace_impl`, whose `attach_jitcell_token_number` is `None` at every mint. The
seeded tokens are **republished** as the new loop's `front_target_tokens`, and *later bridge
compiles*, handed that list by `&mut`, match them and close into the prior loop's body. The
backend registry confirms the executed edge: all three post-store bridges bake the invalidated
module's slot, which then collects ~30.5M entries against a few hundred into the replacement.

## The measured fix (`9fb952f`)

Apply the `warmstate.py:191-196` filter at the seed.

| measurement (`synth/global_quasiimmut_invalidation`) | before | after |
|---|---:|---:|
| executed wasm ops | 5,573,264,522 | **2,705,913,209** (−51.4%) |
| entry census, invalidated module key 2 (N=30000) | 76,845 | **3,880** |
| `guard_failures` | 1003 | **602** |
| `bridges_compiled` | 5 | 3 |

`synth/attr_cache_invalidation` — the type `version_tag` half of the same mechanism — moves by
the same deltas (1002 → 602, 5 → 3). Two fixtures moving together is what makes this the
mechanism rather than a fixture special case.

The target is independently confirmed by a second instrument on a tree that has `main` + #1284
and **not** this PR. `PYRE_WASM_TRACE_ENTRY_CENSUS=1` over the fixture, counting module entries
rather than ops:

```
trace_id=1 key=2   30,566,421     <- the invalidated loop
trace_id=4 key=0          602     <- its replacement
total              71,321,693     = 7.00 entries per outer iteration
```

So the entries this PR removes are 43% of the fixture's total, measured without reference to the
op accounting that found them.

### On the ratio, stated carefully

`30cd766` removes `max-wasm-ratio=6` **because the ratio came down, not because the ceiling went
up** — it was the last such annotation in the tree. But the supporting ratio figure is
**local aarch64 darwin and indicative only**: this repo's own history says a local arm64 run
cannot grade the wasm ratio gate, and execution-only numbers from CI put the fixture at 5.23x on
`main`, not at the 7.8x a local run reads. **CI on this PR is what decides whether removing the
annotation is justified.** If it says otherwise, the annotation comes back — the ceiling does
not go up.

**CI has now answered, and it answers in favour of removal.** In `pyre/check.py
(ubuntu-24.04)`:

| | `main` @ `0d98226` | this PR |
|---|---|---|
| allowance line in the log | `wasm/dynasm ratio raised above 4x by \`# pyre-check: max-wasm-ratio\` for: synth/global_quasiimmut_invalidation 6x` | **absent** |
| wasm ratio FAILs | — | **none** |
| `global_quasiimmut_invalidation` wasm / dynasm | 0.60s / 0.18s = **3.3x** | 0.28s / 0.20s = **1.4x** |

On `main` the annotation was actively suppressing a reading above the 4x default; on this PR the
fixture needs no allowance and nothing complains, which is the shape "the ratio came down" was
supposed to produce. The 3.3x→1.4x pair is cross-run, so read it as consistent with the
annotation's removal rather than as a measured speedup.

**The one red on this PR is pre-existing on `main`.** `FAIL cranelift raise_catch exec 0.50s >
pypy 0.18s ratio 2.9x > gate 2.5x`, then `cranelift 1 failed, 437 passed`. `main` at `0d98226`
fails the identical fixture, gate and backend at **3.3x**, and `main`'s last four completed runs
all failed. macOS in the same PR run passed **438/438** with `raise_catch` at 2.1x. It is a
`main`-wide gate miss, not this PR's to close here. Two other jobs (`sandbox build + e2e`,
`pyre/check.py (windows-latest)`) died in **"Set up job"** on `429 Too Many Requests` / `503`
fetching `Swatinem/rust-cache` — GitHub infrastructure, before any of this diff ran.

Two further cautions against over-reading the numbers above:

- **Entries removed is not a proxy for ratio removed.** Across fixtures the two anti-correlate:
  `int_loop` has ~1 entry total and the best ratio in the set (0.81x), while
  `if_else_jump_forward` has ~87M entries/dynasm-second at 1.82x. This fixture is a ~536M
  outlier, which is what makes it the right thing to attack — it is not a conversion rate.
  −51.4% ops and −43% entries should not be read as the ratio falling by either figure.
- **There is currently no clean control.** The newest completed `main` run predates #1284, and
  PR CI tests the merge ref, so a PR arm carries main commits the baseline arm lacks. Until a
  post-#1284 `main` run completes, a CI delta on this PR is not cleanly attributable.

## The deviation behind it (`20ffefb`, `1b303ab`, `634da99`)

The filter removes only the *invalidated* subset; a live foreign token was still inherited,
which upstream never does. The seeding itself has **no upstream counterpart**. These three
commits close that, and they are parity-only — **no `.jitstats` counter moves on any backend**.

- **`20ffefb`** — the mint inherits nothing. The binding, not the seed argument, is emptied,
  because the same list also feeds the republication fallback. `ensure_preamble_target_token`
  inserts the preamble token into an empty list, as
  `test_ensure_preamble_target_token_inserts_start_descr_first` already pins, so the seeded list
  is `[start_descr]` rather than an absent label.
- **`1b303ab`** — `compile_retrace` has two arms. `compile.py:355-356` resolves the token with
  `get_procedure_token(greenkey)` and asserts it, so the arm that reuses a token keeps the
  accumulated targets — that is orthodox. The arm without a resumekey mints a fresh token at
  `compile.py:1013`, and `ResumeFromInterpDescr.compile_and_attach` assigns that token's
  `target_tokens` nothing at all, so it starts owning nothing. (The commit message said it gets
  the `:245`/`:290` treatment; those are in `compile_simple_loop` / `compile_loop` and not on
  this route — corrected in `4e96b65`, and the correction strengthens the change rather than
  weakening it.) On that arm the same list also feeds the loop that rebinds each prior token's
  `original_jitcell_token_number` to the new number, which is what could make a retired token
  pass the ownership gate.
- **`634da99`** — `history.py:499-503` gives `TargetToken` no producer field; upstream keeps it
  on the optimizer and the reference runs builder→token (`shortpreamble.py:454-457`), with
  `inline_short_preamble` discriminating by `sb.target_token is target_token`
  (`unroll.py:376-385`). pyre parked it on the token, and `seed_prior_target_tokens` stripped it
  off every seeded token for exactly the hazard this PR is about. Moving it to the phase-2
  `Optimizer` retires the strip — but the *discrimination* it provided is not free, since
  `jump_to_existing_trace_impl` walks every candidate, so the identity test replaces it in the
  same commit.

## Two things stated precisely, because they are easy to overstate

**The identity test is not `is`.** `descr_identity` compares descriptor allocations, and
`TargetToken` clones share one `Arc`, so it answers equal across a clone family where
`unroll.py:379` answers False for a distinct object. It is sufficient because
`finalize_short_preamble` mints a fresh `LoopTargetDescr` per compile and no token carries a
producer any more. The comment in the tree says that rather than calling it a spelling of `is`.

**The producer's GC walk moved; it was not dropped.** `walk_rd_consts_refs` reached the producer
through `compiled_loops`, which holds only post-compile copies — but `shortpreamble.rs` records
that a replay op is rooted by `short_preamble_jump`, whose only walk is that arm. The in-flight
optimizer's slot address is published for the duration of a compile, following
`compile_snapshot_root_slots`. That address names a **local of the unroll call**, which returns
before the compile entry does, so it is withdrawn by its own guard bound after that local — not
by `CompileSnapshotRootsGuard`, which drops later and would leave a root walk reading a dropped
local.

## Corrections to comments this touched

- `seed_prior_target_tokens` said `unroll.py:298` was the only setter of
  `short_preamble_producer`. `unroll.py:507` in `import_state` is a second one.
- The comment above `attach_jitcell_token_number` cited `compile.py:797-811` as `compile_retrace`;
  that range is `AbstractResumeGuardDescr.compile_and_attach`.
- **The retrace mint is orthodox, and the comment that said otherwise is now gone** (`de4f9b2`).
  It cited `compile.py:266` — which is in `compile_loop` — and claimed *"RPython avoids this
  entirely by reusing the same `loop_jitcell_token`"*. `compile.py:392-393` dispatches
  `compile_and_attach` on the resumekey's **class**, and the two implementations map onto pyre's
  two arms exactly: `AbstractResumeGuardDescr` (`:797-811`) attaches under
  `resumekey_original_loop_token` without minting; `ResumeFromInterpDescr` (`:1006-1022`)
  **mints** at `:1013`. The token `compile.py:355-356` resolves is the optimization-time one —
  it carries the closing JUMP descr and the retrace budget, not the installation identity.
  `propagate_original_jitcell_token` then runs on **both** arms (`:806`, `:1014`), so the
  re-stamping loop was never a consequence of pyre minting. That also makes the loop over
  `prior_front_target_tokens` provably dead once `1b303ab` binds it to `Vec::new()`, so it is
  deleted rather than rewritten. Nothing else in this PR rested on the false version.
- **`compile.py:245` / `:290` are not on the retrace route** (`4e96b65`). They are the only two
  assignments of `target_tokens` upstream — the third writer is the `history.py:440` class
  default `None` — but `:245` is inside `compile_simple_loop` (`:216-250`) and `:290` inside
  `compile_loop` (`:251-340`), while `compile_retrace` starts at `:341`. Four sites cited them,
  or ranges containing them, to describe the retrace path, including the comment `1b303ab` itself
  added. **The conclusion is strengthened, not weakened**: upstream's minted token on that arm
  does not get `[start_descr]`, it gets nothing, so "seed nothing" was under-argued. The citation
  was still wrong and is fixed. Two sites citing the same lines *on their own routes*
  (`pyjitpl.rs:6507` in `compile_loop_body`, `:9827` in `compile_simple_loop`) are correct and
  left alone.
- **Two claims were wrong on the pyre side, not the upstream side** (`4e96b65`).
  `JitCellToken::target_tokens`' doc said the list is populated so `has_compiled_loop` reads what
  upstream's `has_compiled_targets` reads. `has_compiled_loop` is
  `entry_procedure_token(gk).is_some()`, and pyre's `has_compiled_targets` reads
  `compiled_loops[gk].front_target_tokens` — neither touches this list. Its one reader is
  `first_target_token`. That function's doc in turn implied `pyjitpl.py:3007` closes onto the head
  descr, where upstream passes the JitCellToken and `unroll.py:320-340` selects among
  `target_tokens` by virtual-state match. Re-reading the cited upstream line catches neither,
  because the false half is on the pyre side.
- `has_compiled_targets` was cited as `pyjitpl.py:3898` at seven sites; it is at `:3922-3923`
  (`:3898` is `handler.__name__ = 'handler_' + name`).

### The audit those corrections prompted (`857c0bc`)

Both clusters above were found by stumbling over them, which is a bad way to learn that a
citation is wrong. A citation that **quotes the upstream statement** is machine-checkable, so
the tree was audited on that basis: 9373 citations → 2209 carrying a quote → 827 gradeable
(the quote anchored on a code identifier, not prose) → 760 correct, 67 candidates. Each of the
67 was judged individually against the vendored source; 30 turned out correct (usually a quote
naming a class or function while the cite points inside its body), 36 were stale, and 1 named
the wrong **file** (`optimizer.py:317` for what is `unroll.py:317`). All 37 are fixed here —
21 files, 37 insertions and 37 deletions, comments only.

By upstream file: `history.py` 14, `blackhole.py` 9, `pyjitpl.py` 6, `compile.py` 2,
`rewrite.py` 2, `unroll.py` 2, `warmstate.py` 1, plus the filename fix.

**No mechanical pass is safe on this**, which is why each site was verified. Much of the rot in
`pyjitpl.py` is a uniform `+24` shift, but the stale and the correct **interleave**:
`dont_trace_here` is cited as `:2822` (stale) at one site and `:2846` (correct) at another, in
the same tree — the citations were written at different times against different vendored
revisions, so a `sed` over any line band would corrupt the correct ones. The quote is what
discriminates, which is also an argument for quoting the statement whenever citing upstream.

This is comment-only and unrelated to the target-token subject; it is folded in rather than
split out because the audit was a direct consequence of the two clusters above.

## Refuted along the way, recorded so they are not re-proposed

- **The close gate and the JUMP descr read two sources.** Landed in #1274; the entry census came
  back byte-identical.
- **The `prior_front_target_tokens` fallback in the InvalidLoop path.** An `eprintln` in both
  arms never fired.
- **"There is no zombie."** Read off an undecomposed counter that is a sum over modules.
  Retracted.
- **"The mint's own close resolves into the invalidated loop."** The ownership gate already
  refuses it; the channel is republication into later bridge compiles.

## Still open, deliberately not touched here

**`compile_entry_bridge`'s inheritance — measured, and not this mechanism.** It clones the
retired loop's `front_target_tokens` on the replace path. Rather than argue about it, a
`PYRE_PROBE_EB` counter at the site was run on both invalidation fixtures under dynasm release:
**zero hits on both**, with stdout still correct. So it is not implicated in what the −51.4%
addressed. Zero hits on two fixtures is not "dead in general", only "not this mechanism", and
`CarriedFields`' doc already names it as the one of five replace paths that legitimately
inherits.

**Where pyre still records what upstream leaves empty.** On the minting arm, pyre mirrors the
fresh target tokens onto `JitCellToken.target_tokens`; upstream's `ResumeFromInterpDescr` arm
never assigns that list, and `history.py:440` leaves it `None`, so
`has_compiled_targets(ptoken)` is False for the token `attach_procedure_to_interp` installs.
This is **not** the "trace owns no LABEL" case it resembles — `compile.py:382` puts `[label_op]`
in the retrace's operations, so upstream has a LABEL there and propagates through it; it simply
does not mirror. Closing the gap is not a deletion, because the two trees read the list through
different objects: upstream's JUMP carries the `JitCellToken` and `unroll.py:320-325` walks
`target_tokens` at optimization time, whereas pyre resolves `first_target_token()` at record
time (`compile_trace`) and cancels the bridge when it is absent. Dropping the record here would
change which compiles happen, so it is a separate, measured change — not a comment fix, and out
of scope for this PR.

**That question is now settled, against moving.** Upstream's cell-token descr is a placeholder the
optimizer always consumes, in one of two ways: `unroll.py:196-199` takes `jump_to_preamble` when
the list holds one entry, and `:238-241` rewrites the descr to `cell_token.target_tokens[0]` —
element zero, unconditionally, which is exactly what `first_target_token` answers; otherwise
`:320-359` virtual-state matches and rewrites to the token it picked. **Both consumers exist
here.** `jump_to_existing_trace_impl` iterates every candidate and its `unroll.py:357-359` arm
re-points the JUMP's descr at whichever token matched, so binding early does not bypass the
ladder — only the preamble arm keeps what was recorded. The equivalence holds because recording
and optimizing are one synchronous sequence on the single JIT thread and `optimize_bridge` mints
no targets.

Adopting the literal upstream shape would not pay: it works upstream because
`token.target_tokens` holds the full TargetTokens the ladder consumes, and here it cannot —
`JitCellToken` lives in majit-backend while `TargetToken`-with-`VirtualState` lives in
majit-metainterp, which depends on it, the reverse of `history.py` owning both. The token can
only carry the descr projection, so a JitCellToken-descr'd JUMP would be traded back for the same
side-table list the optimizer already receives as a parameter. That is the RPython↔Rust layering
gap, and it is now cited at the site rather than left implicit.

What the exercise did surface is a real gap, and this PR closes it: **nothing enforced that the
descr list on the token and the value list in `compiled_loops` agree.** They are two projections
of one thing written by separate statements, and upstream cannot drift because it holds one list
of real TargetTokens. A `debug_assert` now checks that the resolved head equals
`front_target_tokens[0]` under `descr_identity`. `cargo test` is a debug build, so the workspace
suite exercises it.

Nothing above should be read as closing the rest: the −51.4% is a measured win on the mint
channel, not proof the others are absent.

## Verification

Re-run on the tip after each commit, and once more on the rebased tip `857c0bc`:

- `cargo fmt --check` — clean
- `cargo test --workspace` — green, 8073 tests
- `python3 pyre/check.py --backend wasm --synthetic-only` — **417/417**
- `python3 pyre/check.py --backend dynasm --synthetic-only` — **421/421**
- `cargo test -p pyre-jit --features dynasm --test gc_stress` — **34/34** (not re-run on
  `857c0bc`, which is comment-only)
- `scripts/extract-llbc.py` — clean, so `pyre-jit.ullbc` is not stale
- no `.jitstats` baseline re-recorded for any of the parity commits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved JIT short-preamble handling during loop compilation and replay.
  * Reduced unnecessary guard failures and bridge compilations in affected benchmarks.

* **Bug Fixes**
  * Improved handling of invalidated loops and retracing.
  * Preserved compiled loop state more reliably during compilation and recovery.

* **Documentation**
  * Corrected numerous internal documentation references and explanatory comments.
  * Updated benchmark notes to reflect revised WebAssembly performance results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->