### PR TITLE
jit: stop a released deadframe from tracing through its old gcmap

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6156,11 +6156,16 @@ fn bind_published_dense_refs(
     info: &GuardInfo,
     constants: &IndexMap<u32, i64>,
 ) {
-    for &slot in &info.failarg_ref_slots {
-        let Some(&arg_ref) = info.fail_arg_refs.get(slot) else {
-            continue;
-        };
-        if arg_ref.is_none() || arg_ref.is_constant() || constants.contains_key(&arg_ref.raw()) {
+    for (slot, &arg_ref) in info.fail_arg_refs.iter().enumerate() {
+        // regalloc.py:164-176 `FrameManager.bind`: publishing a new box into a
+        // frame location replaces the location's previous occupant.  The raw
+        // dense store does the same even when the new value is Int or Float,
+        // so an earlier Ref binding must not survive that store.
+        if !info.failarg_ref_slots.contains(&slot)
+            || arg_ref.is_none()
+            || arg_ref.is_constant()
+            || constants.contains_key(&arg_ref.raw())
+        {
             dense_ref_bindings.swap_remove(&slot);
             continue;
         }

--- a/majit/majit-backend/src/deadframe.rs
+++ b/majit/majit-backend/src/deadframe.rs
@@ -166,3 +166,23 @@ impl JitFrameDeadFrame {
         GcRef(unsafe { *((self.jf_gcref().0 + JF_GUARD_EXC_OFS as usize) as *const usize) })
     }
 }
+
+impl Drop for JitFrameDeadFrame {
+    /// Release the frame's `jf_gcmap` before the root slot goes.
+    ///
+    /// Releasing the root does not take the frame out of the collector's
+    /// remembered set, so the frame stays reachable there after this owner is
+    /// gone — and `jitframe_trace` (`jitframe.py:115-135`) would keep walking
+    /// the exiting guard's map over `jf_frame` items nothing owns any more.
+    /// A null `jf_gcmap` traces no items (`jitframe.py:115-116`) while the
+    /// fixed header GCREFs stay traceable, which is what the frame needs once
+    /// its values have been read out (`llmodel.py:437-451`).
+    ///
+    /// Only the rooted arm: an `Unrooted` frame is not a GC object, so nothing
+    /// traces it at all.
+    fn drop(&mut self) {
+        if let JitFrameRoot::Slot(guard) = &self.jf_root {
+            unsafe { (*(guard.get().0 as *mut JitFrame)).jf_gcmap = std::ptr::null() };
+        }
+    }
+}

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3342,12 +3342,27 @@ impl MiniMarkGC {
                     *word = unsafe { *((holder_addr as *const usize).add(index)) };
                 }
             }
+            let mut child_words = [0usize; 8];
+            for (index, word) in child_words.iter_mut().enumerate() {
+                *word = unsafe { *((obj_addr as *const usize).add(index)) };
+            }
+            let holder_hdr_tid_and_flags = if holder_addr == 0 {
+                0
+            } else {
+                unsafe { (*header_of(holder_addr)).tid_and_flags }
+            };
             panic!(
                 "GC BUG: invalid type_id={} at obj_addr={:#x} \
                  (header_addr={:#x}, nursery_start={:#x}, site={}, \
                  parent_site={}, \
                  nursery_free={:#x}, nursery_top={:#x}, holder_addr={:#x}, \
-                 holder_type_id={:?}, holder_offset={:?}, holder_words={:#x?})",
+                 holder_type_id={:?}, holder_offset={:?}, holder_words={:#x?}, \
+                 child_tid_and_flags={:#x}, child_flag_complement={:#x}, \
+                 child_words={:#x?}, child_vtable_type_id={:?}, \
+                 nearest_header={}, \
+                 child_nursery_offset={:#x}, child_gen={}, holder_gen={}, \
+                 holder_tid_and_flags={:#x}, holder_in_remembered={}, \
+                 enclosing={}, gc_state={:?}, minors={}, majors={})",
                 type_id,
                 obj_addr,
                 obj_addr - GcHeader::SIZE,
@@ -3360,6 +3375,22 @@ impl MiniMarkGC {
                 holder_type_id,
                 slot_addr.checked_sub(holder_addr),
                 holder_words,
+                unsafe { (*hdr_ptr).tid_and_flags },
+                // FORWARDED_MARKER sets every flag bit, so a corpse whose
+                // 64-bit equality no longer holds names the cleared bit here.
+                (!unsafe { (*hdr_ptr).flags() }) as u32,
+                child_words,
+                self.vtable_to_type_id.get(&child_words[0]).copied(),
+                self.describe_nearest_header(obj_addr),
+                obj_addr.wrapping_sub(self.nursery.start_ptr() as usize),
+                self.describe_generation(obj_addr),
+                self.describe_generation(holder_addr),
+                holder_hdr_tid_and_flags,
+                self.remembered_set.contains(&holder_addr),
+                self.describe_enclosing_container(holder_addr, slot_addr, &holder_words),
+                self.gc_state,
+                self.minor_collections,
+                self.major_collections,
             );
         }
         // Compute the actual payload size (for varsize objects, read the length).
@@ -3531,6 +3562,15 @@ impl MiniMarkGC {
 
         // custom_trace_hook parity: use custom trace function if registered.
         if let Some(trace_fn) = custom_trace {
+            // A custom trace names its own slots — for a JITFRAME, `jf_gcmap`
+            // decides them, not the type table. When one of those slots does
+            // not decode as an object, the discriminating question is whether
+            // the *rest* of the same trace is sound: one bad slot among sound
+            // ones is a bad published value, while a trace whose slots are
+            // mostly unsound is a map that no longer describes the object.
+            // Defer the first undecodable slot so the whole walk completes and
+            // the panic can report both.
+            let mut deferred: Option<(usize, usize)> = None;
             unsafe {
                 trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
                     let field_ref = *slot_ptr;
@@ -3542,6 +3582,10 @@ impl MiniMarkGC {
                         site,
                     );
                     if self.is_nursery_object_start(field_ref.0) {
+                        if deferred.is_none() && !self.nursery_start_decodes(field_ref.0) {
+                            deferred = Some((slot_ptr as usize, field_ref.0));
+                            return;
+                        }
                         let new_ref = self.copy_nursery_object(
                             field_ref.0,
                             "minor_custom_trace_target",
@@ -3552,6 +3596,17 @@ impl MiniMarkGC {
                         *slot_ptr = new_ref;
                     }
                 });
+            }
+            if let Some((slot_addr, field)) = deferred {
+                let walk = self.describe_custom_trace_slots(obj_addr, trace_fn);
+                eprintln!("GC BUG: custom-trace slot walk for holder={obj_addr:#x}: {walk}");
+                self.copy_nursery_object(
+                    field,
+                    "minor_custom_trace_target",
+                    site,
+                    obj_addr,
+                    slot_addr,
+                );
             }
             return;
         }
@@ -4613,6 +4668,97 @@ impl MiniMarkGC {
         } else {
             "outside"
         }
+    }
+
+    /// Whether the header in front of a nursery address decodes at all.
+    ///
+    /// `is_nursery_object_start` is a range check, so it answers "could be an
+    /// object", not "is one". This is the cheap half of the question the
+    /// `copy_nursery_object` panic answers in full.
+    fn nursery_start_decodes(&self, obj_addr: usize) -> bool {
+        let hdr = unsafe { *header_of(obj_addr) };
+        hdr.is_forwarded() || (hdr.type_id() as usize) < self.types.len()
+    }
+
+    /// Every slot a custom trace names, with the state of the value in it.
+    ///
+    /// For a JITFRAME the slot set is whatever `jf_gcmap` says, so this is the
+    /// only way to see the map the collector actually acted on.
+    fn describe_custom_trace_slots(
+        &self,
+        obj_addr: usize,
+        trace_fn: crate::trace::CustomTraceFn,
+    ) -> String {
+        let mut slots: Vec<(usize, usize)> = Vec::new();
+        unsafe {
+            trace_fn(obj_addr, &mut |slot_ptr: *mut GcRef| {
+                slots.push((slot_ptr as usize, (*slot_ptr).0));
+            });
+        }
+        let mut out = format!("{} slots:", slots.len());
+        for (slot_addr, value) in slots {
+            let offset = slot_addr.wrapping_sub(obj_addr);
+            let tag = if value == 0 {
+                "null".to_string()
+            } else if !self.is_managed_heap_object(value) {
+                "unmanaged".to_string()
+            } else if !self.nursery_start_decodes(value) {
+                format!("{}-BAD", self.describe_generation(value))
+            } else {
+                let hdr = unsafe { *header_of(value) };
+                if hdr.is_forwarded() {
+                    format!("{}-forwarded", self.describe_generation(value))
+                } else {
+                    format!("{}-tid{}", self.describe_generation(value), hdr.type_id())
+                }
+            };
+            out.push_str(&format!(" [+{offset}]={value:#x}:{tag}"));
+        }
+        out
+    }
+
+    /// The nearest preceding word that decodes as an object header whose
+    /// extent covers `obj_addr`.
+    ///
+    /// `is_nursery_object_start` is a bare range check, so a slot holding an
+    /// *interior* address passes it and the collector then reads a payload
+    /// word as a header. That is a different defect from a header that was
+    /// genuinely clobbered, and the header word alone does not separate them:
+    /// finding a real object that contains the address settles it, and its
+    /// `interior_offset` names the field the slot actually points at.
+    fn describe_nearest_header(&self, obj_addr: usize) -> String {
+        let word = std::mem::size_of::<usize>();
+        let floor = self.nursery.start_ptr() as usize;
+        for back in 1..=64usize {
+            let Some(candidate) = obj_addr.checked_sub(back * word) else {
+                break;
+            };
+            if candidate <= floor + GcHeader::SIZE {
+                break;
+            }
+            let hdr = unsafe { *header_of(candidate) };
+            if hdr.is_forwarded() {
+                let fwd = unsafe { GcHeader::forwarding_address(header_of(candidate)) };
+                return format!("forwarded back={back}w candidate={candidate:#x} fwd={fwd:#x}");
+            }
+            let tid = hdr.type_id();
+            if tid as usize >= self.types.len() {
+                continue;
+            }
+            let Some(size) = self.try_size_for_typeid(candidate, tid) else {
+                continue;
+            };
+            if candidate + size <= obj_addr {
+                continue;
+            }
+            return format!(
+                "tid={tid} back={back}w candidate={candidate:#x} size={size} \
+                 interior_offset={} custom_trace={}",
+                obj_addr - candidate,
+                self.types.get(tid).custom_trace.is_some(),
+            );
+        }
+        "none".to_string()
     }
 
     /// Which object actually owns `slot_addr`.

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -302,6 +302,7 @@
       "dynasm": "PASS"
     },
     "test.test_datetime": {
+      "cranelift": "PASS",
       "dynasm": "PASS"
     },
     "test.test_dbm": {


### PR DESCRIPTION
`test.test_datetime` under the cranelift backend aborted in the collector on every run. The cause is a jitframe that keeps tracing through a gcmap nothing owns any more.

## The defect

`JitFrameDeadFrame` releases its root when the owner drops, but **releasing a root does not take the frame out of the collector's remembered set**. The frame stayed reachable there with `jf_gcmap` still pointing at the exiting guard's map, so a later minor collection custom-traced it and walked `jf_frame` items that no longer held references. `jitframe_trace` (`jitframe.py:115-135`) returns early only on a null map.

That is exactly what the panic said, on every run:

```
GC BUG: invalid type_id=... site=minor_custom_trace_target parent_site=minor_remembered_set
  holder_type_id=Some(3) holder_offset=Some(88) holder_words=[..., 0x9d]
gc_alloc_nursery_shim -> alloc_with_type_slow -> do_collect_nursery
  -> trace_and_update_object -> jitframe_custom_trace -> copy_nursery_object
```

`parent_site` was always `minor_remembered_set` and never `minor_jitframe_root` — Phase 1c of `do_collect_nursery` traces every old-generation jitframe found on the jf shadow stack, and it runs first. The frame had left the shadow stack.

The wasm backend already nulls `jf_gcmap` at the same point, with a comment naming this hazard (`majit-backend-wasm/src/lib.rs`). The jitframe deadframe never did.

## What is in this branch

- **`jit(cranelift): null jf_gcmap when the deadframe owner drops its root`** — the fix. Only the rooted arm: an `Unrooted` frame is not a GC object, so nothing traces it.
- **`jit(cranelift): drop a dense frame binding when the slot is republished as a non-reference`** — a separate defect found while reading. `bind_published_dense_refs` walked only `failarg_ref_slots`, but the publish loop at both call sites stores *every* fail-arg into its dense frame item. A Ref binding therefore survived a later Int or Float store into the same item, and `get_gcmap` kept marking it. `regalloc.py:164-176 FrameManager.bind` replaces a location's previous occupant regardless of the new value's type.
- **`gc: report the child header, the holder generation and the custom-trace slot walk on an invalid type_id`** — the minor-collection panic reported less than `grey_child` does. It now also prints the child's full `tid_and_flags` and flag complement, its leading words, a vtable lookup, the nearest preceding word that decodes as a header covering the address, both generations, remembered-set membership, collector state and collection counts; and for a custom trace it defers the first undecodable slot so the walk completes and every named slot is printed with the state of its value.
- **`cpython_tests: record test_datetime as PASS under cranelift`** — the row carried only a `dynasm` entry.

## Measured

darwin-arm64.

| | result |
|---|---|
| `pyre-cranelift -m test.test_datetime` before | **8/8 abort** |
| same, after (5 on the pre-rebase base, 2 on this base) | **7/7 `Ran 1804 tests ... OK (skipped=29)`** |
| `run.py --backend cranelift --filter test_datetime` | **3/3 `PASS 1, no regressions`**, 11.5s against the 300s per-module timeout |
| `cargo test -p majit-backend` | 27 ok |
| `cargo test -p majit-backend-cranelift` | 137 + 35 + 1 ok |
| `cargo test -p majit-gc` | 268 ok |

The slot walk added in the third commit is what located the defect: on the failing frame it showed 18 gcmap-marked items of which exactly **one** was bad and 17 sound, which ruled out both "the published value is wrong" and "the map is wholesale stale" and left map lifetime.

## Limits

- **`pyre/check.py` was not run.** The machine sat at load average 27–121 throughout; a ratio verdict measured there is not readable in either direction. CI is the right place for it.
- The baseline row was measured on the empty-resource workload the runner selects (`DEFAULT_RESOURCE_MODULES`), not on the per-timezone expansion a bare `-m test.test_datetime` takes. That heavier path is where the abort lived and is covered by the 7/7 above, but no gate runs it.
- The pre-fix binary also passes the gate workload 3/3, so the recorded row is not itself evidence of the fix — the module was simply never recorded for cranelift.
- The first commit's `jit(cranelift)` scope label predates the rebase; `origin/main` moved `JitFrameDeadFrame` into `majit-backend`, and the fix moved with it. The label was left alone rather than rewriting history.

## Rebase note

Rebased onto `origin/main`. Two conflicts, both from `JitFrameDeadFrame` moving out of `majit-backend-cranelift/src/guard.rs` into `majit-backend/src/deadframe.rs` and its rooting changing from `register_gc_roots`/`roots_registered` to an `OwnerRootGuard` slot. Both regions took main's relocation; the fix was rewritten at the new site as a `Drop` impl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFbvNce7TD6xB2Xe2Zh3Vs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of failed call arguments, including unreferenced, constant, and invalid slots.
  * Ensured rooted JIT frames release stale garbage-collection metadata when destroyed.

* **Diagnostics**
  * Enhanced garbage-collection corruption reports with detailed context to simplify troubleshooting.

* **Tests**
  * Updated the CPython compatibility baseline to recognize the datetime test as passing under Cranelift.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->