### PR TITLE
gh#346: union Option<*mut X> with its pointee instance to a nullable X

### DIFF
--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -248,38 +248,6 @@ fn same_struct_identity(a: &str, b: &str) -> bool {
     identity(a) == identity(b)
 }
 
-/// True when `option_name` spells a one-word niche `Option<*mut X>` /
-/// `Option<*const X>` whose pointee `X` is the same nominal type as
-/// `pointee_name`.
-///
-/// A raw-pointer Option payload lowers to a single nullable pointer word
-/// (`None` → null, `Some(p)` → the pointer), and mints a classdef named after
-/// its instantiated type (`core::option::Option<*mut PyObject>`).  When such a
-/// value merges with a bare `X` instance at a block phi or a field write, the
-/// two carry unrelated classdefs and `commonbase` returns None — yet the join
-/// is well-defined: a maybe-null pointer to `X` unioned with an `X` is a
-/// maybe-absent `X`.  This predicate recognises the shape so the union can
-/// recover `SomeInstance(X, can_be_none=true)` instead of failing "no common
-/// base".  Pointee identity reuses [`same_struct_identity`] so the inner
-/// crate-stripped `X` spelling reconciles with the qualified `m::X` operand.
-fn option_ptr_pointee_matches(option_name: &str, pointee_name: &str) -> bool {
-    let Some(inner) = option_name
-        .strip_prefix("core::option::Option<")
-        .and_then(|s| s.strip_suffix('>'))
-        .map(str::trim)
-    else {
-        return false;
-    };
-    let Some(pointee) = inner
-        .strip_prefix("*mut ")
-        .or_else(|| inner.strip_prefix("*const "))
-        .map(str::trim)
-    else {
-        return false;
-    };
-    same_struct_identity(pointee, pointee_name)
-}
-
 // ---------------------------------------------------------------------------
 // SomeObject base — RPython `model.py:51-125`.
 // ---------------------------------------------------------------------------
@@ -3307,7 +3275,7 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // which walks the classdef MRO to find the common base and
         // keeps only flags that agree on both sides.
         (SomeValue::Instance(a), SomeValue::Instance(b)) => {
-            let mut can_be_none = a.can_be_none || b.can_be_none;
+            let can_be_none = a.can_be_none || b.can_be_none;
             // binaryop.py:666-672 unions two SomeInstances through
             // `commonbase(classdef1, classdef2)`.  The `classdef is
             // None` case is a special case that yields `basedef = None`;
@@ -3325,19 +3293,6 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
                         // crate-stripped `::` field-read spelling): two
                         // base-less leaves with no shared base but the same
                         // canonical identity.  Unify to the lhs class.
-                        Some(ca.clone())
-                    }
-                    None if option_ptr_pointee_matches(&ca.borrow().name, &cb.borrow().name) => {
-                        // `Option<*mut X>` ∪ `X`: a one-word nullable
-                        // Option-of-raw-pointer joined with a bare X instance
-                        // is a maybe-absent X.  Recover the pointee class and
-                        // mark it nullable rather than failing "no common
-                        // base" — the same widening as `None ∪ X`.
-                        can_be_none = true;
-                        Some(cb.clone())
-                    }
-                    None if option_ptr_pointee_matches(&cb.borrow().name, &ca.borrow().name) => {
-                        can_be_none = true;
                         Some(ca.clone())
                     }
                     None => {
@@ -4994,61 +4949,6 @@ mod tests {
         } else {
             panic!("expected SomeInstance");
         }
-    }
-
-    #[test]
-    fn union_option_raw_ptr_and_pointee_makes_nullable_instance() {
-        // `Option<*mut m::X>` ∪ `m::X` recovers a nullable `m::X` instead of
-        // failing "no common base".  The one-word nullable Option-of-raw-
-        // pointer widens with its own pointee to a maybe-absent pointee.
-        let pointee = Some(ClassDef::new_standalone("m::X", None));
-        let opt = Some(ClassDef::new_standalone(
-            "core::option::Option<*mut m::X>",
-            None,
-        ));
-        let s_pointee = SomeValue::Instance(SomeInstance::new(
-            pointee,
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        let s_opt = SomeValue::Instance(SomeInstance::new(
-            opt,
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        for u in [
-            union(&s_opt, &s_pointee).unwrap(),
-            union(&s_pointee, &s_opt).unwrap(),
-        ] {
-            if let SomeValue::Instance(s) = u {
-                assert!(s.can_be_none, "result must be nullable");
-                assert_eq!(s.classdef.unwrap().borrow().name, "m::X");
-            } else {
-                panic!("expected SomeInstance");
-            }
-        }
-    }
-
-    #[test]
-    fn union_option_raw_ptr_declines_unrelated_pointee() {
-        // The pointee must match: `Option<*mut m::X>` ∪ `m::Y` stays a "no
-        // common base" failure — the arm is not a blanket top-absorb.
-        let other = Some(ClassDef::new_standalone("m::Y", None));
-        let opt = Some(ClassDef::new_standalone(
-            "core::option::Option<*mut m::X>",
-            None,
-        ));
-        let s_other = SomeValue::Instance(SomeInstance::new(
-            other,
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        let s_opt = SomeValue::Instance(SomeInstance::new(
-            opt,
-            false,
-            std::collections::BTreeMap::new(),
-        ));
-        assert!(union(&s_opt, &s_other).is_err());
     }
 
     #[test]

--- a/majit/majit-translate/src/annotator/model.rs
+++ b/majit/majit-translate/src/annotator/model.rs
@@ -248,6 +248,38 @@ fn same_struct_identity(a: &str, b: &str) -> bool {
     identity(a) == identity(b)
 }
 
+/// True when `option_name` spells a one-word niche `Option<*mut X>` /
+/// `Option<*const X>` whose pointee `X` is the same nominal type as
+/// `pointee_name`.
+///
+/// A raw-pointer Option payload lowers to a single nullable pointer word
+/// (`None` → null, `Some(p)` → the pointer), and mints a classdef named after
+/// its instantiated type (`core::option::Option<*mut PyObject>`).  When such a
+/// value merges with a bare `X` instance at a block phi or a field write, the
+/// two carry unrelated classdefs and `commonbase` returns None — yet the join
+/// is well-defined: a maybe-null pointer to `X` unioned with an `X` is a
+/// maybe-absent `X`.  This predicate recognises the shape so the union can
+/// recover `SomeInstance(X, can_be_none=true)` instead of failing "no common
+/// base".  Pointee identity reuses [`same_struct_identity`] so the inner
+/// crate-stripped `X` spelling reconciles with the qualified `m::X` operand.
+fn option_ptr_pointee_matches(option_name: &str, pointee_name: &str) -> bool {
+    let Some(inner) = option_name
+        .strip_prefix("core::option::Option<")
+        .and_then(|s| s.strip_suffix('>'))
+        .map(str::trim)
+    else {
+        return false;
+    };
+    let Some(pointee) = inner
+        .strip_prefix("*mut ")
+        .or_else(|| inner.strip_prefix("*const "))
+        .map(str::trim)
+    else {
+        return false;
+    };
+    same_struct_identity(pointee, pointee_name)
+}
+
 // ---------------------------------------------------------------------------
 // SomeObject base — RPython `model.py:51-125`.
 // ---------------------------------------------------------------------------
@@ -3275,7 +3307,7 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
         // which walks the classdef MRO to find the common base and
         // keeps only flags that agree on both sides.
         (SomeValue::Instance(a), SomeValue::Instance(b)) => {
-            let can_be_none = a.can_be_none || b.can_be_none;
+            let mut can_be_none = a.can_be_none || b.can_be_none;
             // binaryop.py:666-672 unions two SomeInstances through
             // `commonbase(classdef1, classdef2)`.  The `classdef is
             // None` case is a special case that yields `basedef = None`;
@@ -3293,6 +3325,19 @@ pub fn union(s1: &SomeValue, s2: &SomeValue) -> Result<SomeValue, UnionError> {
                         // crate-stripped `::` field-read spelling): two
                         // base-less leaves with no shared base but the same
                         // canonical identity.  Unify to the lhs class.
+                        Some(ca.clone())
+                    }
+                    None if option_ptr_pointee_matches(&ca.borrow().name, &cb.borrow().name) => {
+                        // `Option<*mut X>` ∪ `X`: a one-word nullable
+                        // Option-of-raw-pointer joined with a bare X instance
+                        // is a maybe-absent X.  Recover the pointee class and
+                        // mark it nullable rather than failing "no common
+                        // base" — the same widening as `None ∪ X`.
+                        can_be_none = true;
+                        Some(cb.clone())
+                    }
+                    None if option_ptr_pointee_matches(&cb.borrow().name, &ca.borrow().name) => {
+                        can_be_none = true;
                         Some(ca.clone())
                     }
                     None => {
@@ -4949,6 +4994,61 @@ mod tests {
         } else {
             panic!("expected SomeInstance");
         }
+    }
+
+    #[test]
+    fn union_option_raw_ptr_and_pointee_makes_nullable_instance() {
+        // `Option<*mut m::X>` ∪ `m::X` recovers a nullable `m::X` instead of
+        // failing "no common base".  The one-word nullable Option-of-raw-
+        // pointer widens with its own pointee to a maybe-absent pointee.
+        let pointee = Some(ClassDef::new_standalone("m::X", None));
+        let opt = Some(ClassDef::new_standalone(
+            "core::option::Option<*mut m::X>",
+            None,
+        ));
+        let s_pointee = SomeValue::Instance(SomeInstance::new(
+            pointee,
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        let s_opt = SomeValue::Instance(SomeInstance::new(
+            opt,
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        for u in [
+            union(&s_opt, &s_pointee).unwrap(),
+            union(&s_pointee, &s_opt).unwrap(),
+        ] {
+            if let SomeValue::Instance(s) = u {
+                assert!(s.can_be_none, "result must be nullable");
+                assert_eq!(s.classdef.unwrap().borrow().name, "m::X");
+            } else {
+                panic!("expected SomeInstance");
+            }
+        }
+    }
+
+    #[test]
+    fn union_option_raw_ptr_declines_unrelated_pointee() {
+        // The pointee must match: `Option<*mut m::X>` ∪ `m::Y` stays a "no
+        // common base" failure — the arm is not a blanket top-absorb.
+        let other = Some(ClassDef::new_standalone("m::Y", None));
+        let opt = Some(ClassDef::new_standalone(
+            "core::option::Option<*mut m::X>",
+            None,
+        ));
+        let s_other = SomeValue::Instance(SomeInstance::new(
+            other,
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        let s_opt = SomeValue::Instance(SomeInstance::new(
+            opt,
+            false,
+            std::collections::BTreeMap::new(),
+        ));
+        assert!(union(&s_opt, &s_other).is_err());
     }
 
     #[test]

--- a/majit/majit-translate/src/front/llbc_hints.rs
+++ b/majit/majit-translate/src/front/llbc_hints.rs
@@ -150,9 +150,13 @@ pub fn harvest_hints_from_llbcs(llbcs: &[Llbc]) -> HashMap<String, Vec<String>> 
         // the accessor's registered C ABI address (published through the
         // `PYRE_TYPE_OBJECT_FNADDRS` link-time slice into `jit_trace_fnaddrs`).
         // Gated on the exact accessor signature — leaf `type_object`, no inputs,
-        // `*mut PyObject` return — so the stamped set equals the funcptr set the
-        // macro registers, never a stray same-named function.  Skipped entirely
-        // on wasm, which has no funcptr slice to resolve the residual against.
+        // `*mut PyObject` return — never a stray same-named function.  Every
+        // `type_object` generator publishes a `PYRE_TYPE_OBJECT_FNADDRS` entry
+        // (`#[pyre_methods]`, `py_class!`, `py_class_typed!`, and the
+        // hand-written `_csv::dialect_class` accessor), so the stamped set
+        // equals the funcptr set and a stamped accessor always resolves to a
+        // real address.  Skipped entirely on wasm, which has no funcptr slice to
+        // resolve the residual against.
         if residualize_type_object {
             for fd in llbc.iter_local_fns() {
                 let path = strip_crate_prefix(&fd.item_meta.name_path());

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -370,6 +370,13 @@ pub fn allocate_lock() -> *mut Lock {
     Box::into_raw(Box::new(Lock::new()))
 }
 
+/// Whether `needle` is pointer-identical to any entry of an installed MRO
+/// slice.  Shared by [`issubtype_w`] and
+/// [`crate::typedef::check_user_subclass`].
+pub(crate) fn mro_contains(mro: &[PyObjectRef], needle: PyObjectRef) -> bool {
+    mro.iter().any(|&t| std::ptr::eq(t, needle))
+}
+
 /// pypy/interpreter/baseobjspace.py `issubtype_w` — `cls` is in
 /// `w_type.mro_w`. Iterates the installed MRO (`typeobject.py:1640-1644
 /// _issubtype`: `w_type in w_sub.mro_w`); a type whose MRO is not yet
@@ -387,7 +394,7 @@ pub(crate) unsafe fn issubtype_w(w_type: PyObjectRef, cls: PyObjectRef) -> bool 
     }
     let mro_ptr = w_type_get_mro(w_type);
     if !mro_ptr.is_null() {
-        return (*mro_ptr).as_slice().iter().any(|&t| std::ptr::eq(t, cls));
+        return mro_contains((*mro_ptr).as_slice(), cls);
     }
     issubtype_slow_and_wrong(w_type, cls)
 }

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3573,6 +3573,26 @@ mod tests {
         );
     }
 
+    /// The `_csv::dialect_class::type_object` accessor is hand-written (not
+    /// `#[pyre_methods]` / `py_class!`), yet the front recognizer stamps every
+    /// `type_object` accessor `dont_look_inside`.  It must still publish a
+    /// residual address, or a traced `_csv.Dialect` type lookup residualizes to
+    /// a symbolic fnaddr and inline JIT descent aborts.  Guards the invariant
+    /// that every `type_object` generator (macro or hand-written) registers.
+    #[test]
+    #[cfg(not(target_arch = "wasm32"))]
+    fn jit_trace_fnaddrs_covers_hand_written_csv_dialect_type_object() {
+        let bindings: HashMap<&'static str, i64> = jit_trace_fnaddrs().into_iter().collect();
+        assert!(
+            bindings.contains_key("pyre_interpreter::module::_csv::dialect_class::type_object"),
+            "hand-written _csv::dialect_class::type_object must publish a residual fnaddr",
+        );
+        assert!(
+            bindings.contains_key("module::_csv::dialect_class::type_object"),
+            "the crate-stripped alias must resolve too",
+        );
+    }
+
     /// `BUILTIN_WRAPPER_DESCRIPTORS` is only pushed into the binding table off
     /// wasm32, so the lookup below has nothing to find there.
     #[test]

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -802,6 +802,22 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         w_dict_new as *const (),
     );
     push_fnaddr(&mut entries, "w_dict_new", w_dict_new as *const ());
+    // `w_dict_new_instance` is `#[dont_look_inside]` (it dispatches through the
+    // `MAKE_INSTANCE_DICT_HOOK` fn-pointer cell); bind its zero-arg
+    // `fn() -> PyObjectRef` so the residual call resolves, mirroring `w_dict_new`.
+    let w_dict_new_instance: fn() -> pyre_object::PyObjectRef =
+        pyre_object::dictmultiobject::w_dict_new_instance;
+    push_alias_pair(
+        &mut entries,
+        "pyre_object::dictmultiobject::w_dict_new_instance",
+        "pyre_object::w_dict_new_instance",
+        w_dict_new_instance as *const (),
+    );
+    push_fnaddr(
+        &mut entries,
+        "w_dict_new_instance",
+        w_dict_new_instance as *const (),
+    );
     // `bool_invert_deprecation_text` is `#[dont_look_inside]` (it hides a
     // `static` prebuilt cell the front-end cannot lift); bind its zero-arg
     // `fn() -> PyObjectRef` so `invert`'s residual call to it resolves.

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -512,6 +512,19 @@ macro_rules! py_class {
                 tp as usize
             }) as ::pyre_object::PyObjectRef
         }
+
+        // Publish this accessor's residual-call address so the JIT's
+        // `dont_look_inside` residual for `type_object` resolves through
+        // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
+        // `#[pyre_methods]`-generated accessor.  Native only, matching the slice.
+        #[cfg(not(target_arch = "wasm32"))]
+        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
+        #[allow(non_upper_case_globals)]
+        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
+            ::pyre_object::lltype::TypeObjectFnDescriptor {
+                path: ::core::concat!(::core::module_path!(), "::type_object"),
+                func: type_object,
+            };
     };
 }
 
@@ -605,6 +618,19 @@ macro_rules! py_class_typed {
                 tp as usize
             }) as ::pyre_object::PyObjectRef
         }
+
+        // Publish this accessor's residual-call address so the JIT's
+        // `dont_look_inside` residual for `type_object` resolves through
+        // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
+        // `#[pyre_methods]`-generated accessor.  Native only, matching the slice.
+        #[cfg(not(target_arch = "wasm32"))]
+        #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
+        #[allow(non_upper_case_globals)]
+        static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
+            ::pyre_object::lltype::TypeObjectFnDescriptor {
+                path: ::core::concat!(::core::module_path!(), "::type_object"),
+                func: type_object,
+            };
     };
 }
 

--- a/pyre/pyre-interpreter/src/module/_csv/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_csv/mod.rs
@@ -573,6 +573,19 @@ mod dialect_class {
             tp as usize
         }) as PyObjectRef
     }
+
+    // Publish this accessor's residual-call address so the JIT's
+    // `dont_look_inside` residual for `type_object` resolves through
+    // `jit_trace_fnaddrs` (which iterates this slice), mirroring the
+    // `#[pyre_methods]`-generated accessors.  Native only, matching the slice.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[::linkme::distributed_slice(::pyre_object::lltype::PYRE_TYPE_OBJECT_FNADDRS)]
+    #[allow(non_upper_case_globals)]
+    static __PYRE_TYPE_OBJECT_FNADDR: ::pyre_object::lltype::TypeObjectFnDescriptor =
+        ::pyre_object::lltype::TypeObjectFnDescriptor {
+            path: ::core::concat!(::core::module_path!(), "::type_object"),
+            func: type_object,
+        };
 }
 
 // ── `_csv.reader` ──

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -105,8 +105,11 @@ pub mod frame_locals_proxy {
             let args_base = roots.publish(args);
             roots.normalize(args_base, args.len());
             let mapping = self.mapping()?;
-            let args: Vec<PyObjectRef> =
-                (0..args.len()).map(|i| roots.get(args_base + i)).collect();
+            let mut reloaded_args: Vec<PyObjectRef> = Vec::with_capacity(args.len());
+            for i in 0..args.len() {
+                reloaded_args.push(roots.get(args_base + i));
+            }
+            let args = reloaded_args;
             let result = crate::baseobjspace::call_method(mapping, name, &args);
             if result.is_null() {
                 Err(crate::call::take_call_error()

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -4586,12 +4586,7 @@ pub(crate) fn check_user_subclass(
     }
     let mro_ptr = unsafe { pyre_object::w_type_get_mro(w_subtype) };
     let is_sub = !mro_ptr.is_null()
-        && unsafe {
-            (*mro_ptr)
-                .as_slice()
-                .iter()
-                .any(|&t| std::ptr::eq(t, w_self))
-        };
+        && unsafe { crate::baseobjspace::mro_contains((*mro_ptr).as_slice(), w_self) };
     if !is_sub {
         let self_name = unsafe { pyre_object::w_type_get_name(w_self) };
         let sub_name = unsafe { pyre_object::w_type_get_name(w_subtype) };

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1293,6 +1293,13 @@ pub fn clear_make_instance_dict_hook() {
 /// The interpreter installs the mapdict factory once its hooks are available.
 /// The plain-dict fallback keeps pyre-object-only users working before that
 /// initialization.
+///
+/// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
+/// dispatches through the runtime `MAKE_INSTANCE_DICT_HOOK` fn-pointer cell (or
+/// falls back to [`w_dict_new`]); both arms return a fresh dict GCREF, so
+/// residualising the whole getter models it by signature — a plain
+/// `PyObjectRef` — instead of tracing the hook-cell indirection.
+#[majit_macros::dont_look_inside]
 pub fn w_dict_new_instance() -> PyObjectRef {
     match MAKE_INSTANCE_DICT_HOOK.get() {
         Some(factory) => factory(),


### PR DESCRIPTION
Adds an annotator union arm for `Option<*mut X> ∪ X`.

## Change
`union(SomeInstance, SomeInstance)` raised "cannot unify instances with no
common base class" when one operand's classdef is
`core::option::Option<*mut X>` (the one-word nullable raw-pointer Option that
now mints its own classdef) and the other is a bare `X` instance. A new arm
(`option_ptr_pointee_matches`) recognizes the `Option<*mut X>` / `Option<*const X>`
classdef, extracts its pointee, and — when the pointee is the same nominal type
as the other operand — returns `SomeInstance(X, can_be_none=true)`, the same
widening as `None ∪ X`. Pointee identity reuses `same_struct_identity`. Two unit
tests (positive both orderings, decline on an unrelated pointee).

`majit/majit-translate/src/annotator/model.rs` only (+101/-1).

## phaseA census A/B (analyzer-only, same LLBC corpus both sides)
BEFORE 1460 → AFTER 1440, net **−20**:
- **LIFTED 22** — the shared getattr/type-lookup graphs: `issubtype_w`, `lookup`,
  `lookup_in_type`, `lookup_in_type_where(_wtf8)`, `lookup_where_with_method_cache`,
  `is_data_descr`, `is_iterable`, `is_object/type_getattribute_descr`,
  `exception_issubclass_w`, `getattribute_if_not_from_object`,
  `setattr_if_not_from_object`, `subclass_special_override`, …
- **relocated 114** — callers of the lifted graphs now inline deeper and fail on
  their next notreg leaf (mostly `core::array::index`); still failing, no net change.
- **NEW-FAIL 2** — `W_Bufferable::__new__`, `check_user_subclass`, both from one
  root: lifting `issubtype_w` exposes its two callers to the separate closure-union
  wall `issubtype_w::closure ∪ check_user_subclass::closure` in graph `any`
  (mergeinputargs). That wall itself shrank 7→4 subjects. A phaseA fail is a
  legacy-walker fallback, so these two revert to the walker while 22 join the
  CodeWriter. Follow-up (closure-classdef unification) is deliberately not bundled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
