### PR TITLE
tests: restore the PyPy skip a re-vendor dropped from test_sort, and clear its stale CRASH

### DIFF
--- a/lib-python/3/test/test_sort.py
+++ b/lib-python/3/test/test_sort.py
@@ -226,6 +226,7 @@ class TestDecorateSortUndecorate(unittest.TestCase):
             return x
         self.assertRaises(ValueError, data.sort, key=k)
 
+    @support.cpython_only  # PyPy's GC doesn't call __del__ immediately (no refcounting)
     def test_key_with_mutating_del(self):
         data = list(range(10))
         class SortKiller(object):

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1042,7 +1042,7 @@
       "dynasm": "PASS"
     },
     "test.test_sort": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_source_encoding": {
       "dynasm": "IMPORTERROR"


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

This decorator was removed in https://github.com/youknowone/pyre/pull/186, which is the main reason for the sort test crash.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [x] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility for sorting tests across Python implementations.
  - Corrected test expectations for the `dynasm` implementation, which now passes successfully.

- **Tests**
  - Excluded an unsupported sorting test from PyPy to prevent inaccurate failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->