### PR TITLE
majit: Defer Dynasm bridge constant conversion to diagnostic path

### DIFF
--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -2637,15 +2637,15 @@ impl Backend for DynasmBackend {
         // format_trace reads raw `i64` values; the assembler stores the
         // typed `Const` pool directly (type rides on `Const::get_type`).
         let const_pool = std::mem::take(&mut self.constants);
-        let constants: indexmap::IndexMap<u32, i64> = const_pool
-            .iter()
-            .map(|(&k, c)| (k, c.as_raw_i64()))
-            .collect();
         let trace_ops_diag = std::env::var("PYRE_TRACE_OPS_DIAG")
             .ok()
             .and_then(|value| value.parse::<u64>().ok())
             == Some(trace_id);
         if trace_ops_diag {
+            let constants: IndexMap<u32, i64> = const_pool
+                .iter()
+                .map(|(&k, c)| (k, c.as_raw_i64()))
+                .collect();
             eprintln!(
                 "--- dynasm bridge prepared ops (trace_id={}, fail_index={}) ---\n{}",
                 trace_id,


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Move the raw constant map conversion into the `PYRE_TRACE_OPS_DIAG` branch, avoiding diagnostic-only allocation and iteration during normal bridge compilation.

`compile_loop` has similar `const_pool` collection logic, but I left it duplicated rather than extracting a helper that isn't needed yet.
https://github.com/youknowone/pyre/blob/21ce53083b17d6c941b863ae20e415e0525009b2/majit/majit-backend-dynasm/src/runner.rs#L2394-L2397

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [x] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal diagnostic handling without changing the resulting output or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->