### PR TITLE
jit: record the implicit __context__ for a raise the trace catches itself

### DIFF
--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -160,9 +160,9 @@ pub use pyjitpl::{
     record_inline_application_traceback_hook_address, residual_write_effect_info,
     resolve_exception_context_for_recording, resolve_exception_context_hook_address,
     set_record_application_traceback_hook, set_record_discarded_level_traceback_hook,
-    set_record_inline_application_traceback_hook, set_resolve_exception_context_hook, trace_jitcode,
-    trace_jitcode_from_merge_point,
-    trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
+    set_record_inline_application_traceback_hook, set_resolve_exception_context_hook,
+    trace_jitcode, trace_jitcode_from_merge_point, trace_jitcode_with_args,
+    trace_jitcode_with_args_and_runtime,
 };
 pub use resume_box_reader::{
     BridgeVirtualCache, decode_fieldnum, default_bridge_array_descr, emit_pending_field_op,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -158,8 +158,10 @@ pub use pyjitpl::{
     record_discarded_level_traceback_for_recording, record_discarded_level_traceback_hook_address,
     record_inline_application_traceback_for_recording,
     record_inline_application_traceback_hook_address, residual_write_effect_info,
+    resolve_exception_context_for_recording, resolve_exception_context_hook_address,
     set_record_application_traceback_hook, set_record_discarded_level_traceback_hook,
-    set_record_inline_application_traceback_hook, trace_jitcode, trace_jitcode_from_merge_point,
+    set_record_inline_application_traceback_hook, set_resolve_exception_context_hook, trace_jitcode,
+    trace_jitcode_from_merge_point,
     trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };
 pub use resume_box_reader::{

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1926,11 +1926,31 @@ pub type RecordInlineApplicationTraceback = extern "C" fn(i64, i64, i64, i64, i6
 /// so this hook takes a PYTHON pc where the two above take a jitcode one.
 pub type RecordDiscardedLevelTraceback = extern "C" fn(i64, i64, i64);
 
+/// Runtime callback that answers the implicit `__context__` of an exception:
+/// the object its `__context__` slot must hold once the raise is recorded, or
+/// `0` when nothing is to be chained.
+///
+/// `pypy/interpreter/error.py:410-420 record_context` runs inside the
+/// interpreter's exception dispatch, so an exception whose handler is part of
+/// the trace never reaches it — the same gap the traceback hooks above close
+/// for `record_application_traceback`.  The host owns the execution context
+/// the active exception is read from, so majit keeps only this ABI hook.
+///
+/// It **answers** rather than stores because the trace records the store as a
+/// `SetfieldGc` of its own.  A callback that wrote the field itself would need
+/// an `EffectInfo` naming that write, and `make_call_descr_with_effect` rejects
+/// a non-trivial raw descr set minted after `compute_bitstrings`
+/// (`effectinfo.py:182-184`); declaring no write instead would let the
+/// optimizer answer a later `__context__` read from its pre-call cache.
+pub type ResolveExceptionContext = extern "C" fn(i64) -> i64;
+
 static RECORD_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 static RECORD_INLINE_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 static RECORD_DISCARDED_LEVEL_TRACEBACK: std::sync::atomic::AtomicUsize =
+    std::sync::atomic::AtomicUsize::new(0);
+static RESOLVE_EXCEPTION_CONTEXT: std::sync::atomic::AtomicUsize =
     std::sync::atomic::AtomicUsize::new(0);
 
 pub fn set_record_application_traceback_hook(hook: Option<RecordApplicationTraceback>) {
@@ -1954,6 +1974,34 @@ pub fn set_record_discarded_level_traceback_hook(hook: Option<RecordDiscardedLev
         hook.map_or(0, |callback| callback as usize),
         std::sync::atomic::Ordering::Release,
     );
+}
+
+pub fn set_resolve_exception_context_hook(hook: Option<ResolveExceptionContext>) {
+    RESOLVE_EXCEPTION_CONTEXT.store(
+        hook.map_or(0, |callback| callback as usize),
+        std::sync::atomic::Ordering::Release,
+    );
+}
+
+pub fn resolve_exception_context_hook_address() -> *const () {
+    RESOLVE_EXCEPTION_CONTEXT.load(std::sync::atomic::Ordering::Acquire) as *const ()
+}
+
+/// The `__context__` of `exc_value`, answered through the same host hook the
+/// compiled run calls, so the one-shot recording iteration reaches the value
+/// its compiled successors will.  `0` when there is nothing to chain.
+pub fn resolve_exception_context_for_recording(exc_value: i64) -> i64 {
+    if exc_value == 0 {
+        return 0;
+    }
+    let hook = RESOLVE_EXCEPTION_CONTEXT.load(std::sync::atomic::Ordering::Acquire);
+    if hook == 0 {
+        return 0;
+    }
+    // SAFETY: the stored address is a `ResolveExceptionContext` published by
+    // `set_resolve_exception_context_hook`.
+    let callback: ResolveExceptionContext = unsafe { std::mem::transmute(hook) };
+    callback(exc_value)
 }
 
 pub fn record_application_traceback_hook_address() -> *const () {

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1936,12 +1936,12 @@ pub type RecordDiscardedLevelTraceback = extern "C" fn(i64, i64, i64);
 /// for `record_application_traceback`.  The host owns the execution context
 /// the active exception is read from, so majit keeps only this ABI hook.
 ///
-/// It **answers** rather than stores because the trace records the store as a
-/// `SetfieldGc` of its own.  A callback that wrote the field itself would need
-/// an `EffectInfo` naming that write, and `make_call_descr_with_effect` rejects
-/// a non-trivial raw descr set minted after `compute_bitstrings`
-/// (`effectinfo.py:182-184`); declaring no write instead would let the
-/// optimizer answer a later `__context__` read from its pre-call cache.
+/// It **answers** the value in addition to chaining, because the trace records
+/// the store as a `SetfieldGc` of its own: a call cannot name `w_context` as
+/// its write set here — `make_call_descr_with_effect` rejects a non-trivial raw
+/// descr set minted after `compute_bitstrings` (`effectinfo.py:182-184`) — so
+/// without the explicit store the optimizer would answer a later `__context__`
+/// read from its pre-call cache.
 pub type ResolveExceptionContext = extern "C" fn(i64) -> i64;
 
 static RECORD_APPLICATION_TRACEBACK: std::sync::atomic::AtomicUsize =
@@ -1987,9 +1987,9 @@ pub fn resolve_exception_context_hook_address() -> *const () {
     RESOLVE_EXCEPTION_CONTEXT.load(std::sync::atomic::Ordering::Acquire) as *const ()
 }
 
-/// The `__context__` of `exc_value`, answered through the same host hook the
-/// compiled run calls, so the one-shot recording iteration reaches the value
-/// its compiled successors will.  `0` when there is nothing to chain.
+/// Chain `exc_value` through the same host hook the compiled run calls, so the
+/// one-shot recording iteration applies the same effect and reaches the same
+/// value its compiled successors will.  `0` when there is nothing to chain.
 pub fn resolve_exception_context_for_recording(exc_value: i64) -> i64 {
     if exc_value == 0 {
         return 0;

--- a/pyre/extra_tests/parity_tests/builtin_raise_context_same_frame.py
+++ b/pyre/extra_tests/parity_tests/builtin_raise_context_same_frame.py
@@ -1,0 +1,73 @@
+# CPython-suite gap: builtin exception tests omit hot in-frame context chains.
+# parity-tests reason: this guards pyre's JIT builtin raising path when the
+# raise and its handler share one frame, so no callee frame is unwound.
+
+"""A compiled builtin raise retains the active exception context.
+
+`builtin_raise_context_specialization` raises inside a called leaf; here the
+raising op and its handler share the loop frame, which is the shape where the
+compiled arm delivers the exception with a traceback entry already stamped.
+
+The counts are compared only after the loop: reading `__context__` inside an
+`assert` keeps the loop from compiling at all (`loops_compiled=0`), which would
+leave the compiled path untested.
+"""
+
+ROUNDS = 20000
+
+
+def count_subscript():
+    outer = KeyError("outer")
+    lost = 0
+    try:
+        raise outer
+    except KeyError:
+        for _ in range(ROUNDS):
+            try:
+                [][0]
+            except IndexError as exc:
+                if exc.__context__ is not outer:
+                    lost += 1
+    return lost
+
+
+def count_floordiv(zero):
+    outer = KeyError("outer")
+    lost = 0
+    try:
+        raise outer
+    except KeyError:
+        for i in range(ROUNDS):
+            try:
+                i // zero
+            except ZeroDivisionError as exc:
+                if exc.__context__ is not outer:
+                    lost += 1
+    return lost
+
+
+def count_attribute():
+    outer = KeyError("outer")
+    obj = object()
+    lost = 0
+    try:
+        raise outer
+    except KeyError:
+        for _ in range(ROUNDS):
+            try:
+                obj.missing
+            except AttributeError as exc:
+                if exc.__context__ is not outer:
+                    lost += 1
+    return lost
+
+
+subscript = count_subscript()
+floordiv = count_floordiv(0)
+attribute = count_attribute()
+
+assert subscript == 0, f"subscript lost {subscript}/{ROUNDS}"
+assert floordiv == 0, f"floordiv lost {floordiv}/{ROUNDS}"
+assert attribute == 0, f"attribute lost {attribute}/{ROUNDS}"
+
+print("OK")

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -349,6 +349,7 @@ impl From<OperationError> for PyError {
             message,
             exc_object: value.w_value,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -385,6 +386,28 @@ pub struct PyError {
     /// `record_application_traceback`.  Default `true` for any
     /// normally-constructed PyError; reraise flips it off.
     pub attach_tb: bool,
+    /// `pypy/interpreter/error.py:410-420 record_context` parity — the
+    /// once-only latch for implicit `__context__` chaining:
+    ///
+    /// ```python
+    /// def record_context(self, space, ec):
+    ///     if self._context_recorded:
+    ///         return
+    ///     last = ec.sys_exc_info()
+    ///     try:
+    ///         if last is not None:
+    ///             self.chain_exceptions(space, last)
+    ///     finally:
+    ///         self._context_recorded = True
+    /// ```
+    ///
+    /// The latch is load-bearing whenever the recorded answer was "no
+    /// context": a null `__context__` cannot distinguish an error that
+    /// recorded none from one not yet recorded, so without it an outer
+    /// frame handling something of its own would hand that to an error
+    /// merely unwinding through.  Set on the first dispatch regardless of
+    /// whether an active exception was found, mirroring the `finally`.
+    pub context_recorded: bool,
     /// `pypy/interpreter/pyopcode.py:122 handle_operation_error(..., reraise_lasti=-1)`
     /// parity.  RERAISE N reads the original raise-site lasti from the
     /// value stack and carries it through `RaiseWithExplicitTraceback`
@@ -544,6 +567,7 @@ impl PyError {
             message: message.into(),
             exc_object: std::ptr::null_mut(),
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -711,6 +735,7 @@ impl PyError {
             message: Wtf8Buf::new(),
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -890,6 +915,7 @@ impl PyError {
             message,
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -1078,6 +1104,7 @@ impl PyError {
             message: Wtf8Buf::new(),
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -1119,6 +1146,7 @@ impl PyError {
             message: Wtf8Buf::new(),
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -1180,6 +1208,7 @@ impl PyError {
             message,
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -1243,6 +1272,7 @@ impl PyError {
             message,
             exc_object: exc,
             attach_tb: true,
+            context_recorded: false,
             reraise_lasti: -1,
             w_name_context: std::ptr::null_mut(),
             w_obj_context: std::ptr::null_mut(),
@@ -1617,6 +1647,7 @@ impl PyError {
                 message: Wtf8Buf::new(),
                 exc_object: obj,
                 attach_tb: true,
+                context_recorded: false,
                 reraise_lasti: -1,
                 w_name_context: std::ptr::null_mut(),
                 w_obj_context: std::ptr::null_mut(),

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1779,34 +1779,17 @@ pub fn handle_exception_with_context(
     //
     // `error.py:410-420 record_context` records it once and then marks the
     // OperationError, so the frames the SAME error merely unwinds through never
-    // re-derive it.  That marking is load-bearing whenever the recorded answer
-    // was "no context": a null `__context__` does not distinguish an error that
-    // recorded none from one not yet recorded, and an outer frame handling
-    // something of its own would hand it that instead.  Pyre's witness for the
-    // unmarked state is the application traceback, which
-    // `record_application_traceback` stamps for this frame below and which is
-    // therefore still empty on exactly the frame where the error first
-    // surfaces.
-    //
-    // A thrown-in exception starts a *new* error over an exception object that
-    // already carries a traceback from wherever it was first raised, so it is
-    // unmarked at the delivery frame no matter what that object holds.
-    let record_context = match context_source {
-        ContextSource::GeneratorChain => {
-            !err.exc_object.is_null()
-                && unsafe {
-                    pyre_object::interp_exceptions::w_exception_get_traceback(err.exc_object)
-                }
-                .is_null()
-        }
-        ContextSource::ResumedFrameOnly => true,
-    };
-    if record_context {
+    // re-derive it.  `PyError::context_recorded` is that mark, and it rides the
+    // error outward because the dispatch loop moves the same value into
+    // `Err(err)` on propagation.  The mark is set below whether or not an active
+    // exception was found, mirroring the `finally`.
+    if !err.context_recorded {
         let active = match context_source {
             ContextSource::GeneratorChain => get_sys_exception(),
             ContextSource::ResumedFrameOnly => get_current_exception(),
         };
         crate::error::chain_context(err.exc_object, active);
+        err.context_recorded = true;
     }
     if err.attach_tb {
         if !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -341,6 +341,24 @@ pub(crate) fn fbw_built_exc_take(op: OpRef) -> bool {
     FBW_BUILT_EXC.with(|s| s.borrow_mut().remove(&op))
 }
 
+/// Record that a raise lowering already emitted the `__context__` chaining for
+/// `op`, so the in-trace catch compensation leaves it alone.
+pub(crate) fn fbw_context_chained_insert(op: OpRef) {
+    FBW_CONTEXT_CHAINED.with(|s| {
+        s.borrow_mut().insert(op);
+    });
+}
+
+/// Whether a raise lowering already chained `op`'s `__context__`.
+///
+/// Read, never consumed: the handler that catches the exception is downstream
+/// of the raise in the same trace, and a second stamp there would both
+/// duplicate the store and hand the exception to a call — forcing the
+/// allocation the optimizer had folded away.
+pub(crate) fn fbw_context_chained_contains(op: OpRef) -> bool {
+    FBW_CONTEXT_CHAINED.with(|s| s.borrow().contains(&op))
+}
+
 /// Clear the store journal and residual-call census before a walk
 /// begins (mirrors [`bool_box_truth_reset`]).
 pub(crate) fn fbw_store_journal_reset() {
@@ -373,6 +391,7 @@ pub(crate) fn fbw_store_journal_reset() {
     // prior aborted walk recorded, so they cannot match a same-numbered
     // OpRef minted by this walk's recorder.
     FBW_BUILT_EXC.with(|s| s.borrow_mut().clear());
+    FBW_CONTEXT_CHAINED.with(|s| s.borrow_mut().clear());
     // B3: drop any unbalanced PUSH_EXC_INFO prev saves a
     // prior aborted walk left (an exception that propagated out without its
     // POP_EXCEPT restore), so a stale saved-prev cannot be popped by an

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5261,6 +5261,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                 // at runtime as well as applying it for the recording pass.
                 let emit_runtime =
                     !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_exception_context(ctx.trace_ctx, exc, exc_concrete);
                 record_inline_application_traceback(
                     ctx,
                     exc,
@@ -7387,6 +7388,7 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
                 // at runtime as well as applying it for the recording pass.
                 let emit_runtime =
                     !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_exception_context(ctx.trace_ctx, exc, exc_concrete);
                 record_inline_application_traceback(
                     ctx,
                     exc,
@@ -7581,6 +7583,7 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
                 // at runtime as well as applying it for the recording pass.
                 let emit_runtime =
                     !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_exception_context(ctx.trace_ctx, exc, exc_concrete);
                 record_inline_application_traceback(
                     ctx,
                     exc,
@@ -7759,6 +7762,7 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
                 // at runtime as well as applying it for the recording pass.
                 let emit_runtime =
                     !record_prepend_application_traceback(ctx, exc, exc_concrete, op.pc);
+                record_inline_exception_context(ctx.trace_ctx, exc, exc_concrete);
                 record_inline_application_traceback(
                     ctx,
                     exc,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -591,6 +591,78 @@ fn journaled_concrete_traceback_attach(exc_ptr: pyre_object::PyObjectRef, attach
     crate::jitcode_dispatch::fbw_traceback_journal_push_if_attached(exc_ptr, previous_head);
 }
 
+/// Record the implicit `__context__` of an exception this trace catches itself.
+///
+/// `error.py:410-420 record_context` runs inside the interpreter's exception
+/// dispatch.  A raise whose handler is part of the trace routes straight to
+/// that handler, so no interpreter dispatch ever sees the error and the chain
+/// is simply never derived — the same gap the traceback recorders above close,
+/// and the reason a hot loop raising under a live `except` reads
+/// `__context__ is None` on exactly its compiled iterations.
+///
+/// The store is not journaled the way the traceback node is.  It only fills a
+/// `__context__` the resolver reported as still unset, and an aborted walk is
+/// replayed by the interpreter, which derives the context from the same
+/// execution context and so writes the same object; a leftover store is
+/// therefore the answer the replay reaches anyway.
+///
+/// The hook only *answers* the context; the store is a `SetfieldGc` of this
+/// trace's own.  A hook that wrote the field itself would need an `EffectInfo`
+/// naming that write, and `make_call_descr_with_effect` rejects a non-trivial
+/// raw descr set minted after `compute_bitstrings` (`effectinfo.py:182-184`);
+/// declaring `default_effect_info` (`EffectInfo::MOST_GENERAL`) instead asserts
+/// "can raise, can force, writes anything", which costs a `GuardNoException`, a
+/// `GuardNotForced` and a full heapcache flush at every raise — enough to
+/// double a hot raise/catch loop.  A reading call plus an explicit store is
+/// both accurate and the shape the optimizer already models.
+fn record_inline_exception_context(ctx: &mut TraceCtx, exc: OpRef, exc_concrete: ConcreteValue) {
+    let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
+        return;
+    };
+    if exc_ptr.is_null() || !unsafe { pyre_object::is_exception(exc_ptr) } {
+        return;
+    }
+    // An exception a raise lowering already chained is not this compensation's
+    // to touch: that lowering emits `exc.w_context = ec.sys_exc_value` as IR on
+    // the still-virtual object and applies the same write to its concrete, so
+    // the store costs nothing and folds away with the exception when the
+    // handler never looks at it.  Stamping it again here would duplicate the
+    // store and, worse, hand the exception to a call, which forces the
+    // allocation the optimizer had removed.  `raise_catch_loop.py` and
+    // `synth/raise_bare_class_slot_kinds.py` both catch without touching the
+    // object, so that forcing alone doubled their execution time.
+    if fbw_context_chained_contains(exc) {
+        return;
+    }
+    let w_context =
+        majit_metainterp::resolve_exception_context_for_recording(exc_ptr as usize as i64);
+    if w_context != 0 {
+        unsafe {
+            pyre_object::interp_exceptions::w_exception_set_context(
+                exc_ptr,
+                w_context as usize as pyre_object::PyObjectRef,
+            )
+        };
+    }
+    let hook = majit_metainterp::resolve_exception_context_hook_address();
+    if !hook.is_null() && !exc.is_none() {
+        // `w_context` sits at one offset for every kind, so the recording
+        // iteration's kind names the right bytes even if a later one differs;
+        // only the descr identity the optimizer aliases on is narrower.
+        let kind = unsafe { pyre_object::interp_exceptions::w_exception_get_kind(exc_ptr) };
+        let context_descr = crate::descr::w_exception_context_descr(kind);
+        let w_context = ctx.call_ref_typed_with_effect(
+            hook,
+            &[exc],
+            &[Type::Ref],
+            majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+        );
+        let context_idx = context_descr.index();
+        ctx.record_op_with_descr(OpCode::SetfieldGc, &[exc, w_context], context_descr);
+        ctx.heapcache_setfield_cached(exc, context_idx, w_context);
+    }
+}
+
 fn record_top_level_application_traceback<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     exc: OpRef,
@@ -3221,6 +3293,7 @@ pub fn walk<Sym: WalkSym>(
                             exc_concrete,
                             node_position,
                         );
+                    record_inline_exception_context(ctx.trace_ctx, exc, exc_concrete);
                     record_inline_application_traceback(
                         ctx,
                         exc,
@@ -6263,6 +6336,15 @@ thread_local! {
     /// exception.  Reset at each FBW walk entry via `fbw_store_journal_reset`
     /// so a stale OpRef key from a prior recorder cannot leak across walks.
     static FBW_BUILT_EXC: std::cell::RefCell<std::collections::HashSet<OpRef>> =
+        std::cell::RefCell::new(std::collections::HashSet::new());
+
+    /// The OpRefs whose `__context__` a raise lowering already emitted as
+    /// `SetfieldGc(exc, GetfieldGcR(ec, sys_exc_value))`.  Distinct from
+    /// [`FBW_BUILT_EXC`], which `RaiseVarargs` *consumes* — by the time the
+    /// exception reaches the handler that catches it in this same trace, that
+    /// set no longer names it, and the in-trace catch compensation would
+    /// stamp the field a second time.  Reset with the other walk state.
+    static FBW_CONTEXT_CHAINED: std::cell::RefCell<std::collections::HashSet<OpRef>> =
         std::cell::RefCell::new(std::collections::HashSet::new());
 
     /// B3: LIFO stack of the previous-exception slot value

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -606,15 +606,19 @@ fn journaled_concrete_traceback_attach(exc_ptr: pyre_object::PyObjectRef, attach
 /// execution context and so writes the same object; a leftover store is
 /// therefore the answer the replay reaches anyway.
 ///
-/// The hook only *answers* the context; the store is a `SetfieldGc` of this
-/// trace's own.  A hook that wrote the field itself would need an `EffectInfo`
-/// naming that write, and `make_call_descr_with_effect` rejects a non-trivial
-/// raw descr set minted after `compute_bitstrings` (`effectinfo.py:182-184`);
-/// declaring `default_effect_info` (`EffectInfo::MOST_GENERAL`) instead asserts
-/// "can raise, can force, writes anything", which costs a `GuardNoException`, a
-/// `GuardNotForced` and a full heapcache flush at every raise — enough to
-/// double a hot raise/catch loop.  A reading call plus an explicit store is
-/// both accurate and the shape the optimizer already models.
+/// The hook performs the chaining and *answers* the resulting value, and the
+/// trace stores that answer itself.  The store cannot be left to the hook
+/// alone: `make_call_descr_with_effect` rejects a non-trivial raw descr set
+/// minted after `compute_bitstrings` (`effectinfo.py:182-184`), so a call
+/// cannot name `w_context` as its write set here, and the only alternative
+/// that admits an unnamed write to it is `default_effect_info`
+/// (`EffectInfo::MOST_GENERAL`) — "can raise, can force, writes anything",
+/// which costs a `GuardNoException`, a `GuardNotForced` and a full heapcache
+/// flush at every raise.  `cannot_raise_effect_info()` covers what the hook
+/// really does: it cannot raise, and it is a heap mutator because breaking a
+/// context cycle nulls the `__context__` of an exception other than this one.
+/// The explicit `SetfieldGc` then gives the optimizer the one write it can
+/// model.
 fn record_inline_exception_context(ctx: &mut TraceCtx, exc: OpRef, exc_concrete: ConcreteValue) {
     let ConcreteValue::Ref(exc_ptr) = exc_concrete else {
         return;
@@ -634,16 +638,10 @@ fn record_inline_exception_context(ctx: &mut TraceCtx, exc: OpRef, exc_concrete:
     if fbw_context_chained_contains(exc) {
         return;
     }
-    let w_context =
-        majit_metainterp::resolve_exception_context_for_recording(exc_ptr as usize as i64);
-    if w_context != 0 {
-        unsafe {
-            pyre_object::interp_exceptions::w_exception_set_context(
-                exc_ptr,
-                w_context as usize as pyre_object::PyObjectRef,
-            )
-        };
-    }
+    // The hook chains through `chain_context`, so calling it here both applies
+    // the effect to this authoritative walk's concrete exception and reaches
+    // the value the compiled iterations will store.
+    majit_metainterp::resolve_exception_context_for_recording(exc_ptr as usize as i64);
     let hook = majit_metainterp::resolve_exception_context_hook_address();
     if !hook.is_null() && !exc.is_none() {
         // `w_context` sits at one offset for every kind, so the recording
@@ -655,7 +653,7 @@ fn record_inline_exception_context(ctx: &mut TraceCtx, exc: OpRef, exc_concrete:
             hook,
             &[exc],
             &[Type::Ref],
-            majit_metainterp::CANNOT_RAISE_NO_HEAP_EFFECT_INFO,
+            majit_metainterp::cannot_raise_effect_info(),
         );
         let context_idx = context_descr.index();
         ctx.record_op_with_descr(OpCode::SetfieldGc, &[exc, w_context], context_descr);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -129,6 +129,7 @@ fn walker_emit_recorded_builtin_raise<Sym: WalkSym>(
         &[raised, active],
         crate::descr::w_exception_context_descr(expected_kind),
     );
+    fbw_context_chained_insert(raised);
     // The authentic helper has published the raised exception but has not
     // chained it yet during the authoritative walk.  Mirror the recorded
     // field write so that iteration observes the same context as replay.
@@ -11544,6 +11545,7 @@ pub(crate) fn try_walker_trace_raise_builtin<Sym: WalkSym>(
         &[exc_op, active],
         crate::descr::w_exception_context_descr(kind),
     );
+    fbw_context_chained_insert(exc_op);
     // The full-body walk is also the authoritative execution of the
     // tracing iteration.  Apply the same context write to its concrete,
     // freshly-built exception that the recorded SETFIELD performs on later
@@ -11748,6 +11750,7 @@ pub(crate) fn try_walker_trace_raise_bare_class<Sym: WalkSym>(
         &[new_op, active],
         crate::descr::w_exception_context_descr(kind),
     );
+    fbw_context_chained_insert(new_op);
     // Apply the same context write to the concrete, freshly-built exception so
     // Python code reached later in this authoritative walk observes the
     // `__context__` the recorded SETFIELD performs on compiled iterations.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -766,6 +766,75 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     }
 }
 
+/// `pypy/interpreter/error.py:410-420 record_context` for an exception whose
+/// handler is part of the trace, split so the trace records the store itself.
+///
+/// The implicit `__context__` is derived by `handle_exception_with_context`,
+/// and a raise the walk routes straight to a handler in the same trace never
+/// surfaces an error the interpreter dispatches — the same gap
+/// [`record_inline_traceback_for_recording`] closes for the traceback node.
+/// Without this, the compiled iterations of a loop raising under a live handler
+/// leave `__context__` null while the interpreted ones set it.
+///
+/// Answers the object the slot must end up holding, so an exception that was
+/// already chained answers its own context and the emitted store is idempotent;
+/// `0` means the slot stays null.
+///
+/// One divergence from `chain_context`: a chain that already reaches `w_exc`
+/// declines here where the interpreter breaks the cycle by nulling the
+/// offending link.  That break writes the `__context__` of an unrelated
+/// exception, which a pure answer cannot do and the emitted `SetfieldGc` does
+/// not describe.  Declining leaves the slot as the compiled path leaves it
+/// today, so it can under-chain a cycle but never answers a wrong context.
+pub(crate) extern "C" fn resolve_exception_context(exc_value: i64) -> i64 {
+    if exc_value == 0 {
+        return 0;
+    }
+    let w_exc = exc_value as PyObjectRef;
+    if !unsafe { pyre_object::is_exception(w_exc) } {
+        return 0;
+    }
+    let existing = unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_exc) };
+    if !existing.is_null() {
+        return existing as i64;
+    }
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_exc);
+    let active = pyre_interpreter::eval::get_sys_exception();
+    if active.is_null()
+        || std::ptr::eq(w_exc, active)
+        || unsafe { pyre_object::is_none(active) }
+        || !unsafe { pyre_object::is_exception(active) }
+    {
+        return 0;
+    }
+    // `error.rs _break_context_cycle` walks the chain tortoise-and-hare so a
+    // pre-existing cycle terminates; the same walk decides here whether
+    // chaining would close one.
+    let mut w_rabbit = active;
+    let mut w_tortoise = active;
+    let mut advance_tortoise = false;
+    loop {
+        let w_next = unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_rabbit) };
+        if w_next.is_null() || unsafe { pyre_object::is_none(w_next) } {
+            break;
+        }
+        if std::ptr::eq(w_next, w_exc) {
+            return 0;
+        }
+        w_rabbit = w_next;
+        if std::ptr::eq(w_rabbit, w_tortoise) {
+            break;
+        }
+        if advance_tortoise {
+            w_tortoise =
+                unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_tortoise) };
+        }
+        advance_tortoise = !advance_tortoise;
+    }
+    active as i64
+}
+
 pub(crate) extern "C" fn record_inline_traceback_for_recording(
     exc_value: i64,
     w_code_value: i64,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -776,16 +776,17 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
 /// Without this, the compiled iterations of a loop raising under a live handler
 /// leave `__context__` null while the interpreted ones set it.
 ///
-/// Answers the object the slot must end up holding, so an exception that was
-/// already chained answers its own context and the emitted store is idempotent;
-/// `0` means the slot stays null.
+/// Chains through `chain_context`, so the active exception is selected, a
+/// non-exception or self-referential pair is refused, and a chain that would
+/// close a cycle is broken by nulling the offending link — all exactly as the
+/// interpreter does it — and then answers the slot's resulting value.  The
+/// trace's own `SetfieldGc` therefore stores what is already there; `0` means
+/// the slot stays null.
 ///
-/// One divergence from `chain_context`: a chain that already reaches `w_exc`
-/// declines here where the interpreter breaks the cycle by nulling the
-/// offending link.  That break writes the `__context__` of an unrelated
-/// exception, which a pure answer cannot do and the emitted `SetfieldGc` does
-/// not describe.  Declining leaves the slot as the compiled path leaves it
-/// today, so it can under-chain a cycle but never answers a wrong context.
+/// The cycle break writes the `__context__` of an exception other than
+/// `w_exc`, which the emitted store does not describe, so the call is declared
+/// `cannot_raise_effect_info()` — a heap mutator that cannot raise — rather
+/// than as having no heap effect.
 pub(crate) extern "C" fn resolve_exception_context(exc_value: i64) -> i64 {
     if exc_value == 0 {
         return 0;
@@ -801,38 +802,8 @@ pub(crate) extern "C" fn resolve_exception_context(exc_value: i64) -> i64 {
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(w_exc);
     let active = pyre_interpreter::eval::get_sys_exception();
-    if active.is_null()
-        || std::ptr::eq(w_exc, active)
-        || unsafe { pyre_object::is_none(active) }
-        || !unsafe { pyre_object::is_exception(active) }
-    {
-        return 0;
-    }
-    // `error.rs _break_context_cycle` walks the chain tortoise-and-hare so a
-    // pre-existing cycle terminates; the same walk decides here whether
-    // chaining would close one.
-    let mut w_rabbit = active;
-    let mut w_tortoise = active;
-    let mut advance_tortoise = false;
-    loop {
-        let w_next = unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_rabbit) };
-        if w_next.is_null() || unsafe { pyre_object::is_none(w_next) } {
-            break;
-        }
-        if std::ptr::eq(w_next, w_exc) {
-            return 0;
-        }
-        w_rabbit = w_next;
-        if std::ptr::eq(w_rabbit, w_tortoise) {
-            break;
-        }
-        if advance_tortoise {
-            w_tortoise =
-                unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_tortoise) };
-        }
-        advance_tortoise = !advance_tortoise;
-    }
-    active as i64
+    pyre_interpreter::error::chain_context(w_exc, active);
+    unsafe { pyre_object::interp_exceptions::w_exception_get_context(w_exc) as i64 }
 }
 
 pub(crate) extern "C" fn record_inline_traceback_for_recording(

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4737,6 +4737,9 @@ fn build_jit_driver_pair() -> JitDriverPair {
     majit_metainterp::set_record_discarded_level_traceback_hook(Some(
         crate::call_jit::record_discarded_level_traceback,
     ));
+    majit_metainterp::set_resolve_exception_context_hook(Some(
+        crate::call_jit::resolve_exception_context,
+    ));
     let info = build_pyframe_virtualizable_info();
     let mut d = JitDriver::new(JIT_THRESHOLD);
     d.set_virtualizable_info(info.clone());


### PR DESCRIPTION
## The bug

A hot loop that raises under a live `except` read `__context__ is None` on every **compiled** iteration:

```python
outer = KeyError("outer")
try:
    raise outer
except KeyError:
    for _ in range(20000):
        try:
            [][0]
        except IndexError as exc:
            if exc.__context__ is None:
                lost += 1
```

| | CPython | PyPy 7.3.20 | `PYRE_NO_JIT=1` | pyre JIT |
|---|---|---|---|---|
| `__context__` lost | 0 | 0 | 0 | **18959/20000** |

Not a subscript quirk — `[][0]`, `{}['k']`, `()[0]`, `i // 0`, `obj.missing` all lose it identically, same-frame and cross-frame. The ~1041 survivors are the interpreted warm-up window.

## Cause

A raise whose handler is part of the trace routes straight to that handler, so the frame never surfaces an error the interpreter dispatches, and `handle_exception_with_context` — the only implicit caller of `chain_context` — never runs. The tracer already knows this and compensates for the **traceback node** at each in-trace catch site; `__context__` simply had no counterpart.

## Fix

A `ResolveExceptionContext` ABI hook beside the existing traceback hooks, answering the value the slot must hold, plus the `SetfieldGc` the trace records itself.

The hook chains through `chain_context`, so the active exception is selected, a non-exception or self-referential pair is refused, and a chain that would close a cycle is broken exactly as the interpreter breaks it. It also **answers** the slot's resulting value, because the store cannot be left to the call alone: `make_call_descr_with_effect` rejects a non-trivial raw descr set minted after `compute_bitstrings`, so the call cannot name `w_context` as its write set, and without the explicit `SetfieldGc` the optimizer would answer a later `__context__` read from its pre-call cache. Since the cycle break writes the `__context__` of an exception other than the one being stored into, the call is declared `cannot_raise_effect_info()` — a heap mutator that cannot raise — not `CANNOT_RAISE_NO_HEAP_EFFECT_INFO`.

The compensation is skipped for exceptions a raise lowering already chained. Those lowerings emit `exc.w_context = ec.sys_exc_value` on the still-virtual exception, so the store folds away with it when the handler never looks at the object — passing the same exception to a call materializes it instead. `FBW_BUILT_EXC` cannot gate this (`RaiseVarargs` consumes it before the handler is reached), so a separate read-only `FBW_CONTEXT_CHAINED` records it at each of the three `w_exception_context_descr` store sites.

Separately, `handle_exception_with_context` stood in for `error.py record_context`'s `_context_recorded` latch with a traceback-null proxy; the latch itself is now carried as `PyError::context_recorded`.

## Verification

Measured on the current base (`21ce53083b1`), darwin arm64.

| | before | after |
|---|---|---|
| `__context__` lost, 22 shapes (incl. a context-cycle break) | 18959/20000 | **0/20000** |
| no active exception ⇒ stays `None` | — | **0 wrong /20000** |
| `loops_compiled` on the witness | 3 | 3 |
| new fixture `builtin_raise_context_same_frame` | AssertionError | **OK** |
| existing `builtin_raise_context_specialization` | OK | OK |

Perf gates, against an in-place `origin/main` control arm:

| bench | main | this branch | gate |
|---|---|---|---|
| `raise_catch` dynasm | 1.3x | **1.1x** | 1.5x |
| `raise_catch` cranelift | 2.4x | **2.0x** | 2.5x |
| `raise_bare_class_slot_kinds` dynasm | — | **6.5x** (47.0x before the `FBW_CONTEXT_CHAINED` gate covered the bare-class site) | 25x |
| `raise_bare_class_slot_kinds` cranelift | — | **7.3x** (55.7x before) | 25x |

`PYRE_TRACE_OPS_DIAG=1` on `raise_bare_class_slot_kinds`: `CallMallocNursery` / `CallR` / `CondCallGcWb` counts are 0/0/0 — the exception stays fully virtual.

`pyre/check.py` on the current base: **dynasm 438/438, cranelift 438/438**. wasm reports one, not from this change:

- `list_append_write_barrier_gc` jit-stats (`bridges_compiled` 4 → 5). The fixture is **bimodal on an unchanged binary** — five runs of one build gave 5, 4, 4, 5, 4 — and it contains no `try`, `except` or `raise` at all, so no in-trace catch site exists for this change to emit at. A `PYRE_TRACE_OPS_DIAG` dump of its traces confirms the resolver call is absent.

## Known gap, deliberately not widened

The immutable-type `STORE_ATTR`/`DELETE_ATTR` TypeError fold builds its exception inline without chaining it, so the compensation correctly fires there and forces that one allocation. Chaining it in IR too would make "inline-built ⇒ chained in IR, never compensated" a total invariant; no gate demands it, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014CJHzazMwwym2dNT4h36VQ


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exception chaining so `__context__` is preserved reliably when errors are raised and handled in the same frame.
  * Preserved exception context across inlined calls, compiled builtin errors, and trace execution.
  * Prevented duplicate context updates during exception handling.

* **Tests**
  * Added coverage for subscript, division, and attribute errors to verify consistent exception context behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->