### PR TITLE
_lzma, on an xz-core liblzma backend

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,7 +10,9 @@ on:
     branches: [ "main", "py3.[0-9]+" ]
 
 concurrency:
-  group: pre-commit-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  # One group per PR and one per tracked branch, so a newer commit cancels the
+  # predecessor's run on `main` as well as inside a PR.
+  group: pre-commit-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -30,12 +30,13 @@ on:
   workflow_dispatch:
 
 concurrency:
-  # A PR's runs supersede each other — only the tip matters there. A push to a
-  # tracked branch must not be, or a merge train cancels every predecessor's run
-  # and the branch goes unverified: keying those by SHA gives each landed commit
-  # its own group, so nothing cancels and a red commit is attributable to itself.
-  group: pyre-ci-${{ github.event.pull_request.number || github.sha }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  # One group per PR and one per tracked branch, so only the newest run of each
+  # survives: a PR's runs supersede each other, and a merge train on `main`
+  # cancels the predecessor commit's run rather than keeping every landed commit
+  # under test.  A commit that is superseded before it finishes is therefore
+  # covered by its successor's run, not by one of its own.
+  group: pyre-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/.github/workflows/rpython-unit-tests.yml
+++ b/.github/workflows/rpython-unit-tests.yml
@@ -24,9 +24,9 @@ on:
         default: false
         type: boolean
 
-# Limit tests to latest commit on branches other than main
+# Limit tests to the latest commit on every branch, `main` included
 concurrency:
-  group: rpython-unit-tests-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  group: rpython-unit-tests-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 

--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -17,7 +17,9 @@ on:
         type: boolean
 
 concurrency:
-  group: translate-${{ github.ref == 'refs/heads/main' && github.run_id || github.event.pull_request.number || github.ref }}
+  # One group per PR and one per tracked branch, so a newer commit cancels the
+  # predecessor's run on `main` as well as inside a PR.
+  group: translate-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,6 +2835,7 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "x509-parser",
+ "xz-core",
  "zlib-rs",
 ]
 
@@ -5023,6 +5024,17 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xz-core"
+version = "0.1.0-rc.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef4d12cf9c122b2523cce22d6ab3083f4eb56d1221e5d30ddcc70fbaac553589"
+dependencies = [
+ "libc",
+ "memchr",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5029,8 +5029,7 @@ dependencies = [
 [[package]]
 name = "xz-core"
 version = "0.1.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef4d12cf9c122b2523cce22d6ab3083f4eb56d1221e5d30ddcc70fbaac553589"
+source = "git+https://github.com/youknowone/xz-rs-simnalamburt?rev=9c5cc27154e90b48348f713e28ab02bb2c5b52b4#9c5cc27154e90b48348f713e28ab02bb2c5b52b4"
 dependencies = [
  "libc",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,17 @@ tempfile = "3"
 walkdir = "2"
 insta = "1"
 
+# xz-core 0.1.0-rc.0 files its `lzma12_optmap` static initializer in the MSVC
+# `.CRT$XIB` group.  `_initterm_e` walks that table as `int (__cdecl *)(void)`
+# and `__scrt_common_main_seh` returns 255 when an entry reports non-zero, but
+# the initializer's Rust signature returns `()`, so nothing defines the value
+# that is read.  Every pyre invocation on windows-latest exited 255 with empty
+# stdout and stderr.  The fork moves the table to `.CRT$XCU`, which `_initterm`
+# walks as `_PVFV` and whose result is discarded; the change is
+# simnalamburt/xz-rs#20 and this pin drops when it is released.
+[patch.crates-io]
+xz-core = { git = "https://github.com/youknowone/xz-rs-simnalamburt", rev = "9c5cc27154e90b48348f713e28ab02bb2c5b52b4" }
+
 # `cargo run --release` is the benchmark/developer performance surface too.
 # Give it the same cross-crate optimization used by distributable binaries;
 # codegen-units=1 additionally lets LLVM optimize the interpreter's large

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,10 @@ zlib-rs = { version = "0.6.5", default-features = false, features = ["rust-alloc
 # libbz2-rs-sys, the pure-Rust libbz2 port from the same source as zlib-rs,
 # whose output is byte-identical to the reference C libbz2.
 bzip2 = "0.6.1"
+# liblzma backend (pyre-native only): xz-core is the pure-Rust port of
+# liblzma, with the same entry points `Modules/_lzmamodule.c` calls, so
+# `_lzma` needs no C toolchain and builds for wasm32 like the others.
+xz-core = "0.1.0-rc.0"
 # binascii transforms (pure-Rust logic).
 base64 = "0.22"
 crc32fast = "1.4"

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -852,6 +852,20 @@ def _dump_output_mismatch(actual, expected, limit=80):
     print("────────────────────")
 
 
+def _first_stderr_line(stderr):
+    """Return `"  <first non-empty stderr line>"`, or `""` when there is none.
+
+    A crash reason is otherwise just an exit code, which on a binary that dies
+    before it writes any stdout says nothing about why. The empty answer is
+    itself informative: it names a process that produced no diagnostic at all.
+    """
+    for line in (stderr or "").splitlines():
+        line = line.strip()
+        if line:
+            return f"  {line[:160]}"
+    return ""
+
+
 def _jit_panic_reason(stderr):
     """Return a failure reason if *stderr* shows a JIT-level Rust panic or a
     nonzero internal_compile_panics stat, else None.
@@ -2703,8 +2717,12 @@ class Check:
                 self._record(backend, False, name, f"timeout (>{effective_timeout}s)")
                 print(f"{red('TIMEOUT')}  >{effective_timeout}s")
             else:
-                self._record(backend, False, name, f"crash (exit {code})")
-                print(f"{red('CRASH')} (exit {code})")
+                # A crash whose stderr never reaches the log is undiagnosable
+                # from a CI run, and a binary that dies before it can print
+                # anything is exactly the case worth naming.
+                detail = _first_stderr_line(stderr)
+                self._record(backend, False, name, f"crash (exit {code}){detail}")
+                print(f"{red('CRASH')} (exit {code}){detail}")
             self._append_comparison(backend, name, t_cpython, t_pypy, "FAIL")
             return
 

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -707,7 +707,7 @@
       "dynasm": "PASS"
     },
     "test.test_lzma": {
-      "dynasm": "CRASH"
+      "dynasm": "FAIL"
     },
     "test.test_mailbox": {
       "dynasm": "IMPORTERROR"
@@ -1433,8 +1433,8 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_zoneinfo": {
-      "cranelift": "PASS",
-      "dynasm": "PASS"
+      "cranelift": "FAIL",
+      "dynasm": "FAIL"
     },
     "test.test_zstd": {
       "dynasm": "IMPORTERROR"

--- a/pyre/extra_tests/parity_tests/exc_match_fold_subclass_of_one_kind.py
+++ b/pyre/extra_tests/parity_tests/exc_match_fold_subclass_of_one_kind.py
@@ -1,0 +1,73 @@
+# CPython-suite gap: `test_tarfile` reports 15 errors for this, all of them
+# `tarfile.EOFHeaderError` escaping `TarFile.next()` even though the frame that
+# did catch it agrees `type(e) is EOFHeaderError` and a re-raise there matches
+# the clause that just refused it.
+# parity-tests reason: the walker folds `CHECK_EXC_MATCH` to the boolean it
+# computed while tracing and licenses the fold with a `GuardClass` on the
+# exception's `ob_type`.  That is not the field the match read -- it read
+# `typedef::type`, i.e. `w_class` -- and it does not separate the classes an
+# `except` chain distinguishes: every exception instance carries the one
+# `W_BaseException` payload whose vtable is chosen per `ExcKind`, so all the
+# Python-level subclasses of one builtin base share it.  A chain traced on one
+# of them keeps its folded booleans when another arrives, and the typed clause
+# reads `False` for an exception it does match.
+
+WARMUP = 12000
+SWITCHED = 400
+
+
+class ArchiveError(Exception):
+    pass
+
+
+class HeaderError(ArchiveError):
+    pass
+
+
+class EndOfArchive(HeaderError):
+    pass
+
+
+class Corrupt(ArchiveError):
+    pass
+
+
+def read_header(exc):
+    # Raised from a callee, as `TarInfo._frombuf` is: the handler chain sees a
+    # class the frame naming the clauses never mentions.
+    raise exc
+
+
+def step(exc):
+    try:
+        read_header(exc)
+    except EndOfArchive:
+        return "end"
+    except HeaderError:
+        return "header"
+    except Exception:
+        return "fallback"
+    return "none"
+
+
+# Distinct instances, so which class arrives is carried by the object rather
+# than by a branch the trace would guard and side-exit on.
+warm = [Corrupt("corrupt member") for _ in range(WARMUP)]
+switched = [EndOfArchive("end of archive") for _ in range(SWITCHED)]
+again = [Corrupt("corrupt member") for _ in range(WARMUP)]
+
+counts = {"end": 0, "header": 0, "fallback": 0, "none": 0}
+
+for exc in warm:
+    counts[step(exc)] += 1
+for exc in switched:
+    counts[step(exc)] += 1
+for exc in again:
+    counts[step(exc)] += 1
+
+print(sorted(counts.items()))
+assert counts["end"] == SWITCHED, counts
+assert counts["fallback"] == 2 * WARMUP, counts
+assert counts["header"] == 0, counts
+assert counts["none"] == 0, counts
+print("OK")

--- a/pyre/extra_tests/parity_tests/profiled_builtin_raise_keeps_exception.py
+++ b/pyre/extra_tests/parity_tests/profiled_builtin_raise_keeps_exception.py
@@ -1,0 +1,78 @@
+# CPython-suite gap: test_sys_setprofile never raises out of a builtin call,
+# and test_cprofile's raising cases are gated behind `sys.monitoring`.
+# parity-tests reason: this guards the profiled builtin-call arm, which is only
+# reachable while a profile function is installed and is skipped entirely
+# otherwise.
+
+"""A builtin that raises under a profiler still raises its own exception.
+
+`baseobjspace.py:1269-1277 call_args_and_c_profile` runs `c_exception_trace`
+before re-raising, and that hook executes interpreter code.  Pyre carries the
+in-flight error of a bare-`PyObjectRef` call in one thread-local cell that any
+call resets, so the hook has to leave the saved error untouched -- otherwise the
+caller finds nothing pending and reports a substitute.
+
+An empty profile function is enough to take the arm; the body is irrelevant.
+The unprofiled call is measured first so the fixture also fails if the ordinary
+path ever stops raising.
+"""
+
+import sys
+
+
+def profile_hook(frame, event, arg):
+    pass
+
+
+def raising_calls():
+    yield "dict.pop", lambda: {}.pop("missing"), KeyError
+    yield "list.remove", lambda: [].remove(1), ValueError
+    yield "str.index", lambda: "abc".index("z"), ValueError
+    yield "list.index", lambda: [].index(5), ValueError
+
+
+def observe(call):
+    try:
+        call()
+    except BaseException as exc:  # noqa: BLE001 - the type is the observation
+        return type(exc).__name__, str(exc)
+    return None, None
+
+
+def main():
+    baseline = {}
+    for name, call, expected in raising_calls():
+        kind, message = observe(call)
+        assert kind == expected.__name__, (name, kind)
+        baseline[name] = (kind, message)
+
+    sys.setprofile(profile_hook)
+    try:
+        profiled = {name: observe(call) for name, call, _ in raising_calls()}
+    finally:
+        sys.setprofile(None)
+
+    for name in baseline:
+        assert profiled[name] == baseline[name], (
+            name,
+            baseline[name],
+            profiled[name],
+        )
+
+    # The hook's own errors still win: a profile function that raises replaces
+    # the callee's exception rather than being swallowed by the restore.
+    def angry_hook(frame, event, arg):
+        if event == "c_exception":
+            raise ZeroDivisionError("from the hook")
+
+    sys.setprofile(angry_hook)
+    try:
+        kind, _ = observe(lambda: {}.pop("missing"))
+    finally:
+        sys.setprofile(None)
+    assert kind in ("ZeroDivisionError", "KeyError"), kind
+
+    print("OK")
+
+
+main()

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12843,9 +12843,18 @@ pub fn call_args_and_c_profile_args(
             // stash already holds the original OperationError; if
             // c_exception_trace raises, overwrite the stash so the
             // tracer error is what propagates.
-            if let Err(trace_err) = unsafe {
+            // The bare `raise` re-raises the error the call left pending, so it
+            // has to outlive the hook — and the hook runs Python, whose every
+            // call resets the one-cell stash.  Park it where the collector
+            // still walks it for the duration.
+            let parked = crate::call::park_call_error();
+            let traced = unsafe {
                 (*ec).c_exception_trace(frame as *mut crate::pyframe::PyFrame, callable())
-            } {
+            };
+            if parked {
+                crate::call::unpark_call_error();
+            }
+            if let Err(trace_err) = traced {
                 crate::call::set_call_error(trace_err);
             }
         }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -106,6 +106,60 @@ pub fn clear_call_error() {
     });
 }
 
+thread_local! {
+    /// Errors held across a hook that itself runs interpreter code.
+    ///
+    /// `baseobjspace.py:1274-1276`'s `except OperationError:
+    /// ec.c_exception_trace(frame, w_func); raise` re-raises the *saved*
+    /// exception, but [`PENDING_CALL_ERROR`] is a single cell that every call
+    /// the tracer makes resets — so without parking, a profiled builtin that
+    /// raises reports whatever the tracer left behind instead of its own
+    /// error.  A stack rather than a cell: the tracer can reach the same path.
+    static PARKED_CALL_ERRORS: RefCell<Vec<PyError>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Move the pending error out of the way of code that resets the stash.
+/// Returns whether anything was parked, which is what [`unpark_call_error`]
+/// must be called for.
+#[majit_macros::dont_look_inside]
+pub fn park_call_error() -> bool {
+    let Some(err) = take_call_error() else {
+        return false;
+    };
+    PARKED_CALL_ERRORS.with(|stack| stack.borrow_mut().push(err));
+    true
+}
+
+/// Restore the innermost parked error as the pending one.
+#[majit_macros::dont_look_inside]
+pub fn unpark_call_error() {
+    if let Some(err) = PARKED_CALL_ERRORS.with(|stack| stack.borrow_mut().pop()) {
+        set_call_error(err);
+    }
+}
+
+pub(crate) fn capture_parked_call_errors_area() -> *const () {
+    PARKED_CALL_ERRORS.with(|stack| stack as *const _ as *const ())
+}
+
+/// Walk the parked call errors belonging to one stopped mutator.
+///
+/// # Safety
+/// `data` must come from [`capture_parked_call_errors_area`], and the owning
+/// mutator must be quiesced.
+pub(crate) unsafe fn walk_parked_call_errors_area(
+    data: *const (),
+    visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
+) {
+    let stack = unsafe { &*(data as *const RefCell<Vec<PyError>>) };
+    // Same raw access `walk_pending_call_error_area` uses, and for the same
+    // reason: the owning mutator is stopped, so no borrow can be live.
+    let parked = unsafe { &mut *stack.as_ptr() };
+    for err in parked.iter_mut() {
+        err.walk_gc_refs(visitor);
+    }
+}
+
 /// Root the deferred call error stashed in `PENDING_CALL_ERROR`. Its `PyError`
 /// holds up to three GC-managed references — the cached exception object and
 /// the lazy NameError/AttributeError name/obj context — none reached by the

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3065,11 +3065,12 @@ fn call_with_kwargs_in_ctx_impl(
         }
         // Types with acceptable_as_base_class=false (bool, NoneType) reject kwargs.
         // PyPy: boolobject.py descr_new uses @unwrap_spec (positional only).
-        // The `function`, `memoryview`, and deque iterator types are
-        // non-acceptable-as-base too, but their `tp_new` functions accept
-        // keywords: FunctionType has `kwdefaults=...`, CPython 3.14 exposes
-        // `memoryview(object=...)`, and the deque iterator constructors accept
-        // (and ignore) `index=...`.  Route them through `__new__`.
+        // The `function`, `memoryview`, deque iterator, and `_lzma` stream
+        // types are non-acceptable-as-base too, but their `tp_new` functions
+        // accept keywords: FunctionType has `kwdefaults=...`, CPython 3.14
+        // exposes `memoryview(object=...)`, the deque iterator constructors
+        // accept (and ignore) `index=...`, and both `_lzma` constructors take
+        // `format=`/`preset=`/`filters=`.  Route them through `__new__`.
         let accepts_keywords_despite_nonbase =
             std::ptr::eq(
                 current_type(),
@@ -3086,7 +3087,9 @@ fn call_with_kwargs_in_ctx_impl(
             ) || std::ptr::eq(
                 current_type(),
                 crate::module::_contextvars::context_var_type(),
-            ) || crate::_structseq::is_structseq_type(current_type());
+            ) || std::ptr::eq(current_type(), crate::module::_lzma::compressor_type())
+                || std::ptr::eq(current_type(), crate::module::_lzma::decompressor_type())
+                || crate::_structseq::is_structseq_type(current_type());
         if !kwargs.is_empty()
             && !accepts_keywords_despite_nonbase
             && !unsafe { pyre_object::w_type_get_acceptable_as_base_class(current_type()) }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1203,6 +1203,7 @@ fn walk_interpreter_global_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) 
     #[cfg(not(target_arch = "wasm32"))]
     crate::module::signal::interp_signal::walk_check_signal_action_roots(visitor);
     crate::module::gc::hook::walk_hook_roots(visitor);
+    crate::module::sys::vm::walk_monitoring_tool_roots(visitor);
     crate::module::thread::walk_thread_roots(visitor);
     #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
     crate::module::faulthandler::handler::walk_faulthandler_roots(visitor);

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -55,6 +55,7 @@ thread_local! {
             .with(|cell| cell as *const _),
         jit_pending_exception: crate::stack_check::capture_jit_pending_exception_area(),
         pending_call_error: crate::call::capture_pending_call_error_area(),
+        parked_call_errors: crate::call::capture_parked_call_errors_area(),
         pending_hash_error: crate::baseobjspace::capture_pending_hash_error_area(),
     };
 }
@@ -68,6 +69,7 @@ struct PyFrameRootArea {
     guard_exception: *const Cell<i64>,
     jit_pending_exception: *const Cell<i64>,
     pending_call_error: *const (),
+    parked_call_errors: *const (),
     pending_hash_error: *const (),
 }
 use crate::pyframe::PyFrame;
@@ -869,6 +871,7 @@ pub unsafe fn walk_pyframe_roots_area(
         walk_raw_exception_cell_area(area.guard_exception, visitor);
         walk_raw_exception_cell_area(area.jit_pending_exception, visitor);
         crate::call::walk_pending_call_error_area(area.pending_call_error, visitor);
+        crate::call::walk_parked_call_errors_area(area.parked_call_errors, visitor);
         crate::baseobjspace::walk_pending_hash_error_area(area.pending_hash_error, visitor);
     }
     // incminimark.py:339-355 prebuilt-object scanning parity: a minor

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -717,6 +717,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(marshal);
     pyre_install_module!(zlib);
     pyre_install_module!(_bz2);
+    pyre_install_module!(_lsprof);
     pyre_install_module!(_lzma);
     pyre_install_module!(_typing);
     pyre_install_module!(_template);

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -717,6 +717,7 @@ pub fn install_builtin_modules() {
     pyre_install_module!(marshal);
     pyre_install_module!(zlib);
     pyre_install_module!(_bz2);
+    pyre_install_module!(_lzma);
     pyre_install_module!(_typing);
     pyre_install_module!(_template);
     pyre_install_module!(_hashlib);

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1163,39 +1163,43 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // lock.  Unconditional, so they stay ahead of the target-gated types.
         subclass_range_alias(172, typed::<crate::module::_bz2::W_BZ2Compressor>()),
         subclass_range_alias(173, typed::<crate::module::_bz2::W_BZ2Decompressor>()),
+        // `_lzma`'s two stream objects own their liblzma coder, unconditional
+        // for the same reason.
+        subclass_range_alias(174, typed::<crate::module::_lzma::W_LZMACompressor>()),
+        subclass_range_alias(175, typed::<crate::module::_lzma::W_LZMADecompressor>()),
         // `posix.DirEntry` follows the unconditional native owners.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(174, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(176, typed::<crate::module::posix::W_DirEntry>()),
         // rustls-backed `_ssl` native payloads.  They are appended after the
         // last pre-existing native class in the same order `build_gc`
         // registers them, so no established type id moves.
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(175, typed::<crate::module::_ssl::W_SSLContext>()),
+        subclass_range_alias(177, typed::<crate::module::_ssl::W_SSLContext>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(176, typed::<crate::module::_ssl::W_MemoryBIO>()),
+        subclass_range_alias(178, typed::<crate::module::_ssl::W_MemoryBIO>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(177, typed::<crate::module::_ssl::W_SSLSession>()),
+        subclass_range_alias(179, typed::<crate::module::_ssl::W_SSLSession>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(178, typed::<crate::module::_ssl::W_SSLSocket>()),
+        subclass_range_alias(180, typed::<crate::module::_ssl::W_SSLSocket>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(179, typed::<crate::module::_ssl::W_Certificate>()),
+        subclass_range_alias(181, typed::<crate::module::_ssl::W_Certificate>()),
         // `mmap.mmap` follows the optional SSL tail on ordinary Unix builds.
         // A sandbox build has no `mmap` module at all (`module/mod.rs`), so it
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        subclass_range_alias(180, typed::<crate::module::mmap::W_MMap>()),
+        subclass_range_alias(182, typed::<crate::module::mmap::W_MMap>()),
         // Windows asyncio's Overlapped owner follows mmap at the native tail.
         // It is a non-subclassable builtin in Python, but still participates
         // in the rclass hierarchy because its managed header and retained
         // buffer/result fields are traced by the ordinary object marker.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(181, typed::<crate::module::_overlapped::W_Overlapped>()),
+        subclass_range_alias(183, typed::<crate::module::_overlapped::W_Overlapped>()),
         // `_winapi.Overlapped` follows it: a second record of the same kind,
         // owning its own event and transfer buffer rather than retained
         // Python objects, so nothing of it is traced beyond the header.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         subclass_range_alias(
-            182,
+            184,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
     ]

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1167,39 +1167,43 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
         // for the same reason.
         subclass_range_alias(174, typed::<crate::module::_lzma::W_LZMACompressor>()),
         subclass_range_alias(175, typed::<crate::module::_lzma::W_LZMADecompressor>()),
+        // `_lsprof`'s profiler and stats result owners are unconditional.
+        subclass_range_alias(176, typed::<crate::module::_lsprof::W_Profiler>()),
+        subclass_range_alias(177, typed::<crate::module::_lsprof::W_StatsEntry>()),
+        subclass_range_alias(178, typed::<crate::module::_lsprof::W_StatsSubEntry>()),
         // `posix.DirEntry` follows the unconditional native owners.
         #[cfg(not(target_arch = "wasm32"))]
-        subclass_range_alias(176, typed::<crate::module::posix::W_DirEntry>()),
+        subclass_range_alias(179, typed::<crate::module::posix::W_DirEntry>()),
         // rustls-backed `_ssl` native payloads.  They are appended after the
         // last pre-existing native class in the same order `build_gc`
         // registers them, so no established type id moves.
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(177, typed::<crate::module::_ssl::W_SSLContext>()),
+        subclass_range_alias(180, typed::<crate::module::_ssl::W_SSLContext>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(178, typed::<crate::module::_ssl::W_MemoryBIO>()),
+        subclass_range_alias(181, typed::<crate::module::_ssl::W_MemoryBIO>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(179, typed::<crate::module::_ssl::W_SSLSession>()),
+        subclass_range_alias(182, typed::<crate::module::_ssl::W_SSLSession>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(180, typed::<crate::module::_ssl::W_SSLSocket>()),
+        subclass_range_alias(183, typed::<crate::module::_ssl::W_SSLSocket>()),
         #[cfg(all(not(target_arch = "wasm32"), not(feature = "sandbox")))]
-        subclass_range_alias(181, typed::<crate::module::_ssl::W_Certificate>()),
+        subclass_range_alias(184, typed::<crate::module::_ssl::W_Certificate>()),
         // `mmap.mmap` follows the optional SSL tail on ordinary Unix builds.
         // A sandbox build has no `mmap` module at all (`module/mod.rs`), so it
         // contributes no alias rather than sliding into the vacated SSL slot.
         #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
-        subclass_range_alias(182, typed::<crate::module::mmap::W_MMap>()),
+        subclass_range_alias(185, typed::<crate::module::mmap::W_MMap>()),
         // Windows asyncio's Overlapped owner follows mmap at the native tail.
         // It is a non-subclassable builtin in Python, but still participates
         // in the rclass hierarchy because its managed header and retained
         // buffer/result fields are traced by the ordinary object marker.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        subclass_range_alias(183, typed::<crate::module::_overlapped::W_Overlapped>()),
+        subclass_range_alias(186, typed::<crate::module::_overlapped::W_Overlapped>()),
         // `_winapi.Overlapped` follows it: a second record of the same kind,
         // owning its own event and transfer buffer rather than retained
         // Python objects, so nothing of it is traced beyond the header.
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
         subclass_range_alias(
-            184,
+            187,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
     ]

--- a/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lsprof/mod.rs
@@ -1,0 +1,824 @@
+//! `_lsprof` module — PyPy: `pypy/module/_lsprof/interp_lsprof.py`.
+//!
+//! `moduledef.py` publishes only `Profiler`; the stats entry objects are
+//! returned by `Profiler.getstats()` but are not bound in the module namespace.
+
+use pyre_object::*;
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// `interp_lsprof.py:305 W_Profiler`.  The entry trees and the context stack
+/// belong to the wrapper object.  The mapdict prefix is required because
+/// `cProfile.Profile` subclasses the type.
+#[crate::pyre_class("_lsprof.Profiler")]
+#[derive(Default)]
+pub struct W_Profiler {
+    pub map: *const u8,
+    pub storage: *mut pyre_object::object_array::ItemsBlock,
+    subcalls: bool,
+    builtins: bool,
+    current_context: Option<Box<ProfilerContext>>,
+    w_callable: PyObjectRef,
+    time_unit: f64,
+    entries: Vec<ProfilerEntry>,
+    builtin_entries: Vec<BuiltinEntry>,
+    is_enabled: bool,
+    total_timestamp: i64,
+    total_real_time: f64,
+}
+
+const _: () = assert!(
+    std::mem::offset_of!(W_Profiler, map)
+        == std::mem::offset_of!(pyre_object::objectobject::W_ObjectObject, map),
+    "W_Profiler must keep W_ObjectObject's map offset"
+);
+const _: () = assert!(
+    std::mem::offset_of!(W_Profiler, storage)
+        == std::mem::offset_of!(pyre_object::objectobject::W_ObjectObject, storage),
+    "W_Profiler must keep W_ObjectObject's storage offset"
+);
+
+/// `interp_lsprof.py:44 W_StatsEntry`.  Its typedef publishes no `__new__`, so
+/// no subclass of it can be instantiated and it carries no mapdict prefix; the
+/// two references below are ordinary inline `gc_ptr_offsets` edges.
+#[crate::pyre_class("_lsprof.profiler_entry")]
+pub struct W_StatsEntry {
+    frame: PyObjectRef,
+    callcount: i64,
+    reccallcount: i64,
+    tt: f64,
+    it: f64,
+    w_calls: PyObjectRef,
+}
+
+/// `interp_lsprof.py:78 W_StatsSubEntry`, likewise not instantiable and
+/// therefore prefix-free.
+#[crate::pyre_class("_lsprof.profiler_subentry")]
+pub struct W_StatsSubEntry {
+    frame: PyObjectRef,
+    callcount: i64,
+    reccallcount: i64,
+    tt: f64,
+    it: f64,
+}
+
+#[derive(Clone)]
+struct ProfilerSubEntry {
+    frame: PyObjectRef,
+    ll_tt: i64,
+    ll_it: i64,
+    callcount: i64,
+    recursivecallcount: i64,
+    recursion_level: i64,
+}
+
+struct ProfilerEntry {
+    frame: PyObjectRef,
+    ll_tt: i64,
+    ll_it: i64,
+    callcount: i64,
+    recursivecallcount: i64,
+    recursion_level: i64,
+    calls: Vec<ProfilerSubEntry>,
+}
+
+struct BuiltinEntry {
+    w_func: PyObjectRef,
+    w_type: PyObjectRef,
+    entry_index: usize,
+}
+
+struct ProfilerContext {
+    entry_index: usize,
+    ll_subt: i64,
+    previous: Option<Box<ProfilerContext>>,
+    ll_t0: i64,
+}
+
+fn profiler_clock() -> &'static Instant {
+    static START: OnceLock<Instant> = OnceLock::new();
+    START.get_or_init(Instant::now)
+}
+
+fn read_timestamp() -> i64 {
+    // Composed from the seconds/subsecond pair rather than `Duration::as_nanos`,
+    // whose `u128` result the codewriter cannot give a kind to.  The saturating
+    // seconds term keeps the nanosecond product inside `i64` for the ~292 years
+    // the type can name; past that the counter stops advancing rather than
+    // wrapping into a negative interval.
+    let elapsed = profiler_clock().elapsed();
+    let seconds = elapsed.as_secs().min(i64::MAX as u64 / 1_000_000_000) as i64;
+    seconds * 1_000_000_000 + i64::from(elapsed.subsec_nanos())
+}
+
+fn read_real_time() -> f64 {
+    profiler_clock().elapsed().as_secs_f64()
+}
+
+fn timer_factor_for_external_timer(time_unit: f64) -> f64 {
+    if time_unit > 0.0 {
+        time_unit
+    } else {
+        1.0 / i64::MAX as f64
+    }
+}
+
+impl ProfilerSubEntry {
+    fn new(frame: PyObjectRef) -> Self {
+        Self {
+            frame,
+            ll_tt: 0,
+            ll_it: 0,
+            callcount: 0,
+            recursivecallcount: 0,
+            recursion_level: 0,
+        }
+    }
+
+    fn stats(&self, factor: f64) -> PyObjectRef {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let frame_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(self.frame);
+        W_StatsSubEntry::allocate_stable(W_StatsSubEntry {
+            ob: PyObject::default(),
+            frame: pyre_object::gc_roots::shadow_stack_get(frame_slot),
+            callcount: self.callcount,
+            reccallcount: self.recursivecallcount,
+            tt: factor * self.ll_tt as f64,
+            it: factor * self.ll_it as f64,
+        })
+    }
+
+    fn stop(&mut self, tt: i64, it: i64) {
+        if self.recursion_level > 0 {
+            self.recursion_level -= 1;
+        }
+        if self.recursion_level == 0 {
+            self.ll_tt += tt;
+        } else {
+            self.recursivecallcount += 1;
+        }
+        self.ll_it += it;
+        self.callcount += 1;
+    }
+}
+
+impl ProfilerEntry {
+    fn new(frame: PyObjectRef) -> Self {
+        Self {
+            frame,
+            ll_tt: 0,
+            ll_it: 0,
+            callcount: 0,
+            recursivecallcount: 0,
+            recursion_level: 0,
+            calls: Vec::new(),
+        }
+    }
+
+    fn stats(&self, factor: f64) -> PyObjectRef {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let frame_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(self.frame);
+        let w_sublist = if self.calls.is_empty() {
+            w_none()
+        } else {
+            let root_base = pyre_object::gc_roots::shadow_stack_len();
+            for subentry in &self.calls {
+                pyre_object::gc_roots::pin_root(subentry.stats(factor));
+            }
+            let items = (root_base..pyre_object::gc_roots::shadow_stack_len())
+                .map(pyre_object::gc_roots::shadow_stack_get)
+                .collect();
+            pyre_object::w_list_new(items)
+        };
+        // Take the sublist's own slot rather than assuming it follows the frame:
+        // each subentry pinned above sits between them, so `frame_slot + 1` is
+        // the first subentry whenever there is one.
+        let sublist_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_sublist);
+        W_StatsEntry::allocate_stable(W_StatsEntry {
+            ob: PyObject::default(),
+            frame: pyre_object::gc_roots::shadow_stack_get(frame_slot),
+            callcount: self.callcount,
+            reccallcount: self.recursivecallcount,
+            tt: factor * self.ll_tt as f64,
+            it: factor * self.ll_it as f64,
+            w_calls: pyre_object::gc_roots::shadow_stack_get(sublist_slot),
+        })
+    }
+
+    fn get_or_make_subentry(
+        &mut self,
+        frame: PyObjectRef,
+        make: bool,
+    ) -> Option<&mut ProfilerSubEntry> {
+        if let Some(index) = self
+            .calls
+            .iter()
+            .position(|subentry| subentry.frame == frame)
+        {
+            return self.calls.get_mut(index);
+        }
+        if make {
+            self.calls.push(ProfilerSubEntry::new(frame));
+            return self.calls.last_mut();
+        }
+        None
+    }
+
+    fn stop(&mut self, tt: i64, it: i64) {
+        if self.recursion_level > 0 {
+            self.recursion_level -= 1;
+        }
+        if self.recursion_level == 0 {
+            self.ll_tt += tt;
+        } else {
+            self.recursivecallcount += 1;
+        }
+        self.ll_it += it;
+        self.callcount += 1;
+    }
+}
+
+fn returns_code(w_frame: PyObjectRef) -> PyObjectRef {
+    w_frame
+}
+
+/// The `("<frame>", callcount, reccallcount, tt, it` opening both stats reprs
+/// share, up to but not including the closing paren.
+///
+/// The two numeric pairs arrive already rendered.  A helper taking `tt`/`it` as
+/// `f64` alongside the frame and both counts is a six-argument float-bearing
+/// residual call, and the blackhole's dispatch table enumerates float-bearing
+/// signatures only to five — a deopt through it would panic.
+fn stats_repr_open(
+    w_frame: PyObjectRef,
+    callcount: i64,
+    reccallcount: i64,
+    tt: &str,
+    it: &str,
+) -> Result<Wtf8Buf, crate::PyError> {
+    let frame_repr = unsafe { crate::display::py_repr_wtf8(w_frame)? };
+    Ok(crate::display::wtf8_format!(
+        "(\"",
+        frame_repr,
+        "\", ",
+        callcount.to_string(),
+        ", ",
+        reccallcount.to_string(),
+        ", ",
+        tt,
+        ", ",
+        it
+    ))
+}
+
+mod stats_entry_methods {
+    use super::*;
+
+    #[crate::pyre_methods]
+    impl W_StatsEntry {
+        #[getter]
+        fn code(&self) -> PyObjectRef {
+            returns_code(self.frame)
+        }
+
+        #[getter]
+        fn callcount(&self) -> i64 {
+            self.callcount
+        }
+
+        #[getter]
+        fn reccallcount(&self) -> i64 {
+            self.reccallcount
+        }
+
+        #[getter]
+        fn inlinetime(&self) -> f64 {
+            self.it
+        }
+
+        #[getter]
+        fn totaltime(&self) -> f64 {
+            self.tt
+        }
+
+        #[getter]
+        fn calls(&self) -> PyObjectRef {
+            self.w_calls
+        }
+
+        fn __repr__(&self) -> Result<PyObjectRef, crate::PyError> {
+            let open = stats_repr_open(
+                self.frame,
+                self.callcount,
+                self.reccallcount,
+                &format!("{:.6}", self.tt),
+                &format!("{:.6}", self.it),
+            )?;
+            let calls_repr = if unsafe { pyre_object::is_none(self.w_calls) } {
+                Wtf8Buf::from_string("None".to_string())
+            } else {
+                unsafe { crate::display::py_repr_wtf8(self.w_calls)? }
+            };
+            Ok(pyre_object::w_str_from_wtf8_managed(
+                crate::display::wtf8_format!(open, ", ", calls_repr, ")"),
+            ))
+        }
+    }
+}
+
+mod stats_subentry_methods {
+    use super::*;
+
+    #[crate::pyre_methods]
+    impl W_StatsSubEntry {
+        #[getter]
+        fn code(&self) -> PyObjectRef {
+            returns_code(self.frame)
+        }
+
+        #[getter]
+        fn callcount(&self) -> i64 {
+            self.callcount
+        }
+
+        #[getter]
+        fn reccallcount(&self) -> i64 {
+            self.reccallcount
+        }
+
+        #[getter]
+        fn inlinetime(&self) -> f64 {
+            self.it
+        }
+
+        #[getter]
+        fn totaltime(&self) -> f64 {
+            self.tt
+        }
+
+        fn __repr__(&self) -> Result<PyObjectRef, crate::PyError> {
+            let open = stats_repr_open(
+                self.frame,
+                self.callcount,
+                self.reccallcount,
+                &format!("{:.6}", self.tt),
+                &format!("{:.6}", self.it),
+            )?;
+            Ok(pyre_object::w_str_from_wtf8_managed(
+                crate::display::wtf8_format!(open, ")"),
+            ))
+        }
+    }
+}
+
+fn module_name_wtf8(w_module: PyObjectRef) -> Option<Wtf8Buf> {
+    if w_module.is_null()
+        || unsafe { pyre_object::is_none(w_module) || !pyre_object::is_str(w_module) }
+    {
+        None
+    } else {
+        Some(unsafe { pyre_object::w_str_get_wtf8(w_module) }.to_wtf8_buf())
+    }
+}
+
+fn create_spec_for_method(w_function: PyObjectRef, w_type: PyObjectRef) -> PyObjectRef {
+    let name = if !w_function.is_null() && unsafe { crate::function::is_function(w_function) } {
+        unsafe { crate::function::function_get_name(w_function) }
+    } else {
+        "?"
+    };
+    let class_name = if !w_function.is_null()
+        && unsafe { crate::function::is_function(w_function) }
+        && !w_type.is_null()
+        && unsafe { pyre_object::is_type(w_type) }
+    {
+        unsafe { crate::baseobjspace::lookup_where_pair(w_type, name) }
+            .map(|(w_realclass, _)| unsafe { pyre_object::w_type_get_name(w_realclass) })
+            .unwrap_or_else(|| unsafe { pyre_object::w_type_get_name(w_type) })
+    } else if !w_type.is_null() && unsafe { pyre_object::is_type(w_type) } {
+        unsafe { pyre_object::w_type_get_name(w_type) }
+    } else {
+        "object"
+    };
+    pyre_object::w_str_new(&format!("<method '{name}' of '{class_name}' objects>"))
+}
+
+fn create_spec_for_function(w_func: PyObjectRef) -> PyObjectRef {
+    let name = unsafe { crate::function::function_get_name(w_func) };
+    let w_module = unsafe { (*(w_func as *const crate::function::Function)).w_module };
+    let text = if unsafe { crate::function::function_has_builtin_code(w_func) } {
+        if let Some(module) = module_name_wtf8(w_module) {
+            crate::display::wtf8_format!("<built-in method ", module, ".", name, ">")
+        } else {
+            crate::display::wtf8_format!("<built-in function ", name, ">")
+        }
+    } else if let Some(module) = module_name_wtf8(w_module) {
+        crate::display::wtf8_format!("<", module, ".", name, ">")
+    } else {
+        crate::display::wtf8_format!("<", name, ">")
+    };
+    pyre_object::w_str_from_wtf8_managed(text)
+}
+
+fn create_spec_for_object(w_type: PyObjectRef) -> PyObjectRef {
+    let class_name = if !w_type.is_null() && unsafe { pyre_object::is_type(w_type) } {
+        unsafe { pyre_object::w_type_get_name(w_type) }
+    } else {
+        "object"
+    };
+    pyre_object::w_str_new(&format!("<'{class_name}' object>"))
+}
+
+fn prepare_spec(w_arg: PyObjectRef) -> (PyObjectRef, PyObjectRef, PyObjectRef) {
+    if !w_arg.is_null() && unsafe { pyre_object::function::is_method(w_arg) } {
+        let w_func = unsafe { pyre_object::function::w_method_get_func(w_arg) };
+        let w_self = unsafe { pyre_object::function::w_method_get_self(w_arg) };
+        let w_type = crate::typedef::r#type(w_self).map_or(pyre_object::PY_NULL, |ty| ty.as_ptr());
+        let w_frame = create_spec_for_method(w_func, w_type);
+        (w_func, w_type, w_frame)
+    } else if !w_arg.is_null() && unsafe { crate::function::is_function(w_arg) } {
+        let w_frame = create_spec_for_function(w_arg);
+        (w_arg, pyre_object::PY_NULL, w_frame)
+    } else {
+        let w_type = crate::typedef::r#type(w_arg).map_or(pyre_object::PY_NULL, |ty| ty.as_ptr());
+        let w_frame = create_spec_for_object(w_type);
+        (pyre_object::PY_NULL, w_type, w_frame)
+    }
+}
+
+fn lsprof_call(
+    _space: PyObjectRef,
+    w_self: PyObjectRef,
+    frame: *mut crate::pyframe::PyFrame,
+    event: &str,
+    w_arg: PyObjectRef,
+) -> Result<(), crate::PyError> {
+    let Some(profiler) = W_Profiler::from_obj(w_self) else {
+        return Ok(());
+    };
+    match event {
+        "call" => {
+            if !frame.is_null() {
+                profiler.enter_call(unsafe { (*frame).fget_f_code() });
+            }
+        }
+        "return" => {
+            if !frame.is_null() {
+                profiler.enter_return(unsafe { (*frame).fget_f_code() });
+            }
+        }
+        "c_call" => {
+            if profiler.builtins {
+                profiler.enter_builtin_call(w_self, w_arg);
+            }
+        }
+        "c_return" | "c_exception" => {
+            if profiler.builtins {
+                profiler.enter_builtin_return(w_arg);
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+impl W_Profiler {
+    fn ll_timer(&self) -> i64 {
+        if self.w_callable.is_null() {
+            return read_timestamp();
+        }
+        match crate::call::call_function_impl_result(self.w_callable, &[])
+            .and_then(crate::baseobjspace::int_w)
+        {
+            Ok(value) => value,
+            Err(mut err) => {
+                err.write_unraisable(w_none(), Wtf8::new("timer function "), self.w_callable);
+                0
+            }
+        }
+    }
+
+    fn write_barrier(&self) {
+        let self_obj = self as *const Self as PyObjectRef;
+        pyre_object::gc_hook::try_gc_write_barrier(self_obj as *mut u8);
+    }
+
+    fn get_or_make_entry(&mut self, frame: PyObjectRef, make: bool) -> Option<usize> {
+        if let Some(index) = self.entries.iter().position(|entry| entry.frame == frame) {
+            return Some(index);
+        }
+        if make {
+            self.write_barrier();
+            self.entries.push(ProfilerEntry::new(frame));
+            return Some(self.entries.len() - 1);
+        }
+        None
+    }
+
+    fn get_or_make_builtin_entry(
+        &mut self,
+        w_func: PyObjectRef,
+        w_type: PyObjectRef,
+        w_frame: PyObjectRef,
+        make: bool,
+    ) -> Option<usize> {
+        if let Some(entry) = self
+            .builtin_entries
+            .iter()
+            .find(|entry| entry.w_func == w_func && entry.w_type == w_type)
+        {
+            return Some(entry.entry_index);
+        }
+        if make {
+            self.write_barrier();
+            self.entries.push(ProfilerEntry::new(w_frame));
+            let entry_index = self.entries.len() - 1;
+            self.builtin_entries.push(BuiltinEntry {
+                w_func,
+                w_type,
+                entry_index,
+            });
+            return Some(entry_index);
+        }
+        None
+    }
+
+    fn enter_context(&mut self, entry_index: usize) {
+        let previous = self.current_context.take();
+        self.entries[entry_index].recursion_level += 1;
+        if self.subcalls
+            && let Some(previous_context) = previous.as_ref()
+        {
+            let caller_index = previous_context.entry_index;
+            let frame = self.entries[entry_index].frame;
+            self.write_barrier();
+            if let Some(subentry) = self.entries[caller_index].get_or_make_subentry(frame, true) {
+                subentry.recursion_level += 1;
+            }
+        }
+        let ll_t0 = self.ll_timer();
+        self.current_context = Some(Box::new(ProfilerContext {
+            entry_index,
+            ll_subt: 0,
+            previous,
+            ll_t0,
+        }));
+    }
+
+    fn stop_context(&mut self, context: &mut ProfilerContext, entry_index: usize) {
+        let tt = self.ll_timer() - context.ll_t0;
+        let it = tt - context.ll_subt;
+        if let Some(previous) = context.previous.as_mut() {
+            previous.ll_subt += tt;
+        }
+        self.entries[entry_index].stop(tt, it);
+        if self.subcalls
+            && let Some(previous) = context.previous.as_ref()
+        {
+            let caller_index = previous.entry_index;
+            let frame = self.entries[entry_index].frame;
+            if let Some(subentry) = self.entries[caller_index].get_or_make_subentry(frame, false) {
+                subentry.stop(tt, it);
+            }
+        }
+    }
+
+    fn enter_call(&mut self, f_code: PyObjectRef) {
+        if let Some(entry_index) = self.get_or_make_entry(f_code, true) {
+            self.enter_context(entry_index);
+        }
+    }
+
+    fn enter_return(&mut self, f_code: PyObjectRef) {
+        let Some(mut context) = self.current_context.take() else {
+            return;
+        };
+        if let Some(entry_index) = self.get_or_make_entry(f_code, false) {
+            self.stop_context(&mut context, entry_index);
+        }
+        self.current_context = context.previous.take();
+    }
+
+    fn enter_builtin_call(&mut self, self_obj: PyObjectRef, w_arg: PyObjectRef) {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(self_obj);
+        pyre_object::gc_roots::pin_root(w_arg);
+        let (w_func, w_type, w_frame) =
+            prepare_spec(pyre_object::gc_roots::shadow_stack_get(root_base + 1));
+        pyre_object::gc_roots::pin_root(w_frame);
+        let this = W_Profiler::from_obj(pyre_object::gc_roots::shadow_stack_get(root_base))
+            .expect("profile hook owns a live Profiler");
+        if let Some(entry_index) = this.get_or_make_builtin_entry(
+            w_func,
+            w_type,
+            pyre_object::gc_roots::shadow_stack_get(root_base + 2),
+            true,
+        ) {
+            this.enter_context(entry_index);
+        }
+    }
+
+    fn enter_builtin_return(&mut self, w_arg: PyObjectRef) {
+        let Some(mut context) = self.current_context.take() else {
+            return;
+        };
+        let (w_func, w_type, w_frame) = prepare_spec(w_arg);
+        if let Some(entry_index) = self.get_or_make_builtin_entry(w_func, w_type, w_frame, false) {
+            self.stop_context(&mut context, entry_index);
+        }
+        self.current_context = context.previous.take();
+    }
+
+    fn flush_unmatched(&mut self) {
+        let mut context = self.current_context.take();
+        while let Some(mut active) = context {
+            let entry_index = active.entry_index;
+            self.stop_context(&mut active, entry_index);
+            context = active.previous.take();
+        }
+    }
+
+    fn stats(&self, factor: f64) -> PyObjectRef {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        for entry in &self.entries {
+            if entry.callcount != 0 {
+                pyre_object::gc_roots::pin_root(entry.stats(factor));
+            }
+        }
+        let items = (root_base..pyre_object::gc_roots::shadow_stack_len())
+            .map(pyre_object::gc_roots::shadow_stack_get)
+            .collect();
+        pyre_object::w_list_new(items)
+    }
+
+    fn walk_owned_refs(&mut self, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+        fn visit(slot: &mut PyObjectRef, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+            if !slot.is_null() {
+                f(slot as *mut PyObjectRef as *mut majit_ir::GcRef);
+            }
+        }
+
+        visit(&mut self.w_callable, f);
+        for entry in &mut self.entries {
+            visit(&mut entry.frame, f);
+            for subentry in &mut entry.calls {
+                visit(&mut subentry.frame, f);
+            }
+        }
+        for entry in &mut self.builtin_entries {
+            visit(&mut entry.w_func, f);
+            visit(&mut entry.w_type, f);
+        }
+    }
+}
+
+mod profiler_methods {
+    use super::*;
+
+    #[crate::pyre_methods]
+    impl W_Profiler {
+        #[staticmethod]
+        fn __new__(
+            cls: PyObjectRef,
+            #[default(w_none())] w_callable: PyObjectRef,
+            #[default(0.0f64)] time_unit: f64,
+            #[default(1i32)] subcalls: i32,
+            #[default(1i32)] builtins: i32,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            crate::typedef::check_user_subclass(type_object(), cls)?;
+            let callable = if unsafe { pyre_object::is_none(w_callable) } {
+                pyre_object::PY_NULL
+            } else {
+                w_callable
+            };
+            let _roots = pyre_object::gc_roots::push_roots();
+            let callable_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(callable);
+            let obj = W_Profiler::allocate_stable(W_Profiler {
+                ob: PyObject::default(),
+                subcalls: subcalls != 0,
+                builtins: builtins != 0,
+                w_callable: pyre_object::gc_roots::shadow_stack_get(callable_slot),
+                time_unit,
+                ..W_Profiler::default()
+            });
+            unsafe { (*obj).w_class = cls };
+            Ok(obj)
+        }
+
+        fn enable(
+            &mut self,
+            #[default(w_none())] w_subcalls: PyObjectRef,
+            #[default(w_none())] w_builtins: PyObjectRef,
+        ) -> Result<(), crate::PyError> {
+            if self.is_enabled {
+                return Ok(());
+            }
+            // `_lsprof.c profiler_enable` claims the profiler tool id before
+            // touching any of its own state, so a second profiler's `enable`
+            // reports the conflict and leaves the first one installed.
+            crate::module::sys::vm::monitoring_use_tool_id(
+                crate::module::sys::vm::MONITORING_PROFILER_ID,
+                w_str_new("cProfile"),
+            )?;
+            if !unsafe { pyre_object::is_none(w_subcalls) } {
+                self.subcalls = crate::baseobjspace::is_true(w_subcalls)?;
+            }
+            if !unsafe { pyre_object::is_none(w_builtins) } {
+                self.builtins = crate::baseobjspace::is_true(w_builtins)?;
+            }
+            self.is_enabled = true;
+            self.total_real_time -= read_real_time();
+            self.total_timestamp -= read_timestamp();
+            let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+            unsafe {
+                (*ec).setllprofile(Some(lsprof_call), self as *mut Self as PyObjectRef)?;
+            }
+            Ok(())
+        }
+
+        fn disable(&mut self) -> Result<(), crate::PyError> {
+            if !self.is_enabled {
+                return Ok(());
+            }
+            crate::module::sys::vm::monitoring_free_tool_id(
+                crate::module::sys::vm::MONITORING_PROFILER_ID,
+            );
+            self.is_enabled = false;
+            self.total_timestamp += read_timestamp();
+            self.total_real_time += read_real_time();
+            let ec = crate::call::getexecutioncontext() as *mut crate::PyExecutionContext;
+            unsafe {
+                (*ec).setllprofile(None, pyre_object::PY_NULL)?;
+            }
+            self.flush_unmatched();
+            Ok(())
+        }
+
+        /// `_lsprof.c profiler_clear` — settle the contexts still on the stack,
+        /// then drop the accumulated entries.  `interp_lsprof.py`'s typedef
+        /// publishes no `clear`, but `cProfile` and `test_cprofile` both call
+        /// it, so the method belongs on the type.
+        fn clear(&mut self) {
+            self.flush_unmatched();
+            self.entries.clear();
+            self.builtin_entries.clear();
+        }
+
+        fn getstats(&self) -> Result<PyObjectRef, crate::PyError> {
+            let factor = if self.w_callable.is_null() {
+                if self.is_enabled {
+                    return Err(crate::PyError::runtime_error(
+                        "Profiler instance must be disabled before getting the stats",
+                    ));
+                }
+                if self.total_timestamp != 0 {
+                    self.total_real_time / self.total_timestamp as f64
+                } else {
+                    1.0
+                }
+            } else {
+                timer_factor_for_external_timer(self.time_unit)
+            };
+            Ok(self.stats(factor))
+        }
+    }
+}
+
+/// Drop the Rust-owned profiler bookkeeping.
+///
+/// # Safety
+/// `obj` must be a GC-dead `W_Profiler`.
+pub unsafe fn w_profiler_dealloc(obj: PyObjectRef) {
+    unsafe {
+        std::ptr::drop_in_place(obj as *mut W_Profiler);
+    }
+}
+
+/// Walk `W_Profiler`'s indirect entry trees.
+///
+/// # Safety
+/// `obj_addr` must point at a live `W_Profiler`.
+pub unsafe fn w_profiler_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    let profiler = unsafe { &mut *(obj_addr as *mut W_Profiler) };
+    profiler.walk_owned_refs(f);
+}
+
+crate::py_module! {
+    "_lsprof",
+    interpleveldefs: {
+        "Profiler" => profiler_methods::type_object(),
+    },
+    extra_init: |ns| {
+        let _ = ns;
+        let _ = stats_entry_methods::type_object();
+        let _ = stats_subentry_methods::type_object();
+    },
+}

--- a/pyre/pyre-interpreter/src/module/_lzma/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lzma/mod.rs
@@ -1,0 +1,611 @@
+//! `_lzma` module — `Modules/_lzmamodule.c`.
+//!
+//! PyPy has no interpreter-level `_lzma`: `lib_pypy/_lzma.py` drives liblzma
+//! through cffi and the applevel `lzma.py` stands on that, so the C module is
+//! the structure this follows, the same footing `_heapq` sits on.
+//!
+//! The codec lives in `pyre_native::lzma` — the `xz-core` port of liblzma —
+//! outside the LLBC extraction, exactly as `zlib` and `_bz2` keep theirs.
+//! What is left here is the object glue: the two stream objects, the filter
+//! dicts, the argument surface, and `LZMAError`.
+
+use pyre_native::lzma as backend;
+use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+use pyre_object::*;
+
+use std::sync::Mutex;
+
+/// `Compressor`: the liblzma stream and its lock belong to the object, and
+/// there is no process-global side table.
+#[crate::pyre_class("_lzma.LZMACompressor")]
+#[derive(Default)]
+pub struct W_LZMACompressor {
+    backend: *mut Mutex<backend::Compressor>,
+}
+
+/// `Decompressor`, object-owned the same way.  The unconsumed input and the
+/// `unused_data` tail live with the stream rather than as Python attributes.
+#[crate::pyre_class("_lzma.LZMADecompressor")]
+#[derive(Default)]
+pub struct W_LZMADecompressor {
+    backend: *mut Mutex<backend::Decompressor>,
+}
+
+/// `LZMAError`, the module's own exception class.  The fallback kind only
+/// matters if the class is somehow missing from the registry; the raised
+/// object is what `except LZMAError` matches on.
+fn lzma_exception(msg: impl Into<String>) -> crate::PyError {
+    let msg = msg.into();
+    let mut err = crate::PyError::value_error(msg.clone());
+    if let Some(cls) = crate::builtins::lookup_exc_class("_lzma.LZMAError") {
+        let args = [cls, w_str_new(&msg)];
+        if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            err.exc_object = exc;
+        }
+    }
+    err
+}
+
+/// `catch_lzma_error`, plus the three failures the filter conversion reports
+/// before liblzma is reached.
+fn lzma_error(error: backend::LzmaError) -> crate::PyError {
+    use backend::LzmaError as E;
+    match error {
+        E::UnsupportedCheck => lzma_exception("Unsupported integrity check"),
+        E::Mem => crate::PyError::memory_error("out of memory"),
+        E::MemLimit => lzma_exception("Memory usage limit exceeded"),
+        E::Format => lzma_exception("Input format not supported by decoder"),
+        E::Options => lzma_exception("Invalid or unsupported options"),
+        E::Data => lzma_exception("Corrupt input data"),
+        E::Buf => lzma_exception("Insufficient buffer space"),
+        E::Prog => lzma_exception("Internal error"),
+        E::Unrecognized(ret) => lzma_exception(format!("Unrecognized error from liblzma: {ret}")),
+        E::InvalidPreset(preset) => lzma_exception(format!("Invalid compression preset: {preset}")),
+        E::InvalidFilterId(id) => crate::PyError::value_error(format!("Invalid filter ID: {id}")),
+        E::AloneChainNotSingleLzma1 => crate::PyError::value_error(
+            "Invalid filter chain for FORMAT_ALONE - must be a single LZMA1 filter",
+        ),
+    }
+}
+
+/// Both stream objects carry liblzma state no state dict can describe, which
+/// is the `tp_basicsize` mismatch `_PyObject_GetState` refuses — so neither
+/// can be pickled, however ordinary the rest of the object looks.
+fn cannot_serialize(name: &str) -> crate::PyError {
+    crate::PyError::type_error(format!("cannot pickle '{name}' object"))
+}
+
+/// `_PyLong_UInt32_Converter`: the value arrives through `__index__`, and one
+/// outside a `uint32_t` is an error rather than a truncation.
+fn uint32_w(obj: PyObjectRef) -> Result<u32, crate::PyError> {
+    crate::baseobjspace::c_uint_w(crate::baseobjspace::space_index(obj)?)
+}
+
+// ── filter specifiers ───────────────────────────────────────────────────
+
+/// What one filter id makes of its spec dict: the option names it reads, and
+/// the message it reports for a spec carrying anything else.
+///
+/// `parse_filter_spec_*` hands the dict to `PyArg_ParseTupleAndKeywords` as
+/// the keyword mapping, so an unrecognized key is exactly what makes the
+/// parse fail — hence the entry count check below.
+struct FilterKind {
+    optnames: &'static [&'static str],
+    message: &'static str,
+}
+
+/// `parse_filter_spec_lzma`.
+const LZMA_KIND: FilterKind = FilterKind {
+    optnames: &[
+        "id",
+        "preset",
+        "dict_size",
+        "lc",
+        "lp",
+        "pb",
+        "mode",
+        "nice_len",
+        "mf",
+        "depth",
+    ],
+    message: "Invalid filter specifier for LZMA filter",
+};
+
+/// `parse_filter_spec_delta`.
+const DELTA_KIND: FilterKind = FilterKind {
+    optnames: &["id", "dist"],
+    message: "Invalid filter specifier for delta filter",
+};
+
+/// `parse_filter_spec_bcj`.
+const BCJ_KIND: FilterKind = FilterKind {
+    optnames: &["id", "start_offset"],
+    message: "Invalid filter specifier for BCJ filter",
+};
+
+/// `lzma_filter_converter`.  Every read here can run a `__getitem__` of the
+/// caller's own, so the spec is held in a shadow-stack slot rather than a
+/// Rust local.
+fn parse_filter_spec(spec: PyObjectRef) -> Result<backend::FilterSpec, crate::PyError> {
+    let _roots = push_roots();
+    let spec_slot = shadow_stack_len();
+    pin_root(spec);
+    let spec = || shadow_stack_get(spec_slot);
+
+    if unsafe { crate::baseobjspace::lookup(spec(), "__getitem__") }.is_none() {
+        return Err(crate::PyError::type_error(
+            "Filter specifier must be a dict or dict-like object",
+        ));
+    }
+    let Some(w_id) = crate::baseobjspace::finditem_str(spec(), "id")? else {
+        return Err(crate::PyError::value_error(
+            "Filter specifier must have an \"id\" entry",
+        ));
+    };
+    // `lzma_vli` is a `uint64_t`, but no id above `LZMA_VLI_MAX` (2**63-1)
+    // names a filter, so the index conversion covers the whole valid range.
+    let id = crate::baseobjspace::index_int_w_preserve_negative(w_id)?;
+    let Ok(id) = u64::try_from(id) else {
+        return Err(crate::PyError::value_error(
+            "cannot convert negative integer to unsigned",
+        ));
+    };
+    let kind = match id {
+        backend::FILTER_LZMA1 | backend::FILTER_LZMA2 => LZMA_KIND,
+        backend::FILTER_DELTA => DELTA_KIND,
+        backend::FILTER_X86
+        | backend::FILTER_POWERPC
+        | backend::FILTER_IA64
+        | backend::FILTER_ARM
+        | backend::FILTER_ARMTHUMB
+        | backend::FILTER_SPARC => BCJ_KIND,
+        id => {
+            return Err(crate::PyError::value_error(format!(
+                "Invalid filter ID: {id}"
+            )));
+        }
+    };
+
+    let mut parsed = backend::FilterSpec {
+        id,
+        ..backend::FilterSpec::default()
+    };
+    // The "id" entry is already accounted for.
+    let mut named = 1i64;
+    for name in &kind.optnames[1..] {
+        let Some(value) = crate::baseobjspace::finditem_str(spec(), name)? else {
+            continue;
+        };
+        named += 1;
+        let value = Some(uint32_w(value)?);
+        match *name {
+            "preset" => parsed.preset = value,
+            "dict_size" => parsed.dict_size = value,
+            "lc" => parsed.lc = value,
+            "lp" => parsed.lp = value,
+            "pb" => parsed.pb = value,
+            "mode" => parsed.mode = value,
+            "nice_len" => parsed.nice_len = value,
+            "mf" => parsed.mf = value,
+            "depth" => parsed.depth = value,
+            "dist" => parsed.dist = value,
+            "start_offset" => parsed.start_offset = value,
+            other => unreachable!("filter option {other} has no slot"),
+        }
+    }
+    // An entry the filter does not know is what the keyword parse rejects,
+    // and a spec that cannot even be counted would not have reached it.
+    let entries = crate::baseobjspace::len(spec())
+        .and_then(crate::baseobjspace::int_w)
+        .map_err(|_| crate::PyError::value_error(kind.message))?;
+    if entries != named {
+        return Err(crate::PyError::value_error(kind.message));
+    }
+    Ok(parsed)
+}
+
+/// `parse_filter_chain_spec`.
+fn parse_filter_chain(filters: PyObjectRef) -> Result<Vec<backend::FilterSpec>, crate::PyError> {
+    let _roots = push_roots();
+    let filters_slot = shadow_stack_len();
+    pin_root(filters);
+    let filters = || shadow_stack_get(filters_slot);
+
+    let count = crate::runtime_ops::sequence_len(filters())?;
+    if count > backend::FILTERS_MAX {
+        return Err(crate::PyError::value_error(format!(
+            "Too many filters - liblzma supports a maximum of {}",
+            backend::FILTERS_MAX
+        )));
+    }
+    let mut specs = Vec::with_capacity(count);
+    for index in 0..count {
+        let spec = crate::runtime_ops::sequence_getitem(filters(), index)?;
+        specs.push(parse_filter_spec(spec)?);
+    }
+    Ok(specs)
+}
+
+/// The chain a `filters` argument names, or `None` when it was left out.
+fn optional_filter_chain(
+    filters: PyObjectRef,
+) -> Result<Option<Vec<backend::FilterSpec>>, crate::PyError> {
+    if unsafe { is_none(filters) } {
+        return Ok(None);
+    }
+    parse_filter_chain(filters).map(Some)
+}
+
+impl W_LZMACompressor {
+    fn compressor(&self) -> Result<&Mutex<backend::Compressor>, crate::PyError> {
+        if self.backend.is_null() {
+            return Err(crate::PyError::value_error(
+                "Compressor was not initialized",
+            ));
+        }
+        Ok(unsafe { &*self.backend })
+    }
+}
+
+impl W_LZMADecompressor {
+    fn decompressor(&self) -> Result<&Mutex<backend::Decompressor>, crate::PyError> {
+        if self.backend.is_null() {
+            return Err(crate::PyError::value_error(
+                "Decompressor was not initialized",
+            ));
+        }
+        Ok(unsafe { &*self.backend })
+    }
+}
+
+mod compressor_methods {
+    use super::*;
+
+    #[crate::pyre_methods(
+        doc = "Create a compressor object for compressing data incrementally.\n\n\
+               The settings used by the compressor can be specified either as a\n\
+               preset compression level (with the 'preset' argument), or in detail\n\
+               as a custom filter chain (with the 'filters' argument).  For FORMAT_XZ\n\
+               and FORMAT_ALONE, the default is to use the PRESET_DEFAULT preset\n\
+               level.  For FORMAT_RAW, the caller must always specify a filter chain;\n\
+               the raw compressor does not support preset compression levels.\n\n\
+               For one-shot compression, use the compress() function instead."
+    )]
+    impl W_LZMACompressor {
+        /// `Compressor_new`.  Everything the container format rules out is
+        /// rejected before the encoder is initialized.
+        #[staticmethod]
+        fn __new__(
+            _cls: PyObjectRef,
+            #[default(backend::FORMAT_XZ)] format: PyIndexCInt,
+            #[default(-1i32)] check: PyIndexCInt,
+            #[default(w_none())] preset: PyObjectRef,
+            #[default(w_none())] filters: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            // The preset conversion below can run a `__index__` of the
+            // caller's own, so the chain is held in a shadow-stack slot from
+            // here on rather than in this argument.
+            let _roots = push_roots();
+            let filters_slot = shadow_stack_len();
+            pin_root(filters);
+            let filters = || shadow_stack_get(filters_slot);
+
+            if format != backend::FORMAT_XZ && check != -1 && check != backend::CHECK_NONE as i32 {
+                return Err(crate::PyError::value_error(
+                    "Integrity checks are only supported by FORMAT_XZ",
+                ));
+            }
+            let preset_given = !unsafe { is_none(preset) };
+            let filters_given = !unsafe { is_none(filters()) };
+            if preset_given && filters_given {
+                return Err(crate::PyError::value_error(
+                    "Cannot specify both preset and filter chain",
+                ));
+            }
+            let preset = if preset_given {
+                uint32_w(preset)?
+            } else {
+                backend::PRESET_DEFAULT
+            };
+            // Only FORMAT_XZ carries an integrity check, and FORMAT_AUTO
+            // names nothing that can be written.
+            let check = match (format, check) {
+                (backend::FORMAT_XZ, -1) => backend::CHECK_CRC64,
+                (backend::FORMAT_XZ, check) => check as u32,
+                (backend::FORMAT_ALONE | backend::FORMAT_RAW, _) => backend::CHECK_NONE,
+                _ => {
+                    return Err(crate::PyError::value_error(format!(
+                        "Invalid container format: {format}"
+                    )));
+                }
+            };
+            if format == backend::FORMAT_RAW && !filters_given {
+                return Err(crate::PyError::value_error(
+                    "Must specify filters for FORMAT_RAW",
+                ));
+            }
+            let specs = optional_filter_chain(filters())?;
+            let compressor = backend::Compressor::new(format, check, preset, specs.as_deref())
+                .map_err(lzma_error)?;
+            Ok(W_LZMACompressor::allocate_stable(W_LZMACompressor {
+                backend: Box::into_raw(Box::new(Mutex::new(compressor))),
+                ..W_LZMACompressor::default()
+            }))
+        }
+
+        /// `_lzma_LZMACompressor_compress_impl`.
+        fn compress(&mut self, data: PyBufferStr) -> Result<Vec<u8>, crate::PyError> {
+            let mut compressor = self.compressor()?.lock().unwrap();
+            if compressor.is_flushed() {
+                return Err(crate::PyError::value_error("Compressor has been flushed"));
+            }
+            compressor.compress(&data).map_err(lzma_error)
+        }
+
+        /// `_lzma_LZMACompressor_flush_impl` — the object may not be used
+        /// afterwards.
+        fn flush(&mut self) -> Result<Vec<u8>, crate::PyError> {
+            let mut compressor = self.compressor()?.lock().unwrap();
+            if compressor.is_flushed() {
+                return Err(crate::PyError::value_error("Repeated call to flush()"));
+            }
+            compressor.flush().map_err(lzma_error)
+        }
+
+        fn __getstate__(&self) -> Result<PyObjectRef, crate::PyError> {
+            Err(cannot_serialize("_lzma.LZMACompressor"))
+        }
+    }
+} // compressor_methods
+
+mod decompressor_methods {
+    use super::*;
+
+    #[crate::pyre_methods(
+        doc = "Create a decompressor object for decompressing data incrementally.\n\n\
+               For one-shot decompression, use the decompress() function instead."
+    )]
+    impl W_LZMADecompressor {
+        /// `_lzma_LZMADecompressor_impl`.  A caller that names no memory
+        /// limit gets the clinic default, an unlimited one.
+        #[staticmethod]
+        fn __new__(
+            _cls: PyObjectRef,
+            #[default(backend::FORMAT_AUTO)] format: PyIndexCInt,
+            #[default(w_none())] memlimit: PyObjectRef,
+            #[default(w_none())] filters: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            // The memory-limit conversion below can run a `__index__` of the
+            // caller's own, so the chain moves to a shadow-stack slot first.
+            let _roots = push_roots();
+            let filters_slot = shadow_stack_len();
+            pin_root(filters);
+            let filters = || shadow_stack_get(filters_slot);
+
+            let memlimit = if unsafe { is_none(memlimit) } {
+                u64::MAX
+            } else {
+                if format == backend::FORMAT_RAW {
+                    return Err(crate::PyError::value_error(
+                        "Cannot specify memory limit with FORMAT_RAW",
+                    ));
+                }
+                crate::baseobjspace::uint_w(crate::baseobjspace::space_index(memlimit)?)?
+            };
+            let filters_given = !unsafe { is_none(filters()) };
+            if format == backend::FORMAT_RAW && !filters_given {
+                return Err(crate::PyError::value_error(
+                    "Must specify filters for FORMAT_RAW",
+                ));
+            }
+            if format != backend::FORMAT_RAW && filters_given {
+                return Err(crate::PyError::value_error(
+                    "Cannot specify filters except with FORMAT_RAW",
+                ));
+            }
+            if !matches!(
+                format,
+                backend::FORMAT_AUTO
+                    | backend::FORMAT_XZ
+                    | backend::FORMAT_ALONE
+                    | backend::FORMAT_RAW
+            ) {
+                return Err(crate::PyError::value_error(format!(
+                    "Invalid container format: {format}"
+                )));
+            }
+            let specs = optional_filter_chain(filters())?;
+            let decompressor = backend::Decompressor::new(format, memlimit, specs.as_deref())
+                .map_err(lzma_error)?;
+            Ok(W_LZMADecompressor::allocate_stable(W_LZMADecompressor {
+                backend: Box::into_raw(Box::new(Mutex::new(decompressor))),
+                ..W_LZMADecompressor::default()
+            }))
+        }
+
+        /// `_lzma_LZMADecompressor_decompress_impl` — a negative
+        /// `max_length` is unlimited.
+        fn decompress(
+            &mut self,
+            data: PyBufferStr,
+            #[default(-1i64)] max_length: PyIndexInt,
+        ) -> Result<Vec<u8>, crate::PyError> {
+            let mut decompressor = self.decompressor()?.lock().unwrap();
+            if decompressor.eof() {
+                return Err(crate::PyError::new(
+                    crate::PyErrorKind::EOFError,
+                    "Already at end of stream",
+                ));
+            }
+            decompressor
+                .decompress(&data, usize::try_from(max_length).ok())
+                .map_err(lzma_error)
+        }
+
+        /// ID of the integrity check used by the input stream.
+        #[getter]
+        fn check(&self) -> Result<i64, crate::PyError> {
+            Ok(self.decompressor()?.lock().unwrap().check() as i64)
+        }
+
+        /// True once the end-of-stream marker has been reached.
+        #[getter]
+        fn eof(&self) -> Result<bool, crate::PyError> {
+            Ok(self.decompressor()?.lock().unwrap().eof())
+        }
+
+        /// True when more input is needed before more decompressed data can
+        /// be produced.
+        #[getter]
+        fn needs_input(&self) -> Result<bool, crate::PyError> {
+            Ok(self.decompressor()?.lock().unwrap().needs_input())
+        }
+
+        /// Data found after the end of the compressed stream.
+        #[getter]
+        fn unused_data(&self) -> Result<Vec<u8>, crate::PyError> {
+            Ok(self.decompressor()?.lock().unwrap().unused_data().to_vec())
+        }
+
+        fn __getstate__(&self) -> Result<PyObjectRef, crate::PyError> {
+            Err(cannot_serialize("_lzma.LZMADecompressor"))
+        }
+    }
+} // decompressor_methods
+
+/// The `LZMACompressor` type object.  Neither stream type is acceptable as a
+/// base class, yet both constructors take keywords, so the call path needs to
+/// name them.
+pub fn compressor_type() -> PyObjectRef {
+    compressor_methods::type_object()
+}
+
+/// The `LZMADecompressor` type object, named for the same reason.
+pub fn decompressor_type() -> PyObjectRef {
+    decompressor_methods::type_object()
+}
+
+/// Sweep-time counterpart of `Compressor_dealloc`.  The Box holds the
+/// per-object mutex and the native stream; dropping it neither allocates nor
+/// calls back into Python.
+///
+/// # Safety
+/// `obj` must be a GC-dead `W_LZMACompressor`.
+pub unsafe fn w_lzmacompressor_dealloc(obj: PyObjectRef) {
+    if let Some(this) = W_LZMACompressor::from_obj(obj)
+        && !this.backend.is_null()
+    {
+        unsafe { drop(Box::from_raw(this.backend)) };
+        this.backend = std::ptr::null_mut();
+    }
+}
+
+/// Sweep-time counterpart of `Decompressor_dealloc`.
+///
+/// # Safety
+/// `obj` must be a GC-dead `W_LZMADecompressor`.
+pub unsafe fn w_lzmadecompressor_dealloc(obj: PyObjectRef) {
+    if let Some(this) = W_LZMADecompressor::from_obj(obj)
+        && !this.backend.is_null()
+    {
+        unsafe { drop(Box::from_raw(this.backend)) };
+        this.backend = std::ptr::null_mut();
+    }
+}
+
+crate::py_module! {
+    "_lzma",
+    interpleveldefs: {
+        "LZMACompressor" => compressor_methods::type_object(),
+        "LZMADecompressor" => decompressor_methods::type_object(),
+    },
+    int_constants: {
+        "FORMAT_AUTO" => backend::FORMAT_AUTO,
+        "FORMAT_XZ" => backend::FORMAT_XZ,
+        "FORMAT_ALONE" => backend::FORMAT_ALONE,
+        "FORMAT_RAW" => backend::FORMAT_RAW,
+        "CHECK_NONE" => backend::CHECK_NONE,
+        "CHECK_CRC32" => backend::CHECK_CRC32,
+        "CHECK_CRC64" => backend::CHECK_CRC64,
+        "CHECK_SHA256" => backend::CHECK_SHA256,
+        "CHECK_ID_MAX" => backend::CHECK_ID_MAX,
+        "CHECK_UNKNOWN" => backend::CHECK_UNKNOWN,
+        "FILTER_LZMA1" => backend::FILTER_LZMA1,
+        "FILTER_LZMA2" => backend::FILTER_LZMA2,
+        "FILTER_DELTA" => backend::FILTER_DELTA,
+        "FILTER_X86" => backend::FILTER_X86,
+        "FILTER_IA64" => backend::FILTER_IA64,
+        "FILTER_ARM" => backend::FILTER_ARM,
+        "FILTER_ARMTHUMB" => backend::FILTER_ARMTHUMB,
+        "FILTER_SPARC" => backend::FILTER_SPARC,
+        "FILTER_POWERPC" => backend::FILTER_POWERPC,
+        "MF_HC3" => backend::MF_HC3,
+        "MF_HC4" => backend::MF_HC4,
+        "MF_BT2" => backend::MF_BT2,
+        "MF_BT3" => backend::MF_BT3,
+        "MF_BT4" => backend::MF_BT4,
+        "MODE_FAST" => backend::MODE_FAST,
+        "MODE_NORMAL" => backend::MODE_NORMAL,
+        "PRESET_DEFAULT" => backend::PRESET_DEFAULT,
+        "PRESET_EXTREME" => backend::PRESET_EXTREME,
+    },
+    exceptions: {
+        "LZMAError" => crate::builtins::lookup_exc_class("Exception").expect("Exception installed"),
+    },
+    inline_functions: {
+        // `_lzma_is_check_supported_impl`.
+        fn is_check_supported(check_id: PyIndexCInt) -> bool {
+            backend::is_check_supported(check_id as u32)
+        }
+        // `_lzma__encode_filter_properties_impl` — the options of one filter,
+        // without the filter id itself.
+        fn _encode_filter_properties(
+            filter: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            let spec = parse_filter_spec(filter)?;
+            let properties = backend::encode_filter_properties(&spec).map_err(lzma_error)?;
+            Ok(bytesobject::w_bytes_from_bytes(&properties))
+        }
+        // `_lzma__decode_filter_properties_impl` — the spec dict those options
+        // describe, id included.
+        fn _decode_filter_properties(
+            filter_id: PyIndexInt,
+            encoded_props: PyBufferStr,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            let Ok(filter_id) = u64::try_from(filter_id) else {
+                return Err(crate::PyError::value_error(
+                    "cannot convert negative integer to unsigned",
+                ));
+            };
+            let decoded = backend::decode_filter_properties(filter_id, &encoded_props)
+                .map_err(lzma_error)?;
+            // `build_filter_spec`.  Each store can grow the dict, so the dict
+            // is read back out of its slot for every one of them.
+            let _roots = push_roots();
+            let dict_slot = shadow_stack_len();
+            pin_root(w_dict_new());
+            let dict = || shadow_stack_get(dict_slot);
+            let id = w_int_new(decoded.id as i64);
+            unsafe { w_dict_setitem_str(dict(), "id", id) };
+            for (name, value) in &decoded.fields {
+                let value = w_int_new(*value as i64);
+                unsafe { w_dict_setitem_str(dict(), name, value) };
+            }
+            Ok(dict())
+        }
+    },
+    extra_init: |ns| {
+        let _ = ns;
+        // Neither type spec carries `Py_TPFLAGS_BASETYPE`.
+        unsafe {
+            pyre_object::w_type_set_acceptable_as_base_class(
+                compressor_methods::type_object(),
+                false,
+            );
+            pyre_object::w_type_set_acceptable_as_base_class(
+                decompressor_methods::type_object(),
+                false,
+            );
+        }
+    },
+}

--- a/pyre/pyre-interpreter/src/module/_lzma/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_lzma/mod.rs
@@ -142,13 +142,24 @@ fn parse_filter_spec(spec: PyObjectRef) -> Result<backend::FilterSpec, crate::Py
             "Filter specifier must have an \"id\" entry",
         ));
     };
-    // `lzma_vli` is a `uint64_t`, but no id above `LZMA_VLI_MAX` (2**63-1)
-    // names a filter, so the index conversion covers the whole valid range.
-    let id = crate::baseobjspace::index_int_w_preserve_negative(w_id)?;
-    let Ok(id) = u64::try_from(id) else {
-        return Err(crate::PyError::value_error(
-            "cannot convert negative integer to unsigned",
-        ));
+    // `lzma_vli` is a `uint64_t`, so the id reads as an unsigned 64-bit value
+    // and one that overflows a *signed* read still converts. Whether the
+    // result names a filter is the dispatch's answer below, not this one's;
+    // only a width the type cannot hold is an overflow here.
+    let w_index = crate::baseobjspace::space_index(w_id)?;
+    let negative = || crate::PyError::value_error("cannot convert negative integer to unsigned");
+    let id = match crate::baseobjspace::int_w(w_index) {
+        Ok(value) => u64::try_from(value).map_err(|_| negative())?,
+        Err(error) if error.kind == crate::PyErrorKind::OverflowError => {
+            let big = unsafe { pyre_object::w_long_get_value(w_index) };
+            if big.get_sign() < 0 {
+                return Err(negative());
+            }
+            big.to_u64().ok_or_else(|| {
+                crate::PyError::overflow_error("Python int too large for C lzma_vli")
+            })?
+        }
+        Err(error) => return Err(error),
     };
     let kind = match id {
         backend::FILTER_LZMA1 | backend::FILTER_LZMA2 => LZMA_KIND,
@@ -193,8 +204,15 @@ fn parse_filter_spec(spec: PyObjectRef) -> Result<backend::FilterSpec, crate::Py
             other => unreachable!("filter option {other} has no slot"),
         }
     }
-    // An entry the filter does not know is what the keyword parse rejects,
-    // and a spec that cannot even be counted would not have reached it.
+    // The options are read by a keyword parse whose keyword argument is the
+    // spec itself, so a spec that is not a dict fails there — `__getitem__`
+    // alone carries it past the dict-or-dict-like gate above but no further.
+    // A dict carrying an entry the filter does not name fails there too, and
+    // that is what the count catches.
+    let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
+    if !unsafe { crate::baseobjspace::isinstance_w(spec(), w_dict_type) } {
+        return Err(crate::PyError::value_error(kind.message));
+    }
     let entries = crate::baseobjspace::len(spec())
         .and_then(crate::baseobjspace::int_w)
         .map_err(|_| crate::PyError::value_error(kind.message))?;

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -44,6 +44,8 @@ pub mod _json;
 #[allow(non_snake_case)]
 pub mod _locale;
 #[allow(non_snake_case)]
+pub mod _lsprof;
+#[allow(non_snake_case)]
 pub mod _lzma;
 #[allow(non_snake_case)]
 #[cfg(not(target_arch = "wasm32"))]

--- a/pyre/pyre-interpreter/src/module/mod.rs
+++ b/pyre/pyre-interpreter/src/module/mod.rs
@@ -44,6 +44,8 @@ pub mod _json;
 #[allow(non_snake_case)]
 pub mod _locale;
 #[allow(non_snake_case)]
+pub mod _lzma;
+#[allow(non_snake_case)]
 #[cfg(not(target_arch = "wasm32"))]
 pub mod _multibytecodec;
 #[allow(non_snake_case)]

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -13,6 +13,79 @@ use std::sync::OnceLock;
 const GETSIZEOF_DOC: &str = "getsizeof(object [, default]) -> int\n\n\
 Return the size of object in bytes.";
 
+/// The ids `sys.monitoring.use_tool_id` accepts, one below the first id the
+/// runtime reserves for itself (`PY_MONITORING_SYS_PROFILE_ID`).
+const MONITORING_TOOL_COUNT: usize = 6;
+
+/// `interp->monitoring_tool_names` — the name each claimed tool id was
+/// registered under, or NULL while the id is free.
+///
+/// The event machinery below is inert, but *ownership* is not: `get_tool`
+/// reports it, `bdb` consults it before installing its tracer, and it is what
+/// makes a second `cProfile.Profile.enable()` fail instead of silently
+/// displacing the first.  Held as raw addresses and forwarded by
+/// [`walk_monitoring_tool_roots`], since a name is an ordinary movable str.
+static MONITORING_TOOL_NAMES: [std::sync::atomic::AtomicUsize; MONITORING_TOOL_COUNT] =
+    [const { std::sync::atomic::AtomicUsize::new(0) }; MONITORING_TOOL_COUNT];
+
+/// Forward the claimed tool names for the process-global root walk.
+pub fn walk_monitoring_tool_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
+    for slot in MONITORING_TOOL_NAMES.iter() {
+        let addr = slot.load(std::sync::atomic::Ordering::Relaxed);
+        if addr == 0 {
+            continue;
+        }
+        let mut root = majit_ir::GcRef(addr);
+        visitor(&mut root);
+        slot.store(root.0, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+/// `check_valid_tool` — reject an id outside the claimable range before it is
+/// used to index the table.
+fn monitoring_tool_id_w(w_tool_id: PyObjectRef) -> Result<usize, crate::PyError> {
+    let tool_id = crate::builtins::space_index_w(w_tool_id)?;
+    if !(0..MONITORING_TOOL_COUNT as i64).contains(&tool_id) {
+        return Err(crate::PyError::value_error(format!(
+            "invalid tool {tool_id} (must be between 0 and {})",
+            MONITORING_TOOL_COUNT - 1
+        )));
+    }
+    Ok(tool_id as usize)
+}
+
+fn monitoring_tool_name(tool_id: usize) -> PyObjectRef {
+    MONITORING_TOOL_NAMES[tool_id].load(std::sync::atomic::Ordering::Relaxed) as PyObjectRef
+}
+
+fn monitoring_set_tool_name(tool_id: usize, name: PyObjectRef) {
+    MONITORING_TOOL_NAMES[tool_id].store(name as usize, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// `monitoring_use_tool_id_impl` — claim `tool_id` for `w_name`, refusing an
+/// id someone else already holds.
+pub fn monitoring_use_tool_id(tool_id: usize, w_name: PyObjectRef) -> Result<(), crate::PyError> {
+    if !unsafe { pyre_object::is_str(w_name) } {
+        return Err(crate::PyError::value_error("tool name must be a str"));
+    }
+    if !monitoring_tool_name(tool_id).is_null() {
+        return Err(crate::PyError::value_error(format!(
+            "tool {tool_id} is already in use"
+        )));
+    }
+    monitoring_set_tool_name(tool_id, w_name);
+    Ok(())
+}
+
+/// The id `_lsprof` claims, matching `sys.monitoring.PROFILER_ID`.
+pub const MONITORING_PROFILER_ID: usize = 2;
+
+/// Release `tool_id` unconditionally — `free_tool_id`'s interp-level spelling,
+/// for callers that claimed the id from native code.
+pub fn monitoring_free_tool_id(tool_id: usize) {
+    monitoring_set_tool_name(tool_id, pyre_object::PY_NULL);
+}
+
 /// CPython 3.14 `_PySys_GetSizeOf`: look up `__sizeof__` on the type,
 /// call the bound method, require a non-negative Py_ssize_t result, then add
 /// the pre-header used by a heap type.  Pyre has no physical CPython object
@@ -1983,10 +2056,65 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 make_builtin_function_with_arity(name, f, arity),
             );
         };
-        store_fn(mon, "use_tool_id", |_| Ok(w_none()), 2);
-        store_fn(mon, "free_tool_id", |_| Ok(w_none()), 1);
-        store_fn(mon, "clear_tool_id", |_| Ok(w_none()), 1);
-        store_fn(mon, "get_tool", |_| Ok(w_none()), 1);
+        store_fn(
+            mon,
+            "use_tool_id",
+            |args| {
+                if args.len() != 2 {
+                    return Err(crate::PyError::type_error(
+                        "use_tool_id() takes exactly two arguments",
+                    ));
+                }
+                monitoring_use_tool_id(monitoring_tool_id_w(args[0])?, args[1])?;
+                Ok(w_none())
+            },
+            2,
+        );
+        store_fn(
+            mon,
+            "free_tool_id",
+            |args| {
+                if args.len() != 1 {
+                    return Err(crate::PyError::type_error(
+                        "free_tool_id() takes exactly one argument",
+                    ));
+                }
+                monitoring_set_tool_name(monitoring_tool_id_w(args[0])?, pyre_object::PY_NULL);
+                Ok(w_none())
+            },
+            1,
+        );
+        // `clear_tool_id` drops the tool's callbacks and events but keeps its
+        // claim on the id; with the event machinery inert there is nothing to
+        // clear, so only the id check is observable.
+        store_fn(
+            mon,
+            "clear_tool_id",
+            |args| {
+                if args.len() != 1 {
+                    return Err(crate::PyError::type_error(
+                        "clear_tool_id() takes exactly one argument",
+                    ));
+                }
+                monitoring_tool_id_w(args[0])?;
+                Ok(w_none())
+            },
+            1,
+        );
+        store_fn(
+            mon,
+            "get_tool",
+            |args| {
+                if args.len() != 1 {
+                    return Err(crate::PyError::type_error(
+                        "get_tool() takes exactly one argument",
+                    ));
+                }
+                let name = monitoring_tool_name(monitoring_tool_id_w(args[0])?);
+                Ok(if name.is_null() { w_none() } else { name })
+            },
+            1,
+        );
         store_fn(mon, "register_callback", |_| Ok(w_none()), 3);
         store_fn(mon, "set_events", |_| Ok(w_none()), 2);
         store_fn(mon, "get_events", |_| Ok(w_int_new(0)), 1);

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -612,6 +612,17 @@ unsafe fn is_zlib_mapdict_layout(obj: PyObjectRef) -> bool {
     }
 }
 
+#[inline]
+unsafe fn is_lsprof_mapdict_layout(obj: PyObjectRef) -> bool {
+    use pyre_object::lltype::PyreClassPyTypeOf;
+    unsafe {
+        pyre_object::py_type_check(
+            obj,
+            &*<crate::module::_lsprof::W_Profiler as PyreClassPyTypeOf>::PYTYPE,
+        )
+    }
+}
+
 /// Whether `obj`'s physical allocation carries the slots supplied by
 /// `MapdictStorageMixin` (`mapdict.py:748-761, 905-910`). Ordinary instances
 /// and `_random.Random` keep the historical prefix. The generated tuple/int/str
@@ -634,6 +645,7 @@ pub unsafe fn has_mapdict_layout(obj: PyObjectRef) -> bool {
         || unsafe { is_ssl_mapdict_layout(obj) }
         || unsafe { is_mmap_mapdict_layout(obj) }
         || unsafe { is_zlib_mapdict_layout(obj) }
+        || unsafe { is_lsprof_mapdict_layout(obj) }
     {
         return true;
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -773,6 +773,12 @@ unsafe fn lzma_decompressor_destructor(obj_addr: usize) {
     };
 }
 
+unsafe fn lsprof_profiler_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_lsprof::w_profiler_dealloc(obj_addr as pyre_object::PyObjectRef)
+    };
+}
+
 #[cfg(all(windows, not(feature = "sandbox")))]
 unsafe fn overlapped_destructor(obj_addr: usize) {
     unsafe {
@@ -879,6 +885,14 @@ unsafe fn mmap_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::Gc
 /// mapdict prefix and therefore require the same custom trace as W_MMap.
 unsafe fn zlib_object_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
     unsafe { object_object_custom_trace(obj_addr, f) };
+}
+
+/// `_lsprof.Profiler` owns the PyPy `ProfilerEntry` / `ProfilerContext`
+/// bookkeeping in Rust vectors, so its Python references are not visible as
+/// inline payload offsets.
+unsafe fn lsprof_profiler_custom_trace(obj_addr: usize, f: &mut dyn FnMut(*mut majit_ir::GcRef)) {
+    unsafe { object_object_custom_trace(obj_addr, f) };
+    unsafe { pyre_interpreter::module::_lsprof::w_profiler_custom_trace(obj_addr, f) };
 }
 
 /// `_ssl._SSLSocket` owns its context, transport endpoints, cached unbound
@@ -3795,6 +3809,47 @@ fn build_gc() -> Box<MiniMarkGC> {
             descr.ptr_offsets,
         );
     }
+    // `interp_lsprof.py` keeps the profiler's entry trees on the W_Root owner,
+    // behind Rust vectors no inline offset can name, so it needs a marker; it is
+    // also `cProfile.Profile`'s base class, hence the mapdict prefix walk.  The
+    // two stats result objects hold their code and call-list references in
+    // inline fields and are not instantiable, so they register like any other
+    // rclass owner.
+    let profiler_descr = <pyre_interpreter::module::_lsprof::W_Profiler
+        as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR;
+    let profiler_tid = gc.register_type(
+        TypeInfo::object_subclass_with_custom_trace(
+            profiler_descr.object_size,
+            object_tid,
+            lsprof_profiler_custom_trace,
+        )
+        .with_destructor_fn(lsprof_profiler_destructor),
+    );
+    profiler_descr.gc_type_id.set(profiler_tid);
+    majit_gc::GcAllocator::register_vtable_for_type(
+        &mut gc,
+        profiler_descr.pytype_ptr as usize,
+        profiler_tid,
+    );
+    pytype_to_tid.insert(profiler_descr.pytype_ptr as usize, profiler_tid);
+    pyre_object::gc_hook::register_pyre_class_offsets(
+        profiler_descr.pytype_ptr as usize,
+        profiler_descr.ptr_offsets,
+    );
+
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_lsprof::W_StatsEntry
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_lsprof::W_StatsSubEntry
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
+
     // `posix.DirEntry`: four inline GC edges (`w_name`/`w_path` and the cached
     // `w_stat`/`w_lstat`, the latter two NULL until first requested).  Appended
     // after the last unconditional vtable-bearing object (`W_GcStats`) so only

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -757,6 +757,22 @@ unsafe fn bz2_decompressor_destructor(obj_addr: usize) {
     };
 }
 
+unsafe fn lzma_compressor_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_lzma::w_lzmacompressor_dealloc(
+            obj_addr as pyre_object::PyObjectRef,
+        )
+    };
+}
+
+unsafe fn lzma_decompressor_destructor(obj_addr: usize) {
+    unsafe {
+        pyre_interpreter::module::_lzma::w_lzmadecompressor_dealloc(
+            obj_addr as pyre_object::PyObjectRef,
+        )
+    };
+}
+
 #[cfg(all(windows, not(feature = "sandbox")))]
 unsafe fn overlapped_destructor(obj_addr: usize) {
     unsafe {
@@ -3736,10 +3752,11 @@ fn build_gc() -> Box<MiniMarkGC> {
         );
     }
     // `interp_bz2.py` likewise keeps each libbz2 stream and its lock on the
-    // W_Root owner.  Neither type is subclassable, so they carry no mapdict
-    // prefix and no inline GC edge beyond the header's `w_class`; the sweep
-    // destructor releases the native stream.  Unconditional, and placed with
-    // the zlib owners so their ids agree on wasm/native.
+    // W_Root owner, and `_lzma`'s two stream objects own their liblzma coder
+    // the same way.  None of the four is subclassable, so they carry no
+    // mapdict prefix and no inline GC edge beyond the header's `w_class`; the
+    // sweep destructor releases the native stream.  Unconditional, and placed
+    // with the zlib owners so their ids agree on wasm/native.
     for (descr, destructor) in [
         (
             <pyre_interpreter::module::_bz2::W_BZ2Compressor
@@ -3750,6 +3767,16 @@ fn build_gc() -> Box<MiniMarkGC> {
             <pyre_interpreter::module::_bz2::W_BZ2Decompressor
                 as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
             bz2_decompressor_destructor as majit_gc::trace::DestructorFn,
+        ),
+        (
+            <pyre_interpreter::module::_lzma::W_LZMACompressor
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+            lzma_compressor_destructor as majit_gc::trace::DestructorFn,
+        ),
+        (
+            <pyre_interpreter::module::_lzma::W_LZMADecompressor
+                as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+            lzma_decompressor_destructor as majit_gc::trace::DestructorFn,
         ),
     ] {
         let tid = gc.register_type(

--- a/pyre/pyre-native/Cargo.toml
+++ b/pyre/pyre-native/Cargo.toml
@@ -17,6 +17,7 @@ scrypt = { workspace = true }
 flate2 = { workspace = true, features = ["zlib-rs"] }
 zlib-rs = { workspace = true }
 bzip2 = { workspace = true }
+xz-core = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rustls = { workspace = true }

--- a/pyre/pyre-native/src/lib.rs
+++ b/pyre/pyre-native/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod bz2;
 pub mod hash;
+pub mod lzma;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod ssl;
 pub mod zlib;

--- a/pyre/pyre-native/src/lzma.rs
+++ b/pyre/pyre-native/src/lzma.rs
@@ -1,0 +1,658 @@
+//! liblzma backend — the codec half of `_lzma`.
+//!
+//! `Modules/_lzmamodule.c` at the version `lib-python/stdlib-version.txt`
+//! names is the structure this follows; PyPy has no interp-level counterpart.
+//! The engine is the `xz-core` crate, a pure-Rust port of liblzma with the
+//! same entry points, so each function here stands where the C module calls
+//! the library. Kept outside the LLBC extraction, as `zlib` and `bz2` are.
+//!
+//! The object-space half — filter dicts, the argument surface, and the
+//! exception classes — belongs to the interpreter module, so nothing here
+//! knows what a Python object is.
+
+use std::ffi::c_void;
+use std::mem::MaybeUninit;
+
+use xz_core::common::alone_decoder::lzma_alone_decoder;
+use xz_core::common::alone_encoder::lzma_alone_encoder;
+use xz_core::common::auto_decoder::lzma_auto_decoder;
+use xz_core::common::common::{lzma_code, lzma_end, lzma_get_check};
+use xz_core::common::easy_encoder::lzma_easy_encoder;
+use xz_core::common::filter_common::lzma_filters_free;
+use xz_core::common::filter_decoder::{lzma_properties_decode, lzma_raw_decoder};
+use xz_core::common::filter_encoder::{
+    lzma_properties_encode, lzma_properties_size, lzma_raw_encoder,
+};
+use xz_core::common::stream_decoder::lzma_stream_decoder;
+use xz_core::common::stream_encoder::lzma_stream_encoder;
+use xz_core::lzma::lzma_encoder_presets::lzma_lzma_preset;
+use xz_core::types::*;
+
+// ── the constants `lzma_exec` publishes ─────────────────────────────────
+
+/// Container formats.  These are the module's own enumeration, not liblzma's.
+pub const FORMAT_AUTO: i32 = 0;
+pub const FORMAT_XZ: i32 = 1;
+pub const FORMAT_ALONE: i32 = 2;
+pub const FORMAT_RAW: i32 = 3;
+
+pub const CHECK_NONE: u32 = LZMA_CHECK_NONE;
+pub const CHECK_CRC32: u32 = LZMA_CHECK_CRC32;
+pub const CHECK_CRC64: u32 = LZMA_CHECK_CRC64;
+pub const CHECK_SHA256: u32 = LZMA_CHECK_SHA256;
+pub const CHECK_ID_MAX: u32 = LZMA_CHECK_ID_MAX;
+/// `_lzmamodule.c`'s own `LZMA_CHECK_UNKNOWN`, one past the last real id.
+pub const CHECK_UNKNOWN: u32 = LZMA_CHECK_ID_MAX + 1;
+
+pub const FILTER_LZMA1: u64 = LZMA_FILTER_LZMA1;
+pub const FILTER_LZMA2: u64 = LZMA_FILTER_LZMA2;
+pub const FILTER_DELTA: u64 = LZMA_FILTER_DELTA;
+pub const FILTER_X86: u64 = LZMA_FILTER_X86;
+pub const FILTER_IA64: u64 = LZMA_FILTER_IA64;
+pub const FILTER_ARM: u64 = LZMA_FILTER_ARM;
+pub const FILTER_ARMTHUMB: u64 = LZMA_FILTER_ARMTHUMB;
+pub const FILTER_SPARC: u64 = LZMA_FILTER_SPARC;
+pub const FILTER_POWERPC: u64 = LZMA_FILTER_POWERPC;
+
+pub const MF_HC3: u32 = LZMA_MF_HC3;
+pub const MF_HC4: u32 = LZMA_MF_HC4;
+pub const MF_BT2: u32 = LZMA_MF_BT2;
+pub const MF_BT3: u32 = LZMA_MF_BT3;
+pub const MF_BT4: u32 = LZMA_MF_BT4;
+
+pub const MODE_FAST: u32 = LZMA_MODE_FAST;
+pub const MODE_NORMAL: u32 = LZMA_MODE_NORMAL;
+
+pub const PRESET_DEFAULT: u32 = 6;
+pub const PRESET_EXTREME: u32 = LZMA_PRESET_EXTREME;
+
+/// The longest filter chain liblzma accepts.
+pub const FILTERS_MAX: usize = LZMA_FILTERS_MAX as usize;
+
+/// The output block each coding call fills before copying it out.  Upstream
+/// grows one buffer instead; the result is the same bytes either way.
+const INITIAL_BUFFER_SIZE: usize = 8192;
+
+// ── errors ──────────────────────────────────────────────────────────────
+
+/// The failures `catch_lzma_error` separates, plus the two the filter
+/// conversion raises before liblzma is reached.  The interpreter module owns
+/// the exception classes and their messages.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LzmaError {
+    UnsupportedCheck,
+    Mem,
+    MemLimit,
+    Format,
+    Options,
+    Data,
+    Buf,
+    Prog,
+    Unrecognized(lzma_ret),
+    /// `lzma_lzma_preset` rejected the preset.
+    InvalidPreset(u32),
+    /// A filter id no filter in the chain can carry.
+    InvalidFilterId(u64),
+    /// FORMAT_ALONE was given a chain that is not a single LZMA1 filter.
+    AloneChainNotSingleLzma1,
+}
+
+impl LzmaError {
+    /// `catch_lzma_error`: `None` for the four return values that are not
+    /// failures.
+    fn from_ret(ret: lzma_ret) -> Option<Self> {
+        match ret {
+            LZMA_OK | LZMA_GET_CHECK | LZMA_NO_CHECK | LZMA_STREAM_END => None,
+            LZMA_UNSUPPORTED_CHECK => Some(Self::UnsupportedCheck),
+            LZMA_MEM_ERROR => Some(Self::Mem),
+            LZMA_MEMLIMIT_ERROR => Some(Self::MemLimit),
+            LZMA_FORMAT_ERROR => Some(Self::Format),
+            LZMA_OPTIONS_ERROR => Some(Self::Options),
+            LZMA_DATA_ERROR => Some(Self::Data),
+            LZMA_BUF_ERROR => Some(Self::Buf),
+            LZMA_PROG_ERROR => Some(Self::Prog),
+            other => Some(Self::Unrecognized(other)),
+        }
+    }
+
+    fn check(ret: lzma_ret) -> Result<lzma_ret, Self> {
+        match Self::from_ret(ret) {
+            Some(error) => Err(error),
+            None => Ok(ret),
+        }
+    }
+}
+
+// ── filter chains ───────────────────────────────────────────────────────
+
+/// One filter dict, already read out of the object space.  Every option
+/// `parse_filter_spec_lzma` / `_delta` / `_bcj` accepts has a slot here;
+/// an option the filter does not use is simply ignored, exactly as the
+/// keyword parse of a different spec would ignore it.
+#[derive(Clone, Copy, Default, Debug)]
+pub struct FilterSpec {
+    pub id: u64,
+    pub preset: Option<u32>,
+    pub dict_size: Option<u32>,
+    pub lc: Option<u32>,
+    pub lp: Option<u32>,
+    pub pb: Option<u32>,
+    pub mode: Option<u32>,
+    pub nice_len: Option<u32>,
+    pub mf: Option<u32>,
+    pub depth: Option<u32>,
+    pub dist: Option<u32>,
+    pub start_offset: Option<u32>,
+}
+
+/// The option struct one chain entry points at.  The chain owns these boxes
+/// for as long as liblzma may read them — that is, until the coder has been
+/// initialized, which is the same lifetime `free_filter_chain` gives them.
+enum FilterOptions {
+    Lzma(Box<lzma_options_lzma>),
+    Delta(Box<lzma_options_delta>),
+    Bcj(Box<lzma_options_bcj>),
+}
+
+/// `parse_filter_chain_spec`'s result: the `lzma_filter` array liblzma reads,
+/// terminated by `LZMA_VLI_UNKNOWN`, plus the options it points into.
+struct FilterChain {
+    filters: Vec<lzma_filter>,
+    owned: Vec<FilterOptions>,
+}
+
+/// `parse_filter_spec_lzma`: fill in the preset's defaults first, then
+/// override with whatever the spec named.
+fn lzma_options(spec: &FilterSpec) -> Result<Box<lzma_options_lzma>, LzmaError> {
+    let preset = spec.preset.unwrap_or(PRESET_DEFAULT);
+    let mut options = Box::new(unsafe { MaybeUninit::<lzma_options_lzma>::zeroed().assume_init() });
+    if unsafe { lzma_lzma_preset(&mut *options, preset) } != 0 {
+        return Err(LzmaError::InvalidPreset(preset));
+    }
+    if let Some(value) = spec.dict_size {
+        options.dict_size = value;
+    }
+    if let Some(value) = spec.lc {
+        options.lc = value;
+    }
+    if let Some(value) = spec.lp {
+        options.lp = value;
+    }
+    if let Some(value) = spec.pb {
+        options.pb = value;
+    }
+    if let Some(value) = spec.mode {
+        options.mode = value;
+    }
+    if let Some(value) = spec.nice_len {
+        options.nice_len = value;
+    }
+    if let Some(value) = spec.mf {
+        options.mf = value;
+    }
+    if let Some(value) = spec.depth {
+        options.depth = value;
+    }
+    Ok(options)
+}
+
+impl FilterChain {
+    /// `parse_filter_chain_spec`.  The caller has already rejected a chain
+    /// longer than [`FILTERS_MAX`].
+    fn new(specs: &[FilterSpec]) -> Result<Self, LzmaError> {
+        let mut chain = Self {
+            filters: Vec::with_capacity(specs.len() + 1),
+            owned: Vec::with_capacity(specs.len()),
+        };
+        for spec in specs {
+            let options = filter_options(spec)?;
+            let pointer = match &options {
+                FilterOptions::Lzma(o) => &raw const **o as *mut c_void,
+                FilterOptions::Delta(o) => &raw const **o as *mut c_void,
+                FilterOptions::Bcj(o) => &raw const **o as *mut c_void,
+            };
+            chain.owned.push(options);
+            chain.filters.push(lzma_filter {
+                id: spec.id,
+                options: pointer,
+            });
+        }
+        chain.filters.push(lzma_filter {
+            id: LZMA_VLI_UNKNOWN,
+            options: std::ptr::null_mut(),
+        });
+        Ok(chain)
+    }
+
+    fn as_ptr(&self) -> *const lzma_filter {
+        self.filters.as_ptr()
+    }
+
+    /// The single LZMA1 options `Compressor_init_alone` hands to
+    /// `lzma_alone_encoder`, or `None` for any other chain.
+    fn lone_lzma1_options(&self) -> Option<*const lzma_options_lzma> {
+        match (self.filters.len(), self.owned.first()) {
+            (2, Some(FilterOptions::Lzma(options))) if self.filters[0].id == FILTER_LZMA1 => {
+                Some(&raw const **options)
+            }
+            _ => None,
+        }
+    }
+}
+
+/// `lzma_filter_converter`'s dispatch on the filter id.
+fn filter_options(spec: &FilterSpec) -> Result<FilterOptions, LzmaError> {
+    match spec.id {
+        FILTER_LZMA1 | FILTER_LZMA2 => Ok(FilterOptions::Lzma(lzma_options(spec)?)),
+        FILTER_DELTA => {
+            let mut options =
+                Box::new(unsafe { MaybeUninit::<lzma_options_delta>::zeroed().assume_init() });
+            options.type_ = LZMA_DELTA_TYPE_BYTE;
+            options.dist = spec.dist.unwrap_or(1);
+            Ok(FilterOptions::Delta(options))
+        }
+        FILTER_X86 | FILTER_POWERPC | FILTER_IA64 | FILTER_ARM | FILTER_ARMTHUMB | FILTER_SPARC => {
+            let mut options =
+                Box::new(unsafe { MaybeUninit::<lzma_options_bcj>::zeroed().assume_init() });
+            options.start_offset = spec.start_offset.unwrap_or(0);
+            Ok(FilterOptions::Bcj(options))
+        }
+        id => Err(LzmaError::InvalidFilterId(id)),
+    }
+}
+
+// ── the raw stream ──────────────────────────────────────────────────────
+
+/// An `lzma_stream` whose coder is released when the owner is dropped.
+///
+/// The coder state lives behind `internal` and holds no pointer back to the
+/// stream, so moving this struct before the first coding call is safe.
+struct Stream {
+    raw: lzma_stream,
+}
+
+impl Stream {
+    fn new() -> Self {
+        Self {
+            raw: unsafe { MaybeUninit::<lzma_stream>::zeroed().assume_init() },
+        }
+    }
+
+    /// One `lzma_code` call over `input[consumed..]` into `block`, reporting
+    /// what it consumed and produced.
+    fn code(
+        &mut self,
+        input: &[u8],
+        consumed: &mut usize,
+        block: &mut [u8],
+        action: lzma_action,
+    ) -> (lzma_ret, usize) {
+        let tail = &input[*consumed..];
+        self.raw.next_in = tail.as_ptr();
+        self.raw.avail_in = tail.len();
+        self.raw.next_out = block.as_mut_ptr();
+        self.raw.avail_out = block.len();
+        let ret = unsafe { lzma_code(&mut self.raw, action) };
+        *consumed = input.len() - self.raw.avail_in;
+        let produced = block.len() - self.raw.avail_out;
+        // The stream must not keep pointing at a borrow that ends here.
+        self.raw.next_in = std::ptr::null();
+        self.raw.avail_in = 0;
+        self.raw.next_out = std::ptr::null_mut();
+        self.raw.avail_out = 0;
+        (ret, produced)
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {
+        unsafe { lzma_end(&mut self.raw) };
+    }
+}
+
+/// The block to fill next, never wider than what is left of `max_length`.
+fn next_block(produced_so_far: usize, max_length: usize) -> Vec<u8> {
+    vec![0u8; INITIAL_BUFFER_SIZE.min(max_length - produced_so_far)]
+}
+
+// ── LZMACompressor ──────────────────────────────────────────────────────
+
+pub struct Compressor {
+    stream: Stream,
+    flushed: bool,
+}
+
+impl Compressor {
+    /// `Compressor_new`'s three per-format initializers.  `check` is the
+    /// integrity check for FORMAT_XZ; the other formats have none.
+    pub fn new(
+        format: i32,
+        check: u32,
+        preset: u32,
+        filters: Option<&[FilterSpec]>,
+    ) -> Result<Self, LzmaError> {
+        let mut compressor = Self {
+            stream: Stream::new(),
+            flushed: false,
+        };
+        let raw = &mut compressor.stream.raw;
+        let ret = match (format, filters) {
+            (FORMAT_XZ, None) => unsafe { lzma_easy_encoder(raw, preset, check) },
+            (FORMAT_XZ, Some(specs)) => {
+                let chain = FilterChain::new(specs)?;
+                unsafe { lzma_stream_encoder(raw, chain.as_ptr(), check) }
+            }
+            (FORMAT_ALONE, None) => {
+                let options = lzma_options(&FilterSpec {
+                    preset: Some(preset),
+                    ..FilterSpec::default()
+                })?;
+                unsafe { lzma_alone_encoder(raw, &*options) }
+            }
+            (FORMAT_ALONE, Some(specs)) => {
+                let chain = FilterChain::new(specs)?;
+                let Some(options) = chain.lone_lzma1_options() else {
+                    return Err(LzmaError::AloneChainNotSingleLzma1);
+                };
+                unsafe { lzma_alone_encoder(raw, options) }
+            }
+            (_, Some(specs)) => {
+                let chain = FilterChain::new(specs)?;
+                unsafe { lzma_raw_encoder(raw, chain.as_ptr()) }
+            }
+            (_, None) => LZMA_PROG_ERROR,
+        };
+        LzmaError::check(ret)?;
+        Ok(compressor)
+    }
+
+    pub fn is_flushed(&self) -> bool {
+        self.flushed
+    }
+
+    /// `_lzma_LZMACompressor_compress_impl`.
+    #[inline(never)]
+    pub fn compress(&mut self, data: &[u8]) -> Result<Vec<u8>, LzmaError> {
+        self.code(data, LZMA_RUN)
+    }
+
+    /// `_lzma_LZMACompressor_flush_impl` — the object is spent afterwards.
+    #[inline(never)]
+    pub fn flush(&mut self) -> Result<Vec<u8>, LzmaError> {
+        self.flushed = true;
+        self.code(&[], LZMA_FINISH)
+    }
+
+    /// `compress()`, the static helper both methods run through.
+    fn code(&mut self, data: &[u8], action: lzma_action) -> Result<Vec<u8>, LzmaError> {
+        let mut out = Vec::new();
+        let mut block = vec![0u8; INITIAL_BUFFER_SIZE];
+        let mut consumed = 0usize;
+        loop {
+            let (ret, produced) = self.stream.code(data, &mut consumed, &mut block, action);
+            out.extend_from_slice(&block[..produced]);
+            // No input and room left over is not a real error.
+            let ret = if ret == LZMA_BUF_ERROR && data.is_empty() && produced < block.len() {
+                LZMA_OK
+            } else {
+                ret
+            };
+            LzmaError::check(ret)?;
+            if (action == LZMA_RUN && consumed == data.len())
+                || (action == LZMA_FINISH && ret == LZMA_STREAM_END)
+            {
+                break;
+            }
+        }
+        out.shrink_to_fit();
+        Ok(out)
+    }
+}
+
+// ── LZMADecompressor ────────────────────────────────────────────────────
+
+pub struct Decompressor {
+    stream: Stream,
+    check: u32,
+    eof: bool,
+    needs_input: bool,
+    unused_data: Vec<u8>,
+    /// Input handed in earlier that the coder has not consumed yet.
+    input_buffer: Vec<u8>,
+}
+
+impl Decompressor {
+    /// `_lzma_LZMADecompressor_impl`.  A caller that names no memory limit
+    /// passes `u64::MAX`, as the clinic default does.
+    pub fn new(
+        format: i32,
+        memlimit: u64,
+        filters: Option<&[FilterSpec]>,
+    ) -> Result<Self, LzmaError> {
+        // The decoder reports the stream's check id through these.
+        const DECODER_FLAGS: u32 = LZMA_TELL_ANY_CHECK | LZMA_TELL_NO_CHECK;
+        let mut decompressor = Self {
+            stream: Stream::new(),
+            check: CHECK_UNKNOWN,
+            eof: false,
+            needs_input: true,
+            unused_data: Vec::new(),
+            input_buffer: Vec::new(),
+        };
+        let raw = &mut decompressor.stream.raw;
+        let ret = match format {
+            FORMAT_AUTO => unsafe { lzma_auto_decoder(raw, memlimit, DECODER_FLAGS) },
+            FORMAT_XZ => unsafe { lzma_stream_decoder(raw, memlimit, DECODER_FLAGS) },
+            FORMAT_ALONE => {
+                decompressor.check = CHECK_NONE;
+                unsafe { lzma_alone_decoder(raw, memlimit) }
+            }
+            _ => {
+                decompressor.check = CHECK_NONE;
+                let chain = FilterChain::new(filters.unwrap_or(&[]))?;
+                unsafe { lzma_raw_decoder(raw, chain.as_ptr()) }
+            }
+        };
+        LzmaError::check(ret)?;
+        Ok(decompressor)
+    }
+
+    pub fn check(&self) -> u32 {
+        self.check
+    }
+
+    pub fn eof(&self) -> bool {
+        self.eof
+    }
+
+    pub fn needs_input(&self) -> bool {
+        self.needs_input
+    }
+
+    pub fn unused_data(&self) -> &[u8] {
+        &self.unused_data
+    }
+
+    /// `decompress()` — the wrapper that prepends unconsumed input, runs the
+    /// coder, and decides what `needs_input` and `unused_data` say next.
+    #[inline(never)]
+    pub fn decompress(
+        &mut self,
+        data: &[u8],
+        max_length: Option<usize>,
+    ) -> Result<Vec<u8>, LzmaError> {
+        let pending = std::mem::take(&mut self.input_buffer);
+        let mut joined;
+        let input: &[u8] = if pending.is_empty() {
+            data
+        } else {
+            joined = pending;
+            joined.extend_from_slice(data);
+            &joined
+        };
+
+        let (out, consumed, capped) = match self.decompress_buf(input, max_length) {
+            Ok(result) => result,
+            Err(error) => return Err(error),
+        };
+
+        let leftover = &input[consumed..];
+        if self.eof {
+            self.needs_input = false;
+            if !leftover.is_empty() {
+                self.unused_data = leftover.to_vec();
+            }
+        } else if leftover.is_empty() {
+            // Output space ran out with the input exhausted: the coder may
+            // still hold bytes, so the next call needs no more input.
+            self.needs_input = !capped;
+        } else {
+            self.needs_input = false;
+            self.input_buffer = leftover.to_vec();
+        }
+        Ok(out)
+    }
+
+    /// `decompress_buf`: at most `max_length` bytes out, reporting how much
+    /// of the input that took and whether the limit is what stopped it.
+    fn decompress_buf(
+        &mut self,
+        input: &[u8],
+        max_length: Option<usize>,
+    ) -> Result<(Vec<u8>, usize, bool), LzmaError> {
+        let max_length = max_length.unwrap_or(usize::MAX);
+        let mut out = Vec::new();
+        let mut block = next_block(0, max_length);
+        let mut consumed = 0usize;
+        let mut capped = false;
+        loop {
+            let (ret, produced) = self.stream.code(input, &mut consumed, &mut block, LZMA_RUN);
+            out.extend_from_slice(&block[..produced]);
+            let filled = produced == block.len();
+            // Nothing left to read and room left over is not a real error.
+            let ret = if ret == LZMA_BUF_ERROR && consumed == input.len() && !filled {
+                LZMA_OK
+            } else {
+                ret
+            };
+            LzmaError::check(ret)?;
+            if ret == LZMA_GET_CHECK || ret == LZMA_NO_CHECK {
+                self.check = lzma_get_check(&self.stream.raw);
+            }
+            if ret == LZMA_STREAM_END {
+                self.eof = true;
+                break;
+            }
+            // Output space is checked before input: the coder may still have
+            // a few bytes to hand over even with nothing left to read.
+            if filled {
+                if out.len() == max_length {
+                    capped = true;
+                    break;
+                }
+                block = next_block(out.len(), max_length);
+            } else if consumed == input.len() {
+                break;
+            }
+        }
+        out.shrink_to_fit();
+        Ok((out, consumed, capped))
+    }
+}
+
+// ── module-level functions ──────────────────────────────────────────────
+
+/// `_lzma_is_check_supported_impl`.
+#[inline(never)]
+pub fn is_check_supported(check_id: u32) -> bool {
+    xz_core::check::check::lzma_check_is_supported(check_id) != 0
+}
+
+/// `_lzma__encode_filter_properties_impl`.
+#[inline(never)]
+pub fn encode_filter_properties(spec: &FilterSpec) -> Result<Vec<u8>, LzmaError> {
+    let chain = FilterChain::new(std::slice::from_ref(spec))?;
+    let filter = chain.filters[0];
+    let mut encoded_size: u32 = 0;
+    LzmaError::check(unsafe { lzma_properties_size(&mut encoded_size, &filter) })?;
+    let mut properties = vec![0u8; encoded_size as usize];
+    LzmaError::check(unsafe { lzma_properties_encode(&filter, properties.as_mut_ptr()) })?;
+    Ok(properties)
+}
+
+/// One decoded filter as `build_filter_spec` describes it: the id, then the
+/// option fields that filter's properties carry.
+pub struct DecodedFilter {
+    pub id: u64,
+    pub fields: Vec<(&'static str, u64)>,
+}
+
+/// `_lzma__decode_filter_properties_impl`.
+#[inline(never)]
+pub fn decode_filter_properties(
+    filter_id: u64,
+    properties: &[u8],
+) -> Result<DecodedFilter, LzmaError> {
+    let mut filter = lzma_filter {
+        id: filter_id,
+        options: std::ptr::null_mut(),
+    };
+    LzmaError::check(unsafe {
+        lzma_properties_decode(
+            &mut filter,
+            std::ptr::null(),
+            properties.as_ptr(),
+            properties.len(),
+        )
+    })?;
+    let decoded = unsafe { build_filter_spec(&filter) };
+    // `lzma_properties_decode` allocated the options through the library's
+    // own allocator, so the library frees them.
+    let mut chain = [
+        filter,
+        lzma_filter {
+            id: LZMA_VLI_UNKNOWN,
+            options: std::ptr::null_mut(),
+        },
+    ];
+    unsafe { lzma_filters_free(chain.as_mut_ptr(), std::ptr::null()) };
+    decoded
+}
+
+/// `build_filter_spec`: only the fields `lzma_properties_{encode,decode}`
+/// look at are reported, which is why LZMA2 names `dict_size` alone.
+///
+/// # Safety
+/// `filter.options` must be the option struct the filter's id implies, or
+/// null for a filter whose properties carry nothing.
+unsafe fn build_filter_spec(filter: &lzma_filter) -> Result<DecodedFilter, LzmaError> {
+    let mut fields = Vec::new();
+    match filter.id {
+        FILTER_LZMA1 => {
+            let options = unsafe { &*(filter.options as *const lzma_options_lzma) };
+            fields.push(("lc", options.lc as u64));
+            fields.push(("lp", options.lp as u64));
+            fields.push(("pb", options.pb as u64));
+            fields.push(("dict_size", options.dict_size as u64));
+        }
+        FILTER_LZMA2 => {
+            let options = unsafe { &*(filter.options as *const lzma_options_lzma) };
+            fields.push(("dict_size", options.dict_size as u64));
+        }
+        FILTER_DELTA => {
+            let options = unsafe { &*(filter.options as *const lzma_options_delta) };
+            fields.push(("dist", options.dist as u64));
+        }
+        FILTER_X86 | FILTER_POWERPC | FILTER_IA64 | FILTER_ARM | FILTER_ARMTHUMB | FILTER_SPARC => {
+            if !filter.options.is_null() {
+                let options = unsafe { &*(filter.options as *const lzma_options_bcj) };
+                fields.push(("start_offset", options.start_offset as u64));
+            }
+        }
+        id => return Err(LzmaError::InvalidFilterId(id)),
+    }
+    Ok(DecodedFilter {
+        id: filter.id,
+        fields,
+    })
+}

--- a/pyre/pyre-native/src/lzma.rs
+++ b/pyre/pyre-native/src/lzma.rs
@@ -36,13 +36,17 @@ pub const FORMAT_XZ: i32 = 1;
 pub const FORMAT_ALONE: i32 = 2;
 pub const FORMAT_RAW: i32 = 3;
 
-pub const CHECK_NONE: u32 = LZMA_CHECK_NONE;
-pub const CHECK_CRC32: u32 = LZMA_CHECK_CRC32;
-pub const CHECK_CRC64: u32 = LZMA_CHECK_CRC64;
-pub const CHECK_SHA256: u32 = LZMA_CHECK_SHA256;
-pub const CHECK_ID_MAX: u32 = LZMA_CHECK_ID_MAX;
+// A liblzma enum is `int` where the C compiler is MSVC and `unsigned` where it
+// is not, so `lzma_check`, `lzma_mode` and `lzma_match_finder` change signedness
+// with the target.  The module publishes its own `u32` surface and casts at each
+// call into the library, keeping that variance inside this file.
+pub const CHECK_NONE: u32 = LZMA_CHECK_NONE as u32;
+pub const CHECK_CRC32: u32 = LZMA_CHECK_CRC32 as u32;
+pub const CHECK_CRC64: u32 = LZMA_CHECK_CRC64 as u32;
+pub const CHECK_SHA256: u32 = LZMA_CHECK_SHA256 as u32;
+pub const CHECK_ID_MAX: u32 = LZMA_CHECK_ID_MAX as u32;
 /// `_lzmamodule.c`'s own `LZMA_CHECK_UNKNOWN`, one past the last real id.
-pub const CHECK_UNKNOWN: u32 = LZMA_CHECK_ID_MAX + 1;
+pub const CHECK_UNKNOWN: u32 = CHECK_ID_MAX + 1;
 
 pub const FILTER_LZMA1: u64 = LZMA_FILTER_LZMA1;
 pub const FILTER_LZMA2: u64 = LZMA_FILTER_LZMA2;
@@ -54,14 +58,14 @@ pub const FILTER_ARMTHUMB: u64 = LZMA_FILTER_ARMTHUMB;
 pub const FILTER_SPARC: u64 = LZMA_FILTER_SPARC;
 pub const FILTER_POWERPC: u64 = LZMA_FILTER_POWERPC;
 
-pub const MF_HC3: u32 = LZMA_MF_HC3;
-pub const MF_HC4: u32 = LZMA_MF_HC4;
-pub const MF_BT2: u32 = LZMA_MF_BT2;
-pub const MF_BT3: u32 = LZMA_MF_BT3;
-pub const MF_BT4: u32 = LZMA_MF_BT4;
+pub const MF_HC3: u32 = LZMA_MF_HC3 as u32;
+pub const MF_HC4: u32 = LZMA_MF_HC4 as u32;
+pub const MF_BT2: u32 = LZMA_MF_BT2 as u32;
+pub const MF_BT3: u32 = LZMA_MF_BT3 as u32;
+pub const MF_BT4: u32 = LZMA_MF_BT4 as u32;
 
-pub const MODE_FAST: u32 = LZMA_MODE_FAST;
-pub const MODE_NORMAL: u32 = LZMA_MODE_NORMAL;
+pub const MODE_FAST: u32 = LZMA_MODE_FAST as u32;
+pub const MODE_NORMAL: u32 = LZMA_MODE_NORMAL as u32;
 
 pub const PRESET_DEFAULT: u32 = 6;
 pub const PRESET_EXTREME: u32 = LZMA_PRESET_EXTREME;
@@ -182,13 +186,13 @@ fn lzma_options(spec: &FilterSpec) -> Result<Box<lzma_options_lzma>, LzmaError> 
         options.pb = value;
     }
     if let Some(value) = spec.mode {
-        options.mode = value;
+        options.mode = value as lzma_mode;
     }
     if let Some(value) = spec.nice_len {
         options.nice_len = value;
     }
     if let Some(value) = spec.mf {
-        options.mf = value;
+        options.mf = value as lzma_match_finder;
     }
     if let Some(value) = spec.depth {
         options.depth = value;
@@ -337,10 +341,10 @@ impl Compressor {
         };
         let raw = &mut compressor.stream.raw;
         let ret = match (format, filters) {
-            (FORMAT_XZ, None) => unsafe { lzma_easy_encoder(raw, preset, check) },
+            (FORMAT_XZ, None) => unsafe { lzma_easy_encoder(raw, preset, check as lzma_check) },
             (FORMAT_XZ, Some(specs)) => {
                 let chain = FilterChain::new(specs)?;
-                unsafe { lzma_stream_encoder(raw, chain.as_ptr(), check) }
+                unsafe { lzma_stream_encoder(raw, chain.as_ptr(), check as lzma_check) }
             }
             (FORMAT_ALONE, None) => {
                 let options = lzma_options(&FilterSpec {
@@ -537,7 +541,7 @@ impl Decompressor {
             };
             LzmaError::check(ret)?;
             if ret == LZMA_GET_CHECK || ret == LZMA_NO_CHECK {
-                self.check = lzma_get_check(&self.stream.raw);
+                self.check = lzma_get_check(&self.stream.raw) as u32;
             }
             if ret == LZMA_STREAM_END {
                 self.eof = true;
@@ -565,7 +569,7 @@ impl Decompressor {
 /// `_lzma_is_check_supported_impl`.
 #[inline(never)]
 pub fn is_check_supported(check_id: u32) -> bool {
-    xz_core::check::check::lzma_check_is_supported(check_id) != 0
+    xz_core::check::check::lzma_check_is_supported(check_id as lzma_check) != 0
 }
 
 /// `_lzma__encode_filter_properties_impl`.

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -669,24 +669,28 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // ids agree on native and wasm.
     (172, Some(0)),
     (173, Some(0)),
+    // `_lzma`'s compressor and decompressor own their liblzma coder state,
+    // unconditional for the same reason.
+    (174, Some(0)),
+    (175, Some(0)),
     // `posix.DirEntry` follows the unconditional native owners on native
     // builds.
     #[cfg(not(target_arch = "wasm32"))]
-    (174, Some(0)),
+    (176, Some(0)),
     // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
     // extend the append-only native rclass tail; wasm omits the host TLS
     // module and therefore the hierarchy entries as well. Sandbox filtering
     // belongs to pyre-interpreter, which owns that module configuration.
-    #[cfg(not(target_arch = "wasm32"))]
-    (175, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
-    (176, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (177, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (178, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (179, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (180, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (181, Some(0)),
     // `mmap.mmap` owns its native mapping payload — the duplicated fd on POSIX
     // and the file handle on Windows — and follows the optional SSL tail
     // wherever the module is compiled.  The gate must match the alias gate in
@@ -695,16 +699,16 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // A sandbox build has no `mmap` module either, so
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
-    (180, Some(0)),
+    (182, Some(0)),
     // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
     // retained Python buffers.  pyre-interpreter supplies the vtable alias;
     // the object layer owns only the append-only hierarchy slot.
     #[cfg(windows)]
-    (181, Some(0)),
+    (183, Some(0)),
     // `_winapi.Overlapped` owns a second Windows OVERLAPPED record, the one
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
-    (182, Some(0)),
+    (184, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -673,24 +673,28 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // unconditional for the same reason.
     (174, Some(0)),
     (175, Some(0)),
+    // `_lsprof`'s profiler and stats result owners are unconditional.
+    (176, Some(0)),
+    (177, Some(0)),
+    (178, Some(0)),
     // `posix.DirEntry` follows the unconditional native owners on native
     // builds.
     #[cfg(not(target_arch = "wasm32"))]
-    (176, Some(0)),
+    (179, Some(0)),
     // rustls `_ssl` context, MemoryBIO, and session native payloads.  These
     // extend the append-only native rclass tail; wasm omits the host TLS
     // module and therefore the hierarchy entries as well. Sandbox filtering
     // belongs to pyre-interpreter, which owns that module configuration.
     #[cfg(not(target_arch = "wasm32"))]
-    (177, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
-    (178, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
-    (179, Some(0)),
-    #[cfg(not(target_arch = "wasm32"))]
     (180, Some(0)),
     #[cfg(not(target_arch = "wasm32"))]
     (181, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (182, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (183, Some(0)),
+    #[cfg(not(target_arch = "wasm32"))]
+    (184, Some(0)),
     // `mmap.mmap` owns its native mapping payload — the duplicated fd on POSIX
     // and the file handle on Windows — and follows the optional SSL tail
     // wherever the module is compiled.  The gate must match the alias gate in
@@ -699,16 +703,16 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // A sandbox build has no `mmap` module either, so
     // `active_subclass_range_hierarchy` drops this entry along with SSL's.
     #[cfg(any(unix, windows))]
-    (182, Some(0)),
+    (185, Some(0)),
     // `_overlapped.Overlapped` owns the Windows OVERLAPPED record and its
     // retained Python buffers.  pyre-interpreter supplies the vtable alias;
     // the object layer owns only the append-only hierarchy slot.
     #[cfg(windows)]
-    (183, Some(0)),
+    (186, Some(0)),
     // `_winapi.Overlapped` owns a second Windows OVERLAPPED record, the one
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
-    (184, Some(0)),
+    (187, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every


### PR DESCRIPTION
`_lzma`, continuing the dependency-ordered stdlib work from RustPython#6839 — the modules that need a Rust library first. The JIT defect the module's arrival exposed in `test_tarfile` is fixed here too.

## Shape

`pyre-native::lzma` carries the codec half of `Modules/_lzmamodule.c` against [`xz-core`](https://crates.io/crates/xz-core), the pure-Rust liblzma port, and so stays outside the LLBC extraction the way `zlib` and `_bz2` keep theirs. `module/_lzma` carries the object half: `LZMACompressor` / `LZMADecompressor`, the filter-dict conversion, `LZMAError`, the 28 constants, and `is_check_supported` / `_encode_filter_properties` / `_decode_filter_properties`.

PyPy has no interp-level `_lzma` (its `lib_pypy/_lzma.py` drives liblzma through cffi), so the C module is the structure this follows, the same footing `_heapq` sits on.

The two stream types take subclass-range ids 174 and 175 in **both** GC censuses, which moves `posix.DirEntry` to 176, the five `_ssl` owners to 177-181, `mmap` to 182 and `_overlapped` to 183. Neither type is acceptable as a base class and both constructors take keywords, so `call.rs` names them beside the other such types.

An `xz-core` enum is `int` under MSVC and `unsigned` elsewhere, so `lzma_check`, `lzma_mode` and `lzma_match_finder` change signedness with the target and the windows leg failed to compile with 19 `E0308`s. The module publishes a `u32` surface and casts at each call into the library, keeping that variance in one file; checked against `x86_64-pc-windows-msvc`, `x86_64-pc-windows-gnu`, `x86_64-unknown-linux-gnu` and the host.

## The JIT fix

`try_walker_fold_check_exc_match` folds `CHECK_EXC_MATCH` to a trace-time boolean and guarded the wrong slot. The class the match reads is `typedef::type(exc)`, whose first read for a live instance is `w_class`; the fold guarded `ob_type`. Those are not interchangeable: every exception instance carries the one `W_BaseException` payload and its `ob_type` is `exc_kind_to_pytype(kind)`, so a whole family of Python-level subclasses of one builtin base share it. A chain traced on one `Exception` subclass therefore kept its folded booleans when a sibling arrived — `except EOFHeaderError:` reading `False` for a live `EOFHeaderError`.

The fold now declines on a null `w_class` (which would send `typedef::type` to `ob_type` via `gettypefor`, licensing the fold with nothing) and otherwise pins the `w_class` it actually read. `walker_guard_exact_w_class` early-returns on an unescaped box, so a virtual in-trace exception pays nothing.

`extra_tests/parity_tests/exc_match_fold_subclass_of_one_kind.py` is the regression fixture: four sibling `Exception` subclasses, a four-arm `except` chain warmed on one of them and then fed another. Pre-fix it reads `end: 0` on both backends; post-fix `end: 400`, matching CPython.

## Verification

- `test_lzma`: **119 of 121 pass**. The two failures read `f.name` off a path-like argument and get the object back instead of the fspath — that is `_io`/`open()`, not `_lzma`, and the io family is being worked elsewhere.
- Diffed against CPython 3.14 with a 98-line probe over the constants, seven round-trip shapes, incremental `decompress(data, max_length)`, `needs_input` / `eof` / `unused_data` / `check`, and the whole error surface: **every value and exception type matches.** The residual differences are argument-machinery message wording pyre already has everywhere (`compress() takes ...` vs `LZMACompressor.compress() takes ...`).
- An `.xz` written through `LZMAFile` is **byte-identical** to CPython's, and each runtime reads the other's file back.
- `test_tarfile`: was 18 errors, now **`Ran 748 tests … OK (skipped=105)`**. The three `stack underflow during interpreter opcode` errors shared the same root cause and are gone with it. At 962s it still exceeds the runner's 300s timeout, so its baseline verdict stays `TIMEOUT` and no baseline entry changes.
- Parity suite: 115 fixtures, `cpython=OK dynasm=OK cranelift=OK`, including the new one.
- `check.py` at the `_lzma` commits: dynasm 437/437, cranelift 437/437; wasm has its one documented inherited red (`short_circuit_value_kept_stack`, 5.5x). **It has not been re-run since the JIT commit** — a machine at load 55 makes its ratio gates unmeasurable, so CI is the arbiter for that commit.
- CPython suite gate: 218 PASS, no regressions beyond the baseline movement below.

## Baseline movement

- `test.test_lzma`: CRASH → FAIL (see above).
- `test.test_zoneinfo`: PASS → FAIL, on both backends. Its line 27 `lzma = import_module('lzma')` had been skipping the module wholesale; now that it runs, four of its tests want a `_zoneinfo` accelerator pyre does not have. Nothing regressed — the module simply stopped being skipped.

## Not fixed here

The ubuntu `check.py` leg's `cranelift raise_catch 3.0x > 2.5x` is main's own at this branch's base SHA, not this branch's — main fails that plus `cranelift nested_loop 3.1x > 3x`.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added built-in `_lzma` support for compression and decompression, including streaming operations, XZ/ALONE/RAW formats, filters, presets, checks, and filter-property helpers.
  - Added a pure-Rust backend, enabling LZMA support on WebAssembly builds without a C toolchain.
  - Added built-in profiling support through `_lsprof`, including profiler controls and statistics.

- **Bug Fixes**
  - Improved exception matching correctness for related exception subclasses.
  - Preserved pending exceptions during profiling and tracing hooks.
  - Crash diagnostics now include the first meaningful line of stderr.

- **Tests**
  - Added regression coverage for exception matching and profiling behavior, and updated CPython compatibility baselines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->