### PR TITLE
generator make delegated `close()` lookup errors unraisable

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1410,7 +1410,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_yield_from": {
-      "dynasm": "CRASH"
+      "dynasm": "PASS"
     },
     "test.test_zipapp": {
       "dynasm": "PASS"

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -17532,7 +17532,10 @@ fn close_yield_from(w_yf: PyObjectRef) -> PyResult {
     let close = match getattr_str(w_yf, "close") {
         Ok(method) => method,
         Err(err) if err.kind == PyErrorKind::AttributeError => return Ok(w_none()),
-        Err(err) => return Err(err),
+        Err(mut err) => {
+            err.write_unraisable(w_none(), Wtf8::new("generator/coroutine.close()"), w_none());
+            return Ok(w_none());
+        }
     };
     crate::call::call_function_impl_result(close, &[])
 }


### PR DESCRIPTION
## Summary

The error propagation of the `generator.close()` has been changed to match CPython



## Self-review

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- [x] I did not use AI to write the code of this patch.
  - If this is not checked, commits must include `Assisted-by`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when closing generators or coroutines if accessing their `close` method encounters an unexpected error.
  - Such errors are now reported appropriately while the close operation completes successfully.
  - Corrected the expected test result for `yield from` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->