### PR TITLE
cmath: back the module with a real complex-number implementation

### DIFF
--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -155,7 +155,7 @@
       "dynasm": "IMPORTERROR"
     },
     "test.test_cmath": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_cmd": {
       "dynasm": "PASS"

--- a/pyre/pyre-interpreter/src/module/cmath/interp_cmath.rs
+++ b/pyre/pyre-interpreter/src/module/cmath/interp_cmath.rs
@@ -1,0 +1,163 @@
+//! cmath module implementations — PyPy: pypy/module/cmath/interp_cmath.py
+//!
+//! Complex math via `pymath::cmath` (the `rpython.rlib.rcomplex` role,
+//! with CPython's special-value tables).  Arguments are unpacked through
+//! `builtins::complex_coerce`, the `unpackcomplex` port, so `__complex__`
+//! / `__float__` / `__index__` objects are accepted like PyPy's
+//! `space.unpackcomplex`.
+
+use num_complex::Complex64;
+use pymath::cmath as pmc;
+use pyre_object::*;
+
+type PyResult = Result<PyObjectRef, crate::PyError>;
+
+/// `space.unpackcomplex(w_z)` — reuse the `complexobject.py unpackcomplex`
+/// port that `complex()` construction goes through.
+fn unpack(obj: PyObjectRef) -> Result<Complex64, crate::PyError> {
+    let (re, im) = crate::builtins::complex_coerce(obj)?;
+    Ok(Complex64::new(re, im))
+}
+
+/// `call_c_func` (interp_cmath.py:19) — errno-style failures become the
+/// fixed cmath messages.
+fn map_err(e: pymath::Error) -> crate::PyError {
+    match e {
+        pymath::Error::EDOM => crate::PyError::value_error("math domain error"),
+        pymath::Error::ERANGE => crate::PyError::overflow_error("math range error"),
+    }
+}
+
+/// `space.newcomplex(resx, resy)`.
+fn wrap(z: Complex64) -> PyObjectRef {
+    complexobject::w_complex_new(z.re, z.im)
+}
+
+/// `unaryfn` (interp_cmath.py:29) — unpack, compute, wrap.  Arity is
+/// enforced by the `/ 1` registration.
+macro_rules! cm1 {
+    ($name:ident) => {
+        pub fn $name(args: &[PyObjectRef]) -> PyResult {
+            pmc::$name(unpack(args[0])?).map(wrap).map_err(map_err)
+        }
+    };
+}
+
+cm1!(sqrt);
+cm1!(exp);
+cm1!(log10);
+cm1!(sin);
+cm1!(cos);
+cm1!(tan);
+cm1!(asin);
+cm1!(acos);
+cm1!(atan);
+cm1!(sinh);
+cm1!(cosh);
+cm1!(tanh);
+cm1!(asinh);
+cm1!(acosh);
+cm1!(atanh);
+
+/// `wrapped_log` (interp_cmath.py:80) — with a base, `log(z)/log(base)`;
+/// `pymath::cmath::log` carries the `_Py_c_quot` division itself.
+pub fn log(args: &[PyObjectRef]) -> PyResult {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(
+            "cmath.log() takes no keyword arguments",
+        ));
+    }
+    if pos.is_empty() {
+        return Err(crate::PyError::type_error(
+            "log expected at least 1 argument, got 0",
+        ));
+    }
+    if pos.len() > 2 {
+        return Err(crate::PyError::type_error(format!(
+            "log expected at most 2 arguments, got {}",
+            pos.len()
+        )));
+    }
+    let z = unpack(pos[0])?;
+    let base = pos.get(1).map(|&b| unpack(b)).transpose()?;
+    pmc::log(z, base).map(wrap).map_err(map_err)
+}
+
+/// `wrapped_phase` — a float result, not a complex.
+pub fn phase(args: &[PyObjectRef]) -> PyResult {
+    let phi = pmc::phase(unpack(args[0])?).map_err(map_err)?;
+    Ok(floatobject::w_float_new(phi))
+}
+
+/// `wrapped_polar` — `(r, phi)` tuple.
+pub fn polar(args: &[PyObjectRef]) -> PyResult {
+    let (r, phi) = pmc::polar(unpack(args[0])?).map_err(map_err)?;
+    Ok(w_tuple_new(vec![
+        floatobject::w_float_new(r),
+        floatobject::w_float_new(phi),
+    ]))
+}
+
+/// `wrapped_rect` — arguments go through `space.float_w`, so a complex
+/// operand is rejected rather than unpacked.
+pub fn rect(args: &[PyObjectRef]) -> PyResult {
+    let r = crate::baseobjspace::float_w(args[0])?;
+    let phi = crate::baseobjspace::float_w(args[1])?;
+    pmc::rect(r, phi).map(wrap).map_err(map_err)
+}
+
+/// `wrapped_isfinite` — both components finite.
+pub fn isfinite(args: &[PyObjectRef]) -> PyResult {
+    Ok(w_bool_from(pmc::isfinite(unpack(args[0])?)))
+}
+
+/// `wrapped_isinf` — either component infinite.
+pub fn isinf(args: &[PyObjectRef]) -> PyResult {
+    Ok(w_bool_from(pmc::isinf(unpack(args[0])?)))
+}
+
+/// `wrapped_isnan` — either component NaN.
+pub fn isnan(args: &[PyObjectRef]) -> PyResult {
+    Ok(w_bool_from(pmc::isnan(unpack(args[0])?)))
+}
+
+/// `cmath.isclose(a, b, *, rel_tol=1e-09, abs_tol=0.0)` — complex
+/// `_Py_c_isclose` equivalent over the two operands' components.
+pub fn isclose(args: &[PyObjectRef]) -> PyResult {
+    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    crate::builtins::kwarg_reject_unknown(kwargs, &["rel_tol", "abs_tol"], "isclose")?;
+    if pos.len() < 2 {
+        return Err(crate::PyError::type_error(
+            "isclose() missing required argument",
+        ));
+    }
+    let (ar, ai) = crate::builtins::complex_coerce(pos[0])?;
+    let (br, bi) = crate::builtins::complex_coerce(pos[1])?;
+    let tol = |name: &str, default: f64| -> Result<f64, crate::PyError> {
+        match crate::builtins::kwarg_get(kwargs, name) {
+            Some(v) => crate::baseobjspace::float_w(v),
+            None => Ok(default),
+        }
+    };
+    let rel_tol = tol("rel_tol", 1e-9)?;
+    let abs_tol = tol("abs_tol", 0.0)?;
+    if rel_tol < 0.0 || abs_tol < 0.0 {
+        return Err(crate::PyError::value_error(
+            "tolerances must be non-negative",
+        ));
+    }
+    // Exact equality (covers the inf == inf case).
+    if ar == br && ai == bi {
+        return Ok(w_bool_from(true));
+    }
+    // Any infinity that is not an exact match is not close.
+    if ar.is_infinite() || ai.is_infinite() || br.is_infinite() || bi.is_infinite() {
+        return Ok(w_bool_from(false));
+    }
+    let diff = (ar - br).hypot(ai - bi);
+    let mag_a = ar.hypot(ai);
+    let mag_b = br.hypot(bi);
+    let close = diff <= (rel_tol * mag_a.max(mag_b)).max(abs_tol);
+    Ok(w_bool_from(close))
+}

--- a/pyre/pyre-interpreter/src/module/cmath/mod.rs
+++ b/pyre/pyre-interpreter/src/module/cmath/mod.rs
@@ -1,102 +1,48 @@
 //! cmath module — PyPy: pypy/module/cmath/
 //!
-//! Complex math functions via `pymath::cmath`.  pyre lacks
-//! `W_ComplexObject` so the real-valued subset is registered; complex
-//! arithmetic will require a follow-up.  `infj` / `nanj` are deferred
-//! along with the complex type.
+//! Function bodies live in `interp_cmath`; this declarative table mirrors
+//! `moduledef.py` interpleveldefs.
 
-use crate::module::math::interp_math;
-use pyre_object::*;
+pub mod interp_cmath;
 
-/// `cmath.isclose(a, b, *, rel_tol=1e-09, abs_tol=0.0)` — complex
-/// `_Py_c_isclose` equivalent over the two operands' components.
-fn isclose_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let (pos, kwargs) = crate::builtins::split_builtin_kwargs(args);
-    crate::builtins::kwarg_reject_unknown(kwargs, &["rel_tol", "abs_tol"], "isclose")?;
-    if pos.len() < 2 {
-        return Err(crate::PyError::type_error(
-            "isclose() missing required argument",
-        ));
-    }
-    let val = |o: PyObjectRef| {
-        unsafe { crate::objspace::descroperation::complex_val(o) }
-            .ok_or_else(|| crate::PyError::type_error("must be a number"))
-    };
-    let (ar, ai) = val(pos[0])?;
-    let (br, bi) = val(pos[1])?;
-    let tol = |name: &str, default: f64| -> Result<f64, crate::PyError> {
-        match crate::builtins::kwarg_get(kwargs, name) {
-            Some(v) => crate::baseobjspace::float_w(v),
-            None => Ok(default),
-        }
-    };
-    let rel_tol = tol("rel_tol", 1e-9)?;
-    let abs_tol = tol("abs_tol", 0.0)?;
-    if rel_tol < 0.0 || abs_tol < 0.0 {
-        return Err(crate::PyError::value_error(
-            "tolerances must be non-negative",
-        ));
-    }
-    // Exact equality (covers the inf == inf case).
-    if ar == br && ai == bi {
-        return Ok(w_bool_from(true));
-    }
-    // Any infinity that is not an exact match is not close.
-    if ar.is_infinite() || ai.is_infinite() || br.is_infinite() || bi.is_infinite() {
-        return Ok(w_bool_from(false));
-    }
-    let diff = (ar - br).hypot(ai - bi);
-    let mag_a = ar.hypot(ai);
-    let mag_b = br.hypot(bi);
-    let close = diff <= (rel_tol * mag_a.max(mag_b)).max(abs_tol);
-    Ok(w_bool_from(close))
-}
-
-fn polar_impl(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    let x = interp_math::get_double(args[0]);
-    Ok(w_tuple_new(vec![
-        floatobject::w_float_new(x.abs()),
-        floatobject::w_float_new(0.0),
-    ]))
-}
+use interp_cmath as m;
 
 crate::py_module! {
     "cmath",
     interpleveldefs: {
-        "pi"  => floatobject::w_float_new(pymath::math::PI),
-        "e"   => floatobject::w_float_new(pymath::math::E),
-        "tau" => floatobject::w_float_new(pymath::math::TAU),
-        "inf" => floatobject::w_float_new(pymath::math::INF),
-        "nan" => floatobject::w_float_new(pymath::math::NAN),
+        "pi"   => pyre_object::floatobject::w_float_new(pymath::math::PI),
+        "e"    => pyre_object::floatobject::w_float_new(pymath::math::E),
+        "tau"  => pyre_object::floatobject::w_float_new(pymath::math::TAU),
+        "inf"  => pyre_object::floatobject::w_float_new(pymath::math::INF),
+        "nan"  => pyre_object::floatobject::w_float_new(pymath::math::NAN),
+        "infj" => pyre_object::complexobject::w_complex_new(0.0, pymath::math::INF),
+        "nanj" => pyre_object::complexobject::w_complex_new(0.0, pymath::math::NAN),
     },
     functions: {
-        "phase" / 1 = |args| Ok(floatobject::w_float_new(interp_math::get_double(args[0]).atan2(0.0))),
-        "polar" / 1 = polar_impl,
-        "rect"  / 2 = |args| Ok(floatobject::w_float_new(
-            interp_math::get_double(args[0]) * interp_math::get_double(args[1]).cos()
-        )),
+        "sqrt"  / 1 = m::sqrt,
+        "exp"   / 1 = m::exp,
+        "log10" / 1 = m::log10,
+        "sin"   / 1 = m::sin,
+        "cos"   / 1 = m::cos,
+        "tan"   / 1 = m::tan,
+        "asin"  / 1 = m::asin,
+        "acos"  / 1 = m::acos,
+        "atan"  / 1 = m::atan,
+        "sinh"  / 1 = m::sinh,
+        "cosh"  / 1 = m::cosh,
+        "tanh"  / 1 = m::tanh,
+        "asinh" / 1 = m::asinh,
+        "acosh" / 1 = m::acosh,
+        "atanh" / 1 = m::atanh,
+        "log"   / * = m::log,
 
-        "isfinite" / 1 = |args| Ok(w_bool_from(interp_math::get_double(args[0]).is_finite())),
-        "isinf"    / 1 = |args| Ok(w_bool_from(interp_math::get_double(args[0]).is_infinite())),
-        "isnan"    / 1 = |args| Ok(w_bool_from(interp_math::get_double(args[0]).is_nan())),
-        "isclose"  / * = isclose_impl,
+        "phase" / 1 = m::phase,
+        "polar" / 1 = m::polar,
+        "rect"  / 2 = m::rect,
 
-        // Real-valued forwards (pending complex type)
-        "sqrt"  / 1 = interp_math::sqrt,
-        "exp"   / 1 = interp_math::exp,
-        "log10" / 1 = interp_math::log10,
-        "sin"   / 1 = interp_math::sin,
-        "cos"   / 1 = interp_math::cos,
-        "tan"   / 1 = interp_math::tan,
-        "asin"  / 1 = interp_math::asin,
-        "acos"  / 1 = interp_math::acos,
-        "atan"  / 1 = interp_math::atan,
-        "sinh"  / 1 = interp_math::sinh,
-        "cosh"  / 1 = interp_math::cosh,
-        "tanh"  / 1 = interp_math::tanh,
-        "asinh" / 1 = interp_math::asinh,
-        "acosh" / 1 = interp_math::acosh,
-        "atanh" / 1 = interp_math::atanh,
-        "log"   / * = interp_math::log,
+        "isfinite" / 1 = m::isfinite,
+        "isinf"    / 1 = m::isinf,
+        "isnan"    / 1 = m::isnan,
+        "isclose"  / * = m::isclose,
     },
 }


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

- Port PyPy's `interp_cmath.py` into a new `interp_cmath` module: each function unpacks its operands through `complex_coerce` (the `unpackcomplex` port) and computes via `pymath::cmath` / `num_complex::Complex64`, instead of forwarding to the real-valued `interp_math` stand-ins that only approximated the real axis.
- `mod.rs` becomes a thin `interpleveldefs`/`functions` table over `interp_cmath`, and gains the `infj` / `nanj` constants.
- Flip `test.test_cmath` to `PASS` on `dynasm` in `cpython_tests/baseline.json` now that the suite runs for real instead of import-erroring.

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
"Structural adaptations."
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive complex-number math support, including trigonometric, hyperbolic, logarithmic, exponential, conversion, and comparison operations.
  * Added support for complex infinity and NaN constants.
  * Improved validation and handling of invalid domains, ranges, arguments, and keywords.

* **Bug Fixes**
  * Fixed the complex math test suite so it now passes successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->