### PR TITLE
jit: run the collected postprocess callbacks when a later pass removes the op

### DIFF
--- a/majit/examples/tla/src/jit_interp.rs
+++ b/majit/examples/tla/src/jit_interp.rs
@@ -355,9 +355,18 @@ mod tests {
              the interpreter is answering alone, which every other assertion in \
              this file would still pass"
         );
+        // 24 until removals started running the postprocess callbacks the pass
+        // chain had already collected for them (`send_extra_operation`,
+        // optimizer.py:600-616, ends the walk but not the callbacks).
+        // `postprocess_INT_SUB` synthesises up to six reverse-pure entries per
+        // op via `pure_from_args2`, so running it for the ops OptPure itself
+        // removes fills the 16-slot `RecentPureOps` ring: this subject's second
+        // exit test recomputes `v - 254`, `v - 509` and `v - 764`, and those
+        // three no longer find the first test's copies in the ring. +3 ops in
+        // the preamble and +3 in the peeled body.
         assert_eq!(
-            ops_after, 24,
-            "compiled loop body is {ops_after} ops, not the pinned 24 — a value \
+            ops_after, 30,
+            "compiled loop body is {ops_after} ops, not the pinned 30 — a value \
              of 1 means the body is a bare `Finish()`, i.e. a dispatch that \
              lowered nothing at all"
         );

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4734,7 +4734,6 @@ impl Optimizer {
                     return Ok(());
                 }
                 OptimizationResult::Remove => {
-                    // optimizer.py:573-575: op removed → no postprocess.
                     ctx.pending_mark_last_guard = None;
                     ctx.pending_guard_class_postprocess = None;
                     // optimizer.py:84-92 `last_emitted_operation = REMOVED`
@@ -4742,6 +4741,14 @@ impl Optimizer {
                     // (e.g. `optimize_GUARD_NO_EXCEPTION`,
                     // rewrite.py:712-718) can observe the drop.
                     ctx.last_op_removed = true;
+                    // optimizer.py:600-616: a removal ends the WALK
+                    // (`op = None; break`) but not the callbacks — the
+                    // `opt_results` collected before it still run, in reverse.
+                    // Same loop as the Restart arm above.
+                    for &pp_idx in postprocess_passes.iter().rev() {
+                        self.passes[pp_idx].propagate_postprocess(&current_op, ctx);
+                    }
+                    self.drain_pending_finish_guard_postprocess(ctx);
                     return Ok(());
                 }
                 OptimizationResult::PassOn => {

--- a/pyre/bench/synth/arith_int_bool.cranelift.jitstats
+++ b/pyre/bench/synth/arith_int_bool.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=10
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2211
+guard_failures=2307
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=7

--- a/pyre/bench/synth/arith_int_bool.dynasm.jitstats
+++ b/pyre/bench/synth/arith_int_bool.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=10
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2211
+guard_failures=2307
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=7

--- a/pyre/bench/synth/arith_int_bool.wasm.jitstats
+++ b/pyre/bench/synth/arith_int_bool.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=10
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2211
+guard_failures=2307
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=7

--- a/pyre/bench/synth/short_circuit_value_kept_stack.cranelift.jitstats
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=2201
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/short_circuit_value_kept_stack.dynasm.jitstats
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=2201
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/short_circuit_value_kept_stack.wasm.jitstats
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=12
+bridges_compiled=11
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=2510
+guard_failures=2201
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1


### PR DESCRIPTION
## The divergence

`send_extra_operation` (`optimizer.py:594-616`) walks the pass chain, collecting
an `OptimizationResult` for each pass that declares a postprocess. A pass that
removes the op returns `None`, and upstream ends the **walk** but not the
callbacks:

```python
opt_result = opt.propagate_forward(op)
if opt_result is None:
    op = None
    break                       # the WALK stops here
...
if opt_results is not None:     # the CALLBACKS still run
    index = len(opt_results) - 1
    while index >= 0:
        opt_results[index].callback()
        index -= 1
```

pyre's `Remove` arm (`optimizeopt/optimizer.rs`) returned immediately and threw
`postprocess_passes` away. Two things say this is a slip rather than a decision:

- the **`Restart` arm twelve lines above already runs exactly this loop**, with a
  comment reasoning about `send_extra_operation`. Two arms of one `match`, one
  right and one wrong.
- the `optimizer.py:573-575` the `Remove` arm cited is the
  `log_operations_intbounds` comment inside `propagate_all_forward` — not a rule
  about postprocess at all.

## What it costs

`default_pipeline` runs `OptIntBounds` before `OptRewrite`
(`__init__.py:15-16`) precisely so `postprocess_call` can attach
`mod_bound = [0, m-1]` to an `int_py_mod` result. `optimize_call_int_py_mod`
then expands the call and returns `Remove` — and pyre dropped the callback.
Nothing in the emitted sequence re-derives `0 <= x % m < m`, so the bound is gone
for good. Upstream runs the callback *after* the expansion, where `make_equal_to`
has already forwarded the call's box onto the expansion result, so the bound
lands there. (This is the "separate change" #1284 and #1296 both flagged;
#1284's body originally mis-located it in `make_equal_to`, and has been
corrected.)

`make_equal_to` itself is fine — `optimizeopt/mod.rs` ports
`optimizer.py:395-396` faithfully, `OpInfo::IntBound` included. The transfer
mechanism was never the problem; the postprocess that produces the bound never
ran.

## What CI was asked, and what it answered

This PR was opened as a draft with the `.jitstats` baselines **deliberately
un-recorded**, so the gate would red and *enumerate* the moved rows per host
instead of one machine deciding them. It has:

| fixture | recorded | observed |
|---|---|---|
| `synth/arith_int_bool` | 10 bridges / 2211 guards | **11 / 2307** |
| `synth/short_circuit_value_kept_stack` | 12 / 2510 | **11 / 2201** |

`ubuntu-24.04` reports both on **dynasm, cranelift and wasm**; `windows-latest`
reports both on **dynasm and cranelift**; a local darwin/aarch64 run reproduces
the same six values on a tree rebased past #1296. **No other row in the corpus
moves** — 438 fixtures, two rows. The second commit records exactly those six
files and nothing else.

**This is not a uniform improvement and is not offered as one.** The two move in
*opposite* directions by the gate's reckoning — one loses 309 guard failures and
a bridge, the other gains 96 and a bridge. What they have in common is that each
lands on the value it read when the residual call was still in place, i.e. when
the bound existed. So this is the optimizer regaining a true bound, and every
host and backend agreeing on the consequence; the direction of any single counter
is incidental.

### It also pins a pair that was previously filed as unexplained drift

`main` was recorded on 2026-08-15 observing *exactly* these two value-pairs on
macOS — `arith_int_bool` 11/2307 and `short_circuit_value_kept_stack` 11/2201
against the same committed 10/2211 and 12/2510 — reproduced under a feature-off
control and filed as per-host drift, with the "11 for both fixtures" coincidence
flagged at the time as suspicious. Losing the bound is what let those counters
sit between a with-bound and a without-bound shape. With the arm fixed, three
hosts and three backends land on one reading, which retires that false-red axis.
(What is established is the agreement; the 08-15 session's own feature-off
control still argued its delta was environment-driven, and nothing here re-runs
that control.)

## The `tla` op-count pin moves 24 → 30

`majit/examples/tla`'s `jit_tier_is_alive` pins the optimized loop body to an
exact op count, and it is the one `cargo test` casualty. The +6 are two runs of
three `int_sub`, and the mechanism was bisected rather than guessed:

- skipping `rewrite`'s postprocess in the `Remove` arm leaves it at 30; skipping
  `intbounds`' puts it back to 24.
- `postprocess_INT_SUB` synthesises up to **six** reverse-pure entries per op via
  `pure_from_args2`. Running it for the ops **OptPure itself removed** fills the
  **16-slot** `RecentPureOps` ring, so the subject's second exit test no longer
  finds the first test's `v - 254`, `v - 509`, `v - 764` and emits them again.
- proof rather than inference: raising `pureop_historylength` 16 → 128 keeps the
  body at 24 **with this change applied**.

Upstream reaches the same place — `OptIntBounds.have_postprocess_op` answers true
for `INT_SUB`, OptPure's CSE hit returns `None`, `pure_from_args2` is unguarded,
and `RecentPureOps(limit=16)` is upstream's own size — so the pin was recording
pyre's pre-fix number. Re-pinned to 30 with the mechanism in a comment.

## Scope

The arm is general plumbing, not an `int_py_mod` fix. A static census of
`default_pipeline`:

| # | pass | declares postprocess for | `Remove` sites |
|---|---|---|---:|
| 0 | OptIntBounds | 34 opcodes — `CallPureI`, `CallI`, int arithmetic, `Getfield*`/`Getarrayitem*`/`Str*`/`Unicode*`, `Guard{True,False,Value}` | 26 |
| 1 | OptRewrite | every opcode — see the correction below | 76 |
| 2 | OptVirtualize | `Finish` | 42 |
| 3 | OptString | none | 14 |
| 4 | OptPure | `is_real_call() \|\| is_cond_call_value()` | 15 |
| 5 | OptEarlyForce | none | 0 |
| 6 | OptHeap | none | 41 |

> **Correction to an earlier revision of this description.** It claimed
> OptRewrite's blanket declaration means "every `Remove` in passes 2-6 (112
> sites)" was discarding a postprocess, and presented that as the shape of the
> risk. The blanket is a **pyre-side divergence, not upstream's shape**: pyre's
> `OptRewrite` has `have_postprocess() = true` and **no `have_postprocess_op`
> override**, so the default answers true for every opcode, whereas upstream sets
> `OptRewrite.have_postprocess_op = have_dispatcher_method(OptRewrite,
> 'postprocess_')` — true only where a `postprocess_<OPNAME>` exists. So the 112
> figure describes pyre, and the honest count of upstream-warranted exposure is
> lower. That divergence is inert for everything measured here (skipping
> rewrite's postprocess in the `Remove` arm changes nothing) and is left for a
> separate change.

Most removals forward the result to a box that already carries its own bound —
OptPure/OptHeap CSE, a virtual's field read, a const fold — so re-running the
postprocess re-derives what is already there. Two lossy shapes turned up:
a removal that replaces the op with a *different computation* (`int_py_mod`), and
a postprocess whose side effects outlive the removed op (`pure_from_args2` into a
bounded ring — the `tla` case above).

## Verification

- `cargo test --all --no-default-features --features dynasm` — 140 suites, **8070
  tests, 0 failures**
- the cranelift leg exactly as CI runs it (`--features cranelift,cpyext` over the
  18 backend-dependent crates) — 79 suites, **3421 tests, 0 failures**,
  `jit_tier_is_alive ... ok`
- `pyre/check.py` without `--snapshot` over both re-recorded fixtures — dynasm
  18/18, cranelift 18/18, wasm 15/15
- `cargo fmt --all -- --check` clean

Two reds have been seen on other PRs from this branch's base and are not from
this change: `cranelift raise_catch` (a pypy-ratio gate whose value wanders 3.0x
/ 3.1x / 3.6x / 4.1x / 4.5x run to run, red on main's own `db1e9bd6f17` windows
job, and with a dedicated `raise_catch profile (diagnostic)` workflow already
tracking it) and `cranelift synth/mapdict_frozen_unboxing_fold` (pypy exec
0.01s, a floor-denominator ratio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
