### PR TITLE
jit(cranelift): test the write-barrier flag inline before calling the helper

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6375,6 +6375,13 @@ fn emit_jitframe_write_barrier(
     builder.switch_to_block(slow_block);
     builder.seal_block(slow_block);
     builder.set_cold_block(slow_block);
+    // The guarded entry, not `jit_remember_young_pointer`.  The inline test is
+    // necessary but not sufficient for a frame: it can be a block built off the
+    // GC (`jitframe::alloc_off_gc_jitframe`), and a forwarded nursery header
+    // reads 0xFF at the flag byte, so the mask fires on addresses only
+    // `do_write_barrier`'s null, `is_in_nursery`, `is_managed_heap_object` and
+    // `registered_pyobject_header` checks decline.
+    // `write_barrier_skips_forwarded_nursery_address` pins the forwarded case.
     let jf_arg = ptr_arg_as_i64(builder, jf_ptr, ptr_type);
     let _ = emit_host_call(
         builder,

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -1529,7 +1529,7 @@ impl<'a> AssemblerARM64<'a> {
         // already spells this gate as `if let Some(wb) = wb_descr`.
         if crate::runner::dynasm_write_barrier_descr().is_some() {
             let loc_base = crate::aarch64::registers::FP;
-            self.emit_write_barrier_fastpath_for_base(loc_base, false, None);
+            self.emit_write_barrier_fastpath_for_base(loc_base, false, true, None);
         }
     }
 
@@ -6115,13 +6115,14 @@ impl<'a> AssemblerARM64<'a> {
         // opassembler.py:996 `loc_index = arglocs[1]` — the location kind is
         // discriminated at the card-marking block, not here.
         let loc_index = arglocs.get(1).copied();
-        self.emit_write_barrier_fastpath_for_base(loc_base, is_array, loc_index);
+        self.emit_write_barrier_fastpath_for_base(loc_base, is_array, false, loc_index);
     }
 
     fn emit_write_barrier_fastpath_for_base(
         &mut self,
         loc_base: crate::regloc::RegLoc,
         is_array: bool,
+        is_frame: bool,
         loc_index: Option<Loc>,
     ) {
         // opassembler.py:917-919 asserts the descriptor is the collector's
@@ -6220,11 +6221,15 @@ impl<'a> AssemblerARM64<'a> {
                 _ => panic!("index is neither RegLoc nor ImmedLoc"),
             }
         } else {
-            // opassembler.py:968-976: non-array slow path
-            self.emit_wb_helper_call(
-                loc_base,
-                crate::runner::dynasm_write_barrier as *const () as i64,
-            );
+            // opassembler.py:968-976: non-array slow path.  The frame takes the
+            // guarded entry; an ordinary store takes the one
+            // `gc.py:295-299 get_write_barrier_fn` names.
+            let helper = if is_frame {
+                crate::runner::dynasm_write_barrier as *const () as i64
+            } else {
+                crate::runner::dynasm_jit_remember_young_pointer as *const () as i64
+            };
+            self.emit_wb_helper_call(loc_base, helper);
         }
 
         dynasm!(self.mc ; .arch aarch64 ; =>done);

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -1270,10 +1270,33 @@ pub extern "C" fn dynasm_malloc_unicode(type_id: u64, length: u64) -> u64 {
     ))
 }
 
-/// opassembler.py:956-976: non-array write barrier slow path.
-/// Calls gc.write_barrier(obj) which is the generic barrier.
+/// opassembler.py:956-976: non-array write barrier slow path, for the case
+/// whose base is a JITFRAME.
+///
+/// `gc.write_barrier` re-checks null, nursery membership, heap membership and
+/// the pyobject-header registry before touching the remembered set. The frame
+/// is the one base that needs those: it can be a block built off the GC
+/// (`jitframe::alloc_off_gc_jitframe`), and a forwarded nursery header reads
+/// `0xFF` at the flag byte, so the inline test admits addresses the barrier
+/// must still decline.
 pub extern "C" fn dynasm_write_barrier(obj_ptr: u64) {
     with_dynasm_active_gc_mut(|gc| gc.write_barrier(majit_ir::GcRef(obj_ptr as usize)));
+}
+
+/// opassembler.py:956-976: non-array write barrier slow path, for an ordinary
+/// store's base.
+///
+/// `gc.py:295-299 get_write_barrier_fn` resolves to
+/// `framework.py:538-544 gcdata.gc.remember_young_pointer`, whose own comment
+/// is "We know that 'addr_struct' has GCFLAG_TRACK_YOUNG_PTRS so far"
+/// (`incminimark.py:1538-1546`) — the inline test already made that true, so
+/// the helper neither repeats it nor guards. The base here is whatever the GC
+/// rewriter emitted `COND_CALL_GC_WB` for, which is a collector-allocated
+/// object with a real header.
+pub extern "C" fn dynasm_jit_remember_young_pointer(obj_ptr: u64) {
+    with_dynasm_active_gc_mut(|gc| {
+        gc.jit_remember_young_pointer(majit_ir::GcRef(obj_ptr as usize))
+    });
 }
 
 /// opassembler.py:953-960: array write barrier slow path.

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2229,7 +2229,7 @@ impl<'a> Assembler386<'a> {
         // a correctness gap and is not yet implemented.
         if crate::runner::dynasm_write_barrier_descr().is_some() {
             let rbp_loc = Loc::Reg(crate::regloc::EBP);
-            self.emit_write_barrier_fastpath_kind(&[rbp_loc], false);
+            self.emit_write_barrier_fastpath_kind(&[rbp_loc], false, true);
         }
     }
 
@@ -7461,16 +7461,21 @@ impl<'a> Assembler386<'a> {
     fn emit_setarrayitem_gc_write_barrier(&mut self, arglocs: &[Loc]) {
         let use_array_barrier =
             crate::runner::dynasm_write_barrier_descr().is_some_and(|wb| wb.jit_wb_cards_set != 0);
-        self.emit_write_barrier_fastpath_kind(arglocs, use_array_barrier);
+        self.emit_write_barrier_fastpath_kind(arglocs, use_array_barrier, false);
     }
 
     /// x86/assembler.py:2438 _write_barrier_fastpath parity.
     fn emit_write_barrier_fastpath(&mut self, op: &Op, arglocs: &[Loc]) {
         let is_array = op.opcode == majit_ir::OpCode::CondCallGcWbArray;
-        self.emit_write_barrier_fastpath_kind(arglocs, is_array);
+        self.emit_write_barrier_fastpath_kind(arglocs, is_array, false);
     }
 
-    fn emit_write_barrier_fastpath_kind(&mut self, arglocs: &[Loc], is_array: bool) {
+    fn emit_write_barrier_fastpath_kind(
+        &mut self,
+        arglocs: &[Loc],
+        is_array: bool,
+        is_frame: bool,
+    ) {
         // x86/assembler.py:2399-2401 asserts the descriptor is the collector's
         // write-barrier class. `COND_CALL_GC_WB` only exists because the GC
         // rewriter emitted it, so a missing descriptor here means the two
@@ -7589,11 +7594,15 @@ impl<'a> Assembler386<'a> {
                 _ => panic!("index is neither RegLoc nor ImmedLoc"),
             }
         } else {
-            // Non-array: generic barrier
-            self.emit_wb_helper_call_x86(
-                loc_base,
-                crate::runner::dynasm_write_barrier as *const () as i64,
-            );
+            // x86/assembler.py:2432-2436: non-array slow path.  The frame takes
+            // the guarded entry; an ordinary store takes the one
+            // `gc.py:295-299 get_write_barrier_fn` names.
+            let helper = if is_frame {
+                crate::runner::dynasm_write_barrier as *const () as i64
+            } else {
+                crate::runner::dynasm_jit_remember_young_pointer as *const () as i64
+            };
+            self.emit_wb_helper_call_x86(loc_base, helper);
         }
 
         dynasm!(self.mc ; .arch x64 ; =>done);

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -5753,7 +5753,7 @@ impl MiniMarkGC {
     /// Not every jitframe is nursery-allocated: the runner's entry frame, the
     /// realloc slowpath, and the JITFRAME nursery slowpath's fallback build
     /// frames off the GC — the class `shadow_stack::register_libc_jitframe`
-    /// exists to track. Those go through `jitframe::alloc_libc_jitframe`,
+    /// exists to track. Those go through `jitframe::alloc_off_gc_jitframe`,
     /// which reserves a zeroed header word so the inline test's read at
     /// `jit_wb_if_flag_byteofs` (negative, where a header would be) stays
     /// inside the allocation and finds the flag clear. Reaching this helper
@@ -8268,7 +8268,7 @@ mod tests {
         //
         // A jitframe allocated off the GC is not in any managed generation,
         // so the word in front of it is not a header this collector owns.
-        // `jitframe::alloc_libc_jitframe` keeps that word reserved and zeroed,
+        // `jitframe::alloc_off_gc_jitframe` keeps that word reserved and zeroed,
         // which is what stops the inline test from entering the helper at all;
         // this test covers the residue — the helper being entered anyway, with
         // the flag bit set, for a block the GC does not manage. Without the

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1389,14 +1389,24 @@ impl TraceCtx {
         // and could never fire, which is exactly the mismatched-nesting bug
         // upstream is asserting against.  A box with no stamp at all is not a
         // mismatch, only an unknown, so it is skipped rather than failed.
-        if let Some(Value::Ref(r)) = self.concrete_of_opref(virtual_obj) {
+        // Both sides are read now, through the stamp, exactly as upstream calls
+        // `getref_base()` on both.  `lastbox_ptr` is the address the object had
+        // when the pair was pushed, and the object it names is movable: a minor
+        // collection between `opimpl_virtual_ref` and here relocates it and
+        // forwards the stamp, leaving the pushed copy naming the old address.
+        // Comparing a forwarded address against that copy reports a mismatch
+        // that is only the move.  A box with no stamp is an unknown, not a
+        // mismatch, so either side missing skips the check.
+        if let Some(Value::Ref(r)) = self.concrete_of_opref(virtual_obj)
+            && let Some(Value::Ref(last)) = self.concrete_of_opref(lastbox)
+        {
             // RPython's plain `assert` fires in both untranslated and
             // translated builds, so this is an `assert_eq!`: a release build
             // must fail at the divergence rather than silently corrupt the
             // vref stack.
             assert_eq!(
                 r.as_usize(),
-                lastbox_ptr,
+                last.as_usize(),
                 "opimpl_virtual_ref_finish: leaving frame ref != top virtualref ref \
                  (virtual_obj={virtual_obj:?}, lastbox={lastbox:?})"
             );


### PR DESCRIPTION
Rebased onto `origin/main` (`629e8e355a5`). #1306 landed the cranelift frame-barrier fastpath in the meantime, so this branch's own copy of it was dropped in favour of that one; what remains are the two fixes it did not cover plus the notes #1306's version does not carry.

## 1. `majit-gc`: name the off-GC jitframe allocator the write-barrier comments cite

`do_write_barrier`'s comment and `write_barrier_ignores_unmanaged_jitframe_with_flag_byte_set` cited `jitframe::alloc_libc_jitframe`; the function is `alloc_off_gc_jitframe`.

`emit_jitframe_write_barrier`'s cold block now records why it calls the guarded entry rather than `jit_remember_young_pointer`. The inline flag test is necessary but not sufficient for a frame: it can be a block built off the GC, and a forwarded nursery header reads `0xFF` at the flag byte, so the mask fires on addresses only `do_write_barrier`'s null / `is_in_nursery` / `is_managed_heap_object` / `registered_pyobject_header` checks decline. `write_barrier_skips_forwarded_nursery_address` (`collector.rs:8352`) pins the forwarded case.

## 2. `jit`: read both virtual-ref finish operands through their stamps

`opimpl_virtual_ref_finish` compared `concrete_of_opref(virtual_obj)` against `lastbox_ptr`, the address recorded when `opimpl_virtual_ref` pushed the pair. That object is movable, so a minor collection between the two points relocates it and forwards the stamp while the pushed copy keeps naming the old address; the assert then reported the move as a mismatched vref nesting. `pyjitpl.py:1825` calls `getref_base()` on both sides, and both sides now resolve through `concrete_of_opref`.

`pyre/bench/synth/selfrec_tail_exception_unwind.py` aborted at that assert under `PYPY_GC_NURSERY=1` and now completes with the output it produces at the default nursery. The 421-program synth corpus is byte-identical either way.

## 3. `jit(dynasm)`: pick the write-barrier helper by the base the fastpath guards

`emit_write_barrier_fastpath_for_base` (aarch64) and `emit_write_barrier_fastpath_kind` (x86) each serve two bases — the JITFRAME, from `_reload_frame_if_necessary`, and an ordinary store's, from `COND_CALL_GC_WB` — through one arm calling `gc.write_barrier`.

`gc.py:295-299 get_write_barrier_fn` resolves through `framework.py:538-544` to `gcdata.gc.remember_young_pointer`, whose own comment is "We know that 'addr_struct' has GCFLAG_TRACK_YOUNG_PTRS so far" (`incminimark.py:1538-1546`): the inline test is what makes that true, and the helper neither repeats the test nor guards. Both emitters now take `is_frame`; the store arm calls `dynasm_jit_remember_young_pointer`, which is what the cranelift backend's `CondCallGcWb` arm calls, and the frame arm keeps the guarded helper for the reason in §1.

Built with `--features dynasm`: the 421-program corpus is byte-identical across the change, as is the 96-program exception/guard subset under `PYPY_GC_NURSERY=1`.

## Not in this PR

- `exc_mixed_classes_bridge_flavor.py` fails 3/3 under `PYPY_GC_NURSERY=1` on main. `getarrayitem_vable_via_metainterp` re-stamps an already-recorded `OpRef` with a different runtime object — no cut involved — which falsifies the heapcache relation keyed on it and trips `_opimpl_getfield_gc_any_pureornot`'s sanity check on the immutable `W_IntObject.intval`. Diagnosed, not fixed.
- pyre has no `heapcache.reset()` call anywhere; upstream has two (`pyjitpl.py:2975`, `:2442`). Adding either does not fix the above and both cost trace quality, so neither is included.
- `exception_subclass_attrs.py`'s stress red is a timeout, not a crash: given a long enough alarm it completes with the default-nursery output.

— *authored by Claude*
