### PR TITLE
majit: skip unused TracePlan liveness in regalloc

### DIFF
--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -620,30 +620,36 @@ mod tests {
         let ops = vec![label, add, lt, guard, jump];
         let plan = TracePlan::build(&[InputArg::from_type(Type::Int, 0)], &ops);
 
-        assert_eq!(TracePlan::lower_ops(&ops), plan.ops);
+        let lowered = TracePlan::lower_ops(&ops);
+        assert_eq!(
+            lowered,
+            vec![
+                LirOp::Label { args: vec![i0] },
+                LirOp::IntBin {
+                    kind: IntBinKind::Add,
+                    dst: OpRef::int_op(1),
+                    lhs: i0,
+                    rhs: c1,
+                },
+                LirOp::IntCmp {
+                    kind: IntCmpKind::SignedLt,
+                    dst: OpRef::int_op(2),
+                    lhs: OpRef::int_op(1),
+                    rhs: c10,
+                },
+                LirOp::Guard {
+                    kind: GuardKind::True,
+                    args: vec![OpRef::int_op(2)],
+                    fail_args: vec![OpRef::int_op(1)],
+                },
+                LirOp::Jump {
+                    args: vec![OpRef::int_op(1)],
+                },
+            ]
+        );
+        assert_eq!(lowered, plan.ops);
 
         assert_eq!(plan.fallback_ops, 0);
-        assert!(matches!(
-            plan.ops[1],
-            LirOp::IntBin {
-                kind: IntBinKind::Add,
-                ..
-            }
-        ));
-        assert!(matches!(
-            plan.ops[2],
-            LirOp::IntCmp {
-                kind: IntCmpKind::SignedLt,
-                ..
-            }
-        ));
-        assert!(matches!(
-            plan.ops[3],
-            LirOp::Guard {
-                kind: GuardKind::True,
-                ..
-            }
-        ));
     }
 
     #[test]

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -171,8 +171,14 @@ pub(crate) struct TracePlan {
 }
 
 impl TracePlan {
+    /// Production lowering entry point.  Register allocation consumes only the
+    /// lowered operations; reverse liveness belongs to the diagnostic plan.
+    pub(crate) fn lower_ops(ops: &[Op]) -> Vec<LirOp> {
+        ops.iter().map(lower_op).collect()
+    }
+
     pub(crate) fn build(inputargs: &[InputArg], ops: &[Op]) -> Self {
-        let lowered: Vec<LirOp> = ops.iter().map(lower_op).collect();
+        let lowered = Self::lower_ops(ops);
         let live_points = compute_live_points(&lowered);
         let max_live = live_points
             .iter()
@@ -611,10 +617,10 @@ mod tests {
         let jump = Op::new(OpCode::Jump, &[rb(OpRef::int_op(1))]);
         jump.pos.set(OpRef::int_op(4));
 
-        let plan = TracePlan::build(
-            &[InputArg::from_type(Type::Int, 0)],
-            &[label, add, lt, guard, jump],
-        );
+        let ops = vec![label, add, lt, guard, jump];
+        let plan = TracePlan::build(&[InputArg::from_type(Type::Int, 0)], &ops);
+
+        assert_eq!(TracePlan::lower_ops(&ops), plan.ops);
 
         assert_eq!(plan.fallback_ops, 0);
         assert!(matches!(

--- a/majit/majit-backend-dynasm/src/j2plan.rs
+++ b/majit/majit-backend-dynasm/src/j2plan.rs
@@ -171,8 +171,8 @@ pub(crate) struct TracePlan {
 }
 
 impl TracePlan {
-    /// Production lowering entry point.  Register allocation consumes only the
-    /// lowered operations; reverse liveness belongs to the diagnostic plan.
+    /// Production lowering entry point. Register allocation uses only lowered
+    /// operations, while reverse liveness is for diagnostics.
     pub(crate) fn lower_ops(ops: &[Op]) -> Vec<LirOp> {
         ops.iter().map(lower_op).collect()
     }

--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -1848,8 +1848,7 @@ impl<'a> RegAlloc<'a> {
         self.jump_target_descr = None;
         self.final_jump_args = None;
         self.final_jump_op_position = -1;
-        let j2_plan = crate::j2plan::TracePlan::build(self.inputargs, self.operations);
-        self.j2_ops = j2_plan.ops;
+        self.j2_ops = crate::j2plan::TracePlan::lower_ops(self.operations);
         // x86/regalloc.py:191 X86RegisterHints().add_hints(longevity, inputargs, operations)
         //
         // Strict parity: upstream `rpython/jit/backend/x86/reghint.py`


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Removed the unused `TracePlan` liveness computation from `RegAlloc::_prepare`. The unnecessary liveness computation is now skipped only on the production path, while `TracePlan::build` is retained for diagnostics and testing.

AI disclosure: I used Codex to resolve coderabbit's suggestions

## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Refactor

* Improved consistency in how execution operations are processed.
* Streamlined planning and register allocation workflows to use a shared operation-lowering path.
* Strengthened validation to ensure generated execution plans accurately reflect the operations being processed.
* These changes improve runtime reliability without changing the application’s user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->