### PR TITLE
jit: two comments the postprocess-on-remove audit turned up

### DIFF
--- a/majit/majit-metainterp/src/optimizeopt/intbounds.rs
+++ b/majit/majit-metainterp/src/optimizeopt/intbounds.rs
@@ -1614,6 +1614,12 @@ impl Optimization for OptIntBounds {
     /// after rewrite postprocess has fixed the guard result to 1/0,
     /// intbounds propagates that knowledge backward through the producing
     /// int expression before later ops (e.g. INT_ADD_OVF) are optimized.
+    ///
+    /// `CallI` is listed alongside `CallPureI` although upstream declares only
+    /// `postprocess_CALL_PURE_I` (intbounds.py:155). It is load-bearing, and it
+    /// is what makes this port's postprocess model agree with upstream's rather
+    /// than a deviation from it — see the `CallPureI | CallI` arm in
+    /// `propagate_postprocess`.
     fn have_postprocess_op(&self, opcode: OpCode) -> bool {
         matches!(
             opcode,
@@ -1763,6 +1769,26 @@ impl Optimization for OptIntBounds {
             }
 
             // ── Call postprocess ──
+            //
+            // intbounds.py:155 `postprocess_CALL_PURE_I` — upstream has no
+            // `postprocess_CALL_I`, and matching `CallI` here is what keeps the
+            // two ports equivalent rather than what makes them differ.
+            //
+            // `OptimizationResult` (optimizer.py:47-53) remembers the op the
+            // pass itself emitted and runs the callback on THAT op, so upstream
+            // still sees `CALL_PURE_I` after OptPure demotes the call to
+            // `CALL_I` further down the chain. This port collects pass indices
+            // instead and hands every callback the FINAL op, so intbounds is
+            // handed the demoted `CallI`. Accepting both opcodes is how the
+            // bound still lands.
+            //
+            // Measured, not assumed: over 150 synth fixtures the demotion fires
+            // 72 times — 58 `CallPureR -> CallR` and 14 `CallPureI -> CallI`,
+            // and it is those 14 where intbounds has already been collected
+            // under `CallPureI` (the R-typed opcode is not in its set at all).
+            // Dropping `CallI` from this arm and from `have_postprocess_op` to
+            // "match upstream" would silently delete `mod_bound` /
+            // `py_div_bound` on every demoted call — the opposite of parity.
             OpCode::CallPureI | OpCode::CallI => {
                 let __descr_arc_d = op.getdescr();
                 if let Some(d) = __descr_arc_d.as_ref()

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -881,9 +881,26 @@ impl Optimization for OptPure {
             self.last_emitted_was_removed = false;
         }
 
-        // Clear any position arm the previous op left un-consumed: a demoted
-        // CALL removed by a downstream pass never reaches postprocess, so the
-        // one-shot could otherwise leak onto this op.
+        // Clear any position arm the previous op left un-consumed, so the
+        // one-shot cannot leak onto this op.
+        //
+        // The arm is armed in `optimize_call_pure` and consumed in
+        // `propagate_postprocess`. Every ordinary exit now consumes it: the op
+        // is collected under its demoted `CallI`/`CallR` opcode, and emission,
+        // a later pass's removal and a restart all run the collected callbacks
+        // (`send_extra_operation`, optimizer.py:600-616, ends the walk on a
+        // removal but not the callbacks). What is left un-consumed is the
+        // error exit — a pass reporting `InvalidLoop`, which abandons the
+        // trace — so this reset is defensive rather than load-bearing.
+        //
+        // Consuming it on a removal is what upstream does too: the callback
+        // rides on the result object `emit_result` built (pure.py:30-33), and
+        // that object stays in `opt_results` whatever a later pass decides. It
+        // then appends `len(_newoperations) - 1`, which for a removed call
+        // names a different op — an exposure both implementations carry.
+        // Unreachable today: the only removal of a call below this pass is
+        // OptHeap's DICT_LOOKUP dedup, and a dict lookup is registered as a
+        // plain residual call, so it never arrives here demoted from a pure one.
         self.pending_call_pure_position = false;
 
         // pure.py: OVF operation postponement.


### PR DESCRIPTION
Two comment-only follow-ups to #1307. No behaviour change; `cargo test -p
majit-metainterp --features dynasm --lib` is 1569 passed / 0 failed and
`cargo fmt --all -- --check` is clean.

Both come from auditing the postprocess machinery #1307 touched. The audit's
main outcome was **negative** — three of the four divergences I first reported
were my own misreading — and that is the reason for the second commit: the one
that survived looks like a deviation and is not one, so the next reader needs
that written down before they "fix" it.

## 1. `pure.rs` — the one-shot reset's stated premise is now false

The reset at the head of `OptPure::propagate_forward` was justified by:

> a demoted CALL removed by a downstream pass never reaches postprocess

#1307 made that false. The demoted call is collected under its `CallI` / `CallR`
opcode, so a later pass's removal now runs the callback exactly as emission and
restart already did. The reset stays — what still leaves the arm un-consumed is
the error exit where a pass reports `InvalidLoop` and the trace is abandoned — but
it is now defensive rather than load-bearing, and the comment says so.

The comment also records what consuming it on a removal costs, since the reset no
longer hides it:

- upstream carries the same exposure. The callback rides on the result object
  `emit_result` built (`pure.py:30-33`), which stays in `opt_results` whatever a
  later pass decides, and appends `len(_newoperations) - 1` — a position that for
  a removed call names a different op.
- it is unreachable today: the only removal of a call below `OptPure` is
  `OptHeap`'s `DICT_LOOKUP` dedup, and `_handle_dict_lookup_call`
  (`jtransform.py:2185-2190`) registers a dict lookup as a plain residual call, so
  it never arrives here demoted from a pure one.

## 2. `intbounds.rs` — why the call postprocess accepts `CallI`

Upstream declares `postprocess_CALL_PURE_I` only (`intbounds.py:155`). This port
matches `CallPureI | CallI` and lists both in `have_postprocess_op`. Compared
against upstream's declaration surface alone that reads as an unwarranted extra,
and deleting it is the obvious "parity fix".

It is the opposite of that. `OptimizationResult` (`optimizer.py:47-53`) remembers
the op **the pass itself emitted** and runs the callback on that op, so upstream
still sees `CALL_PURE_I` after `OptPure` demotes the call to `CALL_I` further down
the chain. This port collects pass *indices* and hands every callback the **final**
op, so intbounds is handed the demoted `CallI`. Accepting both opcodes is what
keeps the two equivalent.

Measured rather than argued — I instrumented the demotion and the callback op over
150 synth fixtures:

| observed | count | effect |
|---|---:|---|
| `pure` replaces `CallPureR` → `CallR` | 58 | inert — rewrite's postprocess matches only `Guard{True,False,Value}`, and `CallPureR` is not in intbounds' set at all |
| `pure` replaces `CallPureI` → `CallI` | 14 | **intbounds was already collected under `CallPureI`** |

So dropping `CallI` from that arm and from `have_postprocess_op` would silently
delete `mod_bound` / `py_div_bound` on every demoted call — reopening precisely the
defect #1307 fixed.

## What the audit refuted (context, no code here)

I reported four `have_postprocess_op` divergences. Three were wrong, and the cause
was one bad assumption: **the declaration surface is not the comparison unit for
this port**, because several upstream postprocesses are deliberately fused into the
`optimize_*` handler.

| suspected | verdict |
|---|---|
| `OptHeap` never runs `postprocess_GETFIELD_GC_I` / `GETARRAYITEM_GC_I` | fused inline at `heap.rs:2313-2333`, upstream citation in place |
| `OptString` never runs `postprocess_NEWSTR` / `NEWUNICODE` | fused inline at `vstring.rs:684-691`; and it correctly does *not* register on the virtualized arm, matching upstream, which creates no result there either |
| `OptPure` declares postprocess where upstream declares none | faithful stand-in — upstream binds the callback per *result object* (`pure.py:30-33`), which this port cannot express, so a per-op one-shot stands in |
| `OptRewrite` declares postprocess for every opcode | **real**, but inert: `have_postprocess() = true` with no `have_postprocess_op` override vs upstream's `have_dispatcher_method` (8 opnums), and its `propagate_postprocess` matches only the three guards with `_ => {}` |

Only the fourth is a genuine declaration divergence, and it is left alone here —
it changes nothing observable, and the honest note is that it is what made the
"112 exposed `Remove` sites" figure in #1307's description port-shaped rather than
a property of upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added explanatory comments clarifying integer division and modulo bound propagation.
  * Expanded documentation around defensive state reset behavior during optimization.

* **Refactor**
  * No user-visible behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->