### PR TITLE
jit: intern EffectInfo and stream its descriptor mints; make id() survive a nursery move

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -100,7 +100,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
-use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, Ordering};
 
 use crate::OpRef;
 use crate::effectinfo::{DescrMintEntry, DescrMintSpec, DescrSetMember};
@@ -191,11 +191,9 @@ pub enum LLType {
     Array(u64),
     /// descr.py:665: (arg_classes, result_type, result_signed,
     ///   RESULT_ERASED, extrainfo).
-    /// Structural key — two calls with the same signature + effects
-    /// share one CallDescr. `effectinfo.py:152-164` keys the EI cache
-    /// on the raw `_*_descrs_*` frozensets (not the lazily-populated
-    /// `bitstring_*` fields), so pyre's `Vec<u32>` lift carries the
-    /// frozenset content.
+    /// Two calls with the same signature and canonical EffectInfo identity
+    /// share one CallDescr. `effectinfo.py:147-148` interns the EI before
+    /// `descr.py:665` places that object in this tuple.
     Func {
         arg_classes: String,
         result_type: Type,
@@ -203,34 +201,12 @@ pub enum LLType {
         result_signed: bool,
         /// descr.py:662: result_size = symbolic.get_size(RESULT_ERASED, tsc)
         result_size: usize,
-        extraeffect: u8,
-        oopspecindex: u16,
-        /// effectinfo.py:128 `_readonly_descrs_fields = frozenset_or_none(...)`
-        ///
-        /// Stored as a `Vec<usize>` of `Arc::as_ptr` ptr-ids
-        /// (`crate::effectinfo::descr_ptr_id` lift of PyPy
-        /// `id(descr)`). The structural cache key collapses to one
-        /// entry when two `LLType::func_key` invocations carry the
-        /// same Arcs in the EI raw set, regardless of any
-        /// `descr.index()` collision between distinct Arcs.
-        readonly_descrs_fields: Option<Vec<usize>>,
-        /// effectinfo.py:131 `_write_descrs_fields`.
-        write_descrs_fields: Option<Vec<usize>>,
-        /// effectinfo.py:129 `_readonly_descrs_arrays`.
-        readonly_descrs_arrays: Option<Vec<usize>>,
-        /// effectinfo.py:132 `_write_descrs_arrays`.
-        write_descrs_arrays: Option<Vec<usize>>,
-        /// effectinfo.py:130 `_readonly_descrs_interiorfields`.
-        readonly_descrs_interiorfields: Option<Vec<usize>>,
-        /// effectinfo.py:133 `_write_descrs_interiorfields`.
-        write_descrs_interiorfields: Option<Vec<usize>>,
-        can_invalidate: bool,
-        can_collect: bool,
-        /// `effectinfo.py:144-146` release-gil cache breaker.  PyPy
-        /// appends a fresh `object()` to the EffectInfo cache key for
-        /// each target so those EIs never collapse.  `None` is the
-        /// normal structural cache key; `Some(_)` is a per-mint breaker.
-        release_gil_cache_breaker: Option<u64>,
+        /// `descr.py:665` stores the canonical `EffectInfo` object in the key.
+        /// `effectinfo.py:147-148` interns ordinary EIs process-globally, so
+        /// object identity carries all six raw sets without copying them into
+        /// every call-cache key. Release-gil EIs receive a fresh canonical
+        /// cell and therefore a fresh identity as well.
+        effect_info_identity: usize,
     },
 }
 
@@ -668,49 +644,7 @@ impl LLType {
         result_type: Type,
         result_signed: bool,
         result_size: usize,
-        effect: &EffectInfo,
-    ) -> Self {
-        Self::func_key_with_release_gil_breaker(
-            arg_types,
-            result_type,
-            result_signed,
-            result_size,
-            effect,
-            None,
-        )
-    }
-
-    /// `effectinfo.py:144-146` release-gil target key variant.
-    ///
-    /// PyPy does not structurally cache these EIs: each construction
-    /// appends a fresh `object()` to the key.  The call-descr cache is
-    /// still `GcCache._cache_call`; this helper simply supplies the
-    /// per-mint cache breaker that keeps release-gil descriptors unique.
-    pub fn func_key_with_fresh_release_gil_breaker(
-        arg_types: &[Type],
-        result_type: Type,
-        result_signed: bool,
-        result_size: usize,
-        effect: &EffectInfo,
-    ) -> Self {
-        static NEXT_RELEASE_GIL_CALL_KEY: AtomicU64 = AtomicU64::new(1);
-        Self::func_key_with_release_gil_breaker(
-            arg_types,
-            result_type,
-            result_signed,
-            result_size,
-            effect,
-            Some(NEXT_RELEASE_GIL_CALL_KEY.fetch_add(1, Ordering::Relaxed)),
-        )
-    }
-
-    fn func_key_with_release_gil_breaker(
-        arg_types: &[Type],
-        result_type: Type,
-        result_signed: bool,
-        result_size: usize,
-        effect: &EffectInfo,
-        release_gil_cache_breaker: Option<u64>,
+        effect: &Arc<crate::effectinfo::EffectInfoCell>,
     ) -> Self {
         let mut arg_classes = String::new();
         for t in arg_types {
@@ -726,32 +660,7 @@ impl LLType {
             result_type,
             result_signed,
             result_size,
-            extraeffect: effect.extraeffect as u8,
-            oopspecindex: effect.oopspecindex as u16,
-            // `effectinfo.py:152-164` cache key: raw `_*_descrs_*` sets
-            // (frozenset[Descr] lift, projected to `Arc::as_ptr`
-            // ptr-ids), NOT the lazily-published `bitstring_*` fields.
-            readonly_descrs_fields: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._readonly_descrs_fields,
-            ),
-            write_descrs_fields: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._write_descrs_fields,
-            ),
-            readonly_descrs_arrays: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._readonly_descrs_arrays,
-            ),
-            write_descrs_arrays: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._write_descrs_arrays,
-            ),
-            readonly_descrs_interiorfields: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._readonly_descrs_interiorfields,
-            ),
-            write_descrs_interiorfields: crate::effectinfo::descr_set_to_ptr_set_pub(
-                &effect._write_descrs_interiorfields,
-            ),
-            can_invalidate: effect.can_invalidate,
-            can_collect: effect.can_collect,
-            release_gil_cache_breaker,
+            effect_info_identity: Arc::as_ptr(effect) as usize,
         }
     }
 }
@@ -2433,6 +2342,7 @@ impl GcCache {
         result_size: usize,
         effect: EffectInfo,
     ) -> DescrRef {
+        let effect = crate::effectinfo::intern_effect_info(effect);
         let key = LLType::func_key(&arg_types, result_type, result_signed, result_size, &effect);
         // descr.py:667-668: cache hit
         if let Some(descr) = self._cache_call.get(&key) {
@@ -2440,7 +2350,7 @@ impl GcCache {
         }
         // descr.py:670-671: CallDescr(arg_classes, result_type, result_signed,
         //   result_size, extrainfo)
-        let descr: DescrRef = Arc::new(SimpleCallDescr::new(
+        let descr: DescrRef = Arc::new(SimpleCallDescr::new_with_effect_cell(
             next_call_descr_heapcache_index(),
             arg_types,
             result_type,
@@ -6488,7 +6398,7 @@ pub struct SimpleCallDescr {
     /// descr.py:453: CallDescr.result_flag — computed from result_type +
     /// result_signed in __init__ (descr.py:478-493).
     result_flag: ArrayFlag,
-    effect: crate::effectinfo::EffectInfoCell,
+    effect: Arc<crate::effectinfo::EffectInfoCell>,
 }
 
 impl Clone for SimpleCallDescr {
@@ -6544,7 +6454,51 @@ impl SimpleCallDescr {
         result_size: usize,
         effect: EffectInfo,
     ) -> Self {
-        // descr.py:478-493: compute result_flag from result_type + result_signed
+        Self::new_with_effect_cell_and_result_class(
+            index,
+            arg_types,
+            result_type,
+            result_class,
+            result_signed,
+            result_size,
+            crate::effectinfo::intern_effect_info(effect),
+        )
+    }
+
+    fn new_with_effect_cell(
+        index: u32,
+        arg_types: Vec<Type>,
+        result_type: Type,
+        result_signed: bool,
+        result_size: usize,
+        effect: Arc<crate::effectinfo::EffectInfoCell>,
+    ) -> Self {
+        let result_class = match result_type {
+            Type::Int => 'i',
+            Type::Ref => 'r',
+            Type::Float => 'f',
+            Type::Void => 'v',
+        };
+        Self::new_with_effect_cell_and_result_class(
+            index,
+            arg_types,
+            result_type,
+            result_class,
+            result_signed,
+            result_size,
+            effect,
+        )
+    }
+
+    fn new_with_effect_cell_and_result_class(
+        index: u32,
+        arg_types: Vec<Type>,
+        result_type: Type,
+        result_class: char,
+        result_signed: bool,
+        result_size: usize,
+        effect: Arc<crate::effectinfo::EffectInfoCell>,
+    ) -> Self {
         let result_flag = match result_type {
             Type::Void => ArrayFlag::Void,
             Type::Int => {
@@ -6565,7 +6519,7 @@ impl SimpleCallDescr {
             result_class,
             result_size,
             result_flag,
-            effect: crate::effectinfo::EffectInfoCell::new(effect),
+            effect,
         }
     }
 }

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -12,6 +12,7 @@
 
 use crate::descr::DescrRef;
 use serde::{Deserialize, Serialize};
+use std::sync::{Arc, LazyLock, Mutex};
 
 /// effectinfo.py:9-10 `class UnsupportedFieldExc(Exception)`.
 #[derive(Debug, Clone)]
@@ -271,6 +272,33 @@ impl Clone for EffectInfoCell {
         // existing test fixtures need.
         Self::new(self.get().clone())
     }
+}
+
+/// `effectinfo.py:14, 147-148 EffectInfo._cache`.
+///
+/// PyPy constructs one canonical EffectInfo object for each structural raw-set
+/// key and the call-descr cache stores that object by identity.  Keep the same
+/// process-global ownership here.  A small insertion-ordered vector is enough
+/// for the translated population and, unlike a second structural key, does not
+/// duplicate all six raw descriptor sets merely to find the canonical cell.
+///
+/// `effectinfo.py:144-146` deliberately bypasses the cache for release-gil
+/// targets by appending a fresh `object()` to the key; those calls receive a
+/// fresh cell here as well.
+pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
+    if effect_info.call_release_gil_target.0 != 0 {
+        return Arc::new(EffectInfoCell::new(effect_info));
+    }
+
+    static CACHE: LazyLock<Mutex<Vec<Arc<EffectInfoCell>>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+    let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(existing) = cache.iter().find(|existing| existing.get() == &effect_info) {
+        return existing.clone();
+    }
+    let canonical = Arc::new(EffectInfoCell::new(effect_info));
+    cache.push(canonical.clone());
+    canonical
 }
 
 /// effectinfo.py:266-269: frozenset_or_none(x)
@@ -1394,14 +1422,11 @@ impl EffectInfo {
 /// to the cache key in PyPy's runtime because the cache hit returns
 /// the same EI instance.
 ///
-/// Pyre lacks a process-global `EffectInfo._cache` today, so we
-/// reconstruct the key here for `compute_bitstrings`'s internal
-/// canonicalisation. Two structurally-equal `EffectInfo` values
-/// produce equal `EiCanonKey`s; `compute_bitstrings` then merges
-/// them into one canonical id, matching PyPy's post-frozenset class
-/// identity. Release-gil targets get a unique counter (mirroring
-/// PyPy's `object()` sentinel) so they remain distinct even when
-/// the rest of the EI matches.
+/// Production EffectInfos are interned by [`intern_effect_info`].  This key is
+/// still reconstructed for `compute_bitstrings` because its input is a set of
+/// owned snapshots, and test/macro callers can supply non-interned values.
+/// Two structurally-equal values produce equal `EiCanonKey`s; release-gil
+/// targets retain the fresh-object distinction below.
 /// `effectinfo.py:144-146` release-gil cache-breaker.
 ///
 /// PyPy: `if tgt_func: key += (object(),)` — every release-gil EI
@@ -1856,6 +1881,22 @@ mod compute_bitstrings_tests {
     }
     fn mk_array(idx: u32) -> DescrRef {
         Arc::new(SimpleArrayDescr::new(idx, 0, 8, 0, Type::Int)) as DescrRef
+    }
+
+    #[test]
+    fn effect_info_cache_reuses_ordinary_identity() {
+        let first = intern_effect_info(EffectInfo::default());
+        let second = intern_effect_info(EffectInfo::default());
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn effect_info_cache_keeps_release_gil_identity_fresh() {
+        let mut effect_info = EffectInfo::default();
+        effect_info.call_release_gil_target = (1, 0);
+        let first = intern_effect_info(effect_info.clone());
+        let second = intern_effect_info(effect_info);
+        assert!(!Arc::ptr_eq(&first, &second));
     }
 
     /// Two EIs share a fielddescr in their write set; the descr's

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -28,7 +28,7 @@ struct MetaCallDescr {
     result_type: Type,
     result_signed: bool,
     result_size: usize,
-    effect_info: EffectInfoCell,
+    effect_info: Arc<EffectInfoCell>,
 }
 
 /// `compile.py:187 isinstance(descr, JitCellToken)` parity.
@@ -719,28 +719,18 @@ fn make_call_descr_sized(
              runs (codewriter setup phase).\n  effect_info: {effect_info:?}"
         );
     }
-    // effectinfo.py:144-146: `if tgt_func: key += (object(),)  # don't
-    // care about caching in this case` — release-gil targets bypass the
-    // EffectInfo._cache via a fresh object() key.  The call descr still
-    // lives in GcCache._cache_call; the key just carries a per-mint
-    // breaker so release-gil call descrs never structurally collapse.
-    let key = if effect_info.call_release_gil_target.0 != 0 {
-        majit_ir::descr::LLType::func_key_with_fresh_release_gil_breaker(
-            arg_types,
-            result_type,
-            result_signed,
-            result_size,
-            &effect_info,
-        )
-    } else {
-        majit_ir::descr::LLType::func_key(
-            arg_types,
-            result_type,
-            result_signed,
-            result_size,
-            &effect_info,
-        )
-    };
+    // effectinfo.py:147-148 interns ordinary EffectInfos before
+    // descr.py:665 puts that object in `_cache_call`'s tuple. Release-gil
+    // targets bypass the interner with a fresh cell, matching the `object()`
+    // cache breaker at effectinfo.py:144-146.
+    let effect_info = majit_ir::effectinfo::intern_effect_info(effect_info);
+    let key = majit_ir::descr::LLType::func_key(
+        arg_types,
+        result_type,
+        result_signed,
+        result_size,
+        &effect_info,
+    );
     let mut gc = majit_ir::descr::gc_cache().lock().unwrap();
     gc.intern_call_descr_with(key, || {
         let descr: DescrRef = Arc::new(MetaCallDescr {
@@ -749,7 +739,7 @@ fn make_call_descr_sized(
             result_type,
             result_signed,
             result_size,
-            effect_info: EffectInfoCell::new(effect_info),
+            effect_info,
         });
         descr
     })
@@ -1052,6 +1042,46 @@ mod set_effect_bitstrings_tests {
             found,
             "GcCache._cache_call snapshot must include the descr we just made"
         );
+    }
+
+    #[test]
+    fn call_cache_keys_on_canonical_effect_info_identity() {
+        let first = make_call_descr_with_effect(
+            &[Type::Int, Type::Int, Type::Ref],
+            Type::Float,
+            EffectInfo::default(),
+        );
+        let second = make_call_descr_with_effect(
+            &[Type::Int, Type::Int, Type::Ref],
+            Type::Float,
+            EffectInfo::default(),
+        );
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(std::ptr::eq(
+            first.as_call_descr().unwrap().get_extra_info(),
+            second.as_call_descr().unwrap().get_extra_info(),
+        ));
+    }
+
+    #[test]
+    fn release_gil_call_cache_keeps_fresh_effect_info_identity() {
+        let mut effect_info = EffectInfo::default();
+        effect_info.call_release_gil_target = (0xfeed, 0);
+        let first = make_call_descr_with_effect(
+            &[Type::Int, Type::Ref, Type::Int],
+            Type::Void,
+            effect_info.clone(),
+        );
+        let second = make_call_descr_with_effect(
+            &[Type::Int, Type::Ref, Type::Int],
+            Type::Void,
+            effect_info,
+        );
+        assert!(!Arc::ptr_eq(&first, &second));
+        assert!(!std::ptr::eq(
+            first.as_call_descr().unwrap().get_extra_info(),
+            second.as_call_descr().unwrap().get_extra_info(),
+        ));
     }
 
     /// The trait-dispatch leg's `make_call_may_force_descr` and the walker

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -18188,6 +18188,28 @@ impl crate::compile::DescrContainer for MetaInterpStaticData {
     }
 }
 
+/// Snapshot the canonical `EffectInfo` object population consumed by
+/// `effectinfo.compute_bitstrings`, paired with one CallDescr that can publish
+/// each result back onto the shared [`majit_ir::effectinfo::EffectInfoCell`].
+fn unique_effect_info_snapshots(
+    all_descrs: &[DescrRef],
+) -> (Vec<majit_ir::EffectInfo>, Vec<DescrRef>) {
+    let mut owned_eis = Vec::new();
+    let mut writeback_descrs = Vec::new();
+    let mut seen_eis: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    for d in all_descrs {
+        if let Some(cd) = d.as_call_descr() {
+            let ei = cd.get_extra_info();
+            let ei_id = std::ptr::from_ref(ei).addr();
+            if seen_eis.insert(ei_id) {
+                owned_eis.push(ei.clone());
+                writeback_descrs.push(d.clone());
+            }
+        }
+    }
+    (owned_eis, writeback_descrs)
+}
+
 impl MetaInterpStaticData {
     /// pyjitpl.py:2289 `self.all_descrs = self.cpu.setup_descrs()` —
     /// descr.py:25-47's dense list, indexed by `descr_index`.  opencoder /
@@ -18625,20 +18647,25 @@ impl MetaInterpStaticData {
         *self.all_descrs().lock().unwrap() = all_descrs.clone();
 
         // pyjitpl.py:2290 `effectinfo.compute_bitstrings(self.all_descrs)`.
-        // Two-pass mutation: clone each call descr's EI for the algorithm
-        // input, run compute_bitstrings, then write the new bitstrings
-        // back to the original descr via Descr::set_effect_bitstrings.
+        // Two-pass mutation: clone each distinct call descr EI for the
+        // algorithm input, run compute_bitstrings, then write the new
+        // bitstrings back through one representative descr via
+        // Descr::set_effect_bitstrings.
         // The two-pass shape avoids holding mutable borrows across the
         // 6 cached fields while compute_bitstrings is doing its
         // cross-EI partitioning.
-        let mut owned_eis: Vec<majit_ir::EffectInfo> = Vec::new();
-        let mut writeback_descrs: Vec<DescrRef> = Vec::new();
-        for d in &all_descrs {
-            if let Some(cd) = d.as_call_descr() {
-                owned_eis.push(cd.get_extra_info().clone());
-                writeback_descrs.push(d.clone());
-            }
-        }
+        //
+        // `effectinfo.py:147-148 EffectInfo._cache` returns the same EI
+        // object for every ordinary structurally-identical request, and
+        // `compute_bitstrings` consumes those canonical objects rather than
+        // one copy per CallDescr.  `intern_effect_info` gives pyre the same
+        // shared `EffectInfoCell`, so deduplicate by the address returned by
+        // `get_extra_info()` before cloning.  Every CallDescr sharing that
+        // address observes the representative writeback through the shared
+        // cell. Release-gil EIs deliberately have distinct cells, matching
+        // effectinfo.py:144-146's fresh `object()` cache breaker, and remain
+        // distinct here too.
+        let (mut owned_eis, writeback_descrs) = unique_effect_info_snapshots(&all_descrs);
         // `effectinfo.py:526 descr.ei_index = …` writes the per-class
         // index directly onto each descr Arc via interior atomic.
         // `heap.rs::field_effect_index` resolves through
@@ -19023,6 +19050,31 @@ mod metainterp_static_data_tests {
     use super::*;
     use crate::jitcode::{JitCode, JitCodeBuilder};
     use majit_translate::jitcode::JitCode as BuildJitCode;
+
+    #[test]
+    fn setup_snapshots_a_shared_effect_info_once() {
+        let first = crate::call_descr::make_call_descr_with_effect(
+            &[],
+            majit_ir::Type::Void,
+            majit_ir::EffectInfo::default(),
+        );
+        let second = crate::call_descr::make_call_descr_with_effect(
+            &[majit_ir::Type::Int],
+            majit_ir::Type::Void,
+            majit_ir::EffectInfo::default(),
+        );
+        assert!(!std::sync::Arc::ptr_eq(&first, &second));
+        assert_eq!(
+            std::ptr::from_ref(first.as_call_descr().unwrap().get_extra_info()).addr(),
+            std::ptr::from_ref(second.as_call_descr().unwrap().get_extra_info()).addr(),
+            "ordinary structurally-equal EffectInfos must share their canonical cell",
+        );
+
+        let (snapshots, writebacks) = unique_effect_info_snapshots(&[first, second]);
+
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(writebacks.len(), 1);
+    }
 
     /// Build a placeholder `Arc<JitCode>` whose `fnaddr` matches the
     /// given address.  Real production code populates `fnaddr` via

--- a/pyre/bench/synth/gc_id_stable_across_move.cranelift.jitstats
+++ b/pyre/bench/synth/gc_id_stable_across_move.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=0
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=0
+retraces_compiled=0

--- a/pyre/bench/synth/gc_id_stable_across_move.dynasm.jitstats
+++ b/pyre/bench/synth/gc_id_stable_across_move.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=0
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=0
+retraces_compiled=0

--- a/pyre/bench/synth/gc_id_stable_across_move.py
+++ b/pyre/bench/synth/gc_id_stable_across_move.py
@@ -1,0 +1,32 @@
+# `id()` must survive the object moving.  A minor collection copies a surviving
+# nursery object to the old generation, so an `id()` that reports the current
+# address hands out a different value before and after — and every id()-keyed
+# memo in the pure-Python stdlib (`pickle._Pickler.memo`, `copy.deepcopy`'s
+# `memo`, `json.encoder`'s `markers`) then misses on a collection landing
+# mid-walk, emitting a shared or recursive reference twice so it round-trips as
+# two distinct objects.  `incminimark.py id_or_identityhash` answers a nursery
+# object with its shadow — the old-gen address the next minor collection will
+# copy it into — and an out-of-nursery object with its own address, which does
+# not move under mark-sweep.
+#
+# The payload must be lists: instances never move here, so an instance-based
+# workload reports a stable id even when the mechanism is missing.  200 lists
+# are held live across 40 rounds of nursery churn plus a full collection, which
+# is enough to move every one of them.
+
+import gc
+
+
+live = [[i] for i in range(200)]
+before = [id(obj) for obj in live]
+
+for _ in range(40):
+    junk = [[j] for j in range(2000)]
+    del junk
+
+gc.collect()
+after = [id(obj) for obj in live]
+changed = sum(1 for old, new in zip(before, after) if old != new)
+assert changed == 0, "id changed for %d/200 objects" % changed
+
+print("OK")

--- a/pyre/bench/synth/gc_id_stable_across_move.wasm.jitstats
+++ b/pyre/bench/synth/gc_id_stable_across_move.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=0
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=0
+retraces_compiled=0

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13404,11 +13404,12 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     // `space.id` (baseobjspace.py): a plain `int` yields its
     // value-derived `immutable_unique_id`; every other object falls back
-    // to `compute_unique_id` — its address.
+    // to `compute_unique_id`, which incminimark implements through
+    // `id_or_identityhash` (incminimark.py) so nursery moves preserve it.
     let obj = args[0];
     Ok(match crate::function::immutable_unique_id(obj) {
         Some(w_id) => w_id,
-        None => w_int_new(obj as usize as i64),
+        None => w_int_new(pyre_object::gc_hook::gc_identity_hash(obj as usize) as i64),
     })
 }
 

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -13,7 +13,7 @@ use walkdir::WalkDir;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v7";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v8";
 /// Retained cache entries. Each is ~6 MB, and a handful covers the
 /// configurations one checkout switches between (native/wasm × release/dev).
 const CODEGEN_CACHE_MAX_ENTRIES: usize = 8;
@@ -73,9 +73,10 @@ const CODEGEN_OUTPUTS: &[&str] = &[
 /// and its byte boundaries in `jitcodes.bin`, and an address is a fixed-width
 /// `i64` there, so a change in jitcode population, order or body length still
 /// moves it while an address change alone does not.
-/// `descrs_index.bin` is likewise a pure byte-offset table: `descrs.bin`
+/// `descrs_index.bin` is likewise a pure byte-offset/kind table: `descrs.bin`
 /// remains host-addressed, but its index contains no address and stays in the
-/// cross-process verdict to judge descriptor population, order, and lengths.
+/// cross-process verdict to judge descriptor population, order, lengths, and
+/// setup-pass classification.
 ///
 /// Caching them is still sound: a restore serves these tables and the
 /// `constants_i` baked against them from the *same* generation, so they stay
@@ -254,7 +255,7 @@ fn emit_llbc_extraction_placeholders() {
     std::fs::write(format!("{out_dir}/descrs.bin"), b"").unwrap();
     std::fs::write(
         format!("{out_dir}/descrs_index.bin"),
-        bincode::serialize(&vec![0_u32]).unwrap(),
+        bincode::serialize(&(vec![0_u32], Vec::<u8>::new())).unwrap(),
     )
     .unwrap();
     std::fs::write(
@@ -1065,8 +1066,20 @@ fn real_main() {
         // reconstituting every descriptor in this process.
         let mut descrs_bin = Vec::new();
         let mut descr_offsets = Vec::with_capacity(pipeline.descrs.len() + 1);
+        let mut descr_kinds = Vec::with_capacity(pipeline.descrs.len());
         descr_offsets.push(0_u32);
         for descr in &pipeline.descrs {
+            // `GcCache.setup_descrs` publishes structural descriptors before
+            // call descriptors.  Persist that two-pass classification beside
+            // the dense offsets so runtime can preserve the ordering without
+            // deserializing every entry once merely to discover its variant.
+            // One byte per dense slot retains upstream's list shape and avoids
+            // introducing a second keyed registry.
+            descr_kinds.push(match descr {
+                majit_translate::jitcode::BhDescr::Call { .. }
+                | majit_translate::jitcode::BhDescr::JitCode { .. } => 1_u8,
+                _ => 0_u8,
+            });
             descrs_bin.extend(bincode::serialize(descr).unwrap());
             descr_offsets.push(
                 u32::try_from(descrs_bin.len())
@@ -1074,10 +1087,11 @@ fn real_main() {
             );
         }
         assert_eq!(descr_offsets.len(), pipeline.descrs.len() + 1);
+        assert_eq!(descr_kinds.len(), pipeline.descrs.len());
         assert_eq!(descr_offsets.first().copied(), Some(0));
         assert_eq!(descr_offsets.last().copied(), Some(descrs_bin.len() as u32));
         assert!(descr_offsets.windows(2).all(|pair| pair[0] <= pair[1]));
-        let descrs_index_bin = bincode::serialize(&descr_offsets).unwrap();
+        let descrs_index_bin = bincode::serialize(&(descr_offsets, descr_kinds)).unwrap();
         std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
         std::fs::write(format!("{out_dir}/descrs_index.bin"), &descrs_index_bin).unwrap();
 

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -13,7 +13,7 @@ use walkdir::WalkDir;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v8";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v9";
 /// Retained cache entries. Each is ~6 MB, and a handful covers the
 /// configurations one checkout switches between (native/wasm × release/dev).
 const CODEGEN_CACHE_MAX_ENTRIES: usize = 8;
@@ -30,6 +30,7 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "descrs.bin",
     "descrs_index.bin",
     "ei_descr_mints.bin",
+    "ei_descr_mints_index.bin",
     "field_mint_census.bin",
     "liveness.bin",
     "fnaddr_bindings.bin",
@@ -68,7 +69,8 @@ const CODEGEN_OUTPUTS: &[&str] = &[
 ///
 /// What decides the cross-process verdict after these exclusions:
 /// `jit_trace_gen.rs`, `jitcodes_index.bin`, `jit_drivers.bin`, `insns.bin`,
-/// `descrs_index.bin`, `ei_descr_mints.bin`, `liveness.bin`.
+/// `descrs_index.bin`, `ei_descr_mints.bin`, `ei_descr_mints_index.bin`,
+/// `liveness.bin`.
 /// `jitcodes_index.bin` is the load-bearing one — it holds each jitcode's name
 /// and its byte boundaries in `jitcodes.bin`, and an address is a fixed-width
 /// `i64` there, so a change in jitcode population, order or body length still
@@ -258,9 +260,10 @@ fn emit_llbc_extraction_placeholders() {
         bincode::serialize(&(vec![0_u32], Vec::<u8>::new())).unwrap(),
     )
     .unwrap();
+    std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), b"").unwrap();
     std::fs::write(
-        format!("{out_dir}/ei_descr_mints.bin"),
-        bincode::serialize(&Vec::<majit_ir::effectinfo::DescrMintEntry>::new()).unwrap(),
+        format!("{out_dir}/ei_descr_mints_index.bin"),
+        bincode::serialize(&vec![0_u32]).unwrap(),
     )
     .unwrap();
     std::fs::write(
@@ -1123,8 +1126,27 @@ fn real_main() {
         // raw-set members no opcode names would have no slot on the far side;
         // persist their mint arguments and let the runtime cache take the same
         // `descr.py:224-238` miss branch this one did.
-        let ei_descr_mints_bin = bincode::serialize(&pipeline.ei_descr_mints).unwrap();
+        // Mint specs are one-shot setup inputs.  Keep the same indexed-entry
+        // shape as `descrs.bin` so the runtime can deserialize and publish one
+        // spec at a time instead of retaining all member/spec strings at the
+        // peak of first-JIT setup.
+        let mut ei_descr_mints_bin = Vec::new();
+        let mut ei_descr_mint_offsets = Vec::with_capacity(pipeline.ei_descr_mints.len() + 1);
+        ei_descr_mint_offsets.push(0_u32);
+        for entry in &pipeline.ei_descr_mints {
+            ei_descr_mints_bin.extend(bincode::serialize(entry).unwrap());
+            ei_descr_mint_offsets.push(
+                u32::try_from(ei_descr_mints_bin.len())
+                    .expect("serialized ei_descr_mints.bin exceeds the u32 offset range"),
+            );
+        }
+        let ei_descr_mints_index_bin = bincode::serialize(&ei_descr_mint_offsets).unwrap();
         std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), &ei_descr_mints_bin).unwrap();
+        std::fs::write(
+            format!("{out_dir}/ei_descr_mints_index.bin"),
+            &ei_descr_mints_index_bin,
+        )
+        .unwrap();
 
         // Analyzer-side descriptor producers run in this build-script process,
         // while the runtime formats the field-position report. Persist the

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -6843,7 +6843,11 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
         ei.single_write_descr_array = None;
     }
 
-    let Some(keys) = ei.descr_set_keys.as_ref() else {
+    // `descr_set_keys` is the build-process -> runtime-process wire channel
+    // for the six raw sets skipped by serde.  Consume it here: after the
+    // canonical DescrRefs below have been installed, retaining the member
+    // names duplicates the live object graph and has no RPython counterpart.
+    let Some(keys) = ei.descr_set_keys.take() else {
         // No serialized key channel.  For a build-time EI that means the
         // codewriter already emitted the `EF_RANDOM_EFFECTS` wildcard, so
         // the six raw sets are `None` and there is nothing to rebuild.  Any

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -685,17 +685,47 @@ pub fn all_descrs() -> &'static [BhDescr] {
     })
 }
 
-/// Deserialized `pipeline.ei_descr_mints` — the gccache slots that only an
-/// `EffectInfo` raw set names, paired with the arguments their mint took.
+/// Indexed `pipeline.ei_descr_mints` — gccache slots named only by an
+/// EffectInfo raw set, paired with the arguments their mint took.
 ///
 /// See `descr::publish_effect_info_descr_mints` for why the opcode table alone
-/// leaves these slots empty on this side of the build/runtime split.
-fn load_ei_descr_mints() -> Vec<majit_ir::effectinfo::DescrMintEntry> {
+/// leaves these slots empty on this side of the build/runtime split.  Entries
+/// are decoded independently so setup never retains all 2,000+ string-heavy
+/// mint specs at once.
+fn ei_descr_mint_offsets() -> &'static [u32] {
+    static OFFSETS: OnceLock<Box<[u32]>> = OnceLock::new();
+    OFFSETS.get_or_init(|| {
+        const INDEX_BYTES: &[u8] =
+            include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints_index.bin"));
+        const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints.bin"));
+        let offsets: Vec<u32> = bincode::deserialize(INDEX_BYTES).unwrap_or_else(|e| {
+            panic!(
+                "pyre-jit-trace: failed to deserialize ei_descr_mints_index.bin \
+                 ({} bytes): {e}",
+                INDEX_BYTES.len(),
+            )
+        });
+        assert!(!offsets.is_empty());
+        assert_eq!(offsets.first().copied(), Some(0));
+        assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
+        assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
+        offsets.into_boxed_slice()
+    })
+}
+
+fn ei_descr_mint_count() -> usize {
+    ei_descr_mint_offsets().len() - 1
+}
+
+fn load_ei_descr_mint(index: usize) -> majit_ir::effectinfo::DescrMintEntry {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints.bin"));
-    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+    let offsets = ei_descr_mint_offsets();
+    let start = offsets[index] as usize;
+    let end = offsets[index + 1] as usize;
+    bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
         panic!(
-            "pyre-jit-trace: failed to deserialize ei_descr_mints.bin \
-             ({} bytes): {e}",
+            "pyre-jit-trace: failed to deserialize ei_descr_mints.bin entry {index} \
+             ({start}..{end} of {} bytes): {e}",
             BYTES.len(),
         )
     })
@@ -825,9 +855,9 @@ pub fn rehydrate_build_descr_raw_sets() {
         // Upstream's descriptors remain in GcCache; the temporary arguments
         // passed to get_*_descr do not.  Drop the decoded strings/specs as
         // soon as their canonical runtime descriptors have been published.
-        {
-            let ei_descr_mints = load_ei_descr_mints();
-            crate::descr::publish_effect_info_descr_mints(&ei_descr_mints);
+        for i in 0..ei_descr_mint_count() {
+            let entry = load_ei_descr_mint(i);
+            crate::descr::publish_effect_info_descr_mints(std::slice::from_ref(&entry));
         }
         for (i, kind) in index.kinds.iter().copied().enumerate() {
             if kind != 1 {
@@ -2018,6 +2048,16 @@ mod tests {
     }
 
     #[test]
+    fn effect_info_mint_index_bounds_each_serialized_entry() {
+        let offsets = ei_descr_mint_offsets();
+        assert_eq!(offsets.len(), ei_descr_mint_count() + 1);
+        for i in 0..ei_descr_mint_count() {
+            let _entry = load_ei_descr_mint(i);
+            assert!(offsets[i] < offsets[i + 1], "mint entry {i} is empty");
+        }
+    }
+
+    #[test]
     fn rehydrate_effect_info_consumes_serialized_set_keys() {
         let mut effect_info = majit_ir::EffectInfo::default();
         assert!(effect_info.descr_set_keys.is_some());
@@ -2103,7 +2143,7 @@ mod tests {
         let base = rss_kb();
         let n_descrs = descr_count();
         let after_descrs = rss_kb();
-        let n_mints = load_ei_descr_mints().len();
+        let n_mints = ei_descr_mint_count();
         let after_mints = rss_kb();
         rehydrate_build_descr_raw_sets();
         let after_rehydrate = rss_kb();
@@ -2117,7 +2157,7 @@ mod tests {
             after_descrs - base
         );
         eprintln!(
-            "[rss-decomp] deserialize_ei_mints n={n_mints} delta={} KB",
+            "[rss-decomp] ei_mint_index        n={n_mints} delta={} KB",
             after_mints - after_descrs
         );
         eprintln!(

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -573,35 +573,48 @@ pub fn insns_byte_to_opname() -> &'static HashMap<u8, String> {
 /// little-endian index into this pool. The resolved `BhDescr` is what
 /// every `bhimpl_*` handler reads for field offsets, call descriptors,
 /// sub-JitCodes, and switch dicts.
-fn load_descr_index() -> &'static [u32] {
+struct DescrIndex {
+    offsets: Box<[u32]>,
+    /// `0` for structural/dispatch descriptors, `1` for Call/JitCode.
+    /// Mirrors the two groups consumed by `rehydrate_build_descr_raw_sets`.
+    kinds: Box<[u8]>,
+}
+
+fn load_descr_index() -> DescrIndex {
     const INDEX_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descrs_index.bin"));
     const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descrs.bin"));
-    let offsets: Vec<u32> = bincode::deserialize(INDEX_BYTES).unwrap_or_else(|e| {
-        panic!(
-            "pyre-jit-trace: failed to deserialize descrs_index.bin \
+    let (offsets, kinds): (Vec<u32>, Vec<u8>) =
+        bincode::deserialize(INDEX_BYTES).unwrap_or_else(|e| {
+            panic!(
+                "pyre-jit-trace: failed to deserialize descrs_index.bin \
              ({} bytes): {e}",
-            INDEX_BYTES.len(),
-        )
-    });
+                INDEX_BYTES.len(),
+            )
+        });
     assert!(!offsets.is_empty());
     assert_eq!(offsets.first().copied(), Some(0));
     assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
     assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
-    Box::leak(offsets.into_boxed_slice())
+    assert_eq!(kinds.len() + 1, offsets.len());
+    assert!(kinds.iter().all(|kind| matches!(kind, 0 | 1)));
+    DescrIndex {
+        offsets: offsets.into_boxed_slice(),
+        kinds: kinds.into_boxed_slice(),
+    }
 }
 
-fn descrs_index() -> &'static [u32] {
-    static INDEX: OnceLock<&'static [u32]> = OnceLock::new();
+fn descrs_index() -> &'static DescrIndex {
+    static INDEX: OnceLock<DescrIndex> = OnceLock::new();
     INDEX.get_or_init(load_descr_index)
 }
 
 fn descr_count() -> usize {
-    descrs_index().len() - 1
+    descrs_index().kinds.len()
 }
 
 fn load_descr_uncached(index: usize) -> BhDescr {
     const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/descrs.bin"));
-    let offsets = descrs_index();
+    let offsets = &descrs_index().offsets;
     let start = offsets[index] as usize;
     let end = offsets[index + 1] as usize;
     bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
@@ -621,7 +634,7 @@ fn descr_cells() -> &'static [OnceLock<&'static BhDescr>] {
         let cells = Box::leak(cells.into_boxed_slice());
         assert_eq!(
             cells.len() + 1,
-            descrs_index().len(),
+            descrs_index().offsets.len(),
             "pyre-jit-trace: descr cell count must match the indexed entry count",
         );
         cells
@@ -658,7 +671,7 @@ pub fn descr_table() -> &'static dyn DescrTable {
 /// gccache walk of `descr.py:25-47`; pyre's counterpart of *that* is
 /// `MetaInterpStaticData::finish_setup_descrs`, which enumerates the live
 /// `descr_registry`. The gap between the two tables is what
-/// [`ALL_EI_DESCR_MINTS`] carries.
+/// [`load_ei_descr_mints`] carries.
 #[cfg(test)]
 pub fn all_descrs() -> &'static [BhDescr] {
     static MATERIALIZED: OnceLock<&'static [BhDescr]> = OnceLock::new();
@@ -677,17 +690,16 @@ pub fn all_descrs() -> &'static [BhDescr] {
 ///
 /// See `descr::publish_effect_info_descr_mints` for why the opcode table alone
 /// leaves these slots empty on this side of the build/runtime split.
-static ALL_EI_DESCR_MINTS: LazyLock<Vec<majit_ir::effectinfo::DescrMintEntry>> =
-    LazyLock::new(|| {
-        const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints.bin"));
-        bincode::deserialize(BYTES).unwrap_or_else(|e| {
-            panic!(
-                "pyre-jit-trace: failed to deserialize ei_descr_mints.bin \
-                 ({} bytes): {e}",
-                BYTES.len(),
-            )
-        })
-    });
+fn load_ei_descr_mints() -> Vec<majit_ir::effectinfo::DescrMintEntry> {
+    const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/ei_descr_mints.bin"));
+    bincode::deserialize(BYTES).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize ei_descr_mints.bin \
+             ({} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+}
 
 /// Analyzer-side release census captured at the end of the build-script
 /// translation. The live process adds its own counters before formatting the
@@ -750,10 +762,13 @@ fn call_descr_result_type(result_type: char) -> majit_ir::Type {
     }
 }
 
-fn rehydrated_call_descr_ref(bh: &majit_translate::jitcode::BhCallDescr) -> majit_ir::DescrRef {
+fn rehydrated_call_descr_ref(bh: majit_translate::jitcode::BhCallDescr) -> majit_ir::DescrRef {
     let arg_types = call_descr_arg_types(&bh.arg_classes);
     let result_type = call_descr_result_type(bh.result_type);
-    let mut effect_info = bh.extra_info.clone();
+    // This BhCallDescr was decoded solely for setup.  Move its EffectInfo
+    // into the canonical runtime CallDescr instead of cloning the complete
+    // six-set serialization payload and then dropping the source copy.
+    let mut effect_info = bh.extra_info;
     crate::descr::rehydrate_effect_info(&mut effect_info);
     majit_metainterp::make_call_descr_sized_with_effect(
         &arg_types,
@@ -783,11 +798,17 @@ pub fn rehydrate_build_descr_raw_sets() {
         // below can only land on slots that already carry their complete
         // layout.  Resolving in the other order would leave every member
         // whose struct has not been published yet unresolvable.
-        for i in 0..descr_count() {
-            let bh = load_descr_uncached(i);
-            if !matches!(bh, BhDescr::Call { .. } | BhDescr::JitCode { .. }) {
-                crate::descr::make_descr_from_bh(&bh);
+        let index = descrs_index();
+        for (i, kind) in index.kinds.iter().copied().enumerate() {
+            if kind != 0 {
+                continue;
             }
+            let bh = load_descr_uncached(i);
+            debug_assert!(!matches!(
+                bh,
+                BhDescr::Call { .. } | BhDescr::JitCode { .. }
+            ));
+            crate::descr::make_descr_from_bh(&bh);
         }
         // Last, and only into what is still empty: the slots no opcode names,
         // which `descrs.bin` — RPython's `opcode_descrs`, not its `all_descrs`
@@ -800,12 +821,22 @@ pub fn rehydrate_build_descr_raw_sets() {
         // field, and going first would mean pre-filling a slot the loop then
         // asks for with its own numbering.  Publishing what the established
         // producers left over keeps their answers untouched.
-        crate::descr::publish_effect_info_descr_mints(&ALL_EI_DESCR_MINTS);
-        for i in 0..descr_count() {
+        // These mint specs are a one-shot wire format, not runtime state.
+        // Upstream's descriptors remain in GcCache; the temporary arguments
+        // passed to get_*_descr do not.  Drop the decoded strings/specs as
+        // soon as their canonical runtime descriptors have been published.
+        {
+            let ei_descr_mints = load_ei_descr_mints();
+            crate::descr::publish_effect_info_descr_mints(&ei_descr_mints);
+        }
+        for (i, kind) in index.kinds.iter().copied().enumerate() {
+            if kind != 1 {
+                continue;
+            }
             let bh = load_descr_uncached(i);
-            let calldescr = match &bh {
+            let calldescr = match bh {
                 BhDescr::Call { calldescr } | BhDescr::JitCode { calldescr, .. } => calldescr,
-                _ => continue,
+                _ => unreachable!("descrs_index call classification disagrees with descrs.bin"),
             };
             rehydrated_call_descr_ref(calldescr);
         }
@@ -1973,6 +2004,65 @@ pub fn resolve_op_at(code: &[u8], pc: usize, regs: RegisterFileView<'_>) -> Opti
 mod tests {
     use super::*;
 
+    #[test]
+    fn descr_index_kind_matches_each_serialized_entry() {
+        let index = descrs_index();
+        assert_eq!(index.kinds.len(), descr_count());
+        for (i, kind) in index.kinds.iter().copied().enumerate() {
+            let call_like = matches!(
+                load_descr_uncached(i),
+                BhDescr::Call { .. } | BhDescr::JitCode { .. }
+            );
+            assert_eq!(kind, u8::from(call_like), "descriptor index {i}");
+        }
+    }
+
+    #[test]
+    fn rehydrate_effect_info_consumes_serialized_set_keys() {
+        let mut effect_info = majit_ir::EffectInfo::default();
+        assert!(effect_info.descr_set_keys.is_some());
+
+        crate::descr::rehydrate_effect_info(&mut effect_info);
+
+        assert!(effect_info.descr_set_keys.is_none());
+        assert!(
+            effect_info
+                ._readonly_descrs_fields
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+        assert!(
+            effect_info
+                ._write_descrs_fields
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+        assert!(
+            effect_info
+                ._readonly_descrs_arrays
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+        assert!(
+            effect_info
+                ._write_descrs_arrays
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+        assert!(
+            effect_info
+                ._readonly_descrs_interiorfields
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+        assert!(
+            effect_info
+                ._write_descrs_interiorfields
+                .as_ref()
+                .is_some_and(Vec::is_empty)
+        );
+    }
+
     /// Splits the first-JIT descr cost into its stages, because the fix for
     /// each is different: deserialization is paid by the wire format,
     /// materialization by how much of the pool a run actually names.
@@ -2013,7 +2103,7 @@ mod tests {
         let base = rss_kb();
         let n_descrs = descr_count();
         let after_descrs = rss_kb();
-        let n_mints = ALL_EI_DESCR_MINTS.len();
+        let n_mints = load_ei_descr_mints().len();
         let after_mints = rss_kb();
         rehydrate_build_descr_raw_sets();
         let after_rehydrate = rss_kb();


### PR DESCRIPTION
Four commits over two independent threads.

## `EffectInfo` interning and streamed descriptor mints

`effectinfo.py:14, 147-148` keeps a process-global `EffectInfo._cache`, so one canonical `EffectInfo` object serves every structurally-identical request and the call-descr cache stores it by identity. pyre had no such cache: each `CallDescr` owned its own `EffectInfoCell`, `compute_bitstrings` received one clone per descr, and the mint specs those raw sets name were deserialized as a single `Vec`.

- **`jit: deduplicate rehydrated effect info`** adds `intern_effect_info`, the `EffectInfo._cache` port. Release-gil targets get a fresh cell, mirroring `effectinfo.py:144-146`'s `object()` cache breaker.
- **`jit: deduplicate effect info setup snapshots`** makes `MetaInterpStaticData::setup` snapshot each *distinct* EI once — keyed by the address `get_extra_info()` returns — instead of once per `CallDescr`. Every descr sharing that cell observes the representative writeback, which is what `compute_bitstrings` consumes upstream: canonical objects, not per-descr copies.
- **`jit: stream effect info descriptor mints`** gives `ei_descr_mints.bin` the same indexed-entry shape `descrs.bin` already has (`ei_descr_mints_index.bin`), so the runtime deserializes and publishes one spec at a time instead of retaining all 2,000+ string-heavy specs at the peak of first-JIT setup.

## `id()` across a nursery move

`builtin_id`'s fallback arm returned the object's raw address. pyre's GC is incminimark, and every minor collection copies surviving nursery objects to the old generation, so `id()` changed for any object that moved. Measured with 200 live `[i]` lists, 40 rounds of nursery churn, then `gc.collect()`: **200/200** ids changed, against 0/200 on pypy3 7.3.20 and CPython 3.14.

That breaks every `id()`-keyed memo in the pure-Python stdlib — `pickle._Pickler.memo`, `copy.deepcopy`'s `memo`, `json.encoder`'s `markers`. A collection landing mid-walk makes the memo miss, so a shared or recursive reference is emitted twice and comes back as two distinct objects. The witness is `test_pickle`'s `PyPicklerTests.test_recursive_multi` (`x[0].attr[1] is x` after a round trip), which fails only in the full 999-test module run and moves with unrelated edits because it sits on a knife edge of allocation volume.

Upstream's chain is `baseobjspace.py:846-853 space.id` → `objectmodel.py:572 compute_unique_id` → the GC's own `id()`, which incminimark answers in `incminimark.py:2864-2876 id_or_identityhash`: a valid GC object **in the nursery** gets `_find_shadow(obj)` — the out-of-nursery address the next minor collection will move it to — and anything else gets its own address, because an object outside the nursery does not move under mark-sweep.

pyre already implemented all of that. `majit-gc`'s collector has `allocate_shadow` / `find_shadow` / `id_or_identityhash`; `gc_id_or_identityhash` is hooked by dynasm, cranelift and wasm; `pyre_object::gc_hook::gc_identity_hash` is the surface interpreter code calls; and `typedef.rs default_identity_hash_value` already uses the exact idiom. The single defect was `builtin_id` bypassing the hook. Routing that arm through it leaves `builtin_id` structurally identical to `default_identity_hash_value` minus the hash mangling — mirroring `id()` vs `identityhash() = mangle_hash(id_or_identityhash(obj))`.

Cost is bounded: for an old-gen object `id_or_identityhash` is two predicates and a return, and a shadow is allocated only for a young object, once, guarded by `HAS_SHADOW`. There is no JIT-level `id()` lowering, so the one interpreter change covers traced code too.

This one-line change rode in on `jit: stream effect info descriptor mints` rather than getting its own commit. The regression fixture is separate: `bench: assert id() is unchanged after a nursery object moves`. Its payload is lists because Python class instances do not move here, so an instance-based workload is green even on the unfixed binary; it compiles no loop, so all three jitstats baselines are zero.

### Verification

darwin-arm64:

- witness 200/200 → **0/200**, on both dynasm and cranelift
- the new fixture fails on the unfixed binary (`id changed for 200/200 objects`) and prints `OK` after
- identity invariants hold: `is` agrees with id-equality before and after a move, no collisions, aliases agree, dict keys too
- a JIT-warmed loop over `id()` is stable and its xor accumulator is **identical** across the move, so traced code sees the same ids
- full `test_pickle` module PASS at default, 1, 2, 4 and 8 MB nursery
- the six pre-existing synth fixtures that call `id()` are unchanged
- `cargo test -p pyre-interpreter` 545 passed

### Not addressed

`baseobjspace.py:96 getaddrstring` calls `space.id(self)`, but pyre's `display::repr_addr` takes `obj as usize` from ~24 call sites. This produces no visible inconsistency today because the two sets do not overlap — objects that move (list, dict) carry no address in their repr, and objects whose repr carries an address (function, instance, generator, `object()`) do not move; measured MATCH on all four, before and after a collection. Worth closing for parity, not urgent.

— *authored by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed object identity handling so `id()` remains stable when objects move during garbage collection.
  * Improved reliability when restoring JIT-compiled code and call descriptors.

* **Performance**
  * Reduced duplicate effect metadata and call descriptors, improving reuse and lowering overhead.
  * Streamlined loading of JIT metadata through indexed, on-demand processing.

* **Tests**
  * Added regression coverage for garbage-collection identity stability and descriptor caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->