### PR TITLE
majit: extract backend-generic descriptor and virtualizable fixes

### DIFF
--- a/.github/workflows/pyre-ci.yml
+++ b/.github/workflows/pyre-ci.yml
@@ -330,6 +330,12 @@ jobs:
           /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
         sudo docker image prune --all --force || true
         df -h /
+    - name: Build test binaries (dynasm)
+      shell: bash
+      # Separate compilation failures from test failures in the job log. The
+      # following test command reuses these artifacts.
+      run: cargo test --all --no-run --no-default-features --features dynasm
+
     - name: Run cargo tests (dynasm)
       shell: bash
       # Only ONE full-workspace run. The dynasm pass runs the whole workspace
@@ -341,6 +347,16 @@ jobs:
       # relinking ~15 extra test binaries (the majit-translate harness alone
       # links >2900 tests).
       run: cargo test --all --no-default-features --features dynasm
+
+    - name: Build test binaries (cranelift)
+      shell: bash
+      # Keep this package list identical to the cranelift test step below.
+      run: |
+        cargo test --no-run --no-default-features --features cranelift \
+          -p majit-metainterp -p majit-backend-cranelift \
+          -p pyre-jit -p pyre-jit-trace -p pyrex -p pyre-interpreter -p majit \
+          -p tlr -p tl -p tla -p tiny2 -p tiny3 -p tinyframe \
+          -p braininterp -p dualtape -p tlc -p calc -p i64env -p spcount
 
     - name: Run cargo tests (cranelift)
       shell: bash

--- a/majit/examples/braininterp/src/jit_interp.rs
+++ b/majit/examples/braininterp/src/jit_interp.rs
@@ -106,6 +106,10 @@ fn mainloop(program: &Bytecode, threshold: u32) -> String {
         if pc >= program.len() {
             break;
         }
+        // Keep the observer/replay form until the backward `]` arm lowers to a
+        // sub-JitCode. In the single-executor form that arm is an abort stub,
+        // so tracing repeats the loop-header guards until trace segmentation
+        // instead of compiling a useful loop body.
         jit_merge_point!();
         let ch = program[pc];
 

--- a/majit/examples/dualtape/src/jit_interp.rs
+++ b/majit/examples/dualtape/src/jit_interp.rs
@@ -8,17 +8,8 @@ pub type Bytecode = [u8];
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 /// Hot loops majit compiled, and the optimized op count of the last one.
-///
-/// `jit_tier_liveness_gate` reads both, and neither is a liveness verdict.
-/// `COMPILES > 0` is necessary and nowhere near sufficient: an empty dispatch
-/// still compiles a trace, just one whose whole body is `Finish()`.
-///
-/// AND THE OP COUNT DOES NOT RESCUE IT, which this doc asserted until the
-/// shape gate refuted it. The count is one integer over at least three states,
-/// and it collides where it matters: `1` is an empty dispatch, `5` is a
-/// segmented runaway, and a healthy body is some other number entirely — so
-/// reading a count tells you a body's SIZE and never its SHAPE. That is why
-/// `jit_tier_shape_gate` exists and why these two booleans do the grading.
+/// A count alone cannot distinguish a useful body from an empty or segmented
+/// trace; [`LAST_HAS_JUMP`] and [`LAST_ALWAYS_FAILS`] record that shape.
 pub static COMPILES: AtomicUsize = AtomicUsize::new(0);
 pub static LAST_OPS_AFTER: AtomicUsize = AtomicUsize::new(0);
 /// Shape of the last compiled body, for `jit_tier_shape_gate`.
@@ -82,6 +73,11 @@ fn mainloop(program: &Bytecode, threshold: u32) -> i64 {
         if pc >= program.len() {
             break;
         }
+        // Keep observer/replay until `OP_LOOP_END` lowers to a sub-JitCode.
+        // Single-executor would otherwise stop at that abort stub before the
+        // remaining program executes. `jit_tier_liveness_gate` checks the
+        // current non-compiling behavior; `jit_tier_shape_gate` is ignored
+        // until a useful loop body can compile.
         jit_merge_point!();
         let ch = program[pc];
 

--- a/majit/examples/tiny2/src/jit_interp.rs
+++ b/majit/examples/tiny2/src/jit_interp.rs
@@ -490,6 +490,11 @@ mod tests {
         }
     }
 
+    /// Factorial through the plain interpreter.
+    ///
+    /// This covers only the plain interpreter. Add a JIT counterpart after
+    /// `OP_LOOP_END` lowers instead of producing an abort stub, and execute it
+    /// through [`run_locked`] to serialize the process-global probe counters.
     #[test]
     fn interp_factorial() {
         let prog: Vec<&str> = "1 { #1 MUL #1 1 SUB ->#1 #1 }".split_whitespace().collect();

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -15324,6 +15324,12 @@ impl CraneliftBackend {
         // Compile
         let mut ctx = Context::for_function(func);
         if std::env::var_os("MAJIT_DUMP_CLIF").is_some() {
+            // Emitted-code text alongside the IR below. Two dumps that agree on
+            // the IR can still disagree on the code: register allocation runs
+            // over the whole function, so a change confined to one block moves
+            // spills in the blocks that survive it, and only the emitted form
+            // shows that.
+            ctx.set_disasm(true);
             // Independent debug toggle — not gated by MAJIT_LOG.
             eprintln!(
                 "[jit][clif-dump] trace_id={trace_id} header_pc={header_pc} num_inputs={} num_ops={}\n{}",
@@ -15350,6 +15356,12 @@ impl CraneliftBackend {
             .compiled_code()
             .map(|code| code.code_info().total_size as usize)
             .unwrap_or(0);
+        if std::env::var_os("MAJIT_DUMP_CLIF").is_some() {
+            eprintln!("[jit][code-size] trace_id={trace_id} body_bytes={body_code_bytes}");
+            if let Some(text) = ctx.compiled_code().and_then(|code| code.vcode.as_deref()) {
+                eprintln!("[jit][disasm-body] trace_id={trace_id}\n{text}");
+            }
+        }
         self.module.clear_context(&mut ctx);
 
         // Build trace_N_entry wrapper: forwards jf_ptr to body via call_indirect,

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -6637,9 +6637,7 @@ impl<'a> AssemblerARM64<'a> {
         let (vtable, w_class_init) = op
             .with_size_descr(|sd| {
                 let w_class_init = sd.w_class_obj().and_then(|w_class| {
-                    sd.gc_fielddescrs()
-                        .iter()
-                        .find(|fd| fd.is_w_class())
+                    sd.class_word_field()
                         .map(|fd| (fd.offset() as i64, w_class))
                 });
                 (sd.vtable() as i64, w_class_init)

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -7910,9 +7910,7 @@ impl<'a> Assembler386<'a> {
         let (vtable, w_class_init) = op
             .with_size_descr(|sd| {
                 let w_class_init = sd.w_class_obj().and_then(|w_class| {
-                    sd.gc_fielddescrs()
-                        .iter()
-                        .find(|fd| fd.is_w_class())
+                    sd.class_word_field()
                         .map(|fd| (fd.offset() as i32, w_class))
                 });
                 (sd.vtable() as i64, w_class_init)

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5251,9 +5251,7 @@ fn build_function(
                 // vtable write above covers `ob_type`, this covers `w_class`.
                 let w_class_init = sd.and_then(|sd| {
                     sd.w_class_obj().and_then(|w_class| {
-                        sd.gc_fielddescrs()
-                            .iter()
-                            .find(|fd| fd.is_w_class())
+                        sd.class_word_field()
                             .map(|fd| (fd.offset() as u64, w_class))
                     })
                 });

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -1215,7 +1215,7 @@ impl GcRewriterImpl {
         // SETFIELD_GC for this header slot.
         if let Some(w_class) = descr.w_class_obj()
             && w_class != 0
-            && let Some(w_class_fd) = descr.gc_fielddescrs().iter().find(|fd| fd.is_w_class())
+            && let Some(w_class_fd) = descr.class_word_field()
         {
             self.gen_initialize_w_class(obj_ref.clone(), w_class, w_class_fd.as_ref(), st);
         }
@@ -1243,7 +1243,15 @@ impl GcRewriterImpl {
         // per GC-pointer field (`descr.gc_fielddescrs` / unpack_fielddescr).
         let entries = st.delayed_zero_setfields(&result);
         for fd in descr.gc_fielddescrs() {
-            if fd.is_w_class() && descr.w_class_obj().is_some_and(|w| w != 0) {
+            // Skip the declared class-word slot: `handle_new` above already
+            // stored the real class object there, so a delayed NULL would
+            // overwrite it.  Matched by byte position rather than by descr
+            // identity because the slot the layout declares and the descr in
+            // this list can be distinct objects describing the same field.
+            let is_class_word_slot = descr
+                .class_word_field()
+                .is_some_and(|cw| cw.offset() == fd.offset());
+            if is_class_word_slot && descr.w_class_obj().is_some_and(|w| w != 0) {
                 continue;
             }
             entries.insert(fd.offset() as i64);

--- a/majit/majit-gc/src/rewrite.rs
+++ b/majit/majit-gc/src/rewrite.rs
@@ -3505,6 +3505,11 @@ mod tests {
     }
 
     impl FieldDescr for TestWClassFieldDescr {
+        // This fixture exists to be the class word; it says so rather than
+        // relying on a consumer to recognise its name.
+        fn is_w_class(&self) -> bool {
+            true
+        }
         fn offset(&self) -> usize {
             self.offset
         }

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -19,7 +19,7 @@
 ///   `ExitPendingFieldLayout` (`majit-backend/src/lib.rs:549`) compare
 ///   descrs via `opt_descr_ptr_eq` for the same reason.
 /// * `ResolvedPendingFieldWrite` / `EncodedPendingFieldWrite`
-///   (`majit-metainterp/src/resume.rs:1496/1523`) and
+///   (`majit-metainterp/src/resume.rs`) and
 ///   `PendingFieldLayoutSummary` (`majit-ir/src/resumedata.rs:137`) use
 ///   the canonical `resumedata::opt_descr_arc_ptr_eq`.
 /// * `GuardPendingFieldEntry` (resoperation.rs:892) carries

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4417,6 +4417,29 @@ pub trait SizeDescr: Descr {
     /// descr that populates the two lists with different objects, and for
     /// that case the GC list is the answer every byte-offset consumer here
     /// was already using.
+    /// The class word's slot position within `all_fielddescrs()`, or `None`
+    /// when this layout has no class word *in that list*.
+    ///
+    /// ⛔ Deliberately NOT answered from [`Self::class_word_field`].  That one
+    /// searches `gc_fielddescrs()` first, and `with_extra_gc_fielddescr`
+    /// appends header edges that are **absent from `all_fielddescrs()` on
+    /// purpose** — its doc says "kept out of `all_fielddescrs` so the
+    /// positional indexing above is unaffected".  `index_in_parent` is defined
+    /// against `all_fielddescrs()`, so reading it off a gc-only edge yields a
+    /// slot number that indexes an unrelated field: pyre seeds every object
+    /// group's `gc_edges` with the shared header descr at `index_in_parent
+    /// == 0`, which lands on the first value field and forwards `Ref <- Int`.
+    ///
+    /// Byte-offset consumers want `class_word_field()`; positional ones want
+    /// this.  The two lists genuinely differ, so one accessor cannot serve
+    /// both.
+    fn class_word_index_in_parent(&self) -> Option<usize> {
+        self.all_fielddescrs()
+            .iter()
+            .find(|fd| fd.is_w_class())
+            .map(|fd| fd.index_in_parent())
+    }
+
     fn class_word_field(&self) -> Option<&Arc<dyn FieldDescr>> {
         self.gc_fielddescrs()
             .iter()
@@ -7586,6 +7609,64 @@ mod tests {
         assert!(typeptr.is_typeptr());
         assert!(!typeptr.is_w_class());
         assert!(typeptr.is_header_field());
+    }
+
+    /// A gc-only header edge must never answer a POSITIONAL question.
+    ///
+    /// pyre seeds every object group's `gc_edges` with the shared header
+    /// descr, which `with_extra_gc_fielddescr` keeps out of
+    /// `all_fielddescrs()` precisely so positional indexing is unaffected.
+    /// Reading `index_in_parent` off that edge yields 0, which indexes the
+    /// first *value* field — an `Int` where the caller expects a `Ref` — and
+    /// `OptVirtualize` then forwards `Ref <- Int`, tripping the `make_equal_to`
+    /// Box.type invariant across most of the synth suite.
+    #[test]
+    fn a_gc_only_header_edge_never_answers_the_positional_question() {
+        let spec = |name: &str, offset: usize, ty: Type, idx: usize| SimpleFieldDescrSpec {
+            index: 0,
+            field_key: name.to_string(),
+            name: name.to_string(),
+            offset,
+            field_size: 8,
+            field_type: ty,
+            is_immutable: false,
+            is_quasi_immutable: false,
+            flag: ArrayFlag::from_field_type(ty),
+            virtualizable: false,
+            index_in_parent: idx,
+        };
+        let header: Arc<dyn FieldDescr> = Arc::new(SimpleFieldDescr::new_with_name(
+            0,
+            8,
+            8,
+            Type::Ref,
+            false,
+            ArrayFlag::Pointer,
+            "w_class".to_string(),
+            "w_class".to_string(),
+        ));
+        assert!(header.is_w_class());
+
+        // A layout that declares no class word of its own, with the shared
+        // header pushed as a gc-only edge — the common pyre object group.
+        let group = make_simple_descr_group_keyed_with_headerless(
+            0,
+            32,
+            7,
+            0x0C1A_0001,
+            0,
+            true,
+            false,
+            &[spec("W_IntObject.intval", 16, Type::Int, 0)],
+            &[header],
+        );
+        let sd = group.size_descr.as_size_descr().expect("a SizeDescr");
+
+        // The byte-offset answer legitimately sees the gc-only edge...
+        assert_eq!(sd.class_word_field().map(|fd| fd.offset()), Some(8));
+        // ...but the positional answer must not, or it returns slot 0 and
+        // collides with `intval`.
+        assert_eq!(sd.class_word_index_in_parent(), None);
     }
 
     #[test]

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4405,8 +4405,10 @@ pub trait SizeDescr: Descr {
     /// that must establish the two describe the same bytes compare
     /// `offset()`/`field_size()` and cannot compare identity.
     ///
-    /// The default body is the *only* place the class word is recovered by
-    /// name, and it is what a declaring producer replaces.
+    /// The default body finds the entry that *declares* itself the class
+    /// word (`FieldDescr::is_w_class`), so nothing here reads a field name.
+    /// A producer that already knows its header slot overrides this and skips
+    /// the scan.
     ///
     /// It searches `gc_fielddescrs()` before `all_fielddescrs()`.  The class
     /// word is a GC pointer, so a real layout lists the *same* `Arc` in both
@@ -4415,8 +4417,6 @@ pub trait SizeDescr: Descr {
     /// descr that populates the two lists with different objects, and for
     /// that case the GC list is the answer every byte-offset consumer here
     /// was already using.
-    // TODO(declared-class-word): drop this body once the field-list builder
-    // declares the slot; a producer that overrides it already opts out.
     fn class_word_field(&self) -> Option<&Arc<dyn FieldDescr>> {
         self.gc_fielddescrs()
             .iter()
@@ -4560,20 +4560,42 @@ pub trait FieldDescr: Descr {
             || name.ends_with(".ob_type")
     }
 
-    /// Pyre object-model: `PyObject.w_class` (offset 8) carries the
-    /// Python-level class identity, distinct from the `typeptr`/vtable
-    /// (offset 0). Like `typeptr`, it is a header field — not a value
-    /// field that may be indexed by `index_in_parent` against a
-    /// virtual's stored fields. Recognised by name so OptVirtualize can
-    /// resolve it from the object's class identity instead of colliding
-    /// with the first value field.
+    /// Whether this descr names the class word: the header slot carrying
+    /// Python-level class identity, distinct from the `typeptr`/vtable at
+    /// offset 0.  Like `typeptr` it is a *header* field, not a value field
+    /// that may be indexed by `index_in_parent` against a virtual's stored
+    /// fields, so consumers resolve it from the object's class identity
+    /// rather than colliding it with the first value field.
     ///
-    /// Handles both formats:
-    /// - `"w_class"` (pyre tracer w_class_descr)
-    /// - `"STRUCT.w_class"` (e.g. "PyObject.w_class")
+    /// **Declared, not inferred.**  A producer that mints a class-word descr
+    /// says so; nothing here reads the field's name.  `false` is the
+    /// upstream-orthodox default rather than a convenience: RPython's field
+    /// lists contain no header field at all (`heaptracker.py:66` drops
+    /// `typeptr` before any descr is built), so "this is an ordinary value
+    /// field" is what a list entry means unless its producer states
+    /// otherwise.
     fn is_w_class(&self) -> bool {
-        let name = self.field_name();
-        name == "w_class" || name.ends_with(".w_class")
+        false
+    }
+
+    /// Whether this descr names *any* header slot — the class word or the
+    /// `typeptr`/vtable.  Both are resolved from class identity and neither
+    /// resolves through the owner's value-field list, so the sites that must
+    /// skip header fields ask this rather than spelling the union.
+    ///
+    /// ⛔ This is the right question **only** where the two header fields are
+    /// genuinely interchangeable.  It must not be substituted for
+    /// `is_w_class()` at a site that has already handled `typeptr`
+    /// separately: `virtualize.rs`'s GETFIELD fold resolves a `typeptr` from
+    /// `known_class` in an earlier arm and only *falls through* to the
+    /// class-word arm when that arm found no known class, so widening the
+    /// class-word test to the union there would route a typeptr read into the
+    /// `w_class` fold. `optimizeopt/mod.rs`'s `ensure_ptr_info_arg0` and
+    /// `info.rs`'s allocation-cover check are likewise about the class word
+    /// specifically. Widening any of the three by symmetry with the sites
+    /// below would be a behaviour change, not a de-duplication.
+    fn is_header_field(&self) -> bool {
+        self.is_typeptr() || self.is_w_class()
     }
 
     /// descr.py: sort_key() — for ordering field descriptors.
@@ -5266,6 +5288,16 @@ pub struct SimpleFieldDescr {
     /// FLAG_POINTER, FLAG_FLOAT, FLAG_SIGNED, FLAG_UNSIGNED, FLAG_STRUCT, FLAG_VOID.
     flag: ArrayFlag,
     virtualizable: bool,
+    /// Whether this field is the owning struct's class word — the declared
+    /// answer behind `FieldDescr::is_w_class()`.
+    ///
+    /// `new_with_name` seeds it from the `"STRUCT.fieldname"` the codewriter
+    /// supplies, which for this descr *is* the producer's declaration:
+    /// `descr.py:227` builds that name from the struct and field being
+    /// described, so a caller cannot pass a class-word name for a field that
+    /// is not one.  `with_class_word` overrides it for a producer that knows
+    /// its layout without going through the name.
+    is_class_word: bool,
     /// descr.py:158 FieldDescr.index — slot position within the
     /// parent struct's `all_fielddescrs`.
     pub index_in_parent: usize,
@@ -5287,6 +5319,19 @@ pub struct SimpleFieldDescr {
     pub vinfo: Option<Weak<dyn VinfoMarker>>,
 }
 
+/// Whether a `"STRUCT.fieldname"` (or bare `"fieldname"`) descr name names a
+/// class word.
+///
+/// The single place in the tree that reads this spelling.  It exists because
+/// `SimpleFieldDescr` is minted by the codewriter from the name
+/// `descr.py:227` builds out of the struct and field being described, so for
+/// that producer the name *is* the declaration.  Every consumer asks the
+/// declared `FieldDescr::is_w_class()` instead, and a producer that knows its
+/// layout without a name uses `SimpleFieldDescr::with_class_word`.
+fn name_is_class_word(name: &str) -> bool {
+    name == "w_class" || name.ends_with(".w_class")
+}
+
 impl Clone for SimpleFieldDescr {
     fn clone(&self) -> Self {
         SimpleFieldDescr {
@@ -5302,6 +5347,7 @@ impl Clone for SimpleFieldDescr {
             is_quasi_immutable: self.is_quasi_immutable,
             flag: self.flag,
             virtualizable: self.virtualizable,
+            is_class_word: self.is_class_word,
             index_in_parent: self.index_in_parent,
             parent_descr: RwLock::new(self.parent_descr.read().unwrap().clone()),
             vinfo: self.vinfo.clone(),
@@ -5373,6 +5419,9 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
+            // Unnamed: this constructor describes a field by geometry alone,
+            // and a producer with a header slot uses `with_class_word`.
+            is_class_word: false,
             index_in_parent: 0,
             parent_descr: RwLock::new(None),
             vinfo: None,
@@ -5397,6 +5446,7 @@ impl SimpleFieldDescr {
         field_key: String,
     ) -> Self {
         let field_key_start = field_key_start(&name, &field_key);
+        let is_class_word = name_is_class_word(&name);
         SimpleFieldDescr {
             index: AtomicU32::new(index),
             descr_index: AtomicI32::new(-1),
@@ -5410,6 +5460,7 @@ impl SimpleFieldDescr {
             is_quasi_immutable: false,
             flag,
             virtualizable: false,
+            is_class_word,
             index_in_parent: 0,
             parent_descr: RwLock::new(None),
             vinfo: None,
@@ -5422,6 +5473,15 @@ impl SimpleFieldDescr {
     /// `FieldDescr::is_quasi_immutable()` below.
     pub fn with_quasi_immutable(mut self, is_quasi_immutable: bool) -> Self {
         self.is_quasi_immutable = is_quasi_immutable;
+        self
+    }
+
+    /// Declare (or retract) that this field is the owning struct's class
+    /// word.  For a producer that knows its own layout and does not spell
+    /// the field's name in the `"STRUCT.fieldname"` form `new_with_name`
+    /// reads.
+    pub fn with_class_word(mut self, is_class_word: bool) -> Self {
+        self.is_class_word = is_class_word;
         self
     }
 
@@ -5520,6 +5580,10 @@ impl Descr for SimpleFieldDescr {
 }
 
 impl FieldDescr for SimpleFieldDescr {
+    fn is_w_class(&self) -> bool {
+        self.is_class_word
+    }
+
     fn offset(&self) -> usize {
         self.offset
     }
@@ -5997,6 +6061,7 @@ fn make_simple_descr_group_inner(
                     is_quasi_immutable: spec.is_quasi_immutable,
                     flag: spec.flag,
                     virtualizable: spec.virtualizable,
+                    is_class_word: name_is_class_word(&spec.name),
                     index_in_parent: spec.index_in_parent,
                     parent_descr: RwLock::new(Some(parent_descr.clone())),
                     vinfo: None,
@@ -6771,6 +6836,9 @@ pub fn make_vtable_field_descr() -> DescrRef {
                     is_quasi_immutable: false,
                     flag: ArrayFlag::Signed,
                     virtualizable: false,
+                    // `typeptr` is the other header field, not the class
+                    // word; `is_typeptr()` answers for it.
+                    is_class_word: false,
                     index_in_parent: 0,
                     parent_descr: RwLock::new(Some(parent_descr)),
                     vinfo: None,
@@ -7479,6 +7547,47 @@ mod tests {
     /// The list precedence is pinned because it is observable: a descr whose
     /// two field lists hold different objects gets the GC-list one, which is
     /// what every byte-offset consumer searched before this accessor existed.
+    /// The class-word answer is the descr's own, and `is_header_field()` is
+    /// strictly wider than it — `typeptr` is a header field that is *not* the
+    /// class word, which is why the three sites that resolve a typeptr
+    /// separately cannot use the union.
+    #[test]
+    fn a_field_descr_declares_whether_it_is_the_class_word() {
+        let named = |offset: usize, ty: Type, flag: ArrayFlag, name: &str| {
+            SimpleFieldDescr::new_with_name(
+                0,
+                offset,
+                8,
+                ty,
+                false,
+                flag,
+                name.to_string(),
+                name.to_string(),
+            )
+        };
+
+        let w = named(8, Type::Ref, ArrayFlag::Pointer, "PyObject.w_class");
+        assert!(w.is_w_class());
+        assert!(w.is_header_field());
+
+        let value = named(16, Type::Int, ArrayFlag::Signed, "W_IntObject.intval");
+        assert!(!value.is_w_class());
+        assert!(!value.is_header_field());
+
+        // Geometry-only construction describes a value field; a producer
+        // that has no name declares the slot explicitly instead.
+        let bare = SimpleFieldDescr::new(0, 8, 8, Type::Ref, false);
+        assert!(!bare.is_w_class());
+        assert!(bare.with_class_word(true).is_w_class());
+
+        // `typeptr` is the other header field: header, but not the class word.
+        let vtable_descr = make_vtable_field_descr();
+        let typeptr = vtable_descr.as_field_descr().expect("a FieldDescr");
+        assert!(typeptr.is_typeptr());
+        assert!(!typeptr.is_w_class());
+        assert!(typeptr.is_header_field());
+    }
+
     #[test]
     fn class_word_field_is_absent_for_a_layout_without_one() {
         #[derive(Debug)]

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -59,6 +59,19 @@
 /// rather than relying on the InteriorFieldDescr backreference for
 /// identity).
 ///
+/// Leaking is not the only thing a cycle costs: any *walk* over the
+/// descr graph must refuse the back-reference too.  `Debug` is such a
+/// walk, and with both ends derived it recursed until the stack ran
+/// out — `SimpleArrayDescr::fmt` → `OnceLock` → `Vec<DescrRef>` →
+/// `SimpleInteriorFieldDescr::fmt` → `SimpleArrayDescr::fmt` → … — for
+/// every `{:?}` that reached a struct-array descr, including
+/// `format_assembler`'s `EffectInfo` render.  `SimpleInteriorFieldDescr`
+/// therefore has a hand-written `Debug` that prints `array_descr` as an
+/// identity summary, matching `descr.py:420-421
+/// InteriorFieldDescr.repr_of_descr`, which never follows
+/// `self.arraydescr`.  A future reader added to this graph has to make
+/// the same choice at the same edge.
+///
 /// **C (landed 2026-05-19).**  Trait-dispatch + structural keying
 /// migration for the virtualizable / virtualref field paths:
 ///
@@ -6311,7 +6324,6 @@ impl ArrayDescr for SimpleArrayDescr {
 }
 
 /// Simple concrete InteriorFieldDescr.
-#[derive(Debug)]
 pub struct SimpleInteriorFieldDescr {
     /// per-trace analyzer slot id. Stored atomic so the analyzer's
     /// `cc.interiorfielddescrof` cache-or-mint can stamp on a
@@ -6339,6 +6351,39 @@ pub struct SimpleInteriorFieldDescr {
     /// `arraydescr`).  Kept for pyre's
     /// `ensure_ptr_info_arg0`-style dispatch paths.
     owner_size_descr: Option<std::sync::Arc<dyn SizeDescr>>,
+}
+
+/// Hand-written rather than derived: `array_descr` is the back half of
+/// the `SimpleArrayDescr.all_interiorfielddescrs` ↔
+/// `SimpleInteriorFieldDescr.array_descr` strong cycle recorded in the
+/// Arc cycle audit at the top of this module, so a derived `Debug`
+/// makes every `{:?}` of a struct-array descr non-terminating
+/// (`SimpleArrayDescr::fmt` → `OnceLock` → `Vec<DescrRef>` →
+/// `SimpleInteriorFieldDescr::fmt` → `SimpleArrayDescr::fmt` → …).
+/// `descr.py:420-421 InteriorFieldDescr.repr_of_descr` renders only
+/// `self.fielddescr.repr_of_descr()` and never follows
+/// `self.arraydescr`, so the back-reference prints as an identity
+/// summary here instead of being traversed.  The forward half stays
+/// derived — one broken edge makes every walk finite, and
+/// `all_interiorfielddescrs` is the half a reader actually wants.
+impl std::fmt::Debug for SimpleInteriorFieldDescr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimpleInteriorFieldDescr")
+            .field("index", &self.index)
+            .field("descr_index", &self.descr_index)
+            .field("ei_index", &self.ei_index)
+            .field(
+                "array_descr",
+                &format_args!(
+                    "<ArrayDescr cache_key={}, type_id={}>",
+                    self.array_descr.cache_key(),
+                    self.array_descr.type_id()
+                ),
+            )
+            .field("field_descr", &self.field_descr)
+            .field("owner_size_descr", &self.owner_size_descr)
+            .finish()
+    }
 }
 
 impl Clone for SimpleInteriorFieldDescr {
@@ -7338,6 +7383,54 @@ mod register_keyed_size_authority_tests {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A struct-array descr and its interior field descrs point at each
+    /// other (the "CYCLE, accepted" row of the Arc cycle audit at the top
+    /// of this module), so a `Debug` that follows both edges never
+    /// terminates.  Formatting either end must finish; a regression here
+    /// aborts the process with a stack overflow rather than failing an
+    /// assertion, which is precisely why the walk has to refuse the
+    /// back-reference.
+    #[test]
+    fn debug_of_a_struct_array_descr_terminates() {
+        let array = Arc::new(SimpleArrayDescr::with_flag(
+            0,
+            16,
+            8,
+            7,
+            Type::Int,
+            ArrayFlag::Struct,
+        ));
+        let field: Arc<dyn FieldDescr> = Arc::new(SimpleFieldDescr::new_with_name(
+            0,
+            0,
+            8,
+            Type::Int,
+            false,
+            ArrayFlag::Signed,
+            "Item.x".to_string(),
+            "x".to_string(),
+        ));
+        let interior: DescrRef = Arc::new(SimpleInteriorFieldDescr::new(
+            0,
+            array.clone() as Arc<dyn ArrayDescr>,
+            field,
+        ));
+        array.set_all_interiorfielddescrs(vec![interior.clone()]);
+
+        // Both entry points, because either can be the one a caller holds.
+        let from_array = format!("{array:?}");
+        let from_interior = format!("{interior:?}");
+
+        // The forward edge still renders the interior descr; only the
+        // back-reference is summarised.
+        assert!(from_array.contains("SimpleInteriorFieldDescr"));
+        assert!(from_interior.contains("<ArrayDescr cache_key=0, type_id=7>"));
+        // One level each way, not many: a walk that re-entered the cycle
+        // even a few times would repeat the array descr's own name.
+        assert_eq!(from_array.matches("SimpleArrayDescr").count(), 1);
+        assert_eq!(from_interior.matches("SimpleInteriorFieldDescr").count(), 1);
+    }
 
     #[test]
     fn strip_instantiation_suffix_drops_generic_args() {

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1942,6 +1942,16 @@ impl GcCache {
         clippy::too_many_arguments,
         reason = "The argument order is the stable JIT IR/descriptor or generated-interpreter ABI shape; grouping it into a Rust-only options object would obscure opcode-field correspondence and macro call-site parity"
     )]
+    /// The name-inferring entry point, for producers that have no spec to
+    /// declare on — chiefly the `BhDescr` path, which rebuilds a descr from a
+    /// serialized field name.  A producer that knows its own layout should
+    /// call [`Self::get_field_descr_declaring`] instead: a name rule cannot
+    /// separate a header row from a payload field a host happens to spell the
+    /// same way.
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The argument order is the stable JIT IR/descriptor or generated-interpreter ABI shape; grouping it into a Rust-only options object would obscure opcode-field correspondence and macro call-site parity"
+    )]
     pub fn get_field_descr(
         &mut self,
         struct_key: LLType,
@@ -1956,6 +1966,45 @@ impl GcCache {
         index: u32,
         virtualizable: bool,
         index_in_parent: Option<usize>,
+    ) -> Arc<SimpleFieldDescr> {
+        self.get_field_descr_declaring(
+            struct_key,
+            field_name,
+            display_name,
+            offset,
+            field_size,
+            field_type,
+            is_immutable,
+            is_quasi_immutable,
+            flag,
+            index,
+            virtualizable,
+            index_in_parent,
+            None,
+        )
+    }
+
+    #[expect(
+        clippy::too_many_arguments,
+        reason = "The argument order is the stable JIT IR/descriptor or generated-interpreter ABI shape; grouping it into a Rust-only options object would obscure opcode-field correspondence and macro call-site parity"
+    )]
+    pub fn get_field_descr_declaring(
+        &mut self,
+        struct_key: LLType,
+        field_name: &str,
+        display_name: Option<&str>,
+        offset: usize,
+        field_size: usize,
+        field_type: Type,
+        is_immutable: bool,
+        is_quasi_immutable: bool,
+        flag: ArrayFlag,
+        index: u32,
+        virtualizable: bool,
+        index_in_parent: Option<usize>,
+        // `Some` when the producer declares whether this field is the class
+        // word.  `None` falls back to the display name.
+        declared_class_word: Option<bool>,
     ) -> Arc<SimpleFieldDescr> {
         // descr.py:234-238: parent_descr = get_size_descr(gccache, STRUCT, vtable)
         let parent = self._cache_size.get(&struct_key).cloned();
@@ -2142,6 +2191,9 @@ impl GcCache {
             name,
             field_name.to_string(),
         );
+        if let Some(is_class_word) = declared_class_word {
+            fd = fd.with_class_word(is_class_word);
+        }
         fd.virtualizable = virtualizable;
         // descr.py:228: index_in_parent (from heaptracker).
         //
@@ -5349,16 +5401,20 @@ pub struct SimpleFieldDescr {
     pub vinfo: Option<Weak<dyn VinfoMarker>>,
 }
 
-/// Whether a `"STRUCT.fieldname"` (or bare `"fieldname"`) descr name names a
-/// class word.
+/// Guess from a descr's display name whether it is a class word.
 ///
-/// The single place in the tree that reads this spelling.  It exists because
-/// `SimpleFieldDescr` is minted by the codewriter from the name
-/// `descr.py:227` builds out of the struct and field being described, so for
-/// that producer the name *is* the declaration.  Every consumer asks the
-/// declared `FieldDescr::is_w_class()` instead, and a producer that knows its
-/// layout without a name uses `SimpleFieldDescr::with_class_word`.
-fn name_is_class_word(name: &str) -> bool {
+/// ⛔ **A fallback, not a rule.** It cannot separate a header row from a
+/// payload field a host happens to spell the same way — pyre's `Method`
+/// carries both an inherited header and a payload field named `w_class`, and
+/// this returns `true` for both. Any producer that knows its own layout must
+/// declare instead, through `SimpleFieldDescrSpec::is_class_word` or
+/// `SimpleFieldDescr::with_class_word`.
+///
+/// It survives for one caller: the serialized-`BhDescr` path, which rebuilds a
+/// descr from a field name with no layout in reach. ⚠ That also means a
+/// declaration does **not** survive a blackhole round trip — `BhFieldSpec`
+/// carries no flag, so a descr rebuilt from one falls back to this guess.
+pub fn class_word_inferred_from_name(name: &str) -> bool {
     name == "w_class" || name.ends_with(".w_class")
 }
 
@@ -5476,7 +5532,7 @@ impl SimpleFieldDescr {
         field_key: String,
     ) -> Self {
         let field_key_start = field_key_start(&name, &field_key);
-        let is_class_word = name_is_class_word(&name);
+        let is_class_word = class_word_inferred_from_name(&name);
         SimpleFieldDescr {
             index: AtomicU32::new(index),
             descr_index: AtomicI32::new(-1),
@@ -5930,6 +5986,14 @@ pub struct SimpleFieldDescrSpec {
     pub flag: ArrayFlag,
     pub virtualizable: bool,
     pub index_in_parent: usize,
+    /// Whether this field is the owning layout's class word.
+    ///
+    /// Declared by the producer, which knows its own layout.  majit-ir cannot
+    /// derive it: a host may spell a *payload* field with the same tail as its
+    /// header row (pyre's `Method` has both `Method.w_class` at the method's
+    /// own class and the inherited header), so any name rule either misses a
+    /// header or claims a payload.
+    pub is_class_word: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -5996,7 +6060,7 @@ pub fn make_simple_descr_group_keyed_with_headerless(
     let field_descrs: Vec<Arc<SimpleFieldDescr>> = field_specs
         .iter()
         .map(|spec| {
-            gc.get_field_descr(
+            gc.get_field_descr_declaring(
                 struct_key.clone(),
                 &spec.field_key,
                 Some(spec.name.as_str()),
@@ -6017,6 +6081,7 @@ pub fn make_simple_descr_group_keyed_with_headerless(
                 // bound is exact only for callers that hand the `Option` in
                 // themselves — the deserialized-`BhDescr::Field` path.
                 Some(spec.index_in_parent),
+                Some(spec.is_class_word),
             )
         })
         .collect();
@@ -6091,7 +6156,7 @@ fn make_simple_descr_group_inner(
                     is_quasi_immutable: spec.is_quasi_immutable,
                     flag: spec.flag,
                     virtualizable: spec.virtualizable,
-                    is_class_word: name_is_class_word(&spec.name),
+                    is_class_word: spec.is_class_word,
                     index_in_parent: spec.index_in_parent,
                     parent_descr: RwLock::new(Some(parent_descr.clone())),
                     vinfo: None,
@@ -7641,6 +7706,8 @@ mod tests {
             flag: ArrayFlag::from_field_type(ty),
             virtualizable: false,
             index_in_parent: idx,
+            // A value field; the class word here arrives as a gc-only edge.
+            is_class_word: false,
         };
         let header: Arc<dyn FieldDescr> = Arc::new(SimpleFieldDescr::new_with_name(
             0,

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4439,8 +4439,9 @@ pub trait SizeDescr: Descr {
     /// The class word's slot position within `all_fielddescrs()`, or `None`
     /// when this layout has no class word *in that list*.
     ///
-    /// ⛔ Deliberately NOT answered from [`Self::class_word_field`].  That one
-    /// searches `gc_fielddescrs()` first, and `with_extra_gc_fielddescr`
+    /// This is deliberately not answered from [`Self::class_word_field`]. That
+    /// accessor searches `gc_fielddescrs()` first, and
+    /// `with_extra_gc_fielddescr`
     /// appends header edges that are **absent from `all_fielddescrs()` on
     /// purpose** — its doc says "kept out of `all_fielddescrs` so the
     /// positional indexing above is unaffected".  `index_in_parent` is defined
@@ -4493,7 +4494,7 @@ pub trait SizeDescr: Descr {
     /// that case the GC list is the answer every byte-offset consumer here
     /// was already using.
     ///
-    /// ⚠ It answers with the *first* declaring entry.  A layout that publishes
+    /// It answers with the *first* declaring entry. A layout that publishes
     /// two — pyre's `Method` declares a payload field named `w_class` beside
     /// the inherited header, and the legacy name inference accepts both — gets
     /// the earlier one, which is not the header.  Pinned by
@@ -4665,7 +4666,7 @@ pub trait FieldDescr: Descr {
     /// resolves through the owner's value-field list, so the sites that must
     /// skip header fields ask this rather than spelling the union.
     ///
-    /// ⛔ This is the right question **only** where the two header fields are
+    /// This is the right question only where the two header fields are
     /// genuinely interchangeable.  It must not be substituted for
     /// `is_w_class()` at a site that has already handled `typeptr`
     /// separately: `virtualize.rs`'s GETFIELD fold resolves a `typeptr` from
@@ -5403,7 +5404,7 @@ pub struct SimpleFieldDescr {
 
 /// Guess from a descr's display name whether it is a class word.
 ///
-/// ⛔ **A fallback, not a rule.** It cannot separate a header row from a
+/// This is a fallback, not a layout rule. It cannot separate a header row from a
 /// payload field a host happens to spell the same way — pyre's `Method`
 /// carries both an inherited header and a payload field named `w_class`, and
 /// this returns `true` for both. Any producer that knows its own layout must
@@ -5411,7 +5412,7 @@ pub struct SimpleFieldDescr {
 /// `SimpleFieldDescr::with_class_word`.
 ///
 /// It survives for one caller: the serialized-`BhDescr` path, which rebuilds a
-/// descr from a field name with no layout in reach. ⚠ That also means a
+/// descr from a field name with no layout in reach. Consequently, a
 /// declaration does **not** survive a blackhole round trip — `BhFieldSpec`
 /// carries no flag, so a descr rebuilt from one falls back to this guess.
 pub fn class_word_inferred_from_name(name: &str) -> bool {

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4383,6 +4383,46 @@ pub trait SizeDescr: Descr {
     fn gc_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
         &[]
     }
+
+    /// The field slot of *this* layout that holds the class word, or `None`
+    /// when this layout has no class word at all.
+    ///
+    /// This is the transposition of `gc.py:33-37`, where a host that sets
+    /// `gcremovetypeptr` gets `fielddescr_vtable = None`: absence of the
+    /// header field is a property the layout *declares*, never one a consumer
+    /// infers from a lookup that missed.
+    ///
+    /// It is deliberately a per-`SizeDescr` question and not a per-host one.
+    /// Upstream's `fielddescr_vtable` answers "what descr do I store
+    /// through" for a single lltype at a fixed offset, and upstream excludes
+    /// `typeptr` from `all_fielddescrs` (`heaptracker.py:66`) so no field
+    /// list ever contains it.  Here the header descr *is* in the list, and
+    /// every consumer needs to know which slot of the struct in front of it
+    /// is the class word — a question one process-global descr cannot
+    /// answer.  Compounding that, pyre has two identity-stable `w_class`
+    /// descrs by construction (a parentless tracer singleton on the op side,
+    /// a per-layout `SimpleFieldDescr` on the allocation side), so consumers
+    /// that must establish the two describe the same bytes compare
+    /// `offset()`/`field_size()` and cannot compare identity.
+    ///
+    /// The default body is the *only* place the class word is recovered by
+    /// name, and it is what a declaring producer replaces.
+    ///
+    /// It searches `gc_fielddescrs()` before `all_fielddescrs()`.  The class
+    /// word is a GC pointer, so a real layout lists the *same* `Arc` in both
+    /// (`gc_fielddescrs` is documented as the `only_gc=True` filter of
+    /// `all_fielddescrs`) and the order cannot matter.  It matters only for a
+    /// descr that populates the two lists with different objects, and for
+    /// that case the GC list is the answer every byte-offset consumer here
+    /// was already using.
+    // TODO(declared-class-word): drop this body once the field-list builder
+    // declares the slot; a producer that overrides it already opts out.
+    fn class_word_field(&self) -> Option<&Arc<dyn FieldDescr>> {
+        self.gc_fielddescrs()
+            .iter()
+            .chain(self.all_fielddescrs())
+            .find(|fd| fd.is_w_class())
+    }
 }
 
 /// Type-erased marker for `VirtualizableInfo`. Upstream parity:
@@ -7430,6 +7470,78 @@ mod tests {
         // even a few times would repeat the array descr's own name.
         assert_eq!(from_array.matches("SimpleArrayDescr").count(), 1);
         assert_eq!(from_interior.matches("SimpleInteriorFieldDescr").count(), 1);
+    }
+
+    /// `class_word_field()` is the layout's own answer, and "this layout has
+    /// no class word" is a real answer rather than a lookup that missed —
+    /// the `fielddescr_vtable = None` case of `gc.py:33-37`.
+    ///
+    /// The list precedence is pinned because it is observable: a descr whose
+    /// two field lists hold different objects gets the GC-list one, which is
+    /// what every byte-offset consumer searched before this accessor existed.
+    #[test]
+    fn class_word_field_is_absent_for_a_layout_without_one() {
+        #[derive(Debug)]
+        struct Layout {
+            all_fields: Vec<Arc<dyn FieldDescr>>,
+            gc_fields: Vec<Arc<dyn FieldDescr>>,
+        }
+        impl Descr for Layout {
+            fn as_size_descr(&self) -> Option<&dyn SizeDescr> {
+                Some(self)
+            }
+        }
+        impl SizeDescr for Layout {
+            fn size(&self) -> usize {
+                32
+            }
+            fn type_id(&self) -> u32 {
+                7
+            }
+            fn is_immutable(&self) -> bool {
+                false
+            }
+            fn all_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
+                &self.all_fields
+            }
+            fn gc_fielddescrs(&self) -> &[Arc<dyn FieldDescr>] {
+                &self.gc_fields
+            }
+        }
+
+        let named = |offset: usize, name: &str| -> Arc<dyn FieldDescr> {
+            Arc::new(SimpleFieldDescr::new_with_name(
+                0,
+                offset,
+                8,
+                Type::Ref,
+                false,
+                ArrayFlag::Pointer,
+                name.to_string(),
+                name.to_string(),
+            ))
+        };
+
+        // A header-less layout: every field is a value field.
+        let headerless = Layout {
+            all_fields: vec![named(0, "Point.x"), named(8, "Point.y")],
+            gc_fields: vec![],
+        };
+        assert!(headerless.class_word_field().is_none());
+
+        // The GC list wins when the two lists disagree.
+        let split = Layout {
+            all_fields: vec![named(24, "PyObject.w_class")],
+            gc_fields: vec![named(8, "w_class")],
+        };
+        assert_eq!(split.class_word_field().map(|fd| fd.offset()), Some(8));
+
+        // Falling back to the all-list covers impls that populate only it.
+        let all_only = Layout {
+            all_fields: vec![named(8, "PyObject.w_class")],
+            gc_fields: vec![],
+        };
+        assert_eq!(all_only.class_word_field().map(|fd| fd.offset()), Some(8));
     }
 
     #[test]

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -4384,6 +4384,29 @@ pub trait SizeDescr: Descr {
         &[]
     }
 
+    /// The class word's slot position within `all_fielddescrs()`, or `None`
+    /// when this layout has no class word *in that list*.
+    ///
+    /// ⛔ Deliberately NOT answered from [`Self::class_word_field`].  That one
+    /// searches `gc_fielddescrs()` first, and `with_extra_gc_fielddescr`
+    /// appends header edges that are **absent from `all_fielddescrs()` on
+    /// purpose** — its doc says "kept out of `all_fielddescrs` so the
+    /// positional indexing above is unaffected".  `index_in_parent` is defined
+    /// against `all_fielddescrs()`, so reading it off a gc-only edge yields a
+    /// slot number that indexes an unrelated field: pyre seeds every object
+    /// group's `gc_edges` with the shared header descr at `index_in_parent
+    /// == 0`, which lands on the first value field and forwards `Ref <- Int`.
+    ///
+    /// Byte-offset consumers want `class_word_field()`; positional ones want
+    /// this.  The two lists genuinely differ, so one accessor cannot serve
+    /// both.
+    fn class_word_index_in_parent(&self) -> Option<usize> {
+        self.all_fielddescrs()
+            .iter()
+            .find(|fd| fd.is_w_class())
+            .map(|fd| fd.index_in_parent())
+    }
+
     /// The field slot of *this* layout that holds the class word, or `None`
     /// when this layout has no class word at all.
     ///
@@ -4417,29 +4440,13 @@ pub trait SizeDescr: Descr {
     /// descr that populates the two lists with different objects, and for
     /// that case the GC list is the answer every byte-offset consumer here
     /// was already using.
-    /// The class word's slot position within `all_fielddescrs()`, or `None`
-    /// when this layout has no class word *in that list*.
     ///
-    /// ⛔ Deliberately NOT answered from [`Self::class_word_field`].  That one
-    /// searches `gc_fielddescrs()` first, and `with_extra_gc_fielddescr`
-    /// appends header edges that are **absent from `all_fielddescrs()` on
-    /// purpose** — its doc says "kept out of `all_fielddescrs` so the
-    /// positional indexing above is unaffected".  `index_in_parent` is defined
-    /// against `all_fielddescrs()`, so reading it off a gc-only edge yields a
-    /// slot number that indexes an unrelated field: pyre seeds every object
-    /// group's `gc_edges` with the shared header descr at `index_in_parent
-    /// == 0`, which lands on the first value field and forwards `Ref <- Int`.
-    ///
-    /// Byte-offset consumers want `class_word_field()`; positional ones want
-    /// this.  The two lists genuinely differ, so one accessor cannot serve
-    /// both.
-    fn class_word_index_in_parent(&self) -> Option<usize> {
-        self.all_fielddescrs()
-            .iter()
-            .find(|fd| fd.is_w_class())
-            .map(|fd| fd.index_in_parent())
-    }
-
+    /// ⚠ It answers with the *first* declaring entry.  A layout that publishes
+    /// two — pyre's `Method` declares a payload field named `w_class` beside
+    /// the inherited header, and the legacy name inference accepts both — gets
+    /// the earlier one, which is not the header.  Pinned by
+    /// `every_groups_class_word_is_the_inherited_pyobject_header_slot` in
+    /// `pyre-jit-trace`.
     fn class_word_field(&self) -> Option<&Arc<dyn FieldDescr>> {
         self.gc_fielddescrs()
             .iter()

--- a/majit/majit-metainterp/src/history.rs
+++ b/majit/majit-metainterp/src/history.rs
@@ -2840,7 +2840,7 @@ impl TraceCtx {
     /// responsible for deduplicating box positions across frames
     /// (RPython's `_number_boxes` does this implicitly via the memo
     /// table; pyre's `Snapshot.encode` does the same in
-    /// `resume.rs:1898 _number_boxes`).
+    /// `resume.rs::_number_boxes`).
     pub fn capture_snapshot_for_last_guard_multi_frame(
         &mut self,
         frames: &[(u32, u32, u32, &[OpRef])],
@@ -3397,7 +3397,7 @@ impl TraceCtx {
     /// separate "that family is constant" from "that family was never
     /// reached", because the const-by-construction callers dilute it.
     ///
-    /// ⇒ The minimal snapshot is load-bearing ONLY for the
+    /// The minimal snapshot is load-bearing only for the
     /// `rd_resume_position >= 0` invariant above. Do not read that as "the
     /// contents do not matter": they matter to any guard that survives
     /// optimization, and whether one survives is a property of the traced

--- a/majit/majit-metainterp/src/jitcode/embedded.rs
+++ b/majit/majit-metainterp/src/jitcode/embedded.rs
@@ -131,9 +131,9 @@ impl EmbeddedJitCodeTable {
 
     /// Install this pool as the process-global `descr_at` fallback.
     ///
-    /// Idempotent through [`init_global_build_descr_pool`]: the first table
-    /// wins. Until this runs, a shell's operands resolve against its own empty
-    /// `exec.descrs` and every lookup returns `None`.
+    /// Idempotent through [`crate::jitcode::init_global_build_descr_pool`]: the
+    /// first table wins. Until this runs, a shell's operands resolve against
+    /// its own empty `exec.descrs` and every lookup returns `None`.
     pub fn install_as_global_pool(&'static self) {
         super::init_global_build_descr_pool(self);
     }

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -2090,6 +2090,20 @@ impl<S: JitState> JitDriver<S> {
         self.meta.backend_mut().set_gc_allocator(gc);
     }
 
+    /// Route compiled `New` / `NewWithVtable` through the installed GC
+    /// allocator instead of the backend's `malloc` stub.
+    ///
+    /// The backends have carried this setting since it was added for aheui's
+    /// nursery-backed nodes, and until now none of them had a caller: it is an
+    /// inherent method on each backend struct, and `backend_mut` is private, so
+    /// no consumer of `JitDriver` could reach it. Only the dynasm backend acts
+    /// on it — cranelift already routes `New` through an installed GC, and the
+    /// wasm backend takes it as a no-op — so on those two the setting is
+    /// already the behaviour and this call is a statement of intent.
+    pub fn set_new_via_gc(&mut self, enabled: bool) {
+        self.meta.backend_mut().set_new_via_gc(enabled);
+    }
+
     /// llmodel.py:64-69 self.vtable_offset configuration.
     /// Frontend supplies the byte offset of the type pointer field, mirroring
     /// RPython's `symbolic.get_field_token(rclass.OBJECT, 'typeptr', ...)`.

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -1792,6 +1792,12 @@ mod tests {
         fn field_name(&self) -> &str {
             self.name
         }
+        // The fixture builds an op-side and a layout-side descr separately and
+        // tells them apart by name, so the mock declares from the name it was
+        // constructed with. Production producers store the flag instead.
+        fn is_w_class(&self) -> bool {
+            self.name == "w_class" || self.name.ends_with(".w_class")
+        }
     }
 
     #[derive(Debug)]

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -70,9 +70,16 @@ fn w_class_store_is_covered_by_alloc(
     let Some(w_class) = size.w_class_obj().filter(|&w| w != 0) else {
         return false;
     };
-    let Some(init_field) = size.gc_fielddescrs().iter().find(|fd| fd.is_w_class()) else {
+    let Some(init_field) = size.class_word_field() else {
         return false;
     };
+    // ⛔ Do NOT drop this comparison because the slot is now declared. The
+    // declared slot replaces the *name* test and nothing else. `field` comes
+    // from the operation and `init_field` from the layout, and pyre mints
+    // those from two independent producers, so they are distinct objects that
+    // may or may not describe the same bytes. This is the check that they do;
+    // removing it would let a store to any field of a class-word-bearing
+    // struct be elided as "already written by the allocation".
     if init_field.offset() != field.offset() || init_field.field_size() != field.field_size() {
         return false;
     }

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -73,7 +73,7 @@ fn w_class_store_is_covered_by_alloc(
     let Some(init_field) = size.class_word_field() else {
         return false;
     };
-    // ⛔ Do NOT drop this comparison because the slot is now declared. The
+    // Keep this comparison even though the slot is now declared. The
     // declared slot replaces the *name* test and nothing else. `field` comes
     // from the operation and `init_field` from the layout, and pyre mints
     // those from two independent producers, so they are distinct objects that

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1103,8 +1103,9 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
     fn is_virtual_raw(&self, opref: OpRef) -> bool {
         // info.py:865 `RawBufferPtrInfo` / RawSlicePtrInfo — Int-typed
         // virtuals.  `get_type()` already classifies these as Int; mirror
-        // the classification here so resume encoding (`resume.rs:3672`)
-        // picks them up via TAGVIRTUAL instead of TAGBOX.
+        // the classification here so resume encoding
+        // (`ResumeDataLoopMemo::_number_boxes`, whose `Type::Int` arm calls
+        // `is_virtual_raw`) picks them up via TAGVIRTUAL instead of TAGBOX.
         let resolved_box = self.ctx.get_box_replacement_operand_opt(opref);
         resolved_box
             .as_ref()
@@ -1215,8 +1216,9 @@ impl<'a> majit_ir::BoxEnv for OptBoxEnv<'a> {
             //         self.parent.visitor_walk_recursive(source_op, visitor)
             // ```
             //
-            // pyre's consumer (`resume.rs::encode_*` worklist at
-            // `resume.rs:3517`) drives the recursion off `get_virtual_fields`
+            // pyre's consumer (the virtual worklist in
+            // `ResumeDataLoopMemo::finish`) drives the recursion off
+            // `get_virtual_fields`
             // — registering the parent OpRef here lets the worklist enqueue
             // the parent and re-enter `get_virtual_fields` on it, which
             // matches RPython's `parent.visitor_walk_recursive(source_op,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -6106,6 +6106,7 @@ mod tests {
             1,
             0,
             &[majit_ir::descr::SimpleFieldDescrSpec {
+                is_class_word: false,
                 index: 91,
                 field_key: "CallResult.field".to_string(),
                 name: "CallResult.field".to_string(),
@@ -6198,6 +6199,7 @@ mod tests {
             0,
             &[
                 majit_ir::descr::SimpleFieldDescrSpec {
+                    is_class_word: false,
                     index: 101,
                     field_key: "CallResult.type".to_string(),
                     name: "CallResult.type".to_string(),
@@ -6211,6 +6213,7 @@ mod tests {
                     index_in_parent: 0,
                 },
                 majit_ir::descr::SimpleFieldDescrSpec {
+                    is_class_word: false,
                     index: 102,
                     field_key: "CallResult.value".to_string(),
                     name: "CallResult.value".to_string(),

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -4221,7 +4221,7 @@ impl Optimizer {
             // jitcell is the one the recorded close JUMP points to, which is
             // also where `front_target_tokens` comes from (`compile_bridge`
             // resolves it off the JUMP target, not the bridge origin).
-            // `assert cell_token.target_tokens` ⇒ require a target.
+            // `assert cell_token.target_tokens`: require a target.
             if !front_target_tokens.is_empty() {
                 let mut ctx = self.final_ctx.take().unwrap_or_else(|| {
                     // opencoder.py:259 inputarg_from_tp parity — seed inputarg

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -2285,6 +2285,7 @@ mod tests {
             1,
             0,
             &[majit_ir::descr::SimpleFieldDescrSpec {
+                is_class_word: false,
                 index,
                 field_key: format!("CseField{index}"),
                 name: format!("CseField{index}"),

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -990,12 +990,7 @@ impl OptVirtualize {
                 let stored = vinfo
                     .descr
                     .as_size_descr()
-                    .and_then(|sd| {
-                        sd.all_fielddescrs()
-                            .iter()
-                            .find(|fd| fd.is_w_class())
-                            .map(|fd| fd.index_in_parent() as u32)
-                    })
+                    .and_then(|sd| sd.class_word_field().map(|fd| fd.index_in_parent() as u32))
                     .and_then(|widx| get_field(&vinfo.fields, widx));
                 if let Some(val_ref) = stored {
                     let b_old = Operand::from_bound_op(op_rc);

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -250,13 +250,19 @@ impl VirtualizableTracker {
         };
         // Input-layout seeding applies only to the initial loop/preamble entry
         // (`inputarg_base == 0`), whose inputargs carry the
-        // `[frame, vable_scalars..., array_items...]` layout. A bridge
-        // (`inputarg_base > 0`) inherits only the failing guard's live boxes as
-        // inputargs (frame first, then the surviving reds), NOT the unpacked
-        // vable scalar/array slots; it re-establishes the virtualizable fields
-        // from the explicit SetfieldGc/SetarrayitemGc reconstruction ops the
-        // resume path records into the bridge body. So the bridge frame is
-        // seeded as an empty Virtualizable and populated by those ops.
+        // `[frame, vable_scalars..., array_items...]` layout. The gate is the
+        // base and not `building_bridge` because the seeding below addresses
+        // slots with unshifted raw indices (`input_arg_typed(flat_input_idx)`),
+        // which name this run's inputargs only when the base is 0.
+        //
+        // A bridge inherits only the failing guard's live boxes as inputargs
+        // (frame first, then the surviving reds), not the unpacked vable
+        // scalar/array slots; it re-establishes the virtualizable fields from
+        // the explicit SetfieldGc/SetarrayitemGc reconstruction ops the resume
+        // path records into the bridge body. So the bridge frame is seeded as
+        // an empty Virtualizable and populated by those ops. An unrolled
+        // Phase 2 body is also shifted and skips the seeding, but keeps the
+        // resolved identity slot; see `identity_input_ref`.
         let base = ctx.inputarg_base;
         if base == 0 {
             let mut flat_input_idx = 1usize + self.config.vable_input_offset;

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -989,7 +989,7 @@ impl OptVirtualize {
                 let stored = vinfo
                     .descr
                     .as_size_descr()
-                    .and_then(|sd| sd.class_word_field().map(|fd| fd.index_in_parent() as u32))
+                    .and_then(|sd| sd.class_word_index_in_parent().map(|idx| idx as u32))
                     .and_then(|widx| get_field(&vinfo.fields, widx));
                 if let Some(val_ref) = stored {
                     let b_old = Operand::from_bound_op(op_rc);

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -4465,6 +4465,7 @@ mod tests {
             1,
             0,
             &[majit_ir::descr::SimpleFieldDescrSpec {
+                is_class_word: false,
                 index: 10,
                 field_key: "Node.value".to_string(),
                 name: "Node.value".to_string(),
@@ -6155,6 +6156,7 @@ mod tests {
             1,
             0,
             &[majit_ir::descr::SimpleFieldDescrSpec {
+                is_class_word: false,
                 index: 10,
                 field_key: "Node.value".to_string(),
                 name: "Node.value".to_string(),

--- a/majit/majit-metainterp/src/optimizeopt/virtualize.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualize.rs
@@ -948,8 +948,7 @@ impl OptVirtualize {
         // excluded for the reason the arms below give -- they do not resolve
         // through the field list at all.
         if !is_raw_op
-            && !is_typeptr
-            && !field_descr.is_w_class()
+            && !field_descr.is_header_field()
             && let (Some(b), Some(parent_descr)) =
                 (struct_box.as_ref(), field_descr.get_parent_descr())
         {
@@ -1076,7 +1075,7 @@ impl OptVirtualize {
                 _ => true,
             };
             let slot_resolvable =
-                slot_identifies_field || is_raw_op || is_typeptr || field_descr.is_w_class();
+                slot_identifies_field || is_raw_op || field_descr.is_header_field();
             if !slot_resolvable && crate::majit_log_enabled() {
                 // What the skip is worth: a populated slot is the value
                 // `get_field` would have forwarded for a field not in it.
@@ -1163,8 +1162,7 @@ impl OptVirtualize {
             // because upstream defines this handler for GETFIELD_GC_{I,R,F}
             // only.
             let folds_to_zero = !is_raw_op
-                && !is_typeptr
-                && !field_descr.is_w_class()
+                && !field_descr.is_header_field()
                 && matches!(info, PtrInfo::Virtual(_) | PtrInfo::VirtualStruct(_));
             if folds_to_zero {
                 // optimizer.py:528-534 new_const: CONST_NULL for a pointer

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -10737,6 +10737,45 @@ impl<M: Clone> MetaInterp<M> {
         self.execute_assembler_at_dispatch_key(&token, green_key, live_values, dispatch_key)
     }
 
+    /// `compile.py:658-672 _DoneWithThisFrameDescr.get_result` and
+    /// `handle_fail`'s exit read: decode a returned frame's exit slots into the
+    /// raw and typed lists every consumer of a compiled run reads.
+    ///
+    /// The slot types come from the descr the run ended on, so this is the one
+    /// step both outcomes of a compiled entry share.
+    fn decode_exit_slots(
+        backend: &BackendImpl,
+        frame: &majit_backend::DeadFrame,
+        exit_types: &[Type],
+    ) -> (ExitRawValues, ExitValues) {
+        let mut values = ExitRawValues::with_capacity(exit_types.len());
+        let mut typed_values = ExitValues::with_capacity(exit_types.len());
+        for (i, &tp) in exit_types.iter().enumerate() {
+            match tp {
+                Type::Int => {
+                    let value = backend.get_int_value(frame, i);
+                    values.push(value);
+                    typed_values.push(Value::Int(value));
+                }
+                Type::Ref => {
+                    let value = backend.get_ref_value(frame, i);
+                    values.push(value.as_usize() as i64);
+                    typed_values.push(Value::Ref(value));
+                }
+                Type::Float => {
+                    let value = backend.get_float_value(frame, i);
+                    values.push(value.to_bits() as i64);
+                    typed_values.push(Value::Float(value));
+                }
+                Type::Void => {
+                    values.push(0);
+                    typed_values.push(Value::Void);
+                }
+            }
+        }
+        (values, typed_values)
+    }
+
     /// `warmstate.py:405-419 execute_assembler(loop_token, *args)`: the run
     /// RECEIVES the token whoever decided to enter already resolved, and never
     /// looks the cell up again. Upstream hands it over the same way —
@@ -10788,6 +10827,66 @@ impl<M: Clone> MetaInterp<M> {
         // copy was paid on every call for the benefit of the guard-failure arm
         // alone.
         let exit_types: &[Type] = descr.fail_arg_types();
+        // The exit slots are read for both outcomes, so they are decoded before
+        // the split rather than once in each arm.
+        let (values, typed_values) = Self::decode_exit_slots(&self.backend, &frame, exit_types);
+
+        // `warmstate.py:404-418`: "First, a fast path to avoid raising and
+        // immediately catching a DoneWithThisFrame exception". On a final
+        // descr, upstream returns `fail_descr.get_result(cpu, deadframe)` — the
+        // exit slots and nothing else. What the general case goes on to gather
+        // is `handle_fail`'s input: which slots hold references and which hold
+        // force tokens, the guard's own status counter (`compile.py:741-745`),
+        // the loop token the guard's resume data belongs to, the frame's saved
+        // data, and the pending exception a guard exit parks in the frame. A
+        // final descr resumes nothing, is counted by nothing, and owns no
+        // resume data, so every one of those is gathered and dropped unread.
+        //
+        // Split here rather than lower down because a portal whose calls each
+        // run one compiled body to completion reaches this point once per call
+        // and never reaches the general case at all.
+        if is_finish {
+            Self::finish_compiled_run_io();
+            // The same layout the general arm synthesizes when it has no trace
+            // to build one from: a final descr carries none. The two guard-only
+            // slot lists stay empty because nothing past a final descr reads
+            // them — they exist for the blackhole resume and the bridge,
+            // neither of which a returned frame reaches. Built before the
+            // result so the descr borrow behind `exit_types` ends first.
+            let exit_layout = CompiledExitLayout {
+                rd_loop_token: green_key,
+                trace_id,
+                fail_index,
+                source_op_index: None,
+                exit_types: ExitTypes::from_slice(exit_types),
+                is_finish,
+                is_exception_exit: is_exit_frame_with_exception,
+                gc_ref_slots: Vec::new(),
+                force_token_slots: Vec::new(),
+                recovery_layout: None,
+                resume_layout: None,
+                storage: None,
+            };
+            return Some(CompileResult {
+                values,
+                typed_values,
+                meta,
+                fail_index,
+                trace_id,
+                descr_arc,
+                is_finish,
+                is_exit_frame_with_exception,
+                exit_layout,
+                savedata: None,
+                exception: ExceptionState {
+                    exc_class: 0,
+                    exc_value: 0,
+                    ovf_flag: false,
+                },
+                status: 0,
+            });
+        }
+
         let gc_ref_slots: Vec<usize> = exit_types
             .iter()
             .enumerate()
@@ -10809,18 +10908,24 @@ impl<M: Clone> MetaInterp<M> {
             self.record_guard_failure_event(green_key, fail_index, back_edge_poll);
         }
 
-        let exit_arity = exit_types.len();
         // Fresh lookup, and fallible: the run can re-enter the driver through
         // a residual call and drop this green key (`jitdriver.rs:4361`
         // `remove_compiled_loop` on the unrecoverable-resume path), in which
         // case the exit falls through to the `rd_loop_token` lookup and then
         // to the synthesized default layout below.
         let compiled = self.compiled_loops.get(&green_key);
-        // FINISH descrs (singletons) have `trace_id == 0`; skip the
-        // trace lookup and synthesize the default layout per
-        // `run_compiled_detailed`.
-        let mut exit_layout = if is_finish {
-            CompiledExitLayout {
+        // Only a guard exit reaches here — a final descr returned through the
+        // fast path above — so the layout comes from the failing guard's own
+        // trace, and falls back to a synthesized one per `run_compiled_detailed`
+        // when the green key no longer holds it.
+        let mut exit_layout = compiled
+            .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
+            .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
+            .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
+            .and_then(|(owning_key, resolved_id, trace)| {
+                Self::compiled_exit_layout_from_trace(trace, owning_key, resolved_id, fail_index)
+            })
+            .unwrap_or_else(|| CompiledExitLayout {
                 rd_loop_token: green_key,
                 trace_id,
                 fail_index,
@@ -10828,77 +10933,22 @@ impl<M: Clone> MetaInterp<M> {
                 exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
-                // Moved rather than cloned: the `else` arm below is the only
-                // other consumer and it is mutually exclusive with this one.
                 gc_ref_slots,
                 force_token_slots,
                 recovery_layout: None,
                 resume_layout: None,
-                storage: None,
-            }
-        } else {
-            compiled
-                .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
-                .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
-                .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
-                .and_then(|(owning_key, resolved_id, trace)| {
-                    Self::compiled_exit_layout_from_trace(
-                        trace,
-                        owning_key,
-                        resolved_id,
-                        fail_index,
-                    )
-                })
-                .unwrap_or_else(|| CompiledExitLayout {
-                    rd_loop_token: green_key,
-                    trace_id,
-                    fail_index,
-                    source_op_index: None,
-                    exit_types: ExitTypes::from_slice(exit_types),
-                    is_finish,
-                    is_exception_exit: is_exit_frame_with_exception,
-                    gc_ref_slots,
-                    force_token_slots,
-                    recovery_layout: None,
-                    resume_layout: None,
-                    // The green-key index no longer holds this trace, but the
-                    // failing descr still carries the resume payload it was
-                    // compiled with (`compile.py:849 get_resumestorage`), so a
-                    // blackhole resume off this layout stays possible.
-                    storage: crate::resume::ResumeStorage::from_fail_descr(descr)
-                        .map(std::sync::Arc::new),
-                })
-        };
+                // The green-key index no longer holds this trace, but the
+                // failing descr still carries the resume payload it was
+                // compiled with (`compile.py:849 get_resumestorage`), so a
+                // blackhole resume off this layout stays possible.
+                storage: crate::resume::ResumeStorage::from_fail_descr(descr)
+                    .map(std::sync::Arc::new),
+            });
         // RPython: deadframe has ALL jitframe slots accessible.
         // If the backend's descr covers more slots than the trace layout,
         // extend exit_layout.exit_types to match (conservative Int for extras).
         if exit_types.len() > exit_layout.exit_types.len() {
             exit_layout.exit_types.resize(exit_types.len(), Type::Int);
-        }
-        let mut values = ExitRawValues::with_capacity(exit_arity);
-        let mut typed_values = ExitValues::with_capacity(exit_arity);
-        for (i, &tp) in exit_types.iter().enumerate() {
-            match tp {
-                Type::Int => {
-                    let value = self.backend.get_int_value(&frame, i);
-                    values.push(value);
-                    typed_values.push(Value::Int(value));
-                }
-                Type::Ref => {
-                    let value = self.backend.get_ref_value(&frame, i);
-                    values.push(value.as_usize() as i64);
-                    typed_values.push(Value::Ref(value));
-                }
-                Type::Float => {
-                    let value = self.backend.get_float_value(&frame, i);
-                    values.push(value.to_bits() as i64);
-                    typed_values.push(Value::Float(value));
-                }
-                Type::Void => {
-                    values.push(0);
-                    typed_values.push(Value::Void);
-                }
-            }
         }
         let savedata = self.backend.get_savedata_ref(&frame);
         // pyjitpl.py:3119-3123: exc_class = ptr2int(exception_obj.typeptr)

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -7189,7 +7189,7 @@ where
                     //     return self.execute_varargs(rop.CALL_I,
                     //                                 allboxes, descr,
                     //                                 exc, pure)
-                    // pure ⇒ post-record fold via record_result_of_call_pure
+                    // Pure calls fold after recording via record_result_of_call_pure.
                     // (pyjitpl.py:1947-1949).  Only the plain branch carries
                     // pure: forces/release_gil/loopinvariant don't combine
                     // with elidable in upstream call.py:282-299 getcalldescr.
@@ -10292,8 +10292,8 @@ pub fn build_state_field_snapshot(
     // the virtualizable list: the virtualizable identity (stored at
     // `boxes[-1]` per `TraceCtx::init_virtualizable_boxes`) is moved
     // to the FRONT, then the rest follow in original order.  The
-    // resume reader (`resume.py:1404 consume_vable_info` ↔
-    // `resume.rs:6477`) reads the first entry as the virtualizable
+    // resume reader (`resume.py:1404 consume_vable_info` and
+    // `resume.rs::consume_vable_info`) reads the first entry as the virtualizable
     // pointer, so this reorder is load-bearing.
     // `opencoder.py:718-726 _list_of_boxes_virtualizable` /
     // `opencoder.py:712-717 _list_of_boxes` encode every list element
@@ -10316,7 +10316,7 @@ pub fn build_state_field_snapshot(
 /// reorder for the virtualizable box list.  `virtualizable_boxes[-1]` is the
 /// virtualizable identity (placed there by
 /// `TraceCtx::init_virtualizable_boxes`); the snapshot moves it to slot 0 so
-/// the resume reader's `consume_vable_info` (`resume.rs:6477`, mirroring
+/// the resume reader's `consume_vable_info` (in `resume.rs`, mirroring
 /// `resume.py:1404`) reads the identity first.  Each entry must carry
 /// `OpRef::ty()`; misshapen entries panic rather than silently shrink the
 /// snapshot relative to upstream.

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -66,6 +66,7 @@ fn field_spec_from_bh(
     majit_ir::descr::SimpleFieldDescrSpec {
         index: f.index,
         field_key: f.field_key().to_string(),
+        is_class_word: majit_ir::descr::class_word_inferred_from_name(&f.name),
         name: f.name.clone(),
         offset: f.offset,
         field_size: f.field_size,
@@ -240,6 +241,9 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                                 specs.push(majit_ir::descr::SimpleFieldDescrSpec {
                                     index: u32::MAX,
                                     field_key: name.clone(),
+                                    is_class_word: majit_ir::descr::class_word_inferred_from_name(
+                                        name,
+                                    ),
                                     name: name.clone(),
                                     offset: *offset,
                                     field_size: *field_size,
@@ -372,6 +376,7 @@ pub fn field_descr_ref_from_bh(descr: &crate::blackhole::BhDescr) -> (usize, maj
                         let spec = majit_ir::descr::SimpleFieldDescrSpec {
                             index: u32::MAX,
                             field_key: name.clone(),
+                            is_class_word: majit_ir::descr::class_word_inferred_from_name(name),
                             name: name.clone(),
                             offset: *offset,
                             field_size: *field_size,
@@ -542,6 +547,7 @@ pub fn residual_write_effect_info(
                 majit_ir::descr::SimpleFieldDescrSpec {
                     index: u32::MAX,
                     field_key: name.to_string(),
+                    is_class_word: majit_ir::descr::class_word_inferred_from_name(name),
                     name: name.to_string(),
                     offset,
                     // Same width rule as the `field_specs_from_layout` twin

--- a/majit/majit-metainterp/src/resume.rs
+++ b/majit/majit-metainterp/src/resume.rs
@@ -181,8 +181,8 @@ pub struct NumberingState {
     /// Ref,Float}, resoperation.py:564-638 *Op mixins) so that
     /// `InputArgRef(0)` and `RefOp(0)` do not collapse onto the same
     /// raw u32 — pyre's flat-OpRef stand-in for PyPy's `box is box`
-    /// identity. See `LiveboxMap` (resume.rs:98) for the matching
-    /// typed-key convention.
+    /// identity. See `LiveboxMap` for the matching typed-key
+    /// convention.
     pub livebox_types: LiveboxTypeMap,
 }
 
@@ -2215,8 +2215,8 @@ impl EncodedResumeData {
             TAGCONST => match value {
                 // resume.py:1552-1596 decode_ref: `if tagged_eq(tagged,
                 // NULLREF): return CONST_NULL`. The i64 decoder mirrors
-                // the i16 `decode_box`'s NULLREF fast-path (resume.rs
-                // line 4363) so encoder/decoder stay symmetric.
+                // the free `decode_box(tagged: i16, ..)`'s NULLREF
+                // fast-path so encoder/decoder stay symmetric.
                 ENCODED_NULLREF => {
                     ResumeValueSource::Constant(majit_ir::Const::Ref(majit_ir::GcRef::NULL))
                 }
@@ -3607,7 +3607,8 @@ impl ResumeDataLoopMemo {
             // element type is not itself optional.  We use the
             // `RdVirtualInfo::Empty` sentinel variant to mark hole slots;
             // downstream consumers (compile.rs:644, compiler.rs:10952,
-            // state.rs:3180, eval.rs:2680, resume.rs:1766) match `Empty`
+            // state.rs:3180, eval.rs:2680,
+            // `resume.rs::rd_virtual_to_virtual_info`) match `Empty`
             // and treat it as `None` equivalent.  Functional parity is
             // preserved; the structural divergence stays isolated to
             // this one type.
@@ -4053,7 +4054,7 @@ impl ResumeDataLoopMemo {
 
         // resume.py:414-426: iterate liveboxes_from_env, discover virtual
         // fields. RPython walks the dict in insertion order; pyre's
-        // `LiveboxMap` is built on `IndexMap` (resume.rs:98) so the
+        // `LiveboxMap` is built on `IndexMap` so the
         // `.iter()` sequence already matches that order, which the
         // virtual worklist drain below relies on for byte-identical
         // visitor_walk_recursive sequencing. Sorting by tag would
@@ -4267,9 +4268,9 @@ impl ResumeDataLoopMemo {
         // livebox slots.
         //
         // resume.py:412-417 + regalloc.py:1204: liveboxes contains ONLY
-        // non-Const boxes — `_number_boxes` (resume.rs:3755-3826) classifies
-        // Const via `is_const(opref)` → TAGCONST inline (lines 3773-3777)
-        // before the box ever reaches liveboxes. PyPy `resume.py:finish` has
+        // non-Const boxes — `_number_boxes` classifies Const via its
+        // `is_const(opref)` → TAGCONST branch before the box ever
+        // reaches liveboxes. PyPy `resume.py:finish` has
         // no post-numbering Const→hole step; the invariant is that liveboxes
         // entries stay non-Const through finish(). Hard-assert that
         // `get_box_replacement_not_const` does not produce a
@@ -6020,7 +6021,7 @@ pub trait VirtualInfoBlackholeExt {
     fn is_about_raw(&self) -> bool;
     /// `resume.py:973 if rd_virtual is not None`: detect the
     /// `RdVirtualInfo::Empty` placeholder propagated as a zero-shaped
-    /// `VirtualObj` (resume.rs:1446 conversion).  Used by
+    /// `VirtualObj` (the `rd_virtual_to_virtual_info` conversion). Used by
     /// `force_all_virtuals` to skip slots that PyPy keeps as `None`.
     fn is_empty_placeholder(&self) -> bool;
     fn allocate(
@@ -6150,8 +6151,8 @@ impl VirtualInfoBlackholeExt for VirtualInfo {
     }
 
     fn is_empty_placeholder(&self) -> bool {
-        // The `RdVirtualInfo::Empty` → `VirtualObj` conversion at
-        // `resume.rs:1446` produces this exact shape.
+        // The `RdVirtualInfo::Empty` → `VirtualObj` conversion in
+        // `rd_virtual_to_virtual_info` produces this exact shape.
         matches!(
             self,
             VirtualInfo::VirtualObj {
@@ -6498,8 +6499,8 @@ impl<'a> ResumeDataDirectReader<'a> {
     ///     `optimizeopt/optimizer.rs:3453` initializes both to
     ///     `UNASSIGNED`, but the entries are immediately fed through
     ///     `memo.finish()` (`optimizeopt/mod.rs:3390`) →
-    ///     `_add_pending_fields` (`resume.rs:3554`), which writes
-    ///     the tags from `_gettagged`.
+    ///     `_add_pending_fields`, which writes the tags from
+    ///     `_gettagged`.
     ///   * The sharing path (`_copy_resume_data_from`) routes resume
     ///     reads through `ResumeGuardCopiedDescr.prev` (compile.py:849
     ///     `get_resumestorage(): return prev`); readers reach the

--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -1220,7 +1220,7 @@ impl WarmEnterState {
     /// reader enters at `jitcounter.lookup_chain(hash)`
     /// (warmstate.py:459-460, :597-598, :632-633), and `lookup_chain`
     /// (counter.py:239-240) is a bare `celltable[self._get_index(hash)]`. See
-    /// [`a_raw_hash_equal_to_a_minted_key_resolves_through_one_bucket`].
+    /// `a_raw_hash_equal_to_a_minted_key_resolves_through_one_bucket`.
     #[inline]
     pub fn bucket_is_chained(&self, green_key_hash: u64) -> bool {
         self.lookup_chain(green_key_hash)
@@ -5318,8 +5318,8 @@ mod tests {
     /// chains every cell whose `should_remove_jitcell` is false, so three warm
     /// keys sharing a bucket is enough.
     ///
-    /// **Pre-fix reading.** This test does not fail, it HANGS — the run was
-    /// killed after 11 minutes of CPU inside `mint_cell_key`'s retry loop.
+    /// A regression does not reach an assertion: it hangs in
+    /// `mint_cell_key`'s retry loop because every retry proposes the same key.
     #[test]
     fn a_bucket_that_mints_twice_gets_two_different_keys() {
         let mut ws = WarmEnterState::new(100);
@@ -5387,19 +5387,10 @@ mod tests {
     /// (counter.py:239-240) is a bare `celltable[self._get_index(hash)]` with
     /// nothing in front of it.
     ///
-    /// **Pre-fix reading.** Routing `bucket_is_chained` through `bucket_of`
-    /// fails the third assertion below, and substituting that one line back is
-    /// the whole difference between the two trees:
-    ///
-    /// ```text
-    /// panicked at majit/majit-metainterp/src/warmstate.rs:5446:9:
-    /// the two readers of one raw hash must describe ONE bucket: `sole_cell_key`
-    /// declined because the bucket this hash names is chained, and this answered
-    /// `unchained` about the bucket `bucket_of` sent it to instead
-    /// ```
-    ///
-    /// The assertions after it are what that costs: the entry resolves to a
-    /// cell belonging to neither the arriving key nor its sibling.
+    /// Routing `bucket_is_chained` through `bucket_of` makes the readers
+    /// disagree about whether this raw hash names a chained bucket. The later
+    /// assertions pin the consequence: the entry would resolve to a cell
+    /// belonging to neither the arriving key nor its sibling.
     #[test]
     fn a_raw_hash_equal_to_a_minted_key_resolves_through_one_bucket() {
         let mut ws = WarmEnterState::new(100);

--- a/majit/majit-rlib/src/lltypesystem/rlist.rs
+++ b/majit/majit-rlib/src/lltypesystem/rlist.rs
@@ -18,17 +18,74 @@
 
 use std::alloc::{Layout, alloc, alloc_zeroed};
 
+/// No host has declared this array's GC type id yet.
+///
+/// Not `0`: `TypeRegistry::register` hands out `entries.len()`, so `0` is a
+/// legitimate slot — whatever the host registers first. A zero sentinel would
+/// read "unset" and "the first registered type" the same way, which is the
+/// very confusion these ids exist to prevent.
+pub const UNSET_GC_TYPE_ID: u32 = u32::MAX;
+
+/// The sentinel has to be a value no registration can produce, or "undeclared"
+/// and "declared as that type" are the same word again — the exact aliasing
+/// the sentinel exists to avoid, just moved to the top of the range.
+const _: () = assert!(
+    UNSET_GC_TYPE_ID as usize >= majit_gc::trace::TypeRegistry::MAX_TYPES,
+    "UNSET_GC_TYPE_ID collides with a slot TypeRegistry::register can return"
+);
+
 /// GC type id for `Ptr(GcArray(Signed))`. This is a distinct ARRAY identity
 /// from `GcArray(Float)` even though the collector trace shape is the same —
 /// `GcLLDescr_framework.init_array_descr` gives each ARRAY lltype its own tid.
 ///
-/// The value is the slot `gc.register_type` returns for it in pyre's
-/// registration order; `pyre_object::object_array` re-exports it alongside the
-/// rest of that numbering.
-pub const GC_INT_ARRAY_GC_TYPE_ID: u32 = 41;
+/// A type id is not a property of the lltype; it is a **slot in one host's
+/// type registry**, handed out by that host's `gc.register_type` in that
+/// host's registration order. The collector reads the word back to index the
+/// same registry. So a literal baked in here is another host's slot number:
+/// any host but the one it was copied from stamps a foreign index into its own
+/// GC headers, and the mis-trace surfaces at collection time — a wrong type
+/// for a live object, arbitrarily far from the store that wrote it. The host
+/// therefore declares its own, the way it already declares the `rbigint`
+/// payload's ([`crate::rbigint::set_rbigint_gc_type_id`]).
+static GC_INT_ARRAY_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(UNSET_GC_TYPE_ID);
 
-/// GC type id for `Ptr(GcArray(Float))` — the [`GC_INT_ARRAY_GC_TYPE_ID`] twin.
-pub const GC_FLOAT_ARRAY_GC_TYPE_ID: u32 = 42;
+/// GC type id for `Ptr(GcArray(Float))` — the [`gc_int_array_gc_type_id`] twin.
+static GC_FLOAT_ARRAY_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
+    std::sync::atomic::AtomicU32::new(UNSET_GC_TYPE_ID);
+
+/// Declare the slot this host's `gc.register_type` returned for
+/// `GcArray(Signed)`. Call it from the same place the host registers the type.
+pub fn set_gc_int_array_gc_type_id(id: u32) {
+    GC_INT_ARRAY_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// Declare the slot this host's `gc.register_type` returned for
+/// `GcArray(Float)`.
+pub fn set_gc_float_array_gc_type_id(id: u32) {
+    GC_FLOAT_ARRAY_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+}
+
+/// [`UNSET_GC_TYPE_ID`] until a host declares one.
+///
+/// Undeclared is not defaulted to anything here, and the caller is not asked
+/// to check: an items block allocated while the GC owns the heap carries this
+/// word in its header, so [`try_alloc_typed_items_block_nursery`] refuses an
+/// undeclared id there and says so. Returning the sentinel rather than
+/// panicking on the read keeps the `std::alloc` path this file already
+/// documents — bare unit tests and the pre-`init_gc_subsystem` bootstrap,
+/// where no collector will ever read the word — working without a
+/// registration it has no registry for.
+#[majit_macros::dont_look_inside]
+pub fn gc_int_array_gc_type_id() -> u32 {
+    GC_INT_ARRAY_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// [`gc_int_array_gc_type_id`]'s twin; same undeclared contract.
+#[majit_macros::dont_look_inside]
+pub fn gc_float_array_gc_type_id() -> u32 {
+    GC_FLOAT_ARRAY_GC_TYPE_ID.load(std::sync::atomic::Ordering::Relaxed)
+}
 
 /// Route items-block allocations through the moving nursery instead of
 /// `std::alloc`. Read once; default ON — the nursery path mirrors the
@@ -154,6 +211,20 @@ pub unsafe fn try_alloc_typed_items_block_nursery(
     // that rather than a block outside the managed heap
     // (`majit_gc::gc_allocator_installed`).
     if itemsblock_gc_enabled() && majit_gc::gc_allocator_installed() {
+        // Past this point the id is written into the block's GC header and the
+        // collector will index its type registry with it, so an undeclared one
+        // cannot be defaulted: any value picked here would name some other
+        // type in this host's registry and mis-trace a live object at the next
+        // collection. Fail at the store instead, where the host that skipped
+        // the registration is still on the stack.
+        assert!(
+            tid != UNSET_GC_TYPE_ID,
+            "items block allocated with an undeclared GC type id: a type id is \
+             a slot in this host's type registry, so the host must pass the \
+             value its own `gc.register_type` returned — for the \
+             `GcArray(Signed)` / `GcArray(Float)` bodies, via \
+             `set_gc_int_array_gc_type_id` / `set_gc_float_array_gc_type_id`"
+        );
         // `GcArray(Signed)` / `GcArray(Float)` bodies: no finalizer, not a
         // WEAKREF, so `gct_fv_gc_malloc` (`framework.py:820-838`) reaches
         // `malloc_fast`.
@@ -225,7 +296,7 @@ impl Digits {
         reason = "This is the direct ll_newlist allocator port from rlist.py; the translated low-level result is a TypedItemsBlock pointer rather than a Rust Digits namespace value"
     )]
     pub unsafe fn new(length: usize) -> *mut TypedItemsBlock {
-        unsafe { alloc_typed_items_block_nursery(length, GC_INT_ARRAY_GC_TYPE_ID) }
+        unsafe { alloc_typed_items_block_nursery(length, gc_int_array_gc_type_id()) }
     }
 
     /// Fallible [`Digits::new`], for the upstream paths whose translated
@@ -235,7 +306,7 @@ impl Digits {
     /// Same obligation as [`Digits::new`].
     #[inline]
     pub unsafe fn try_new(length: usize) -> Option<*mut TypedItemsBlock> {
-        unsafe { try_alloc_typed_items_block_nursery(length, GC_INT_ARRAY_GC_TYPE_ID) }
+        unsafe { try_alloc_typed_items_block_nursery(length, gc_int_array_gc_type_id()) }
     }
 
     /// `ll_alloc_and_set(LIST, count, 0)` (rtyper/rlist.py:494-503) —
@@ -305,5 +376,29 @@ pub unsafe fn alloc_typed_items_block_immortal(cap: usize) -> *mut TypedItemsBlo
         let block = raw as *mut TypedItemsBlock;
         (*block).capacity = cap;
         block
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The declaration channel carries whatever slot the host's registry
+    /// handed out, including `0` — which is a real slot (`TypeRegistry::
+    /// register` returns `entries.len()`), and which the undeclared state
+    /// must stay distinguishable from.
+    #[test]
+    fn a_declared_array_type_id_reads_back_and_zero_is_a_real_slot() {
+        set_gc_int_array_gc_type_id(0);
+        assert_eq!(gc_int_array_gc_type_id(), 0);
+        assert_ne!(gc_int_array_gc_type_id(), UNSET_GC_TYPE_ID);
+
+        set_gc_float_array_gc_type_id(42);
+        assert_eq!(gc_float_array_gc_type_id(), 42);
+
+        // Leave both declared: a sibling test that allocates an items block
+        // while a collector owns the heap would otherwise trip the
+        // undeclared-id refusal in `try_alloc_typed_items_block_nursery`.
+        set_gc_int_array_gc_type_id(41);
     }
 }

--- a/majit/majit-rlib/src/lltypesystem/rlist.rs
+++ b/majit/majit-rlib/src/lltypesystem/rlist.rs
@@ -47,6 +47,9 @@ const _: () = assert!(
 /// for a live object, arbitrarily far from the store that wrote it. The host
 /// therefore declares its own, the way it already declares the `rbigint`
 /// payload's ([`crate::rbigint::set_rbigint_gc_type_id`]).
+///
+/// One host per process: see [`declare_array_gc_type_id`] for what that costs
+/// and where the instance-scoped owner is upstream.
 static GC_INT_ARRAY_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(UNSET_GC_TYPE_ID);
 
@@ -54,16 +57,56 @@ static GC_INT_ARRAY_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
 static GC_FLOAT_ARRAY_GC_TYPE_ID: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(UNSET_GC_TYPE_ID);
 
+/// Publish `id` as the declaring host's slot for `lltype`.
+///
+/// The cell is process-global because the collector it indexes is: `gc_sync`
+/// holds one collector singleton for the process, and the allocator hook these
+/// ids feed (`ACTIVE_ALLOC_NURSERY_TYPED`) is a single global cell as well.
+/// One host per process is a standing assumption of the whole allocation path,
+/// not a shortcut taken here. Upstream carries no such cell:
+/// `GcLLDescr_framework.init_array_descr` (`gc.py:544-549`) reads the tid off
+/// `self.layoutbuilder` and writes it into the individual `ArrayDescr`, both
+/// instance-owned, so two backends in one process keep separate ids. Pyre has
+/// no descriptor object at the allocation site — the block allocators take a
+/// bare `tid: u32` — so there is nothing instance-scoped for the id to live on
+/// until that plumbing exists, and moving only these two ids off the static
+/// would buy no second host while the singleton and the allocator hook remain.
+///
+/// Re-declaring the SAME slot is how a rebuilt heap
+/// (`eval.rs reset_gc_fresh_for_test`) re-announces its registration: the
+/// registry belongs to the collector and the registration order is fixed, so a
+/// fresh collector hands the same ids back. A DIFFERENT slot is a second host
+/// stamping over the first host's registrations, which nothing downstream can
+/// detect — the collector reads the word and indexes its own registry with it.
+/// Refuse it here in debug rather than let it surface as a mis-trace.
+fn declare_array_gc_type_id(slot: &std::sync::atomic::AtomicU32, id: u32, lltype: &str) {
+    let previous = slot.swap(id, std::sync::atomic::Ordering::Relaxed);
+    debug_assert!(
+        previous == UNSET_GC_TYPE_ID || previous == id,
+        "{lltype} GC type id re-declared as {id} over {previous}: a second host \
+         is stamping its own registry slots over the first host's"
+    );
+}
+
 /// Declare the slot this host's `gc.register_type` returned for
 /// `GcArray(Signed)`. Call it from the same place the host registers the type.
 pub fn set_gc_int_array_gc_type_id(id: u32) {
-    GC_INT_ARRAY_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+    declare_array_gc_type_id(&GC_INT_ARRAY_GC_TYPE_ID, id, "GcArray(Signed)");
 }
 
 /// Declare the slot this host's `gc.register_type` returned for
 /// `GcArray(Float)`.
 pub fn set_gc_float_array_gc_type_id(id: u32) {
-    GC_FLOAT_ARRAY_GC_TYPE_ID.store(id, std::sync::atomic::Ordering::Relaxed);
+    declare_array_gc_type_id(&GC_FLOAT_ARRAY_GC_TYPE_ID, id, "GcArray(Float)");
+}
+
+/// Return both slots to [`UNSET_GC_TYPE_ID`] so a test can exercise the
+/// declaration channel more than once. The production channel is
+/// declare-once-per-process; only the tests below need to undo it.
+#[cfg(test)]
+fn undeclare_array_gc_type_ids() {
+    GC_INT_ARRAY_GC_TYPE_ID.store(UNSET_GC_TYPE_ID, std::sync::atomic::Ordering::Relaxed);
+    GC_FLOAT_ARRAY_GC_TYPE_ID.store(UNSET_GC_TYPE_ID, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// [`UNSET_GC_TYPE_ID`] until a host declares one.
@@ -383,22 +426,60 @@ pub unsafe fn alloc_typed_items_block_immortal(cap: usize) -> *mut TypedItemsBlo
 mod tests {
     use super::*;
 
+    /// The declaration cells are process-global, so the tests that write them
+    /// take turns — and each starts from the undeclared state, which is the
+    /// only state a fresh process ever presents to a host.
+    static DECLARATION: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Serialize on [`DECLARATION`] and hand back the undeclared state a host
+    /// starts from. A test that ends by panicking poisons the lock; the next
+    /// test is not the one that failed, so take the guard through the poison.
+    ///
+    /// This leaves the ids briefly undeclared while other tests in this binary
+    /// run. Nothing here installs a GC allocator, and that is the gate
+    /// `try_alloc_typed_items_block_nursery` takes its undeclared-id refusal
+    /// from, so no sibling can observe the window.
+    fn declaration_lock() -> std::sync::MutexGuard<'static, ()> {
+        let guard = DECLARATION.lock().unwrap_or_else(|e| e.into_inner());
+        undeclare_array_gc_type_ids();
+        guard
+    }
+
     /// The declaration channel carries whatever slot the host's registry
     /// handed out, including `0` — which is a real slot (`TypeRegistry::
     /// register` returns `entries.len()`), and which the undeclared state
     /// must stay distinguishable from.
     #[test]
     fn a_declared_array_type_id_reads_back_and_zero_is_a_real_slot() {
+        let _guard = declaration_lock();
         set_gc_int_array_gc_type_id(0);
         assert_eq!(gc_int_array_gc_type_id(), 0);
         assert_ne!(gc_int_array_gc_type_id(), UNSET_GC_TYPE_ID);
 
         set_gc_float_array_gc_type_id(42);
         assert_eq!(gc_float_array_gc_type_id(), 42);
+    }
 
-        // Leave both declared: a sibling test that allocates an items block
-        // while a collector owns the heap would otherwise trip the
-        // undeclared-id refusal in `try_alloc_typed_items_block_nursery`.
-        set_gc_int_array_gc_type_id(41);
+    /// A rebuilt heap (`eval.rs reset_gc_fresh_for_test`) re-runs the host's
+    /// registrations against a fresh collector, whose registry hands the same
+    /// slots back in the same order. That re-declaration is the supported
+    /// case, not the overwrite the guard is looking for.
+    #[test]
+    fn re_declaring_the_same_slot_is_accepted() {
+        let _guard = declaration_lock();
+        set_gc_int_array_gc_type_id(7);
+        set_gc_int_array_gc_type_id(7);
+        assert_eq!(gc_int_array_gc_type_id(), 7);
+    }
+
+    /// A second host's registry hands out its own slots; stamping them over
+    /// the first host's is undetectable once the word reaches a GC header.
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic = "re-declared"]
+    fn a_conflicting_re_declaration_is_refused() {
+        let _guard = declaration_lock();
+        set_gc_float_array_gc_type_id(7);
+        set_gc_float_array_gc_type_id(8);
     }
 }

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -9961,7 +9961,8 @@ impl<'a> Lowering<'a> {
     ///
     /// Five conditions, cheapest first (so the body scans run only on
     /// genuine candidates): the callee is `<ptr>::add`; two arguments;
-    /// the receiver is `*mut PyObjectRef`; the index is a runtime local
+    /// the receiver points at a managed reference
+    /// ([`is_object_ref_items_ptr`]); the index is a runtime local
     /// (not the constant offset brick 1 collapses); the base traces to
     /// an items-base accessor ([`base_traces_to_items_block_accessor`])
     /// — so the header `base_size` re-add lands on `items[0]`; and the
@@ -13847,19 +13848,20 @@ fn regular_call_is_ptr_add(reg: &RegularCall, llbc: &Llbc) -> bool {
 /// `items_block_items_ptr`).  brick 3's `*base.add(idx)` lowering only
 /// fires when the base traces to one of these (their header return is
 /// what the `base_size = ITEMS_BLOCK_ITEMS_OFFSET` array descr re-adds);
-/// a `*mut PyObjectRef` from any other producer already points at
+/// an items pointer from any other producer already points at
 /// `items[0]` and must keep its residual `add`.
+///
+/// Recognised through [`is_object_items_block_base_accessor`], the same
+/// module-qualified suffix brick 1 keys on. An earlier revision matched two
+/// whole `pyre_object::` paths here while brick 1 already matched by suffix,
+/// which made brick 3 strictly narrower than the rewrite it is paired with —
+/// see that function for why the two must not disagree.
 fn regular_call_is_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool {
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return false;
     };
-    llbc.fn_by_id(*id).is_some_and(|fd| {
-        matches!(
-            fd.item_meta.name_path().as_str(),
-            "pyre_object::object_array::items_block_items_base"
-                | "pyre_object::object_array::items_block_items_ptr"
-        )
-    })
+    llbc.fn_by_id(*id)
+        .is_some_and(|fd| is_object_items_block_base_accessor(fd.item_meta.name_path().as_str()))
 }
 
 /// The [`TyRef`] of a plain-place [`Operand`], or `None` for a
@@ -13892,7 +13894,7 @@ fn is_list_items_elem_ptr_add_parts(
 ) -> bool {
     args_len == 2
         && regular_call_is_ptr_add(reg, llbc)
-        && base_ty.is_some_and(|ty| is_pyobjectref_items_ptr(ty, llbc))
+        && base_ty.is_some_and(|ty| is_object_ref_items_ptr(ty, llbc))
         && index_local.is_some()
         && base_local.is_some_and(|base| base_traces_to_items_block_accessor(body, base, llbc))
         && add_dest_used_only_as_single_deref(body, dest_local)
@@ -16197,15 +16199,31 @@ fn tyref_is_raw_byte_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
     })
 }
 
-/// Whether `ty` is a `*mut PyObjectRef` / `*const PyObjectRef`
-/// (`RawPtr` onto a `RawPtr` onto `PyObject`) — the pointer-to-pointer
-/// signature of the object-element store an `ItemsBlock` lays out after
-/// its length header, and the receiver type of brick 3's
-/// `*base.add(idx)` ([`Lowering::is_list_items_elem_ptr_add`]).  A typed
-/// primitive array carries a scalar pointee (`*mut u8` / `*mut i64`),
-/// excluded by the inner-`RawPtr` test; the `PyObject` pointee root pins
-/// it to the object family rather than any `*mut *mut T`.
-fn is_pyobjectref_items_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
+/// Whether `ty` is a pointer to a MANAGED REFERENCE — `RawPtr` onto a `RawPtr`
+/// onto a named class root — the pointer-to-pointer signature of the object
+/// element an items block lays out after its length header, and the receiver
+/// type of brick 3's `*base.add(idx)`
+/// ([`Lowering::is_list_items_elem_ptr_add`]).
+///
+/// Two tests, and what each one excludes is different. The inner `RawPtr`
+/// rejects a typed primitive array, whose pointee is a scalar (`*mut u8` /
+/// `*mut i64`) — that is what keeps a `TypedItemsBlock` out of the `Ref`-typed
+/// array ops. [`raw_ptr_pointee_class_root`] answering `Some` rejects a
+/// pointer-to-pointer whose pointee is not a class at all.
+///
+/// The root is DERIVED, not fixed. An earlier revision compared it against the
+/// literal `"PyObject"`, which made the whole route unreachable from any host
+/// but pyre — `adt_node_class_root` answers with the pointee's own leaf name,
+/// so a host class family rooted at some other header answered its own name
+/// and was declined for having one. That is the same correction
+/// `Lowering::resolve_place`'s class-singleton narrow already carries: a
+/// prebuilt is annotated with the class of the object itself
+/// (`rpython/annotator/bookkeeper.py:339-345`), so the root comes off the type
+/// rather than out of the front end. Naming one host's root here bought no
+/// safety the accessor gate does not already provide — what makes the base an
+/// items pointer is [`base_traces_to_items_block_accessor`], not the spelling
+/// of its element.
+fn is_object_ref_items_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
     let Some(outer) = tyref_node(ty, llbc).and_then(|n| strip_ty_wrappers(n, llbc)) else {
         return false;
     };
@@ -16218,7 +16236,7 @@ fn is_pyobjectref_items_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
     else {
         return false;
     };
-    raw_ptr_pointee_class_root(inner, llbc).as_deref() == Some("PyObject")
+    raw_ptr_pointee_class_root(inner, llbc).is_some()
 }
 
 /// The `__cast_pointer/<Root>` marker call — front::mir's carrier for
@@ -17734,16 +17752,45 @@ fn strip_crate_prefix(path: &str) -> String {
     }
 }
 
-/// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
-/// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
-/// receiver (see [`Lowering::is_items_block_base_ptr_add`]).  Matched on
-/// the module-qualified path so a leaf collision in another module
-/// cannot widen the gate, and crate-prefix-independent so the same
-/// accessor matches whether reached from `majit_rlib`, `pyre_object`,
-/// `pyre_interpreter`, or `pyre_jit`'s monomorphized copy.
-fn graph_is_items_block_base_accessor(name: &str) -> bool {
+/// True for the two REFERENCE items-base accessors — the ones whose block
+/// lays `Ptr` items after its length header.
+///
+/// Split out of [`graph_is_items_block_base_accessor`] rather than spelled
+/// twice, because brick 1 (the accessor-body collapse) and brick 3 (the
+/// element `*base.add(i)`) must recognise the same accessor or the pointer
+/// means different things at the two ends: brick 1 rewrites the accessor to
+/// return the block HEADER, and only brick 3's `base_size`-bearing array descr
+/// adds the item offset back. An accessor collapsed by the first and declined
+/// by the second leaves a residual `.add` striding from the LENGTH WORD — a
+/// silent one-element mis-index, not a missed optimisation. One list, two
+/// call sites.
+///
+/// Matched on the module-qualified path so a leaf collision in another module
+/// cannot widen the gate, and crate-prefix-independent so the same accessor
+/// matches whether reached from `pyre_object`, `pyre_interpreter`, `pyre_jit`'s
+/// monomorphized copy — or a non-pyre host crate that lays its block out this
+/// way. The prefix carries no information the suffix does not: what makes the
+/// collapse sound is the accessor's CONTRACT (return the interior pointer for
+/// descr-based consumption), which the module-qualified name states and the
+/// crate name does not.
+fn is_object_items_block_base_accessor(name: &str) -> bool {
     name.ends_with("object_array::items_block_items_base")
         || name.ends_with("object_array::items_block_items_ptr")
+}
+
+/// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
+/// whose `.add(*_ITEMS_OFFSET)` the front-end collapses to the
+/// receiver (see [`Lowering::is_items_block_base_ptr_add`]).
+///
+/// The typed (scalar) accessor is here and NOT in
+/// [`is_object_items_block_base_accessor`]: its block holds `u64` words, so a
+/// `*base.add(i)` through it is not a reference element store and brick 3 must
+/// not lower it as one. That separation is what keeps the shared-list
+/// invariant above from pulling a scalar block into the `Ref`-typed array ops
+/// — the element side is refused by [`is_object_ref_items_ptr`] as well, so the
+/// two gates agree by construction rather than by coincidence.
+fn graph_is_items_block_base_accessor(name: &str) -> bool {
+    is_object_items_block_base_accessor(name)
         || name.ends_with("rlist::typed_items_block_items_base")
 }
 
@@ -21316,6 +21363,48 @@ mod tests {
         assert!(!graph_is_items_block_base_accessor(
             "pyre_object::other_mod::items_block_items_base_helper"
         ));
+    }
+
+    /// brick 1 collapses an accessor to its receiver — the block header — and
+    /// only brick 3's `base_size`-bearing array descr adds the item offset
+    /// back. So every REFERENCE accessor brick 1 rewrites must also be one
+    /// brick 3 recognises, or the residual `.add` strides from the length
+    /// word. The typed accessor is the deliberate exception: brick 1 collapses
+    /// it, and its scalar element is refused on the element side instead
+    /// (`is_object_ref_items_ptr`), so no `Ref`-typed array op is minted for a
+    /// `u64` block.
+    #[test]
+    fn the_two_bricks_agree_on_every_reference_items_base_accessor() {
+        use super::{graph_is_items_block_base_accessor, is_object_items_block_base_accessor};
+
+        for name in [
+            "pyre_object::object_array::items_block_items_base",
+            "pyre_object::object_array::items_block_items_ptr",
+            "pyre_jit::object_array::items_block_items_base",
+        ] {
+            assert!(
+                is_object_items_block_base_accessor(name),
+                "brick 3 declines {name}, which brick 1 rewrites"
+            );
+            assert!(graph_is_items_block_base_accessor(name));
+        }
+
+        // The typed block: brick 1 only.
+        let typed = "majit_rlib::lltypesystem::rlist::typed_items_block_items_base";
+        assert!(graph_is_items_block_base_accessor(typed));
+        assert!(!is_object_items_block_base_accessor(typed));
+
+        // Neither gate is keyed on a crate: a host crate laying its block out
+        // the same way is recognised by the same module-qualified suffix. The
+        // name below is a shape, not a crate this workspace contains.
+        let host = "some_host::runtime::object_array::items_block_items_base";
+        assert!(is_object_items_block_base_accessor(host));
+        assert!(graph_is_items_block_base_accessor(host));
+
+        // A leaf collision still cannot widen either gate.
+        let collision = "some_host::other_mod::items_block_items_base_helper";
+        assert!(!is_object_items_block_base_accessor(collision));
+        assert!(!graph_is_items_block_base_accessor(collision));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -17773,9 +17773,18 @@ fn strip_crate_prefix(path: &str) -> String {
 /// collapse sound is the accessor's CONTRACT (return the interior pointer for
 /// descr-based consumption), which the module-qualified name states and the
 /// crate name does not.
+///
+/// Compared with [`path_ends_with_segments`] and not with `str::ends_with`. On
+/// a `::`-joined path `ends_with` is a SUBSTRING test, not a path test: it
+/// accepts `some_host::my_object_array::items_block_items_base`, because
+/// `object_array::…` is a byte suffix of `my_object_array::…` while naming a
+/// different module. A module that merely *ends in* `object_array` would then
+/// have its accessor collapsed to the block header on the strength of its
+/// spelling. The segment-aware comparator already existed in this file; these
+/// gates were the ones not using it.
 fn is_object_items_block_base_accessor(name: &str) -> bool {
-    name.ends_with("object_array::items_block_items_base")
-        || name.ends_with("object_array::items_block_items_ptr")
+    path_ends_with_segments(name, "object_array::items_block_items_base")
+        || path_ends_with_segments(name, "object_array::items_block_items_ptr")
 }
 
 /// True for the `ItemsBlock` / `TypedItemsBlock` items-base accessor bodies
@@ -17791,7 +17800,7 @@ fn is_object_items_block_base_accessor(name: &str) -> bool {
 /// two gates agree by construction rather than by coincidence.
 fn graph_is_items_block_base_accessor(name: &str) -> bool {
     is_object_items_block_base_accessor(name)
-        || name.ends_with("rlist::typed_items_block_items_base")
+        || path_ends_with_segments(name, "rlist::typed_items_block_items_base")
 }
 
 /// One path segment, with a raw-identifier prefix removed.  `r#struct` and
@@ -17832,6 +17841,19 @@ fn path_has_suffix_ignoring_raw(path: &str, key: &str) -> bool {
             _ => return false,
         }
     }
+}
+
+/// `key` names the trailing `::` segments of `path` — as a PATH, not as a
+/// substring. The drop-in for `path.ends_with(key)` wherever `key` is a
+/// `::`-joined path rather than a bare leaf.
+///
+/// Both arms are needed. [`path_has_suffix_ignoring_raw`] deliberately demands
+/// a *proper* suffix — at least one segment of `path` left over — so on its own
+/// it would reject a `path` that is exactly `key`, which `ends_with` accepted.
+/// Pairing it with [`path_eq_ignoring_raw`] leaves the substring collision as
+/// the only input whose answer changes.
+fn path_ends_with_segments(path: &str, key: &str) -> bool {
+    path_eq_ignoring_raw(path, key) || path_has_suffix_ignoring_raw(path, key)
 }
 
 fn static_key_matches(full: &str, stripped: &str, key: &str) -> bool {
@@ -21401,10 +21423,27 @@ mod tests {
         assert!(is_object_items_block_base_accessor(host));
         assert!(graph_is_items_block_base_accessor(host));
 
-        // A leaf collision still cannot widen either gate.
+        // A leaf collision still cannot widen either gate. Note this case
+        // proves less than it looks: it is refused for TWO independent
+        // reasons — the leaf is `…_helper`, and the module is `other_mod` —
+        // so it passes even under a plain `ends_with`, and it never tested
+        // whether the comparison respects `::` boundaries at all.
         let collision = "some_host::other_mod::items_block_items_base_helper";
         assert!(!is_object_items_block_base_accessor(collision));
         assert!(!graph_is_items_block_base_accessor(collision));
+
+        // The case that does test it. Every segment of the key appears, the
+        // leaf is exact, and the whole key is a byte-suffix of the path — so
+        // `ends_with` accepts it — yet the module is `my_object_array` and not
+        // `object_array`, so a path comparison must refuse it. This is the one
+        // input whose answer changed when the gates moved off `ends_with`.
+        let neighbour = "some_host::runtime::my_object_array::items_block_items_base";
+        assert!(!is_object_items_block_base_accessor(neighbour));
+        assert!(!graph_is_items_block_base_accessor(neighbour));
+
+        // The same defect on the other predicate's own arm.
+        let neighbour_typed = "majit_rlib::lltypesystem::my_rlist::typed_items_block_items_base";
+        assert!(!graph_is_items_block_base_accessor(neighbour_typed));
     }
 
     #[test]

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -13852,10 +13852,9 @@ fn regular_call_is_ptr_add(reg: &RegularCall, llbc: &Llbc) -> bool {
 /// `items[0]` and must keep its residual `add`.
 ///
 /// Recognised through [`is_object_items_block_base_accessor`], the same
-/// module-qualified suffix brick 1 keys on. An earlier revision matched two
-/// whole `pyre_object::` paths here while brick 1 already matched by suffix,
-/// which made brick 3 strictly narrower than the rewrite it is paired with —
-/// see that function for why the two must not disagree.
+/// module-qualified suffix brick 1 keys on. Matching whole `pyre_object::`
+/// paths here would make brick 3 strictly narrower than the rewrite it is
+/// paired with; see that function for why the two must not disagree.
 fn regular_call_is_items_block_accessor(reg: &RegularCall, llbc: &Llbc) -> bool {
     let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
         return false;
@@ -16211,11 +16210,10 @@ fn tyref_is_raw_byte_ptr(ty: &TyRef, llbc: &Llbc) -> bool {
 /// array ops. [`raw_ptr_pointee_class_root`] answering `Some` rejects a
 /// pointer-to-pointer whose pointee is not a class at all.
 ///
-/// The root is DERIVED, not fixed. An earlier revision compared it against the
-/// literal `"PyObject"`, which made the whole route unreachable from any host
-/// but pyre — `adt_node_class_root` answers with the pointee's own leaf name,
-/// so a host class family rooted at some other header answered its own name
-/// and was declined for having one. That is the same correction
+/// The root is derived rather than fixed. Comparing it against the literal
+/// `"PyObject"` would make the route unreachable from any other host:
+/// `adt_node_class_root` answers with the pointee's own leaf name, so a class
+/// family rooted at another header answers its own name. This matches
 /// `Lowering::resolve_place`'s class-singleton narrow already carries: a
 /// prebuilt is annotated with the class of the object itself
 /// (`rpython/annotator/bookkeeper.py:339-345`), so the root comes off the type

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1070,9 +1070,11 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
     );
     // Coverage gate. Every `skipped` entry is a function whose MIR shape
     // the driver could not lower — already after the reverse-postorder
-    // retry in `lower_fun_decl`. The single known, tracked gap is an
-    // "uninitialised local read" that even RPO could not bind (a genuine
-    // loop-carried def — none in the current snapshot); such a function
+    // retry in `lower_fun_decl`. The tracked gaps are exactly the shapes
+    // `is_known_lowering_gap` recognises; its arms are the only statement
+    // of that set that cannot go stale. One of them, an "uninitialised local
+    // read" that even RPO could not bind, needs a genuine loop-carried def.
+    // Such a function
     // would degrade the program by being dropped to a residual call,
     // never a correctness loss. Any *other* lowering failure likewise
     // degrades to a residual call — matching `exceptiontransform.py:212`,
@@ -1089,8 +1091,10 @@ fn build_semantic_program_from_llbc_with_static_addrs_filtered(
             .partition(|(_, msg)| is_known_lowering_gap(msg));
         if std::env::var("PYRE_MIR_FRONTEND_DEBUG").is_ok() && !tracked.is_empty() {
             eprintln!(
-                "[mir-frontend] {} function(s) skipped via the tracked \
-                 uninitialised-local gap:",
+                "[mir-frontend] {} function(s) skipped via a shape \
+                 `is_known_lowering_gap` recognises; the per-function \
+                 message below names which one, and all degrade to a \
+                 residual call:",
                 tracked.len()
             );
             for (name, msg) in tracked.iter().take(20) {
@@ -3433,7 +3437,7 @@ impl<'a> Lowering<'a> {
                         state[nxt] = 1;
                         stack.push((nxt, 0));
                     }
-                    1 => headers[nxt] = true, // grey successor ⇒ back-edge target
+                    1 => headers[nxt] = true, // a grey successor is a back-edge target
                     _ => {}
                 }
             } else {
@@ -18777,7 +18781,7 @@ fn block_dominates(graph: &FunctionGraph, dom: BlockId, target: BlockId) -> bool
             }
         }
     }
-    // `target` unreachable once `dom` is cut ⇒ `dom` dominates `target`.
+    // If cutting `dom` makes `target` unreachable, `dom` dominates `target`.
     // Guard against an unreachable `target` (vacuously "dominated"): only
     // treat as dominated when `target` is genuinely reachable in the full
     // graph.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3179,7 +3179,7 @@ impl MapdictObject for Object {
 /// rerased `erase_unboxed` / `unerase_unboxed` (mapdict.py:38-41) — the
 /// unboxed longlong list lives in an otherwise-`PyObjectRef` storage slot.
 ///
-/// The list is a varsize leaf GcArray (`GC_INT_ARRAY_GC_TYPE_ID`), so the slot
+/// The list is a varsize leaf GcArray (`gc_int_array_gc_type_id()`), so the slot
 /// holds an ordinary GC reference like every other storage slot: the collector
 /// marks it through the instance and reclaims it when the instance dies, and no
 /// walker has to be told to skip the slot. Every mutation allocates a fresh
@@ -3195,7 +3195,7 @@ fn erase_unboxed(values: &[i64]) -> PyObjectRef {
     unsafe {
         let block = pyre_object::object_array::alloc_typed_items_block(
             values.len(),
-            pyre_object::object_array::GC_INT_ARRAY_GC_TYPE_ID,
+            pyre_object::object_array::gc_int_array_gc_type_id(),
         );
         std::ptr::copy_nonoverlapping(
             values.as_ptr(),

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -474,7 +474,7 @@ pub(crate) fn walk_prebuilt_code_roots(visitor: &mut dyn FnMut(&mut majit_ir::Gc
 /// a `debug_assert_eq!` in the pyre-jit type-registration sequence: the
 /// `PyCode` `TypeInfo` is registered explicitly just before the
 /// foreign-pytype loop, taking the slot directly after
-/// `GC_FLOAT_ARRAY_GC_TYPE_ID = 42`.  Pre-registering it there (and
+/// the two `GcArray` tids (41 and 42 in that order).  Pre-registering it there (and
 /// inserting `CODE_TYPE` into `pytype_to_tid`) makes the foreign loop
 /// skip `CODE_TYPE`, so the net register-call count up to
 /// `W_MODULE_DICT_GC_TYPE_ID = 48` is unchanged and no downstream tid

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4641,6 +4641,139 @@ mod tests {
         );
     }
 
+    /// Every layout's class word is the inherited `PyObject` header slot, and
+    /// both accessors must name that one field.
+    ///
+    /// `SimpleFieldDescr`'s legacy producer infers `is_w_class` from the field
+    /// name (`name_is_class_word`: `== "w_class"` or `ends_with(".w_class")`),
+    /// and `build_object_descr_group_with_extra_gc_edges` qualifies every name
+    /// with the group's simple name.  So a group that declares a payload field
+    /// literally called `w_class` publishes *two* descrs reporting
+    /// `is_w_class()`, and both accessors take the first — which is the payload
+    /// field, at the wrong offset and the wrong slot.
+    ///
+    /// Both halves are asserted because the two accessors read different lists:
+    /// `class_word_field` answers a byte offset off `gc_fielddescrs`, and
+    /// `class_word_index_in_parent` a slot position off `all_fielddescrs`.
+    #[test]
+    fn every_groups_class_word_is_the_inherited_pyobject_header_slot() {
+        let groups: &[(&str, DescrRef)] = &[
+            ("Function", w_function_size_descr()),
+            ("Method", w_method_size_descr()),
+            ("W_ListObject", w_list_size_descr()),
+            ("W_ObjectObject", w_object_object_size_descr()),
+            ("W_IntObject", w_int_size_descr()),
+            ("W_BoolObject", w_bool_size_descr()),
+            ("W_RangeIterObject", w_range_iter_size_descr()),
+            ("W_RangeObject", w_range_size_descr()),
+            ("W_FloatObject", w_float_size_descr()),
+            ("W_LongObject", w_long_size_descr()),
+            ("W_TupleObject", w_tuple_size_descr()),
+            ("W_TupleIter", tuple_iter_size_descr()),
+            ("W_ZipObject", w_zip_size_descr()),
+            ("SpecialisedTupleII", specialised_tuple_ii_size_descr()),
+            ("SpecialisedTupleFF", specialised_tuple_ff_size_descr()),
+            ("SpecialisedTupleOO", specialised_tuple_oo_size_descr()),
+            ("PyTraceback", pytraceback_size_descr()),
+            ("W_SliceObject", w_slice_size_descr()),
+            ("PyFrame", pyframe_size_descr()),
+        ];
+
+        // Violations are accumulated rather than asserted in place: a test that
+        // stops at the first bad group reports which one comes *first*, not
+        // which ones are wrong, and the population is the finding here.
+        let mut violations: Vec<String> = Vec::new();
+        let mut positional_answers = 0usize;
+        for (label, descr) in groups {
+            let size = descr
+                .as_size_descr()
+                .unwrap_or_else(|| panic!("{label} must be a SizeDescr"));
+
+            // (a) the byte-offset answer names the header slot
+            if let Some(fd) = size.class_word_field()
+                && fd.offset() != W_CLASS_OFFSET
+            {
+                violations.push(format!(
+                    "{label}: class_word_field() -> `{}` at offset {} (want the \
+                     inherited PyObject header at {W_CLASS_OFFSET})",
+                    fd.field_name(),
+                    fd.offset(),
+                ));
+            }
+
+            // (b) the positional answer indexes that same field
+            if let Some(idx) = size.class_word_index_in_parent() {
+                positional_answers += 1;
+                match size.all_fielddescrs().get(idx) {
+                    None => violations.push(format!(
+                        "{label}: class_word_index_in_parent() = {idx} is out of \
+                         range for all_fielddescrs() (len {})",
+                        size.all_fielddescrs().len(),
+                    )),
+                    Some(fd) if fd.offset() != W_CLASS_OFFSET => {
+                        violations.push(format!(
+                            "{label}: class_word_index_in_parent() = {idx} names \
+                             `{}` at offset {} (want the inherited PyObject \
+                             header at {W_CLASS_OFFSET})",
+                            fd.field_name(),
+                            fd.offset(),
+                        ))
+                    }
+                    Some(_) => {}
+                }
+            }
+        }
+
+        // The accessor must not be able to degenerate to a constant `None`:
+        // that would silently disable OptVirtualize's class-word fold instead
+        // of correcting it, and every check above would still hold.
+        assert!(
+            positional_answers > 0,
+            "no group answered class_word_index_in_parent() — a fold that never \
+             fires is indistinguishable from a fold that is right"
+        );
+        // `Method` declares a payload field literally called `w_class` — the
+        // class the bound function was found on, which `method_w_class_descr`
+        // documents as "distinct from the inherited `PyObject.w_class` naming
+        // the Method's own type".  The group factory qualifies it to
+        // `Method.w_class`, `name_is_class_word` accepts the `.w_class`
+        // suffix, and it precedes the header row in both lists, so `find()`
+        // stops on it.  `genop_new_with_vtable` then writes the class object at
+        // `METHOD_W_CLASS_OFFSET` and leaves the real header word NULL.
+        //
+        // Pre-existing and independent of the accessor split: the inline
+        // `all_fielddescrs().find(..)` this replaced picked the same wrong
+        // field.  Fixing it needs a declaration channel into
+        // `SimpleFieldDescrSpec` so the host states which slot is its class
+        // word instead of majit-ir inferring it from a pyre field name — the
+        // same coupling `name_is_class_word` represents.
+        //
+        // Listed rather than skipped, and compared by equality rather than
+        // subset, so this exception RETIRES ITSELF: fixing `Method` makes the
+        // assertion below fail and forces the entry to be deleted.
+        let known: Vec<String> = vec![
+            format!(
+                "Method: class_word_field() -> `Method.w_class` at offset {} \
+                 (want the inherited PyObject header at {W_CLASS_OFFSET})",
+                pyre_object::function::METHOD_W_CLASS_OFFSET,
+            ),
+            format!(
+                "Method: class_word_index_in_parent() = 2 names `Method.w_class` \
+                 at offset {} (want the inherited PyObject header at \
+                 {W_CLASS_OFFSET})",
+                pyre_object::function::METHOD_W_CLASS_OFFSET,
+            ),
+        ];
+        assert_eq!(
+            violations,
+            known,
+            "the set of groups resolving a class word that is not the inherited \
+             PyObject header has changed. A NEW entry means some group's payload \
+             field shadows its header; a MISSING entry means the known `Method` \
+             defect is fixed and this exception list must be deleted."
+        );
+    }
+
     #[test]
     fn jit_emitted_tracebacks_are_movable_but_raw_pointer_objects_are_not() {
         let traceback_descr = pytraceback_size_descr();

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -107,6 +107,11 @@ pub struct PyreFieldDescr {
     quasi_immutable: bool,
     /// RPython descr.py:227 — field name for heaptracker.py:66 filtering.
     name: &'static str,
+    /// Whether this field is the owning struct's class word — the declared
+    /// answer behind `FieldDescr::is_w_class()`.  Stated per construction
+    /// site rather than recovered from `name`, so a consumer never has to
+    /// know how this host spells its header.
+    is_class_word: bool,
     index_in_parent: usize,
     parent_descr: Option<Weak<dyn Descr>>,
     /// `effectinfo.py:465 compute_bitstrings` ei_index. `u32::MAX` until
@@ -330,6 +335,9 @@ impl Descr for PyreFieldDescr {
 }
 
 impl FieldDescr for PyreFieldDescr {
+    fn is_w_class(&self) -> bool {
+        self.is_class_word
+    }
     fn offset(&self) -> usize {
         self.offset
     }
@@ -370,6 +378,7 @@ pub fn make_field_descr(
         immutable: false,
         quasi_immutable: false,
         name: "",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -405,6 +414,7 @@ pub fn make_field_descr_full(
         immutable,
         quasi_immutable: false,
         name: "",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -427,6 +437,7 @@ pub fn make_immutable_field_descr(
         immutable: true,
         quasi_immutable: false,
         name: "",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -449,6 +460,7 @@ pub fn make_quasi_immutable_field_descr(
         immutable: false,
         quasi_immutable: true,
         name: "",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -2008,6 +2020,7 @@ static PYFRAME_VABLE_TOKEN_FIELD_DESCR: LazyLock<Arc<dyn FieldDescr>> = LazyLock
         immutable: false,
         quasi_immutable: false,
         name: "vable_token",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -2277,6 +2290,7 @@ fn array_lendescr_at_offset(offset: usize) -> DescrRef {
         immutable: false,
         quasi_immutable: false,
         name: "len",
+        is_class_word: false,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),
@@ -2416,11 +2430,12 @@ use pyre_object::{FLOAT_TYPE, INT_TYPE};
 ///
 /// Mutable because __class__ assignment can change it.
 fn new_w_class_field_descr() -> Arc<dyn FieldDescr> {
-    // Named "w_class" so `FieldDescr::is_w_class()` recognises the
-    // header field; OptVirtualize must resolve it from the object's
-    // class identity rather than indexing it against a virtual's value
-    // fields (its `index_in_parent` of 0 would otherwise collide with
-    // the first value field, e.g. `W_IntObject.intval`).
+    // Declares itself the class word (`is_class_word`), which is what
+    // `FieldDescr::is_w_class()` reports; the name is for diagnostics only
+    // and no consumer reads it. OptVirtualize must resolve this field from
+    // the object's class identity rather than indexing it against a
+    // virtual's value fields (its `index_in_parent` of 0 would otherwise
+    // collide with the first value field, e.g. `W_IntObject.intval`).
     Arc::new(PyreFieldDescr {
         offset: pyre_object::pyobject::W_CLASS_OFFSET,
         // `WORD` on paper — the field is a `*mut PyObject`, so 4 bytes on
@@ -2438,6 +2453,7 @@ fn new_w_class_field_descr() -> Arc<dyn FieldDescr> {
         immutable: false,
         quasi_immutable: false,
         name: "w_class",
+        is_class_word: true,
         index_in_parent: 0,
         parent_descr: None,
         ei_index: AtomicU32::new(u32::MAX),

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3519,6 +3519,12 @@ static PYCODE_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLoc
         is_quasi_immutable: false,
         flag,
         virtualizable: false,
+        // The group lists only the four read-only payload fields; the
+        // inherited `PyObject` header row is not among them, so none of them
+        // is the class word and `class_word_field` answers `None` for this
+        // layout. Testing `offset == W_CLASS_OFFSET` the way the object-group
+        // factory does would read as if the header could appear here.
+        is_class_word: false,
         index_in_parent: 0,
     };
     let mut specs = vec![

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -4664,8 +4664,9 @@ mod tests {
     /// both accessors must name that one field.
     ///
     /// `SimpleFieldDescr`'s legacy producer infers `is_w_class` from the field
-    /// name (`name_is_class_word`: `== "w_class"` or `ends_with(".w_class")`),
-    /// and `build_object_descr_group_with_extra_gc_edges` qualifies every name
+    /// name (`class_word_inferred_from_name`: `== "w_class"` or
+    /// `ends_with(".w_class")`), and
+    /// `build_object_descr_group_with_extra_gc_edges` qualifies every name
     /// with the group's simple name.  So a group that declares a payload field
     /// literally called `w_class` publishes *two* descrs reporting
     /// `is_w_class()`, and both accessors take the first — which is the payload

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -806,6 +806,14 @@ fn build_object_descr_group_with_extra_gc_edges(
                 is_quasi_immutable: quasi_immutable,
                 flag: runtime_array_flag(field_type, signed),
                 virtualizable: false,
+                // pyre's layout invariant, not a name rule: the inherited
+                // `PyObject` header sits at `W_CLASS_OFFSET` in every object
+                // group. A name rule cannot express this — `Method` has a
+                // *payload* field called `w_class` (the class the bound
+                // function was found on) whose qualified name
+                // `"Method.w_class"` matches the header spelling exactly, and
+                // it sits ahead of the real header in the field list.
+                is_class_word: offset == pyre_object::pyobject::W_CLASS_OFFSET,
                 index_in_parent,
             },
         )
@@ -4358,6 +4366,11 @@ static EC_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLock::n
         is_quasi_immutable: false,
         flag: ArrayFlag::Unsigned,
         virtualizable: false,
+        // `ExecutionContext` is not a `PyObject` layout; it carries no class
+        // word. Its offsets are `EC_*` and share no origin with
+        // `W_CLASS_OFFSET`, so matching on offset here would be a coincidence,
+        // not an invariant.
+        is_class_word: false,
         // Stamped below, once the specs are in offset order.
         index_in_parent: 0,
     };
@@ -4710,15 +4723,13 @@ mod tests {
                          range for all_fielddescrs() (len {})",
                         size.all_fielddescrs().len(),
                     )),
-                    Some(fd) if fd.offset() != W_CLASS_OFFSET => {
-                        violations.push(format!(
-                            "{label}: class_word_index_in_parent() = {idx} names \
+                    Some(fd) if fd.offset() != W_CLASS_OFFSET => violations.push(format!(
+                        "{label}: class_word_index_in_parent() = {idx} names \
                              `{}` at offset {} (want the inherited PyObject \
                              header at {W_CLASS_OFFSET})",
-                            fd.field_name(),
-                            fd.offset(),
-                        ))
-                    }
+                        fd.field_name(),
+                        fd.offset(),
+                    )),
                     Some(_) => {}
                 }
             }
@@ -4732,45 +4743,26 @@ mod tests {
             "no group answered class_word_index_in_parent() — a fold that never \
              fires is indistinguishable from a fold that is right"
         );
-        // `Method` declares a payload field literally called `w_class` — the
-        // class the bound function was found on, which `method_w_class_descr`
-        // documents as "distinct from the inherited `PyObject.w_class` naming
-        // the Method's own type".  The group factory qualifies it to
-        // `Method.w_class`, `name_is_class_word` accepts the `.w_class`
-        // suffix, and it precedes the header row in both lists, so `find()`
-        // stops on it.  `genop_new_with_vtable` then writes the class object at
-        // `METHOD_W_CLASS_OFFSET` and leaves the real header word NULL.
+        // This held two `Method` exceptions until the host gained a declaration
+        // channel.  `Method` carries a payload field literally called `w_class`
+        // — the class the bound function was found on, which
+        // `method_w_class_descr` documents as "distinct from the inherited
+        // `PyObject.w_class` naming the Method's own type" — and the group
+        // factory qualifies it to `Method.w_class`, which the name fallback
+        // accepts on the `.w_class` suffix.  It precedes the header row, so
+        // `find()` stopped on it in both lists.
         //
-        // Pre-existing and independent of the accessor split: the inline
-        // `all_fielddescrs().find(..)` this replaced picked the same wrong
-        // field.  Fixing it needs a declaration channel into
-        // `SimpleFieldDescrSpec` so the host states which slot is its class
-        // word instead of majit-ir inferring it from a pyre field name — the
-        // same coupling `name_is_class_word` represents.
-        //
-        // Listed rather than skipped, and compared by equality rather than
-        // subset, so this exception RETIRES ITSELF: fixing `Method` makes the
-        // assertion below fail and forces the entry to be deleted.
-        let known: Vec<String> = vec![
-            format!(
-                "Method: class_word_field() -> `Method.w_class` at offset {} \
-                 (want the inherited PyObject header at {W_CLASS_OFFSET})",
-                pyre_object::function::METHOD_W_CLASS_OFFSET,
-            ),
-            format!(
-                "Method: class_word_index_in_parent() = 2 names `Method.w_class` \
-                 at offset {} (want the inherited PyObject header at \
-                 {W_CLASS_OFFSET})",
-                pyre_object::function::METHOD_W_CLASS_OFFSET,
-            ),
-        ];
-        assert_eq!(
-            violations,
-            known,
-            "the set of groups resolving a class word that is not the inherited \
-             PyObject header has changed. A NEW entry means some group's payload \
-             field shadows its header; a MISSING entry means the known `Method` \
-             defect is fixed and this exception list must be deleted."
+        // Now `build_object_descr_group_with_extra_gc_edges` declares
+        // `is_class_word: offset == W_CLASS_OFFSET`, a layout invariant a name
+        // rule cannot express, and the exceptions retired.
+        assert!(
+            violations.is_empty(),
+            "{} of {} groups resolve a class word that is not the inherited \
+             PyObject header — a payload field is shadowing its layout's \
+             header row:\n  {}",
+            violations.len(),
+            groups.len(),
+            violations.join("\n  "),
         );
     }
 
@@ -5471,6 +5463,11 @@ fn simple_field_spec_from_bh(
         is_quasi_immutable: spec.is_quasi_immutable,
         flag: spec.field_flag,
         virtualizable: false,
+        // `BhFieldSpec` carries no class-word flag, so a declaration does not
+        // survive the blackhole round trip and the name is all that is left.
+        // Inherits the fallback's limitation: a `Method.w_class` payload
+        // rebuilt from a blackhole spec still reads as a class word.
+        is_class_word: majit_ir::descr::class_word_inferred_from_name(&spec.name),
         index_in_parent: spec.index_in_parent,
     }
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -558,8 +558,10 @@ pub use pyre_object::listobject::W_LIST_GC_TYPE_ID;
 // Array GC type ids live in `pyre-object` alongside the backing storage
 // structs/constants they describe (matching W_INT/W_FLOAT/W_LIST/W_TUPLE
 // pattern). Re-exported here for existing call sites.
+// The two `GcArray` tids are accessors, not constants: pyre declares them from
+// its own `gc.register_type` results at GC build time (`pyre-jit/src/eval.rs`).
 pub use pyre_object::object_array::{
-    GC_FLOAT_ARRAY_GC_TYPE_ID, GC_INT_ARRAY_GC_TYPE_ID, PY_OBJECT_ARRAY_GC_TYPE_ID,
+    PY_OBJECT_ARRAY_GC_TYPE_ID, gc_float_array_gc_type_id, gc_int_array_gc_type_id,
 };
 pub use pyre_object::tupleobject::W_TUPLE_GC_TYPE_ID;
 // GC type ids for `W_SpecialisedTupleObject_{ii,ff,oo}` live in

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1356,7 +1356,7 @@ pub(crate) fn emit_walker_loop_callee_call_assembler<Sym: WalkSym>(
     // than a decline.
     // Run the call concretely to stamp `ca_result` (same rationale as the
     // self-recursive arm: the downstream consumer needs the real concrete to
-    // take its int specialization). ⚠️ The inlined prologue already ran the
+    // take its int specialization). The inlined prologue already ran the
     // callee's pre-loop bytecode concretely during the sub-walk; the executor
     // re-runs the WHOLE call fresh, so a side-effecting pre-loop body would
     // execute twice at trace time. The corpus target (`loop_callee_return`)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/tests.rs
@@ -891,6 +891,148 @@ fn array_vable_handlers_with_none_obj_surface_vable_box_not_seeded() {
     }
 }
 
+/// `_opimpl_getarrayitem_vable` (pyjitpl.py:1218-1230) and
+/// `_opimpl_setarrayitem_vable` (:1236-1247) take the
+/// `_nonstandard_virtualizable` decision FIRST, and their non-standard branch
+/// reaches `getarrayitem_gc_*` / `setarrayitem_gc_any` with the index box as it
+/// stands. The promote lives at the head of `_get_arrayitem_vable_index`
+/// (:1201-1216), which only the standard branch enters. So a non-standard
+/// access must mint no GUARD_VALUE on the index — promoting there pins a value
+/// upstream leaves free, over-specializing the trace on an access that reads
+/// ordinary heap.
+///
+/// The non-standard branch mints a GUARD_VALUE of its own (the Step 4 PTR_EQ
+/// promote), so the subject here is which BOX a guard names, not how many
+/// guards there are.
+#[test]
+fn a_nonstandard_vable_array_access_does_not_promote_the_index() {
+    for opname in ["getarrayitem_vable_i", "setarrayitem_vable_i"] {
+        let mut tc = TraceCtx::for_test_types(&[Type::Ref]);
+        let info = crate::frame_layout::build_pyframe_virtualizable_info();
+        let array_len = 3;
+        let slot_count = info.num_static_extra_boxes + array_len;
+        // The standard virtualizable, i.e. `virtualizable_boxes[-1]`.
+        let standard = tc.const_ref(1);
+        let initial_boxes = vec![tc.const_null(); slot_count];
+        let initial_values = vec![Value::Ref(majit_ir::GcRef::NULL); slot_count];
+        tc.init_virtualizable_boxes(
+            &info,
+            standard,
+            Value::Ref(majit_ir::GcRef(1)),
+            &initial_boxes,
+            &initial_values,
+            &[array_len],
+        );
+        // A different frame: `_nonstandard_virtualizable` reaches its Step 4
+        // PTR_EQ, reads unequal, and takes the non-standard branch.
+        let vable = tc.const_ref(2);
+        // A non-constant index carrying a recording-time concrete — the only
+        // shape for which the promote is not already a no-op.
+        let zero = tc.const_int(0);
+        let index = tc.record_op(majit_ir::OpCode::IntAdd, &[zero, zero]);
+        tc.set_opref_concrete(index, Value::Int(0));
+        assert!(!index.is_constant(), "the index box must be promotable");
+
+        let bh_array = majit_translate::jitcode::BhDescr::from_array_descr(
+            info.array_descrs[0]
+                .as_array_descr()
+                .expect("the fixture's array descr"),
+        );
+        let raw_pool = vec![
+            majit_metainterp::jitcode::RuntimeBhDescr::Descr(Box::new(
+                majit_translate::jitcode::BhDescr::VableArray { index: 0 },
+            )),
+            majit_metainterp::jitcode::RuntimeBhDescr::Descr(Box::new(bh_array)),
+        ];
+        // `ridd>i` (read): r-reg(0) + i-reg(1) + fdescr(0) + adescr(1) + dst(2).
+        // `riidd` (write): r-reg(0) + i-reg(1) + value i-reg(2) + fdescr(0) +
+        // adescr(1).
+        let code: [u8; 8] = if opname == "getarrayitem_vable_i" {
+            [0x00, 0x00, 0x01, 0x00, 0x00, 0x01, 0x00, 0x02]
+        } else {
+            [0x00, 0x00, 0x01, 0x02, 0x00, 0x00, 0x01, 0x00]
+        };
+        let stored_value = tc.const_int(7);
+        let mut regs_r = vec![vable];
+        let mut regs_i = vec![zero, index, stored_value];
+        let descr_pool: Vec<DescrRef> = Vec::new();
+        let guards_before = tc.num_guards();
+        let session = std::cell::RefCell::new(WalkSession::default());
+        let mut wc = WalkContext {
+            callee_shadow: None,
+            inline_callee_consts: None,
+            fbw_mode: test_fbw_mode(),
+            session: &session,
+            registers_r: &mut regs_r,
+            registers_i: &mut regs_i,
+            registers_f: &mut [],
+            concrete_registers_r: &mut [],
+            concrete_registers_i: &mut [],
+            descr_refs: &descr_pool,
+            raw_descrs: RawDescrPool::PerFn(&raw_pool),
+            is_authoritative_executor: false,
+            trace_ctx: &mut tc,
+            is_top_level: true,
+            sub_jitcode_lookup: &no_sub_jitcodes,
+            last_exc_value: None,
+            last_exc_value_concrete: ConcreteValue::Null,
+            entry_py_pc: EntryPyPc::Py(0),
+            outer_resume_marker_jit_pc: None,
+            outer_jitcode_index: 0,
+            outer_active_boxes: Vec::new(),
+            pending_guard_snapshot_error: None,
+            vstack_boxes: Vec::new(),
+            vstack_depth: 0,
+            vstack_cur_pypc: 0,
+            vstack_valid: false,
+            vstack_last_ref: OpRef::NONE,
+            vstack_reorder_ceiling: u32::MAX,
+            vstack_reorder_saved: None,
+            vstack_handler_landing_py: None,
+            live_before_jit_pc: usize::MAX,
+            live_after_jit_pc: usize::MAX,
+        };
+        let op = DecodedOp {
+            key: opname,
+            opname,
+            argcodes: "",
+            pc: 0,
+            next_pc: code.len(),
+        };
+        let result = match opname {
+            "getarrayitem_vable_i" => getarrayitem_vable_via_metainterp(&code, &op, &mut wc, 'i'),
+            _ => setarrayitem_vable_via_metainterp(&code, &op, &mut wc, 'i'),
+        };
+        drop(wc);
+        assert!(
+            tc.num_guards() > guards_before,
+            "{opname} must still mint the Step 4 PTR_EQ promote, or this test \
+             would pass on a walk that never took the non-standard branch",
+        );
+        // Read the guard before the dispatch outcome: an unconditional promote
+        // records its GUARD_VALUE and only then tries to build a snapshot, so
+        // checking the outcome first would report the snapshot failure and
+        // leave the promote itself unnamed.
+        let promoted_index = tc.ops().iter().any(|recorded| {
+            recorded.opcode == majit_ir::OpCode::GuardValue
+                && recorded
+                    .getarglist()
+                    .first()
+                    .is_some_and(|arg| arg.to_opref() == index)
+        });
+        assert!(
+            !promoted_index,
+            "{opname} promoted the index on the non-standard branch; \
+             pyjitpl.py:1220/:1239 reach the heap op with the index box unpromoted",
+        );
+        assert_eq!(
+            result.map(|(outcome, _)| outcome),
+            Ok(DispatchOutcome::Continue),
+            "{opname} must dispatch through the non-standard branch",
+        );
+    }
+}
+
 #[test]
 #[ignore = "T3 audit probe — dumps runtime opnames + walker-handled set + \
                 per-opname JitCode hit count. Run with \

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/vable_ops.rs
@@ -430,13 +430,54 @@ pub(crate) fn vable_array_descrs_from_jitcode<Sym: WalkSym>(
     Ok((fdescr, adescr))
 }
 
+/// `pyjitpl.py:1201-1216 _get_arrayitem_vable_index` opens with
+/// `indexbox = self.implement_guard_value(indexbox, pc)`: the flat array slot
+/// is derived from the index's recording-time value, so the trace is only
+/// sound if it also pins that value.
+///
+/// The promote is hoisted out of `TraceCtx::get_arrayitem_vable_index` to the
+/// walker for the reason `pyjitpl/dispatch.rs` states at its own six
+/// `BC_*ARRAYITEM_VABLE_*` sites: promoting at the call site gets the guard a
+/// full-framestack, vable-carrying snapshot, where the callee can only build
+/// the minimal one `TraceCtx::promote_int` produces without an `MIFrameStack`.
+/// The hoist moves the promote to the caller, not ahead of the branch that
+/// selects it: `_get_arrayitem_vable_index` is reached only from the standard
+/// leg of `_opimpl_get|setarrayitem_vable` (pyjitpl.py:1229, :1244), so both
+/// call sites run `TraceCtx::nonstandard_virtualizable` first and skip this
+/// promote on the non-standard leg.
+///
+/// Mirrors `guard_value_record` (`arith.rs`) step for step, including the
+/// `replace_box` and register-bank rewrite. The callee's promote discards its
+/// promoted box, so nothing downstream would otherwise see the pinned value.
+fn walker_promote_vable_array_index<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    pc: usize,
+    index: OpRef,
+    index_value: i64,
+) -> Result<OpRef, DispatchError> {
+    if index.is_constant() {
+        return Ok(index);
+    }
+    let expected = ctx.trace_ctx.const_int(index_value);
+    ctx.trace_ctx
+        .record_guard(OpCode::GuardValue, &[index, expected], 0);
+    walker_capture_snapshot_for_last_guard(ctx, pc)?;
+    ctx.trace_ctx.replace_box(index, expected);
+    for slot in ctx.registers_i.iter_mut() {
+        if *slot == index {
+            *slot = expected;
+        }
+    }
+    Ok(expected)
+}
+
 /// `getarrayitem_vable_<i|r|f>/ridd>X` handler. Operand layout `ridd>X`:
 /// 1B r-reg(vable) + 1B i-reg(index) + 2B fdescr(VableArray) + 2B
 /// adescr(Array) + 1B X-dst.
 ///
 /// RPython parity: `pyjitpl.py _opimpl_getarrayitem_vable`
 /// (`opimpl_getarrayitem_vable_{i,r,f}`).  Delegates to
-/// `TraceCtx::vable_getarrayitem_{int,ref,float}_indexed`
+/// `TraceCtx::vable_getarrayitem_{int,ref,float}_checked`
 /// (`trace_ctx.rs`) which implements the
 /// `_nonstandard_virtualizable` GETFIELD_GC + GETARRAYITEM_GC fallback
 /// and the standard-vable `virtualizable_boxes[index]` cache read.
@@ -508,9 +549,22 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
         }
     };
     let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 2, 4, ctx)?;
+    // Upstream decides standardness before promoting the index: an ordinary
+    // heap access on the non-standard leg must retain the index box as-is.
+    let check_guards_before = ctx.trace_ctx.num_guards();
+    let nonstandard = ctx
+        .trace_ctx
+        .nonstandard_virtualizable(op.pc, vable, &fdescr);
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, check_guards_before, None)?;
+    let index = if nonstandard {
+        index
+    } else {
+        walker_promote_vable_array_index(ctx, op.pc, index, index_value)?
+    };
     let guards_before = ctx.trace_ctx.num_guards();
     let (result, shadow_value) = match dst_bank {
-        'i' => ctx.trace_ctx.vable_getarrayitem_int_indexed(
+        'i' => ctx.trace_ctx.vable_getarrayitem_int_checked(
+            nonstandard,
             op.pc,
             vable,
             index,
@@ -518,7 +572,8 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
             fdescr,
             adescr,
         ),
-        'r' => ctx.trace_ctx.vable_getarrayitem_ref_indexed(
+        'r' => ctx.trace_ctx.vable_getarrayitem_ref_checked(
+            nonstandard,
             op.pc,
             vable,
             index,
@@ -526,7 +581,8 @@ pub(crate) fn getarrayitem_vable_via_metainterp<Sym: WalkSym>(
             fdescr,
             adescr,
         ),
-        'f' => ctx.trace_ctx.vable_getarrayitem_float_indexed(
+        'f' => ctx.trace_ctx.vable_getarrayitem_float_checked(
+            nonstandard,
             op.pc,
             vable,
             index,
@@ -703,7 +759,7 @@ fn active_frame_nlocals<Sym: WalkSym>(ctx: &WalkContext<'_, '_, Sym>) -> Option<
 }
 
 /// RPython parity: `pyjitpl.py _opimpl_setarrayitem_vable`.
-/// Delegates to `TraceCtx::vable_setarrayitem_indexed`
+/// Delegates to `TraceCtx::vable_setarrayitem_checked`
 /// (`trace_ctx.rs`) which implements the `_nonstandard_virtualizable`
 /// SETARRAYITEM_GC fallback + the standard-vable
 /// `virtualizable_boxes[index] = valuebox` + `synchronize_virtualizable`.
@@ -774,6 +830,19 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
             });
         }
     };
+    let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
+    // As in the read path, only the standard virtualizable leg promotes the
+    // array index and needs the full walker-owned resume snapshot.
+    let check_guards_before = ctx.trace_ctx.num_guards();
+    let nonstandard = ctx
+        .trace_ctx
+        .nonstandard_virtualizable(op.pc, vable, &fdescr);
+    walker_capture_inline_nonstandard_vable_guard(ctx, op.pc, check_guards_before, None)?;
+    let index = if nonstandard {
+        index
+    } else {
+        walker_promote_vable_array_index(ctx, op.pc, index, index_value)?
+    };
     let encoded_value = match value_bank {
         'i' => read_int_reg(code, op, 2, ctx)?,
         'r' => read_ref_reg(code, op, 2, ctx)?,
@@ -805,13 +874,13 @@ pub(crate) fn setarrayitem_vable_via_metainterp<Sym: WalkSym>(
     {
         value = tos;
     }
-    let (fdescr, adescr) = vable_array_descrs_from_jitcode(code, op, 3, 5, ctx)?;
     let concrete =
         vable_effective_value_concrete(code, op, 2, ctx, value_bank, encoded_value, value)
             .unwrap_or(Value::Void);
     let is_stack_push = value_bank == 'r' && vable_store_is_stack_push(ctx, index_value);
     let guards_before = ctx.trace_ctx.num_guards();
-    let write = match ctx.trace_ctx.vable_setarrayitem_indexed(
+    let write = match ctx.trace_ctx.vable_setarrayitem_checked(
+        nonstandard,
         op.pc,
         vable,
         index,

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -3446,7 +3446,7 @@ pub(crate) fn int_gcarray_descr() -> DescrRef {
     crate::descr::make_array_descr_with_type(
         token.base_size,
         token.item_size,
-        pyre_object::GC_INT_ARRAY_GC_TYPE_ID,
+        pyre_object::gc_int_array_gc_type_id(),
         Some(token.len_offset),
         Type::Int,
         true,
@@ -3493,7 +3493,7 @@ pub(crate) fn float_gcarray_descr() -> DescrRef {
     crate::descr::make_array_descr_with_type(
         token.base_size,
         token.item_size,
-        pyre_object::GC_FLOAT_ARRAY_GC_TYPE_ID,
+        pyre_object::gc_float_array_gc_type_id(),
         Some(token.len_offset),
         Type::Float,
         false,

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3156,7 +3156,7 @@ fn handle_blackhole_result(bh_result: BlackholeResult, _green_key: u64) -> Optio
 /// Derive the (`green_key`, `trace_id`, `fail_index`) bridge-source identity
 /// strictly from the failing guard's descr Arc.
 ///
-/// `pyjitpl.py:2890 handle_guard_failure(self, resumedescr, deadframe)`
+/// `pyjitpl.py:2914 handle_guard_failure(self, resumedescr, deadframe)`
 /// reads identity from `resumedescr` directly: `resumedescr.rd_loop_token
 /// .loop_token_wref()` (line 2897) yields the owning `JitCellToken`,
 /// `resumedescr.get_resumestorage()` (line 2893) yields the `ResumeGuardDescr`
@@ -3186,7 +3186,7 @@ pub(crate) fn bridge_source_identity_from_descr(
 
 /// Outcome of `trace_and_compile_from_bridge`.
 ///
-/// `pyjitpl.py:2884 handle_guard_failure` never returns — it raises
+/// `pyjitpl.py:2914 handle_guard_failure` never returns — it raises
 /// `ContinueRunningNormally` (bridge attached, resume in compiled code),
 /// switches to the blackhole, or raises `DoneWithThisFrame` when
 /// `interpret()` runs the resumed frames forward to a `Finish`.  Pyre
@@ -3225,7 +3225,7 @@ fn bridge_resolution_from_bool(compiled_continue: bool) -> BridgeResolution {
 /// Traces the alternative path from the guard failure point and compiles
 /// a bridge.
 ///
-/// pyjitpl.py:2884 handle_guard_failure:
+/// pyjitpl.py:2914 handle_guard_failure:
 ///   initialize_state_from_guard_failure(resumedescr, deadframe)
 ///   prepare_resume_from_failure(deadframe, inputargs, resumedescr, excdata)
 ///   self.interpret()
@@ -3250,7 +3250,7 @@ fn bridge_resolution_from_bool(compiled_continue: bool) -> BridgeResolution {
 #[cfg_attr(target_arch = "wasm32", allow(unreachable_code))]
 #[majit_macros::dont_look_inside]
 pub fn trace_and_compile_from_bridge(
-    // pyjitpl.py:2890 `handle_guard_failure(self, resumedescr, deadframe)`
+    // pyjitpl.py:2914 `handle_guard_failure(self, resumedescr, deadframe)`
     // threads `resumedescr` (the descr) as the canonical identity source
     // through the entire bridge tracer.  Pyre's backend FailDescr Arc
     // plays the same role: `descr_owning_jct(arc).green_key` (mirroring
@@ -3346,7 +3346,7 @@ pub fn trace_and_compile_from_bridge(
         info
     };
 
-    // pyjitpl.py:2890-2911 handle_guard_failure parity:
+    // pyjitpl.py:2914-2935 handle_guard_failure parity:
     // RPython creates a fresh MetaInterp and calls
     // initialize_state_from_guard_failure(resumedescr, deadframe)
     // which internally calls rebuild_from_resumedata (resume.py:1042).
@@ -3976,7 +3976,7 @@ pub fn trace_and_compile_from_bridge(
 /// Checks must_compile (jitcounter.tick), and if threshold reached,
 /// traces the alternate path via trace_and_compile_from_bridge.
 ///
-/// pyjitpl.py:2890 `handle_guard_failure(self, resumedescr, deadframe)`
+/// pyjitpl.py:2914 `handle_guard_failure(self, resumedescr, deadframe)`
 /// — descr identity is the only argument crossing the C-ABI boundary;
 /// the receiver derives `(green_key, trace_id, fail_index)` from the
 /// recovered Arc, mirroring `compile.py:706-708 _trace_and_compile_
@@ -3990,7 +3990,7 @@ fn jit_ca_handle_guard_failure(
     if raw_values_ptr.is_null() || num_values == 0 {
         return false;
     }
-    // `enter_profiler_tracing` is not re-entrant (pyjitpl.py:2890 — RPython's
+    // `enter_profiler_tracing` is not re-entrant (pyjitpl.py:2914 — RPython's
     // `handle_guard_failure` unwinds to the top-level `execute_token` before any
     // tracing decision, so a guard never fires while another trace is open).
     // pyre's CALL_ASSEMBLER guard callback runs synchronously from the backend

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -1436,17 +1436,17 @@ enum JitAction {
 
 use crate::jit::descr::{
     BUILTIN_CODE_GC_TYPE_ID, FRAME_BLOCK_GC_TYPE_ID, FRAME_DEBUG_DATA_GC_TYPE_ID,
-    FUNCTION_GC_TYPE_ID, GC_FLOAT_ARRAY_GC_TYPE_ID, GC_INT_ARRAY_GC_TYPE_ID, JITFRAME_GC_TYPE_ID,
-    OBJECT_GC_TYPE_ID, PY_OBJECT_ARRAY_GC_TYPE_ID, PYFRAME_GC_TYPE_ID, RANGE_ITER_GC_TYPE_ID,
-    SPECIALISED_TUPLE_FF_GC_TYPE_ID, SPECIALISED_TUPLE_II_GC_TYPE_ID,
-    SPECIALISED_TUPLE_OO_GC_TYPE_ID, VREF_GC_TYPE_ID, W_BASE_EXCEPTION_GC_TYPE_ID,
-    W_BOOL_GC_TYPE_ID, W_BYTEARRAY_GC_TYPE_ID, W_BYTES_GC_TYPE_ID, W_CELL_GC_TYPE_ID,
-    W_CLASSMETHOD_GC_TYPE_ID, W_COUNT_GC_TYPE_ID, W_DICT_GC_TYPE_ID, W_DICT_PROXY_GC_TYPE_ID,
-    W_FLOAT_GC_TYPE_ID, W_GENERATOR_GC_TYPE_ID, W_INT_GC_TYPE_ID, W_LIST_GC_TYPE_ID,
-    W_LONG_GC_TYPE_ID, W_MEMBER_GC_TYPE_ID, W_METHOD_GC_TYPE_ID, W_MODULE_DICT_GC_TYPE_ID,
-    W_MODULE_GC_TYPE_ID, W_PROPERTY_GC_TYPE_ID, W_REPEAT_GC_TYPE_ID, W_SEQ_ITER_GC_TYPE_ID,
-    W_SET_GC_TYPE_ID, W_SLICE_GC_TYPE_ID, W_STATICMETHOD_GC_TYPE_ID, W_SUPER_GC_TYPE_ID,
-    W_TUPLE_GC_TYPE_ID, W_TYPE_GC_TYPE_ID, W_UNICODE_GC_TYPE_ID, W_UNION_GC_TYPE_ID,
+    FUNCTION_GC_TYPE_ID, JITFRAME_GC_TYPE_ID, OBJECT_GC_TYPE_ID, PY_OBJECT_ARRAY_GC_TYPE_ID,
+    PYFRAME_GC_TYPE_ID, RANGE_ITER_GC_TYPE_ID, SPECIALISED_TUPLE_FF_GC_TYPE_ID,
+    SPECIALISED_TUPLE_II_GC_TYPE_ID, SPECIALISED_TUPLE_OO_GC_TYPE_ID, VREF_GC_TYPE_ID,
+    W_BASE_EXCEPTION_GC_TYPE_ID, W_BOOL_GC_TYPE_ID, W_BYTEARRAY_GC_TYPE_ID, W_BYTES_GC_TYPE_ID,
+    W_CELL_GC_TYPE_ID, W_CLASSMETHOD_GC_TYPE_ID, W_COUNT_GC_TYPE_ID, W_DICT_GC_TYPE_ID,
+    W_DICT_PROXY_GC_TYPE_ID, W_FLOAT_GC_TYPE_ID, W_GENERATOR_GC_TYPE_ID, W_INT_GC_TYPE_ID,
+    W_LIST_GC_TYPE_ID, W_LONG_GC_TYPE_ID, W_MEMBER_GC_TYPE_ID, W_METHOD_GC_TYPE_ID,
+    W_MODULE_DICT_GC_TYPE_ID, W_MODULE_GC_TYPE_ID, W_PROPERTY_GC_TYPE_ID, W_REPEAT_GC_TYPE_ID,
+    W_SEQ_ITER_GC_TYPE_ID, W_SET_GC_TYPE_ID, W_SLICE_GC_TYPE_ID, W_STATICMETHOD_GC_TYPE_ID,
+    W_SUPER_GC_TYPE_ID, W_TUPLE_GC_TYPE_ID, W_TYPE_GC_TYPE_ID, W_UNICODE_GC_TYPE_ID,
+    W_UNION_GC_TYPE_ID,
 };
 use majit_gc::collector::MiniMarkGC;
 use majit_metainterp::JitDriver;
@@ -2497,7 +2497,12 @@ fn build_gc() -> Box<MiniMarkGC> {
         false,
         Vec::new(),
     ));
-    debug_assert_eq!(gc_int_array_tid, GC_INT_ARRAY_GC_TYPE_ID);
+    // Declare the slot to `majit-rlib`, which owns the block but has no
+    // registry of its own: `Digits::new` and the list-strategy allocators
+    // stamp this word into every items-block header, and the collector indexes
+    // *this* registry with it. Announcing the value the line above just
+    // returned is what keeps the two ends the same host's.
+    pyre_object::object_array::set_gc_int_array_gc_type_id(gc_int_array_tid);
     let float_token = &pyre_object::TYPED_ITEMS_BLOCK_FLOAT_TOKEN;
     let gc_float_array_tid = gc.register_type(TypeInfo::varsize(
         float_token.base_size,
@@ -2506,7 +2511,7 @@ fn build_gc() -> Box<MiniMarkGC> {
         false,
         Vec::new(),
     ));
-    debug_assert_eq!(gc_float_array_tid, GC_FLOAT_ARRAY_GC_TYPE_ID);
+    pyre_object::object_array::set_gc_float_array_gc_type_id(gc_float_array_tid);
     // `pypy/interpreter/pycode.py:52 class PyCode(W_Root)` — code
     // objects are normal GC heap objects in PyPy.  Pre-register
     // `PyCode` here, immediately after the GcArray tids and

--- a/pyre/pyre-object/src/float_array.rs
+++ b/pyre/pyre-object/src/float_array.rs
@@ -1,8 +1,8 @@
 use std::ops::{Index, IndexMut};
 
 use crate::object_array::{
-    GC_FLOAT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
-    alloc_typed_items_block, dealloc_typed_items_block, grow_typed_items_block,
+    TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock, alloc_typed_items_block,
+    dealloc_typed_items_block, gc_float_array_gc_type_id, grow_typed_items_block,
     typed_items_block_capacity,
 };
 
@@ -52,7 +52,7 @@ impl FloatArray {
     pub fn from_vec(values: Vec<f64>) -> Self {
         let len = values.len();
         let arr = Self {
-            block: unsafe { alloc_typed_items_block(len, GC_FLOAT_ARRAY_GC_TYPE_ID) },
+            block: unsafe { alloc_typed_items_block(len, gc_float_array_gc_type_id()) },
             len,
         };
         unsafe {
@@ -137,7 +137,12 @@ impl FloatArray {
             .max(self.capacity().saturating_mul(2))
             .max(FLOAT_ARRAY_INLINE_CAP);
         self.block = unsafe {
-            grow_typed_items_block(self.block, target_cap, self.len, GC_FLOAT_ARRAY_GC_TYPE_ID)
+            grow_typed_items_block(
+                self.block,
+                target_cap,
+                self.len,
+                gc_float_array_gc_type_id(),
+            )
         };
     }
 

--- a/pyre/pyre-object/src/int_array.rs
+++ b/pyre/pyre-object/src/int_array.rs
@@ -1,8 +1,8 @@
 use std::ops::{Index, IndexMut};
 
 use crate::object_array::{
-    GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock,
-    alloc_typed_items_block, dealloc_typed_items_block, grow_typed_items_block,
+    TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TypedItemsBlock, alloc_typed_items_block,
+    dealloc_typed_items_block, gc_int_array_gc_type_id, grow_typed_items_block,
     typed_items_block_capacity,
 };
 
@@ -70,7 +70,7 @@ impl IntArray {
     pub fn from_vec(values: Vec<i64>) -> Self {
         let len = values.len();
         let arr = Self {
-            block: unsafe { alloc_typed_items_block(len, GC_INT_ARRAY_GC_TYPE_ID) },
+            block: unsafe { alloc_typed_items_block(len, gc_int_array_gc_type_id()) },
             len,
         };
         unsafe {
@@ -180,7 +180,7 @@ impl IntArray {
             .max(self.capacity().saturating_mul(2))
             .max(INT_ARRAY_INLINE_CAP);
         self.block = unsafe {
-            grow_typed_items_block(self.block, target_cap, self.len, GC_INT_ARRAY_GC_TYPE_ID)
+            grow_typed_items_block(self.block, target_cap, self.len, gc_int_array_gc_type_id())
         };
     }
 

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -7,12 +7,17 @@ use crate::{PY_NULL, PyObjectRef};
 // live with `rbigint`, whose `_digits` is lowered to one
 // (`majit_rlib::lltypesystem::rlist`). The stable-tier constructors below are
 // this crate's, because they root through this crate's shadow stack.
+// The two `GcArray` tids are read through accessors rather than re-exported as
+// constants: they are slots in *this* host's type registry, so pyre declares
+// them from its own `gc.register_type` results (`pyre-jit/src/eval.rs`) instead
+// of majit-rlib carrying pyre's numbering.
 pub use majit_rlib::lltypesystem::rlist::{
-    GC_FLOAT_ARRAY_GC_TYPE_ID, GC_INT_ARRAY_GC_TYPE_ID, TYPED_ITEMS_BLOCK_ITEMS_OFFSET,
-    TYPED_ITEMS_BLOCK_LEN_OFFSET, TypedItemsBlock, alloc_typed_items_block_immortal,
-    alloc_typed_items_block_nursery, itemsblock_gc_enabled, try_alloc_typed_items_block_nursery,
-    try_typed_items_block_layout, typed_items_block_capacity, typed_items_block_clear,
-    typed_items_block_items_base, typed_items_block_layout,
+    TYPED_ITEMS_BLOCK_ITEMS_OFFSET, TYPED_ITEMS_BLOCK_LEN_OFFSET, TypedItemsBlock,
+    alloc_typed_items_block_immortal, alloc_typed_items_block_nursery, gc_float_array_gc_type_id,
+    gc_int_array_gc_type_id, itemsblock_gc_enabled, set_gc_float_array_gc_type_id,
+    set_gc_int_array_gc_type_id, try_alloc_typed_items_block_nursery, try_typed_items_block_layout,
+    typed_items_block_capacity, typed_items_block_clear, typed_items_block_items_base,
+    typed_items_block_layout,
 };
 
 /// GC type id for the variable-length backing block of
@@ -660,14 +665,14 @@ unsafe fn grow_items_block(
 // in, which roots through this crate's shadow stack, plus the array tokens the
 // descr registry reads.
 
-/// `get_array_token(GcArray(Signed))` — [`GC_INT_ARRAY_GC_TYPE_ID`].
+/// `get_array_token(GcArray(Signed))` — [`gc_int_array_gc_type_id`].
 pub const TYPED_ITEMS_BLOCK_INT_TOKEN: ArrayToken = ArrayToken {
     base_size: TYPED_ITEMS_BLOCK_ITEMS_OFFSET,
     item_size: std::mem::size_of::<i64>(),
     len_offset: TYPED_ITEMS_BLOCK_LEN_OFFSET,
 };
 
-/// `get_array_token(GcArray(Float))` — [`GC_FLOAT_ARRAY_GC_TYPE_ID`]. A distinct
+/// `get_array_token(GcArray(Float))` — [`gc_float_array_gc_type_id`]. A distinct
 /// ARRAY identity from the signed one, sharing this block's layout.
 pub const TYPED_ITEMS_BLOCK_FLOAT_TOKEN: ArrayToken = ArrayToken {
     base_size: TYPED_ITEMS_BLOCK_ITEMS_OFFSET,

--- a/pyre/pyre-object/src/tagged_int.rs
+++ b/pyre/pyre-object/src/tagged_int.rs
@@ -10,7 +10,7 @@
 //! never tagged.
 //!
 //! The tag path is gated behind [`CAN_BE_TAGGED`], which is currently `false`.
-//! If it is enabled: the
+//! Once enabled, the
 //! maker (`intobject::w_int_new`) returns small ints as immediates, the
 //! readers/dispatch chokepoints `& 1`-precheck before any `ob_type`
 //! deref, and the GC collector skips tagged immediates
@@ -26,9 +26,9 @@ use crate::pyobject::PyObjectRef;
 
 /// `rpython/rtyper/lltypesystem/rtagged.py:64-96` static `can_be_tagged`
 /// gate, collapsed to the single runtime `int` class. Off, mirroring
-/// `rpython/config/translationoption.py:185 taggedpointers` left off. If it is
-/// enabled, every consumer chokepoint
-/// takes the `& 1` tag precheck and the maker emits small ints as
+/// `rpython/config/translationoption.py:185 taggedpointers` left off. When
+/// enabled, every consumer chokepoint takes the `& 1` tag precheck and the
+/// maker emits small ints as
 /// immediates. `rerased.py:1-3`: the point is to avoid putting `& 1` tag
 /// checks on every object — they are gated on this static, which is kept
 /// in lockstep with the GC `taggedpointers` config (`pyre-jit`

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -990,9 +990,10 @@ fn maybe_print_fbw_depth_census() {
 /// native run at all.
 ///
 /// Deliberately NOT under the `[jit-stats]` prefix: `check.py`'s
-/// `_jit_stats_snapshot` keeps the LAST such line, so a second one would
-/// silently replace the committed per-bench baseline. Its own env gate keeps it
-/// off the default `check.py` run, which sets `MAJIT_STATS` for every bench.
+/// `_jit_stats_snapshot` merges every such line into one key/value set, so a
+/// key printed under that prefix joins the counters instead of sitting beside
+/// them. Its own env gate keeps it off the default `check.py` run, which sets
+/// `MAJIT_STATS` for every bench.
 fn maybe_print_mc_diag() {
     if std::env::var_os("PYRE_MC_DIAG").is_none() {
         return;

--- a/scripts/check-citation-drift.py
+++ b/scripts/check-citation-drift.py
@@ -1,0 +1,373 @@
+#!/usr/bin/env python3
+"""Report stale line-number citations into the vendored RPython/PyPy sources.
+
+A citation of ``file.py:line symbol`` is checkable when ``symbol`` names a
+function or class in the resolved file. The tool reports citations whose line
+now belongs to a different definition. It does not validate prose about
+upstream behavior, call-site citations, or names that are not definitions.
+
+The report partitions checkable and unmeasured citations so a zero cannot be
+mistaken for complete coverage. This is a reporting tool; it exits nonzero only
+when its own population or partition invariant fails.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Share the basename pattern between the `rg` prefilter and parser so files
+# containing digits cannot be accepted by one and dropped by the other.
+BASENAME = r"[a-z_][a-z0-9_]*\.py"
+RG_PREFILTER = BASENAME + r":[0-9]+"
+PY_PATH = r"(?:[A-Za-z0-9_.-]+/)*" + BASENAME
+
+# LOCATOR is a non-overlapping population control. CITE shares its prefix but
+# parses more text, so equal counts prove the parser did not consume a following
+# citation accidentally.
+LOCATOR = re.compile(rf"({PY_PATH}):(\d+)(?:-\d+)?")
+
+# The separator admits adjacent code spans. The negative lookahead prevents a
+# broadened separator from consuming the basename of the next citation as the
+# current citation's symbol. `--self-test` exercises that interaction.
+SEPARATOR = r"[\s`'\"*:\-]*"
+SYMBOL = r"(?:([A-Za-z_][A-Za-z0-9_]*)\b(?!\.py))?"
+CITE = re.compile(rf"({PY_PATH}):(\d+)(?:-\d+)?" + SEPARATOR + SYMBOL)
+
+# A deliberately broken parser used as the population-control self-test.
+SEPARATOR_OVERCORRECTION = r"[\s`'\"*:,()\-]*"
+SYMBOL_NO_LOOKAHEAD = r"(?:([A-Za-z_][A-Za-z0-9_]*)\b)?"
+
+UPSTREAM_ROOTS = ("rpython", "pypy", "lib-python")
+SEARCH_ROOTS = ("majit", "pyre")
+
+DEF_RE = re.compile(r"^(\s*)(def|class)\s+([A-Za-z_][A-Za-z0-9_]*)")
+
+
+def build_symbol_index(root: Path, upstream_roots):
+    """basename -> [(path, defs, total)], and relpath -> (path, defs, total)."""
+    index = defaultdict(list)
+    by_path = {}
+    for base in upstream_roots:
+        base_dir = root / base
+        if not base_dir.is_dir():
+            continue
+        for p in base_dir.rglob("*.py"):
+            try:
+                text = p.read_text(errors="replace")
+            except OSError:
+                continue
+            defs = []
+            for i, line in enumerate(text.splitlines(), 1):
+                m = DEF_RE.match(line)
+                if m:
+                    defs.append((i, len(m.group(1)), m.group(2), m.group(3)))
+            entry = (p, defs, len(text.splitlines()))
+            index[p.name].append(entry)
+            by_path[str(p.relative_to(root))] = entry
+    return index, by_path
+
+
+def enclosing_symbols(defs, total, lineno):
+    """Every def/class whose body plausibly contains `lineno`, innermost first.
+
+    A def at indent d owns lines until the next def/class at indent <= d, so a
+    method inside a class yields [method, class].  Returns None when the line is
+    outside the file, which is a distinct and louder defect than drift.
+    """
+    if lineno < 1 or lineno > total:
+        return None
+    out = []
+    for idx, (ln, indent, _kind, name) in enumerate(defs):
+        if ln > lineno:
+            break
+        end = total
+        for ln2, indent2, _, _ in defs[idx + 1:]:
+            if indent2 <= indent:
+                end = ln2 - 1
+                break
+        if ln <= lineno <= end:
+            out.append(name)
+    out.reverse()
+    return out
+
+
+def scan_tree(root: Path, search_roots):
+    """Every line under `search_roots` that contains an upstream citation."""
+    missing = [r for r in search_roots if not (root / r).exists()]
+    if missing:
+        sys.exit(f"error: search root(s) not found under {root}: {', '.join(missing)}")
+    proc = subprocess.run(
+        ["rg", "-n", "--no-heading", "--type", "rust", RG_PREFILTER, *search_roots],
+        cwd=root, capture_output=True, text=True,
+    )
+    # rg exits 1 for "no matches", which for this tool is itself a red flag: the
+    # tree is known to carry tens of thousands of citations, so an empty result
+    # means the search was misconfigured, not that the tree is clean.
+    if proc.returncode not in (0, 1):
+        sys.exit(f"error: rg failed ({proc.returncode}): {proc.stderr.strip()}")
+    rows = []
+    for row in proc.stdout.splitlines():
+        try:
+            path, lno, text = row.split(":", 2)
+        except ValueError:
+            continue
+        rows.append((path, lno, text))
+    return rows
+
+
+def classify(rows, index, by_path):
+    stats = defaultdict(int)
+    drifted = []
+    out_of_range = []
+
+    for path, lno, text in rows:
+        for m in CITE.finditer(text):
+            pyfile, cited_line, symbol = m.group(1), int(m.group(2)), m.group(3)
+            stats["total_citations"] += 1
+            if not symbol:
+                stats["no_symbol_named"] += 1
+                continue
+            if "/" in pyfile:
+                # the citation NAMES its corpus -- resolve by path suffix, never
+                # by basename, or a same-named file in another corpus wins.
+                hits = [v for k, v in by_path.items() if k.endswith(pyfile)]
+                if len(hits) > 1:
+                    stats["ambiguous_path"] += 1
+                    continue
+                if not hits:
+                    stats["cited_path_not_found"] += 1
+                    continue
+                entry = hits[0]
+            else:
+                cands = index.get(pyfile)
+                if not cands:
+                    stats["upstream_file_not_found"] += 1
+                    continue
+                if len(cands) > 1:
+                    stats["ambiguous_basename"] += 1
+                    continue
+                entry = cands[0]
+            _p, defs, total = entry
+            encl = enclosing_symbols(defs, total, cited_line)
+            if encl is None:
+                stats["out_of_range"] += 1
+                out_of_range.append((path, lno, pyfile, cited_line, symbol, total))
+                continue
+            if symbol in encl:
+                stats["ok"] += 1
+                continue
+            # Only a def/class elsewhere in the same file gives us an assertion
+            # to falsify. Other trailing words may describe call sites or prose.
+            names = {n for _, _, _, n in defs}
+            if symbol not in names:
+                stats["symbol_is_prose"] += 1
+                continue
+            stats["drifted"] += 1
+            true_lines = [ln for ln, _, _, n in defs if n == symbol]
+            dist = min(abs(t - cited_line) for t in true_lines)
+            drifted.append((path, lno, pyfile, cited_line, symbol,
+                            encl[0] if encl else "<module level>", dist))
+    return stats, drifted, out_of_range
+
+
+def tier_of(dist):
+    if dist > 100:
+        return "A"
+    if dist > 20:
+        return "B"
+    if dist > 5:
+        return "C"
+    return "D"
+
+
+TIER_LABEL = {
+    "A": "A >100 lines",
+    "B": "B 21-100",
+    "C": "C 6-20",
+    "D": "D <=5 (adjacent def)",
+}
+
+
+def check_population(rows):
+    """CITE must find exactly as many citations as the non-overlapping LOCATOR.
+
+    This is the guard on parser edits.  It is a within-run comparison rather
+    than a recorded number precisely so that adding citations to the tree -- the
+    normal thing to do -- cannot make it stale and get it rekeyed blindly.
+    """
+    located = sum(len(LOCATOR.findall(text)) for _, _, text in rows)
+    parsed = sum(len(CITE.findall(text)) for _, _, text in rows)
+    return located, parsed
+
+
+def self_test(rows):
+    """Prove the population guard catches a known parser mutation."""
+    located, parsed = check_population(rows)
+
+    def count(sep, sym):
+        r = re.compile(rf"({PY_PATH}):(\d+)(?:-\d+)?" + sep + sym)
+        return sum(len(r.findall(text)) for _, _, text in rows)
+
+    wide_pair = count(SEPARATOR_OVERCORRECTION, SYMBOL_NO_LOOKAHEAD)
+    no_look = count(SEPARATOR, SYMBOL_NO_LOOKAHEAD)
+    wide_only = count(SEPARATOR_OVERCORRECTION, SYMBOL)
+
+    print(f"locator population (ground truth)     {located:,}")
+    print(f"shipped parser                        {parsed:,}"
+          f"   (must EQUAL locator)")
+    print(f"mutation: wide separator + no lookahead {wide_pair:>8,}"
+          f"   (must be LESS -- this is the guard's control)")
+    print(f"mutation: no lookahead alone          {no_look:,}"
+          f"   (latent today: equal is expected)")
+    print(f"mutation: wide separator alone        {wide_only:,}"
+          f"   (latent today: equal is expected)")
+
+    ok = parsed == located and wide_pair < located
+    if parsed != located:
+        print(f"\nFAIL: the shipped parser already loses "
+              f"{located - parsed:,} citations.")
+    if wide_pair >= located:
+        print("\nFAIL: the guard is DEAD -- the control mutation no longer "
+              "trips it, so this control no longer proves anything and the "
+              "population assertion is unvalidated.")
+    if ok:
+        print(f"\nPASS: guard is live -- the control mutation eats "
+              f"{located - wide_pair:,} citations and the assertion catches it.")
+    return 0 if ok else 1
+
+
+def main():
+    default_root = Path(__file__).resolve().parent.parent
+    ap = argparse.ArgumentParser(
+        description=__doc__.splitlines()[0],
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--root", type=Path, default=default_root,
+                    help="repository root (default: parent of scripts/)")
+    ap.add_argument("--search-root", action="append", dest="search_roots",
+                    metavar="DIR",
+                    help=f"tree to scan (repeatable; default: {', '.join(SEARCH_ROOTS)})")
+    ap.add_argument("--upstream-root", action="append", dest="upstream_roots",
+                    metavar="DIR",
+                    help=f"upstream corpus (repeatable; default: {', '.join(UPSTREAM_ROOTS)})")
+    ap.add_argument("--claims", type=int, default=25, metavar="N",
+                    help="distinct drifted claims to list in detail (default: 25, 0 for all)")
+    ap.add_argument("--summary", action="store_true",
+                    help="print the headline and partition only")
+    ap.add_argument("--self-test", action="store_true",
+                    help="prove the population guard is live, then exit")
+    args = ap.parse_args()
+
+    root = args.root.resolve()
+    search_roots = args.search_roots or list(SEARCH_ROOTS)
+    upstream_roots = args.upstream_roots or list(UPSTREAM_ROOTS)
+
+    rows = scan_tree(root, search_roots)
+    if args.self_test:
+        return self_test(rows)
+
+    located, parsed = check_population(rows)
+    if parsed != located:
+        sys.exit(
+            f"POPULATION INVARIANT FAILED: the parser found {parsed:,} citations "
+            f"where the non-overlapping locator found {located:,}.\n"
+            f"A match is running into the next citation and consuming it, so "
+            f"{located - parsed:,} citations are being lost silently -- every "
+            f"count below would be a fraction of an unknown whole. Fix the "
+            f"parser before reading any number from this tool."
+        )
+
+    index, by_path = build_symbol_index(root, upstream_roots)
+    stats, drifted, out_of_range = classify(rows, index, by_path)
+
+    checkable = stats["ok"] + stats["drifted"] + stats["out_of_range"]
+    unverifiable = (stats["no_symbol_named"] + stats["symbol_is_prose"]
+                    + stats["ambiguous_basename"] + stats["ambiguous_path"]
+                    + stats["upstream_file_not_found"]
+                    + stats["cited_path_not_found"])
+    total = checkable + unverifiable
+    if total != stats["total_citations"]:
+        sys.exit(
+            f"PARTITION INVARIANT FAILED: {total:,} != "
+            f"{stats['total_citations']:,} -- a bucket is missing or "
+            f"double-counted, so the headline percentage is unusable."
+        )
+
+    tiers = defaultdict(int)
+    for *_rest, dist in drifted:
+        tiers[tier_of(dist)] += 1
+    tier_str = " ".join(f"{t}:{tiers[t]}" for t in "ABCD")
+    rate = 100.0 * (stats["drifted"] + stats["out_of_range"]) / checkable if checkable else 0.0
+
+    print(f"checked {checkable:,} of {stats['total_citations']:,} claims")
+    print(f"  {unverifiable:,} not checkable (name no symbol / ambiguous "
+          f"basename / symbol is prose)")
+    print(f"drifted {stats['drifted']:,} ({rate:.1f}%) -- {tier_str} -- "
+          f"past EOF {stats['out_of_range']:,}")
+    print("NOTE: this finds stale line numbers. It cannot find a comment that "
+          "describes")
+    print("      control flow upstream does not have.")
+    print(f"NOTE: the {unverifiable:,} not-checkable citations are UNMEASURED, "
+          f"not clean. The only")
+    print("      hand-audited sample of that bucket was 10 of 10 drifted.")
+    print("WARNING: much of the pyjitpl.py drift is a uniform +24, which looks "
+          "like one")
+    print("      upstream insertion and therefore like a one-line sed. It is "
+          "not. A blanket")
+    print("      +24 breaks every citation whose target sits ABOVE the "
+          "insertion point,")
+    print("      including the ones that are correct today. Repoint per site.")
+
+    print("\n=== PARTITION (must sum to total) ===")
+    print(f"  CHECKABLE                {checkable:,}")
+    print(f"    correct                  {stats['ok']:,}")
+    print(f"    DRIFTED                  {stats['drifted']:,}")
+    print(f"    out of range (past EOF)  {stats['out_of_range']:,}")
+    print(f"  UNVERIFIABLE (unmeasured){unverifiable:>8,}")
+    print(f"    names no symbol          {stats['no_symbol_named']:,}")
+    print(f"    trailing word not a def  {stats['symbol_is_prose']:,}")
+    print(f"    ambiguous basename       {stats['ambiguous_basename']:,}")
+    print(f"    ambiguous path           {stats['ambiguous_path']:,}")
+    print(f"    upstream file not found  {stats['upstream_file_not_found']:,}")
+    print(f"    cited path not found     {stats['cited_path_not_found']:,}")
+    print(f"  SUM                      {total:,}")
+
+    print("\n=== DRIFT SEVERITY (distance from cited line to the named symbol) ===")
+    for t in "ABCD":
+        print(f"  {TIER_LABEL[t]:24s} {tiers[t]:,}")
+    print("  D is mostly an adjacent def and is not listed below.")
+
+    if args.summary:
+        return 0
+
+    by_claim = defaultdict(list)
+    for path, lno, pyfile, cited, sym, actual, dist in drifted:
+        if dist > 5:
+            by_claim[(pyfile, cited, sym, actual, dist)].append(f"{path}:{lno}")
+    ordered = sorted(by_claim.items(), key=lambda kv: (-len(kv[1]), kv[0][0], kv[0][1]))
+    shown = ordered if args.claims == 0 else ordered[:args.claims]
+    print(f"\n=== DRIFTED CLAIMS: cited line is inside a DIFFERENT function ===")
+    print(f"({len(ordered):,} distinct claims above tier D; showing {len(shown):,})")
+    for (pyfile, cited, sym, actual, dist), sites in shown:
+        print(f"\n{pyfile}:{cited} claims `{sym}` -> inside `{actual}`"
+              f"  (symbol is {dist} lines away)  [{len(sites)} site(s)]")
+        for s in sites[:6]:
+            print(f"    {s}")
+        if len(sites) > 6:
+            print(f"    ... +{len(sites) - 6} more")
+
+    if out_of_range:
+        print("\n=== OUT OF RANGE: cited line exceeds the upstream file ===")
+        for path, lno, pyfile, cited, sym, total_lines in out_of_range:
+            print(f"  {path}:{lno}  {pyfile}:{cited} "
+                  f"(file has {total_lines} lines) `{sym}`")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

- Make class-word metadata explicit in layout descriptors and route all lookups through the descriptor API.
- Derive items-block and GC-array identities from host metadata instead of pyre-specific names or baked type IDs.
- Keep virtualizable array-index promotion in the owning walker and on the standard access path.
- Carry the remaining backend-generic runtime fixes: GC allocation forwarding, finish-result handling, Cranelift dump support, and a citation-drift reporting script.

## Why

These changes are independent of the CEL example. Landing them first reduces the CEL stack while making the shared majit runtime describe layout and virtualizable behavior through general metadata rather than application-specific assumptions.

## Checks

- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test --all --no-default-features --features dynasm`
- `python3 scripts/check-citation-drift.py --self-test`
- `python3 pyre/check.py --backend dynasm --no-synthetic` (dynasm 10/10)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime registration for typed-array GC identifiers, improving compatibility across host configurations.
  - Added optional Cranelift machine-code size and disassembly diagnostics.
  - Added a citation-drift checker for validating source references.

- **Bug Fixes**
  - Improved class-field detection to avoid confusing payload fields with object headers.
  - Fixed virtualizable array access handling for non-standard layouts.
  - Improved compiled-execution exit handling and loop tracing reliability.

- **Documentation**
  - Clarified interpreter, JIT, runtime, and diagnostic behavior throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->