### PR TITLE
cel: complete translator cutover and deadframe integration

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -231,7 +231,7 @@ fn attached_descr_ptrs_with_fallbacks(
 fn match_metainterp_finish_descr(
     jf_descr_raw: i64,
     attachments: &CpuDescrAttachments,
-) -> Option<(majit_ir::DescrRef, DescrRef)> {
+) -> Option<majit_ir::DescrRef> {
     let ptr = jf_descr_raw as usize;
     fn check(slot: &Option<majit_ir::DescrRef>, expected: usize) -> Option<majit_ir::DescrRef> {
         slot.as_ref().and_then(|arc| {
@@ -242,34 +242,21 @@ fn match_metainterp_finish_descr(
             }
         })
     }
-    for (slot, cl_singleton) in [
-        (
-            &attachments.done_with_this_frame_descr_int,
-            &*DONE_WITH_THIS_FRAME_DESCR_INT,
-        ),
-        (
-            &attachments.done_with_this_frame_descr_float,
-            &*DONE_WITH_THIS_FRAME_DESCR_FLOAT,
-        ),
-        (
-            &attachments.done_with_this_frame_descr_ref,
-            &*DONE_WITH_THIS_FRAME_DESCR_REF,
-        ),
-        (
-            &attachments.done_with_this_frame_descr_void,
-            &*DONE_WITH_THIS_FRAME_DESCR_VOID,
-        ),
-        (
-            &attachments.exit_frame_with_exception_descr_ref,
-            &*EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL,
-        ),
+    // The attached descr and nothing beside it. Each of these has a cranelift
+    // singleton twin (`DONE_WITH_THIS_FRAME_DESCR_*`,
+    // `EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL`), but the twin is what the
+    // *unattached* fall-through below reaches for; naming it here read one
+    // `LazyLock` per candidate and cloned an `Arc` the caller dropped unread,
+    // on the arm every finished entry takes.
+    for slot in [
+        &attachments.done_with_this_frame_descr_int,
+        &attachments.done_with_this_frame_descr_float,
+        &attachments.done_with_this_frame_descr_ref,
+        &attachments.done_with_this_frame_descr_void,
+        &attachments.exit_frame_with_exception_descr_ref,
     ] {
         if let Some(arc) = check(slot, ptr) {
-            // cl_singleton is `&DescrRef` (the metainterp's
-            // `Arc<DoneWithThisFrameDescr*>` or
-            // `Arc<ExitFrameWithExceptionDescrRef>` directly — no
-            // CraneliftFailDescr wrapper).
-            return Some((arc, cl_singleton.clone()));
+            return Some(arc);
         }
     }
     None
@@ -8074,7 +8061,13 @@ fn run_compiled_code_inner(
     let depth = max_output_slots.max(inputs.len()).max(1);
     let header_words = (JF_FRAME_ITEM0_OFS as usize) / 8; // 8 words = 64 bytes
     let frame_depth = depth + num_ref_roots;
-    if majit_log_enabled() {
+    // Read once, ahead of the run. Each of these is a `Once`-guarded load of a
+    // flag fixed at process start, and the compiled call between the sites
+    // below is opaque to the optimizer, so asking again after it re-reads.
+    let log_enabled = majit_log_enabled();
+    let debug_prints = majit_ir::debug::have_debug_prints();
+    let verify_enabled = majit_verify_enabled();
+    if log_enabled {
         eprintln!(
             "[jf-alloc] frame_depth={} depth={} max_output={} inputs={} ref_roots={}",
             frame_depth,
@@ -8176,12 +8169,12 @@ fn run_compiled_code_inner(
             std::hint::black_box(&mut scratch);
         }
     }
-    if majit_ir::debug::have_debug_prints() {
+    if debug_prints {
         let preview: Vec<i64> = (0..inputs.len().min(10)).map(|i| inputs.raw(i)).collect();
         majit_ir::debug::log_one("jit-running", &format!("pre-call-inputs {preview:?}"));
     }
     // Debug: verify first input (frame ptr) is valid
-    if majit_verify_enabled() && !inputs.is_empty() {
+    if verify_enabled && !inputs.is_empty() {
         let frame_ptr = inputs.raw(0);
         if frame_ptr != 0 && (frame_ptr < 0x1000 || (frame_ptr as usize & 0x7) != 0) {
             majit_ir::debug::log_one(
@@ -8208,7 +8201,7 @@ fn run_compiled_code_inner(
     // _call_footer_shadowstack are emitted as inline MOVs in compiled
     // code's prologue/epilogue. The caller does NOT touch root_stack_top.
 
-    if majit_ir::debug::have_debug_prints() {
+    if debug_prints {
         majit_ir::debug::log_one(
             "jit-running",
             &format!(
@@ -8218,7 +8211,7 @@ fn run_compiled_code_inner(
         );
     }
     let result_jf = unsafe { func(jf_ptr, dispatch_key as i32) };
-    if majit_ir::debug::have_debug_prints() {
+    if debug_prints {
         majit_ir::debug::log_one("jit-running", &format!("post-call result_jf={result_jf:p}"));
     }
 
@@ -8304,8 +8297,7 @@ fn run_compiled_code_inner(
         } else {
             (0u32, None)
         }
-    } else if let Some((metainterp_finish, _cl_singleton)) =
-        match_metainterp_finish_descr(jf_descr_raw, attachments)
+    } else if let Some(metainterp_finish) = match_metainterp_finish_descr(jf_descr_raw, attachments)
     {
         // `history.py:125` `cpu.get_latest_descr(deadframe)` parity:
         // `jf_descr` carries the metainterp `Arc<DoneWithThisFrameDescr*>`
@@ -8350,7 +8342,7 @@ fn run_compiled_code_inner(
         });
         (fi, arc)
     };
-    if majit_log_enabled() {
+    if log_enabled {
         eprintln!(
             "[post-call-descr] raw={:#x} fail_index={} matched_local={}",
             jf_descr_raw,
@@ -9201,7 +9193,6 @@ impl CraneliftBackend {
         inputs: FrameInputs<'_>,
         dispatch_key: u32,
     ) -> DeadFrame {
-        slice_x2_probe::arm_reporter();
         // Current trace state (equivalent to LLFrame.lltrace)
         let mut cur_code_ptr = compiled.code_ptr;
         // Borrowed, not cloned: the dispatch loop only READS this table, and
@@ -9234,7 +9225,7 @@ impl CraneliftBackend {
         let attachments: &CpuDescrAttachments = &attachments_guard;
 
         loop {
-            let exec = run_compiled_code(
+            let mut exec = run_compiled_code(
                 cur_code_ptr,
                 &cur_fail_descrs,
                 cur_num_ref_roots,
@@ -9244,7 +9235,9 @@ impl CraneliftBackend {
                 cur_dispatch_key,
             );
             let fail_index = exec.fail_index;
-            let direct_descr = exec.direct_descr.clone();
+            // Taken, not cloned: this is the field's only reader, and what is
+            // left of `exec` is the frame and its owner.
+            let direct_descr = exec.direct_descr.take();
 
             // CALL_ASSEMBLER deadframe interception.
             if let Some(frame) = maybe_take_call_assembler_deadframe(fail_index, &exec) {
@@ -9275,8 +9268,28 @@ impl CraneliftBackend {
                         .unwrap_or_else(|| compiled.fail_descrs[0].clone())
                 })
             };
-            let fail_descr = &fail_descr;
-            let fail_descr_fd = as_fd(fail_descr);
+            // `compile.py` `_DoneWithThisFrameDescr.final_descr = True` is a
+            // class attribute, i.e. a field load after translation. The FINISH
+            // family answers `fail_index()` with `u32::MAX`
+            // (`majit-backend/src/finish_descrs.rs`) and the resolution above
+            // already keyed on that, so the three trait queries below would
+            // ask the descr what this word has already said. The arm is a
+            // SUPERSET of `is_finish()` — a `PropagateExceptionDescr` answers
+            // `u32::MAX` too and is not final — and it is right only because
+            // the fall-through return is byte-identical and
+            // `maybe_increment_fail_count` is inert on both. Anything added
+            // between the two returns below has to be re-checked here.
+            debug_assert!(
+                fail_index != u32::MAX || {
+                    let fd = as_fd(&fail_descr);
+                    !fd.is_external_jump() && !fd.is_resume_guard() && !fd.is_resume_guard_copied()
+                },
+                "a u32::MAX fail_index must be a final or propagate descr, never a guard"
+            );
+            if fail_index == u32::MAX {
+                return deadframe_from_jitframe(exec.jf_gcref, fail_descr, exec.heap_owner);
+            }
+            let fail_descr_fd = as_fd(&fail_descr);
 
             // llgraph/runner.py Jump exception caught by execute():
             // cross-loop JUMP — switch to the target loop trace identified
@@ -9313,7 +9326,7 @@ impl CraneliftBackend {
                 // Real FINISH — function completed.
                 // jf_savedata already correct in jf_frame memory.
                 // jf_guard_exc already written by emit_guard_exit.
-                return deadframe_from_jitframe(exec.jf_gcref, fail_descr.clone(), exec.heap_owner);
+                return deadframe_from_jitframe(exec.jf_gcref, fail_descr, exec.heap_owner);
             }
 
             maybe_increment_fail_count(fail_descr_fd);
@@ -9335,7 +9348,7 @@ impl CraneliftBackend {
             // production traces; when control reaches this return the
             // descr genuinely has no bridge attached (cache was null at
             // guard exit time → in-code dispatch returned deadframe).
-            return deadframe_from_jitframe(exec.jf_gcref, fail_descr.clone(), exec.heap_owner);
+            return deadframe_from_jitframe(exec.jf_gcref, fail_descr, exec.heap_owner);
         } // end loop
     }
 
@@ -16744,6 +16757,12 @@ impl majit_backend::Backend for CraneliftBackend {
         if let Some(clt) = token.compiled_loop_token() {
             majit_backend::record_compiled_loop_token(&self.cpu_tracker, &clt);
         }
+        // Armed here rather than at the entry it reports on. The guard only
+        // has to exist by the time the thread ends, and registering a
+        // thread-local with a destructor is a call — one this thread was
+        // going to make anyway, on a path taken once per compiled loop
+        // instead of once per entry into one.
+        slice_x2_probe::arm_reporter();
         // Deep-clone Op out of OpRc for the internal pipeline (post-optimizer
         // boundary; backend stages do not depend on `_forwarded` sharing).
         let ops_owned: Vec<Op> = ops.iter().map(|rc| (**rc).clone()).collect();

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -3835,9 +3835,12 @@ pub struct JittedGuard {
 
 impl JittedGuard {
     /// Create a new guard, setting `we_are_jitted()` to `true`.
+    ///
+    /// Read and set in one thread-local access rather than through the two
+    /// public accessors: this runs on every entry into compiled code, and the
+    /// pair resolved the same key twice.
     pub fn enter() -> Self {
-        let prev = we_are_jitted();
-        set_jitted(true);
+        let prev = JIT_MODE_FLAG.with(|f| f.replace(true));
         JittedGuard { prev }
     }
 }

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -249,7 +249,20 @@ pub struct CompileResult<M> {
     /// `pyjitpl.py compile_exit_frame_with_exception`).
     /// jitdriver routes this to `jitexc.ExitFrameWithExceptionRef`.
     pub is_exit_frame_with_exception: bool,
-    pub exit_layout: CompiledExitLayout,
+    /// The failing guard's exit description, and `None` on a FINISH exit.
+    ///
+    /// Held behind a pointer for the reason
+    /// [`CompiledExitLayout::recovery_layout`] gives one level down, applied to
+    /// the layout as a whole: this result is returned BY VALUE from every
+    /// compiled entry, so an inline layout is bytes moved on each one. Every
+    /// reader (`jitdriver`'s two run loops and pyre's drain loop) opens the
+    /// layout only past its own FINISH and `fail_index == u32::MAX` arms, so a
+    /// call that returns through either was copying a layout nothing read.
+    ///
+    /// The allocation lands where the layout is built, which the FINISH arm now
+    /// returns before reaching. A FINISH exit stores one null word here, so the
+    /// steady entry path's allocation count is unchanged.
+    pub exit_layout: Option<Box<CompiledExitLayout>>,
     pub savedata: Option<GcRef>,
     pub exception: ExceptionState,
     /// compile.py: ResumeGuardDescr.status read at guard failure.

--- a/majit/majit-metainterp/src/io_buffer.rs
+++ b/majit/majit-metainterp/src/io_buffer.rs
@@ -71,10 +71,22 @@ pub fn io_buffer_write_fmt(args: fmt::Arguments<'_>) {
 }
 
 /// Flush the JIT I/O buffer to stdout.
+///
+/// The gate inlines and the work does not: this runs on every exit from
+/// compiled code, and on a build that buffers no I/O the whole call is one
+/// relaxed load and a not-taken branch — which is only true if the caller can
+/// see the load, rather than reaching it through a call.
+#[inline]
 pub fn io_buffer_commit() {
     if !io_buffer_possibly_nonempty() {
         return;
     }
+    io_buffer_commit_slow();
+}
+
+#[cold]
+#[inline(never)]
+fn io_buffer_commit_slow() {
     JIT_IO_BUFFER.with(|buf| {
         let mut b = buf.borrow_mut();
         if !b.is_empty() {
@@ -87,11 +99,18 @@ pub fn io_buffer_commit() {
     });
 }
 
-/// Discard the JIT I/O buffer contents.
+/// Discard the JIT I/O buffer contents. Split like [`io_buffer_commit`].
+#[inline]
 pub fn io_buffer_discard() {
     if !io_buffer_possibly_nonempty() {
         return;
     }
+    io_buffer_discard_slow();
+}
+
+#[cold]
+#[inline(never)]
+fn io_buffer_discard_slow() {
     JIT_IO_BUFFER.with(|buf| {
         buf.borrow_mut().clear();
     });

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -489,6 +489,7 @@ impl Drop for TraceContinuationSuspendGuard {
 /// reason [`no_bridge_enabled`] is — a frontend that owns state the diagnostic
 /// is about has to report it from its own side, and a variable that only the
 /// metainterp honours reads as broken when a frontend's half stays silent.
+#[inline]
 pub fn spdiag_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_SPDIAG").is_some())
@@ -541,6 +542,7 @@ fn failvals_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_FAILVALS").is_some())
 }
+#[inline]
 fn portal_rca_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_PORTAL_RCA").is_some())
@@ -5495,7 +5497,7 @@ impl<S: JitState> JitDriver<S> {
                         state.state_field_layout().total_live_values(),
                     );
                     let extended = self.extend_compiled_live_values_into(
-                        green_key,
+                        &procedure_token,
                         state,
                         &compiled_meta,
                         vable,
@@ -5536,7 +5538,7 @@ impl<S: JitState> JitDriver<S> {
                 }
 
                 if !self.extend_compiled_live_values_into(
-                    green_key,
+                    &procedure_token,
                     state,
                     &compiled_meta,
                     vable,
@@ -5638,7 +5640,11 @@ impl<S: JitState> JitDriver<S> {
             pre_run();
 
             let selected_dispatch_key = dispatch_key.unwrap_or(0);
-            if portal_rca_enabled() {
+            // One read for the pair below. The flag is fixed at process start,
+            // but the compiled run sits between the two sites and is opaque to
+            // the optimizer, so asking twice is two loads and two calls.
+            let portal_rca = portal_rca_enabled();
+            if portal_rca {
                 let labels = state.debug_state_live_labels(&compiled_meta);
                 eprintln!(
                     "[portal-rca][compiled-entry] green_key={green_key} target_pc={target_pc} \
@@ -5669,7 +5675,7 @@ impl<S: JitState> JitDriver<S> {
             // this point.
             self.entry_scratch_out(scratch);
             let mut result = result?;
-            if portal_rca_enabled() {
+            if portal_rca {
                 eprintln!(
                     "[portal-rca][compiled-exit] green_key={green_key} \
                      dispatch_key={selected_dispatch_key} is_finish={} fail_index={} \
@@ -6724,7 +6730,7 @@ impl<S: JitState> JitDriver<S> {
     /// declining caller sees the buffer it passed.
     fn extend_compiled_live_values_into(
         &self,
-        green_key: u64,
+        procedure_token: &majit_backend::JitCellToken,
         state: &S,
         meta: &S::Meta,
         virtualizable: Option<&JitDriverVar>,
@@ -6733,13 +6739,15 @@ impl<S: JitState> JitDriver<S> {
         arrays: &mut Vec<Vec<i64>>,
     ) -> bool {
         // `warmstate.py:188 cell.loop_token` is the single PyPy source of
-        // truth for the entry-path inputarg shape; route through
-        // `warm_state.get_compiled` so this site never consults pyre's
-        // `compiled_loops` side table (the retirement target).
-        let Some(compiled) = self.meta.warm_state_ref().get_compiled(green_key) else {
-            return false;
-        };
-        let compiled_inputs = compiled.inputarg_types().len();
+        // truth for the entry-path inputarg shape, and this token IS what
+        // `warm_state.get_compiled` returns — so the shape still comes off the
+        // cell and never off pyre's `compiled_loops` side table (the
+        // retirement target). Arrives resolved for the reason `sync_before`
+        // gives: `warmstate.py maybe_compile_and_run` reads the cell's token
+        // once and carries the object into `execute_assembler`, where asking
+        // the celltable again costs a walk, a `Weak::upgrade` and an `Arc`
+        // drop for one length.
+        let compiled_inputs = procedure_token.inputarg_types().len();
         if compiled_inputs <= live_values.len() {
             return true;
         }
@@ -6781,10 +6789,13 @@ impl<S: JitState> JitDriver<S> {
         virtualizable: Option<&JitDriverVar>,
         mut live_values: Vec<Value>,
     ) -> Option<Vec<Value>> {
+        // The cold form keeps the lookup: its callers hold a green key and no
+        // token.
+        let procedure_token = self.meta.warm_state_ref().get_compiled(green_key)?;
         let mut statics = Vec::new();
         let mut arrays = Vec::new();
         self.extend_compiled_live_values_into(
-            green_key,
+            &procedure_token,
             state,
             meta,
             virtualizable,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5758,7 +5758,13 @@ impl<S: JitState> JitDriver<S> {
             // compile.py handle_fail
             let fail_index = result.fail_index;
             let trace_id = result.trace_id;
-            let exit_layout = result.exit_layout.clone();
+            // Taken, not cloned: `result` is dropped a few lines below, and
+            // the finish arm above — the one that carries no layout — has
+            // already returned.
+            let exit_layout = *result
+                .exit_layout
+                .take()
+                .expect("a guard exit carries its exit layout");
             let raw_values = result.values.clone();
             let descr_arc = std::sync::Arc::clone(&result.descr_arc);
             let guard_value_operand = result.guard_value_operand;
@@ -7339,7 +7345,9 @@ impl<S: JitState> JitDriver<S> {
         let fail_index = result.fail_index;
         let trace_id = result.trace_id;
         let descr_arc = std::sync::Arc::clone(&result.descr_arc);
-        let exit_layout = result.exit_layout.clone();
+        // The pointer travels; the layout behind it is opened past the finish
+        // arm below, which is the one that carries none.
+        let exit_layout = result.exit_layout.take();
         // Taken, not copied: every field this arm needs is read out here and
         // `result` is dropped just below, so neither buffer has a reader left.
         let typed_values = std::mem::take(&mut result.typed_values).into_vec();
@@ -7375,6 +7383,7 @@ impl<S: JitState> JitDriver<S> {
         }
 
         // compile.py handle_fail / must_compile: single tick+check.
+        let exit_layout = *exit_layout.expect("a guard exit carries its exit layout");
         let fallback_green_key = if exit_layout.rd_loop_token != 0 {
             exit_layout.rd_loop_token
         } else {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5667,6 +5667,12 @@ impl<S: JitState> JitDriver<S> {
             let result = self.meta.execute_assembler_at_dispatch_key(
                 &procedure_token,
                 green_key,
+                // The run is handed the meta the gate above already read out of
+                // `compiled_loops`, rather than probing that map a third time
+                // for the same slot. Nothing between the two can replace the
+                // entry: `pre_run` cannot capture the driver and the
+                // `on_compiled_entry` hook is called through `&self.meta`.
+                std::sync::Arc::clone(&compiled_meta),
                 live_values,
                 selected_dispatch_key,
             );
@@ -5674,7 +5680,7 @@ impl<S: JitState> JitDriver<S> {
             // arguments, so the buffers go back before the first exit past
             // this point.
             self.entry_scratch_out(scratch);
-            let mut result = result?;
+            let mut result = result;
             if portal_rca {
                 eprintln!(
                     "[portal-rca][compiled-exit] green_key={green_key} \
@@ -5719,7 +5725,10 @@ impl<S: JitState> JitDriver<S> {
                 // Taken, not copied: this arm returns below, so the exit values
                 // in `result` have no reader past this point.
                 self.meta.back_edge_finish = Some(std::mem::take(&mut result.typed_values));
-                let run_meta = result.meta.clone();
+                // The meta the run was handed, not a second handle to it:
+                // cloning `result.meta` here bought a refcount pair for a value
+                // already in scope.
+                let run_meta = &compiled_meta;
                 // The FINISH arguments are NOT the loop-carried state, so they
                 // are not written back into it. `warmstate.py:405-419
                 // execute_assembler` takes the `DoneWithThisFrameDescr*` fast
@@ -5740,7 +5749,7 @@ impl<S: JitState> JitDriver<S> {
                 // `descriptor_cache`), so a second consultation could only
                 // return the same object at the cost of one more refcount pair
                 // per compiled entry.
-                self.sync_after(state, &run_meta, vable);
+                self.sync_after(state, run_meta, vable);
                 // Kept for callers that cannot consume the latch (a portal whose
                 // return type the expansion cannot build from a `Value`). Those
                 // callers see today's behaviour unchanged; a caller that drains
@@ -5750,14 +5759,15 @@ impl<S: JitState> JitDriver<S> {
 
             // Normal loop back-edge JUMP, not a guard failure.
             if result.fail_index == u32::MAX {
-                let run_meta = result.meta.clone();
+                // Same handle as the FINISH arm above, for the same reason.
+                let run_meta = &compiled_meta;
                 if !result.typed_values.is_empty() {
-                    state.restore_values(&run_meta, &result.typed_values);
+                    state.restore_values(run_meta, &result.typed_values);
                 }
                 // Carried from the entry decision above, not re-resolved; see
                 // the FINISH arm for why one resolution serves both ends of a
                 // compiled entry.
-                self.sync_after(state, &run_meta, vable);
+                self.sync_after(state, run_meta, vable);
                 return Some(target_pc);
             }
 

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -423,6 +423,7 @@ pub fn bh_debug_enabled() -> bool {
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_BH_DEBUG").is_some())
 }
 
+#[inline]
 pub fn callee_rca_enabled() -> bool {
     static FLAG: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
     *FLAG.get_or_init(|| std::env::var_os("MAJIT_CALLEE_RCA").is_some())

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11056,60 +11056,55 @@ impl<M: Clone> MetaInterp<M> {
         // FINISH descrs are singletons (`DONE_WITH_THIS_FRAME_DESCR_*` /
         // `EXIT_FRAME_WITH_EXCEPTION_DESCR_REF_CL`) with `trace_id == 0`
         // and `fail_index == u32::MAX`; they carry no per-trace exit
-        // metadata. Skip the trace lookup entirely and synthesize the
-        // default layout, mirroring RPython where FINISH descrs are
-        // dispatched on identity rather than trace-keyed lookup.
+        // metadata. Skip the trace lookup entirely and carry no layout,
+        // mirroring RPython where FINISH descrs are dispatched on identity
+        // rather than trace-keyed lookup — every field of one built here
+        // would be a default, and this result's readers open the layout only
+        // on the guard arm.
         let mut exit_layout = if is_finish {
-            CompiledExitLayout {
-                rd_loop_token: green_key,
-                trace_id,
-                fail_index,
-                source_op_index: None,
-                exit_types: ExitTypes::from_slice(exit_types),
-                is_finish,
-                is_exception_exit: is_exit_frame_with_exception,
-                recovery_layout: None,
-                resume_layout: None,
-                storage: None,
-            }
+            None
         } else {
-            // Fresh, fallible lookup — see `run_compiled_raw_detailed_with_values`.
-            self.compiled_loops
-                .get(&green_key)
-                .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
-                .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
-                .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
-                .and_then(|(owning_key, resolved_id, trace)| {
-                    Self::compiled_exit_layout_from_trace(
-                        trace,
-                        owning_key,
-                        resolved_id,
+            Some(
+                // Fresh, fallible lookup — see `run_compiled_raw_detailed_with_values`.
+                self.compiled_loops
+                    .get(&green_key)
+                    .and_then(|compiled| Self::trace_for_exit(compiled, trace_id))
+                    .map(|(resolved_id, trace)| (green_key, resolved_id, trace))
+                    .or_else(|| self.trace_for_exit_by_rd_loop_token(rd_loop_token, trace_id))
+                    .and_then(|(owning_key, resolved_id, trace)| {
+                        Self::compiled_exit_layout_from_trace(
+                            trace,
+                            owning_key,
+                            resolved_id,
+                            fail_index,
+                        )
+                    })
+                    .unwrap_or_else(|| CompiledExitLayout {
+                        rd_loop_token: green_key,
+                        trace_id,
                         fail_index,
-                    )
-                })
-                .unwrap_or_else(|| CompiledExitLayout {
-                    rd_loop_token: green_key,
-                    trace_id,
-                    fail_index,
-                    source_op_index: None,
-                    exit_types: ExitTypes::from_slice(exit_types),
-                    is_finish,
-                    is_exception_exit: is_exit_frame_with_exception,
-                    recovery_layout: None,
-                    resume_layout: None,
-                    // The green-key index no longer holds this trace, but the
-                    // failing descr still carries the resume payload it was
-                    // compiled with (`compile.py get_resumestorage`), so a
-                    // blackhole resume off this layout stays possible.
-                    storage: crate::resume::ResumeStorage::from_fail_descr(descr)
-                        .map(std::sync::Arc::new),
-                })
+                        source_op_index: None,
+                        exit_types: ExitTypes::from_slice(exit_types),
+                        is_finish,
+                        is_exception_exit: is_exit_frame_with_exception,
+                        recovery_layout: None,
+                        resume_layout: None,
+                        // The green-key index no longer holds this trace, but the
+                        // failing descr still carries the resume payload it was
+                        // compiled with (`compile.py get_resumestorage`), so a
+                        // blackhole resume off this layout stays possible.
+                        storage: crate::resume::ResumeStorage::from_fail_descr(descr)
+                            .map(std::sync::Arc::new),
+                    }),
+            )
         };
         // RPython: deadframe has ALL jitframe slots accessible.
         // If the backend's descr covers more slots than the trace layout,
         // extend exit_layout.exit_types to match (conservative Int for extras).
-        if exit_types.len() > exit_layout.exit_types.len() {
-            exit_layout.exit_types.resize(exit_types.len(), Type::Int);
+        if let Some(layout) = exit_layout.as_mut()
+            && exit_types.len() > layout.exit_types.len()
+        {
+            layout.exit_types.resize(exit_types.len(), Type::Int);
         }
         let mut values = ExitRawValues::with_capacity(exit_arity);
         let mut typed_values = ExitValues::with_capacity(exit_arity);
@@ -11160,7 +11155,7 @@ impl<M: Clone> MetaInterp<M> {
             descr_arc,
             is_finish,
             is_exit_frame_with_exception,
-            exit_layout,
+            exit_layout: exit_layout.map(Box::new),
             savedata,
             exception,
             status,
@@ -11382,24 +11377,13 @@ impl<M: Clone> MetaInterp<M> {
         // and never reaches the general case at all.
         if is_finish {
             Self::finish_compiled_run_io();
-            // The same layout the general arm synthesizes when it has no trace
-            // to build one from: a final descr carries none. The two guard-only
-            // slot lists stay empty because nothing past a final descr reads
-            // them — they exist for the blackhole resume and the bridge,
-            // neither of which a returned frame reaches. Built before the
-            // result so the descr borrow behind `exit_types` ends first.
-            let exit_layout = CompiledExitLayout {
-                rd_loop_token: green_key,
-                trace_id,
-                fail_index,
-                source_op_index: None,
-                exit_types: ExitTypes::from_slice(exit_types),
-                is_finish,
-                is_exception_exit: is_exit_frame_with_exception,
-                recovery_layout: None,
-                resume_layout: None,
-                storage: None,
-            };
+            // No layout. A final descr resumes nothing, so every field of one
+            // built here is a default: the two guard-only slot lists are empty
+            // because they exist for the blackhole resume and the bridge, and
+            // a returned frame reaches neither. Both readers of this field
+            // (`jitdriver`'s two run loops) take their copy after their finish
+            // and JUMP arms have returned, so a layout built here would be
+            // copied out of this result and dropped without a reader.
             return Some(CompileResult {
                 values,
                 typed_values,
@@ -11409,7 +11393,7 @@ impl<M: Clone> MetaInterp<M> {
                 descr_arc,
                 is_finish,
                 is_exit_frame_with_exception,
-                exit_layout,
+                exit_layout: None,
                 savedata: None,
                 exception: ExceptionState {
                     exc_class: 0,
@@ -11501,7 +11485,7 @@ impl<M: Clone> MetaInterp<M> {
             descr_arc,
             is_finish,
             is_exit_frame_with_exception,
-            exit_layout,
+            exit_layout: Some(Box::new(exit_layout)),
             savedata,
             exception,
             status,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -11191,7 +11191,14 @@ impl<M: Clone> MetaInterp<M> {
         // having decided anything about the cell first. A caller that already
         // gated on the token holds it and calls the run directly.
         let token = self.warm_state.get_procedure_token(green_key)?;
-        self.execute_assembler_at_dispatch_key(&token, green_key, live_values, dispatch_key)
+        let meta = self.compiled_loops.get(&green_key)?.meta.clone();
+        Some(self.execute_assembler_at_dispatch_key(
+            &token,
+            green_key,
+            meta,
+            live_values,
+            dispatch_key,
+        ))
     }
 
     /// `compile.py must_compile` reads the failing GUARD_VALUE's operand off the
@@ -11268,11 +11275,10 @@ impl<M: Clone> MetaInterp<M> {
         &mut self,
         procedure_token: &std::sync::Arc<JitCellToken>,
         green_key: u64,
+        meta: std::sync::Arc<M>,
         live_values: &[Value],
         dispatch_key: u32,
-    ) -> Option<CompileResult<M>> {
-        let meta = self.compiled_loops.get(&green_key)?.meta.clone();
-
+    ) -> CompileResult<M> {
         // Read once per run, ahead of every stage, so no stage's difference
         // carries it. See [`ExecuteStageRepeats`]; a default build has neither
         // this load nor the loops it feeds.
@@ -11384,7 +11390,7 @@ impl<M: Clone> MetaInterp<M> {
             // (`jitdriver`'s two run loops) take their copy after their finish
             // and JUMP arms have returned, so a layout built here would be
             // copied out of this result and dropped without a reader.
-            return Some(CompileResult {
+            return CompileResult {
                 values,
                 typed_values,
                 meta,
@@ -11402,7 +11408,7 @@ impl<M: Clone> MetaInterp<M> {
                 },
                 status: 0,
                 guard_value_operand: None,
-            });
+            };
         }
 
         let status = descr.get_status();
@@ -11476,7 +11482,7 @@ impl<M: Clone> MetaInterp<M> {
             ovf_flag: false,
         };
 
-        Some(CompileResult {
+        CompileResult {
             values,
             typed_values,
             meta,
@@ -11490,7 +11496,7 @@ impl<M: Clone> MetaInterp<M> {
             exception,
             status,
             guard_value_operand,
-        })
+        }
     }
 
     /// Attach resume data to a specific guard in a compiled loop.

--- a/majit/majit-metainterp/src/virt_array.rs
+++ b/majit/majit-metainterp/src/virt_array.rs
@@ -234,11 +234,21 @@ impl<T: Copy> VirtArray<T> {
     /// alone — so a length change is a reallocation. A length that does not
     /// change is not, which is the case a caller reusing one array across calls
     /// is in.
+    ///
+    /// The unchanged case inlines to the length compare and the reallocation
+    /// does not, so a caller that reuses one array across calls pays a load and
+    /// a branch rather than a call frame.
+    #[inline]
     pub fn resize(&mut self, new_len: usize, value: T) {
-        let old_len = self.len();
-        if new_len == old_len {
+        if new_len == self.len() {
             return;
         }
+        self.reallocate(new_len, value);
+    }
+
+    #[inline(never)]
+    fn reallocate(&mut self, new_len: usize, value: T) {
+        let old_len = self.len();
         let mut grown = Self::with_len(new_len);
         let kept = old_len.min(new_len);
         grown[..kept].copy_from_slice(&self[..kept]);

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -11,8 +11,8 @@ Each module is launched one of three ways, selectable with `--mode`:
 
   * script (default): `pyre <path>/test_xxx.py` — runs the test file directly
     as `__main__` so its `if __name__ == "__main__": unittest.main()` block
-    fires. Needs only `unittest` plus the module's own imports, so it remains
-    the most robust mode today. A package, and a file carrying no such block,
+    fires. Needs only `unittest` plus the module's own imports, making it the
+    most robust default. A package, and a file carrying no such block,
     go through a synthesized unittest entry instead — running those directly
     exits 0 without testing anything. Runner metadata gives
     resource-heavy or dotted-identity-sensitive modules the corresponding
@@ -837,18 +837,114 @@ def host_baseline_path(path: Path) -> Path:
     return path.with_name(f"{path.stem}.{HOST_TAG}{path.suffix}")
 
 
-def expected_status(baseline: dict, overlay: dict, module: str,
-                    backend: str) -> str | None:
-    """Recorded verdict for `module`, the host overlay winning over the shared
-    file.  Within one file `dynasm` stands in for a backend with no entry."""
-    for source in (overlay, baseline):
+# Metadata keys stored beside per-backend verdicts in a module entry.
+NON_BACKEND_ENTRY_KEYS = ("reason", "provenance")
+
+
+def cell_sources(baseline: dict, overlay: dict) -> tuple[dict, dict]:
+    """The two files a cell can come from, in the order they are consulted.
+
+    One helper rather than the pair spelled at each site: `expected_cell` and
+    `cell_provenance` have to agree about precedence, or a status read from the
+    host overlay is graded against an axis read from the shared file.
+    """
+    return (overlay, baseline)
+
+
+def expected_cell(baseline: dict, overlay: dict, module: str,
+                  backend: str) -> tuple[str | None, str | None]:
+    """Return a status and the backend that recorded it.
+
+    The host overlay is consulted before the shared file, and a cell it holds
+    wins — including when it answers by borrowing `dynasm`. An overlay row that
+    holds no cell for this backend is not an answer, though: `write_baseline`
+    mints a row carrying only the backend whose status diverged on this host,
+    so a row exists for every module any backend ever diverged on. Treating
+    that as an answer would drop the shared file's expectation for every OTHER
+    backend, and a module recorded PASS there would stop being one — no longer
+    selected by the gate, and no longer a regression when it fails.
+
+    Missing backend cells fall back to dynasm; returning the source makes that
+    substitution visible to selection and reporting.
+    """
+    for source in cell_sources(baseline, overlay):
         entry = source.get("modules", {}).get(module)
         if entry is None:
             continue
-        status = entry.get(backend) or entry.get("dynasm")
-        if status is not None:
-            return status
+        own = entry.get(backend)
+        if own:
+            return own, backend
+        borrowed = entry.get("dynasm")
+        if borrowed:
+            return borrowed, "dynasm"
+    return None, None
+
+
+def cell_provenance(baseline: dict, overlay: dict, module: str,
+                    backend: str) -> dict | None:
+    """Return the recorded measurement axis, or None for legacy cells.
+
+    Reads the same source order as `expected_cell`, and falls through the same
+    way, so the axis returned is the one under the status that lookup returned.
+    Reading only the shared file here would pair an overlay host's status with
+    the axis of a cell it overrode; stopping at a row that holds no cell for
+    this backend would pair a shared-file status with no axis at all.
+    """
+    for source in cell_sources(baseline, overlay):
+        entry = source.get("modules", {}).get(module)
+        if entry is None:
+            continue
+        prov = entry.get("provenance", {}).get(backend)
+        if prov is not None:
+            return prov
     return None
+
+
+def run_axis(args: argparse.Namespace, binary: Path) -> dict:
+    """Return the configuration that gives this run's statuses meaning."""
+    return {
+        "backend": args.backend,
+        # Name only, not the resolved path: the absolute path is host state and
+        # would rewrite every cell on a different machine without any of them
+        # having been re-measured.
+        "binary": binary.name,
+        "mode": args.mode,
+        "jit": not args.no_jit,
+        "stdlib_version": stdlib_version(),
+    }
+
+
+def axis_drift_report(baseline: dict, overlay: dict, selected: list[str],
+                      axis: dict) -> list[str]:
+    """Report axis drift for cells recorded by the requested backend.
+
+    Borrowed cells are reported separately. Drift is informational because
+    legacy cells do not carry provenance.
+    """
+    unrecorded = 0
+    differing: dict[str, int] = {}
+    compared = 0
+    for m in selected:
+        _status, src = expected_cell(baseline, overlay, m, axis["backend"])
+        if src != axis["backend"]:
+            continue
+        prov = cell_provenance(baseline, overlay, m, src)
+        if prov is None:
+            unrecorded += 1
+            continue
+        compared += 1
+        for key, value in axis.items():
+            if key == "backend":
+                continue
+            if prov.get(key) != value:
+                differing[key] = differing.get(key, 0) + 1
+    own = compared + unrecorded
+    lines = [f"{compared} of {own} own-backend cells carry a recorded axis, "
+             f"{unrecorded} predate it"]
+    for key in sorted(differing):
+        lines.append(f"  axis drift: {differing[key]} of {compared} recorded "
+                     f"under a different {key} (this run: {axis[key]!r})")
+    return lines
 
 
 # ── main ─────────────────────────────────────────────────────────────
@@ -915,6 +1011,8 @@ def main() -> int:
     overlay_path = host_baseline_path(args.baseline)
     overlay = load_baseline(overlay_path) if overlay_path.exists() else {"modules": {}}
     modules = discover_modules(args.filter)
+    # Derive once for reports, baseline updates, and drift checks.
+    axis = run_axis(args, binary)
 
     if args.list:
         for m in modules:
@@ -953,6 +1051,8 @@ def main() -> int:
     skipped: list[str] = []
     off_platform: list[tuple[str, str]] = []
     deselected = 0
+    # Selected modules whose expected status came from another backend.
+    borrowed_gated: list[str] = []
     for m in modules:
         # Even full/update runs must not overwrite another platform's result.
         gate_reason = platform_gate(m)
@@ -960,7 +1060,7 @@ def main() -> int:
             off_platform.append((m, gate_reason))
             skipped.append(m)
             continue
-        exp = expected_status(baseline, overlay, m, args.backend)
+        exp, exp_src = expected_cell(baseline, overlay, m, args.backend)
         is_skip = (exp == "SKIP") or (m in KNOWN_SKIPS)
         if is_skip and not args.full and not args.update_baseline:
             skipped.append(m)
@@ -969,9 +1069,12 @@ def main() -> int:
             deselected += 1
             continue
         to_run.append(m)
+        if exp_src is not None and exp_src != args.backend:
+            borrowed_gated.append(m)
 
-    print(f"pyre CPython suite — backend={args.backend} mode={args.mode} "
-          f"jit={'off' if args.no_jit else 'on'} jobs={args.jobs}")
+    # Print the same derived axis that baseline updates record.
+    print(f"pyre CPython suite — backend={axis['backend']} mode={axis['mode']} "
+          f"jit={'on' if axis['jit'] else 'off'} jobs={args.jobs}")
     print(f"binary: {binary}")
     overlay_count = len(overlay.get("modules", {}))
     print(f"baseline: {args.baseline.name} + "
@@ -981,7 +1084,13 @@ def main() -> int:
         print(f"  off-platform on {sys.platform}: {m} ({reason})")
     extra = f", {deselected} not gated (non-PASS)" if deselected else ""
     print(f"{len(to_run)} to run, {len(skipped)} skipped{extra}, "
-          f"timeout={args.timeout}s\n")
+          f"timeout={args.timeout}s")
+    # Expose how much of this run was gated against another backend.
+    print(f"{len(borrowed_gated)} of {len(to_run)} gated against another "
+          f"backend's recorded status")
+    for line in axis_drift_report(baseline, overlay, to_run, axis):
+        print(line)
+    print()
 
     results: dict[str, tuple[str, str]] = {}
     done = 0
@@ -1049,11 +1158,16 @@ def main() -> int:
     regressions: list[str] = []
     improvements: list[str] = []
     for m, (status, detail) in sorted(results.items()):
-        exp = expected_status(baseline, overlay, m, args.backend)
+        exp, exp_src = expected_cell(baseline, overlay, m, args.backend)
+        # Name the backend a verdict is measured against whenever it is not the
+        # one under test. Without it a regression line reads as this backend
+        # having gone from PASS to FAIL, when what happened may be that this
+        # backend was never recorded passing.
+        via = "" if exp_src in (None, args.backend) else f" (expected from {exp_src})"
         if exp == "PASS" and status != "PASS":
-            regressions.append(f"{m}: PASS -> {status}  {detail}")
+            regressions.append(f"{m}: PASS -> {status}{via}  {detail}")
         elif exp != "PASS" and status == "PASS":
-            improvements.append(f"{m}: {exp or 'new'} -> PASS")
+            improvements.append(f"{m}: {exp or 'new'} -> PASS{via}")
 
     if improvements:
         print(f"\n── improvements ({len(improvements)}) ──")
@@ -1062,10 +1176,7 @@ def main() -> int:
 
     if args.report:
         report = {
-            "backend": args.backend,
-            "mode": args.mode,
-            "jit": not args.no_jit,
-            "stdlib_version": stdlib_version(),
+            **axis,
             "counts": counts,
             "modules": {m: {"status": s, "detail": d}
                         for m, (s, d) in sorted(results.items())},
@@ -1076,11 +1187,18 @@ def main() -> int:
         print(f"\nreport written: {args.report}")
 
     if args.update_baseline:
-        written = write_baseline(args.baseline, baseline, overlay, results,
-                                 args.backend)
+        # `axis`, not `args.backend`: the cells this writes record the axis
+        # they were measured along, and `run_axis` is the one place that
+        # derives it.
+        written = write_baseline(args.baseline, baseline, overlay, results, axis)
         recorded = sum(1 for s, _ in results.values() if s == "PASS")
         for target in written:
             print(f"\nbaseline written: {target} ({recorded} PASS recorded)")
+        # Read the file as written, not as loaded: this bless repairs some of
+        # what these would otherwise name, and a report naming a cell the same
+        # run just corrected is wrong the moment it prints.
+        for line in phantom_row_report(baseline) + stale_curated_cell_report(baseline):
+            print(line)
         return 0
 
     if regressions:
@@ -1101,8 +1219,41 @@ def main() -> int:
     return 0
 
 
+def phantom_row_report(baseline: dict) -> list[str]:
+    """Lines naming baseline rows that no longer have a discoverable module.
+
+    Rows are reported rather than deleted because the caller may be running a
+    filtered subset. Discovery is repeated without that filter here.
+    """
+    rows = baseline.get("modules", {})
+    phantom = sorted(set(rows) - set(discover_modules(None)))
+    if not phantom:
+        return []
+    return [f"{len(phantom)} of {len(rows)} baseline rows have no discoverable "
+            f"module (carried unchanged, not gated):"] + [f"  ? {m}" for m in phantom]
+
+
+def stale_curated_cell_report(baseline: dict) -> list[str]:
+    """Lines naming cells on a curated-skip row that still record a measurement.
+
+    `KNOWN_SKIPS` already governs selection, so these cells are inert. Preserve
+    their last measured status in case the module leaves the curated skip set.
+    """
+    rows = baseline.get("modules", {})
+    stale = [(m, backend, status)
+             for m, entry in sorted(rows.items()) if m in KNOWN_SKIPS
+             for backend, status in sorted(entry.items())
+             if backend not in NON_BACKEND_ENTRY_KEYS and status != "SKIP"]
+    if not stale:
+        return []
+    return [f"{len(stale)} cell(s) on {len({m for m, _, _ in stale})} curated-skip "
+            f"row(s) still record a measurement (reported, not synced — the "
+            f"curated table governs selection, so these are stale and inert):"] + [
+        f"  * {m} [{backend}] {status}" for m, backend, status in stale]
+
+
 def write_baseline(path: Path, baseline: dict, overlay: dict, results: dict,
-                   backend: str) -> list[Path]:
+                   axis: dict) -> list[Path]:
     """Record `results`, splitting them between the shared baseline and this
     host's overlay.  Returns the files actually written.
 
@@ -1111,11 +1262,20 @@ def write_baseline(path: Path, baseline: dict, overlay: dict, results: dict,
     that a host writes to its own overlay only where it disagrees, and a run
     that comes back into agreement drops the overlay entry again -- so an
     overlay never outlives the divergence that created it.
+
+    A cell's provenance travels with the status into whichever of the two files
+    ends up holding it, so an overlay cell is a measurement with an axis under
+    it rather than a bare status.
     """
+    backend = axis["backend"]
     modules = baseline.setdefault("modules", {})
     overlay_modules = overlay.setdefault("modules", {})
+    # Keep the legacy file-level value; per-cell provenance is authoritative for
+    # a measurement's stdlib version.
     baseline["stdlib_version"] = stdlib_version()
     overlay_dirty = False
+    # The containing cell already identifies the backend.
+    cell_axis = {k: v for k, v in axis.items() if k != "backend"}
     for m, (status, _detail) in results.items():
         # Defensive: never overwrite another platform's recorded result.
         if platform_gate(m) is not None:
@@ -1128,24 +1288,56 @@ def write_baseline(path: Path, baseline: dict, overlay: dict, results: dict,
         if m in KNOWN_SKIPS:
             entry = modules.setdefault(m, {})
             entry[backend] = "SKIP"
-            entry.setdefault("reason", KNOWN_SKIPS[m])
+            # Curated reasons are row-wide and refreshed from their source of
+            # truth. Warn before replacing a different recorded rationale.
+            recorded = entry.get("reason")
+            if recorded is not None and recorded != KNOWN_SKIPS[m]:
+                # Leading blank line: the improvements block prints immediately
+                # above, and an unseparated `  ! ` line reads as one of its rows.
+                print(f"\n  ! {m}: recorded `reason` replaced by the curated text")
+                print(f"      was    : {recorded}")
+                print(f"      curated: {KNOWN_SKIPS[m]}")
+            entry["reason"] = KNOWN_SKIPS[m]
+            # A curated skip is a decision, not a measurement, so it has no
+            # measurement provenance.
+            prov = entry.get("provenance")
+            if prov is not None:
+                prov.pop(backend, None)
+                if not prov:
+                    del entry["provenance"]
+            # The skip is a decision about the module rather than about this
+            # host, so it is shared and any host entry for it is dropped.
             overlay_dirty |= overlay_modules.pop(m, None) is not None
             continue
         shared = modules.get(m, {}).get(backend)
         if shared is None:
-            modules.setdefault(m, {})[backend] = status
+            entry = modules.setdefault(m, {})
+            entry[backend] = status
+            entry.setdefault("provenance", {})[backend] = dict(cell_axis)
             continue
         if status == shared:
             host_entry = overlay_modules.get(m)
             if host_entry is not None and host_entry.pop(backend, None) is not None:
                 overlay_dirty = True
-                # `reason` is prose about the divergence, so it cannot keep the
-                # entry alive once no backend still records one.
-                if not any(k != "reason" for k in host_entry):
+                # The axis goes with the cell it described. Left behind it would
+                # be provenance for a status this file no longer records.
+                host_prov = host_entry.get("provenance")
+                if host_prov is not None:
+                    host_prov.pop(backend, None)
+                    if not host_prov:
+                        del host_entry["provenance"]
+                # Neither `reason` nor a leftover `provenance` is a verdict, so
+                # neither can keep the entry alive once no backend still records
+                # one. Spelled through the constant rather than as a literal:
+                # this is the second site walking an entry generically, and two
+                # spellings of "which keys are not backends" is how they drift.
+                if not any(k not in NON_BACKEND_ENTRY_KEYS for k in host_entry):
                     del overlay_modules[m]
             continue
-        if overlay_modules.setdefault(m, {}).get(backend) != status:
-            overlay_modules[m][backend] = status
+        host_entry = overlay_modules.setdefault(m, {})
+        if host_entry.get(backend) != status:
+            host_entry[backend] = status
+            host_entry.setdefault("provenance", {})[backend] = dict(cell_axis)
             overlay_dirty = True
 
     written = [path]

--- a/pyre/gate-triage.md
+++ b/pyre/gate-triage.md
@@ -243,10 +243,11 @@ its frames on the heap. Lowering it is how the `SubWalkDepthExceeded` decline
 is exercised without building a pathological helper chain; it retires when the
 descent stops recursing on the host stack.
 
-### §6c — Default-OFF diagnostics, censuses and probes (75): keep, cost nothing
+### §6c — Default-OFF diagnostics, censuses and probes (74): keep, cost nothing
 
-Each is inert unless set, so none is a removal target by this file's
-already-ON criterion. They are listed so they cannot be missed again.
+Deleting one of these environment reads does not change behavior when the
+variable is unset. They remain listed so diagnostics are not mistaken for dead
+configuration.
 
 `PYRE_ALLOCSITES`, `PYRE_BH_NULL_ARG`, `PYRE_BRIDGE_LATCH_AUDIT`,
 `MAJIT_CALLEE_RCA`, `PYRE_CATCH_LIVE_CENSUS`,
@@ -264,8 +265,7 @@ already-ON criterion. They are listed so they cannot be missed again.
 `PYRE_GC_DIAG`, `MAJIT_GC_FREELIST_DIAG`, `PYRE_GC_SIZE_AUDIT`,
 `PYRE_GEN_ENTRY_DIAG`,
 `PYRE_JD1_DEBUG`, `PYRE_JD1_DUMP`,
-`PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LLBC_STRICT`,
-`PYRE_LOOP_CENSUS`,
+`PYRE_LB_SITE`, `PYRE_LLBC_SKIP_FINGERPRINT_CHECK`, `PYRE_LOOP_CENSUS`,
 `PYRE_M73_BACKXLAT_TWIN_AUDIT`, `PYRE_M73_EMPTYTWIN_CENSUS`,
 `PYRE_M73_LASTINSTR_AUDIT`, `PYRE_M73_MIDBODY_CARRY_AUDIT`,
 `PYRE_MAJIT_STATS_ANCESTOR`, `PYRE_MAJIT_STATS_ROOT_ONLY`, `PYRE_MC_DIAG`,
@@ -344,6 +344,13 @@ inherited one is startup allocation and moves `guard_failures`; setting the
 gate restores the whole-environment copy, so the size of that effect stays
 measurable on one binary. It goes when the allowlist stops being the thing
 under measurement.
+
+### §6d — Default-ON safety controls
+
+| gate | behavior | retirement condition |
+|---|---|---|
+| `PYRE_LLBC_STRICT` | treats stale frozen LLBC artifacts as an error; setting it to `0` demotes the error to a warning | retain while the build consumes frozen LLBC artifacts |
+
 
 ## §7 — Additional runtime diagnostics
 

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1794,12 +1794,9 @@ fn u32_as_i64(x: u32) -> i64 {
 /// provide a `From<u32> for usize` impl (u32 → usize is not
 /// universally lossless: 16-bit hosts have `usize` smaller than u32).
 /// On supported pyre targets (64-bit Darwin) the conversion is
-/// always lossless, so the runtime `expect(...)` never trips. Walker
-/// lowers as `simple_call(getattr(<usize>, "try_from"), x).expect(…)`
-/// — `lower_method_call` then chains the `.expect` getattr+simple_call
-/// per `build_flow.rs:lower_method_call`. Drop `const fn` because
-/// neither `usize::try_from` nor `Result::expect` is yet stable as
-/// const.
+/// always lossless, so the runtime `expect(...)` never trips. Drop
+/// `const fn` because neither `usize::try_from` nor `Result::expect` is
+/// yet stable as const.
 #[inline]
 fn u32_as_usize(x: u32) -> usize {
     usize::try_from(x).expect("u32 fits in usize on supported pyre targets (64-bit only)")

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7102,13 +7102,25 @@ fn drive_unpack_iterable_trace(
             // Extract owned copies so the `&mut meta` borrow held by the
             // `CompileResult` is released before the blackhole resume (which
             // re-acquires `driver_pair()`).
-            let Some((is_finish, fail_index, has_storage, values, exit_layout, guard_exc)) = meta
+            let Some((
+                is_finish,
+                is_exception_exit,
+                fail_index,
+                has_storage,
+                values,
+                exit_layout,
+                guard_exc,
+            )) = meta
                 .run_compiled_detailed_with_values(green_key, &live_values)
                 .map(|r| {
                     (
                         r.is_finish,
+                        // Off the result, not off the layout: a finish exit
+                        // carries no layout, and the flag one would have held
+                        // is a copy of this word.
+                        r.is_exit_frame_with_exception,
                         r.fail_index,
-                        r.exit_layout.storage.is_some(),
+                        r.exit_layout.as_ref().is_some_and(|l| l.storage.is_some()),
                         r.values.clone(),
                         r.exit_layout.clone(),
                         r.exception.exc_value,
@@ -7124,7 +7136,7 @@ fn drive_unpack_iterable_trace(
                 // `ExitFrameWithExceptionRef` trace as the loop for this green
                 // key, so the next crossing lands here). `compile.py`
                 // takes the value from result slot 0, not from `jf_guard_exc`.
-                if exit_layout.is_exception_exit {
+                if is_exception_exit {
                     pending_err = drain_error_from_exc_ref(values.first().copied().unwrap_or(0));
                 }
                 break;
@@ -7147,7 +7159,9 @@ fn drive_unpack_iterable_trace(
             // `next()`/`append` and run forward to the next merge point.
             let bh = resume_in_blackhole_from_exit_layout(
                 &values,
-                &exit_layout,
+                exit_layout
+                    .as_deref()
+                    .expect("a guard exit carrying resume storage carries its layout"),
                 guard_exc,
                 // jd1 is novable: it has no virtualizable to force.
                 std::ptr::null(),


### PR DESCRIPTION
## What

- Complete the remaining CEL-oriented translator cutover, indirect-family census, and MIR corpus coverage.
- Move libc-backed deadframe storage into the backend-neutral crate and verify GC-visible deadframe slots across dynasm and Cranelift.
- Add CEL release gates for scalar, column, policy, float, and probe execution paths.
- Record structured decline reasons for translation walls and keep the gate triage documents synchronized.

## Why

This is the CEL-specific remainder after extracting the reusable majit work into the base branch. Keeping it as one commit directly above `majit-runtime-followup` makes the merge order explicit and allows a linear merge after the base PR lands.

## Stack

- Base: `majit-runtime-followup` (must land first)
- This branch is exactly one commit above the base.

## Checks

- Fresh LLBC extraction for `majit-rlib`, `pyre-object`, `pyre-interpreter`, and `pyre-jit`
- `cargo check --features dynasm`
- `cargo test --features dynasm`
- `cargo test --all --no-default-features --features dynasm`
- `cargo test --release -p cel --no-default-features --features dynasm` (5/5)
- `python3 scripts/check-citation-drift.py --self-test`
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps --locked -p majit-rlib -p majit-trace`
- `python3 pyre/check.py --backend dynasm --no-synthetic` (dynasm 10/10; `fib_recursive` counters were unstable and non-gated on this run)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved runtime efficiency across compiled execution, guard handling, virtual arrays, and I/O buffer operations.
  - Reduced unnecessary metadata processing and repeated configuration checks.

- **Testing**
  - Enhanced CPython test baselines with configuration provenance and clearer reporting for mismatches, stale entries, and unexpected results.

- **Documentation**
  - Clarified safety-control guidance and updated diagnostic documentation.
  - Simplified internal implementation comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->