### PR TITLE
Raise winsound.MessageBeep's Win32 failure

### DIFF
--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -1003,7 +1003,7 @@ impl PyError {
     /// full stop `FormatMessageW` appends removed.  Reporting the bare code is
     /// the answer for a code the system cannot describe.
     #[cfg(windows)]
-    fn win32_strerror(winerror: i32) -> String {
+    pub(crate) fn win32_strerror(winerror: i32) -> String {
         #[cfg(feature = "host_env")]
         if let Some(message) =
             rustpython_host_env::windows::format_error_message(Some(winerror as u32))

--- a/pyre/pyre-interpreter/src/module/_winapi/host.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/host.rs
@@ -226,8 +226,12 @@ pub fn CreateJunction(src_path: PyObjectRef, dst_path: PyObjectRef) -> Result<()
 /// `_winapi.CopyFile2(existing_file_name, new_file_name, flags,
 /// progress_routine=None)`
 ///
-/// `progress_routine` is accepted and never called: the callback belongs in
-/// `CopyFile2`'s extended parameters, and that field is left unset.
+/// `progress_routine` is accepted and never called, which is what
+/// `_winapi.CopyFile2`'s own documentation states: "reserved for future use,
+/// but is currently not implemented.  Its value is ignored."  The parameter
+/// exists so a caller only has to test for `CopyFile2` itself, and the code
+/// that would put the callback in the extended parameters is commented out
+/// upstream.
 #[crate::pyre_function]
 pub fn CopyFile2(
     existing_file_name: PyObjectRef,
@@ -398,9 +402,13 @@ const WAIT_TIMEOUT: u32 = 258;
 
 /// `_winapi.WaitForMultipleObjects(handle_seq, wait_flag, milliseconds)`
 ///
-/// The reserved slot is where the interruption event goes upstream — pyre has
-/// no Windows event behind its SIGINT flag, so the slot stays empty and a wait
-/// runs to its timeout instead of ending in `InterruptedError`.
+/// The reserved slot is where `_PyOS_SigintEvent()` goes upstream.  pyre
+/// installs no OS signal handler on Windows at all — `pypysig_setflag` is a
+/// `#[cfg(unix)]` body and its Windows twin declines — so there is no SIGINT
+/// flag for an event to stand beside, the slot stays empty, and a wait runs to
+/// its timeout instead of ending in `InterruptedError`.  Wiring one in belongs
+/// with Windows signal delivery, not here; `lib_pypy/_winapi.py:379` leaves
+/// the same gap.
 #[crate::pyre_function]
 pub fn WaitForMultipleObjects(
     handle_seq: PyObjectRef,

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -3225,9 +3225,13 @@ fn make_std_stream(name: &'static str, fd: i32) -> PyObjectRef {
     // descriptor instead of going through `TextIOWrapper.write`, so it
     // substitutes the line separator itself — on the text, before encoding,
     // because at the byte level a utf-16 stdio encoding would be corrupted.
-    // The substitution is the one the stream is configured for and is read
-    // back from it, so a `reconfigure(newline=...)` reaches this path too.
-    // The count the caller gets back stays the length of what it passed in.
+    // The substitution is the one the stream is configured for, so a
+    // `reconfigure(newline=...)` reaches this path too.  It is resolved by
+    // name off `sys`, the way `live_stdio_encoding_errors` beside it resolves
+    // the encoding and the error handler: the function sits in the stream's
+    // instance dictionary rather than being bound to it, so it is handed the
+    // text and nothing else.  The count the caller gets back stays the length
+    // of what it passed in.
     fn encode_stdio_text(
         w_text: PyObjectRef,
         stream_name: &str,

--- a/pyre/pyre-interpreter/src/module/winsound/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winsound/mod.rs
@@ -73,6 +73,38 @@ fn sound_name(sound: PyObjectRef) -> Result<Vec<u16>, crate::PyError> {
     Ok(units)
 }
 
+/// `PyErr_SetExcFromWindowsErr(PyExc_RuntimeError, 0)` — a `RuntimeError`
+/// carrying the arguments the OSError constructor takes: errno 0, the system's
+/// own text for the code, no filename, the code as a signed int, no second
+/// filename.  `RuntimeError` reads none of them and keeps the five as `args`.
+fn win32_runtime_error(code: u32) -> crate::PyError {
+    let message = crate::PyError::win32_strerror(code as i32);
+    let Some(cls) = crate::builtins::lookup_exc_class("RuntimeError") else {
+        return crate::PyError::runtime_error(message);
+    };
+    // Building an argument can collect, so each one is pinned as it is made:
+    // a Rust array of raw references is not something the collector updates.
+    let roots = pyre_object::gc_roots::push_roots();
+    let cls_slot = roots.base();
+    roots.pin_root(cls);
+    roots.pin_root(pyre_object::w_int_new(0));
+    roots.pin_root(pyre_object::w_str_new(&message));
+    roots.pin_root(pyre_object::w_none());
+    roots.pin_root(pyre_object::w_int_new(i64::from(code as i32)));
+    roots.pin_root(pyre_object::w_none());
+    let args = [
+        roots.get(cls_slot + 1),
+        roots.get(cls_slot + 2),
+        roots.get(cls_slot + 3),
+        roots.get(cls_slot + 4),
+        roots.get(cls_slot + 5),
+    ];
+    match crate::call::call_function_impl_result(roots.get(cls_slot), &args) {
+        Ok(exc) => unsafe { crate::PyError::from_exc_object(exc) },
+        Err(error) => error,
+    }
+}
+
 crate::py_module! {
     "winsound",
     int_constants: {
@@ -187,12 +219,17 @@ crate::py_module! {
             }
             Ok(())
         }
-        // The BOOL is dropped: a sound id the system has no sound for is not
-        // an error, it just plays nothing.
-        fn MessageBeep(#[default(0i32)] type_: PyIndexCInt) {
-            unsafe {
-                windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(type_ as u32);
+        fn MessageBeep(#[default(0i32)] type_: PyIndexCInt) -> Result<(), crate::PyError> {
+            let beeped = {
+                let _blocked = crate::module::thread::before_external_block();
+                unsafe { windows_sys::Win32::System::Diagnostics::Debug::MessageBeep(type_ as u32) }
+            };
+            if beeped == 0 {
+                return Err(win32_runtime_error(unsafe {
+                    windows_sys::Win32::Foundation::GetLastError()
+                }));
             }
+            Ok(())
         }
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #1308, from the four review comments that arrived after it was
pushed and before it merged.

**`winsound.MessageBeep`.** The BOOL was dropped and every call answered
`None`. `winsound_MessageBeep_impl` reports a false one with
`PyErr_SetExcFromWindowsErr(PyExc_RuntimeError, 0)` — a `RuntimeError` carrying
the five arguments the OSError constructor takes: errno 0, the system's own
text for the code, no filename, the code, no second filename. The call also
releases the GIL for its duration, as `PlaySound` and `Beep` beside it already
did. `PyError::win32_strerror` becomes `pub(crate)` so the message text is not
spelled a second time.

The other three are answered in comments rather than in code:

- `_winapi.WaitForMultipleObjects` and `BatchedWaitForMultipleObjects` pass no
  SIGINT event because there is none to pass. pyre installs no OS signal
  handler on Windows at all — `pypysig_setflag` is a `#[cfg(unix)]` body and
  its Windows twin declines — so Ctrl-C does not mark SIGINT pending in the
  first place and an event would have nothing to stand beside.
  `lib_pypy/_winapi.py:379` leaves the same gap in the same words. Windows
  signal delivery is its own change.
- `_winapi.CopyFile2` ignores `progress_routine`, which is what its own
  documentation states: "reserved for future use, but is currently not
  implemented. Its value is ignored." The lines that would put the callback in
  the extended parameters are commented out in `_winapi.c`, and the parameter
  exists so a caller only has to test for `CopyFile2` itself.
- The instance `sys.stdout.write` resolves the newline mode by name off `sys`,
  as `live_stdio_encoding_errors` beside it already resolves the encoding and
  the error handler, so an alias retained across a `sys.stdout` replacement
  follows the replacement. That function sits in the stream's instance
  dictionary rather than being bound to it, and `BuiltinCodeFn` is a bare `fn`
  pointer, so it is handed the text and nothing else; reading the mode off the
  owning stream means giving that fast path a self-bound form, which is a
  change to the fast path rather than to this.

### Verification

`MessageBeep` does not fail on demand, so its new branch was exercised by
inverting the test in a throwaway build: it answers
`RuntimeError(0, '<the system's text>', None, 2, None)` — the same five
arguments CPython 3.14 builds, read out of it through
`ctypes.pythonapi.PyErr_SetExcFromWindowsErr`. `test.test_winsound`'s
`MessageBeepTest` passes, 11 tests. `print` into a
`redirect_stdout(StringIO())` still carries no newline substitution, on both.

check.py `dynasm 438/438`, `cranelift 438/438`; `cargo test --all
--no-default-features --features dynasm` all pass (140 test binaries, 0
failures); `extra_tests/parity_tests` all pass; `extra_tests/upstream` has
nothing to run on `nt`; `cargo fmt --check` clean. No jit-stats baseline was
re-recorded.

`cpython_tests` on Windows: 28 regressions, the same set #1308 was verified
against, every one a Windows-vs-Linux difference.

## Self-review

<!--
Written by Claude (Opus 5) in a Claude Code session, which is also where the
review comments above were triaged, so a review pass from outside that session
is still owed.
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [x] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows sound support by reporting runtime errors when `MessageBeep` fails instead of silently continuing.
  * Clarified that Windows wait operations may time out rather than raise an interruption error when no interrupt event is available.

* **Documentation**
  * Updated documentation for Windows file-copy progress callbacks and stream newline handling, including behavior after stream reconfiguration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->