### PR TITLE
majit-gc: scope the do_write_barrier JIT claim to the jitframe base

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -5747,7 +5747,11 @@ impl MiniMarkGC {
     ///
     /// The guard is equally load-bearing on the JIT path, which is why this
     /// entry point — not `jit_remember_young_pointer` — is what the backends'
-    /// non-array COND_CALL_GC_WB helper calls. `_reload_frame_if_necessary`
+    /// non-array COND_CALL_GC_WB helper calls for a JITFRAME base. An ordinary
+    /// store's base takes `jit_remember_young_pointer` instead
+    /// (`framework.py:538-544`), the unguarded entry the array barrier already
+    /// reaches through `jit_remember_young_pointer_from_array`.
+    /// `_reload_frame_if_necessary`
     /// (aarch64/assembler.py:967-980) re-applies the non-array barrier fast
     /// path to the *current jitframe* after every collecting helper call.
     /// Not every jitframe is nursery-allocated: the runner's entry frame, the


### PR DESCRIPTION
Follow-up to #1309, on a base that contains it.

`do_write_barrier`'s doc said this entry point is what "the backends' non-array
`COND_CALL_GC_WB` helper calls". That stopped being true for half the cases once
the dynasm emitters began selecting the helper by base kind: only a JITFRAME base
reaches the guarded entry, while an ordinary store's base reaches
`jit_remember_young_pointer` — the same unguarded entry the array barrier already
reaches through `jit_remember_young_pointer_from_array`
(`majit/majit-gc/src/collector.rs:5889`).

The stale sentence was not cosmetic: a Codex review of #1309 quoted it as the
basis for a P1 asking that ordinary stores keep the guarded entry. The routing it
objected to is a pre-existing property of `main` rather than something #1309
introduced — `majit/majit-backend-cranelift/src/compiler.rs:13123` already passes
the unguarded shim for the non-card `CondCallGcWb` slow path, and both backends
consume one op stream from a single emitter (`majit/majit-gc/src/rewrite.rs`).
This commit corrects the claim instead of the routing.

Doc-only; no behavior change.

Local gates on this commit, darwin-arm64:

| gate | result |
|---|---|
| `pyre/check.py` dynasm / cranelift / wasm | 438/438 · 438/438 · 431/431 |
| `pyre/extra_tests/parity_tests/run.py` | all pass |
| `cargo test --all --no-default-features --features dynasm` | 8072 passed, 0 failed, 112 ignored |
| `pyre/cpython_tests/run.py --backend dynasm` | PASS 207 / FAIL 1 |

The one CPython-suite red is `test.test_pickle::test_recursive_multi` and it is
not owned by this branch: a sibling worktree at `2ce63fad8c0`, which does not
carry the #1309 commits, fails it 3/3. Its cause is `builtin_id` answering with
the raw address, so a list's or dict's `id()` changes when the header moves and
the pure-Python `pickle._Pickler.memo` loses the object. The fix for that is
`builtins.rs`'s `gc_identity_hash` fallback, which is in flight on #1316 and not
yet in `origin/main`.

— *authored by Claude*
