### PR TITLE
Moving-GC correctness, two cranelift forwarded-slot defects, and the check_exc_match fold's wrong header word

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -6054,6 +6054,67 @@ fn emit_host_call(
     return_type.map(|_| builder.inst_results(call)[0])
 }
 
+/// `regalloc.py before_call()`: write the paired `GUARD_NOT_FORCED`'s fail
+/// args into the jitframe slots the guard's resume data names, so a callee
+/// that forces this frame reads the values the resume decoder expects.
+/// `force_token_to_dead_frame` hands `jf_frame` straight to
+/// `ResumeDataDirectReader`, whose `TAGBOX(n)` items index these slots; a slot
+/// left unwritten is decoded as whatever the entry left there.
+///
+/// `call_result` is the not-yet-bound result variable of the call being
+/// emitted: a fail arg naming it has no value yet, so it is stored as 0.
+/// `history.py:227/268/314` Const fail args carry their value inline and never
+/// alias the result, so only body-namespace refs take that branch.
+#[allow(clippy::too_many_arguments)]
+fn spill_guard_fail_args(
+    builder: &mut FunctionBuilder,
+    info: &GuardInfo,
+    call_result: u32,
+    ptr_type: cranelift_codegen::ir::Type,
+    call_conv: cranelift_codegen::isa::CallConv,
+    jf_ptr: CValue,
+    constants: &indexmap::IndexMap<u32, i64>,
+    ref_root_slots: &[(u32, usize)],
+    stale_ref_vars: &IndexSet<u32>,
+    demoted_failarg_slots: &IndexMap<u32, i32>,
+    ref_root_base_ofs: i32,
+) {
+    for (index, &arg_ref) in info.fail_arg_refs.iter().enumerate() {
+        let raw = if !arg_ref.is_constant()
+            && arg_ref.raw() == call_result
+            && !constants.contains_key(&arg_ref.raw())
+        {
+            builder.ins().iconst(cl_types::I64, 0)
+        } else {
+            resolve_failarg_opref(
+                builder,
+                constants,
+                jf_ptr,
+                ref_root_slots,
+                stale_ref_vars,
+                demoted_failarg_slots,
+                ref_root_base_ofs,
+                arg_ref,
+            )
+        };
+        builder.ins().store(
+            MemFlagsData::trusted(),
+            raw,
+            jf_ptr,
+            JF_FRAME_ITEM0_OFS + (index as i32) * 8,
+        );
+    }
+    if info.gcmap != 0 {
+        emit_jitframe_write_barrier(
+            builder,
+            ptr_type,
+            call_conv,
+            jf_ptr,
+            jitframe_write_barrier_flag(),
+        );
+    }
+}
+
 /// assembler.py:1348-1367 _push_all_regs_to_frame:
 /// Save all defined GC ref variables to jf_frame slots before a call
 /// that may trigger GC. The per-call gcmap (from get_gcmap) tells the
@@ -10524,7 +10585,7 @@ impl CraneliftBackend {
                 jf_ptr = builder.ins().get_pinned_reg(ptr_type);
             }
 
-            let paired_may_force = matches!(
+            let paired_guard_not_forced = matches!(
                 op.opcode,
                 OpCode::CallMayForceI
                     | OpCode::CallMayForceR
@@ -10533,8 +10594,12 @@ impl CraneliftBackend {
                     | OpCode::CallReleaseGilI
                     | OpCode::CallReleaseGilF
                     | OpCode::CallReleaseGilN
+                    | OpCode::CallAssemblerI
+                    | OpCode::CallAssemblerR
+                    | OpCode::CallAssemblerF
+                    | OpCode::CallAssemblerN
             );
-            // Both emitters below publish the paired GUARD_NOT_FORCED's Ref
+            // The three emitters below publish the paired GUARD_NOT_FORCED's Ref
             // fail-args into the dense `jf_frame` area *before* the call
             // (regalloc.py:812-820 `before_call`, which spills through the
             // frame manager so those boxes stay in `fm.bindings` and every
@@ -10543,7 +10608,7 @@ impl CraneliftBackend {
             // otherwise leaves the just-written copies holding pre-collection
             // addresses that `force_token_to_dead_frame` and the guard's exit
             // republish.
-            let pre_call_failarg_slots: &[usize] = if paired_may_force {
+            let pre_call_failarg_slots: &[usize] = if paired_guard_not_forced {
                 guard_infos
                     .get(guard_idx)
                     .filter(|info| info.source_op_index == op_idx + 1)
@@ -11922,6 +11987,30 @@ impl CraneliftBackend {
                         builder
                             .ins()
                             .store(MemFlagsData::trusted(), zero, cur_jf, JF_DESCR_OFS);
+                        // regalloc.py before_call() parity, as the
+                        // `call_may_force` / `call_release_gil` arms do: the
+                        // descr stored above is what `force` copies into
+                        // `jf_descr`, so the slots that descr's resume data
+                        // indexes have to hold this guard's fail args before
+                        // the callee runs.  A callee that reaches
+                        // `force_virtualizable_token` on this frame otherwise
+                        // decodes a `TAGBOX` against slots the entry left
+                        // behind — the entry's own reds — and writes them into
+                        // the virtualizable's static fields.
+                        spill_guard_fail_args(
+                            &mut builder,
+                            info,
+                            vi,
+                            ptr_type,
+                            call_conv,
+                            cur_jf,
+                            &constants,
+                            &ref_root_slots,
+                            &stale_ref_vars,
+                            &demoted_failarg_slots,
+                            ref_root_base_ofs,
+                        );
+                        bind_published_dense_refs(&mut dense_ref_bindings, info, &constants);
                     }
 
                     // rewrite.py:613-653 gen_malloc_frame parity:
@@ -12345,45 +12434,19 @@ impl CraneliftBackend {
                     // regalloc.py before_call() parity: spill fail_args to
                     // jf_frame so force_token_to_dead_frame() reads correct
                     // values if the callee forces the frame.
-                    for (index, &arg_ref) in info.fail_arg_refs.iter().enumerate() {
-                        // The call result (vi) is not yet available — write 0.
-                        // history.py:227/268/314: Const fail_args carry value
-                        // inline and never alias the call-result body var
-                        // `vi`. Only body-namespace refs participate in the
-                        // `raw == vi` not-yet-bound check.
-                        let raw = if !arg_ref.is_constant()
-                            && arg_ref.raw() == vi
-                            && !constants.contains_key(&arg_ref.raw())
-                        {
-                            builder.ins().iconst(cl_types::I64, 0)
-                        } else {
-                            resolve_failarg_opref(
-                                &mut builder,
-                                &constants,
-                                cur_jf,
-                                &ref_root_slots,
-                                &stale_ref_vars,
-                                &demoted_failarg_slots,
-                                ref_root_base_ofs,
-                                arg_ref,
-                            )
-                        };
-                        builder.ins().store(
-                            MemFlagsData::trusted(),
-                            raw,
-                            cur_jf,
-                            JF_FRAME_ITEM0_OFS + (index as i32) * 8,
-                        );
-                    }
-                    if info.gcmap != 0 {
-                        emit_jitframe_write_barrier(
-                            &mut builder,
-                            ptr_type,
-                            call_conv,
-                            cur_jf,
-                            jitframe_write_barrier_flag(),
-                        );
-                    }
+                    spill_guard_fail_args(
+                        &mut builder,
+                        info,
+                        vi,
+                        ptr_type,
+                        call_conv,
+                        cur_jf,
+                        &constants,
+                        &ref_root_slots,
+                        &stale_ref_vars,
+                        &demoted_failarg_slots,
+                        ref_root_base_ofs,
+                    );
                     bind_published_dense_refs(&mut dense_ref_bindings, info, &constants);
                     let call_jf = builder.ins().get_pinned_reg(ptr_type);
 
@@ -12436,44 +12499,19 @@ impl CraneliftBackend {
                     // regalloc.py before_call() parity: spill fail_args to
                     // jf_frame so force_token_to_dead_frame() reads correct
                     // values if the callee forces the frame.
-                    for (index, &arg_ref) in info.fail_arg_refs.iter().enumerate() {
-                        // history.py:227/268/314: Const fail_args carry value
-                        // inline and never alias the call-result body var
-                        // `vi`. Only body-namespace refs participate in the
-                        // `raw == vi` not-yet-bound check.
-                        let raw = if !arg_ref.is_constant()
-                            && arg_ref.raw() == vi
-                            && !constants.contains_key(&arg_ref.raw())
-                        {
-                            builder.ins().iconst(cl_types::I64, 0)
-                        } else {
-                            resolve_failarg_opref(
-                                &mut builder,
-                                &constants,
-                                cur_jf,
-                                &ref_root_slots,
-                                &stale_ref_vars,
-                                &demoted_failarg_slots,
-                                ref_root_base_ofs,
-                                arg_ref,
-                            )
-                        };
-                        builder.ins().store(
-                            MemFlagsData::trusted(),
-                            raw,
-                            cur_jf,
-                            JF_FRAME_ITEM0_OFS + (index as i32) * 8,
-                        );
-                    }
-                    if info.gcmap != 0 {
-                        emit_jitframe_write_barrier(
-                            &mut builder,
-                            ptr_type,
-                            call_conv,
-                            cur_jf,
-                            jitframe_write_barrier_flag(),
-                        );
-                    }
+                    spill_guard_fail_args(
+                        &mut builder,
+                        info,
+                        vi,
+                        ptr_type,
+                        call_conv,
+                        cur_jf,
+                        &constants,
+                        &ref_root_slots,
+                        &stale_ref_vars,
+                        &demoted_failarg_slots,
+                        ref_root_base_ofs,
+                    );
                     bind_published_dense_refs(&mut dense_ref_bindings, info, &constants);
                     let call_jf = builder.ins().get_pinned_reg(ptr_type);
 

--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10458,12 +10458,31 @@ impl CraneliftBackend {
                                 demoted_failarg_slots.insert(raw, home_ofs);
                             }
                         }
+                        // Same rule as the local JUMP below: an arg an earlier
+                        // LABEL demoted has no maintained SSA value in the body
+                        // — `spill_ref_roots` / `reload_ref_roots` skip it
+                        // precisely because its ref-root slot is the copy the
+                        // collector forwards. Reading `use_var` here would hand
+                        // this later LABEL's parameter the address the value had
+                        // before the last collection, and the header's
+                        // `sync_ref_root_var` would then write that dead address
+                        // back over the live one.
+                        let mut fallthrough_jf_ptr = None;
                         let vals: Vec<CValue> = ops[op_idx]
                             .getarglist()
                             .iter()
                             .enumerate()
                             .filter(|(i, _)| loop_phi_keep.is_none_or(|keep| keep[*i]))
-                            .map(|(_, r)| resolve_opref(&mut builder, &constants, r.to_opref()))
+                            .map(|(_, r)| {
+                                resolve_local_jump_arg(
+                                    &mut builder,
+                                    &constants,
+                                    ptr_type,
+                                    &mut fallthrough_jf_ptr,
+                                    &demoted_failarg_slots,
+                                    r.to_opref(),
+                                )
+                            })
                             .collect();
                         let args = block_args_to(&mut builder, *label_block, &vals);
                         builder.ins().jump(*label_block, &args);

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -1997,15 +1997,182 @@ impl MiniMarkGC {
         }
     }
 
+    /// Walk everything reachable from the roots at the end of a minor and
+    /// report each traced slot that still names an unpinned nursery address.
+    ///
+    /// Reachability is what makes the answer usable: a block the mutator
+    /// abandoned — a grown-out-of mapdict storage, a replaced items block —
+    /// keeps whatever it last held until the sweep frees it, and those stale
+    /// words are not violations. Only declared slots are read, so a word of
+    /// padding or a non-reference field that happens to fall inside the
+    /// nursery range cannot be mistaken for one either.
+    ///
+    /// Returns `(holder, slot offset, value, parent)` per bad slot, where the
+    /// parent is the object the holder was first reached through: a block with
+    /// no header of its own is traced only via its owner's custom trace, so
+    /// the owner is what the remembered set has to carry.
+    fn bh_probe_stale_young_slots(&self) -> Vec<(usize, usize, usize, Option<usize>)> {
+        let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut stale: Vec<(usize, usize, usize, Option<usize>)> = Vec::new();
+        let mut pending: Vec<(GcRef, Option<usize>)> = self
+            .enumerate_all_root_values()
+            .into_iter()
+            .map(|gcref| (gcref, None))
+            .collect();
+        while let Some((gcref, parent)) = pending.pop() {
+            if gcref.is_null()
+                || !self.is_managed_heap_object(gcref.0)
+                || self.nursery.contains(gcref.0)
+                || !seen.insert(gcref.0)
+            {
+                continue;
+            }
+            let here = gcref.0;
+            self.visit_referent_slots(here, &mut |slot| {
+                let value = unsafe { *slot }.0;
+                if value == 0 {
+                    return;
+                }
+                if self.nursery.contains(value) && !self.pinned_objects.contains(&value) {
+                    stale.push((here, slot as usize - here, value, parent));
+                    return;
+                }
+                pending.push((GcRef(value), Some(here)));
+            });
+        }
+        stale
+    }
+
+    /// TEMPORARY DIAGNOSTIC (`MAJIT_GC_BH_PROBE`), run before a minor starts.
+    ///
+    /// A minor traces the roots and the remembered set and nothing else, so an
+    /// old-generation object holding a young reference while off that set has
+    /// its slot left behind: the value moves and the slot keeps the dead
+    /// address. That is a missing write barrier, and the moment before the
+    /// collection is the only one at which the evidence still exists — after
+    /// it the slot is indistinguishable from one that was never written.
+    ///
+    /// Panics naming the holder, the slot, and the object the holder was first
+    /// reached through, since a block with no header of its own is traced only
+    /// through its owner and it is the owner that has to carry the barrier.
+    fn bh_probe_check_barriers_before_minor(&mut self) {
+        if !crate::bh_probe_enabled()
+            || self.minor_collections < read_uint_from_env("MAJIT_GC_BH_PROBE_FROM").unwrap_or(0)
+        {
+            return;
+        }
+        let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+        let mut pending: Vec<(GcRef, Option<usize>)> = self
+            .enumerate_all_root_values()
+            .into_iter()
+            .map(|gcref| (gcref, None))
+            .collect();
+        let mut bad: Vec<String> = Vec::new();
+        while let Some((gcref, parent)) = pending.pop() {
+            if gcref.is_null() || !self.is_managed_heap_object(gcref.0) || !seen.insert(gcref.0) {
+                continue;
+            }
+            let here = gcref.0;
+            // A young holder needs no barrier: the minor traces the nursery in
+            // full, so only an old-generation slot can be left behind.
+            let holder_is_old = self.oldgen.contains(here);
+            let remembered = self.remembered_set.contains(&here);
+            let parent_remembered = parent.is_some_and(|p| self.remembered_set.contains(&p));
+            self.visit_referent_slots(here, &mut |slot| {
+                let value = unsafe { *slot }.0;
+                if value == 0 {
+                    return;
+                }
+                // Two ways a traced slot can already be wrong here: it names a
+                // managed address whose header is not a type at all (the value
+                // died and its memory was handed out again), or it names a
+                // young object from an old holder the barrier never remembered.
+                let managed = self.nursery.contains(value) || self.oldgen.contains(value);
+                let bad_target = managed
+                    && (unsafe { (*header_of(value)).type_id() } as usize) >= self.types.len();
+                let unbarriered = holder_is_old
+                    && !remembered
+                    && !parent_remembered
+                    && self.nursery.contains(value)
+                    && !self.pinned_objects.contains(&value);
+                if bad_target || unbarriered {
+                    let tid = unsafe { (*header_of(here)).type_id() };
+                    let parent_tid = parent.map(|p| unsafe { (*header_of(p)).type_id() });
+                    bad.push(format!(
+                        "{} holder={here:#x} tid={tid} old={holder_is_old} slot={:#x} \
+                         offset={} value={value:#x} young={} track_young={} remembered={} \
+                         barriered_ever={} | parent={:#x} tid={parent_tid:?} remembered={} \
+                         barriered_ever={}",
+                        if bad_target {
+                            "BAD-TARGET"
+                        } else {
+                            "UNBARRIERED"
+                        },
+                        slot as usize,
+                        slot as usize - here,
+                        self.nursery.contains(value),
+                        unsafe { (*header_of(here)).has_flag(flags::TRACK_YOUNG_PTRS) },
+                        remembered,
+                        crate::bh_probe_was_barriered(here),
+                        parent.unwrap_or(0),
+                        parent_remembered,
+                        parent.is_some_and(crate::bh_probe_was_barriered),
+                    ));
+                }
+                if !bad_target {
+                    pending.push((GcRef(value), Some(here)));
+                }
+            });
+        }
+        // The root walk only covers what `enumerate_all_root_values` names, and
+        // an object the mutator is writing to is live whether or not that
+        // enumeration reaches it. Sweep every recorded old-generation block of
+        // the type under investigation instead, since the population that
+        // matters is "old holders with a young reference and no barrier".
+        // The remembered set is traced whether or not anything still points at
+        // its entries, so it is its own population: an entry the root walk
+        // never reached is a dead object the minor will still read.
+        for index in 0..self.remembered_set.len() {
+            let here = self.remembered_set[index];
+            let root_reachable = seen.contains(&here);
+            self.visit_referent_slots(here, &mut |slot| {
+                let value = unsafe { *slot }.0;
+                if value == 0 || !(self.nursery.contains(value) || self.oldgen.contains(value)) {
+                    return;
+                }
+                if (unsafe { (*header_of(value)).type_id() } as usize) < self.types.len() {
+                    return;
+                }
+                let tid = unsafe { (*header_of(here)).type_id() };
+                bad.push(format!(
+                    "REMEMBERED-BAD-TARGET holder={here:#x} tid={tid} \
+                     root_reachable={root_reachable} slot={:#x} offset={} value={value:#x} \
+                     young={} barriered_ever={}",
+                    slot as usize,
+                    slot as usize - here,
+                    self.nursery.contains(value),
+                    crate::bh_probe_was_barriered(here),
+                ));
+            });
+        }
+        if !bad.is_empty() {
+            panic!(
+                "BH PROBE: {} unbarriered old->young slot(s) before minor #{}\n  {}",
+                bad.len(),
+                self.minor_collections,
+                bad.join("\n  ")
+            );
+        }
+    }
+
     /// TEMPORARY DIAGNOSTIC (`MAJIT_GC_BH_PROBE`).
     ///
     /// At the end of a minor every live nursery object has been forwarded and
     /// every traced slot rewritten, so no surviving object may still name a
-    /// nursery address. Scan every old-generation block for one and accumulate
-    /// the distinct `(type, offset)` classes, then panic once with the whole
-    /// table — the wasm runner recovers a guest panic message out of linear
-    /// memory, so this is the one diagnostic channel that reaches the console
-    /// from inside the module.
+    /// nursery address. Accumulate the distinct `(type, offset)` classes of
+    /// those that do, then panic once with the whole table — the wasm runner
+    /// recovers a guest panic message out of linear memory, so this is the one
+    /// diagnostic channel that reaches the console from inside the module.
     fn bh_probe_check_no_young_refs(&mut self) {
         if !crate::bh_probe_enabled() {
             return;
@@ -2017,22 +2184,38 @@ impl MiniMarkGC {
         // show pre-JIT allocations.
         let class_budget = read_uint_from_env("MAJIT_GC_BH_PROBE_CLASSES").unwrap_or(10);
         let report_at_minor = read_uint_from_env("MAJIT_GC_BH_PROBE_MINOR").unwrap_or(120);
+        // The reachability walk below is a whole-heap traversal per minor, far
+        // too slow to leave on for a whole run; skip the minors before the one
+        // being investigated.
+        if self.minor_collections < read_uint_from_env("MAJIT_GC_BH_PROBE_FROM").unwrap_or(0) {
+            return;
+        }
         const WORD: usize = std::mem::size_of::<usize>();
+        // The recorded allocation size and origin of each old-generation block,
+        // which the walk below does not carry.
+        let blocks: std::collections::HashMap<usize, (usize, u8, &'static str)> =
+            crate::with_bh_objects(|objects| {
+                objects
+                    .iter()
+                    .map(|&(addr, payload_size, origin, phase)| {
+                        (addr, (payload_size, origin, phase))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
         let mut fresh: Vec<crate::BhProbeViolation> = Vec::new();
-        crate::with_bh_objects(|objects| {
-            for &(addr, payload_size, origin, phase) in objects {
-                if self.nursery.contains(addr) || !self.oldgen.contains(addr) {
-                    continue;
-                }
+        {
+            for (addr, offset, word, parent) in self.bh_probe_stale_young_slots() {
+                let (payload_size, origin, phase) =
+                    blocks
+                        .get(&addr)
+                        .copied()
+                        .unwrap_or((0, crate::BH_PROBE_ORIGIN_BORN_OLD, "?"));
                 let tid = unsafe { (*header_of(addr)).type_id() };
                 if (tid as usize) >= self.types.len() || crate::bh_probe_tid_ignored(tid) {
                     continue;
                 }
-                for offset in (0..payload_size).step_by(std::mem::size_of::<usize>()) {
-                    let word = unsafe { *((addr + offset) as *const usize) };
-                    if !self.nursery.contains(word) || self.pinned_objects.contains(&word) {
-                        continue;
-                    }
+                {
                     if crate::bh_probe_violation_seen(tid, offset, origin) {
                         continue;
                     }
@@ -2083,7 +2266,7 @@ impl MiniMarkGC {
                         },
                         neighbourhood: {
                             let lo = offset.saturating_sub(2 * WORD);
-                            let hi = (offset + 3 * WORD).min(payload_size);
+                            let hi = (offset + 3 * WORD).min(payload_size.max(offset + WORD));
                             (lo..hi)
                                 .step_by(WORD)
                                 .map(|o| (o, unsafe { *((addr + o) as *const usize) }))
@@ -2096,10 +2279,21 @@ impl MiniMarkGC {
                         barriered_ever: crate::bh_probe_was_barriered(addr),
                         traced_this_minor: crate::bh_probe_was_traced(addr),
                         store_sites: crate::bh_probe_store_sites(addr, offset),
+                        parent,
+                        parent_tid: parent.map(|p| unsafe { (*header_of(p)).type_id() }),
+                        parent_name: parent
+                            .filter(|&p| {
+                                self.vtable_to_type_id
+                                    .contains_key(&unsafe { *(p as *const usize) })
+                            })
+                            .and_then(crate::bh_probe_type_name),
+                        parent_remembered: parent.is_some_and(|p| self.remembered_set.contains(&p)),
+                        parent_barriered_ever: parent.is_some_and(crate::bh_probe_was_barriered),
+                        parent_traced_this_minor: parent.is_some_and(crate::bh_probe_was_traced),
                     });
                 }
             }
-        });
+        }
         let total = crate::bh_probe_record_violations(fresh);
         if total >= class_budget || (total > 0 && self.minor_collections >= report_at_minor) {
             panic!(
@@ -2227,6 +2421,7 @@ impl MiniMarkGC {
             );
         }
         self.minor_collections += 1;
+        self.bh_probe_check_barriers_before_minor();
         // `bytes_made_old_since_cycle` is the running sum of every
         // `copy_nursery_object` payload, so its delta across this collection is
         // exactly what was promoted out of the nursery. The major-collection
@@ -3361,7 +3556,7 @@ impl MiniMarkGC {
             };
             panic!(
                 "GC BUG: invalid type_id={} at obj_addr={:#x} \
-                 (header_addr={:#x}, nursery_start={:#x}, site={}, \
+                 (minor={}, header_addr={:#x}, nursery_start={:#x}, site={}, \
                  parent_site={}, \
                  nursery_free={:#x}, nursery_top={:#x}, holder_addr={:#x}, \
                  holder_type_id={:?}, holder_offset={:?}, holder_words={:#x?}, \
@@ -3373,6 +3568,7 @@ impl MiniMarkGC {
                  enclosing={}, gc_state={:?}, minors={}, majors={})",
                 type_id,
                 obj_addr,
+                self.minor_collections,
                 obj_addr - GcHeader::SIZE,
                 self.nursery.start_ptr() as usize,
                 site,
@@ -4041,6 +4237,28 @@ impl MiniMarkGC {
     fn visit_referents(&self, obj_addr: usize, visitor: &mut dyn FnMut(GcRef)) {
         let type_id = unsafe { (*header_of(obj_addr)).type_id() };
         self.visit_referents_with_type_id(obj_addr, type_id, visitor);
+    }
+
+    /// `visit_referents`, but handing the visitor each slot's address instead
+    /// of its value, so a caller can report where a bad reference is stored.
+    fn visit_referent_slots(&self, obj_addr: usize, visitor: &mut dyn FnMut(*mut GcRef)) {
+        let type_id = unsafe { (*header_of(obj_addr)).type_id() };
+        self.validate_type_id(type_id, obj_addr, "visit_referent_slots");
+        let type_info = self.types.get(type_id);
+        if let Some(trace_fn) = type_info.custom_trace {
+            unsafe { trace_fn(obj_addr, visitor) };
+            return;
+        }
+        for &offset in &type_info.gc_ptr_offsets {
+            visitor((obj_addr + offset) as *mut GcRef);
+        }
+        if type_info.items_have_gc_ptrs && type_info.item_size > 0 {
+            let length = unsafe { *((obj_addr + type_info.length_offset) as *const usize) };
+            let items_start = obj_addr + type_info.size;
+            for i in 0..length {
+                visitor((items_start + i * type_info.item_size) as *mut GcRef);
+            }
+        }
     }
 
     /// `visit_referents` for a caller that already resolved the type id,

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3631,6 +3631,19 @@ impl MiniMarkGC {
             }
             if shadow_was_visited {
                 unsafe { (*(shadow_hdr as *mut GcHeader)).set_flag(flags::VISITED) };
+                // The copy above replaced every field of an object the marker
+                // has already accounted for as black, and the incoming values
+                // are this cycle's first sight of them: the shadow was reserved
+                // black before anything was copied into it (`allocate_shadow`),
+                // so nothing has ever traced these slots.  A black object is
+                // never pushed again by `grey_child`, so without this its
+                // children stay white and the sweep frees them while the object
+                // still points at them.  Re-greying a modified black object is
+                // what `_add_to_more_objects_to_trace` (incminimark.py:2357-2360)
+                // does for every other mid-cycle mutation.
+                if self.gc_state == GcState::Marking {
+                    self.incr_state.more_gray_stack.push(shadow_obj);
+                }
             }
             shadow_hdr
         } else {

--- a/majit/majit-gc/src/lib.rs
+++ b/majit/majit-gc/src/lib.rs
@@ -3185,6 +3185,17 @@ pub struct BhProbeViolation {
     pub barriered_ever: bool,
     pub traced_this_minor: bool,
     pub store_sites: u32,
+    /// The object the root walk reached this holder through, `None` when the
+    /// holder is itself a root. A block that carries no header of its own —
+    /// an items block, a mapdict storage — is only ever traced through its
+    /// owner, so the owner is what has to be on the remembered set and the
+    /// only place a missing barrier can live.
+    pub parent: Option<usize>,
+    pub parent_tid: Option<u32>,
+    pub parent_name: Option<&'static str>,
+    pub parent_remembered: bool,
+    pub parent_barriered_ever: bool,
+    pub parent_traced_this_minor: bool,
 }
 
 thread_local! {
@@ -3225,7 +3236,8 @@ pub fn bh_probe_violation_report(minor: usize) -> String {
                  forwarded={} | type: size={} item_size={} length_offset={} gc_ptr_offsets={:?} \
                  items_have_gc_ptrs={} custom_trace={} is_object={} | holder: track_young={} \
                  remembered={} barriered_ever={} traced_this_minor={} store_sites={:#b} \
-                 | value_type={} around={:x?} | layout={:?}",
+                 | value_type={} around={:x?} | layout={:?} \
+                 | parent={:#x} tid={} name={} remembered={} barriered_ever={} traced_this_minor={}",
                 e.minor,
                 if e.origin == BH_PROBE_ORIGIN_PROMOTED {
                     "promoted"
@@ -3256,6 +3268,12 @@ pub fn bh_probe_violation_report(minor: usize) -> String {
                 e.value_name.unwrap_or("?"),
                 e.neighbourhood,
                 bh_probe_layout(e.tid),
+                e.parent.unwrap_or(0),
+                e.parent_tid.map(|t| t as i64).unwrap_or(-1),
+                e.parent_name.unwrap_or("?"),
+                e.parent_remembered,
+                e.parent_barriered_ever,
+                e.parent_traced_this_minor,
             );
         }
     });

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1442,23 +1442,40 @@ pub(crate) unsafe fn set_name(
     // `space.get_and_call_function(w_meth, w_value, w_type, key)` — `w_value`
     // is the descriptor instance (bound as the receiver), and the call args
     // are `(owner, name)`: `__set_name__(self, owner, name)`.
+    //
+    // The hook is arbitrary Python, so the three operands cannot stay in Rust
+    // locals across it: the failure arm below names the descriptor, its type
+    // and the owner, and reading any of them from a pre-call address would
+    // build the note out of reclaimed memory.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let owner_slot = pyre_object::gc_roots::pin_roots(&[w_owner, w_name, w_value]);
+    let name_slot = owner_slot + 1;
+    let value_slot = owner_slot + 2;
     match unsafe {
         get_and_call_function(
             set_name_meth,
-            w_value,
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
             w_valtype.as_ptr(),
-            &[w_owner, w_name],
+            &[
+                pyre_object::gc_roots::shadow_stack_get(owner_slot),
+                pyre_object::gc_roots::shadow_stack_get(name_slot),
+            ],
         )
     } {
         Ok(_) => Ok(()),
         Err(mut e) => {
+            let w_name = pyre_object::gc_roots::shadow_stack_get(name_slot);
+            let w_owner = pyre_object::gc_roots::shadow_stack_get(owner_slot);
+            let w_value = pyre_object::gc_roots::shadow_stack_get(value_slot);
             let name_repr = if unsafe { is_str(w_name) } {
                 crate::display::format_wtf8_repr(unsafe { w_str_get_wtf8(w_name) })
             } else {
                 String::new()
             };
-            let val_type_name =
-                unsafe { pyre_object::w_type_get_name(w_valtype.as_ptr()) }.to_string();
+            let val_type_name = match crate::typedef::r#type(w_value) {
+                Some(t) => unsafe { pyre_object::w_type_get_name(t.as_ptr()) }.to_string(),
+                None => String::new(),
+            };
             let owner_name = unsafe { pyre_object::w_type_get_name(w_owner) }.to_string();
             add_internal_exception_note(
                 &mut e,

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5907,17 +5907,25 @@ fn type_descr_new_with_metaclass(
         // The pairs sit in a native Vec the collector does not walk and every
         // `__set_name__` runs Python, so a class body's list and dict values
         // move out from under the entries still to come.  Pin them and read
-        // each back at the call that consumes it.
+        // each back at the call that consumes it.  The owner goes in the same
+        // scope: a type never moves, so the local stays a good address, but
+        // nothing refers to a class this young — the classcell is optional and
+        // `weak_subclasses` is weak — so a major cycle under a hook would
+        // sweep it.  The scope runs to the end of the branch, which is what
+        // keeps the owner alive through `__init_subclass__` as well.
         let _entry_roots = pyre_object::gc_roots::push_roots();
-        let flat: Vec<PyObjectRef> = set_name_entries
-            .iter()
-            .flat_map(|&(key, value)| [key, value])
-            .collect();
-        let entry_base = pyre_object::gc_roots::pin_roots(&flat);
+        let mut livevars = Vec::with_capacity(set_name_entries.len() * 2 + 1);
+        livevars.push(w_type);
+        livevars.extend(
+            set_name_entries
+                .iter()
+                .flat_map(|&(key, value)| [key, value]),
+        );
+        let owner_slot = pyre_object::gc_roots::pin_roots(&livevars);
         for index in 0..set_name_entries.len() {
-            let key = pyre_object::gc_roots::shadow_stack_get(entry_base + index * 2);
+            let key = pyre_object::gc_roots::shadow_stack_get(owner_slot + 1 + index * 2);
             if unsafe { pyre_object::is_str(key) } {
-                let value = pyre_object::gc_roots::shadow_stack_get(entry_base + index * 2 + 1);
+                let value = pyre_object::gc_roots::shadow_stack_get(owner_slot + 2 + index * 2);
                 unsafe { crate::baseobjspace::set_name(w_type, key, value) }?;
             }
         }

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4274,6 +4274,22 @@ fn build_class_inner(
     });
     let current_kwds = || kwds_roots.as_ref().map(|(scope, slot)| scope.get(*slot));
 
+    // `bases` and `w_orig_bases` are raw copies taken before `__prepare__` and
+    // before the class body runs, and both execute Python.  A tuple does not
+    // move, but one with no heap edge is sweepable rather than merely immobile,
+    // so a copy held across those calls can name freed memory by the time
+    // `is_tuple` / `w_tuple_len` read it.  Publish both and read them back at
+    // each site that consumes them.
+    let bases_scope = pyre_object::gc_roots::push_roots();
+    let bases_slot = bases_scope.base();
+    bases_scope.pin_root(bases);
+    let orig_bases_slot = w_orig_bases.map(|w_orig_bases| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_orig_bases);
+        slot
+    });
+    let bases = || bases_scope.get(bases_slot);
+
     let w_code = unsafe { crate::getcode(body_fn) };
     let w_globals = unsafe { function_get_globals_obj(body_fn) };
     let closure = unsafe { function_get_closure(body_fn) };
@@ -4303,12 +4319,12 @@ fn build_class_inner(
                     call_with_kwargs_in_ctx(
                         take_last_exec_ctx(),
                         prepare,
-                        &[pyre_object::w_str_new(name), bases],
+                        &[pyre_object::w_str_new(name), bases()],
                         &prepare_kwds,
                     )?
                 } else {
                     clear_call_error();
-                    let r = crate::call_function(prepare, &[pyre_object::w_str_new(name), bases]);
+                    let r = crate::call_function(prepare, &[pyre_object::w_str_new(name), bases()]);
                     if r.is_null() {
                         // __prepare__ was found but raised during execution —
                         // propagate that exception rather than silently using
@@ -4598,16 +4614,22 @@ fn build_class_inner(
 
     // compiling.py:211-212 — when __mro_entries__ rewrote the bases, expose
     // the user-declared bases via __orig_bases__ in the class namespace.
-    if let Some(w_orig_bases) = w_orig_bases {
+    if let Some(orig_bases_slot) = orig_bases_slot {
         let class_ns = pyre_object::gc_roots::shadow_stack_get(class_ns_root);
         unsafe {
-            pyre_object::w_dict_setitem_str_no_proxy(class_ns, "__orig_bases__", w_orig_bases)
+            pyre_object::w_dict_setitem_str_no_proxy(
+                class_ns,
+                "__orig_bases__",
+                pyre_object::gc_roots::shadow_stack_get(orig_bases_slot),
+            )
         };
         if let Some(w_ns) = mapping_namespace {
+            // `w_str_new` allocates, so the value is read back after it.
+            let key = pyre_object::w_str_new("__orig_bases__");
             crate::baseobjspace::setitem(
                 w_ns,
-                pyre_object::w_str_new("__orig_bases__"),
-                w_orig_bases,
+                key,
+                pyre_object::gc_roots::shadow_stack_get(orig_bases_slot),
             )?;
         }
     }
@@ -4653,18 +4675,18 @@ fn build_class_inner(
     // Create W_TypeObject from the class namespace
     // PyPy: type.__new__(type, name, bases, dict_w) + compute_mro + ready()
     // PyPy: typeobject.py — if not bases_w: bases_w = [space.w_object]
-    let w_effective_bases = if bases.is_null()
-        || !unsafe { pyre_object::is_tuple(bases) }
-        || unsafe { pyre_object::w_tuple_len(bases) } == 0
+    let w_effective_bases = if bases().is_null()
+        || !unsafe { pyre_object::is_tuple(bases()) }
+        || unsafe { pyre_object::w_tuple_len(bases()) } == 0
     {
         let w_object = crate::typedef::w_object();
         if !w_object.is_null() {
             pyre_object::w_tuple_new(vec![w_object])
         } else {
-            bases
+            bases()
         }
     } else {
-        bases
+        bases()
     };
     // The C3 validations read `__bases__` off classic bases and
     // `create_all_slots` unpacks `__slots__`; both execute Python, so the
@@ -4765,12 +4787,12 @@ fn build_class_inner(
             // Only use kwargs path if there are actual extra kwargs
             let has_extra = unsafe { pyre_object::is_dict(kw) && pyre_object::w_dict_len(kw) > 0 };
             if has_extra {
-                call_metaclass_with_kwargs(w_metaclass, name_obj, bases, w_namespace_dict, kw)
+                call_metaclass_with_kwargs(w_metaclass, name_obj, bases(), w_namespace_dict, kw)
             } else {
-                crate::call_function(w_metaclass, &[name_obj, bases, w_namespace_dict])
+                crate::call_function(w_metaclass, &[name_obj, bases(), w_namespace_dict])
             }
         } else {
-            crate::call_function(w_metaclass, &[name_obj, bases, w_namespace_dict])
+            crate::call_function(w_metaclass, &[name_obj, bases(), w_namespace_dict])
         };
         // If the metaclass call raised, propagate the original error rather
         // than silently producing a NULL class object.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -5157,10 +5157,24 @@ pub unsafe fn instance_walk_boxed_storage(obj: PyObjectRef, f: &mut dyn FnMut(*m
         if (*storage_slot).is_null() {
             return;
         }
-        let storage = *storage_slot;
-        if pyre_object::gc_hook::try_gc_owns_object(storage as *mut u8) {
+        if pyre_object::gc_hook::try_gc_owns_object(*storage_slot as *mut u8) {
             f(storage_slot as *mut PyObjectRef);
         }
+        // Both forms are needed, unlike in `list_object_custom_trace`, which
+        // picks one: handing over the field slot only forwards the block
+        // pointer, and the block is `alloc_stable`, so a minor never descends
+        // into it to reach the values.  Walking the items here is what keeps
+        // an attribute value alive; a list's items block can be young, which
+        // is what makes the either/or correct there and wrong here.
+        //
+        // The block's own tid registers `items_have_gc_ptrs`, which is not a
+        // reason to drop this walk: a declared walker is not a guarantee that
+        // the walk runs.  That flag describes what happens *when* the block is
+        // traversed, and a minor does not traverse an old-gen block at all.
+        //
+        // Read the block back out of the slot, since the call above is free to
+        // have forwarded it.
+        let storage = *storage_slot;
         // The storage block is exact-size (capacity == map.storage_needed()).
         let len = pyre_object::object_array::items_block_capacity(storage);
         let base = pyre_object::object_array::items_block_items_base(storage);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -4854,6 +4854,18 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     if pyre_interpreter::eval::validate_check_exc_match_class(match_type).is_err() {
         return Ok(None);
     }
+    // The answer depends on `space.type(exc)`, and `typedef::type` reaches an
+    // exception's class through the kind registry whenever the `w_class` slot
+    // still holds the generic stub. The guard below can only pin a class the
+    // slot itself holds, so decline the registry answer rather than emit a
+    // guard that pins something else.
+    let Some(exc_class) = pyre_interpreter::typedef::r#type(exc) else {
+        return Ok(None);
+    };
+    let exc_class = exc_class.as_ptr();
+    if !std::ptr::eq(unsafe { (*exc).w_class }, exc_class) {
+        return Ok(None);
+    }
     // `eval::check_exc_match_against` = `exception_match(type(exc), match)`
     // (eval.rs), walking the exception class MRO and accepting a tuple of
     // classes. Inlined here.
@@ -4870,9 +4882,12 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
     // elements are what the match actually reads and what a rebinding would
     // change, so guarding them is both sound and stable across the
     // re-allocation.
+    //
+    // A known class does not stand in for the pin: every class object shares
+    // the one `type` layout, so `is_class_known` on the clause operand says
+    // only that it is a class and leaves which class free to change.
     if !match_op.is_constant()
         && !walker_guard_exc_match_tuple_items(ctx, op_pc, match_op, match_type)?
-        && !ctx.trace_ctx.heap_cache().is_class_known(match_op)
     {
         let expected = ctx.trace_ctx.const_ref(match_type as i64);
         ctx.trace_ctx
@@ -4882,19 +4897,39 @@ pub(crate) fn try_walker_fold_check_exc_match<Sym: WalkSym>(
             .heap_cache_mut()
             .replace_box(match_op, expected);
     }
-    // Defensive `GuardClass` on the exception when its class is not yet
-    // known (the construct fold marks it known, so this is a no-op for a
-    // virtual inline-built exc; it pins the class for any other exc that
-    // reaches this fold).
-    if !exc_op.is_constant() && !ctx.trace_ctx.heap_cache().is_class_known(exc_op) {
-        let exc_class_ptr = unsafe { (*(exc as *const pyre_object::pyobject::PyObject)).ob_type };
-        let cls_const = ctx.trace_ctx.const_int(exc_class_ptr as usize as i64);
-        ctx.trace_ctx
-            .record_guard(OpCode::GuardClass, &[exc_op, cls_const], 0);
-        walker_capture_snapshot_for_last_guard(ctx, op_pc)?;
+    // Pin the exception's Python-level class, the value the match walked the
+    // MRO of. `GuardClass` alone cannot do it: every exception of one
+    // `ExcKind` carries the same `ob_type`, so `class A(Exception)` and
+    // `class B(Exception)` share a layout and one's recorded answer would
+    // replay for the other. The layout guard still comes first — it is what
+    // makes the `w_class` read below name the field it was recorded against.
+    if !exc_op.is_constant() {
+        if !ctx.trace_ctx.heap_cache().is_class_known(exc_op) {
+            let exc_layout =
+                unsafe { (*(exc as *const pyre_object::pyobject::PyObject)).ob_type } as i64;
+            let layout_const = ctx.trace_ctx.const_int(exc_layout);
+            walker_emit_fold_guard_with_snapshot(
+                ctx,
+                op_pc,
+                OpCode::GuardClass,
+                &[exc_op, layout_const],
+            )?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(exc_op, exc_layout);
+        }
+        let w_class_op =
+            walker_record_getfield_gc_r_uncached(ctx, exc_op, crate::descr::w_class_descr());
+        let expected = ctx.trace_ctx.const_ref(exc_class as i64);
+        walker_emit_fold_guard_with_snapshot(
+            ctx,
+            op_pc,
+            OpCode::GuardValue,
+            &[w_class_op, expected],
+        )?;
         ctx.trace_ctx
             .heap_cache_mut()
-            .class_now_known(exc_op, exc_class_ptr as usize as i64);
+            .replace_box(w_class_op, expected);
     }
 
     // The match is a constant at trace time: emit the immortal bool


### PR DESCRIPTION
Eight fixes. Seven share one theme: a value the collector may move must be reachable, traced, and read back from wherever the collector actually maintains it. The eighth is a tracer fold that pinned the wrong header word.

## Interpreter rooting

- **`type`** — root the `__set_name__` owner and the failure note's operands.
- **`call`** — root `build_class`'s bases tuple across `__prepare__` and the class body, both of which run arbitrary Python and can collect.
- **`mapdict`** — `instance_walk_boxed_storage` handed the visitor the `storage` field slot and then walked the block, but had already computed `len`/`base` from the pre-visit value; the visitor may forward it. Read the field back first.

## Collector

- **`majit-gc`** — restrict the post-minor probe to reachable holders and declared slots, so it stops reporting on words it was never entitled to read.
- **`gc`** — `allocate_shadow` sets `VISITED` on a shadow it reserves during `Marking`, so `copy_nursery_object` promotes into an object the marker already counted as black. The copy replaces every field with values nothing has traced and `grey_child` never pushes a black object again, so the children stayed white and the sweep freed them under a live parent. Push the promoted object onto `more_gray_stack` while marking — what `_add_to_more_objects_to_trace` (`incminimark.py:2357-2360`) does for every other mid-cycle mutation of a black object.

## cranelift

Both were found from a single `test.test_unittest` crash (`GC BUG: invalid type_id ... site=minor_custom_trace_target, holder_type_id=Some(37)`).

- **CALL_ASSEMBLER fail-arg spill.** The `CallAssembler*` arm stored the paired guard's descr into `jf_force_descr` but never wrote that guard's fail args into the slots its resume data indexes — which `CallMayForce*` and `CallReleaseGil*` do (`regalloc.py:812-820 before_call`). A callee that forced the caller's frame decoded `TAGBOX(n)` against slots still holding the compiled loop's entry inputs. The spill the two existing arms shared is extracted into `spill_guard_fail_args` and called from all three, and `paired_guard_not_forced` (was `paired_may_force`) now covers the four `CallAssembler*` opcodes so the per-call gcmap names those slots.

- **Demoted LABEL arg on the fall-through edge.** `compute_loop_phi_keep` can demote an arg at one LABEL while a later LABEL keeps it as a block parameter. `demoted_failarg_slots` is global, so from the first demotion on `spill_ref_roots` and `reload_ref_roots` both skip that var — its ref-root slot is the copy the collector forwards and its SSA variable is left unmaintained. The local JUMP into such a LABEL already reads the slot through `resolve_local_jump_arg`; the fall-through used `resolve_opref`, so it passed the address the value held before the last collection, and the header's `sync_ref_root_var` stored that address back **over** the forwarded one. Every guard exit below then published a corpse as a `Ref` fail arg, which the resume wrote into `PyFrame.locals_cells_stack_w`.

## The `test.test_pickle` red on main

This branch previously reported `test.test_pickle` as red on main and left it alone. It is fixed here.

Two errors, both `except _Stop as stopinst: return stopinst.value` at `pickle.py:1322` raising `AttributeError: 'CustomError' object has no attribute 'value'` — an `except _Stop` clause matching an exception that is not a `_Stop`. JIT-only, identical on both backends.

`try_walker_fold_check_exc_match` folds `CHECK_EXC_MATCH` to a constant at trace time and pinned its inputs with `GuardClass(exc, ob_type)`. But the folded answer comes from `check_exc_match_against` → `typedef::type`, which reads **`w_class`**. `w_exception_new_empty_impl` stamps `ob_type = exc_kind_to_pytype(kind)` and `w_class = lookup_exc_class_for_kind(kind)`, and `exc_new_wrapper` overwrites only `w_class` with the class that was called — so every exception of one `ExcKind` shares one `ob_type`. `_Stop`, `CustomError` and `PickleError` are all direct or indirect `Exception` subclasses and therefore one layout, which that guard cannot separate: the `matched = True` recorded for `_Stop` replayed for a `CustomError`.

The fix pins the Python-level class the same way the LOAD_METHOD fold already does — `getfield_gc_r(w_class)` + `GuardValue`, behind the layout guard that makes the field read name what it was recorded against — and declines the fold when `typedef::type` answered from the `ExcKind` registry rather than from the slot, which no single field read reproduces. It also drops the `is_class_known` skip on the clause operand: every class object shares the one `type` layout, so that flag never says *which* class the operand holds.

## Verification

| gate | result |
|---|---|
| `test.test_pickle`, dynasm | `FAILED (errors=2, skipped=68)` → `OK (skipped=68)` |
| CPython suite, dynasm | 208 PASS / 0 FAIL, no regressions |
| CPython suite, cranelift | 208 PASS / 0 FAIL, no regressions |
| `cargo test --all --features dynasm` | 140 suites, 0 failures |
| `cargo test` cranelift subset (the CI leg's package list) | 79 suites, 0 failures |
| `cargo test -p majit-backend-wasm --test codegen_test -- --ignored` | 6/6 |
| `check.py --synthetic-only` | dynasm 430/430, cranelift 430/430 |
| `check.py --no-synthetic` (bench corpus) | dynasm 10/10, cranelift 10/10 |
| `pyre/check.py` (full, incl. wasm) | all passed, measured before the exc-match commit |

`test.test_unittest` was `PASS -> CRASH` on cranelift before the LABEL commit and is green after.

The exception-fold commit adds one `getfield_gc_r` + `GuardValue` per folded `CHECK_EXC_MATCH`. The whole synthetic corpus passes on both backends — 430/430 each — with no jit-stats snapshot diff and no ratio row moving off its gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZKxAmCTcGFbJssJrbPSfV
