### PR TITLE
gc: root the movable locals native code holds across allocations

### DIFF
--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -1122,14 +1122,14 @@ impl Arguments {
             input_argcount += take;
         }
 
-        // `w_kw_defs`, the `**kwargs` dict, the keyword values and the words
-        // already copied into `scope_w` are all read after the allocations
-        // below — the vararg tuple, the dict itself, the keyword collection,
-        // the kwonly-default lookups — and a `list` or `dict` among them moves
-        // under any of those.  A by-value parameter copy is no more a slot the
-        // collector updates than the caller's scope buffer or `Arguments`' own
-        // vectors are, so each word is pinned here, ahead of the first
-        // allocation, and read back where it is used.
+        // `w_kw_defs`, the `**kwargs` dict, the keyword values, the positional
+        // defaults and the words already copied into `scope_w` are all read
+        // after the allocations below — the vararg tuple, the dict itself, the
+        // keyword collection, the kwonly-default lookups — and a `list` or
+        // `dict` among them moves under any of those.  A by-value parameter
+        // copy is no more a slot the collector updates than the caller's scope
+        // buffer or `Arguments`' own vectors are, so each word is pinned here,
+        // ahead of the first allocation, and read back where it is used.
         let _roots = pyre_object::gc_roots::push_roots();
         let kw_defs_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(w_kw_defs);
@@ -1145,6 +1145,11 @@ impl Arguments {
                 pyre_object::gc_roots::pin_root(w_name);
             }
         }
+        // The defaults arrive as a caller-owned slice — `Function`'s `defs_w`
+        // reaches here through a borrow, and a gateway builds its own array —
+        // so the collector rewrites neither, while the run is read out one
+        // entry at a time in the defaults loop far below.
+        let defaults_base = pyre_object::gc_roots::pin_roots(defaults_w.unwrap_or_default());
         // The scope buffer keeps its own run of slots: `w_firstarg` and the
         // positional copy above are in it already, and every later store goes
         // through `store` so the refresh before `Ok(())` reads the whole scope
@@ -1321,7 +1326,9 @@ impl Arguments {
                 }
                 let defnum = (i as isize) - def_first;
                 if defnum >= 0 {
-                    store(scope_w, i, defaults_w.unwrap()[defnum as usize]);
+                    let w_default =
+                        pyre_object::gc_roots::shadow_stack_get(defaults_base + defnum as usize);
+                    store(scope_w, i, w_default);
                 } else if let Some(list) = missing_positional.as_mut() {
                     list.push(signature.argnames[i].to_string());
                 } else {

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -377,8 +377,21 @@ pub fn combine_starargs_wrapped(
     w_stararg: PyObjectRef,
     w_function: PyObjectRef,
 ) -> Result<(), crate::PyError> {
-    match crate::baseobjspace::fixedview(w_stararg, -1) {
+    // `fixedview` iterates the star argument, which runs Python — a generator
+    // body or a subtype `__iter__`.  The words the caller already put in
+    // `arguments_w` and these by-value parameters are native copies no root
+    // walker updates, so they are published before the unpack and read back
+    // after it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(&arguments_w[..]);
+    let star_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_stararg);
+    pyre_object::gc_roots::pin_root(w_function);
+    let w_stararg = || pyre_object::gc_roots::shadow_stack_get(star_slot);
+    let w_function = || pyre_object::gc_roots::shadow_stack_get(star_slot + 1);
+    match crate::baseobjspace::fixedview(w_stararg(), -1) {
         Ok(args_w) => {
+            pyre_object::gc_roots::shadow_stack_copy_range(args_base, &mut arguments_w[..]);
             // argument.py:104 — `self.arguments_w = self.arguments_w + args_w`.
             arguments_w.extend(args_w);
             Ok(())
@@ -388,11 +401,11 @@ pub fn combine_starargs_wrapped(
             // `"argument after * must be an iterable, not %T"`; other
             // errors propagate.
             if e.kind == crate::PyErrorKind::TypeError
-                && !crate::baseobjspace::is_iterable(w_stararg)
+                && !crate::baseobjspace::is_iterable(w_stararg())
             {
-                let tp = type_name_of(w_stararg);
+                let tp = type_name_of(w_stararg());
                 Err(raise_type_error(
-                    w_function,
+                    w_function(),
                     format!("argument after * must be an iterable, not {tp}"),
                 ))
             } else {
@@ -463,6 +476,16 @@ pub fn combine_starstarargs_wrapped(
     pyre_object::gc_roots::pin_root(w_function);
     let w_starstararg = || pyre_object::gc_roots::shadow_stack_get(root_base);
     let w_function = || pyre_object::gc_roots::shadow_stack_get(root_base + 1);
+    // The pairs the caller already accepted are in the same position: native
+    // vectors that this merge both reads (the duplicate check) and outlives.
+    // They are published here and read back before each of those uses; the
+    // merge only appends, so the published prefix keeps its indices.
+    let names_base = pyre_object::gc_roots::pin_roots(&keyword_names_out[..]);
+    let values_base = pyre_object::gc_roots::pin_roots(&keywords_out[..]);
+    let refresh_out = |names: &mut Vec<PyObjectRef>, values: &mut Vec<PyObjectRef>| {
+        pyre_object::gc_roots::shadow_stack_copy_range(names_base, &mut names[..]);
+        pyre_object::gc_roots::shadow_stack_copy_range(values_base, &mut values[..]);
+    };
     // argument.py:109 — fast path via view_as_kwargs.  Both halves of
     // the tuple are `Option`; PyPy's base default is `(None, None)`
     // while the kwargsdict-aware override returns `(Some, Some)`.
@@ -470,6 +493,7 @@ pub fn combine_starstarargs_wrapped(
     if let Some(names) = fast_names {
         let values = fast_values
             .expect("baseobjspace.py:1159 view_as_kwargs returns matching Some/Some or None/None");
+        refresh_out(keyword_names_out, keywords_out);
         // argument.py:111-119 — merge with optional duplicate check.
         if !keyword_names_out.is_empty() {
             check_not_duplicate_kwargs(keyword_names_out, &names, &values, w_function())?;
@@ -578,6 +602,7 @@ pub fn combine_starstarargs_wrapped(
     let mut keywords_w: Vec<PyObjectRef> = vec![pyre_object::PY_NULL; n];
     // argument.py:142-144 — slow-path body fills name/value buffers,
     // checking for duplicates against keyword_names_out (existing).
+    refresh_out(keyword_names_out, keywords_out);
     let existing: Option<&[PyObjectRef]> = if keyword_names_out.is_empty() {
         None
     } else {
@@ -593,6 +618,7 @@ pub fn combine_starstarargs_wrapped(
         w_function(),
     )?;
     // argument.py:145-150 — merge into the running output buffers.
+    refresh_out(keyword_names_out, keywords_out);
     keyword_names_out.extend(keyword_names_w);
     keywords_out.extend(keywords_w);
     Ok(())
@@ -761,8 +787,17 @@ impl Arguments {
         w_starstararg: Option<PyObjectRef>,
         w_function: PyObjectRef,
     ) -> Result<(), crate::PyError> {
+        // Unpacking `*` runs Python, so the mapping the `**` arm has yet to
+        // read, the callable and the positional words the first arm leaves in
+        // `arguments_w` are published here and read back where the second arm
+        // uses them; none of the three sits in storage a root walker updates.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let root_base = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_starstararg.unwrap_or(pyre_object::PY_NULL));
+        pyre_object::gc_roots::pin_root(w_function);
         // argument.py:87-88 — `if w_stararg is not None: self._combine_starargs_wrapped(...)`.
         if let Some(w_star) = w_stararg {
+            let w_function = pyre_object::gc_roots::shadow_stack_get(root_base + 1);
             combine_starargs_wrapped(&mut self.arguments_w, w_star, w_function)?;
         }
         // argument.py:89-90 — `if w_starstararg is not None: self._combine_starstarargs_wrapped(...)`.
@@ -773,10 +808,17 @@ impl Arguments {
         // the helper runs whether or not it produced any keys, mirroring
         // PyPy's unconditional `self.keyword_names_w = ...` at lines
         // 145-150.
-        if let Some(w_starstar) = w_starstararg {
+        if w_starstararg.is_some() {
+            let args_base = pyre_object::gc_roots::pin_roots(&self.arguments_w[..]);
             let mut names = self.keyword_names_w.take().unwrap_or_default();
             let mut values = self.keywords_w.take().unwrap_or_default();
-            combine_starstarargs_wrapped(&mut names, &mut values, w_starstar, w_function)?;
+            combine_starstarargs_wrapped(
+                &mut names,
+                &mut values,
+                pyre_object::gc_roots::shadow_stack_get(root_base),
+                pyre_object::gc_roots::shadow_stack_get(root_base + 1),
+            )?;
+            pyre_object::gc_roots::shadow_stack_copy_range(args_base, &mut self.arguments_w[..]);
             self.keyword_names_w = Some(names);
             self.keywords_w = Some(values);
         }
@@ -1080,6 +1122,39 @@ impl Arguments {
             input_argcount += take;
         }
 
+        // `w_kw_defs`, the `**kwargs` dict, the keyword values and the words
+        // already copied into `scope_w` are all read after the allocations
+        // below — the vararg tuple, the dict itself, the keyword collection,
+        // the kwonly-default lookups — and a `list` or `dict` among them moves
+        // under any of those.  A by-value parameter copy is no more a slot the
+        // collector updates than the caller's scope buffer or `Arguments`' own
+        // vectors are, so each word is pinned here, ahead of the first
+        // allocation, and read back where it is used.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let kw_defs_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_kw_defs);
+        let keywords_base = pyre_object::gc_roots::shadow_stack_len();
+        if let Some(values) = self.keywords_w.as_ref() {
+            for &w_value in values {
+                pyre_object::gc_roots::pin_root(w_value);
+            }
+        }
+        let names_base = pyre_object::gc_roots::shadow_stack_len();
+        if let Some(names) = self.keyword_names_w.as_ref() {
+            for &w_name in names {
+                pyre_object::gc_roots::pin_root(w_name);
+            }
+        }
+        // The scope buffer keeps its own run of slots: `w_firstarg` and the
+        // positional copy above are in it already, and every later store goes
+        // through `store` so the refresh before `Ok(())` reads the whole scope
+        // back at its current addresses.
+        let scope_base = pyre_object::gc_roots::pin_roots(&scope_w[..]);
+        let store = |scope_w: &mut [PyObjectRef], index: usize, w_value: PyObjectRef| {
+            scope_w[index] = w_value;
+            pyre_object::gc_roots::shadow_stack_set(scope_base + index, w_value);
+        };
+
         // argument.py:222-236 — *vararg collection.
         if signature.has_vararg() {
             let args_left = co_argcount - upfront;
@@ -1095,20 +1170,23 @@ impl Arguments {
                 Vec::new()
             };
             let loc = co_argcount + co_kwonlyargcount;
-            scope_w[loc] = pyre_object::w_tuple_new(starargs_w);
+            let w_stararg = pyre_object::w_tuple_new(starargs_w);
+            store(scope_w, loc, w_stararg);
         } else if avail > co_argcount {
             too_many_args = true;
         }
 
         // argument.py:238-242 — **kwargs dict allocation.
+        let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
+        let kwarg_loc = co_argcount + co_kwonlyargcount + (signature.has_vararg() as usize);
         let mut w_kwds: PyObjectRef = pyre_object::PY_NULL;
         if signature.has_kwarg() {
             // PyPy: `space.newdict(kwargs=True)` produces a kwargs-strategy
             // dict; pyre's W_DictObject lacks the strategy variant so a
             // plain dict is used (TODO: add kwargs strategy).
-            w_kwds = pyre_object::dictmultiobject::w_dict_new();
-            let kwarg_loc = co_argcount + co_kwonlyargcount + (signature.has_vararg() as usize);
-            scope_w[kwarg_loc] = w_kwds;
+            pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
+            w_kwds = pyre_object::gc_roots::shadow_stack_get(kwds_slot);
+            store(scope_w, kwarg_loc, w_kwds);
         }
 
         // argument.py:244-271 — keyword arg matching.
@@ -1131,10 +1209,16 @@ impl Arguments {
             if num_remainingkwds > 0 {
                 if !w_kwds.is_null() {
                     // argument.py:266-268 — collect overflow into **kwarg.
+                    // The helper pins whatever slice it is handed, so it takes
+                    // the published words rather than the ones the vector has
+                    // been holding since the two allocations above.
+                    let values_w: Vec<PyObjectRef> = (0..keywords_w.unwrap().len())
+                        .map(|i| pyre_object::gc_roots::shadow_stack_get(keywords_base + i))
+                        .collect();
                     collect_keyword_args(
                         keyword_names_w.unwrap(),
-                        keywords_w.unwrap(),
-                        w_kwds,
+                        &values_w,
+                        pyre_object::gc_roots::shadow_stack_get(kwds_slot),
                         &mapping,
                     )?;
                 } else {
@@ -1191,7 +1275,10 @@ impl Arguments {
                     let kwds_index = mapping[j];
                     j += 1;
                     if kwds_index >= 0 {
-                        scope_w[i] = keywords_w.unwrap()[kwds_index as usize];
+                        let w_value = pyre_object::gc_roots::shadow_stack_get(
+                            keywords_base + kwds_index as usize,
+                        );
+                        store(scope_w, i, w_value);
                     }
                 }
             }
@@ -1234,7 +1321,7 @@ impl Arguments {
                 }
                 let defnum = (i as isize) - def_first;
                 if defnum >= 0 {
-                    scope_w[i] = defaults_w.unwrap()[defnum as usize];
+                    store(scope_w, i, defaults_w.unwrap()[defnum as usize]);
                 } else if let Some(list) = missing_positional.as_mut() {
                     list.push(signature.argnames[i].to_string());
                 } else {
@@ -1260,8 +1347,11 @@ impl Arguments {
                 // dict with a subclass `__getitem__` raising e.g.
                 // `RuntimeError` surfaces here instead of being
                 // mis-classified as "default missing".
-                match crate::baseobjspace::finditem_str(w_kw_defs, name)? {
-                    Some(w_def) => scope_w[i] = w_def,
+                match crate::baseobjspace::finditem_str(
+                    pyre_object::gc_roots::shadow_stack_get(kw_defs_slot),
+                    name,
+                )? {
+                    Some(w_def) => store(scope_w, i, w_def),
                     None => {
                         if let Some(list) = missing_kwonly.as_mut() {
                             list.push(name.to_string());
@@ -1286,6 +1376,12 @@ impl Arguments {
             }
         }
 
+        // The collection points above have all run by now, so the buffer takes
+        // the scope's current addresses instead of keeping the ones it was
+        // filled with.  The early `return Err(...)` paths skip this refresh and
+        // leave pre-move words in the buffer; that is sound only because every
+        // caller drops `scope_w` unread on an error.
+        pyre_object::gc_roots::shadow_stack_copy_range(scope_base, scope_w);
         Ok(())
     }
 
@@ -1436,15 +1532,38 @@ impl Arguments {
     /// ```
     pub fn topacked(&self) -> Result<(PyObjectRef, PyObjectRef), crate::PyError> {
         let w_args = pyre_object::w_tuple_new(self.arguments_w.clone());
-        let w_kwds = pyre_object::dictmultiobject::w_dict_new();
+        // Each `setitem` below hashes a key, can grow the dictionary's storage
+        // and can run a subclass `__setitem__`, so every turn is a collection
+        // point.  The dictionary moves under one, and the names and values sit
+        // in native vectors no root walker updates, so the whole set is
+        // published before the first turn and read back on the turn that uses
+        // it.  A tuple is allocated stable, so `w_args` only needs the one pin
+        // that keeps it alive across the same run.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_args);
+        let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(pyre_object::dictmultiobject::w_dict_new());
         if let (Some(names), Some(values)) =
             (self.keyword_names_w.as_ref(), self.keywords_w.as_ref())
         {
+            // `zip` stops at the shorter side; the pinned pairs match it.
+            let npairs = names.len().min(values.len());
+            let pairs_base = pyre_object::gc_roots::shadow_stack_len();
             for (w_key, w_value) in names.iter().zip(values.iter()) {
-                crate::baseobjspace::setitem(w_kwds, *w_key, *w_value)?;
+                pyre_object::gc_roots::pin_root(*w_key);
+                pyre_object::gc_roots::pin_root(*w_value);
+            }
+            for i in 0..npairs {
+                let w_key = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i);
+                let w_value = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i + 1);
+                crate::baseobjspace::setitem(
+                    pyre_object::gc_roots::shadow_stack_get(kwds_slot),
+                    w_key,
+                    w_value,
+                )?;
             }
         }
-        Ok((w_args, w_kwds))
+        Ok((w_args, pyre_object::gc_roots::shadow_stack_get(kwds_slot)))
     }
 }
 
@@ -1595,12 +1714,34 @@ pub fn collect_keyword_args(
     w_kwds: PyObjectRef,
     kwds_mapping: &[isize],
 ) -> Result<(), crate::PyError> {
+    // Every `setitem` is a collection point, so the dictionary and the pairs it
+    // forwards are published before the first one and read back at each turn.
+    // A name the mapping claimed keeps an empty pair of slots so the two loops
+    // agree on the index.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let kwds_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_kwds);
+    let pairs_base = pyre_object::gc_roots::shadow_stack_len();
+    for i in 0..keyword_names_w.len() {
+        if mapping_contains(kwds_mapping, i as isize) {
+            pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+            pyre_object::gc_roots::pin_root(pyre_object::PY_NULL);
+            continue;
+        }
+        pyre_object::gc_roots::pin_root(keyword_names_w[i]);
+        pyre_object::gc_roots::pin_root(keywords_w[i]);
+    }
     for i in 0..keyword_names_w.len() {
         if mapping_contains(kwds_mapping, i as isize) {
             continue;
         }
-        let w_key = keyword_names_w[i];
-        crate::baseobjspace::setitem(w_kwds, w_key, keywords_w[i])?;
+        let w_key = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i);
+        let w_value = pyre_object::gc_roots::shadow_stack_get(pairs_base + 2 * i + 1);
+        crate::baseobjspace::setitem(
+            pyre_object::gc_roots::shadow_stack_get(kwds_slot),
+            w_key,
+            w_value,
+        )?;
     }
     Ok(())
 }

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -15496,6 +15496,11 @@ pub fn next(obj: PyObjectRef) -> PyResult {
             let result_len = pyre_object::w_list_len(lst);
             let mut result_slots = Vec::with_capacity(result_len);
             for index in 0..result_len {
+                // Reading an element out of an unboxed list boxes it, and that
+                // allocation can relocate the list itself, so the owner supplies
+                // it again on every step instead of a word carried across.
+                let w_self = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                let lst = (*(w_self as *const pyre_object::interp_itertools::W_Product)).lst;
                 let item = pyre_object::w_list_getitem(lst, index as i64)
                     .expect("product result in range");
                 pyre_object::gc_roots::pin_root(item);

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -10321,21 +10321,27 @@ fn builtin_getattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     // was supplied AND the error is an AttributeError; other errors (and the
     // no-default case) propagate.  With a default the error never surfaces,
     // so that arm runs suppressed (`_PyObject_LookupAttr`).
-    let lookup = if args.len() > 2 {
-        crate::baseobjspace::lookup_attr(obj, args[1])
-    } else {
-        crate::baseobjspace::getattr(obj, args[1])
-    };
-    match lookup {
-        Ok(val) => Ok(val),
-        Err(e) => {
-            if args.len() > 2 && e.kind == crate::PyErrorKind::AttributeError {
-                Ok(args[2]) // default value
-            } else {
-                Err(e) // propagate
+    if args.len() > 2 {
+        // `args` is a native slice the gateway copied out of its own root
+        // slots: the pin keeps the default alive, but nothing rewrites this
+        // copy, and `lookup_attr` runs Python (`__getattr__`,
+        // `__getattribute__`, a property getter).  A list or dict default
+        // moves, so returning `args[2]` after the lookup hands back a pre-move
+        // address.  Scope the slot to the three-argument form: `pin_root` and
+        // `RootScope::get` are `dont_look_inside`, and the two-argument shape
+        // is the one the tracer folds.
+        let default_root = pyre_object::gc_roots::push_roots();
+        let default_base = default_root.base();
+        default_root.pin_root(args[2]);
+        return match crate::baseobjspace::lookup_attr(obj, args[1]) {
+            Ok(val) => Ok(val),
+            Err(e) if e.kind == crate::PyErrorKind::AttributeError => {
+                Ok(default_root.get(default_base))
             }
-        }
+            Err(e) => Err(e),
+        };
     }
+    crate::baseobjspace::getattr(obj, args[1])
 }
 
 /// `pypy/module/__builtin__/operation.py:191-196 setattr`:
@@ -10875,13 +10881,23 @@ fn builtin_next(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    match crate::baseobjspace::next(args[0]) {
-        Ok(v) => Ok(v),
-        Err(e) if e.kind == crate::PyErrorKind::StopIteration && args.len() > 1 => {
-            Ok(args[1]) // default value
-        }
-        Err(e) => Err(e),
+    if args.len() > 1 {
+        // The iterator body runs Python between the gateway's pin and this
+        // return, and `args` is a native copy nothing rewrites when a list or
+        // dict default is moved -- see `builtin_getattr`.  Keep the
+        // one-argument form free of the slot.
+        let default_root = pyre_object::gc_roots::push_roots();
+        let default_base = default_root.base();
+        default_root.pin_root(args[1]);
+        return match crate::baseobjspace::next(args[0]) {
+            Ok(v) => Ok(v),
+            Err(e) if e.kind == crate::PyErrorKind::StopIteration => {
+                Ok(default_root.get(default_base))
+            }
+            Err(e) => Err(e),
+        };
     }
+    crate::baseobjspace::next(args[0])
 }
 
 /// `callable(obj)` — PyPy: baseobjspace.py callable

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -2572,22 +2572,26 @@ fn memoryview_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
 /// native `W_MemoryView` fields rather than per-instance attribute slots.
 pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
     type MvFn = fn(&[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>;
+    // The producer's own root slot tracks its copy of the namespace, not this
+    // by-value parameter, so the word is pinned again here for the run of
+    // allocating insertions below.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
     // `__new__` is a `BuiltinFunction`-typed staticmethod descriptor like
     // every other native type's `tp_new` (typedef::make_new_descr), so it
     // does not bind the class and pickle's `isinstance(new, type(int.__new__))`
     // check matches.
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__doc__",
-            w_str_new("Create a new memoryview object which references the given object."),
-        );
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__new__",
-            crate::typedef::make_new_descr(memoryview_descr_new),
-        )
-    };
+    type_ns_store(
+        ns_slot,
+        "__doc__",
+        w_str_new("Create a new memoryview object which references the given object."),
+    );
+    type_ns_store(
+        ns_slot,
+        "__new__",
+        crate::typedef::make_new_descr(memoryview_descr_new),
+    );
     for (name, f, arity) in [
         ("__getitem__", memoryview_getitem as MvFn, 2u16),
         ("__setitem__", memoryview_setitem, 3),
@@ -2608,53 +2612,56 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         ("__hash__", memoryview_hash, 1),
         ("_pypy_raw_address", memoryview_raw_address, 1),
     ] {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
-                name,
-                make_builtin_function_with_arity(name, f, arity),
-            )
-        };
+        type_ns_store(
+            ns_slot,
+            name,
+            make_builtin_function_with_arity(name, f, arity),
+        );
     }
+    // Nothing references the two classmethod carriers until they are wrapped
+    // and stored, several allocations later.  A function does not move, so one
+    // pin apiece keeps them from being swept and the words stay usable.
     let class_getitem = make_builtin_function(
         "__class_getitem__",
         crate::_pypy_generic_alias::generic_alias_class_getitem,
     );
+    pyre_object::gc_roots::pin_root(class_getitem);
     let from_flags = make_builtin_function_with_arity("_from_flags", memoryview_from_flags, 3);
+    pyre_object::gc_roots::pin_root(from_flags);
     unsafe {
         crate::function::fset_func_text_signature(class_getitem, w_str_new("($type, object, /)"));
         crate::function::fset_func_text_signature(
             from_flags,
             w_str_new("($type, /, object, flags)"),
         );
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__buffer__",
-            make_builtin_function_with_arity(
-                "__buffer__",
-                |args| {
-                    let flags = crate::baseobjspace::c_int_w(args[1])?;
-                    w_memoryview_new_native_with_flags(args[0], flags)
-                },
-                2,
-            ),
-        );
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__class_getitem__",
-            pyre_object::function::w_classmethod_new(class_getitem),
-        );
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "_from_flags",
-            pyre_object::function::w_classmethod_new(from_flags),
-        );
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "index",
-            make_builtin_function("index", memoryview_index),
-        );
     }
+    type_ns_store(
+        ns_slot,
+        "__buffer__",
+        make_builtin_function_with_arity(
+            "__buffer__",
+            |args| {
+                let flags = crate::baseobjspace::c_int_w(args[1])?;
+                w_memoryview_new_native_with_flags(args[0], flags)
+            },
+            2,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "__class_getitem__",
+        pyre_object::function::w_classmethod_new(class_getitem),
+    );
+    type_ns_store(
+        ns_slot,
+        "_from_flags",
+        pyre_object::function::w_classmethod_new(from_flags),
+    );
+    type_ns_store(
+        ns_slot,
+        "index",
+        make_builtin_function("index", memoryview_index),
+    );
     // `__exit__(self, *exc)`, `__release_buffer__(self, view)`,
     // `__delitem__(self, *args)`, `hex(self, sep=, bytes_per_sep=)`, and
     // `cast(format[, shape])` take variable / optional trailing arguments,
@@ -2667,13 +2674,7 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         ("hex", memoryview_hex),
         ("cast", memoryview_cast),
     ] {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
-                name,
-                make_builtin_function(name, f),
-            )
-        };
+        type_ns_store(ns_slot, name, make_builtin_function(name, f));
     }
     for (attr, getter) in [
         ("obj", memoryview_obj as MvFn),
@@ -2689,17 +2690,15 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         ("f_contiguous", memoryview_f_contiguous),
         ("contiguous", memoryview_contiguous),
     ] {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
-                attr,
-                pyre_object::w_property_new(
-                    make_builtin_function_with_arity(attr, getter, 1),
-                    pyre_object::PY_NULL,
-                    pyre_object::PY_NULL,
-                ),
-            )
-        };
+        type_ns_store(
+            ns_slot,
+            attr,
+            pyre_object::w_property_new(
+                make_builtin_function_with_arity(attr, getter, 1),
+                pyre_object::PY_NULL,
+                pyre_object::PY_NULL,
+            ),
+        );
     }
     // CPython 3.14 Argument Clinic metadata for the PyPy memoryview TypeDef.
     // The two classmethod carriers are stamped before wrapping above.
@@ -2731,8 +2730,10 @@ pub(crate) fn init_memoryview_type(ns: PyObjectRef) {
         ("__enter__", "($self, /)"),
         ("__exit__", "($self, /, *exc_info)"),
     ] {
-        let function = unsafe { pyre_object::w_dict_getitem_str(ns, name) }
-            .expect("memoryview TypeDef callable was just installed");
+        let function = unsafe {
+            pyre_object::w_dict_getitem_str(pyre_object::gc_roots::shadow_stack_get(ns_slot), name)
+        }
+        .expect("memoryview TypeDef callable was just installed");
         unsafe { crate::function::fset_func_text_signature(function, w_str_new(text_signature)) };
     }
 }
@@ -5488,7 +5489,17 @@ pub(crate) fn type_new_set_hash_if_eq(ns: PyObjectRef) {
 /// is the sole exception because the class variable would collide with its
 /// member descriptor.
 pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
-    if unsafe { pyre_object::w_dict_getitem_str(ns, "__doc__") }.is_some() {
+    // Each lookup interns its key, and the caller's root slot tracks the
+    // caller's own copy of the moving namespace rather than this by-value
+    // parameter, so the word is pinned here and read back at every use.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
+    if unsafe {
+        pyre_object::w_dict_getitem_str(pyre_object::gc_roots::shadow_stack_get(ns_slot), "__doc__")
+    }
+    .is_some()
+    {
         return Ok(pyre_object::w_none());
     }
     // `create_all_slots` owns iteration of `__slots__`.  In particular, it
@@ -5496,8 +5507,15 @@ pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
     // entry whenever slots are present; `create_all_slots` installs it after
     // collecting the complete slot-name sequence if `__doc__` was not among
     // those names.
-    if unsafe { pyre_object::w_dict_getitem_str(ns, "__slots__") }.is_none() {
-        unsafe { pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none()) };
+    if unsafe {
+        pyre_object::w_dict_getitem_str(
+            pyre_object::gc_roots::shadow_stack_get(ns_slot),
+            "__slots__",
+        )
+    }
+    .is_none()
+    {
+        type_ns_store(ns_slot, "__doc__", pyre_object::w_none());
     }
     Ok(pyre_object::w_none())
 }
@@ -5507,7 +5525,18 @@ pub(crate) fn type_new_set_doc(ns: PyObjectRef) -> crate::PyResult {
 /// Keeping it in the namespace changes `cls.__dict__` and makes libraries
 /// such as `typing.Protocol` mistake it for a user-declared member.
 pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> crate::PyResult {
-    let Some(value) = (unsafe { pyre_object::w_dict_getitem_str(ns, "__qualname__") }) else {
+    // The lookup and the delete each intern `__qualname__`, so the moving
+    // namespace is read back out of a root slot for both.  `w_type` and the
+    // string value do not move, and the dict holds the value until the delete.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
+    let Some(value) = (unsafe {
+        pyre_object::w_dict_getitem_str(
+            pyre_object::gc_roots::shadow_stack_get(ns_slot),
+            "__qualname__",
+        )
+    }) else {
         return Ok(pyre_object::w_none());
     };
     if !unsafe { pyre_object::is_str(value) } {
@@ -5519,7 +5548,10 @@ pub(crate) fn type_new_take_qualname(w_type: PyObjectRef, ns: PyObjectRef) -> cr
     check_surrogate(value)?;
     unsafe {
         pyre_object::w_type_set_qualname(w_type, value);
-        pyre_object::w_dict_delitem_str_no_proxy(ns, "__qualname__");
+        pyre_object::w_dict_delitem_str_no_proxy(
+            pyre_object::gc_roots::shadow_stack_get(ns_slot),
+            "__qualname__",
+        );
     }
     Ok(pyre_object::w_none())
 }
@@ -5859,7 +5891,9 @@ fn type_descr_new_with_metaclass(
         pyre_object::gc_roots::pin_root(dict_obj);
         let dict_obj = pyre_object::gc_roots::shadow_stack_get(dict_root);
         let w_type = pyre_object::w_type_new(name, w_effective_bases, dict_obj as *mut u8);
-        type_new_take_qualname(w_type, dict_obj)?;
+        // The type allocation may have moved the namespace, so the qualname
+        // pass receives the forwarded address rather than the word above.
+        type_new_take_qualname(w_type, pyre_object::gc_roots::shadow_stack_get(dict_root))?;
         // typeobject.py:1143-1204 create_all_slots parity.
         unsafe { crate::call::create_all_slots(w_type, w_effective_bases)? };
         // rclass.py:739-743 — set w_class (typeptr) at allocation time.
@@ -7897,17 +7931,41 @@ pub(crate) fn exception_getset_fget_obj() -> PyObjectRef {
     exception_getset_ends().0
 }
 
+/// Store `value` under `key` in the type namespace dict rooted at shadow-stack
+/// slot `ns_slot`.
+///
+/// A `dict` header moves, and the store allocates on its own account: the key
+/// string it interns, and the dict's storage when it grows.  The namespace word
+/// is therefore read back out of the slot instead of being carried in a Rust
+/// local across the descriptors a namespace is filled with.  Taking the value
+/// already built is what makes that read safe — call arguments evaluate left to
+/// right, so spelling it inline with an allocating value expression would hand
+/// the store a pre-move address.  The value is pinned for the length of the
+/// store because nothing references it yet.
+fn type_ns_store(ns_slot: usize, key: &str, value: PyObjectRef) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(value);
+    unsafe {
+        pyre_object::w_dict_setitem_str_no_proxy(
+            pyre_object::gc_roots::shadow_stack_get(ns_slot),
+            key,
+            value,
+        )
+    };
+}
+
 /// Install the class's `interp_exceptions.py` typedef getsets into `ns`.
 fn install_exception_getsets(ns: PyObjectRef, class_name: &str) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
     let (fget, fset, fdel) = exception_getset_ends();
     for attr in exception_typedef_attrs(class_name) {
-        unsafe {
-            pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                ns,
-                attr,
-                crate::typedef::make_getset_property_named(fget, fset, fdel, attr),
-            )
-        };
+        type_ns_store(
+            ns_slot,
+            attr,
+            crate::typedef::make_getset_property_named(fget, fset, fdel, attr),
+        );
     }
 }
 
@@ -7957,32 +8015,26 @@ pub(crate) fn make_exc_type_with_init(
     let cls = crate::typedef::make_builtin_type_with_layout(
         name,
         move |ns| {
-            unsafe {
-                if let Some(doc) = doc {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__doc__",
-                        pyre_object::w_str_new(doc),
-                    );
-                }
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    ns,
-                    "__new__",
-                    crate::typedef::make_new_descr(new_fn),
-                )
-            };
+            // The producer's own root slot tracks its copy of the namespace,
+            // not this by-value parameter, so the word is pinned again here for
+            // the run of allocating insertions below.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(ns);
+            if let Some(doc) = doc {
+                type_ns_store(ns_slot, "__doc__", pyre_object::w_str_new(doc));
+            }
+            type_ns_store(ns_slot, "__new__", crate::typedef::make_new_descr(new_fn));
             if let Some(init_fn) = init_fn {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__init__",
-                        make_builtin_function("__init__", init_fn),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__init__",
+                    make_builtin_function("__init__", init_fn),
+                );
             }
             // `interp_exceptions.py` declares each class's typed attributes
             // as `GetSetProperty` entries on its own `TypeDef`.
-            install_exception_getsets(ns, name);
+            install_exception_getsets(pyre_object::gc_roots::shadow_stack_get(ns_slot), name);
             if name == "SyntaxError" {
                 for (member_name, kind, doc) in [
                     ("msg", pyre_object::MEMBER_SYNTAX_ERROR_MSG, "exception msg"),
@@ -8027,46 +8079,40 @@ pub(crate) fn make_exc_type_with_init(
                         "exception private metadata",
                     ),
                 ] {
-                    unsafe {
-                        pyre_object::w_dict_setitem_str_no_proxy(
-                            ns,
-                            member_name,
-                            pyre_object::w_member_new_direct_with_doc(
-                                kind,
-                                member_name.to_owned(),
-                                doc.to_owned(),
-                                pyre_object::PY_NULL,
-                            ),
-                        );
-                    }
+                    type_ns_store(
+                        ns_slot,
+                        member_name,
+                        pyre_object::w_member_new_direct_with_doc(
+                            kind,
+                            member_name.to_owned(),
+                            doc.to_owned(),
+                            pyre_object::PY_NULL,
+                        ),
+                    );
                 }
             }
             if name == "StopIteration" {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "value",
-                        pyre_object::w_member_new_direct_with_doc(
-                            pyre_object::MEMBER_STOP_ITERATION_VALUE,
-                            "value".to_owned(),
-                            "generator return value".to_owned(),
-                            pyre_object::PY_NULL,
-                        ),
-                    );
-                }
+                type_ns_store(
+                    ns_slot,
+                    "value",
+                    pyre_object::w_member_new_direct_with_doc(
+                        pyre_object::MEMBER_STOP_ITERATION_VALUE,
+                        "value".to_owned(),
+                        "generator return value".to_owned(),
+                        pyre_object::PY_NULL,
+                    ),
+                );
             }
             if name == "BaseException" {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__suppress_context__",
-                        pyre_object::w_member_new_direct(
-                            pyre_object::MEMBER_EXCEPTION_SUPPRESS_CONTEXT,
-                            "__suppress_context__".to_owned(),
-                            pyre_object::PY_NULL,
-                        ),
-                    );
-                }
+                type_ns_store(
+                    ns_slot,
+                    "__suppress_context__",
+                    pyre_object::w_member_new_direct(
+                        pyre_object::MEMBER_EXCEPTION_SUPPRESS_CONTEXT,
+                        "__suppress_context__".to_owned(),
+                        pyre_object::PY_NULL,
+                    ),
+                );
             }
             if name == "AttributeError" {
                 for (member_name, kind, doc) in [
@@ -8077,33 +8123,29 @@ pub(crate) fn make_exc_type_with_init(
                     ),
                     ("obj", pyre_object::MEMBER_ATTRIBUTE_ERROR_OBJ, "object"),
                 ] {
-                    unsafe {
-                        pyre_object::w_dict_setitem_str_no_proxy(
-                            ns,
-                            member_name,
-                            pyre_object::w_member_new_direct_with_doc(
-                                kind,
-                                member_name.to_owned(),
-                                doc.to_owned(),
-                                pyre_object::PY_NULL,
-                            ),
-                        );
-                    }
-                }
-            }
-            if name == "NameError" {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "name",
+                    type_ns_store(
+                        ns_slot,
+                        member_name,
                         pyre_object::w_member_new_direct_with_doc(
-                            pyre_object::MEMBER_NAME_ERROR_NAME,
-                            "name".to_owned(),
-                            "name".to_owned(),
+                            kind,
+                            member_name.to_owned(),
+                            doc.to_owned(),
                             pyre_object::PY_NULL,
                         ),
                     );
                 }
+            }
+            if name == "NameError" {
+                type_ns_store(
+                    ns_slot,
+                    "name",
+                    pyre_object::w_member_new_direct_with_doc(
+                        pyre_object::MEMBER_NAME_ERROR_NAME,
+                        "name".to_owned(),
+                        "name".to_owned(),
+                        pyre_object::PY_NULL,
+                    ),
+                );
             }
             if name == "ImportError" {
                 for (member_name, kind, doc) in [
@@ -8120,18 +8162,16 @@ pub(crate) fn make_exc_type_with_init(
                     ),
                     ("path", pyre_object::MEMBER_IMPORT_ERROR_PATH, "module path"),
                 ] {
-                    unsafe {
-                        pyre_object::w_dict_setitem_str_no_proxy(
-                            ns,
-                            member_name,
-                            pyre_object::w_member_new_direct_with_doc(
-                                kind,
-                                member_name.to_owned(),
-                                doc.to_owned(),
-                                pyre_object::PY_NULL,
-                            ),
-                        );
-                    }
+                    type_ns_store(
+                        ns_slot,
+                        member_name,
+                        pyre_object::w_member_new_direct_with_doc(
+                            kind,
+                            member_name.to_owned(),
+                            doc.to_owned(),
+                            pyre_object::PY_NULL,
+                        ),
+                    );
                 }
             }
             if name == "OSError" {
@@ -8168,33 +8208,29 @@ pub(crate) fn make_exc_type_with_init(
                 #[cfg(not(windows))]
                 const WINERROR_MEMBER: &[(&str, u32, &str)] = &[];
                 for &(member_name, kind, doc) in OS_ERROR_MEMBERS.iter().chain(WINERROR_MEMBER) {
-                    unsafe {
-                        pyre_object::w_dict_setitem_str_no_proxy(
-                            ns,
-                            member_name,
-                            pyre_object::w_member_new_direct_with_doc(
-                                kind,
-                                member_name.to_owned(),
-                                doc.to_owned(),
-                                pyre_object::PY_NULL,
-                            ),
-                        );
-                    }
-                }
-            }
-            if name == "SystemExit" {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "code",
+                    type_ns_store(
+                        ns_slot,
+                        member_name,
                         pyre_object::w_member_new_direct_with_doc(
-                            pyre_object::MEMBER_SYSTEM_EXIT_CODE,
-                            "code".to_owned(),
-                            "exception code".to_owned(),
+                            kind,
+                            member_name.to_owned(),
+                            doc.to_owned(),
                             pyre_object::PY_NULL,
                         ),
                     );
                 }
+            }
+            if name == "SystemExit" {
+                type_ns_store(
+                    ns_slot,
+                    "code",
+                    pyre_object::w_member_new_direct_with_doc(
+                        pyre_object::MEMBER_SYSTEM_EXIT_CODE,
+                        "code".to_owned(),
+                        "exception code".to_owned(),
+                        pyre_object::PY_NULL,
+                    ),
+                );
             }
             if matches!(
                 name,
@@ -8227,18 +8263,16 @@ pub(crate) fn make_exc_type_with_init(
                         "exception reason",
                     ),
                 ] {
-                    unsafe {
-                        pyre_object::w_dict_setitem_str_no_proxy(
-                            ns,
-                            member_name,
-                            pyre_object::w_member_new_direct_with_doc(
-                                kind,
-                                member_name.to_owned(),
-                                doc.to_owned(),
-                                pyre_object::PY_NULL,
-                            ),
-                        );
-                    }
+                    type_ns_store(
+                        ns_slot,
+                        member_name,
+                        pyre_object::w_member_new_direct_with_doc(
+                            kind,
+                            member_name.to_owned(),
+                            doc.to_owned(),
+                            pyre_object::PY_NULL,
+                        ),
+                    );
                 }
             }
             // `interp_exceptions.py:291-292` registers `__str__` /
@@ -8248,18 +8282,16 @@ pub(crate) fn make_exc_type_with_init(
             // `LookupError.__str__` resolves up the MRO to
             // `BaseException`'s the way `KeyError.__str__` does not.
             if name == "BaseException" {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__repr__",
-                        make_builtin_function_with_arity("__repr__", exception_repr_method, 1),
-                    );
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__str__",
-                        make_builtin_function_with_arity("__str__", base_exception_str_method, 1),
-                    );
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__repr__",
+                    make_builtin_function_with_arity("__repr__", exception_repr_method, 1),
+                );
+                type_ns_store(
+                    ns_slot,
+                    "__str__",
+                    make_builtin_function_with_arity("__str__", base_exception_str_method, 1),
+                );
             } else if matches!(
                 name,
                 "KeyError"
@@ -8270,13 +8302,11 @@ pub(crate) fn make_exc_type_with_init(
                     | "UnicodeEncodeError"
                     | "UnicodeTranslateError"
             ) {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__str__",
-                        make_builtin_function_with_arity("__str__", exception_str_method, 1),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__str__",
+                    make_builtin_function_with_arity("__str__", exception_str_method, 1),
+                );
             }
             // `pypy/module/exceptions/interp_exceptions.py:225-235`
             // `BaseException.with_traceback` — installed on every
@@ -8290,27 +8320,24 @@ pub(crate) fn make_exc_type_with_init(
             // time, so without per-class install `subclass.with_traceback`
             // raises AttributeError.
             if name == "BaseException" {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
+                type_ns_store(
+                    ns_slot,
+                    "with_traceback",
+                    make_builtin_function_with_arity(
                         "with_traceback",
-                        make_builtin_function_with_arity(
-                            "with_traceback",
-                            |args| {
-                                let w_self = *args.first().ok_or_else(|| {
+                        |args| {
+                            let w_self = *args.first().ok_or_else(|| {
                                 crate::PyError::type_error(
                                     "with_traceback() missing 1 required positional argument: 'self'",
                                 )
                             })?;
-                                let w_tb = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
-                                if !w_self.is_null() && unsafe { pyre_object::is_exception(w_self) }
-                                {
-                                    // `interp_exceptions.py:213-219
-                                    // descr_settraceback` — only None or
-                                    // PyTraceback is accepted.
-                                    let value = if w_tb.is_null()
-                                        || unsafe { pyre_object::is_none(w_tb) }
-                                    {
+                            let w_tb = args.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+                            if !w_self.is_null() && unsafe { pyre_object::is_exception(w_self) } {
+                                // `interp_exceptions.py:213-219
+                                // descr_settraceback` — only None or
+                                // PyTraceback is accepted.
+                                let value =
+                                    if w_tb.is_null() || unsafe { pyre_object::is_none(w_tb) } {
                                         pyre_object::PY_NULL
                                     } else if unsafe { crate::pytraceback::is_pytraceback(w_tb) } {
                                         w_tb
@@ -8319,169 +8346,152 @@ pub(crate) fn make_exc_type_with_init(
                                             "__traceback__ must be a traceback or None",
                                         ));
                                     };
-                                    unsafe {
-                                        pyre_object::interp_exceptions::w_exception_set_traceback(
-                                            w_self, value,
-                                        );
-                                    }
+                                unsafe {
+                                    pyre_object::interp_exceptions::w_exception_set_traceback(
+                                        w_self, value,
+                                    );
                                 }
-                                Ok(w_self)
-                            },
-                            2,
-                        ),
-                    )
-                };
+                            }
+                            Ok(w_self)
+                        },
+                        2,
+                    ),
+                );
                 // `interp_exceptions.py:236-247 BaseException.add_note`
                 // (Python 3.11+ PEP 678).  Appends a string to
                 // `self.__notes__`, allocating the list on first call.
                 // The list lives in the exception's instance dict
                 // (`W_BaseException.w_dict`), reached through the
                 // setattr/getattr paths in baseobjspace.
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
+                type_ns_store(
+                    ns_slot,
+                    "add_note",
+                    make_builtin_function_with_arity(
                         "add_note",
-                        make_builtin_function_with_arity(
-                            "add_note",
-                            |args| {
-                                let w_self = *args.first().ok_or_else(|| {
-                                    crate::PyError::type_error(
-                                        "add_note() missing 1 required positional argument: 'self'",
-                                    )
-                                })?;
-                                let w_note = *args.get(1).ok_or_else(|| {
-                                    crate::PyError::type_error(
-                                        "add_note() missing 1 required positional argument: 'note'",
-                                    )
-                                })?;
-                                // `interp_exceptions.py:257-260` — accept
-                                // `str` and any `str` subclass
-                                // (`isinstance_w(w_note, space.w_unicode)`).
-                                // The rejection wording is the argument-clinic
-                                // one (`_PyArg_BadArgument`), which names the
-                                // method and renders `None` as `None` rather
-                                // than as its type.
-                                if !unsafe { crate::baseobjspace::isinstance_str_w(w_note) } {
-                                    let got = if w_note == pyre_object::w_none() {
-                                        "None".to_string()
-                                    } else {
-                                        crate::baseobjspace::object_functionstr_type_name(w_note)
-                                    };
-                                    return Err(crate::PyError::type_error(format!(
-                                        "add_note() argument must be str, not {got}"
-                                    )));
-                                }
-                                // `interp_exceptions.py:240-254` — lazy
-                                // list allocation on first call; if the
-                                // attribute is already set but NOT a list,
-                                // PyPy raises TypeError("Cannot add note:
-                                // __notes__ is not a list") per `:254`.
-                                let existing =
-                                    crate::baseobjspace::getattr_str(w_self, "__notes__")
-                                        .ok()
-                                        .filter(|w| !w.is_null());
-                                let notes = match existing {
-                                    Some(v)
-                                        if unsafe { crate::baseobjspace::isinstance_list_w(v) } =>
-                                    {
-                                        v
-                                    }
-                                    Some(_) => {
-                                        return Err(crate::PyError::type_error(
-                                            "Cannot add note: __notes__ is not a list",
-                                        ));
-                                    }
-                                    None => {
-                                        let fresh = pyre_object::w_list_new(Vec::new());
-                                        crate::baseobjspace::setattr_str(
-                                            w_self,
-                                            "__notes__",
-                                            fresh,
-                                        )?;
-                                        fresh
-                                    }
+                        |args| {
+                            let w_self = *args.first().ok_or_else(|| {
+                                crate::PyError::type_error(
+                                    "add_note() missing 1 required positional argument: 'self'",
+                                )
+                            })?;
+                            let w_note = *args.get(1).ok_or_else(|| {
+                                crate::PyError::type_error(
+                                    "add_note() missing 1 required positional argument: 'note'",
+                                )
+                            })?;
+                            // `interp_exceptions.py:257-260` — accept
+                            // `str` and any `str` subclass
+                            // (`isinstance_w(w_note, space.w_unicode)`).
+                            // The rejection wording is the argument-clinic
+                            // one (`_PyArg_BadArgument`), which names the
+                            // method and renders `None` as `None` rather
+                            // than as its type.
+                            if !unsafe { crate::baseobjspace::isinstance_str_w(w_note) } {
+                                let got = if w_note == pyre_object::w_none() {
+                                    "None".to_string()
+                                } else {
+                                    crate::baseobjspace::object_functionstr_type_name(w_note)
                                 };
-                                unsafe { pyre_object::w_list_append(notes, w_note) };
-                                Ok(pyre_object::w_none())
-                            },
-                            2,
-                        ),
-                    )
-                };
+                                return Err(crate::PyError::type_error(format!(
+                                    "add_note() argument must be str, not {got}"
+                                )));
+                            }
+                            // `interp_exceptions.py:240-254` — lazy
+                            // list allocation on first call; if the
+                            // attribute is already set but NOT a list,
+                            // PyPy raises TypeError("Cannot add note:
+                            // __notes__ is not a list") per `:254`.
+                            let existing = crate::baseobjspace::getattr_str(w_self, "__notes__")
+                                .ok()
+                                .filter(|w| !w.is_null());
+                            // A `list` header moves, and storing the fresh
+                            // one allocates: the attribute name, the
+                            // instance dict that receives it, and whatever
+                            // a `__setattr__` on the way runs.  The list is
+                            // therefore read back out of a root slot after
+                            // the store rather than reusing the word the
+                            // constructor answered.
+                            let _roots = pyre_object::gc_roots::push_roots();
+                            let notes_slot = pyre_object::gc_roots::shadow_stack_len();
+                            let notes = match existing {
+                                Some(v) if unsafe { crate::baseobjspace::isinstance_list_w(v) } => {
+                                    v
+                                }
+                                Some(_) => {
+                                    return Err(crate::PyError::type_error(
+                                        "Cannot add note: __notes__ is not a list",
+                                    ));
+                                }
+                                None => {
+                                    pyre_object::gc_roots::pin_root(pyre_object::w_list_new(
+                                        Vec::new(),
+                                    ));
+                                    crate::baseobjspace::setattr_str(
+                                        w_self,
+                                        "__notes__",
+                                        pyre_object::gc_roots::shadow_stack_get(notes_slot),
+                                    )?;
+                                    pyre_object::gc_roots::shadow_stack_get(notes_slot)
+                                }
+                            };
+                            unsafe { pyre_object::w_list_append(notes, w_note) };
+                            Ok(pyre_object::w_none())
+                        },
+                        2,
+                    ),
+                );
                 // `interp_exceptions.py:233-241` — `descr_reduce` /
                 // `descr_setstate`, installed on `BaseException` so every
                 // subclass inherits them through the MRO.
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__reduce__",
-                        make_builtin_function_with_arity("__reduce__", base_exception_reduce, 1),
-                    )
-                };
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__setstate__",
-                        make_builtin_function_with_arity(
-                            "__setstate__",
-                            base_exception_setstate,
-                            2,
-                        ),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__reduce__",
+                    make_builtin_function_with_arity("__reduce__", base_exception_reduce, 1),
+                );
+                type_ns_store(
+                    ns_slot,
+                    "__setstate__",
+                    make_builtin_function_with_arity("__setstate__", base_exception_setstate, 2),
+                );
             }
             // `interp_exceptions.py:379-397` — ImportError overrides reduce
             // and setstate to carry the `name`/`path`/`name_from` slots.
             // ModuleNotFoundError (built via `make_exc_type`) inherits these
             // through the MRO.
             if name == "ImportError" {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__reduce__",
-                        make_builtin_function_with_arity("__reduce__", import_error_reduce, 1),
-                    )
-                };
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__setstate__",
-                        make_builtin_function_with_arity("__setstate__", import_error_setstate, 2),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__reduce__",
+                    make_builtin_function_with_arity("__reduce__", import_error_reduce, 1),
+                );
+                type_ns_store(
+                    ns_slot,
+                    "__setstate__",
+                    make_builtin_function_with_arity("__setstate__", import_error_setstate, 2),
+                );
             }
             // CPython 3.14 gives AttributeError a producer-specific pickle
             // state: preserve `name` and `args`, but deliberately omit `obj`.
             if name == "AttributeError" {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__getstate__",
-                        make_builtin_function_with_arity(
-                            "__getstate__",
-                            attribute_error_getstate,
-                            1,
-                        ),
-                    )
-                };
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__reduce__",
-                        make_builtin_function_with_arity("__reduce__", attribute_error_reduce, 1),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__getstate__",
+                    make_builtin_function_with_arity("__getstate__", attribute_error_getstate, 1),
+                );
+                type_ns_store(
+                    ns_slot,
+                    "__reduce__",
+                    make_builtin_function_with_arity("__reduce__", attribute_error_reduce, 1),
+                );
             }
             // `interp_exceptions.py:655-665` — OSError overrides reduce to
             // re-append the filename(s); its subclasses inherit it.
             if name == "OSError" {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__reduce__",
-                        make_builtin_function_with_arity("__reduce__", os_error_reduce, 1),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    "__reduce__",
+                    make_builtin_function_with_arity("__reduce__", os_error_reduce, 1),
+                );
             }
         },
         base,
@@ -8577,13 +8587,10 @@ pub(crate) fn make_exc_type_multi(
     let cls = crate::typedef::make_builtin_type_with_bases(
         name,
         move |ns| {
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-                    ns,
-                    "__new__",
-                    crate::typedef::make_new_descr(new_fn),
-                )
-            };
+            let _roots = pyre_object::gc_roots::push_roots();
+            let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(ns);
+            type_ns_store(ns_slot, "__new__", crate::typedef::make_new_descr(new_fn));
         },
         bases,
     );
@@ -9205,14 +9212,11 @@ fn make_exception_group_type(
     let cls = crate::typedef::make_builtin_type_with_bases(
         name,
         move |ns| {
+            let _roots = pyre_object::gc_roots::push_roots();
+            let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(ns);
             if let Some(doc) = doc {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__doc__",
-                        pyre_object::w_str_new(doc),
-                    )
-                };
+                type_ns_store(ns_slot, "__doc__", pyre_object::w_str_new(doc));
             }
             if name == "ExceptionGroup" {
                 // CPython 3.14 creates ExceptionGroup as the heap type over
@@ -9220,14 +9224,8 @@ fn make_exception_group_type(
                 // carries `__module__ = "builtins"` and `__doc__ = None`;
                 // BaseExceptionGroup is a static builtin and has no own module
                 // entry.
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        "__module__",
-                        pyre_object::w_str_new("builtins"),
-                    );
-                    pyre_object::w_dict_setitem_str_no_proxy(ns, "__doc__", pyre_object::w_none());
-                };
+                type_ns_store(ns_slot, "__module__", pyre_object::w_str_new("builtins"));
+                type_ns_store(ns_slot, "__doc__", pyre_object::w_none());
             }
             if name != "BaseExceptionGroup" {
                 return;
@@ -9259,57 +9257,53 @@ fn make_exception_group_type(
                     1,
                 ),
             ] {
-                unsafe {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        method_name,
-                        make_builtin_function_with_arity(method_name, function, arity),
-                    )
-                };
+                type_ns_store(
+                    ns_slot,
+                    method_name,
+                    make_builtin_function_with_arity(method_name, function, arity),
+                );
             }
-            unsafe {
-                pyre_object::w_dict_setitem_str_no_proxy(
-                    ns,
-                    "__new__",
-                    crate::typedef::make_new_descr(exception_group_new),
-                );
-                pyre_object::w_dict_setitem_str_no_proxy(
-                    ns,
-                    "__init__",
-                    make_builtin_function("__init__", exception_group_init),
-                );
-                pyre_object::w_dict_setitem_str_no_proxy(
-                    ns,
+            type_ns_store(
+                ns_slot,
+                "__new__",
+                crate::typedef::make_new_descr(exception_group_new),
+            );
+            type_ns_store(
+                ns_slot,
+                "__init__",
+                make_builtin_function("__init__", exception_group_init),
+            );
+            type_ns_store(
+                ns_slot,
+                "__class_getitem__",
+                pyre_object::function::w_classmethod_new(make_builtin_function(
                     "__class_getitem__",
-                    pyre_object::function::w_classmethod_new(make_builtin_function(
-                        "__class_getitem__",
-                        crate::_pypy_generic_alias::generic_alias_class_getitem,
-                    )),
+                    crate::_pypy_generic_alias::generic_alias_class_getitem,
+                )),
+            );
+            for (member_name, kind, doc) in [
+                (
+                    "message",
+                    pyre_object::MEMBER_EXCEPTION_GROUP_MESSAGE,
+                    "exception message",
+                ),
+                (
+                    "exceptions",
+                    pyre_object::MEMBER_EXCEPTION_GROUP_EXCEPTIONS,
+                    "nested exceptions",
+                ),
+            ] {
+                type_ns_store(
+                    ns_slot,
+                    member_name,
+                    pyre_object::w_member_new_direct_with_doc(
+                        kind,
+                        member_name.to_owned(),
+                        doc.to_owned(),
+                        pyre_object::PY_NULL,
+                    ),
                 );
-                for (member_name, kind, doc) in [
-                    (
-                        "message",
-                        pyre_object::MEMBER_EXCEPTION_GROUP_MESSAGE,
-                        "exception message",
-                    ),
-                    (
-                        "exceptions",
-                        pyre_object::MEMBER_EXCEPTION_GROUP_EXCEPTIONS,
-                        "nested exceptions",
-                    ),
-                ] {
-                    pyre_object::w_dict_setitem_str_no_proxy(
-                        ns,
-                        member_name,
-                        pyre_object::w_member_new_direct_with_doc(
-                            kind,
-                            member_name.to_owned(),
-                            doc.to_owned(),
-                            pyre_object::PY_NULL,
-                        ),
-                    );
-                }
-            };
+            }
         },
         bases,
     );
@@ -14921,305 +14915,271 @@ pub fn file_wrapper_type() -> PyObjectRef {
 
 /// PyPy: pypy/module/_io/interp_iobase.py W_IOBase.
 pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "read",
-            make_builtin_function("read", file_method_read),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "readline",
-            make_builtin_function("readline", file_method_readline),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "readlines",
-            make_builtin_function("readlines", file_method_readlines),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "write",
-            make_builtin_function_with_arity("write", file_method_write, 2),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "writelines",
-            make_builtin_function_with_arity(
-                "writelines",
-                crate::module::_io::iobase_writelines,
-                2,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "close",
-            make_builtin_function_with_arity("close", file_method_close, 1),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "flush",
-            make_builtin_function_with_arity("flush", file_method_flush, 1),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__enter__",
-            make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__exit__",
-            make_builtin_function("__exit__", |args| {
-                // Call close on exit.
-                file_method_close(&args[..1])?;
-                Ok(w_none())
-            }),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
+    // The producer's own root slot tracks its copy of the namespace, not this
+    // by-value parameter, so the word is pinned again here for the run of
+    // allocating insertions below.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
+    type_ns_store(
+        ns_slot,
+        "read",
+        make_builtin_function("read", file_method_read),
+    );
+    type_ns_store(
+        ns_slot,
+        "readline",
+        make_builtin_function("readline", file_method_readline),
+    );
+    type_ns_store(
+        ns_slot,
+        "readlines",
+        make_builtin_function("readlines", file_method_readlines),
+    );
+    type_ns_store(
+        ns_slot,
+        "write",
+        make_builtin_function_with_arity("write", file_method_write, 2),
+    );
+    type_ns_store(
+        ns_slot,
+        "writelines",
+        make_builtin_function_with_arity("writelines", crate::module::_io::iobase_writelines, 2),
+    );
+    type_ns_store(
+        ns_slot,
+        "close",
+        make_builtin_function_with_arity("close", file_method_close, 1),
+    );
+    type_ns_store(
+        ns_slot,
+        "flush",
+        make_builtin_function_with_arity("flush", file_method_flush, 1),
+    );
+    type_ns_store(
+        ns_slot,
+        "__enter__",
+        make_builtin_function_with_arity("__enter__", |args| Ok(args[0]), 1),
+    );
+    type_ns_store(
+        ns_slot,
+        "__exit__",
+        make_builtin_function("__exit__", |args| {
+            // Call close on exit.
+            file_method_close(&args[..1])?;
+            Ok(w_none())
+        }),
+    );
+    type_ns_store(
+        ns_slot,
+        "__iter__",
+        make_builtin_function_with_arity(
             "__iter__",
-            make_builtin_function_with_arity(
-                "__iter__",
-                |args| {
-                    file_check_closed(args[0])?;
-                    Ok(args[0])
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__next__",
-            make_builtin_function_with_arity(
-                "__next__",
-                |args| {
-                    let line = file_method_readline(args)?;
-                    unsafe {
-                        let s = pyre_object::w_str_get_value(line);
-                        if s.is_empty() {
-                            return Err(crate::PyError::stop_iteration());
-                        }
-                    }
-                    Ok(line)
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "fileno",
-            make_builtin_function_with_arity(
-                "fileno",
-                |args| {
-                    let self_obj = args[0];
-                    file_check_closed(self_obj)?;
-                    match file_get_fd(self_obj) {
-                        Some(fd) => Ok(w_int_new(fd as i64)),
-                        None => Err(crate::PyError::os_error(
-                            "fileno() on a file without a descriptor",
-                        )),
-                    }
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "readable",
-            make_builtin_function_with_arity(
-                "readable",
-                |args| {
-                    file_check_closed(args[0])?;
-                    let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
-                        .ok()
-                        .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
-                        .unwrap_or_default();
-                    Ok(w_bool_from(mode.contains('r') || mode.contains('+')))
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "writable",
-            make_builtin_function_with_arity(
-                "writable",
-                |args| {
-                    file_check_closed(args[0])?;
-                    let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
-                        .ok()
-                        .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
-                        .unwrap_or_default();
-                    Ok(w_bool_from(
-                        mode.contains('w')
-                            || mode.contains('a')
-                            || mode.contains('x')
-                            || mode.contains('+'),
-                    ))
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "seekable",
-            make_builtin_function_with_arity("seekable", file_method_seekable, 1),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "seek",
-            make_builtin_function("seek", |args| {
-                if args.len() < 2 || args.len() > 3 {
-                    return Err(crate::PyError::type_error(format!(
-                        "seek() takes from 1 to 2 arguments ({} given)",
-                        args.len().saturating_sub(1)
-                    )));
-                }
+            |args| {
                 file_check_closed(args[0])?;
-                // interp_fileio.py:267-275
-                // `@unwrap_spec(pos=r_longlong, whence=int)`: both operands
-                // go through Python's integer/index conversion before the
-                // host lseek.  Reading their object payloads unchecked made a
-                // float such as 0.0 look like offset zero instead of raising
-                // TypeError (test_io.IOTest.write_ops).
-                let offset = crate::builtins::space_index_w(args[1])?;
-                let whence = match args.get(2).copied() {
-                    Some(value) => crate::baseobjspace::index_c_int_w(value)?,
-                    None => 0,
-                };
-                // CPython 3.14 TextIOWrapper only permits the opaque-cookie
-                // forms for current/end-relative seeks; FileIO remains free
-                // to use ordinary non-zero offsets.
-                if !file_is_binary(args[0]) && offset != 0 {
-                    // POSIX/Python's public SEEK_CUR and SEEK_END values are
-                    // 1 and 2.  Keep this semantic validation target-neutral;
-                    // wasm libc intentionally does not expose lseek constants.
-                    if whence == 1 {
-                        return Err(crate::module::_io::unsupported(
-                            "can't do nonzero cur-relative seeks",
-                        ));
-                    }
-                    if whence == 2 {
-                        return Err(crate::module::_io::unsupported(
-                            "can't do nonzero end-relative seeks",
-                        ));
+                Ok(args[0])
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "__next__",
+        make_builtin_function_with_arity(
+            "__next__",
+            |args| {
+                let line = file_method_readline(args)?;
+                unsafe {
+                    let s = pyre_object::w_str_get_value(line);
+                    if s.is_empty() {
+                        return Err(crate::PyError::stop_iteration());
                     }
                 }
+                Ok(line)
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "fileno",
+        make_builtin_function_with_arity(
+            "fileno",
+            |args| {
+                let self_obj = args[0];
+                file_check_closed(self_obj)?;
+                match file_get_fd(self_obj) {
+                    Some(fd) => Ok(w_int_new(fd as i64)),
+                    None => Err(crate::PyError::os_error(
+                        "fileno() on a file without a descriptor",
+                    )),
+                }
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "readable",
+        make_builtin_function_with_arity(
+            "readable",
+            |args| {
+                file_check_closed(args[0])?;
+                let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
+                    .ok()
+                    .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
+                    .unwrap_or_default();
+                Ok(w_bool_from(mode.contains('r') || mode.contains('+')))
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "writable",
+        make_builtin_function_with_arity(
+            "writable",
+            |args| {
+                file_check_closed(args[0])?;
+                let mode = crate::baseobjspace::getattr_str(args[0], "__file_mode__")
+                    .ok()
+                    .map(|m| unsafe { pyre_object::w_str_get_value(m).to_string() })
+                    .unwrap_or_default();
+                Ok(w_bool_from(
+                    mode.contains('w')
+                        || mode.contains('a')
+                        || mode.contains('x')
+                        || mode.contains('+'),
+                ))
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "seekable",
+        make_builtin_function_with_arity("seekable", file_method_seekable, 1),
+    );
+    type_ns_store(
+        ns_slot,
+        "seek",
+        make_builtin_function("seek", |args| {
+            if args.len() < 2 || args.len() > 3 {
+                return Err(crate::PyError::type_error(format!(
+                    "seek() takes from 1 to 2 arguments ({} given)",
+                    args.len().saturating_sub(1)
+                )));
+            }
+            file_check_closed(args[0])?;
+            // interp_fileio.py:267-275
+            // `@unwrap_spec(pos=r_longlong, whence=int)`: both operands
+            // go through Python's integer/index conversion before the
+            // host lseek.  Reading their object payloads unchecked made a
+            // float such as 0.0 look like offset zero instead of raising
+            // TypeError (test_io.IOTest.write_ops).
+            let offset = crate::builtins::space_index_w(args[1])?;
+            let whence = match args.get(2).copied() {
+                Some(value) => crate::baseobjspace::index_c_int_w(value)?,
+                None => 0,
+            };
+            // CPython 3.14 TextIOWrapper only permits the opaque-cookie
+            // forms for current/end-relative seeks; FileIO remains free
+            // to use ordinary non-zero offsets.
+            if !file_is_binary(args[0]) && offset != 0 {
+                // POSIX/Python's public SEEK_CUR and SEEK_END values are
+                // 1 and 2.  Keep this semantic validation target-neutral;
+                // wasm libc intentionally does not expose lseek constants.
+                if whence == 1 {
+                    return Err(crate::module::_io::unsupported(
+                        "can't do nonzero cur-relative seeks",
+                    ));
+                }
+                if whence == 2 {
+                    return Err(crate::module::_io::unsupported(
+                        "can't do nonzero end-relative seeks",
+                    ));
+                }
+            }
+            if let Some(fd) = file_get_fd(args[0]) {
+                #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+                {
+                    #[cfg(not(feature = "sandbox"))]
+                    let pos = {
+                        let pos = crt_call!(libc::lseek(fd, offset as libc::off_t, whence));
+                        if pos < 0 {
+                            return Err(fd_errno_err(crt_errno()));
+                        }
+                        pos
+                    };
+                    #[cfg(feature = "sandbox")]
+                    let pos = crate::host_seam::ops::lseek(fd, offset, whence)
+                        .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
+                    return Ok(w_int_new(pos as i64));
+                }
+                #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
+                {
+                    let _ = (fd, offset, whence);
+                    return Err(crate::PyError::not_implemented(
+                        "fd seek requires host_env feature",
+                    ));
+                }
+            }
+            let base = match whence {
+                0 => 0,
+                1 => file_get_pos(args[0]) as i64,
+                2 => file_get_data(args[0]).len() as i64,
+                _ => return Err(crate::PyError::value_error("invalid whence")),
+            };
+            let pos = base
+                .checked_add(offset)
+                .filter(|pos| *pos >= 0)
+                .ok_or_else(|| crate::PyError::value_error("negative seek position"))?;
+            file_set_pos(args[0], pos as usize);
+            Ok(w_int_new(pos))
+        }),
+    );
+    type_ns_store(
+        ns_slot,
+        "tell",
+        make_builtin_function_with_arity(
+            "tell",
+            |args| {
+                file_check_closed(args[0])?;
                 if let Some(fd) = file_get_fd(args[0]) {
                     #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
                     {
                         #[cfg(not(feature = "sandbox"))]
                         let pos = {
-                            let pos = crt_call!(libc::lseek(fd, offset as libc::off_t, whence));
+                            let pos = crt_call!(libc::lseek(fd, 0, libc::SEEK_CUR));
                             if pos < 0 {
                                 return Err(fd_errno_err(crt_errno()));
                             }
                             pos
                         };
                         #[cfg(feature = "sandbox")]
-                        let pos = crate::host_seam::ops::lseek(fd, offset, whence)
+                        let pos = crate::host_seam::ops::lseek(fd, 0, libc::SEEK_CUR)
                             .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
                         return Ok(w_int_new(pos as i64));
                     }
                     #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
                     {
-                        let _ = (fd, offset, whence);
-                        return Err(crate::PyError::not_implemented(
-                            "fd seek requires host_env feature",
-                        ));
+                        let _ = fd;
                     }
                 }
-                let base = match whence {
-                    0 => 0,
-                    1 => file_get_pos(args[0]) as i64,
-                    2 => file_get_data(args[0]).len() as i64,
-                    _ => return Err(crate::PyError::value_error("invalid whence")),
-                };
-                let pos = base
-                    .checked_add(offset)
-                    .filter(|pos| *pos >= 0)
-                    .ok_or_else(|| crate::PyError::value_error("negative seek position"))?;
-                file_set_pos(args[0], pos as usize);
-                Ok(w_int_new(pos))
-            }),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "tell",
-            make_builtin_function_with_arity(
-                "tell",
-                |args| {
-                    file_check_closed(args[0])?;
-                    if let Some(fd) = file_get_fd(args[0]) {
-                        #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
-                        {
-                            #[cfg(not(feature = "sandbox"))]
-                            let pos = {
-                                let pos = crt_call!(libc::lseek(fd, 0, libc::SEEK_CUR));
-                                if pos < 0 {
-                                    return Err(fd_errno_err(crt_errno()));
-                                }
-                                pos
-                            };
-                            #[cfg(feature = "sandbox")]
-                            let pos = crate::host_seam::ops::lseek(fd, 0, libc::SEEK_CUR)
-                                .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
-                            return Ok(w_int_new(pos as i64));
-                        }
-                        #[cfg(any(not(feature = "host_env"), target_arch = "wasm32"))]
-                        {
-                            let _ = fd;
-                        }
-                    }
-                    if let Ok(pos) = crate::baseobjspace::getattr_str(args[0], "__file_pos__") {
-                        Ok(pos)
-                    } else {
-                        Ok(w_int_new(0))
-                    }
-                },
-                1,
-            ),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "isatty",
-            make_builtin_function_with_arity("isatty", file_method_isatty, 1),
-        )
-    };
+                if let Ok(pos) = crate::baseobjspace::getattr_str(args[0], "__file_pos__") {
+                    Ok(pos)
+                } else {
+                    Ok(w_int_new(0))
+                }
+            },
+            1,
+        ),
+    );
+    type_ns_store(
+        ns_slot,
+        "isatty",
+        make_builtin_function_with_arity("isatty", file_method_isatty, 1),
+    );
 }
 
 /// PyPy `W_FileIO.typedef` — raw-stream methods override the shared
@@ -15227,34 +15187,32 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
 /// Keeping this as a separate initializer mirrors FileIO's distinct typedef
 /// instead of teaching the text wrapper about raw-only operations.
 pub(crate) fn init_fileio_type(ns: PyObjectRef) {
-    for (name, function) in [
-        ("read", make_builtin_function("read", fileio_method_read)),
+    // The producer's own root slot tracks its copy of the namespace, not this
+    // by-value parameter, so the word is pinned again here for the run of
+    // allocating insertions below.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(ns);
+    // The table carries the code pointer and arity, not the built function:
+    // building all six up front would leave the early ones in a Rust array the
+    // collector does not walk while the later ones allocate.
+    for (name, f, arity) in [
         (
-            "readinto",
-            make_builtin_function_with_arity("readinto", fileio_method_readinto, 2),
+            "read",
+            fileio_method_read as crate::gateway::BuiltinCodeFn,
+            None,
         ),
-        (
-            "readall",
-            make_builtin_function_with_arity("readall", fileio_method_readall, 1),
-        ),
-        (
-            "write",
-            make_builtin_function_with_arity("write", fileio_method_write, 2),
-        ),
-        (
-            "truncate",
-            make_builtin_function("truncate", fileio_method_truncate),
-        ),
-        (
-            "_isatty_open_only",
-            make_builtin_function_with_arity(
-                "_isatty_open_only",
-                fileio_method_isatty_open_only,
-                1,
-            ),
-        ),
+        ("readinto", fileio_method_readinto, Some(2u16)),
+        ("readall", fileio_method_readall, Some(1)),
+        ("write", fileio_method_write, Some(2)),
+        ("truncate", fileio_method_truncate, None),
+        ("_isatty_open_only", fileio_method_isatty_open_only, Some(1)),
     ] {
-        unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, function) };
+        let function = match arity {
+            Some(arity) => make_builtin_function_with_arity(name, f, arity),
+            None => make_builtin_function(name, f),
+        };
+        type_ns_store(ns_slot, name, function);
     }
     for (name, getter, doc) in [
         (
@@ -15289,22 +15247,18 @@ pub(crate) fn init_fileio_type(ns: PyObjectRef) {
             ),
             None => crate::typedef::make_getset_descriptor_named(getter, name),
         };
-        unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(ns, name, descriptor) };
+        type_ns_store(ns_slot, name, descriptor);
     }
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "__repr__",
-            make_builtin_function_with_arity("__repr__", fileio_method_repr, 1),
-        )
-    };
-    unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
-            ns,
-            "_dealloc_warn",
-            make_builtin_function_with_arity("_dealloc_warn", fileio_method_dealloc_warn, 2),
-        )
-    };
+    type_ns_store(
+        ns_slot,
+        "__repr__",
+        make_builtin_function_with_arity("__repr__", fileio_method_repr, 1),
+    );
+    type_ns_store(
+        ns_slot,
+        "_dealloc_warn",
+        make_builtin_function_with_arity("_dealloc_warn", fileio_method_dealloc_warn, 2),
+    );
 }
 
 fn fileio_method_dealloc_warn(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3842,6 +3842,21 @@ fn call_metaclass_with_kwargs(
     w_namespace_dict: PyObjectRef,
     kwargs: PyObjectRef,
 ) -> PyObjectRef {
+    // Every argument arrives as a bare word and is held across the metaclass
+    // `__new__` and `__init__` calls, both arbitrary Python.  The caller roots
+    // the namespace and reads it back immediately before this call, and that
+    // is undone the moment it is passed by value.  The namespace is a
+    // `W_DictObject`, whose header moves, so it needs the slot read back at
+    // every consumer that follows one of those calls; `w_metaclass`, `name`,
+    // `bases` and `kwargs` are stable kinds and need the scope alone, since
+    // old-gen is swept even though it does not move.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_namespace_dict);
+    pyre_object::gc_roots::pin_root(kwargs);
+    pyre_object::gc_roots::pin_root(w_metaclass);
+    pyre_object::gc_roots::pin_root(name);
+    pyre_object::gc_roots::pin_root(bases);
     if unsafe { !pyre_object::is_type(w_metaclass) } {
         // compiling.py:215-221 — `space.call_args(w_meta, Arguments(name,
         // bases, ns, **kwds))`; a non-type metaclass receives the
@@ -3932,6 +3947,10 @@ fn call_metaclass_with_kwargs(
     if instance.is_null() {
         return PY_NULL;
     }
+    // A fresh type is allocated stable, so it never moves and needs no
+    // read-back -- but until `type_call_init_type` stores it, this local is
+    // its only reference, and `__init__` below runs Python.
+    pyre_object::gc_roots::pin_root(instance);
 
     if let Some(w_insttype) = type_call_init_type(instance, w_metaclass)
         && let Some(init_fn) =
@@ -3942,7 +3961,13 @@ fn call_metaclass_with_kwargs(
                 !crate::is_builtin_code(crate::getcode(init_fn) as pyre_object::PyObjectRef)
             };
         if is_user_fn && !kw_items.is_empty() {
-            let mut call_args = vec![instance, name, bases, w_namespace_dict];
+            // The metaclass `__new__` ran between the pin and here.
+            let mut call_args = vec![
+                instance,
+                name,
+                bases,
+                pyre_object::gc_roots::shadow_stack_get(ns_slot),
+            ];
             let mut names = Vec::with_capacity(kw_items.len());
             for (k, v) in &kw_items {
                 call_args.push(*v);
@@ -3973,9 +3998,15 @@ fn call_metaclass_with_kwargs(
             // to the __init_subclass__ forwarding path instead of being
             // rejected here (typeobject.py descr_call passes __args__ to a
             // builtin __init__, which tolerates them).
-            if let Err(e) =
-                call_function_impl_result(init_fn, &[instance, name, bases, w_namespace_dict])
-            {
+            if let Err(e) = call_function_impl_result(
+                init_fn,
+                &[
+                    instance,
+                    name,
+                    bases,
+                    pyre_object::gc_roots::shadow_stack_get(ns_slot),
+                ],
+            ) {
                 set_call_error(e);
                 return PY_NULL;
             }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2800,10 +2800,14 @@ impl IterOpcodeHandler for PyFrame {
             // mappingproxy iterates over its backing dict's keys.
             // dictproxyobject.py:41 descr_iter → space.iter(self.w_mapping).
             // The backing mapping is a `dict`, which moves, and publishing it
-            // to the stack slot runs the frame array's write barrier, which
-            // can collect.  Pin the mapping on the read and take the operand
-            // the rest of this function dispatches on out of the root slot,
-            // not from the word that was live before the store.
+            // to the stack slot runs the frame array's write barrier, whose
+            // slow path can wait behind a foreign collection
+            // (`FixedObjectArray::set_ref` reloads both operands across it for
+            // that reason).  Pin the mapping on the read, so both the store and
+            // the operand this dispatches on come out of the root slot rather
+            // than the word that was live before the barrier.  The bracket ends
+            // with the branch: past it the mapping is the frame's own stack
+            // slot, which the collector updates.
             let iter = if pyre_object::is_dict_proxy(iter) {
                 let roots = pyre_object::gc_roots::push_roots();
                 let mapping_slot = roots.base();

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2799,11 +2799,18 @@ impl IterOpcodeHandler for PyFrame {
         unsafe {
             // mappingproxy iterates over its backing dict's keys.
             // dictproxyobject.py:41 descr_iter → space.iter(self.w_mapping).
+            // The backing mapping is a `dict`, which moves, and publishing it
+            // to the stack slot runs the frame array's write barrier, which
+            // can collect.  Pin the mapping on the read and take the operand
+            // the rest of this function dispatches on out of the root slot,
+            // not from the word that was live before the store.
             let iter = if pyre_object::is_dict_proxy(iter) {
-                let mapping = pyre_object::w_dict_proxy_get_mapping(iter);
+                let roots = pyre_object::gc_roots::push_roots();
+                let mapping_slot = roots.base();
+                roots.pin_root(pyre_object::w_dict_proxy_get_mapping(iter));
                 let tos = self.valuestackdepth - 1;
-                self.set_locals_w(tos, mapping);
-                mapping
+                self.set_locals_w(tos, roots.get(mapping_slot));
+                roots.get(mapping_slot)
             } else {
                 iter
             };

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -827,6 +827,11 @@ fn init_string_module(ns: PyObjectRef) {
                 FieldType::Index(n) => pyre_object::w_int_new(n as i64),
                 FieldType::Keyword(s) => pyre_object::w_str_from_wtf8(s),
             };
+            // A `str` and an `int` never move, so `first` is never read back,
+            // but nothing else refers to it while the parts below allocate:
+            // one liveness pin covers it to the end of the call.
+            let roots = pyre_object::gc_roots::push_roots();
+            roots.pin_root(first);
             let rest = parts
                 .into_iter()
                 .map(|part| match part {
@@ -874,28 +879,30 @@ fn init_sysconfig_stub(ns: PyObjectRef) {
         ns,
         "config_vars",
         crate::make_builtin_function("config_vars", |_| {
-            let vars = pyre_object::w_dict_new();
+            // A `dict` header moves, and every store allocates the key, the
+            // value, and the dict's own storage when it grows, so the word is
+            // read back out of a root slot per store.  Call arguments evaluate
+            // left to right, so the key and value are bound before that read.
+            let roots = pyre_object::gc_roots::push_roots();
+            let vars_slot = roots.base();
+            roots.pin_root(pyre_object::w_dict_new());
             let so_ext = extension_abi_suffix();
             unsafe {
                 for (name, value) in [("Py_DEBUG", 0), ("Py_GIL_DISABLED", 1)] {
-                    pyre_object::w_dict_store(
-                        vars,
-                        pyre_object::w_str_new(name),
-                        pyre_object::w_int_new(value),
-                    );
+                    let w_key = pyre_object::w_str_new(name);
+                    let w_value = pyre_object::w_int_new(value);
+                    pyre_object::w_dict_store(roots.get(vars_slot), w_key, w_value);
                 }
                 for (name, value) in [
                     ("SOABI", soabi_middle(&so_ext)),
                     ("EXT_SUFFIX", so_ext.clone()),
                 ] {
-                    pyre_object::w_dict_store(
-                        vars,
-                        pyre_object::w_str_new(name),
-                        pyre_object::w_str_new(&value),
-                    );
+                    let w_key = pyre_object::w_str_new(name);
+                    let w_value = pyre_object::w_str_new(&value);
+                    pyre_object::w_dict_store(roots.get(vars_slot), w_key, w_value);
                 }
             }
-            Ok(vars)
+            Ok(roots.get(vars_slot))
         }),
     );
 }
@@ -1062,21 +1069,27 @@ fn quote_for_cflags(path: &str) -> String {
 /// `_PYTHON_SYSCONFIGDATA_NAME` and `_PYTHON_SYSCONFIGDATA_PATH` have had their
 /// turn, so a cross-compilation snapshot still overrides it.
 fn init_sysconfigdata(ns: PyObjectRef) {
-    fn store_str(vars: PyObjectRef, key: &str, value: &str) {
+    // These take the root slot rather than the dict itself: a word passed by
+    // value goes stale the moment the key or the value allocates.
+    fn store_str(vars_slot: usize, key: &str, value: &str) {
         unsafe {
+            let w_key = pyre_object::w_str_new(key);
+            let w_value = pyre_object::w_str_new(value);
             pyre_object::w_dict_store(
-                vars,
-                pyre_object::w_str_new(key),
-                pyre_object::w_str_new(value),
+                pyre_object::gc_roots::shadow_stack_get(vars_slot),
+                w_key,
+                w_value,
             );
         }
     }
-    fn store_int(vars: PyObjectRef, key: &str, value: i64) {
+    fn store_int(vars_slot: usize, key: &str, value: i64) {
         unsafe {
+            let w_key = pyre_object::w_str_new(key);
+            let w_value = pyre_object::w_int_new(value);
             pyre_object::w_dict_store(
-                vars,
-                pyre_object::w_str_new(key),
-                pyre_object::w_int_new(value),
+                pyre_object::gc_roots::shadow_stack_get(vars_slot),
+                w_key,
+                w_value,
             );
         }
     }
@@ -1152,20 +1165,22 @@ fn init_sysconfigdata(ns: PyObjectRef) {
         String::new()
     };
 
-    let vars = pyre_object::w_dict_new();
+    let _roots = pyre_object::gc_roots::push_roots();
+    let vars_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
     // `_init_non_posix` derives the same `t` from `Py_GIL_DISABLED` below.
     // The lower-case `abiflags` that forms the include and site-packages
     // directory names is a separate variable, read from `sys.abiflags`
     // (`sysconfig:545`), and stays empty: the release tree has no `t` suffix
     // on its stdlib directory for `site.py:409` to find.
-    store_str(vars, "ABIFLAGS", "t");
-    store_str(vars, "SOABI", &soabi);
+    store_str(vars_slot, "ABIFLAGS", "t");
+    store_str(vars_slot, "SOABI", &soabi);
     // Deprecated in Python 3, kept for backward compatibility.
-    store_str(vars, "SO", &so_ext);
-    store_str(vars, "MULTIARCH", multiarch());
-    store_str(vars, "CC", &cc);
-    store_str(vars, "CXX", &cxx);
-    store_str(vars, "OPT", "-DNDEBUG -O2");
+    store_str(vars_slot, "SO", &so_ext);
+    store_str(vars_slot, "MULTIARCH", multiarch());
+    store_str(vars_slot, "CC", &cc);
+    store_str(vars_slot, "CXX", &cxx);
+    store_str(vars_slot, "OPT", "-DNDEBUG -O2");
     // `setuptools`' vendored `_distutils.sysconfig._get_python_inc_posix_prefix`
     // builds the include directory as `include/<impl><version><abiflags>` with
     // `<impl>` chosen by `IS_PYPY = '__pypy__' in sys.builtin_module_names`.
@@ -1179,24 +1194,24 @@ fn init_sysconfigdata(ns: PyObjectRef) {
         cflags.push_str(" -I");
         cflags.push_str(&quote_for_cflags(&include_py));
     }
-    store_str(vars, "CFLAGS", &cflags);
-    store_str(vars, "CCSHARED", "-fPIC");
-    store_str(vars, "LDFLAGS", &ldflags);
-    store_str(vars, "LDSHARED", &ldshared);
-    store_str(vars, "LDCXXSHARED", &ldcxxshared);
-    store_str(vars, "EXT_SUFFIX", &so_ext);
-    store_str(vars, "SHLIB_SUFFIX", ".so");
-    store_str(vars, "AR", "ar");
-    store_str(vars, "ARFLAGS", "rc");
-    store_str(vars, "EXE", "");
-    store_str(vars, "VERSION", "3.14");
-    store_str(vars, "LDVERSION", "3.14");
+    store_str(vars_slot, "CFLAGS", &cflags);
+    store_str(vars_slot, "CCSHARED", "-fPIC");
+    store_str(vars_slot, "LDFLAGS", &ldflags);
+    store_str(vars_slot, "LDSHARED", &ldshared);
+    store_str(vars_slot, "LDCXXSHARED", &ldcxxshared);
+    store_str(vars_slot, "EXT_SUFFIX", &so_ext);
+    store_str(vars_slot, "SHLIB_SUFFIX", ".so");
+    store_str(vars_slot, "AR", "ar");
+    store_str(vars_slot, "ARFLAGS", "rc");
+    store_str(vars_slot, "EXE", "");
+    store_str(vars_slot, "VERSION", "3.14");
+    store_str(vars_slot, "LDVERSION", "3.14");
     // cpyext never uses Py_DEBUG.  Pyre runs its mutators without a global
     // interpreter lock.  Py_ENABLE_SHARED at 1 would add a python shared
     // object to link lines as `-lpython3.x`.
-    store_int(vars, "Py_DEBUG", 0);
-    store_int(vars, "Py_GIL_DISABLED", 1);
-    store_int(vars, "Py_ENABLE_SHARED", 0);
+    store_int(vars_slot, "Py_DEBUG", 0);
+    store_int(vars_slot, "Py_GIL_DISABLED", 1);
+    store_int(vars_slot, "Py_ENABLE_SHARED", 0);
     // Pyre has no separately linkable runtime library.  Keep the build ABI
     // metadata above for wheel tags, but never invent files that are absent
     // from the installation.
@@ -1208,7 +1223,7 @@ fn init_sysconfigdata(ns: PyObjectRef) {
         "CONFINCLUDEPY",
         "LIBDIR",
     ] {
-        store_str(vars, key, "");
+        store_str(vars_slot, key, "");
     }
     // The headers are the one entry above a build can have: they exist in a
     // `cpyext` build and nowhere else, so the empty default stands until there
@@ -1216,12 +1231,12 @@ fn init_sysconfigdata(ns: PyObjectRef) {
     // `_distutils` — meson-python, scikit-build, CMake's FindPython — read
     // `INCLUDEPY` directly.
     if !include_py.is_empty() {
-        store_str(vars, "INCLUDEPY", &include_py);
-        store_str(vars, "CONFINCLUDEPY", &include_py);
+        store_str(vars_slot, "INCLUDEPY", &include_py);
+        store_str(vars_slot, "CONFINCLUDEPY", &include_py);
     }
-    store_int(vars, "SIZEOF_VOID_P", std::mem::size_of::<usize>() as i64);
+    store_int(vars_slot, "SIZEOF_VOID_P", std::mem::size_of::<usize>() as i64);
     if gnuld {
-        store_str(vars, "GNULD", "yes");
+        store_str(vars_slot, "GNULD", "yes");
     }
     #[cfg(target_os = "macos")]
     {
@@ -1231,9 +1246,9 @@ fn init_sysconfigdata(ns: PyObjectRef) {
         // pypa/wheel, and check the interaction with `build_cffi_imports.py`
         // before removing it.  Keep it in sync with DARWIN_VERSION_MIN in
         // `rpython/translator/platform/darwin.py` and `Lib/_osx_support.py`.
-        store_int(vars, "WITH_DYLD", 1);
+        store_int(vars_slot, "WITH_DYLD", 1);
         store_str(
-            vars,
+            vars_slot,
             "MACOSX_DEPLOYMENT_TARGET",
             if arch == "arm64" { "11.0" } else { "10.15" },
         );
@@ -1241,7 +1256,12 @@ fn init_sysconfigdata(ns: PyObjectRef) {
     // Python 3.14's relocation check reads these from the generated data.
     unsafe {
         for key in ["prefix", "exec_prefix", "srcdir"] {
-            pyre_object::w_dict_store(vars, pyre_object::w_str_new(key), base_prefix_str);
+            let w_key = pyre_object::w_str_new(key);
+            pyre_object::w_dict_store(
+                pyre_object::gc_roots::shadow_stack_get(vars_slot),
+                w_key,
+                base_prefix_str,
+            );
         }
     }
     // Keep PyPy's relocatable zoneinfo search rooted at `base_prefix`.  The
@@ -1276,14 +1296,21 @@ fn init_sysconfigdata(ns: PyObjectRef) {
             joined.push(path);
         }
         unsafe {
+            let w_key = pyre_object::w_str_new("TZPATH");
+            let w_value =
+                pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_os_str_wtf8(&joined));
             pyre_object::w_dict_store(
-                vars,
-                pyre_object::w_str_new("TZPATH"),
-                pyre_object::w_str_from_wtf8(crate::gateway::fsdecode_os_str_wtf8(&joined)),
+                pyre_object::gc_roots::shadow_stack_get(vars_slot),
+                w_key,
+                w_value,
             );
         }
     }
-    crate::module_ns_store(ns, "build_time_vars", vars);
+    crate::module_ns_store(
+        ns,
+        "build_time_vars",
+        pyre_object::gc_roots::shadow_stack_get(vars_slot),
+    );
 }
 
 /// `_tracemalloc` stub — allocation tracking is not implemented, so the
@@ -1362,20 +1389,19 @@ fn init_scproxy(ns: PyObjectRef) {
         ns,
         "_get_proxy_settings",
         crate::make_builtin_function("_get_proxy_settings", |_| {
-            let d = pyre_object::w_dict_new();
+            // The `dict` moves across the allocations each store makes.
+            let roots = pyre_object::gc_roots::push_roots();
+            let d_slot = roots.base();
+            roots.pin_root(pyre_object::w_dict_new());
             unsafe {
-                pyre_object::w_dict_store(
-                    d,
-                    pyre_object::w_str_new("exclude_simple"),
-                    pyre_object::w_bool_from(false),
-                );
-                pyre_object::w_dict_store(
-                    d,
-                    pyre_object::w_str_new("exceptions"),
-                    pyre_object::w_list_new(Vec::new()),
-                );
+                let w_key = pyre_object::w_str_new("exclude_simple");
+                let w_value = pyre_object::w_bool_from(false);
+                pyre_object::w_dict_store(roots.get(d_slot), w_key, w_value);
+                let w_key = pyre_object::w_str_new("exceptions");
+                let w_value = pyre_object::w_list_new(Vec::new());
+                pyre_object::w_dict_store(roots.get(d_slot), w_key, w_value);
             }
-            Ok(d)
+            Ok(roots.get(d_slot))
         }),
     );
 }
@@ -2615,11 +2641,17 @@ pub fn set_sys_module(name: &str, module: PyObjectRef) {
         .lock()
         .unwrap()
         .insert(name.to_string(), module as usize);
-    // Keep the Python-visible sys.modules dict in sync.
+    // Keep the Python-visible sys.modules dict in sync.  The read is fresh —
+    // the collector walks that cell — but the `dict` moves, and the key string
+    // minted below can be the collection that moves it.
     let dict = sys_modules_dict();
     if !dict.is_null() {
+        let roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = roots.base();
+        roots.pin_root(dict);
+        let w_key = pyre_object::w_str_new(name);
         unsafe {
-            pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module);
+            pyre_object::w_dict_store(roots.get(dict_slot), w_key, module);
         }
     }
 }
@@ -2985,10 +3017,17 @@ pub fn set_sys_modules_dict(dict: PyObjectRef) {
     // a possibly-young dict; rescan on the next minor collection.
     pyre_object::gc_roots::mark_prebuilt_roots_dirty();
     SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
+    // The cell just stored is walked; the parameter is a bare local the
+    // collector never updates, and every iteration below mints a key string
+    // and may grow the dict.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(dict);
     // Populate with all modules already in the cache.
     for (name, &module) in SYS_MODULES.lock().unwrap().iter() {
+        let w_key = pyre_object::w_str_new(name);
         unsafe {
-            pyre_object::w_dict_store(dict, pyre_object::w_str_new(name), module as PyObjectRef);
+            pyre_object::w_dict_store(roots.get(dict_slot), w_key, module as PyObjectRef);
         }
     }
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1234,7 +1234,11 @@ fn init_sysconfigdata(ns: PyObjectRef) {
         store_str(vars_slot, "INCLUDEPY", &include_py);
         store_str(vars_slot, "CONFINCLUDEPY", &include_py);
     }
-    store_int(vars_slot, "SIZEOF_VOID_P", std::mem::size_of::<usize>() as i64);
+    store_int(
+        vars_slot,
+        "SIZEOF_VOID_P",
+        std::mem::size_of::<usize>() as i64,
+    );
     if gnuld {
         store_str(vars_slot, "GNULD", "yes");
     }

--- a/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
+++ b/pyre/pyre-interpreter/src/module/_ast/moduledef.rs
@@ -16,6 +16,16 @@ fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
     let Some((&zelf, values)) = positional.split_first() else {
         return Err(crate::PyError::type_error("AST.__init__() missing self"));
     };
+    // `builtin_code_call` hands the body a native slice the collector does not
+    // update, and every store below allocates — a field value may be a `list`
+    // or a `dict`, and the keyword dict moves too.  The values and the keyword
+    // dict are one livevar set, so both slices are written before either is
+    // queried (a forwarding query is itself a safepoint), and each use reads
+    // its slot back.  `zelf` and the `_fields` strings do not move.
+    let roots = pyre_object::gc_roots::push_roots();
+    let values_base = roots.publish(values);
+    let kwargs_slot = kwargs.map(|kwargs| roots.publish(&[kwargs]));
+    roots.normalize(values_base, values.len() + usize::from(kwargs.is_some()));
     let fields_obj = crate::baseobjspace::getattr_str(zelf, "_fields")?;
     let fields = unsafe { pyre_object::w_tuple_items_copy_as_vec(fields_obj) };
     if values.len() > fields.len() {
@@ -26,23 +36,27 @@ fn ast_init(args: &[PyObjectRef]) -> crate::PyResult {
         )));
     }
     let mut positional_names = Vec::with_capacity(values.len());
-    for (&field, &value) in fields.iter().zip(values) {
+    for (index, &field) in fields.iter().take(values.len()).enumerate() {
         let name = unsafe { pyre_object::w_str_get_value(field) };
         positional_names.push(name.to_owned());
-        crate::baseobjspace::setattr_str(zelf, name, value)?;
+        crate::baseobjspace::setattr_str(zelf, name, roots.get(values_base + index))?;
     }
-    if let Some(kwargs) = kwargs {
-        for (name, value) in unsafe { pyre_object::w_dict_str_entries(kwargs) } {
+    if let Some(kwargs_slot) = kwargs_slot {
+        let entries = unsafe { pyre_object::w_dict_str_entries(roots.get(kwargs_slot)) };
+        let entry_values: Vec<PyObjectRef> = entries.iter().map(|(_, value)| *value).collect();
+        let entries_base = roots.publish(&entry_values);
+        roots.normalize(entries_base, entry_values.len());
+        for (index, (name, _)) in entries.iter().enumerate() {
             if name == "__pyre_kw__" {
                 continue;
             }
-            if positional_names.iter().any(|positional| positional == &name) {
+            if positional_names.iter().any(|positional| positional == name) {
                 return Err(crate::PyError::type_error(format!(
                     "{} got multiple values for argument '{name}'",
                     unsafe { pyre_object::type_name_of(zelf) }
                 )));
             }
-            crate::baseobjspace::setattr_str(zelf, &name, value)?;
+            crate::baseobjspace::setattr_str(zelf, name, roots.get(entries_base + index))?;
         }
     }
     Ok(pyre_object::w_none())
@@ -136,18 +150,34 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // generated AST types report `__module__ == "ast"` (astcompiler/ast.py:150;
     // the host `_ast.Module.__module__` is likewise `'ast'`).
     let make = |name: &str, base: PyObjectRef| -> PyObjectRef {
-        let dict = pyre_object::w_dict_new();
-        crate::baseobjspace::setitem(dict, pyre_object::w_str_new("__module__"), pyre_object::w_str_new("ast"))
+        // A `dict` header moves, and every store below allocates: the key
+        // string, the value, and the dict's own storage when it grows.  Both
+        // namespace dicts are pinned the moment they are built — the second
+        // pin takes the slot after the first — and the word is read back out
+        // of its slot at every use.
+        let roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = roots.base();
+        roots.pin_root(pyre_object::w_dict_new());
+        let field_types_slot = dict_slot + 1;
+        roots.pin_root(pyre_object::w_dict_new());
+        // The value arrives already built.  Call arguments evaluate left to
+        // right, so reading a dict slot inline with an allocating value
+        // expression would read the slot first and hand over a pre-move word.
+        // `_field_types` is a `dict` too, so the value is rooted as well.
+        let put = |target_slot: usize, key: &str, value: PyObjectRef| -> crate::PyResult {
+            let value_roots = pyre_object::gc_roots::push_roots();
+            let value_slot = value_roots.base();
+            value_roots.pin_root(value);
+            let key = pyre_object::w_str_new(key);
+            crate::baseobjspace::setitem(roots.get(target_slot), key, value_roots.get(value_slot))
+        };
+        put(dict_slot, "__module__", pyre_object::w_str_new("ast"))
             .expect("set __module__ on _ast type namespace");
-        crate::baseobjspace::setitem(
-            dict,
-            pyre_object::w_str_new("_fields"),
-            tuple_of_names(node_fields(name)),
-        )
-        .expect("set _fields on _ast type namespace");
-        crate::baseobjspace::setitem(
-            dict,
-            pyre_object::w_str_new("_attributes"),
+        put(dict_slot, "_fields", tuple_of_names(node_fields(name)))
+            .expect("set _fields on _ast type namespace");
+        put(
+            dict_slot,
+            "_attributes",
             tuple_of_names(if node_has_location(name) {
                 LOCATION_ATTRIBUTES
             } else {
@@ -155,21 +185,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }),
         )
         .expect("set _attributes on _ast type namespace");
-        let field_types = pyre_object::w_dict_new();
-        for field in node_fields(name) {
-            crate::baseobjspace::setitem(
-                field_types,
-                pyre_object::w_str_new(field),
-                crate::typedef::w_object(),
-            )
-            .expect("set _field_types item");
+        for &field in node_fields(name) {
+            put(field_types_slot, field, crate::typedef::w_object())
+                .expect("set _field_types item");
         }
-        crate::baseobjspace::setitem(
-            dict,
-            pyre_object::w_str_new("_field_types"),
-            field_types,
-        )
-        .expect("set _field_types on _ast type namespace");
+        put(dict_slot, "_field_types", roots.get(field_types_slot))
+            .expect("set _field_types on _ast type namespace");
         // `type_descr_new` reads the metatype off the first argument, the way
         // `descr__new__` takes it as a parameter beside `arguments_w`.  Every
         // other caller reaches it through an attribute lookup that supplies
@@ -178,7 +199,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::typedef::w_type(),
             pyre_object::w_str_new(name),
             pyre_object::w_tuple_new(vec![base]),
-            dict,
+            roots.get(dict_slot),
         ];
         crate::builtins::type_descr_new(&args).expect("_ast heap type creation")
     };

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -347,6 +347,11 @@ pub(super) fn simple_from_param(args: &[PyObjectRef]) -> Result<PyObjectRef, cra
         let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
         new_simplecdata_obj(cls, &tc, Some(value))?
     };
+    // A converted temporary is reachable only from here, and both the address
+    // lookup and the carrier allocate — the address is into its buffer, so the
+    // instance has to outlive them.  It does not move, so one pin is enough.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(converted);
     let addr = cdata_addr(converted)
         .ok_or_else(|| crate::PyError::type_error("ctypes instance has no buffer"))?;
     Ok(super::interp_ctypes::make_carg(addr, converted))
@@ -375,9 +380,19 @@ pub(super) fn new_simplecdata_obj(
 ) -> Result<PyObjectRef, crate::PyError> {
     let size = host_ctypes::simple_type_size(tc).ok_or_else(invalid_type_code_error)?;
     let obj = new_cdata_obj_from_bytes(cls, size, &[])?;
+    // The new instance is reachable only from this frame while `encode_value_into`
+    // runs, and that call can run Python.  It does not move, so it is pinned once
+    // and never re-read; the bytearray rides along through the instance dict.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(obj);
     let ba = cdata_buffer(obj).expect("new cdata object has a backing buffer");
     // Encode after the instance exists so a `char*` keepalive can attach to it.
     if let Some(v) = value {
+        // `v` is an arbitrary object, so under `"O"` it can be a `list` or a
+        // `dict`, both of which move: pin it before the encode and read the slot
+        // back where it is stored.
+        let v_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(v);
         let mut bytes = encode_value_into(tc, v, obj, "0")?;
         if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
             bytes.reverse();
@@ -388,6 +403,7 @@ pub(super) fn new_simplecdata_obj(
         }
         if matches!(tc, "z" | "Z" | "O") {
             let d = crate::baseobjspace::getdict_native(obj);
+            let v = pyre_object::gc_roots::shadow_stack_get(v_slot);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, v) };
         }
     }
@@ -399,8 +415,15 @@ pub(super) fn new_cdata_obj_from_bytes(
     size: usize,
     bytes: &[u8],
 ) -> Result<PyObjectRef, crate::PyError> {
+    // Until the store below links them, the bytearray and the instance are
+    // reachable only from this frame, and `w_instance_new`, `getdict_native`
+    // and the store each allocate.  Neither kind moves, so one pin apiece keeps
+    // them live and no word has to be re-read.
     let ba = pyre_object::w_bytearray_new(size);
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(ba);
     let obj = pyre_object::w_instance_new(cls);
+    pyre_object::gc_roots::pin_root(obj);
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return Err(crate::PyError::type_error(
@@ -454,6 +477,12 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let value = args[2];
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let tc = type_code_of(cls).ok_or_else(|| crate::PyError::type_error("abstract class"))?;
+    // `value` is an arbitrary object, so under `"O"` it can be a `list` or a
+    // `dict`, both of which move, and `encode_value_into` can run Python: pin it
+    // and read the slot back where it is stored.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(value);
     let mut bytes = encode_value_into(&tc, value, obj, "0")?;
     if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
         bytes.reverse();
@@ -461,6 +490,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     cdata_write(obj, 0, &bytes);
     if matches!(tc.as_str(), "z" | "Z" | "O") {
         let d = crate::baseobjspace::getdict_native(obj);
+        let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
         unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, value) };
     }
     Ok(pyre_object::w_none())
@@ -811,28 +841,53 @@ pub(super) fn make_subview(
     field_offset: usize,
     size: usize,
 ) -> PyObjectRef {
+    // The fresh instance is reachable only from this frame, so it is pinned for
+    // its lifetime; it does not move, so its word is never re-read.  An instance
+    // dictionary does move, and every store below allocates, so that is pinned
+    // and read back at each store.  Each value is built into a local first: call
+    // arguments evaluate left to right, so an inline allocating value would
+    // consume a pre-move dictionary word.
+    let _roots = pyre_object::gc_roots::push_roots();
     let inst = pyre_object::w_instance_new(proto);
+    pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
     if d.is_null() {
         return inst;
     }
+    pyre_object::gc_roots::pin_root(d);
+    let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         if let Some(ba) = cdata_buffer(parent) {
-            pyre_object::w_dict_setitem_str(d, CDATA_BUFFER_KEY, ba);
             pyre_object::w_dict_setitem_str(
-                d,
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
+                CDATA_BUFFER_KEY,
+                ba,
+            );
+            let w_offset = pyre_object::w_int_new((boff(parent) + field_offset) as i64);
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
                 BOFF_KEY,
-                pyre_object::w_int_new((boff(parent) + field_offset) as i64),
+                w_offset,
             );
         } else if let Some(addr) = baddr(parent) {
+            let w_address = pyre_object::w_int_new((addr + field_offset) as i64);
             pyre_object::w_dict_setitem_str(
-                d,
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
                 BADDR_KEY,
-                pyre_object::w_int_new((addr + field_offset) as i64),
+                w_address,
             );
         }
-        pyre_object::w_dict_setitem_str(d, BSZ_KEY, pyre_object::w_int_new(size as i64));
-        pyre_object::w_dict_setitem_str(d, BBASE_KEY, parent);
+        let w_size = pyre_object::w_int_new(size as i64);
+        pyre_object::w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(d_slot),
+            BSZ_KEY,
+            w_size,
+        );
+        pyre_object::w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(d_slot),
+            BBASE_KEY,
+            parent,
+        );
     }
     inst
 }
@@ -845,10 +900,21 @@ pub(super) fn make_indexed_subview(
     index: usize,
 ) -> PyObjectRef {
     let view = make_subview(proto, parent, field_offset, size);
+    // `make_subview` dropped its own root bracket on the way out, so the view is
+    // reachable only from this frame again across the lookup and the store.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(view);
     let d = crate::baseobjspace::getdict_native(view);
     if !d.is_null() {
+        pyre_object::gc_roots::pin_root(d);
+        let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let w_index = pyre_object::w_int_new(index as i64);
         unsafe {
-            pyre_object::w_dict_setitem_str(d, BINDEX_KEY, pyre_object::w_int_new(index as i64));
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
+                BINDEX_KEY,
+                w_index,
+            );
         }
     }
     view
@@ -864,14 +930,34 @@ pub(super) fn make_at_address(
     size: usize,
     base: PyObjectRef,
 ) -> PyObjectRef {
+    // The fresh instance is reachable only from this frame across the lookup and
+    // the stores below; it does not move, so one pin covers it.
+    let _roots = pyre_object::gc_roots::push_roots();
     let inst = pyre_object::w_instance_new(proto);
+    pyre_object::gc_roots::pin_root(inst);
     let d = crate::baseobjspace::getdict_native(inst);
     if !d.is_null() {
+        pyre_object::gc_roots::pin_root(d);
+        let d_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         unsafe {
-            pyre_object::w_dict_setitem_str(d, BADDR_KEY, pyre_object::w_int_new(address as i64));
-            pyre_object::w_dict_setitem_str(d, BSZ_KEY, pyre_object::w_int_new(size as i64));
+            let w_address = pyre_object::w_int_new(address as i64);
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
+                BADDR_KEY,
+                w_address,
+            );
+            let w_size = pyre_object::w_int_new(size as i64);
+            pyre_object::w_dict_setitem_str(
+                pyre_object::gc_roots::shadow_stack_get(d_slot),
+                BSZ_KEY,
+                w_size,
+            );
             if !base.is_null() && !pyre_object::is_none(base) {
-                pyre_object::w_dict_setitem_str(d, BBASE_KEY, base);
+                pyre_object::w_dict_setitem_str(
+                    pyre_object::gc_roots::shadow_stack_get(d_slot),
+                    BBASE_KEY,
+                    base,
+                );
             }
         }
     }
@@ -912,28 +998,29 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
     }
     root = pyre_object::gc_roots::shadow_stack_get(root_slot);
     let mut d = crate::baseobjspace::getdict_native(root);
-    let objs = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
-        Some(o) if !o.is_null() && unsafe { pyre_object::is_dict(o) } => o,
+    // An existing keepalive dictionary is reused; any other holder is replaced,
+    // and a `bytes` one drops its keepalive count on the way out.
+    let existing = match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
+        Some(o) if !o.is_null() && unsafe { pyre_object::is_dict(o) } => Some(o),
         Some(previous) if !previous.is_null() && !unsafe { pyre_object::is_none(previous) } => {
             if unsafe { pyre_object::is_bytes(previous) } {
                 unsafe { pyre_object::bytesobject::w_bytes_dec_ctypes_keepalive_refs(previous) };
             }
-            let nd = pyre_object::w_dict_new();
-            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-            d = crate::baseobjspace::getdict_native(root);
-            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
-            nd
+            None
         }
-        _ => {
-            let nd = pyre_object::w_dict_new();
-            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-            d = crate::baseobjspace::getdict_native(root);
-            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
-            nd
-        }
+        _ => None,
     };
-    pyre_object::gc_roots::pin_root(objs);
-    let objs_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let objs_slot = pyre_object::gc_roots::shadow_stack_len();
+    match existing {
+        Some(objs) => pyre_object::gc_roots::pin_root(objs),
+        None => {
+            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+            root = pyre_object::gc_roots::shadow_stack_get(root_slot);
+            d = crate::baseobjspace::getdict_native(root);
+            let nd = pyre_object::gc_roots::shadow_stack_get(objs_slot);
+            unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, nd) };
+        }
+    }
     let objs = pyre_object::gc_roots::shadow_stack_get(objs_slot);
     let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     unsafe {
@@ -945,6 +1032,8 @@ pub(super) fn keep_ref(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
         if pyre_object::is_bytes(obj) {
             pyre_object::bytesobject::w_bytes_inc_ctypes_keepalive_refs(obj);
         }
+        let objs = pyre_object::gc_roots::shadow_stack_get(objs_slot);
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         pyre_object::w_dict_setitem_str(objs, &composite_key, obj)
     };
 }
@@ -958,16 +1047,18 @@ pub(super) fn objects_for_keep(value: PyObjectRef) -> PyObjectRef {
     let value_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     let mut d = crate::baseobjspace::getdict_native(value);
     if d.is_null() {
-        return value;
+        return pyre_object::gc_roots::shadow_stack_get(value_slot);
     }
     match unsafe { pyre_object::w_dict_getitem_str(d, OBJECTS_KEY) } {
         Some(objects) if !objects.is_null() && !unsafe { pyre_object::is_none(objects) } => objects,
         _ => {
-            let objects = pyre_object::w_dict_new();
+            let objects_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             let value = pyre_object::gc_roots::shadow_stack_get(value_slot);
             d = crate::baseobjspace::getdict_native(value);
+            let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
             unsafe { pyre_object::w_dict_setitem_str(d, OBJECTS_KEY, objects) };
-            objects
+            pyre_object::gc_roots::shadow_stack_get(objects_slot)
         }
     }
 }
@@ -1000,9 +1091,12 @@ fn keep_alive(anchor: PyObjectRef, key: &str, obj: PyObjectRef) {
         }
     }
     root = pyre_object::gc_roots::shadow_stack_get(root_slot);
-    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let d = crate::baseobjspace::getdict_native(root);
     if !d.is_null() {
+        // Read the holder back only after the dictionary lookup: that lookup can
+        // materialise the dict view and collect, which would leave an earlier
+        // read holding a pre-move word.
+        let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
         unsafe { pyre_object::w_dict_setitem_str(d, &format!("_keep_{key}"), obj) };
     }
 }
@@ -1048,25 +1142,32 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
             && !unsafe { pyre_object::is_none(objects) }
             && !unsafe { pyre_object::is_dict(objects) }
     }) {
+        // A non-dict holder is whatever was stored under `_objects_`, so it can
+        // be a `list` that moves; the lookup that follows can collect, so it is
+        // pinned here and read back at the store.
+        let holder_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(objects);
         let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
         let result_dict = crate::baseobjspace::getdict_native(result);
         if !result_dict.is_null() {
+            let objects = pyre_object::gc_roots::shadow_stack_get(holder_slot);
             unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
         }
         return;
     }
-    let objects = match existing {
-        Some(objects) if !objects.is_null() && unsafe { pyre_object::is_dict(objects) } => objects,
+    let objects_slot = pyre_object::gc_roots::shadow_stack_len();
+    match existing {
+        Some(objects) if !objects.is_null() && unsafe { pyre_object::is_dict(objects) } => {
+            pyre_object::gc_roots::pin_root(objects)
+        }
         _ => {
-            let objects = pyre_object::w_dict_new();
+            pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             root = pyre_object::gc_roots::shadow_stack_get(root_slot);
             source_dict = crate::baseobjspace::getdict_native(root);
+            let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
             unsafe { pyre_object::w_dict_setitem_str(source_dict, OBJECTS_KEY, objects) };
-            objects
         }
-    };
-    pyre_object::gc_roots::pin_root(objects);
-    let objects_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    }
     let source = pyre_object::gc_roots::shadow_stack_get(source_slot);
     let identity_key = pyre_object::w_int_new(source as usize as i64);
     pyre_object::gc_roots::pin_root(identity_key);
@@ -1076,9 +1177,9 @@ pub(super) fn share_objects_for_cast(result: PyObjectRef, source: PyObjectRef) {
     let identity_key = pyre_object::gc_roots::shadow_stack_get(key_slot);
     unsafe { pyre_object::w_dict_store(objects, identity_key, source) };
     let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
-    let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
     let result_dict = crate::baseobjspace::getdict_native(result);
     if !result_dict.is_null() {
+        let objects = pyre_object::gc_roots::shadow_stack_get(objects_slot);
         unsafe { pyre_object::w_dict_setitem_str(result_dict, OBJECTS_KEY, objects) };
     }
 }
@@ -1228,7 +1329,12 @@ pub(super) fn encode_value_into(
         let copy =
             pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::null_terminated_bytes(raw));
         // Retain the copy before reading its address, so a GC triggered while
-        // inserting the keepalive cannot leave the stored pointer stale.
+        // inserting the keepalive cannot leave the stored pointer stale.  Until
+        // `keep_alive` links it into the root, only this frame holds the copy and
+        // `keep_ref` allocates, so pin it for that window; it does not move, so
+        // the word is never re-read.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(copy);
         keep_ref(dest, key, value);
         keep_alive(dest, key, copy);
         let addr = unsafe { pyre_object::bytesobject::w_bytes_data(copy).as_ptr() } as usize;
@@ -1242,6 +1348,8 @@ pub(super) fn encode_value_into(
         let raw = unsafe { pyre_object::w_str_get_wtf8(value) };
         let copy =
             pyre_object::w_bytearray_from_bytes(&host_ctypes::wchar_null_terminated_bytes(raw));
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(copy);
         keep_ref(dest, key, value);
         keep_alive(dest, key, copy);
         let addr =

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -323,6 +323,13 @@ fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::
     if d.is_null() {
         return Err(crate::PyError::type_error("pointer instance has no dict"));
     }
+    // The instance dict moves, and the bytearray allocated below is a
+    // collection point, so the dict word is read back out of a root slot at the
+    // store.  The null check stays ahead of the bracket, leaving the error path
+    // rootless.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(d);
     let psize = host_ctypes::pointer_size();
     let ba = pyre_object::w_bytearray_new(psize);
     let bytes = host_ctypes::simple_storage_value_to_bytes_endian(
@@ -333,7 +340,11 @@ fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::
     let n = bytes.len().min(psize);
     unsafe {
         pyre_object::w_bytearray_data_mut(ba)[..n].copy_from_slice(&bytes[..n]);
-        pyre_object::w_dict_setitem_str(d, "_b_", ba);
+        pyre_object::w_dict_setitem_str(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            "_b_",
+            ba,
+        );
     }
     Ok(obj)
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -780,15 +780,24 @@ fn comerror_init(
             positional.len()
         )));
     };
-    crate::baseobjspace::setattr_str(w_self, "hresult", *hresult)?;
-    crate::baseobjspace::setattr_str(w_self, "text", *text)?;
-    crate::baseobjspace::setattr_str(w_self, "details", *details)?;
-    // `args = args[1:]`, so the hresult is reachable only through its slot.
-    crate::baseobjspace::setattr_str(
-        w_self,
-        "args",
-        pyre_object::tupleobject::w_tuple_new(vec![*text, *details]),
-    )?;
+    // Every `setattr_str` allocates its key string and may run a Python
+    // `__setattr__`, and the argument slice is a plain array no root walker
+    // updates, so a `list` or `dict` argument in it goes stale after the first
+    // store.  Pin the three before that store and read them back at each use.
+    let roots = pyre_object::gc_roots::push_roots();
+    let args_slot = roots.base();
+    roots.pin_root(*hresult);
+    roots.pin_root(*text);
+    roots.pin_root(*details);
+    crate::baseobjspace::setattr_str(w_self, "hresult", roots.get(args_slot))?;
+    crate::baseobjspace::setattr_str(w_self, "text", roots.get(args_slot + 1))?;
+    crate::baseobjspace::setattr_str(w_self, "details", roots.get(args_slot + 2))?;
+    // `args = args[1:]`, so the hresult is reachable only through its attribute.
+    let w_args = pyre_object::tupleobject::w_tuple_new(vec![
+        roots.get(args_slot + 1),
+        roots.get(args_slot + 2),
+    ]);
+    crate::baseobjspace::setattr_str(w_self, "args", w_args)?;
     Ok(pyre_object::w_none())
 }
 
@@ -969,9 +978,19 @@ pub(super) fn make_carg(addr: usize, obj: pyre_object::PyObjectRef) -> pyre_obje
     let carg = pyre_object::w_instance_new(carg_type());
     let d = crate::baseobjspace::getdict_native(carg);
     if !d.is_null() {
+        // The instance dictionary moves under a minor collection and both
+        // stores allocate — the address value, the key string each store
+        // builds, and the dictionary's own storage when it grows — so it is
+        // pinned on acquisition and read back for every store.  The address is
+        // hoisted out of the call: arguments evaluate left to right, so an
+        // inline slot read would precede that allocation and go stale.
+        let roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = roots.base();
+        roots.pin_root(d);
+        let ptr = pyre_object::w_int_new(addr as i64);
         unsafe {
-            pyre_object::w_dict_setitem_str(d, "_ptr", pyre_object::w_int_new(addr as i64));
-            pyre_object::w_dict_setitem_str(d, "_obj", obj);
+            pyre_object::w_dict_setitem_str(roots.get(dict_slot), "_ptr", ptr);
+            pyre_object::w_dict_setitem_str(roots.get(dict_slot), "_obj", obj);
         }
     }
     carg

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -471,18 +471,36 @@ fn simple_init_stginfo(cls: PyObjectRef) -> PyResult {
         set_type_attr(cls, "__ctype_le__", cls);
         set_type_attr(cls, "__ctype_be__", cls);
     } else if endian_capable && own_dict_get(cls, "_ctypes_native_peer").is_none() {
-        let ns = pyre_object::w_dict_new();
+        // The namespace `dict` moves: each insertion allocates the key string
+        // and may grow the dict, and building the swapped class allocates
+        // throughout, so the word is read back out of a root slot at every use.
+        // The allocated values arrive already built — call arguments evaluate
+        // left to right, so reading the slot inline with an allocating value
+        // expression would hand the store a pre-move address.
+        let roots = pyre_object::gc_roots::push_roots();
+        let ns_slot = roots.base();
+        roots.pin_root(pyre_object::w_dict_new());
+        let w_tc = pyre_object::w_str_new(&tc);
         unsafe {
-            pyre_object::w_dict_setitem_str(ns, "_type_", pyre_object::w_str_new(&tc));
-            pyre_object::w_dict_setitem_str(ns, "_swappedbytes_", pyre_object::w_bool_from(true));
-            pyre_object::w_dict_setitem_str(ns, "_ctypes_native_peer", cls);
+            pyre_object::w_dict_setitem_str(roots.get(ns_slot), "_type_", w_tc);
+            pyre_object::w_dict_setitem_str(
+                roots.get(ns_slot),
+                "_swappedbytes_",
+                pyre_object::w_bool_from(true),
+            );
+            pyre_object::w_dict_setitem_str(roots.get(ns_slot), "_ctypes_native_peer", cls);
         }
         let bases = unsafe { pyre_object::typeobject::w_type_get_bases(cls) };
         let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
+        let w_name = pyre_object::w_str_new(name);
         let swapped = crate::call::type_call_instantiate(
             pycsimpletype_type(),
-            &[pyre_object::w_str_new(name), bases, ns],
+            &[w_name, bases, roots.get(ns_slot)],
         )?;
+        // The new class does not move, but nothing references it until the
+        // first `set_type_attr` below completes and that store allocates its
+        // key string, so it takes one pin for liveness.
+        roots.pin_root(swapped);
         if cfg!(target_endian = "little") {
             set_type_attr(cls, "__ctype_le__", cls);
             set_type_attr(cls, "__ctype_be__", swapped);
@@ -595,14 +613,21 @@ fn promote_anonymous_fields(
                 cf_usize(child, "byte_size"),
                 cf_usize(child, "index"),
             );
-            let d = crate::baseobjspace::getdict_native(promoted);
+            // The promoted field's `dict` moves and each copied entry
+            // allocates the key string, so the word is read back out of a
+            // root slot on every iteration.  `promoted` does not move but is
+            // unreferenced until `set_type_attr` below, so it takes one pin.
+            let roots = pyre_object::gc_roots::push_roots();
+            roots.pin_root(promoted);
+            let d_slot = roots.base() + 1;
+            roots.pin_root(crate::baseobjspace::getdict_native(promoted));
             unsafe {
                 for key in ["size", "bit_size", "bit_offset", "is_bitfield"] {
                     if let Some(value) = pyre_object::w_dict_getitem_str(
                         crate::baseobjspace::getdict_native(child),
                         key,
                     ) {
-                        pyre_object::w_dict_setitem_str(d, key, value);
+                        pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value);
                     }
                 }
             }
@@ -758,6 +783,13 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     // StgInfo: POINTER(Complete) must remain the type made while Complete was
     // incomplete (including its frozen PEP 3118 "&B" format).
     let cached_pointer_type = stginfo::stginfo_of(cls).and_then(stginfo::stginfo_pointer_type);
+    // `_fields_` is accepted as a `list` as well as a tuple, and a `list`
+    // moves; the whole layout pass below allocates before the sequence is
+    // stored back on the class, so it is pinned here and read back at that
+    // store.
+    let fields_roots = pyre_object::gc_roots::push_roots();
+    let fields_slot = fields_roots.base();
+    fields_roots.pin_root(fields);
     let entries = field_entries(fields)?;
     let anonymous = anonymous_names(cls)?;
 
@@ -904,30 +936,32 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
         let (field_offset, size, align, bitfield) = pending[index];
         mark_type_final(entry.ty, size, align);
         let cf = cfield_new(&entry.name, entry.ty, field_offset, size, index);
-        let d = crate::baseobjspace::getdict_native(cf);
+        // The descriptor's `dict` moves and each insertion allocates both the
+        // value and the key string, so the word is read back out of a root
+        // slot with the value already built.  `cf` does not move but is
+        // unreferenced until `set_type_attr` below, so it takes one pin.
+        let roots = pyre_object::gc_roots::push_roots();
+        roots.pin_root(cf);
+        let d_slot = roots.base() + 1;
+        roots.pin_root(crate::baseobjspace::getdict_native(cf));
+        let put = |key: &str, value: PyObjectRef| {
+            // SAFETY: the slot holds the descriptor dict pinned above.
+            unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
+        };
         if let Some((bits, bit_offset)) = bitfield {
-            unsafe {
-                pyre_object::w_dict_setitem_str(
-                    d,
-                    "size",
-                    pyre_object::w_int_new(((bits << 16) | bit_offset) as i64),
-                );
-                pyre_object::w_dict_setitem_str(d, "bit_size", pyre_object::w_int_new(bits as i64));
-                pyre_object::w_dict_setitem_str(
-                    d,
-                    "bit_offset",
-                    pyre_object::w_int_new(bit_offset as i64),
-                );
-                pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(true));
-            }
+            put(
+                "size",
+                pyre_object::w_int_new(((bits << 16) | bit_offset) as i64),
+            );
+            put("bit_size", pyre_object::w_int_new(bits as i64));
+            put("bit_offset", pyre_object::w_int_new(bit_offset as i64));
+            put("is_bitfield", pyre_object::w_bool_from(true));
         }
         if anonymous
             .iter()
             .any(|anonymous_name| anonymous_name == &entry.name)
         {
-            unsafe {
-                pyre_object::w_dict_setitem_str(d, "is_anonymous", pyre_object::w_bool_from(true));
-            }
+            put("is_anonymous", pyre_object::w_bool_from(true));
         }
         set_type_attr(cls, &entry.name, cf);
     }
@@ -963,7 +997,7 @@ fn process_fields(cls: PyObjectRef, fields: PyObjectRef, is_union: bool) -> PyRe
     stginfo::stginfo_set(cls, new_info);
 
     // Store the raw `_fields_` so the metaclass getset can return it.
-    set_type_attr(cls, "_fields_", fields);
+    set_type_attr(cls, "_fields_", fields_roots.get(fields_slot));
     Ok(pyre_object::w_none())
 }
 
@@ -1065,26 +1099,34 @@ fn cfield_new(
     index: usize,
 ) -> PyObjectRef {
     let inst = pyre_object::w_instance_new(cfield_type());
-    let d = crate::baseobjspace::getdict_native(inst);
-    unsafe {
-        pyre_object::w_dict_setitem_str(d, "name", pyre_object::w_str_new(name));
-        pyre_object::w_dict_setitem_str(d, "proto", proto);
-        pyre_object::w_dict_setitem_str(d, "type", proto);
-        pyre_object::w_dict_setitem_str(d, "offset", pyre_object::w_int_new(offset as i64));
-        pyre_object::w_dict_setitem_str(d, "byte_offset", pyre_object::w_int_new(offset as i64));
-        pyre_object::w_dict_setitem_str(d, "size", pyre_object::w_int_new(size as i64));
-        pyre_object::w_dict_setitem_str(d, "byte_size", pyre_object::w_int_new(size as i64));
-        let bit_size = BigInt::from(size) * BigInt::from(8u8);
-        pyre_object::w_dict_setitem_str(
-            d,
-            "bit_size",
-            pyre_object::longobject::w_long_new(bit_size),
-        );
-        pyre_object::w_dict_setitem_str(d, "bit_offset", pyre_object::w_int_new(0));
-        pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(false));
-        pyre_object::w_dict_setitem_str(d, "is_anonymous", pyre_object::w_bool_from(false));
-        pyre_object::w_dict_setitem_str(d, "index", pyre_object::w_int_new(index as i64));
-    }
+    // The instance `dict` moves, and every insertion below allocates: the
+    // value, the key string `w_dict_setitem_str` builds, and the dict's own
+    // storage when it grows.  A minor collection anywhere in that run
+    // relocates the dict, so the word is read back out of a root slot for
+    // each insertion.  `inst` does not move, but nothing else references it
+    // while the run allocates, so it takes one pin for liveness.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(inst);
+    // The dict lands in the slot after `inst`.
+    let d_slot = roots.base() + 1;
+    roots.pin_root(crate::baseobjspace::getdict_native(inst));
+    let put = |key: &str, value: PyObjectRef| {
+        // SAFETY: the slot holds the instance dict pinned above.
+        unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
+    };
+    put("name", pyre_object::w_str_new(name));
+    put("proto", proto);
+    put("type", proto);
+    put("offset", pyre_object::w_int_new(offset as i64));
+    put("byte_offset", pyre_object::w_int_new(offset as i64));
+    put("size", pyre_object::w_int_new(size as i64));
+    put("byte_size", pyre_object::w_int_new(size as i64));
+    let bit_size = BigInt::from(size) * BigInt::from(8u8);
+    put("bit_size", pyre_object::longobject::w_long_new(bit_size));
+    put("bit_offset", pyre_object::w_int_new(0));
+    put("is_bitfield", pyre_object::w_bool_from(false));
+    put("is_anonymous", pyre_object::w_bool_from(false));
+    put("index", pyre_object::w_int_new(index as i64));
     inst
 }
 
@@ -1469,6 +1511,10 @@ fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
         byte_size as usize,
         index.max(0) as usize,
     );
+    // `field` does not move, but nothing else references it before the return
+    // and the argument decoding below allocates, so it takes one pin.
+    let field_roots = pyre_object::gc_roots::push_roots();
+    field_roots.pin_root(field);
     let bit_size = get("bit_size", 7)?
         .map(crate::baseobjspace::int_w)
         .transpose()?;
@@ -1486,12 +1532,19 @@ fn cfield_new_internal(args: &[PyObjectRef]) -> PyResult {
                 byte_size * 8,
             )));
         }
-        let d = crate::baseobjspace::getdict_native(field);
-        unsafe {
-            pyre_object::w_dict_setitem_str(d, "bit_size", pyre_object::w_int_new(bits));
-            pyre_object::w_dict_setitem_str(d, "bit_offset", pyre_object::w_int_new(bit_offset));
-            pyre_object::w_dict_setitem_str(d, "is_bitfield", pyre_object::w_bool_from(true));
-        }
+        // The field's `dict` moves and each insertion allocates both the value
+        // and the key string, so the word is read back out of a root slot with
+        // the value already built.
+        let roots = pyre_object::gc_roots::push_roots();
+        let d_slot = roots.base();
+        roots.pin_root(crate::baseobjspace::getdict_native(field));
+        let put = |key: &str, value: PyObjectRef| {
+            // SAFETY: the slot holds the field dict pinned above.
+            unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), key, value) };
+        };
+        put("bit_size", pyre_object::w_int_new(bits));
+        put("bit_offset", pyre_object::w_int_new(bit_offset));
+        put("is_bitfield", pyre_object::w_bool_from(true));
     }
     Ok(field)
 }
@@ -1517,7 +1570,15 @@ fn structure_new(args: &[PyObjectRef]) -> PyResult {
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }
-    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(size)) };
+    // The instance `dict` moves and the buffer allocates, so the buffer is
+    // built first and the dict word is read back out of a root slot for the
+    // store; `obj` does not move and takes one pin for liveness.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(obj);
+    let d_slot = roots.base() + 1;
+    roots.pin_root(d);
+    let buffer = pyre_object::w_bytearray_new(size);
+    unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };
     Ok(obj)
 }
 
@@ -1538,20 +1599,41 @@ fn structure_init(args: &[PyObjectRef]) -> PyResult {
     if args.is_empty() {
         return Err(crate::PyError::type_error("__init__ requires self"));
     }
+    // The argument slice is the caller's own native array, which no root
+    // walker updates, so an initialiser that moves is named by its pre-move
+    // address once an earlier `setattr_str` has allocated.  Pin every argument
+    // and take the movable operands back out of their slots.
+    let roots = pyre_object::gc_roots::push_roots();
+    let args_slot = roots.base();
+    for &arg in args {
+        roots.pin_root(arg);
+    }
     let obj = args[0];
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
+    let pos_len = pos.len();
+    // The keyword carrier, when present, is the trailing argument.
+    let kw_slot = kwargs.map(|_| args_slot + args.len() - 1);
     let cls = unsafe { pyre_object::w_instance_get_type(obj) };
     let names = field_names_base_first(cls);
 
-    if pos.len() > names.len() {
+    if pos_len > names.len() {
         return Err(crate::PyError::type_error("too many initializers"));
     }
-    for (i, &val) in pos.iter().enumerate() {
-        crate::baseobjspace::setattr_str(obj, &names[i], val)?;
+    for i in 0..pos_len {
+        crate::baseobjspace::setattr_str(obj, &names[i], roots.get(args_slot + 1 + i))?;
     }
 
-    if let Some(kw) = kwargs {
-        for (key_obj, val) in unsafe { pyre_object::w_dict_items(kw) } {
+    if let Some(kw_slot) = kw_slot {
+        // `w_dict_items` returns a native `Vec` snapshot the collector does not
+        // update either, and a string-keyed strategy mints its key objects
+        // there, so each pair takes a pin and the values are read back.
+        let items = unsafe { pyre_object::w_dict_items(roots.get(kw_slot)) };
+        let items_slot = pyre_object::gc_roots::shadow_stack_len();
+        for &(key_obj, val) in &items {
+            roots.pin_root(key_obj);
+            roots.pin_root(val);
+        }
+        for (i, &(key_obj, _)) in items.iter().enumerate() {
             if !unsafe { pyre_object::is_str(key_obj) } {
                 continue;
             }
@@ -1561,13 +1643,13 @@ fn structure_init(args: &[PyObjectRef]) -> PyResult {
             }
             // Duplicate positional + keyword assignment for the same field.
             if let Some(pos_idx) = names.iter().position(|n| *n == key)
-                && pos_idx < pos.len()
+                && pos_idx < pos_len
             {
                 return Err(crate::PyError::type_error(format!(
                     "duplicate values for field '{key}'"
                 )));
             }
-            crate::baseobjspace::setattr_str(obj, &key, val)?;
+            crate::baseobjspace::setattr_str(obj, &key, roots.get(items_slot + i * 2 + 1))?;
         }
     }
     Ok(pyre_object::w_none())
@@ -1702,29 +1784,39 @@ fn array_init_stginfo(cls: PyObjectRef) -> PyResult {
 
 /// `ctype * n` — cache lookup on `(ctype, n)`, else create `ctype_Array_n`.
 fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
-    let cache = match crate::type_dict_lookup(elem, ARRAY_TYPE_CACHE_KEY) {
-        Some(d) => d,
-        None => {
-            let d = pyre_object::w_dict_new();
-            if crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, d) {
-                pyre_object::gc_hook::try_gc_write_barrier(elem as *mut u8);
-            }
-            d
-        }
-    };
-    if let Some(found) = unsafe { pyre_object::w_dict_getitem(cache, n as i64) } {
+    // Both dicts below move.  Storing the cache on `elem`'s dict keeps it
+    // reachable but leaves a plain local naming the pre-move address, and the
+    // class construction that sits between the cache read and the cache write
+    // allocates throughout — so both words live in root slots and are read
+    // back at every use.
+    let roots = pyre_object::gc_roots::push_roots();
+    let cache_slot = roots.base();
+    let cached = crate::type_dict_lookup(elem, ARRAY_TYPE_CACHE_KEY);
+    roots.pin_root(cached.unwrap_or_else(pyre_object::w_dict_new));
+    if cached.is_none()
+        && crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, roots.get(cache_slot))
+    {
+        pyre_object::gc_hook::try_gc_write_barrier(elem as *mut u8);
+    }
+    if let Some(found) = unsafe { pyre_object::w_dict_getitem(roots.get(cache_slot), n as i64) } {
         return Ok(found);
     }
     let name = format!("{}_Array_{}", type_name(elem), n);
-    let ns = pyre_object::w_dict_new();
+    let ns_roots = pyre_object::gc_roots::push_roots();
+    let ns_slot = ns_roots.base();
+    ns_roots.pin_root(pyre_object::w_dict_new());
+    let w_length = pyre_object::w_int_new(n as i64);
     unsafe {
-        pyre_object::w_dict_setitem_str(ns, "_type_", elem);
-        pyre_object::w_dict_setitem_str(ns, "_length_", pyre_object::w_int_new(n as i64));
+        pyre_object::w_dict_setitem_str(ns_roots.get(ns_slot), "_type_", elem);
+        pyre_object::w_dict_setitem_str(ns_roots.get(ns_slot), "_length_", w_length);
     }
     let bases = pyre_object::w_tuple_new(vec![array_type()]);
-    let args = [pyre_object::w_str_new(&name), bases, ns];
-    let new_cls = crate::call::type_call_instantiate(pycarraytype_type(), &args)?;
-    unsafe { pyre_object::w_dict_setitem(cache, n as i64, new_cls) };
+    let w_name = pyre_object::w_str_new(&name);
+    let new_cls = crate::call::type_call_instantiate(
+        pycarraytype_type(),
+        &[w_name, bases, ns_roots.get(ns_slot)],
+    )?;
+    unsafe { pyre_object::w_dict_setitem(roots.get(cache_slot), n as i64, new_cls) };
     Ok(new_cls)
 }
 
@@ -1762,7 +1854,14 @@ fn array_new(args: &[PyObjectRef]) -> PyResult {
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }
-    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(size)) };
+    // The instance `dict` moves under the buffer allocation; `obj` does not
+    // move and takes one pin for liveness.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(obj);
+    let d_slot = roots.base() + 1;
+    roots.pin_root(d);
+    let buffer = pyre_object::w_bytearray_new(size);
+    unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };
     Ok(obj)
 }
 
@@ -2190,8 +2289,15 @@ fn pointer_new(args: &[PyObjectRef]) -> PyResult {
     if d.is_null() {
         return Err(crate::PyError::type_error("ctypes instance has no dict"));
     }
+    // The instance `dict` moves under the buffer allocation; `obj` does not
+    // move and takes one pin for liveness.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(obj);
+    let d_slot = roots.base() + 1;
+    roots.pin_root(d);
     let psize = host_ctypes::pointer_size();
-    unsafe { pyre_object::w_dict_setitem_str(d, "_b_", pyre_object::w_bytearray_new(psize)) };
+    let buffer = pyre_object::w_bytearray_new(psize);
+    unsafe { pyre_object::w_dict_setitem_str(roots.get(d_slot), "_b_", buffer) };
     Ok(obj)
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1793,8 +1793,7 @@ fn array_type_from_ctype(elem: PyObjectRef, n: usize) -> PyResult {
     let cache_slot = roots.base();
     let cached = crate::type_dict_lookup(elem, ARRAY_TYPE_CACHE_KEY);
     roots.pin_root(cached.unwrap_or_else(pyre_object::w_dict_new));
-    if cached.is_none()
-        && crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, roots.get(cache_slot))
+    if cached.is_none() && crate::type_dict_store(elem, ARRAY_TYPE_CACHE_KEY, roots.get(cache_slot))
     {
         pyre_object::gc_hook::try_gc_write_barrier(elem as *mut u8);
     }

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -49,19 +49,35 @@ struct LocaleConvData {
 /// grouping lists already carry the trailing 0 that `_w_copy_grouping`
 /// appends to a non-empty grouping (`interp_locale.py:36-40`).
 fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
-    let d = pyre_object::w_dict_new();
-    let put_str = |k: &str, b: &[u8]| unsafe {
-        pyre_object::w_dict_setitem_str(d, k, crate::typedef::charp2uni(b));
+    // A `dict` header moves, and each of the eighteen insertions below
+    // allocates: the value, the key string `w_dict_setitem_str` builds, and
+    // the dict's own storage when it grows.  A minor collection anywhere in
+    // that run relocates the dict, so the word is read back out of a root slot
+    // for every insertion and for the return.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(pyre_object::w_dict_new());
+    // The value arrives already built.  Call arguments evaluate left to right,
+    // so reading the dict slot inline with an allocating value expression
+    // would read the slot first and hand over a pre-move word.
+    let put = |k: &str, value: pyre_object::PyObjectRef| {
+        // `grouping` is a `list`, which moves as well, and the key string is
+        // allocated after this value is handed over.
+        let value_root = pyre_object::gc_roots::push_roots();
+        let value_slot = value_root.base();
+        value_root.pin_root(value);
+        // SAFETY: the slot holds the `W_DictObject` pinned above.
+        unsafe {
+            pyre_object::w_dict_setitem_str(roots.get(dict_slot), k, value_root.get(value_slot));
+        }
     };
-    let put_int = |k: &str, v: i64| unsafe {
-        pyre_object::w_dict_setitem_str(d, k, pyre_object::w_int_new(v));
-    };
-    let put_grouping = |k: &str, v: &[i64]| unsafe {
-        pyre_object::w_dict_setitem_str(
-            d,
+    let put_str = |k: &str, b: &[u8]| put(k, crate::typedef::charp2uni(b));
+    let put_int = |k: &str, v: i64| put(k, pyre_object::w_int_new(v));
+    let put_grouping = |k: &str, v: &[i64]| {
+        put(
             k,
             pyre_object::w_list_new(v.iter().map(|&x| pyre_object::w_int_new(x)).collect()),
-        );
+        )
     };
     put_str("decimal_point", &c.decimal_point);
     put_str("thousands_sep", &c.thousands_sep);
@@ -81,7 +97,7 @@ fn localeconv_to_dict(c: &LocaleConvData) -> pyre_object::PyObjectRef {
     put_int("n_sep_by_space", c.n_sep_by_space);
     put_int("p_sign_posn", c.p_sign_posn);
     put_int("n_sign_posn", c.n_sign_posn);
-    d
+    roots.get(dict_slot)
 }
 
 /// POSIX "C" locale `localeconv` defaults for builds without libc; the

--- a/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
+++ b/pyre/pyre-interpreter/src/module/_pickle/pickler.rs
@@ -3080,11 +3080,12 @@ fn save_reduce(
     w_obj_opt: Option<PyObjectRef>,
 ) -> Result<(), PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
-    // Recursive saves (and the reduce callbacks they invoke) relocate young
-    // objects, so pin the reduce values in a GC-walked `list` and re-read each
-    // one immediately before it is consumed.
-    let rv_len = rv.len();
-    let rv_slot = pin_items(rv.to_vec());
+    // Reach a slot before anything allocates.  The object being reduced can be
+    // a `list` subclass instance, whose header moves, and `pin_items` below
+    // builds a GC-walked `list` -- a collection point.  `pin_root` publishes
+    // whatever word it is handed and does not normalize it under a single
+    // mutator, so a pin taken after that allocation would freeze a forwarding
+    // stub into the slot and every later read of it would return the stub.
     let w_obj_slot = match w_obj_opt {
         Some(o) => {
             pyre_object::gc_roots::pin_root(o);
@@ -3092,6 +3093,11 @@ fn save_reduce(
         }
         None => None,
     };
+    // Recursive saves (and the reduce callbacks they invoke) relocate young
+    // objects, so pin the reduce values in a GC-walked `list` and re-read each
+    // one immediately before it is consumed.
+    let rv_len = rv.len();
+    let rv_slot = pin_items(rv.to_vec());
     let rv_get = |i: usize| pinned_get(rv_slot, i);
     let present = |i: usize| i < rv_len && !unsafe { pyre_object::is_none(pinned_get(rv_slot, i)) };
 

--- a/pyre/pyre-interpreter/src/module/errno/mod.rs
+++ b/pyre/pyre-interpreter/src/module/errno/mod.rs
@@ -12,16 +12,28 @@ crate::py_module! {
         // `interp_errno.py` builds `errorcode = {code: name, ...}`
         // alongside each exported constant.  We populate it incrementally
         // as we register the constants below.
-        let errorcode = pyre_object::w_dict_new();
-        crate::module_ns_store(ns, "errorcode", errorcode);
+        //
+        // A `dict` header moves, and every registration allocates: the
+        // constant's `int`, the name `str`, the key string each namespace
+        // store builds, and the dict's own storage as it grows.  A minor
+        // collection anywhere in that run relocates the dict — being reachable
+        // from the module namespace keeps it alive but does not hold it still
+        // — so the word lives in a root slot and is read back for every
+        // insertion.  `ns` is a module dict, which is allocated stable, so it
+        // stays valid across the same run.
+        let roots = pyre_object::gc_roots::push_roots();
+        let errorcode_slot = roots.base();
+        roots.pin_root(pyre_object::w_dict_new());
+        crate::module_ns_store(ns, "errorcode", roots.get(errorcode_slot));
         let mut store = |name: &str, value: i64| {
             crate::module_ns_store(ns, name, pyre_object::w_int_new(value));
+            // Call arguments evaluate left to right, so the key and the value
+            // are built first: reading the dict slot inline with them would
+            // read it before those allocations and hand over a pre-move word.
+            let w_code = pyre_object::w_int_new(value);
+            let w_name = pyre_object::w_str_new(name);
             unsafe {
-                pyre_object::w_dict_store(
-                    errorcode,
-                    pyre_object::w_int_new(value),
-                    pyre_object::w_str_new(name),
-                );
+                pyre_object::w_dict_store(roots.get(errorcode_slot), w_code, w_name);
             }
         };
         #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]

--- a/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
+++ b/pyre/pyre-interpreter/src/module/pyexpat/mod.rs
@@ -228,9 +228,17 @@ impl<'a> MiniXmlParser<'a> {
     fn parse_xml_decl(&mut self) -> Result<(), crate::PyError> {
         let event_pos = self.pos;
         self.expect("<?xml")?;
+        // `encoding` and `standalone` are freshly minted and reachable only
+        // from these locals, while the rest of the loop, the position update
+        // and the handler call all allocate and can run Python — a collection
+        // that completes in that window would reclaim them.  Each mint takes
+        // one liveness pin; neither kind moves, so the locals stay current and
+        // are never read back.  `w_none()` is a singleton and needs nothing.
+        let roots = pyre_object::gc_roots::push_roots();
         let mut version = String::new();
         let mut encoding = w_none();
         let mut standalone = w_int_new(-1);
+        roots.pin_root(standalone);
         loop {
             self.skip_ws();
             if self.consume("?>") {
@@ -246,9 +254,13 @@ impl<'a> MiniXmlParser<'a> {
             let value = self.read_quoted()?;
             match key.as_str() {
                 "version" => version = value,
-                "encoding" => encoding = w_str_new(&value),
+                "encoding" => {
+                    encoding = w_str_new(&value);
+                    roots.pin_root(encoding);
+                }
                 "standalone" => {
                     standalone = w_int_new(if value == "yes" { 1 } else { 0 });
+                    roots.pin_root(standalone);
                 }
                 _ => {}
             }
@@ -348,6 +360,12 @@ impl<'a> MiniXmlParser<'a> {
         self.expect("<!DOCTYPE")?;
         self.skip_ws();
         let name = self.read_name()?;
+        // The two identifiers are minted here and used again only at the very
+        // end, past the not-standalone callback, the internal subset and the
+        // start-doctype handler — all of which run Python.  Nothing else refers
+        // to them in between, so each mint takes one liveness pin; a `str` does
+        // not move, so the locals stay current.  `w_none()` needs nothing.
+        let roots = pyre_object::gc_roots::push_roots();
         let mut sysid = w_none();
         let mut pubid = w_none();
         let mut has_internal_subset = false;
@@ -356,12 +374,15 @@ impl<'a> MiniXmlParser<'a> {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(pubid);
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(sysid);
         }
         self.skip_ws();
         if crate::baseobjspace::getattr_str(self.parser, "_pyre_not_standalone_pending")
@@ -435,6 +456,13 @@ impl<'a> MiniXmlParser<'a> {
         };
         let name = self.read_name()?;
         self.skip_ws();
+        // Every identifier this declaration mints is reachable only from its
+        // local until the handler call at the end, and the reads that follow —
+        // another `read_quoted`, the position update, the handler itself — both
+        // allocate and run Python.  Each mint takes one liveness pin; strings do
+        // not move, so no local is read back.  `base` stays the `w_none()`
+        // singleton, which needs nothing.
+        let roots = pyre_object::gc_roots::push_roots();
         let mut value = w_none();
         let mut base = w_none();
         let mut sysid = w_none();
@@ -444,10 +472,12 @@ impl<'a> MiniXmlParser<'a> {
             let v = self.read_quoted()?;
             self.internal_entities.insert(name.clone(), v.clone());
             value = w_str_new(&v);
+            roots.pin_root(value);
         } else if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(pubid);
             self.skip_ws();
             let system = self.read_quoted()?;
             self.external_entities.insert(
@@ -458,6 +488,7 @@ impl<'a> MiniXmlParser<'a> {
                 ),
             );
             sysid = w_str_new(&system);
+            roots.pin_root(sysid);
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
@@ -465,12 +496,14 @@ impl<'a> MiniXmlParser<'a> {
             self.external_entities
                 .insert(name.clone(), (system.clone(), None));
             sysid = w_str_new(&system);
+            roots.pin_root(sysid);
         }
         self.skip_ws();
         if self.starts_with("NDATA") {
             self.expect("NDATA")?;
             self.skip_ws();
             notation = w_str_new(&self.read_name()?);
+            roots.pin_root(notation);
         }
         self.skip_until_gt()?;
         let _ = &mut base;
@@ -524,12 +557,19 @@ impl<'a> MiniXmlParser<'a> {
                 _ => {}
             }
         }
+        // The content model is a fresh `tuple` that nothing but this local
+        // refers to while the position update writes three parser slots and the
+        // handler runs Python; a collection completing there would reclaim it.
+        // One liveness pin at the mint — a tuple does not move, so the local
+        // stays current.
+        let roots = pyre_object::gc_roots::push_roots();
         let model = w_tuple_new(vec![
             w_int_new(2),
             w_int_new(0),
             w_none(),
             w_tuple_new(vec![]),
         ]);
+        roots.pin_root(model);
         self.set_event_position(event_pos);
         self.call_handler("ElementDeclHandler", &[w_str_new(&name), model])
     }
@@ -580,20 +620,28 @@ impl<'a> MiniXmlParser<'a> {
         self.skip_ws();
         let name = self.read_name()?;
         self.skip_ws();
+        // Both identifiers are minted here and held across the remaining
+        // `read_quoted` calls, the position update and the handler, all of which
+        // allocate or run Python.  One liveness pin per mint; a `str` does not
+        // move, so the locals stay current and `w_none()` needs nothing.
+        let roots = pyre_object::gc_roots::push_roots();
         let mut sysid = w_none();
         let mut pubid = w_none();
         if self.starts_with("PUBLIC") {
             self.expect("PUBLIC")?;
             self.skip_ws();
             pubid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(pubid);
             self.skip_ws();
             if matches!(self.peek_char(), Some('"' | '\'')) {
                 sysid = w_str_new(&self.read_quoted()?);
+                roots.pin_root(sysid);
             }
         } else if self.starts_with("SYSTEM") {
             self.expect("SYSTEM")?;
             self.skip_ws();
             sysid = w_str_new(&self.read_quoted()?);
+            roots.pin_root(sysid);
         }
         self.skip_until_gt()?;
         self.set_event_position(event_pos);
@@ -642,9 +690,17 @@ impl<'a> MiniXmlParser<'a> {
                 self.apply_namespace_decls(&attrs, &mut ns_declared)?;
                 let name = self.expand_name(&raw_name, false)?;
                 let expanded_attrs = self.expand_attributes(&attrs)?;
-                let w_attrs = self.convert_attributes(&expanded_attrs);
+                // The attribute container is a `dict` or a `list`, both of which
+                // move, and the position update and the interned element name
+                // that follow allocate.  Pin it on creation and read it back out
+                // of the root slot at the call; the name is built into a local
+                // first, since the argument list evaluates left to right.
+                let roots = pyre_object::gc_roots::push_roots();
+                let attrs_slot = roots.base();
+                roots.pin_root(self.convert_attributes(&expanded_attrs));
                 self.set_event_position(event_pos);
-                self.call_handler("StartElementHandler", &[self.intern_string(&name), w_attrs])?;
+                let w_name = self.intern_string(&name);
+                self.call_handler("StartElementHandler", &[w_name, roots.get(attrs_slot)])?;
                 self.set_event_position(self.pos);
                 self.call_handler("EndElementHandler", &[self.intern_string(&name)])?;
                 self.end_namespace_scope(ns_declared)?;
@@ -659,9 +715,12 @@ impl<'a> MiniXmlParser<'a> {
                 let expanded_attrs = self.expand_attributes(&attrs)?;
                 self.stack.push(name.clone());
                 self.ns_stack.push(ns_declared);
-                let w_attrs = self.convert_attributes(&expanded_attrs);
+                let roots = pyre_object::gc_roots::push_roots();
+                let attrs_slot = roots.base();
+                roots.pin_root(self.convert_attributes(&expanded_attrs));
                 self.set_event_position(event_pos);
-                self.call_handler("StartElementHandler", &[self.intern_string(&name), w_attrs])?;
+                let w_name = self.intern_string(&name);
+                self.call_handler("StartElementHandler", &[w_name, roots.get(attrs_slot)])?;
                 return Ok(());
             }
             let attr_name = self.read_name()?;
@@ -736,19 +795,41 @@ impl<'a> MiniXmlParser<'a> {
         let ordered = crate::baseobjspace::getattr_str(self.parser, "ordered_attributes")
             .map(is_true_obj)
             .unwrap_or(false);
+        // Both arms convert one attribute at a time and hold what they have
+        // already converted across the next conversion's allocations.
+        // `intern_string` hands back whatever the caller's intern map holds under
+        // the name, so a name can be a `list` or a `dict`, whose header moves,
+        // and a fresh value string has no heap edge until the container takes it.
+        // Every converted word is therefore pinned at its mint and read back at
+        // the call that consumes it.
         if ordered {
-            let mut items = Vec::with_capacity(attrs.len() * 2);
+            let roots = pyre_object::gc_roots::push_roots();
+            let base = roots.base();
             for (name, value) in attrs {
-                items.push(self.intern_string(name));
-                items.push(w_str_new(value));
+                roots.pin_root(self.intern_string(name));
+                roots.pin_root(w_str_new(value));
             }
-            w_list_new(items)
+            // `w_list_new` pins the vector it is handed, so the vector is built
+            // out of the slots at the call rather than while the members are
+            // still allocating.
+            w_list_new((0..attrs.len() * 2).map(|i| roots.get(base + i)).collect())
         } else {
-            let w_attrs = w_dict_new();
+            // The dict's storage allocates as it grows and its header moves with
+            // it, so it takes a slot of its own.  The value string is built into
+            // a local first — call arguments evaluate left to right, so reading
+            // the slots inline with it would take their addresses before it
+            // allocates.
+            let roots = pyre_object::gc_roots::push_roots();
+            let attrs_slot = roots.base();
+            roots.pin_root(w_dict_new());
             for (name, value) in attrs {
-                unsafe { w_dict_store(w_attrs, self.intern_string(name), w_str_new(value)) };
+                let name_roots = pyre_object::gc_roots::push_roots();
+                let name_slot = name_roots.base();
+                name_roots.pin_root(self.intern_string(name));
+                let w_value = w_str_new(value);
+                unsafe { w_dict_store(roots.get(attrs_slot), name_roots.get(name_slot), w_value) };
             }
-            w_attrs
+            roots.get(attrs_slot)
         }
     }
 
@@ -808,10 +889,22 @@ impl<'a> MiniXmlParser<'a> {
     }
 
     fn call_handler(&mut self, name: &str, args: &[PyObjectRef]) -> Result<(), crate::PyError> {
+        // The handler lookup below is a full `getattr`, and the flush hands
+        // buffered text to a Python handler; both run Python and so can collect,
+        // and an attribute `dict` or `list` in `args` moves under either.  A
+        // plain Rust slice is not a place the collector updates, so the argument
+        // words are pinned before the lookup and read back out of their root
+        // slots at the call.
+        let roots = pyre_object::gc_roots::push_roots();
+        let base = roots.base();
+        for &arg in args {
+            roots.pin_root(arg);
+        }
         if name != "CharacterDataHandler" && self.handler_is_set(name) {
             self.flush_character_buffer()?;
         }
-        self.call_handler_raw(name, args)
+        let args: Vec<PyObjectRef> = (0..args.len()).map(|i| roots.get(base + i)).collect();
+        self.call_handler_raw(name, &args)
     }
 
     fn call_handler_raw(&self, name: &str, args: &[PyObjectRef]) -> Result<(), crate::PyError> {
@@ -1048,6 +1141,13 @@ impl<'a> MiniXmlParser<'a> {
         if handler.is_null() || unsafe { is_none(handler) } {
             return Ok(());
         }
+        // A handler held on the class comes back as a freshly bound method that
+        // only this local names, and the base lookup below is a full `getattr`
+        // that can run Python.  Pin it for the window between the two; a method
+        // does not move, so the local is not read back.  `base` needs nothing:
+        // it is the parser's own attribute and stays reachable through it.
+        let roots = pyre_object::gc_roots::push_roots();
+        roots.pin_root(handler);
         let base = crate::baseobjspace::getattr_str(self.parser, "_pyre_base")
             .unwrap_or_else(|_| w_none());
         let ret = crate::call::call_function_impl_result(
@@ -1087,6 +1187,12 @@ impl<'a> MiniXmlParser<'a> {
         if handler.is_null() || unsafe { is_none(handler) } {
             return Ok(());
         }
+        // A class-held handler is a freshly bound method named only by this
+        // local, and the base lookup that follows is a full `getattr`, so it
+        // takes one liveness pin.  `sysid` / `pubid` are the caller's, pinned
+        // there for the whole doctype.
+        let roots = pyre_object::gc_roots::push_roots();
+        roots.pin_root(handler);
         let base = crate::baseobjspace::getattr_str(self.parser, "_pyre_base")
             .unwrap_or_else(|_| w_none());
         let ret = crate::call::call_function_impl_result(handler, &[w_none(), base, sysid, pubid])?;
@@ -1097,18 +1203,31 @@ impl<'a> MiniXmlParser<'a> {
     }
 
     fn intern_string(&self, value: &str) -> PyObjectRef {
+        // Nothing holds the new string until the map takes it, and everything
+        // below can collect, so it gets one liveness pin at its mint; a `str`
+        // does not move, so the local stays current.
+        let value_roots = pyre_object::gc_roots::push_roots();
         let w_value = w_str_new(value);
+        value_roots.pin_root(w_value);
         let Ok(intern) = crate::baseobjspace::getattr_str(self.parser, "intern") else {
             return w_value;
         };
         if unsafe { is_none(intern) } {
             return w_value;
         }
+        // The intern map is a caller-supplied `dict`, whose header moves.  A
+        // borrowed-str probe compares against whatever a colliding bucket
+        // holds, so a stored non-string key can reach a user `__eq__`; that
+        // runs Python and can collect, leaving the local naming the pre-move
+        // address.  The map is read back out of its root slot for both uses.
+        let roots = pyre_object::gc_roots::push_roots();
+        let intern_slot = roots.base();
+        roots.pin_root(intern);
         unsafe {
-            if let Some(existing) = w_dict_getitem_str(intern, value) {
+            if let Some(existing) = w_dict_getitem_str(roots.get(intern_slot), value) {
                 existing
             } else {
-                w_dict_setitem_str(intern, value, w_value);
+                w_dict_setitem_str(roots.get(intern_slot), value, w_value);
                 w_value
             }
         }
@@ -1371,6 +1490,13 @@ fn parse_impl(
     data: PyObjectRef,
     isfinal: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // `data` can be the fresh chunk a Python `read()` just returned, named
+    // only by this parameter, and the pending-input lookup below runs a full
+    // `getattr` before it is decoded.  One liveness pin; a `str`/`bytes` does
+    // not move, so the parameter stays current.  `parser` is the receiver and
+    // stays reachable through the caller.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(data);
     if crate::baseobjspace::getattr_str(parser, "_pyre_finished")
         .map(is_true_obj)
         .unwrap_or(false)
@@ -1453,6 +1579,11 @@ fn call_foreign_dtd_handler(
     if handler.is_null() || unsafe { is_none(handler) } {
         return Ok(());
     }
+    // A class-held handler is a freshly bound method named only by this local,
+    // and the base lookup that follows is a full `getattr`, so it takes one
+    // liveness pin.
+    let roots = pyre_object::gc_roots::push_roots();
+    roots.pin_root(handler);
     let base = crate::baseobjspace::getattr_str(parser, "_pyre_base").unwrap_or_else(|_| w_none());
     let ret = crate::call::call_function_impl_result(handler, &[w_none(), base, sysid, pubid])?;
     if unsafe { is_int(ret) && w_int_get_value(ret) == 0 } {
@@ -1491,6 +1622,13 @@ fn pyexpat_error(msg: String, code: i64, lineno: i64, offset: i64) -> crate::PyE
     if let Some(cls) = crate::builtins::lookup_exc_class("pyexpat.error") {
         let args = [cls, w_str_new(&msg)];
         if let Ok(exc) = crate::builtins::exc_exception_new(&args) {
+            // The fresh exception is named only by this local while the three
+            // stores below build their values and grow its attribute storage.
+            // One liveness pin at the mint; an exception instance does not move,
+            // so the local stays current.  `cls` is the registered class and
+            // stays reachable through the registry.
+            let roots = pyre_object::gc_roots::push_roots();
+            roots.pin_root(exc);
             crate::baseobjspace::setdictvalue_native(exc, "code", w_int_new(code));
             crate::baseobjspace::setdictvalue_native(exc, "lineno", w_int_new(lineno));
             crate::baseobjspace::setdictvalue_native(exc, "offset", w_int_new(offset));
@@ -1547,7 +1685,13 @@ mod xmlparser_class {
                 self_obj: PyObjectRef,
                 file: PyObjectRef,
             ) -> Result<PyObjectRef, crate::PyError> {
+                // `read` comes back as a freshly bound method that only this
+                // local names, and it is reused after every chunk is parsed —
+                // arbitrary Python runs in between.  One liveness pin; a method
+                // does not move, so the local stays current.
+                let roots = pyre_object::gc_roots::push_roots();
                 let read = crate::baseobjspace::getattr_str(file, "read")?;
+                roots.pin_root(read);
                 let mut result = w_int_new(1);
                 loop {
                     let data = crate::call::call_function_impl_result(read, &[w_int_new(2048)])?;
@@ -1648,7 +1792,13 @@ mod xmlparser_class {
                 context: PyObjectRef,
                 #[default(w_none())] encoding: PyObjectRef,
             ) -> PyObjectRef {
+                // The fresh sub-parser is named only by this local while its
+                // default slots are installed and the parent's configuration is
+                // copied over, both of which allocate and read attributes; it
+                // takes one liveness pin, and an instance does not move.
+                let roots = pyre_object::gc_roots::push_roots();
                 let parser = w_instance_new(xmlparser_class::type_object());
+                roots.pin_root(parser);
                 init_parser_slots(parser);
                 copy_parser_config(self_obj, parser);
                 crate::baseobjspace::setdictvalue_native(parser, "_pyre_is_subparser", w_bool_from(true));
@@ -1758,7 +1908,18 @@ fn parser_create3(
     namespace_separator: PyObjectRef,
     intern: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // `intern` is whatever the caller passed, so it can be a `dict`, whose
+    // header moves; the instance and its slot defaults below allocate all the
+    // way down.  Pin it on entry and read it back for the store, or the parser
+    // would keep a pre-move address.  The absent marker is a null word, which a
+    // walker treats as no root.  The fresh parser is named only by its local
+    // across the same run — every default slot it is given allocates — so it
+    // takes one liveness pin; an instance does not move and is not read back.
+    let roots = pyre_object::gc_roots::push_roots();
+    let intern_slot = roots.base();
+    roots.pin_root(intern);
     let parser = w_instance_new(xmlparser_class::type_object());
+    roots.pin_root(parser);
     init_parser_slots(parser);
     if unsafe { !is_none(encoding) } {
         if unsafe { !is_str(encoding) } {
@@ -1800,6 +1961,7 @@ fn parser_create3(
     // `init_parser_slots` installed that new dictionary already, so an omitted
     // argument has nothing to write and the two named cases write themselves;
     // `intern_string` reads `None` back as "do not intern".
+    let intern = roots.get(intern_slot);
     if !intern.is_null() {
         crate::baseobjspace::setdictvalue_native(parser, "intern", intern);
     }
@@ -1931,7 +2093,14 @@ const ERROR_NAMES: &[&str] = &[
 fn make_namespace(name: &'static str) -> PyObjectRef {
     let tp = crate::typedef::make_builtin_type(name, |_| {});
     unsafe { typeobject::w_type_set_hasdict(tp, true) };
+    // The fresh instance is named only by this local while the name store below
+    // builds its string and installs the instance's attribute storage, so it
+    // takes one liveness pin; an instance does not move, so the local stays
+    // current.  `tp` is pinned by `w_instance_new` for its own allocation and is
+    // held by the instance afterwards.
+    let roots = pyre_object::gc_roots::push_roots();
     let obj = w_instance_new(tp);
+    roots.pin_root(obj);
     crate::baseobjspace::setdictvalue_native(obj, "__name__", w_str_new(name));
     obj
 }
@@ -1973,7 +2142,13 @@ crate::py_module! {
         }
 
         // model — content-model integer constants.
+        // Each submodule object is a fresh instance named only by its local
+        // while the constants below are built and written into it, and every
+        // one of those stores allocates.  Each takes one liveness pin at its
+        // mint; an instance does not move, so the locals stay current.
+        let ns_roots = pyre_object::gc_roots::push_roots();
         let model = make_namespace("pyexpat.model");
+        ns_roots.pin_root(model);
         for (name, value) in MODEL_CONSTANTS {
             crate::baseobjspace::setdictvalue_native(model, name, w_int_new(*value));
         }
@@ -1982,8 +2157,19 @@ crate::py_module! {
         // errors — XML_ERROR_* message strings plus the `codes`
         // (message -> code) and `messages` (code -> message) maps.
         let errors = make_namespace("pyexpat.errors");
-        let codes = w_dict_new();
-        let messages = w_dict_new();
+        ns_roots.pin_root(errors);
+        // Both maps are dicts, whose headers move, and every iteration of the
+        // loop allocates: the message string, the code objects, the key strings
+        // the stores build, and each dict's own storage as it grows.  They are
+        // pinned on creation and read back out of their root slots at each use.
+        // The values are built into locals first — call arguments evaluate left
+        // to right, so reading a slot inline would take the address before the
+        // value allocates.
+        let error_map_roots = pyre_object::gc_roots::push_roots();
+        let codes_slot = error_map_roots.base();
+        error_map_roots.pin_root(w_dict_new());
+        let messages_slot = codes_slot + 1;
+        error_map_roots.pin_root(w_dict_new());
         for (idx, name) in ERROR_NAMES.iter().enumerate() {
             // ERROR_NAMES[0] is XML_ERROR_NONE (no message); codes start at 1.
             if idx == 0 {
@@ -1992,12 +2178,16 @@ crate::py_module! {
             let (msg, code) = ERROR_TABLE[idx - 1];
             let w_msg = w_str_new(msg);
             crate::baseobjspace::setdictvalue_native(errors, name, w_msg);
-            unsafe {
-                w_dict_setitem_str(codes, msg, w_int_new(code));
-                w_dict_store(messages, w_int_new(code), w_msg);
-            }
+            let w_code = w_int_new(code);
+            let codes = error_map_roots.get(codes_slot);
+            unsafe { w_dict_setitem_str(codes, msg, w_code) };
+            let w_key = w_int_new(code);
+            let messages = error_map_roots.get(messages_slot);
+            unsafe { w_dict_store(messages, w_key, w_msg) };
         }
+        let codes = error_map_roots.get(codes_slot);
         crate::baseobjspace::setdictvalue_native(errors, "codes", codes);
+        let messages = error_map_roots.get(messages_slot);
         crate::baseobjspace::setdictvalue_native(errors, "messages", messages);
         crate::module_ns_store(ns, "errors", errors);
 

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3550,10 +3550,28 @@ unsafe fn maybe_migrate_to_boxed<O: MapdictObject>(
 /// # Safety
 /// `attr_node` must point to a live `PlainAttribute`; `obj` to a live carrier.
 unsafe fn copy_attr<O: MapdictObject>(attr_node: MapRef, obj: &O, new_obj: &mut Object) {
-    let w_value = unsafe { plain_direct_read(attr_node, obj) };
+    // The carrier's storage is a plain `Vec` no collector updates, and the read
+    // below boxes an unboxed attribute. Publish the values already copied,
+    // copy them back once the read is done, and only then hand `add_attr` a
+    // storage it is free to re-lay-out.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let storage_slot = pyre_object::gc_roots::pin_roots(&new_obj.storage);
+    let value_slot =
+        pyre_object::gc_roots::pin_roots(&[unsafe { plain_direct_read(attr_node, obj) }]);
+    for (i, slot) in new_obj.storage.iter_mut().enumerate() {
+        *slot = pyre_object::gc_roots::shadow_stack_get(storage_slot + i);
+    }
     let p = unsafe { (*attr_node).as_plain() };
     let map = new_obj._get_mapdict_map();
-    unsafe { add_attr(map, new_obj, &p.name, p.attrkind, w_value) };
+    unsafe {
+        add_attr(
+            map,
+            new_obj,
+            &p.name,
+            p.attrkind,
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
+        )
+    };
 }
 
 /// mapdict.py:326-330 `Terminator.copy` / 472-475 `PlainAttribute.copy` — build
@@ -3653,10 +3671,21 @@ unsafe fn node_delete<O: MapdictObject>(
             // — mapdict.py:403-407 swallows KeyError), then return an empty
             // carrier on this terminator (`Terminator.copy(self, obj)`).
             TerminatorKind::Devolved if attrkind == DICT => {
+                // The backing dict moves and the key is allocated after it has
+                // been resolved, so it is published and read back at the delete.
+                let _roots = pyre_object::gc_roots::push_roots();
                 let w_dict = obj.getdict();
-                let backing = crate::type_methods::resolve_dict_backing(w_dict);
+                let backing_slot =
+                    pyre_object::gc_roots::pin_roots(&[crate::type_methods::resolve_dict_backing(
+                        w_dict,
+                    )]);
                 let w_key = pyre_object::w_str_from_wtf8(name.to_owned());
-                unsafe { pyre_object::w_dict_delitem(backing, w_key) };
+                unsafe {
+                    pyre_object::w_dict_delitem(
+                        pyre_object::gc_roots::shadow_stack_get(backing_slot),
+                        w_key,
+                    )
+                };
                 Some(unsafe { node_copy(self_node, obj) })
             }
             _ => None,
@@ -3714,16 +3743,43 @@ unsafe fn node_materialize_dict<O: MapdictObject>(
 ) -> Object {
     if unsafe { (*self_node).is_plain() } {
         let p = unsafe { (*self_node).as_plain() };
+        // The dict moves and both steps before this node's store allocate: the
+        // recursion fills in every node closer to the terminator, and boxing
+        // this node's name runs once its value has already been read. Publish
+        // the dict and the value and read both back at the store.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
         // mapdict.py:494/503 — recurse into `back` first.
-        let mut new_obj = unsafe { node_materialize_dict(p.back, obj, w_dict) };
+        let mut new_obj = unsafe {
+            node_materialize_dict(
+                p.back,
+                obj,
+                pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            )
+        };
         if p.attrkind == DICT {
             // mapdict.py:495-497/504-506 — move the DICT attribute into the
             // materialised dict (`dict_w[space.newtext(name)] =
             // self._prim_direct_read(obj)`). `plain_direct_read` performs that
             // prim read, boxing the slot when the attribute is unboxed.
-            let w_value = unsafe { plain_direct_read(self_node, obj) };
+            //
+            // The carrier the recursion returned holds every lower node's value
+            // in a plain `Vec` the collector does not update, and nothing
+            // touches it here, so the run copies back index for index.
+            let storage_slot = pyre_object::gc_roots::pin_roots(&new_obj.storage);
+            let value_slot =
+                pyre_object::gc_roots::pin_roots(&[unsafe { plain_direct_read(self_node, obj) }]);
             let w_attr = pyre_object::unicodeobject::box_str_constant(&p.name);
-            unsafe { pyre_object::w_dict_store(w_dict, w_attr, w_value) };
+            unsafe {
+                pyre_object::w_dict_store(
+                    pyre_object::gc_roots::shadow_stack_get(dict_slot),
+                    w_attr,
+                    pyre_object::gc_roots::shadow_stack_get(value_slot),
+                )
+            };
+            for (i, slot) in new_obj.storage.iter_mut().enumerate() {
+                *slot = pyre_object::gc_roots::shadow_stack_get(storage_slot + i);
+            }
         } else {
             // mapdict.py:499/508 — keep the non-DICT attribute on the carrier.
             unsafe { copy_attr(self_node, obj, &mut new_obj) };
@@ -4407,10 +4463,20 @@ unsafe fn write_terminator<O: MapdictObject>(
         TerminatorKind::Devolved if attrkind == DICT => {
             // mapdict.py:390-396: the devolved terminator writes DICT attributes
             // into the materialised instance dict (`space.setitem_str(
-            // obj.getdict(space), name, w_value)`).
+            // obj.getdict(space), name, w_value)`).  `getdict` builds the
+            // wrapper when the SPECIAL slot is still empty, so the incoming
+            // value is published across it and read back at the store.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let value_slot = pyre_object::gc_roots::pin_roots(&[w_value]);
             let w_dict = obj.getdict();
             let backing = crate::type_methods::resolve_dict_backing(w_dict);
-            unsafe { pyre_object::w_dict_setitem_wtf8(backing, name, w_value) };
+            unsafe {
+                pyre_object::w_dict_setitem_wtf8(
+                    backing,
+                    name,
+                    pyre_object::gc_roots::shadow_stack_get(value_slot),
+                )
+            };
             return true;
         }
         _ => {}
@@ -4634,12 +4700,21 @@ pub unsafe fn instance_node_dict_values(obj: PyObjectRef) -> Vec<PyObjectRef> {
     ensure_mapdict_initialized(obj);
     let inst = mapdict_carrier(obj);
     let nodes = dict_nodes_in_order(&inst);
+    // The read boxes an unboxed slot, so each allocation stales the values
+    // already collected; pin them as they are read and copy the run back.
+    let roots = pyre_object::gc_roots::push_roots();
+    let values_base = roots.base();
     let mut vals: Vec<PyObjectRef> = Vec::new();
     let mut i: usize = 0;
     while i < nodes.len() {
         let node = nodes[i];
-        vals.push(plain_direct_read(node, &inst));
+        let w_value = plain_direct_read(node, &inst);
+        roots.pin_root(w_value);
+        vals.push(w_value);
         i += 1;
+    }
+    for (i, slot) in vals.iter_mut().enumerate() {
+        *slot = roots.get(values_base + i);
     }
     vals
 }
@@ -4658,6 +4733,12 @@ pub unsafe fn instance_node_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, Py
     ensure_mapdict_initialized(obj);
     let inst = mapdict_carrier(obj);
     let nodes = dict_nodes_in_order(&inst);
+    // Every iteration allocates — `box_str_constant` on an intern miss, the
+    // read on an unboxed slot — so a value collected earlier goes stale while
+    // the walk is still running. Pin each value at its read and copy the run
+    // back once the walk is over; the names are immortal interned constants.
+    let roots = pyre_object::gc_roots::push_roots();
+    let values_base = roots.base();
     let mut out: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();
     let mut i: usize = 0;
     while i < nodes.len() {
@@ -4665,8 +4746,12 @@ pub unsafe fn instance_node_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, Py
         let name = &(*node).as_plain().name;
         let w_key = pyre_object::unicodeobject::box_str_constant(name);
         let w_value = plain_direct_read(node, &inst);
+        roots.pin_root(w_value);
         out.push((w_key, w_value));
         i += 1;
+    }
+    for (i, entry) in out.iter_mut().enumerate() {
+        entry.1 = roots.get(values_base + i);
     }
     out
 }
@@ -4700,15 +4785,27 @@ unsafe fn mapdict_strategy_unerase(w_dict: PyObjectRef) -> PyObjectRef {
 #[majit_macros::dont_look_inside]
 pub unsafe fn mapdict_switch_to_object_strategy(w_dict: PyObjectRef) {
     use pyre_object::dictmultiobject::DictStrategy;
+    // A `dict` moves and `get_empty_storage` allocates, so the wrapper is
+    // published before the new storage is built: a `&mut` taken beforehand
+    // would write both fields to the pre-move address. The instance does not
+    // move, but overwriting `dstorage` severs the dict's only edge to it, so it
+    // is published for liveness across the materialisation that follows.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
     // w_obj = self.unerase(w_dict.dstorage) — the backing instance.
-    let w_obj = unsafe { mapdict_strategy_unerase(w_dict) };
+    let w_obj =
+        unsafe { mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
+    pyre_object::gc_roots::pin_root(w_obj);
     // dict_w = strategy.unerase(strategy.get_empty_storage()); set_strategy(Object);
     // w_dict.dstorage = strategy.erase(dict_w).
-    let dict = unsafe { &mut *(w_dict as *mut pyre_object::W_DictObject) };
-    dict.dstorage = pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY.get_empty_storage();
+    let dstorage = pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY.get_empty_storage();
+    let dict = unsafe {
+        &mut *(pyre_object::gc_roots::shadow_stack_get(dict_slot) as *mut pyre_object::W_DictObject)
+    };
+    dict.dstorage = dstorage;
     dict.dstrategy = &pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY_REF;
     // materialize_r_dict(space, w_obj, dict_w).
-    unsafe { materialize_dict(w_obj, w_dict) };
+    unsafe { materialize_dict(w_obj, pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
 }
 
 /// `MapDictStrategy.switch_to_text_strategy` (mapdict.py:1148-1155) — the
@@ -4721,12 +4818,19 @@ pub unsafe fn mapdict_switch_to_object_strategy(w_dict: PyObjectRef) {
 #[majit_macros::dont_look_inside]
 pub unsafe fn mapdict_switch_to_text_strategy(w_dict: PyObjectRef) {
     use pyre_object::dictmultiobject::DictStrategy;
-    let w_obj = unsafe { mapdict_strategy_unerase(w_dict) };
-    let dict = unsafe { &mut *(w_dict as *mut pyre_object::W_DictObject) };
-    dict.dstorage = pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage();
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
+    let w_obj =
+        unsafe { mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
+    pyre_object::gc_roots::pin_root(w_obj);
+    let dstorage = pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage();
+    let dict = unsafe {
+        &mut *(pyre_object::gc_roots::shadow_stack_get(dict_slot) as *mut pyre_object::W_DictObject)
+    };
+    dict.dstorage = dstorage;
     dict.dstrategy = &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF;
     // materialize_str_dict(space, w_obj, str_dict).
-    unsafe { materialize_dict(w_obj, w_dict) };
+    unsafe { materialize_dict(w_obj, pyre_object::gc_roots::shadow_stack_get(dict_slot)) };
 }
 
 /// mapdict.py:1123-1279 `MapDictStrategy` — the dict strategy a user instance's
@@ -4803,8 +4907,17 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         if pyre_object::_never_equal_to_string(w_key) {
             return None;
         }
-        self.switch_to_object_strategy(w_dict);
-        pyre_object::w_dict_lookup(w_dict, w_key)
+        // A `dict` moves, and the switch allocates the object storage and
+        // materialises every attribute into it, so the receiver and the key are
+        // published across it and read back at the lookup.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict, w_key]);
+        let key_slot = dict_slot + 1;
+        self.switch_to_object_strategy(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+        pyre_object::w_dict_lookup(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+        )
     }
 
     /// mapdict.py:1168-1170 `getitem_str` — `w_obj.getdictvalue(space, key)`.
@@ -4829,8 +4942,16 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         }
         // Non-string key: it cannot be a mapdict node, so degrade to the
         // object strategy before storing.
-        self.switch_to_object_strategy(w_dict);
-        pyre_object::w_dict_store(w_dict, w_key, w_value);
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict, w_key, w_value]);
+        let key_slot = dict_slot + 1;
+        let value_slot = dict_slot + 2;
+        self.switch_to_object_strategy(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+        pyre_object::w_dict_store(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+            pyre_object::gc_roots::shadow_stack_get(value_slot),
+        );
     }
 
     /// mapdict.py:1172-1175 `setitem_str` — `flag = w_obj.setdictvalue(...);
@@ -4849,19 +4970,35 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         w_key: PyObjectRef,
         w_default: PyObjectRef,
     ) -> PyObjectRef {
+        // The string arm allocates as well: reading an unboxed attribute boxes
+        // it. `w_key`'s WTF-8 view stays valid across both arms because a `str`
+        // does not move.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict, w_key, w_default]);
+        let key_slot = dict_slot + 1;
+        let default_slot = dict_slot + 2;
         if pyre_object::is_exact_type(w_key, &pyre_object::STR_TYPE) {
             let key = pyre_object::w_str_get_wtf8(w_key);
-            if let Some(w_result) =
-                instance_node_getdictvalue(mapdict_strategy_unerase(w_dict), key)
-            {
+            if let Some(w_result) = instance_node_getdictvalue(
+                mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)),
+                key,
+            ) {
                 return w_result;
             }
-            instance_node_setdictvalue(mapdict_strategy_unerase(w_dict), key, w_default);
-            return w_default;
+            instance_node_setdictvalue(
+                mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot)),
+                key,
+                pyre_object::gc_roots::shadow_stack_get(default_slot),
+            );
+            return pyre_object::gc_roots::shadow_stack_get(default_slot);
         }
-        self.switch_to_object_strategy(w_dict);
-        pyre_object::dictmultiobject::w_dict_setdefault_checked(w_dict, w_key, w_default)
-            .unwrap_or(w_default)
+        self.switch_to_object_strategy(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+        pyre_object::dictmultiobject::w_dict_setdefault_checked(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+            pyre_object::gc_roots::shadow_stack_get(default_slot),
+        )
+        .unwrap_or_else(|_| pyre_object::gc_roots::shadow_stack_get(default_slot))
     }
 
     /// mapdict.py:1198-1211 `delitem`. pyre's trait returns `bool` (true =
@@ -4878,8 +5015,14 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         if pyre_object::_never_equal_to_string(w_key) {
             return false;
         }
-        self.switch_to_object_strategy(w_dict);
-        pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY.delitem(w_dict, w_key)
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict, w_key]);
+        let key_slot = dict_slot + 1;
+        self.switch_to_object_strategy(pyre_object::gc_roots::shadow_stack_get(dict_slot));
+        pyre_object::dictmultiobject::OBJECT_DICT_STRATEGY.delitem(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+        )
     }
 
     /// mapdict.py:1213-1220 `length`.
@@ -4909,7 +5052,12 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
 
     /// mapdict.py:1227-1235 `popitem`.
     unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
-        let w_obj = mapdict_strategy_unerase(w_dict);
+        // The receiver is a `dict` and moves; it is published before the first
+        // allocation below rather than alongside the carrier further down,
+        // because a pin taken after a collection would freeze a pre-move word.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
+        let w_obj = mapdict_strategy_unerase(pyre_object::gc_roots::shadow_stack_get(dict_slot));
         let _instance_guard = instance_lock(w_obj);
         ensure_mapdict_initialized(w_obj);
         let inst = mapdict_carrier(w_obj);
@@ -4931,7 +5079,6 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         // a Rust local. Pin the carrier and the two results and read them back
         // from the shadow stack after every such call. `map`, `curr` and `key`
         // need no pin: map nodes are not GC-allocated.
-        let _roots = pyre_object::gc_roots::push_roots();
         let obj_slot = pyre_object::gc_roots::pin_roots(&[w_obj]);
         let key_slot =
             pyre_object::gc_roots::pin_roots(&[pyre_object::unicodeobject::box_str_constant(key)]);
@@ -4944,7 +5091,10 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         // the two the same way.
         let mut inst = mapdict_carrier(pyre_object::gc_roots::shadow_stack_get(obj_slot));
         maybe_migrate_to_boxed(map, &mut inst, key, DICT);
-        self.delitem(w_dict, pyre_object::gc_roots::shadow_stack_get(key_slot));
+        self.delitem(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+            pyre_object::gc_roots::shadow_stack_get(key_slot),
+        );
         Some((
             pyre_object::gc_roots::shadow_stack_get(key_slot),
             pyre_object::gc_roots::shadow_stack_get(value_slot),
@@ -4955,14 +5105,33 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
     unsafe fn copy(&self, w_dict: PyObjectRef) -> PyObjectRef {
         use pyre_object::dictmultiobject::DictStrategy;
 
-        let copy = pyre_object::w_dict_new_with(
+        // Both dicts move, and every step after the receiver arrives collects:
+        // the copy and its storage are allocated, materialising the items boxes
+        // each unboxed attribute, and a store hashes its key through `__hash__`.
+        // Publish the receiver and the copy and read each back at its use. The
+        // item values are published as one run before the first store, because
+        // a store that relocates one of them would leave every entry still to
+        // come naming a pre-move address; the names are interned constants,
+        // which do not move.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let dict_slot = pyre_object::gc_roots::pin_roots(&[w_dict]);
+        let copy_slot = pyre_object::gc_roots::pin_roots(&[pyre_object::w_dict_new_with(
             &pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY_REF,
             pyre_object::dictmultiobject::UNICODE_DICT_STRATEGY.get_empty_storage(),
-        );
-        for (w_key, w_value) in instance_node_dict_items(mapdict_strategy_unerase(w_dict)) {
-            pyre_object::w_dict_store(copy, w_key, w_value);
+        )]);
+        let items = instance_node_dict_items(mapdict_strategy_unerase(
+            pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        ));
+        let values: Vec<PyObjectRef> = items.iter().map(|&(_, w_value)| w_value).collect();
+        let values_slot = pyre_object::gc_roots::pin_roots(&values);
+        for (i, &(w_key, _)) in items.iter().enumerate() {
+            pyre_object::w_dict_store(
+                pyre_object::gc_roots::shadow_stack_get(copy_slot),
+                w_key,
+                pyre_object::gc_roots::shadow_stack_get(values_slot + i),
+            );
         }
-        copy
+        pyre_object::gc_roots::shadow_stack_get(copy_slot)
     }
 
     /// mapdict.py:1268-1276 iterator order.

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -4346,6 +4346,13 @@ unsafe fn switch_map_and_write_increase_storage1<O: MapdictObject>(
             if u.firstunwrapped {
                 // a fresh longlong list of one element occupies a new slot
                 let unboxed = erase_unboxed(&[val]);
+                // `erase_unboxed` hands back a block nothing references yet, so
+                // it needs a root until whichever store below lands claims it.
+                // The block does not move, so one pin carries it and it is
+                // never read back.  The sibling arm needs none: its
+                // `erase_unboxed` is the argument expression of the store.
+                let _unboxed_root = pyre_object::gc_roots::push_roots();
+                pyre_object::gc_roots::pin_root(unboxed);
                 if unsafe { (*attr).storage_needed() } > obj._mapdict_storage_length() {
                     obj._set_mapdict_increase_storage1(attr, unboxed);
                     return;
@@ -4382,10 +4389,24 @@ unsafe fn reorder_and_add<O: MapdictObject>(
     obj: &mut O,
     mut number_to_readd: usize,
     mut attr: MapRef,
-    mut w_value: PyObjectRef,
+    w_value: PyObjectRef,
 ) {
-    let mut stack: Vec<(MapRef, PyObjectRef)> =
-        Vec::with_capacity(unsafe { (*self_node).num_attributes() } * 2);
+    // The saved values pile up in a plain `Vec` and the incoming `w_value` sits
+    // in a by-value parameter, neither of which the collector walks, while the
+    // loop keeps collecting: `_mapdict_pop_attribute` does so in either arm,
+    // and a value the read had to box carries no heap edge until something
+    // stores it, so being born old-gen buys it immobility rather than survival
+    // (`alloc_typed_items_block`).  Every word here is an arbitrary attribute
+    // value, so it can equally be a `list` or a `dict` and move.  All of them
+    // live in root slots and are read back at every use.  Map nodes are not GC
+    // objects, so the map half of each saved pair stays a plain pointer.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let value_slot = pyre_object::gc_roots::pin_roots(&[w_value]);
+    // mapdict.py:227 flattens the to-be-readded `(map, value)` pairs into one
+    // array indexed by `stack_index`, which reuses its cells; taking a fresh
+    // slot per push keeps the same LIFO order without the fixed bound.
+    let mut stack: Vec<(MapRef, usize)> =
+        Vec::with_capacity(unsafe { (*self_node).num_attributes() });
     loop {
         // we found the attributes further up, need to save the previous
         // values of the attributes we passed
@@ -4394,24 +4415,39 @@ unsafe fn reorder_and_add<O: MapdictObject>(
             for _ in 0..number_to_readd {
                 // current is a PlainAttribute
                 let w_self_value = unsafe { plain_direct_read(current, obj) };
-                stack.push((current, w_self_value));
+                pyre_object::gc_roots::pin_root(w_self_value);
+                stack.push((current, pyre_object::gc_roots::shadow_stack_len() - 1));
                 current = unsafe { (*current).as_plain() }.back;
                 obj._mapdict_pop_attribute(current);
             }
         }
-        unsafe { switch_map_and_write_increase_storage1(attr, obj, w_value) };
+        unsafe {
+            switch_map_and_write_increase_storage1(
+                attr,
+                obj,
+                pyre_object::gc_roots::shadow_stack_get(value_slot),
+            )
+        };
 
         // readd the current top of the stack
         match stack.pop() {
             None => return,
-            Some((next_map, next_value)) => {
-                w_value = next_value;
+            Some((next_map, next_slot)) => {
+                pyre_object::gc_roots::shadow_stack_set(
+                    value_slot,
+                    pyre_object::gc_roots::shadow_stack_get(next_slot),
+                );
                 let (name, attrkind) = {
                     let p = unsafe { (*next_map).as_plain() };
                     (p.name.clone(), p.attrkind)
                 };
                 self_node = obj._get_mapdict_map();
-                let unbox_type = unsafe { pick_unbox_type(self_node, w_value) };
+                let unbox_type = unsafe {
+                    pick_unbox_type(
+                        self_node,
+                        pyre_object::gc_roots::shadow_stack_get(value_slot),
+                    )
+                };
                 let (n, holder) =
                     unsafe { find_branch_to_move_into(self_node, &name, attrkind, unbox_type) };
                 number_to_readd = n;
@@ -5158,14 +5194,25 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         let _instance_guard = instance_lock(w_obj);
         ensure_mapdict_initialized(w_obj);
         let inst = mapdict_carrier(w_obj);
-        let mut items = Vec::new();
+        // Same walk as `instance_node_dict_items`, so the same bracket: a value
+        // the read had to box is named by nothing the collector walks until the
+        // `Vec` is handed on, and old-gen birth buys immobility rather than
+        // survival, so the walk's own allocations can sweep one collected
+        // earlier.  Pin each value at its read and copy the run back once the
+        // walk is over; the names are immortal interned constants.
+        let roots = pyre_object::gc_roots::push_roots();
+        let values_base = roots.base();
+        let mut items: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();
         let mut curr = node_search(inst._get_mapdict_map(), DICT);
         while let Some(node) = curr {
-            items.push((
-                pyre_object::unicodeobject::box_str_constant(&(*node).as_plain().name),
-                plain_direct_read(node, &inst),
-            ));
+            let w_key = pyre_object::unicodeobject::box_str_constant(&(*node).as_plain().name);
+            let w_value = plain_direct_read(node, &inst);
+            roots.pin_root(w_value);
+            items.push((w_key, w_value));
             curr = node_search((*node).as_plain().back, DICT);
+        }
+        for (i, entry) in items.iter_mut().enumerate() {
+            entry.1 = roots.get(values_base + i);
         }
         items
     }

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -3550,10 +3550,12 @@ unsafe fn maybe_migrate_to_boxed<O: MapdictObject>(
 /// # Safety
 /// `attr_node` must point to a live `PlainAttribute`; `obj` to a live carrier.
 unsafe fn copy_attr<O: MapdictObject>(attr_node: MapRef, obj: &O, new_obj: &mut Object) {
-    // The carrier's storage is a plain `Vec` no collector updates, and the read
-    // below boxes an unboxed attribute. Publish the values already copied,
-    // copy them back once the read is done, and only then hand `add_attr` a
-    // storage it is free to re-lay-out.
+    // The carrier's storage is a plain `Vec` no collector updates, and a value
+    // the read had to box is named by nothing else until `add_attr` stores it
+    // — old-gen birth buys it immobility rather than survival, so the
+    // re-lay-out below can sweep it. Publish both, copy the storage run back
+    // once the read is done, and only then hand `add_attr` a storage it is
+    // free to re-lay-out.
     let _roots = pyre_object::gc_roots::push_roots();
     let storage_slot = pyre_object::gc_roots::pin_roots(&new_obj.storage);
     let value_slot =
@@ -4736,8 +4738,10 @@ pub unsafe fn instance_node_dict_values(obj: PyObjectRef) -> Vec<PyObjectRef> {
     ensure_mapdict_initialized(obj);
     let inst = mapdict_carrier(obj);
     let nodes = dict_nodes_in_order(&inst);
-    // The read boxes an unboxed slot, so each allocation stales the values
-    // already collected; pin them as they are read and copy the run back.
+    // A value the read had to box is named by nothing the collector walks
+    // until this `Vec` is handed on, and old-gen birth buys immobility rather
+    // than survival, so the walk's own allocations can sweep one collected
+    // earlier; pin them as they are read and copy the run back.
     let roots = pyre_object::gc_roots::push_roots();
     let values_base = roots.base();
     let mut vals: Vec<PyObjectRef> = Vec::new();
@@ -4769,10 +4773,11 @@ pub unsafe fn instance_node_dict_items(obj: PyObjectRef) -> Vec<(PyObjectRef, Py
     ensure_mapdict_initialized(obj);
     let inst = mapdict_carrier(obj);
     let nodes = dict_nodes_in_order(&inst);
-    // Every iteration allocates — `box_str_constant` on an intern miss, the
-    // read on an unboxed slot — so a value collected earlier goes stale while
-    // the walk is still running. Pin each value at its read and copy the run
-    // back once the walk is over; the names are immortal interned constants.
+    // A value the read had to box is named by nothing the collector walks
+    // until this `Vec` is handed on, and old-gen birth buys immobility rather
+    // than survival, so the walk's own allocations can sweep one collected
+    // earlier. Pin each value at its read and copy the run back once the walk
+    // is over; the names are immortal interned constants.
     let roots = pyre_object::gc_roots::push_roots();
     let values_base = roots.base();
     let mut out: Vec<(PyObjectRef, PyObjectRef)> = Vec::new();

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -729,8 +729,18 @@ pub fn store_slice_values(
     stop: PyObjectRef,
     value: PyObjectRef,
 ) -> Result<(), PyError> {
+    // `w_slice_new` allocates and holds neither the receiver nor the stored
+    // value, so a `list` / `dict` in either relocates while the slice is built.
+    // The bounds it does hold are pinned by the constructor itself; the fresh
+    // slice reaches the heap only through `setitem`, so it takes one pin.
+    let roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = roots.base();
+    let value_slot = obj_slot + 1;
+    roots.publish(&[obj, value]);
+    roots.normalize(obj_slot, 2);
     let slice = pyre_object::w_slice_new(start, stop, pyre_object::w_none());
-    crate::baseobjspace::setitem(obj, slice, value)?;
+    roots.pin_root(slice);
+    crate::baseobjspace::setitem(roots.get(obj_slot), slice, roots.get(value_slot))?;
     Ok(())
 }
 
@@ -746,6 +756,19 @@ pub fn binary_slice_values(
     stop: PyObjectRef,
 ) -> Result<PyObjectRef, PyError> {
     unsafe {
+        // `eval_slice_index` may run a user `__index__`, and every arm below
+        // allocates: a `list` / `dict` operand relocates across either.  The
+        // three operands are published as one livevar set and read back at the
+        // consumers that follow a collection point; a `str` / `tuple` receiver
+        // is proven non-moving by its type test, so those arms keep the word.
+        let roots = pyre_object::gc_roots::push_roots();
+        let obj_slot = roots.base();
+        let (start_slot, stop_slot) = (obj_slot + 1, obj_slot + 2);
+        roots.publish(&[obj, start, stop]);
+        roots.normalize(obj_slot, 3);
+        let obj = roots.get(obj_slot);
+        let start = roots.get(start_slot);
+        let stop = roots.get(stop_slot);
         if pyre_object::is_list(obj) {
             let len = pyre_object::w_list_len(obj) as i64;
             let s = if pyre_object::is_none(start) {
@@ -753,6 +776,7 @@ pub fn binary_slice_values(
             } else {
                 crate::sliceobject::eval_slice_index(start)?
             };
+            let stop = roots.get(stop_slot);
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
@@ -760,12 +784,20 @@ pub fn binary_slice_values(
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
-            let mut items = Vec::new();
+            // A fetch off an unboxed strategy boxes the element it returns, so
+            // the elements accumulate in root slots: a plain `Vec` is scanned by
+            // nothing while the next box is allocated.  The block is read back
+            // as one indexed run once no further allocation separates it from
+            // the constructor, which pins the whole item set itself.
+            let items_base = pyre_object::gc_roots::shadow_stack_len();
+            let mut fetched = 0usize;
             for i in s..e {
-                if let Some(v) = pyre_object::w_list_getitem(obj, i as i64) {
-                    items.push(v);
+                if let Some(v) = pyre_object::w_list_getitem(roots.get(obj_slot), i as i64) {
+                    roots.pin_root(v);
+                    fetched += 1;
                 }
             }
+            let items = (0..fetched).map(|i| roots.get(items_base + i)).collect();
             return Ok(pyre_object::w_list_new(items));
         }
         if pyre_object::is_str(obj) {
@@ -784,6 +816,7 @@ pub fn binary_slice_values(
             } else {
                 crate::sliceobject::eval_slice_index(start)?
             };
+            let stop = roots.get(stop_slot);
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
@@ -806,6 +839,7 @@ pub fn binary_slice_values(
             } else {
                 crate::sliceobject::eval_slice_index(start)?
             };
+            let stop = roots.get(stop_slot);
             let e = if pyre_object::is_none(stop) {
                 len
             } else {
@@ -813,18 +847,26 @@ pub fn binary_slice_values(
             };
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
-            let mut items = Vec::new();
+            // The arity-2 specialisations box their payload on fetch, the same
+            // allocating fetch the `list` arm accumulates in root slots.
+            let items_base = pyre_object::gc_roots::shadow_stack_len();
+            let mut fetched = 0usize;
             for i in s..e {
                 if let Some(v) = pyre_object::w_tuple_getitem(obj, i as i64) {
-                    items.push(v);
+                    roots.pin_root(v);
+                    fetched += 1;
                 }
             }
+            let items = (0..fetched).map(|i| roots.get(items_base + i)).collect();
             return Ok(pyre_object::w_tuple_new(items));
         }
         // Fall back to slice(start, stop) → getitem dispatch.
         // Handles bytes, bytearray, instances with __getitem__, etc.
         let slice_obj = pyre_object::sliceobject::w_slice_new(start, stop, pyre_object::w_none());
-        crate::baseobjspace::getitem(obj, slice_obj)
+        // The receiver is live across that allocation, and the fresh slice has
+        // no heap edge until `getitem` stores it.
+        roots.pin_root(slice_obj);
+        crate::baseobjspace::getitem(roots.get(obj_slot), slice_obj)
     }
 }
 
@@ -1304,7 +1346,22 @@ pub fn unpack_sequence_exact(seq: PyObjectRef, count: usize) -> Result<Vec<PyObj
             };
             return Err(PyError::value_error(msg));
         }
-        return (0..count).map(|idx| sequence_getitem(seq, idx)).collect();
+        // A fetch off an unboxed `list` strategy boxes the element, and a `str`
+        // fetch builds the one-character string, so every turn allocates: the
+        // receiver relocates and a plain accumulator is scanned by nothing.
+        // Publish both and rebuild the flat return from the slots, as the
+        // iterator loop below does.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let seq_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(seq);
+        let seq = || pyre_object::gc_roots::shadow_stack_get(seq_slot);
+        let items_base = pyre_object::gc_roots::shadow_stack_len();
+        for idx in 0..count {
+            pyre_object::gc_roots::pin_root(sequence_getitem(seq(), idx)?);
+        }
+        return Ok((0..count)
+            .map(|index| pyre_object::gc_roots::shadow_stack_get(items_base + index))
+            .collect());
     }
     // Fallback: iteration protocol (handles type objects with metaclass __iter__, etc.)
     // baseobjspace.py:1031 _unpackiterable_known_length_jitlook.  pyopcode.py:872
@@ -1387,22 +1444,32 @@ pub fn unpack_ex_slots(
     after: usize,
     value: PyObjectRef,
 ) -> Result<Vec<PyObjectRef>, PyError> {
+    // `collect_iterable` runs the iterator's `__next__` on every turn and the
+    // starred middle `list` is allocated part-way through the split, so neither
+    // `value` nor the element words may stay in plain natives across them: a
+    // `list` / `dict` among them relocates and the native copy names the
+    // pre-move address.  Publish them and read every operand back out of the
+    // slots, as `unpack_sequence_exact` does for the same split.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(value);
+    let value = || pyre_object::gc_roots::shadow_stack_get(value_slot);
     let elements: Vec<PyObjectRef> = unsafe {
-        if is_tuple(value) {
-            pyre_object::w_tuple_items_copy_as_vec(value)
-        } else if is_list(value) {
-            pyre_object::w_list_items_copy_as_vec(value)
+        if is_tuple(value()) {
+            pyre_object::w_tuple_items_copy_as_vec(value())
+        } else if is_list(value()) {
+            pyre_object::w_list_items_copy_as_vec(value())
         } else {
             // pyopcode.py:884 UNPACK_EX wraps `fixedview` in a
             // TypeError → "cannot unpack non-iterable %T object" remap.
             // `collect_iterable` is the `fixedview` analog (iter + next
             // loop), so any TypeError it raises is remapped here.
-            match crate::builtins::collect_iterable(value) {
+            match crate::builtins::collect_iterable(value()) {
                 Ok(items) => items,
                 Err(e) if e.kind == PyErrorKind::TypeError => {
                     return Err(PyError::type_error(format!(
                         "cannot unpack non-iterable {} object",
-                        crate::baseobjspace::object_functionstr_type_name(value)
+                        crate::baseobjspace::object_functionstr_type_name(value())
                     )));
                 }
                 Err(e) => return Err(e),
@@ -1417,16 +1484,21 @@ pub fn unpack_ex_slots(
             elements.len()
         )));
     }
+    let elements_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &elements {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let element = |index: usize| pyre_object::gc_roots::shadow_stack_get(elements_base + index);
     let middle_len = elements.len() - min_expected;
+    let middle: Vec<PyObjectRef> = (before..before + middle_len).map(element).collect();
+    let middle_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(w_list_new(middle));
+    // Head and tail are read back only after the middle list exists, so the
+    // returned slots all carry post-move words.
     let mut slots = Vec::with_capacity(before + 1 + after);
-    for &item in elements.iter().take(before) {
-        slots.push(item);
-    }
-    let middle: Vec<PyObjectRef> = elements[before..before + middle_len].to_vec();
-    slots.push(w_list_new(middle));
-    for i in 0..after {
-        slots.push(elements[before + middle_len + i]);
-    }
+    slots.extend((0..before).map(element));
+    slots.push(pyre_object::gc_roots::shadow_stack_get(middle_slot));
+    slots.extend((before + middle_len..elements.len()).map(element));
     Ok(slots)
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2931,8 +2931,7 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<Wtf8Buf, crate::
             if unsafe { pyre_object::is_none(roots.get(spec_loader_slot)) } {
                 return Ok(wtf8_format!("<module ", name_repr, ">"));
             }
-            let loader_repr =
-                unsafe { crate::display::py_repr_wtf8(roots.get(spec_loader_slot))? };
+            let loader_repr = unsafe { crate::display::py_repr_wtf8(roots.get(spec_loader_slot))? };
             return Ok(wtf8_format!("<module ", name_repr, " (", loader_repr, ")>"));
         }
         let name_repr = unsafe { crate::display::py_repr_wtf8(roots.get(name_slot))? };

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -2394,7 +2394,11 @@ fn new_typeobject_with_base_and_layout(
     }
     let bases = w_tuple_new(vec![base]);
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
+    // The type object it allocates is what the namespace has to survive: the
+    // word handed over is stored in the new type, but this frame's copy is
+    // pre-move, so the probes below take a fresh read.
     let type_obj = new_builtin_typeobject(name, bases, ns as *mut u8, layout_pytype);
+    let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
 
     // typeobject.py:1273-1280 setup_builtin_type:
     //   parent_layout = w_bestbase.layout
@@ -2486,6 +2490,7 @@ pub fn make_builtin_type_with_bases(
     let bases_tuple = w_tuple_new(bases.to_vec());
     let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
     let type_obj = new_builtin_typeobject(name, bases_tuple, ns as *mut u8, layout_pytype);
+    let ns = pyre_object::gc_roots::shadow_stack_get(ns_slot);
 
     unsafe {
         let parent_layout = pyre_object::w_type_get_layout_ptr(base);
@@ -2838,13 +2843,21 @@ fn module_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     // exercises one), so projecting through `w_str_get_value` would both lose
     // the upstream storage shape and panic on a valid Python `str`.
     unsafe { pyre_object::w_module_set_name(self_, w_name) };
-    let w_dict = unsafe { pyre_object::w_module_get_w_dict(self_) };
+    // The module dict moves and each store allocates — the key string it
+    // interns and the storage when it grows — so the destination is read back
+    // for every one of them.  `w_doc` is an arbitrary object the caller
+    // supplied and rides the same run; `w_name` is a `str` and never moves.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(self_) });
+    let doc_slot = dict_slot + 1;
+    roots.pin_root(w_doc);
     unsafe {
-        pyre_object::w_dict_setitem_str(w_dict, "__name__", w_name);
-        pyre_object::w_dict_setitem_str(w_dict, "__doc__", w_doc);
-        pyre_object::w_dict_setitem_str(w_dict, "__package__", pyre_object::w_none());
-        pyre_object::w_dict_setitem_str(w_dict, "__loader__", pyre_object::w_none());
-        pyre_object::w_dict_setitem_str(w_dict, "__spec__", pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__name__", w_name);
+        pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__doc__", roots.get(doc_slot));
+        pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__package__", pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__loader__", pyre_object::w_none());
+        pyre_object::w_dict_setitem_str(roots.get(dict_slot), "__spec__", pyre_object::w_none());
     }
     Ok(pyre_object::w_none())
 }
@@ -2877,31 +2890,55 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<Wtf8Buf, crate::
         let result = crate::call::call_function_impl_result(repr_fn, &[module])?;
         return Ok(crate::baseobjspace::text_wtf8_w(result)?.to_wtf8_buf());
     }
-    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
-    let loader = crate::baseobjspace::finditem_str(w_dict, "__loader__")?;
-    if let Some(spec) = crate::baseobjspace::finditem_str(w_dict, "__spec__")?
-        && !spec.is_null()
+    // The module dict moves, and every lookup and `repr` below runs Python.
+    // The dict and each value that outlives one of those calls ride the shadow
+    // stack; a missing key is pinned as the null word its consumers already
+    // test for.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
+    let loader_slot = dict_slot + 1;
+    roots.pin_root(
+        crate::baseobjspace::finditem_str(roots.get(dict_slot), "__loader__")?.unwrap_or(PY_NULL),
+    );
+    let spec_slot = loader_slot + 1;
+    roots.pin_root(
+        crate::baseobjspace::finditem_str(roots.get(dict_slot), "__spec__")?.unwrap_or(PY_NULL),
+    );
+    let spec = roots.get(spec_slot);
+    if !spec.is_null()
         && !unsafe { pyre_object::is_none(spec) }
         && crate::baseobjspace::is_true(spec)?
     {
-        let mut name = crate::baseobjspace::getattr_str(spec, "name")?;
+        let mut name = crate::baseobjspace::getattr_str(roots.get(spec_slot), "name")?;
         if unsafe { pyre_object::is_none(name) } {
             name = pyre_object::w_str_new("?");
         }
-        let origin = crate::baseobjspace::getattr_str(spec, "origin")?;
-        if unsafe { pyre_object::is_none(origin) } {
-            let spec_loader = crate::baseobjspace::getattr_str(spec, "loader")?;
-            let name_repr = unsafe { crate::display::py_repr_wtf8(name)? };
-            if unsafe { pyre_object::is_none(spec_loader) } {
+        let name_slot = spec_slot + 1;
+        roots.pin_root(name);
+        let origin_slot = name_slot + 1;
+        roots.pin_root(crate::baseobjspace::getattr_str(
+            roots.get(spec_slot),
+            "origin",
+        )?);
+        if unsafe { pyre_object::is_none(roots.get(origin_slot)) } {
+            let spec_loader_slot = origin_slot + 1;
+            roots.pin_root(crate::baseobjspace::getattr_str(
+                roots.get(spec_slot),
+                "loader",
+            )?);
+            let name_repr = unsafe { crate::display::py_repr_wtf8(roots.get(name_slot))? };
+            if unsafe { pyre_object::is_none(roots.get(spec_loader_slot)) } {
                 return Ok(wtf8_format!("<module ", name_repr, ">"));
             }
-            let loader_repr = unsafe { crate::display::py_repr_wtf8(spec_loader)? };
+            let loader_repr =
+                unsafe { crate::display::py_repr_wtf8(roots.get(spec_loader_slot))? };
             return Ok(wtf8_format!("<module ", name_repr, " (", loader_repr, ")>"));
         }
-        let name_repr = unsafe { crate::display::py_repr_wtf8(name)? };
-        let has_location = crate::baseobjspace::getattr_str(spec, "has_location")?;
+        let name_repr = unsafe { crate::display::py_repr_wtf8(roots.get(name_slot))? };
+        let has_location = crate::baseobjspace::getattr_str(roots.get(spec_slot), "has_location")?;
         if crate::baseobjspace::is_true(has_location)? {
-            let origin_repr = unsafe { crate::display::py_repr_wtf8(origin)? };
+            let origin_repr = unsafe { crate::display::py_repr_wtf8(roots.get(origin_slot))? };
             return Ok(wtf8_format!(
                 "<module ",
                 name_repr,
@@ -2910,22 +2947,20 @@ pub(crate) fn module_repr_string(module: PyObjectRef) -> Result<Wtf8Buf, crate::
                 ">"
             ));
         }
-        let origin_str = unsafe { crate::display::py_str_wtf8(origin)? };
+        let origin_str = unsafe { crate::display::py_str_wtf8(roots.get(origin_slot))? };
         return Ok(wtf8_format!("<module ", name_repr, " (", origin_str, ")>"));
     }
-    let name = crate::baseobjspace::finditem_str(w_dict, "__name__")?
+    let name = crate::baseobjspace::finditem_str(roots.get(dict_slot), "__name__")?
         .unwrap_or_else(|| pyre_object::w_str_new("?"));
     let name_repr = unsafe { crate::display::py_repr_wtf8(name)? };
-    if let Some(filename) = crate::baseobjspace::finditem_str(w_dict, "__file__")? {
+    if let Some(filename) = crate::baseobjspace::finditem_str(roots.get(dict_slot), "__file__")? {
         let file_repr = unsafe { crate::display::py_repr_wtf8(filename)? };
         return Ok(wtf8_format!(
             "<module ", name_repr, " from ", file_repr, ">"
         ));
     }
-    if let Some(loader) = loader
-        && !loader.is_null()
-        && !unsafe { pyre_object::is_none(loader) }
-    {
+    let loader = roots.get(loader_slot);
+    if !loader.is_null() && !unsafe { pyre_object::is_none(loader) } {
         let loader_repr = unsafe { crate::display::py_repr_wtf8(loader)? };
         return Ok(wtf8_format!("<module ", name_repr, " (", loader_repr, ")>"));
     }
@@ -2954,7 +2989,13 @@ fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // module.py:164 — deliberately perform ordinary attribute lookup rather
     // than reading `self.w_dict`: a ModuleType subclass may shadow
     // `__dict__`, in which case the resulting non-dict is a TypeError.
-    let w_dict = crate::baseobjspace::getattr_str(module, "__dict__")?;
+    // The mapping is a `dict` and moves, and the `__dir__` probe below runs
+    // Python, so it is pinned where the lookup produces it and read back for
+    // the listing that follows the probe.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(crate::baseobjspace::getattr_str(module, "__dict__")?);
+    let w_dict = roots.get(dict_slot);
     if w_dict.is_null()
         || (!unsafe { pyre_object::is_dict(w_dict) }
             && !unsafe { pyre_object::dictmultiobject::is_module_dict(w_dict) }
@@ -2967,10 +3008,10 @@ fn module_descr_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             ".__dict__ is not a dictionary"
         )));
     }
-    if let Some(w_dir) = crate::baseobjspace::finditem_str(w_dict, "__dir__")? {
+    if let Some(w_dir) = crate::baseobjspace::finditem_str(roots.get(dict_slot), "__dir__")? {
         return crate::call::call_function_impl_result(w_dir, &[]);
     }
-    crate::builtins::builtin_list_ctor(&[w_dict])
+    crate::builtins::builtin_list_ctor(&[roots.get(dict_slot)])
 }
 
 fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -2982,7 +3023,10 @@ fn module_annotations_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     if let Some(annotations) = crate::baseobjspace::finditem_str(w_dict, "__annotations__")? {
         return Ok(annotations);
     }
-    let annotations = match crate::baseobjspace::finditem_str(w_dict, "__annotate__")? {
+    let annotations = match crate::baseobjspace::finditem_str(
+        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+        "__annotate__",
+    )? {
         Some(annotate) if !annotate.is_null() && !unsafe { pyre_object::is_none(annotate) } => {
             let annotate_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(annotate);
@@ -3061,12 +3105,19 @@ fn module_annotations_del(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
 
 fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let module = module_require(args.get(1).copied().unwrap_or(PY_NULL), "__annotate__")?;
-    let w_dict = unsafe { pyre_object::w_module_get_w_dict(module) };
-    if let Some(annotate) = crate::baseobjspace::finditem_str(w_dict, "__annotate__")? {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::w_module_get_w_dict(module) });
+    if let Some(annotate) = crate::baseobjspace::finditem_str(roots.get(dict_slot), "__annotate__")?
+    {
         return Ok(annotate);
     }
     let none = pyre_object::w_none();
-    crate::baseobjspace::setitem(w_dict, pyre_object::w_str_new("__annotate__"), none)?;
+    // Allocate the key first: call arguments evaluate left to right, so
+    // reading the dict slot ahead of `w_str_new` would hand the store a
+    // pre-move word.
+    let annotate_key = pyre_object::w_str_new("__annotate__");
+    crate::baseobjspace::setitem(roots.get(dict_slot), annotate_key, none)?;
     Ok(none)
 }
 
@@ -3548,9 +3599,23 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // run.  `__dict_data__` is pyre's reserved layout-slot equivalent, so
     // write it through object.__setattr__'s terminal path rather than
     // dispatching a subclass override.
+    //
+    // Nothing references the instance until the backing mapping is installed,
+    // and both that allocation and the attribute store are collection points.
+    // Its allocation is stable, so the word never moves and needs no read
+    // back — the pin is what keeps a major collection from reclaiming it.
+    // The mapping is a `dict` and does move, so it is pinned at the mint and
+    // read back where the store consumes it.
+    let _roots = pyre_object::gc_roots::push_roots();
     let instance = pyre_object::w_instance_new(cls);
-    let backing = pyre_object::w_dict_new();
-    crate::baseobjspace::object_setattr(instance, "__dict_data__", backing)?;
+    pyre_object::gc_roots::pin_root(instance);
+    let backing_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    crate::baseobjspace::object_setattr(
+        instance,
+        "__dict_data__",
+        pyre_object::gc_roots::shadow_stack_get(backing_slot),
+    )?;
     Ok(instance)
 }
 /// boolobject.py descr_new — bool.__new__(cls, obj=False)
@@ -4857,19 +4922,41 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // positional-only argument passed as keyword argument: 'iterable'",
     // `set(x=1)` → "set.__init__() got an unexpected keyword argument 'x'".
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
-    let mut keyword_names_w: Vec<PyObjectRef> = Vec::new();
-    let mut keywords_w: Vec<PyObjectRef> = Vec::new();
-    if let Some(dict) = kwargs {
-        for (key, val) in unsafe { pyre_object::w_dict_str_entries_wtf8(dict) } {
-            if key.as_str() == Ok("__pyre_kw__") {
-                continue;
+    // The argument columns live in a borrowed slice and an owned `Vec`, neither
+    // of which the collector rewrites, and each keyword name allocated below
+    // can move a `list` or `dict` still waiting in them.  Both columns are
+    // published before the first of those allocations and read back where the
+    // `Arguments` copy is taken; a keyword name is a `str` and never moves, so
+    // its pin is liveness only.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let positional_base = pyre_object::gc_roots::pin_roots(positional);
+    let (keyword_names_w, keyword_values_base) = match kwargs {
+        Some(dict) => {
+            let entries: Vec<_> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+                .into_iter()
+                .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
+                .collect();
+            let values: Vec<PyObjectRef> = entries.iter().map(|(_, value)| *value).collect();
+            let base = pyre_object::gc_roots::pin_roots(&values);
+            let mut names = Vec::with_capacity(entries.len());
+            for (key, _) in entries {
+                let w_name = pyre_object::w_str_from_wtf8(key);
+                pyre_object::gc_roots::pin_root(w_name);
+                names.push(w_name);
             }
-            keyword_names_w.push(pyre_object::w_str_from_wtf8(key));
-            keywords_w.push(val);
+            (names, base)
         }
-    }
+        None => (Vec::new(), 0),
+    };
+    let keywords_w: Vec<PyObjectRef> = (0..keyword_names_w.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(keyword_values_base + index))
+        .collect();
+    let positional_w: Vec<PyObjectRef> = (0..positional.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(positional_base + index))
+        .collect();
     let signature = crate::gateway::Signature::new(vec!["self", "iterable"], None, None, 0, 2);
-    let arguments = crate::argument::Arguments::with_kw(positional, &keyword_names_w, &keywords_w);
+    let arguments =
+        crate::argument::Arguments::with_kw(&positional_w, &keyword_names_w, &keywords_w);
     let defaults = [pyre_object::w_none()];
     let mut scope_w = vec![pyre_object::PY_NULL; signature.scope_length()];
     arguments.parse_into_scope(
@@ -4880,12 +4967,15 @@ fn set_descr_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         Some(&defaults),
         pyre_object::PY_NULL,
     )?;
-    let w_iterable = scope_w[1];
+    let iterable_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(scope_w[1]);
 
     // setobject.py `_initialize_set` — `w_obj.clear()` drops the
     // storage in one go, then the iterable populates it when it is not None
-    // (the parsed default).
+    // (the parsed default).  Dropping the storage allocates the empty
+    // replacement, so the iterable is read back after it.
     unsafe { pyre_object::w_set_clear(set_obj) };
+    let w_iterable = pyre_object::gc_roots::shadow_stack_get(iterable_slot);
     if !w_iterable.is_null() && !unsafe { pyre_object::is_none(w_iterable) } {
         set_init_from_iterable(set_obj, w_iterable)?;
     }
@@ -6113,7 +6203,16 @@ fn init_str_type(ns: PyObjectRef) {
                         )));
                     }
 
-                    let d = pyre_object::w_dict_new();
+                    // A `dict` header moves, and every store below allocates
+                    // its key and, when the mapping grows, the dict's own
+                    // storage.  The fresh word is pinned at the mint and the
+                    // receiver read back per store, with each allocating
+                    // argument hoisted into a local first: call arguments
+                    // evaluate left to right, so an inline mint would hand over
+                    // a receiver read before it ran.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let d_slot = pyre_object::gc_roots::shadow_stack_len();
+                    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
                     if args.len() >= 2 {
                         if !unsafe { pyre_object::is_str(args[0]) } {
                             return Err(crate::PyError::type_error(
@@ -6143,21 +6242,29 @@ fn init_str_type(ns: PyObjectRef) {
                             ));
                         }
                         for (xc, yc) in x.code_points().zip(y.code_points()) {
+                            // Nothing references the key while the value is
+                            // being built, so it takes a liveness pin; an `int`
+                            // never moves, so it is not read back.
+                            let _pair = pyre_object::gc_roots::push_roots();
+                            let key = pyre_object::w_int_new(xc.to_u32() as i64);
+                            pyre_object::gc_roots::pin_root(key);
+                            let value = pyre_object::w_int_new(yc.to_u32() as i64);
                             unsafe {
                                 pyre_object::w_dict_store(
-                                    d,
-                                    pyre_object::w_int_new(xc.to_u32() as i64),
-                                    pyre_object::w_int_new(yc.to_u32() as i64),
+                                    pyre_object::gc_roots::shadow_stack_get(d_slot),
+                                    key,
+                                    value,
                                 );
                             }
                         }
                         if args.len() == 3 {
                             let z = unsafe { pyre_object::w_str_get_wtf8(args[2]) };
                             for zc in z.code_points() {
+                                let key = pyre_object::w_int_new(zc.to_u32() as i64);
                                 unsafe {
                                     pyre_object::w_dict_store(
-                                        d,
-                                        pyre_object::w_int_new(zc.to_u32() as i64),
+                                        pyre_object::gc_roots::shadow_stack_get(d_slot),
+                                        key,
                                         pyre_object::w_none(),
                                     );
                                 }
@@ -6174,7 +6281,16 @@ fn init_str_type(ns: PyObjectRef) {
                             // `w_dict_items` dispatches through `is_module_dict`
                             // so `str.maketrans(some_module.__dict__)` walks the
                             // strategy storage when handed a W_ModuleDictObject.
-                            for (k, v) in pyre_object::w_dict_items(src) {
+                            // Its owned `Vec` is not a slot the collector
+                            // rewrites, so the pairs still waiting in it are
+                            // rooted before the first store.
+                            let entries = pyre_object::w_dict_items(src);
+                            let flat: Vec<PyObjectRef> =
+                                entries.iter().flat_map(|&(k, v)| [k, v]).collect();
+                            let pair_base = pyre_object::gc_roots::pin_roots(&flat);
+                            for index in 0..entries.len() {
+                                let k =
+                                    pyre_object::gc_roots::shadow_stack_get(pair_base + index * 2);
                                 let ord_key = if pyre_object::is_int(k) {
                                     k
                                 } else if pyre_object::is_str(k) {
@@ -6192,11 +6308,17 @@ fn init_str_type(ns: PyObjectRef) {
                                         "keys in translate table must be strings or integers",
                                     ));
                                 };
-                                pyre_object::w_dict_store(d, ord_key, v);
+                                pyre_object::w_dict_store(
+                                    pyre_object::gc_roots::shadow_stack_get(d_slot),
+                                    ord_key,
+                                    pyre_object::gc_roots::shadow_stack_get(
+                                        pair_base + index * 2 + 1,
+                                    ),
+                                );
                             }
                         }
                     }
-                    Ok(d)
+                    Ok(pyre_object::gc_roots::shadow_stack_get(d_slot))
                 },
                 "(x, y=<unrepresentable>, z=<unrepresentable>, /)"
             ),
@@ -6381,6 +6503,40 @@ fn dict_descr_sizeof(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             .checked_add(keys_size)
             .ok_or_else(crate::builtins::reservation_failed)? as i64,
     ))
+}
+
+/// The result `dictmultiobject.py:288 descr_or` builds as `descr_copy`
+/// followed by `descr_update`: a fresh mapping holding `base`'s entries with
+/// `overlay`'s on top.  `:295 descr_ror` is the same with the two swapped, and
+/// a null operand is the "no backing mapping" case both skip.
+///
+/// The destination `dict` moves, and `w_dict_store` allocates when the storage
+/// grows or the strategy is promoted, so the destination is pinned at the mint
+/// and read back for every store.  `w_dict_items` hands back an owned `Vec`,
+/// which is not a slot the collector rewrites — the pairs still waiting in it
+/// are rooted before the first store of their round.
+fn dict_or_new(base: PyObjectRef, overlay: PyObjectRef) -> PyObjectRef {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let dst_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
+    for source in [base, overlay] {
+        if source.is_null() {
+            continue;
+        }
+        let entries = unsafe { pyre_object::w_dict_items(source) };
+        let flat: Vec<PyObjectRef> = entries.iter().flat_map(|&(k, v)| [k, v]).collect();
+        let pair_base = pyre_object::gc_roots::pin_roots(&flat);
+        for index in 0..entries.len() {
+            unsafe {
+                pyre_object::w_dict_store(
+                    pyre_object::gc_roots::shadow_stack_get(dst_slot),
+                    pyre_object::gc_roots::shadow_stack_get(pair_base + index * 2),
+                    pyre_object::gc_roots::shadow_stack_get(pair_base + index * 2 + 1),
+                );
+            }
+        }
+    }
+    pyre_object::gc_roots::shadow_stack_get(dst_slot)
 }
 
 fn init_dict_type(ns: PyObjectRef) {
@@ -6812,16 +6968,7 @@ fn init_dict_type(ns: PyObjectRef) {
                     // `descr_copy` then `descr_update`: copy LHS, overlay
                     // RHS — both reads go through `w_dict_items`, matching
                     // PyPy's storage-strategy delitem/iter parity.
-                    let dst = pyre_object::w_dict_new();
-                    if !src.is_null() {
-                        for (k, v) in unsafe { pyre_object::w_dict_items(src) } {
-                            unsafe { pyre_object::w_dict_store(dst, k, v) };
-                        }
-                    }
-                    for (k, v) in unsafe { pyre_object::w_dict_items(other) } {
-                        unsafe { pyre_object::w_dict_store(dst, k, v) };
-                    }
-                    Ok(dst)
+                    Ok(dict_or_new(src, other))
                 },
                 2,
             ),
@@ -6842,16 +6989,7 @@ fn init_dict_type(ns: PyObjectRef) {
                     if other.is_null() {
                         return Ok(pyre_object::w_not_implemented());
                     }
-                    let dst = pyre_object::w_dict_new();
-                    for (k, v) in unsafe { pyre_object::w_dict_items(other) } {
-                        unsafe { pyre_object::w_dict_store(dst, k, v) };
-                    }
-                    if !self_.is_null() {
-                        for (k, v) in unsafe { pyre_object::w_dict_items(self_) } {
-                            unsafe { pyre_object::w_dict_store(dst, k, v) };
-                        }
-                    }
-                    Ok(dst)
+                    Ok(dict_or_new(other, self_))
                 },
                 2,
             ),
@@ -16160,11 +16298,27 @@ fn staticmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
     }
     let function = positional[1];
     unsafe { pyre_object::function::w_staticmethod_set_func(sm, function) };
-    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
+    // The instance dict moves, the lookup runs Python once per name, and the
+    // key string is allocated after the value arrives — so the dict, the
+    // wrapped object and each fetched value are read back out of root slots at
+    // the store rather than out of the locals that produced them.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let function_slot = dict_slot + 1;
+    roots.pin_root(function);
     for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
-        match crate::baseobjspace::getattr_str(function, name) {
+        match crate::baseobjspace::getattr_str(roots.get(function_slot), name) {
             Ok(value) => {
-                crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+                let value_roots = pyre_object::gc_roots::push_roots();
+                let value_slot = value_roots.base();
+                value_roots.pin_root(value);
+                let key = w_str_new(name);
+                crate::baseobjspace::setitem(
+                    roots.get(dict_slot),
+                    key,
+                    value_roots.get(value_slot),
+                )?;
             }
             Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
             Err(err) => return Err(err),
@@ -16224,14 +16378,22 @@ fn staticmethod_isabstract(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn staticmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResult {
     let sm = staticmethod_require(obj, name)?;
-    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
-    if let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)? {
+    // The instance dict moves, and both the probe and the fallback lookup run
+    // Python before the store; the fetched value is minted before the key
+    // string, so it rides a slot too and is read back at the store and at the
+    // return.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    if let Some(value) = crate::baseobjspace::finditem_str(roots.get(dict_slot), name)? {
         return Ok(value);
     }
     let function = unsafe { pyre_object::function::w_staticmethod_get_func(sm) };
-    let value = crate::baseobjspace::getattr_str(function, name)?;
-    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
-    Ok(value)
+    let value_slot = dict_slot + 1;
+    roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
+    let key = w_str_new(name);
+    crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
+    Ok(roots.get(value_slot))
 }
 
 fn staticmethod_annotations_get(args: &[PyObjectRef]) -> crate::PyResult {
@@ -16244,9 +16406,16 @@ fn staticmethod_annotate_get(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn staticmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyResult {
     let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
-    let value = args.get(2).copied().unwrap_or(PY_NULL);
-    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
-    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    // Allocating the key after both words are pinned is what keeps the store
+    // from receiving pre-move addresses: call arguments evaluate left to
+    // right, so an inline `w_str_new` would run after the dict was read.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let value_slot = dict_slot + 1;
+    roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
+    let key = w_str_new(name);
+    crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(w_none())
 }
 
@@ -16260,8 +16429,11 @@ fn staticmethod_annotate_set(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn staticmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyResult {
     let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
-    let w_dict = unsafe { pyre_object::function::w_staticmethod_getdict(sm) };
-    if let Err(err) = crate::baseobjspace::delitem(w_dict, w_str_new(name)) {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });
+    let key = w_str_new(name);
+    if let Err(err) = crate::baseobjspace::delitem(roots.get(dict_slot), key) {
         if err.kind == crate::PyErrorKind::KeyError {
             return Err(crate::PyError::attribute_error(format!(
                 "'staticmethod' object has no attribute '{name}'"
@@ -16473,11 +16645,24 @@ fn classmethod_descr_init(args: &[PyObjectRef]) -> crate::PyResult {
     }
     let function = positional[1];
     unsafe { pyre_object::function::w_classmethod_set_func(cm, function) };
-    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
+    // The `staticmethod.__init__` bracket, for the same reasons.
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let function_slot = dict_slot + 1;
+    roots.pin_root(function);
     for name in ["__module__", "__name__", "__qualname__", "__doc__"] {
-        match crate::baseobjspace::getattr_str(function, name) {
+        match crate::baseobjspace::getattr_str(roots.get(function_slot), name) {
             Ok(value) => {
-                crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+                let value_roots = pyre_object::gc_roots::push_roots();
+                let value_slot = value_roots.base();
+                value_roots.pin_root(value);
+                let key = w_str_new(name);
+                crate::baseobjspace::setitem(
+                    roots.get(dict_slot),
+                    key,
+                    value_roots.get(value_slot),
+                )?;
             }
             Err(err) if err.kind == crate::PyErrorKind::AttributeError => {}
             Err(err) => return Err(err),
@@ -16526,14 +16711,18 @@ fn classmethod_isabstract(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn classmethod_wrapped_attr_get(obj: PyObjectRef, name: &str) -> crate::PyResult {
     let cm = classmethod_require(obj, name)?;
-    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
-    if let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)? {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    if let Some(value) = crate::baseobjspace::finditem_str(roots.get(dict_slot), name)? {
         return Ok(value);
     }
     let function = unsafe { pyre_object::function::w_classmethod_get_func(cm) };
-    let value = crate::baseobjspace::getattr_str(function, name)?;
-    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
-    Ok(value)
+    let value_slot = dict_slot + 1;
+    roots.pin_root(crate::baseobjspace::getattr_str(function, name)?);
+    let key = w_str_new(name);
+    crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
+    Ok(roots.get(value_slot))
 }
 
 fn classmethod_annotations_get(args: &[PyObjectRef]) -> crate::PyResult {
@@ -16546,9 +16735,13 @@ fn classmethod_annotate_get(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn classmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyResult {
     let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
-    let value = args.get(2).copied().unwrap_or(PY_NULL);
-    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
-    crate::baseobjspace::setitem(w_dict, w_str_new(name), value)?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let value_slot = dict_slot + 1;
+    roots.pin_root(args.get(2).copied().unwrap_or(PY_NULL));
+    let key = w_str_new(name);
+    crate::baseobjspace::setitem(roots.get(dict_slot), key, roots.get(value_slot))?;
     Ok(w_none())
 }
 
@@ -16562,8 +16755,11 @@ fn classmethod_annotate_set(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn classmethod_wrapped_attr_del(args: &[PyObjectRef], name: &str) -> crate::PyResult {
     let cm = classmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
-    let w_dict = unsafe { pyre_object::function::w_classmethod_getdict(cm) };
-    if let Err(err) = crate::baseobjspace::delitem(w_dict, w_str_new(name)) {
+    let roots = pyre_object::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(unsafe { pyre_object::function::w_classmethod_getdict(cm) });
+    let key = w_str_new(name);
+    if let Err(err) = crate::baseobjspace::delitem(roots.get(dict_slot), key) {
         if err.kind == crate::PyErrorKind::KeyError {
             return Err(crate::PyError::attribute_error(format!(
                 "'classmethod' object has no attribute '{name}'"
@@ -26001,13 +26197,21 @@ pub(crate) fn set_method_intersection(
     if args.is_empty() {
         return Ok(pyre_object::w_set_new());
     }
-    let mut others_w: Vec<pyre_object::PyObjectRef> = args.to_vec();
+    // An operand column copied into a plain `Vec` is not something the
+    // collector rewrites, and both loops below run Python for every entry —
+    // `len_w` calls a user `__len__`, the drain calls `__iter__` — so a `list`
+    // or `dict` operand waiting its turn would be intersected at a pre-move
+    // address.  The column is published once and every operand is read back
+    // from its slot when its turn comes; the seed swap becomes an index
+    // permutation over those slots rather than a move inside a `Vec`.
+    let operand_roots = pyre_object::gc_roots::push_roots();
+    let operand_base = pyre_object::gc_roots::pin_roots(args);
 
-    // find smallest set in others_w to reduce comparisons
+    // find smallest set in the operands to reduce comparisons
     let mut startindex = 0usize;
     let mut startlength: i64 = -1;
-    for i in 0..others_w.len() {
-        let length = match crate::baseobjspace::len_w(others_w[i]) {
+    for i in 0..args.len() {
+        let length = match crate::baseobjspace::len_w(operand_roots.get(operand_base + i)) {
             Ok(length) => length,
             Err(e)
                 if e.kind == crate::PyErrorKind::TypeError
@@ -26022,7 +26226,14 @@ pub(crate) fn set_method_intersection(
             startlength = length;
         }
     }
-    others_w.swap(0, startindex);
+    let operand = |position: usize| {
+        let index = match position {
+            0 => startindex,
+            p if p == startindex => 0,
+            p => p,
+        };
+        operand_roots.get(operand_base + index)
+    };
 
     // `setobject.py` — the seed and every operand become sets, and a
     // set operand is intersected as it stands rather than rebuilt.
@@ -26033,9 +26244,10 @@ pub(crate) fn set_method_intersection(
     // addresses; what they need is to survive the collection points around
     // them, the iterable drain and the `__eq__` a bucket probe runs.
     let _roots = pyre_object::gc_roots::push_roots();
-    let mut result = set_newobj_intersection(others_w[0])?;
+    let mut result = set_newobj_intersection(operand(0))?;
     pyre_object::gc_roots::pin_root(result);
-    for &w_other in &others_w[1..] {
+    for position in 1..args.len() {
+        let w_other = operand(position);
         let w_other_as_set = if unsafe { pyre_object::is_set_or_frozenset(w_other) } {
             w_other
         } else {
@@ -26065,7 +26277,13 @@ pub(crate) fn set_method_difference(
     if args.is_empty() {
         return Ok(pyre_object::w_set_new());
     }
+    // The copy has no referrer yet and the update below drains each operand
+    // through Python, so it needs the same lifetime pin the intersection
+    // accumulator takes.  A set never moves, so one pin is the whole fix and
+    // the word stays usable as it stands.
+    let _roots = pyre_object::gc_roots::push_roots();
     let result = set_copy_real(args[0]);
+    pyre_object::gc_roots::pin_root(result);
     let mut update_args: Vec<pyre_object::PyObjectRef> = vec![result];
     update_args.extend_from_slice(&args[1..]);
     set_method_difference_update(&update_args)?;
@@ -26082,12 +26300,18 @@ pub(crate) fn set_method_symmetric_difference(
     };
     crate::type_methods::arity_exact(args, name, 1)?;
     // `setobject.py symmetric_difference` wraps the computed storage
-    // in a set of self's class.
+    // in a set of self's class.  Each set below is freshly minted with no
+    // referrer and outlives a further allocation, so each takes the
+    // lifetime pin the intersection path takes; sets never move.
+    let _roots = pyre_object::gc_roots::push_roots();
     let w_other_as_set = set_operand_as_set(args[1])?;
+    pyre_object::gc_roots::pin_root(w_other_as_set);
     let w_new = set_symmetric_difference_storage(args[0], w_other_as_set)?;
+    pyre_object::gc_roots::pin_root(w_new);
     unsafe {
         if pyre_object::is_frozenset(args[0]) {
             let w_frozenset = pyre_object::w_frozenset_new();
+            pyre_object::gc_roots::pin_root(w_frozenset);
             pyre_object::w_set_copy_storage_from(w_frozenset, w_new);
             return Ok(w_frozenset);
         }
@@ -28084,19 +28308,31 @@ fn itertools_constructor_scope_kwonly(
     let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
     let cls = positional.first().copied().unwrap_or(PY_NULL);
     let positional = positional.get(1..).unwrap_or(&[]);
-    let mut keyword_names_w = Vec::new();
-    let mut keywords_w = Vec::new();
-    if let Some(dict) = kwargs {
-        for (key, value) in unsafe { pyre_object::w_dict_str_entries_wtf8(dict) } {
-            if key.as_str() == Ok("__pyre_kw__") {
-                continue;
+    // The positional slice and the entry `Vec` are not slots the collector
+    // rewrites, and the names and defaults dict allocated below can move a
+    // `list` or `dict` waiting in either.  Both columns are published before
+    // the first of those allocations and read back where the `Arguments` copy
+    // is taken; a keyword name is a `str` and never moves, so its pin is
+    // liveness only.
+    let positional_base = pyre_object::gc_roots::pin_roots(positional);
+    let (keyword_names_w, keyword_values_base) = match kwargs {
+        Some(dict) => {
+            let entries: Vec<_> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+                .into_iter()
+                .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
+                .collect();
+            let values: Vec<PyObjectRef> = entries.iter().map(|(_, value)| *value).collect();
+            let base = pyre_object::gc_roots::pin_roots(&values);
+            let mut names = Vec::with_capacity(entries.len());
+            for (key, _) in entries {
+                let w_name = pyre_object::w_str_from_wtf8(key);
+                pyre_object::gc_roots::pin_root(w_name);
+                names.push(w_name);
             }
-            let w_name = pyre_object::w_str_from_wtf8(key);
-            pyre_object::gc_roots::pin_root(w_name);
-            keyword_names_w.push(w_name);
-            keywords_w.push(value);
+            (names, base)
         }
-    }
+        None => (Vec::new(), 0),
+    };
     let positional_default_count = defaults.len().saturating_sub(kwonlyargcount);
     let w_kw_defs = if kwonlyargcount == 0 {
         PY_NULL
@@ -28117,7 +28353,14 @@ fn itertools_constructor_scope_kwonly(
         unsafe { pyre_object::gc_roots::shadow_stack_get(kw_defs_slot) }
     };
     let signature = crate::gateway::Signature::new(names, None, None, kwonlyargcount, 0);
-    let arguments = crate::argument::Arguments::with_kw(positional, &keyword_names_w, &keywords_w);
+    let keywords_w: Vec<PyObjectRef> = (0..keyword_names_w.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(keyword_values_base + index))
+        .collect();
+    let positional_w: Vec<PyObjectRef> = (0..positional.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(positional_base + index))
+        .collect();
+    let arguments =
+        crate::argument::Arguments::with_kw(&positional_w, &keyword_names_w, &keywords_w);
     let mut scope_w = vec![PY_NULL; signature.scope_length()];
     arguments.parse_into_scope(
         PY_NULL,
@@ -28802,32 +29045,62 @@ fn batched_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     let _roots = pyre_object::gc_roots::push_roots();
     pyre_object::gc_roots::pin_root(cls);
     let cls_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
-    let mut keyword_names_w = Vec::new();
-    let mut keywords_w = Vec::new();
-    if let Some(dict) = kwargs {
-        for (key, value) in unsafe { pyre_object::w_dict_str_entries_wtf8(dict) } {
-            if key.as_str() == Ok("__pyre_kw__") {
-                continue;
+    // The positional column is a borrowed slice, not a slot the collector
+    // rewrites either, and the keyword names and defaults below all allocate
+    // before the parse reads it — so it is published alongside the keyword
+    // values and read back at the same point.
+    let positional_base = pyre_object::gc_roots::pin_roots(positional);
+    // The entries come back in an owned `Vec`, which is not a slot the
+    // collector rewrites, and every allocation between here and the parse can
+    // move a value sitting in it.  The value column is published as one root
+    // set before the first of those allocations and read back where the
+    // `Arguments` copy is taken; a keyword name is a `str` and never moves, so
+    // its pin is liveness only.
+    let (keyword_names_w, keyword_values_base) = match kwargs {
+        Some(dict) => {
+            let entries: Vec<_> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+                .into_iter()
+                .filter(|(key, _)| key.as_str() != Ok("__pyre_kw__"))
+                .collect();
+            let values: Vec<PyObjectRef> = entries.iter().map(|(_, value)| *value).collect();
+            let base = pyre_object::gc_roots::pin_roots(&values);
+            let mut names = Vec::with_capacity(entries.len());
+            for (key, _) in entries {
+                let w_name = pyre_object::w_str_from_wtf8(key);
+                pyre_object::gc_roots::pin_root(w_name);
+                names.push(w_name);
             }
-            let w_name = pyre_object::w_str_from_wtf8(key);
-            pyre_object::gc_roots::pin_root(w_name);
-            keyword_names_w.push(w_name);
-            keywords_w.push(value);
+            (names, base)
         }
-    }
+        None => (Vec::new(), 0),
+    };
     let signature =
         crate::gateway::Signature::new(vec!["iterable", "n", "strict"], None, None, 1, 0);
-    let arguments = crate::argument::Arguments::with_kw(positional, &keyword_names_w, &keywords_w);
     let w_kw_defaults = pyre_object::w_dict_new();
+    // A `dict` header moves, and the insertion below allocates both the key
+    // string and the dict's storage, so the pin has to be taken on the fresh
+    // word and the receiver read back out of the slot.  `w_bool_from` hands
+    // back an immortal singleton, so evaluating it after that read allocates
+    // nothing.
+    pyre_object::gc_roots::pin_root(w_kw_defaults);
+    let kw_defaults_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     unsafe {
         pyre_object::w_dict_setitem_str_no_proxy(
-            w_kw_defaults,
+            pyre_object::gc_roots::shadow_stack_get(kw_defaults_slot),
             "strict",
             pyre_object::w_bool_from(false),
         )
     };
-    pyre_object::gc_roots::pin_root(w_kw_defaults);
-    let kw_defaults_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+    let keywords_w: Vec<PyObjectRef> = (0..keyword_names_w.len())
+        .map(|index| unsafe {
+            pyre_object::gc_roots::shadow_stack_get(keyword_values_base + index)
+        })
+        .collect();
+    let positional_w: Vec<PyObjectRef> = (0..positional.len())
+        .map(|index| unsafe { pyre_object::gc_roots::shadow_stack_get(positional_base + index) })
+        .collect();
+    let arguments =
+        crate::argument::Arguments::with_kw(&positional_w, &keyword_names_w, &keywords_w);
     let mut scope_w = vec![PY_NULL; signature.scope_length()];
     arguments.parse_into_scope(PY_NULL, &mut scope_w, "batched", &signature, None, unsafe {
         pyre_object::gc_roots::shadow_stack_get(kw_defaults_slot)
@@ -30283,7 +30556,15 @@ fn descr_del_dict(
     if unsafe { pyre_object::is_exception(w_obj) } {
         return Err(crate::PyError::type_error("__dict__ may not be deleted"));
     }
-    crate::baseobjspace::setdict(w_obj, pyre_object::w_dict_new())?;
+    // A `list` subclass instance is a real `W_ListObject` and moves, so the
+    // receiver is pinned and the replacement mapping is built before the slot
+    // is read — an inline `w_dict_new()` would run after the receiver had
+    // already been evaluated.
+    let roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = roots.base();
+    roots.pin_root(w_obj);
+    let w_dict = pyre_object::w_dict_new();
+    crate::baseobjspace::setdict(roots.get(obj_slot), w_dict)?;
     Ok(pyre_object::w_none())
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -3112,9 +3112,10 @@ fn module_annotate_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         return Ok(annotate);
     }
     let none = pyre_object::w_none();
-    // Allocate the key first: call arguments evaluate left to right, so
-    // reading the dict slot ahead of `w_str_new` would hand the store a
-    // pre-move word.
+    // The lookup above is a full `finditem_str`, so a `__getitem__` on a dict
+    // subclass runs Python between the pin and this store and the module dict
+    // moves under it; the store therefore reads the slot rather than the word
+    // pinned earlier.  The key is an immortal non-GC string and needs no slot.
     let annotate_key = pyre_object::w_str_new("__annotate__");
     crate::baseobjspace::setitem(roots.get(dict_slot), annotate_key, none)?;
     Ok(none)
@@ -16405,9 +16406,10 @@ fn staticmethod_annotate_get(args: &[PyObjectRef]) -> crate::PyResult {
 
 fn staticmethod_wrapped_attr_set(args: &[PyObjectRef], name: &str) -> crate::PyResult {
     let sm = staticmethod_require(args.get(1).copied().unwrap_or(PY_NULL), name)?;
-    // Allocating the key after both words are pinned is what keeps the store
-    // from receiving pre-move addresses: call arguments evaluate left to
-    // right, so an inline `w_str_new` would run after the dict was read.
+    // `w_staticmethod_getdict` mints the dict on the first access and the value
+    // arrives as a by-value argument, neither of them a word the collector
+    // rewrites, so both take a slot and the store reads them back.  The key is
+    // an immortal non-GC string and needs none.
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = roots.base();
     roots.pin_root(unsafe { pyre_object::function::w_staticmethod_getdict(sm) });

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -5731,11 +5731,7 @@ pub trait DictStrategy {
         // next use.  A `None` default slots a null word, which the root stack
         // tolerates.
         let roots = crate::gc_roots::push_roots();
-        let dict_slot = roots.publish(&[
-            w_dict,
-            w_key,
-            w_default.unwrap_or(std::ptr::null_mut()),
-        ]);
+        let dict_slot = roots.publish(&[w_dict, w_key, w_default.unwrap_or(std::ptr::null_mut())]);
         let value_slot = dict_slot + 3;
         let w_item = self.getitem(w_dict, w_key);
         if let Some(val) = w_item {

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -360,7 +360,14 @@ pub unsafe fn dict_entries_insert_object(
     key: PyObjectRef,
     value: PyObjectRef,
 ) {
-    entries.insert(object_key_for(key), value);
+    // `object_key_for` hashes through the key's `__hash__`, so the caller's
+    // `value` word is already handed over when the collection runs.  Publish it
+    // here and insert the reloaded one.
+    let roots = crate::gc_roots::push_roots();
+    let value_slot = roots.base();
+    roots.pin_root(value);
+    let object_key = object_key_for(key);
+    entries.insert(object_key, roots.get(value_slot));
 }
 
 /// The stored key's object word at an entry index, `None` once the walk has
@@ -2127,14 +2134,22 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
         // (`setitem_str` keeps `newtext(key)` for the inserted key only —
         // `dictmultiobject.py:1220-1221`).  A new-key wrap dispatches through
         // `dict_keys_equal` so str subclasses honour their `__eq__`/`__hash__`.
+        // The receiver and its storage are non-moving, but a movable `w_value`
+        // is only a by-value copy of the guard's slot, and both the probe (a
+        // str-subclass `__eq__`) and the miss arm's key wrap collect before the
+        // store — so hold the value in a slot of its own and read it back at
+        // whichever arm writes it.
+        let roots = crate::gc_roots::push_roots();
+        let value_slot = roots.base();
+        roots.pin_root(w_value);
         let entries = w_module_dict_object_storage_mut(obj);
         match dict_entries_index_of_str(entries, key) {
             Some(idx) => {
-                dict_entries_value_set_at(entries, idx, w_value);
+                dict_entries_value_set_at(entries, idx, roots.get(value_slot));
             }
             None => {
                 let w_key = crate::w_str_new(key);
-                dict_entries_insert_object(entries, w_key, w_value);
+                dict_entries_insert_object(entries, w_key, roots.get(value_slot));
                 w_dict_bump_keys_version(obj);
             }
         };
@@ -4571,9 +4586,21 @@ pub unsafe fn w_dict_length_int_strategy(obj: PyObjectRef) -> usize {
 /// Same as [`w_dict_length_int_strategy`].
 pub unsafe fn w_dict_items_int_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
     lock_dict_refs!(_dict_guard, obj);
-    w_dict_int_storage(obj)
-        .iter()
-        .map(|(&k, &v)| (crate::w_int_new(k), v))
+    // The result is a Rust-heap Vec the collector never walks and one key is
+    // wrapped per entry, so a pair pushed early would be pre-move by the next
+    // wrap.  Accumulate the run in root slots — each value re-read from the
+    // traced storage after its own iteration's wrap — and copy it out at the
+    // end.
+    let roots = crate::gc_roots::push_roots();
+    let base = roots.base();
+    let entries = w_dict_int_storage(obj);
+    let len = entries.len();
+    for i in 0..len {
+        let w_key = crate::w_int_new(*entries.get_index(i).unwrap().0);
+        roots.publish(&[w_key, *entries.get_index(i).unwrap().1]);
+    }
+    (0..len)
+        .map(|i| (roots.get(base + 2 * i), roots.get(base + 2 * i + 1)))
         .collect()
 }
 
@@ -4593,7 +4620,12 @@ pub unsafe fn w_dict_nth_item_int_strategy(
     let (k, v) = w_dict_int_storage(obj)
         .get_index(index)
         .map(|(&k, &v)| (k, v))?;
-    Some((crate::w_int_new(k), v))
+    // Wrapping the key collects, and `v` is a bare local by then.
+    let roots = crate::gc_roots::push_roots();
+    let value_slot = roots.base();
+    roots.pin_root(v);
+    let w_key = crate::w_int_new(k);
+    Some((w_key, roots.get(value_slot)))
 }
 
 /// Internal helper: `IntDictStrategy::clear` body —
@@ -4627,19 +4659,47 @@ pub unsafe fn w_dict_clear_int_strategy(obj: PyObjectRef) {
 /// `w_dict` must be a valid `W_DictObject` on `INT_DICT_STRATEGY`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_switch_int_to_object_strategy(w_dict: PyObjectRef) {
-    let dict = &mut *(w_dict as *mut W_DictObject);
+    // Three separate hazards, one bracket.  The receiver moves, so the field
+    // stores at the end must go through a reloaded word.  Each wrapped key is
+    // minted inside the loop and is reachable from nothing the collector walks
+    // until the new table is attached.  And the new table is a Rust-heap map:
+    // a pair copied into it early would be pre-move by the next iteration's
+    // mint.  So the run is accumulated in root slots and the table is filled
+    // from those slots once every allocation is behind us.
+    let roots = crate::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(w_dict);
     // Borrow the old typed box (its field stays live, so it is traced
     // while the migration allocates keys); after the store the box is
     // unreachable and the sweep reclaims it.
-    let old = &*(dict.dstorage as *const IntDictStorage);
-    let mut new_map = ObjectDictStorage::with_capacity(old.len());
-    for (&k, &v) in old.iter() {
+    let old = &*((*(w_dict as *const W_DictObject)).dstorage as *const IntDictStorage);
+    let len = old.len();
+    let mut hashes = Vec::with_capacity(len);
+    let pairs_base = dict_slot + 1;
+    for i in 0..len {
+        let k = *old.get_index(i).unwrap().0;
         let w_key = crate::w_int_new(k);
-        new_map.insert(object_key_for(w_key), v);
+        let object_key = object_key_for(w_key);
+        // Take the value only now: the old table is traced, so re-reading the
+        // slot after this iteration's allocations yields the current word.
+        let v = *old.get_index(i).unwrap().1;
+        hashes.push(object_key.hash);
+        roots.publish(&[object_key.obj, v]);
     }
-    dict.dstorage =
-        crate::gc_storage::gc_alloc_storage_box(new_map, object_dict_storage_gc_type_id())
-            as *mut u8;
+    // The empty box is allocated before the fill so the last collection point
+    // is behind the pairs being copied out of their slots.
+    let new_storage = crate::gc_storage::gc_alloc_storage_box(
+        ObjectDictStorage::with_capacity(len),
+        object_dict_storage_gc_type_id(),
+    );
+    let new_map = &mut *new_storage;
+    for (i, &hash) in hashes.iter().enumerate() {
+        let obj = roots.get(pairs_base + 2 * i);
+        let value = roots.get(pairs_base + 2 * i + 1);
+        new_map.insert(ObjectKey { hash, obj }, value);
+    }
+    let dict = &mut *(roots.get(dict_slot) as *mut W_DictObject);
+    dict.dstorage = new_storage as *mut u8;
     dict.dstrategy = &OBJECT_DICT_STRATEGY_REF;
 }
 
@@ -4725,9 +4785,17 @@ pub unsafe fn w_dict_length_bytes_strategy(obj: PyObjectRef) -> usize {
 /// Same as [`w_dict_bytes_storage`].
 pub unsafe fn w_dict_items_bytes_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
     lock_dict_refs!(_dict_guard, obj);
-    w_dict_bytes_storage(obj)
-        .iter()
-        .map(|(k, v)| (crate::w_bytes_from_bytes(k.as_slice()), *v))
+    // Accumulated in root slots for [`w_dict_items_int_strategy`]'s reason.
+    let roots = crate::gc_roots::push_roots();
+    let base = roots.base();
+    let entries = w_dict_bytes_storage(obj);
+    let len = entries.len();
+    for i in 0..len {
+        let w_key = crate::w_bytes_from_bytes(entries.get_index(i).unwrap().0.as_slice());
+        roots.publish(&[w_key, *entries.get_index(i).unwrap().1]);
+    }
+    (0..len)
+        .map(|i| (roots.get(base + 2 * i), roots.get(base + 2 * i + 1)))
         .collect()
 }
 
@@ -4743,8 +4811,12 @@ pub unsafe fn w_dict_nth_item_bytes_strategy(
     let entries = w_dict_bytes_storage(obj);
     let (k, v) = entries.get_index(index)?;
     let key_bytes = k.clone();
-    let value = *v;
-    Some((crate::w_bytes_from_bytes(key_bytes.as_slice()), value))
+    // Wrapping the key collects, and `value` is a bare local by then.
+    let roots = crate::gc_roots::push_roots();
+    let value_slot = roots.base();
+    roots.pin_root(*v);
+    let w_key = crate::w_bytes_from_bytes(key_bytes.as_slice());
+    Some((w_key, roots.get(value_slot)))
 }
 
 /// Internal helper: `BytesDictStrategy::clear` body.
@@ -4768,16 +4840,34 @@ pub unsafe fn w_dict_clear_bytes_strategy(obj: PyObjectRef) {
 /// `w_dict` must be a valid `W_DictObject` on `BYTES_DICT_STRATEGY`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn w_dict_switch_bytes_to_object_strategy(w_dict: PyObjectRef) {
-    let dict = &mut *(w_dict as *mut W_DictObject);
-    let old = &*(dict.dstorage as *const BytesDictStorage);
-    let mut new_map = ObjectDictStorage::with_capacity(old.len());
-    for (k, v) in old.iter() {
-        let w_key = crate::w_bytes_from_bytes(k.as_slice());
-        new_map.insert(object_key_for(w_key), *v);
+    // Rooted exactly as [`w_dict_switch_int_to_object_strategy`] is, for the
+    // same three reasons.
+    let roots = crate::gc_roots::push_roots();
+    let dict_slot = roots.base();
+    roots.pin_root(w_dict);
+    let old = &*((*(w_dict as *const W_DictObject)).dstorage as *const BytesDictStorage);
+    let len = old.len();
+    let mut hashes = Vec::with_capacity(len);
+    let pairs_base = dict_slot + 1;
+    for i in 0..len {
+        let w_key = crate::w_bytes_from_bytes(old.get_index(i).unwrap().0.as_slice());
+        let object_key = object_key_for(w_key);
+        let v = *old.get_index(i).unwrap().1;
+        hashes.push(object_key.hash);
+        roots.publish(&[object_key.obj, v]);
     }
-    dict.dstorage =
-        crate::gc_storage::gc_alloc_storage_box(new_map, object_dict_storage_gc_type_id())
-            as *mut u8;
+    let new_storage = crate::gc_storage::gc_alloc_storage_box(
+        ObjectDictStorage::with_capacity(len),
+        object_dict_storage_gc_type_id(),
+    );
+    let new_map = &mut *new_storage;
+    for (i, &hash) in hashes.iter().enumerate() {
+        let obj = roots.get(pairs_base + 2 * i);
+        let value = roots.get(pairs_base + 2 * i + 1);
+        new_map.insert(ObjectKey { hash, obj }, value);
+    }
+    let dict = &mut *(roots.get(dict_slot) as *mut W_DictObject);
+    dict.dstorage = new_storage as *mut u8;
     dict.dstrategy = &OBJECT_DICT_STRATEGY_REF;
 }
 
@@ -4959,10 +5049,19 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
     } else {
         let strategy = &*w_module_dict_get_strategy(obj);
         let storage = &*w_module_dict_get_storage(obj);
+        // Wrapping a name allocates, so a value zipped in before a later wrap
+        // would be pre-move in the Rust-heap result.  Wrap every name into a
+        // root slot first, then walk the values — which the cell storage keeps
+        // traced — with no allocation left to run.
+        let roots = crate::gc_roots::push_roots();
+        let keys_base = roots.base();
+        for k in strategy.getiterkeys(storage) {
+            roots.pin_root(crate::w_str_new(k));
+        }
         strategy
-            .getiterkeys(storage)
-            .zip(strategy.getitervalues(storage))
-            .map(|(k, v)| (crate::w_str_new(k), v))
+            .getitervalues(storage)
+            .enumerate()
+            .map(|(i, v)| (roots.get(keys_base + i), v))
             .collect()
     }
 }
@@ -5545,11 +5644,20 @@ pub trait DictStrategy {
         w_key: PyObjectRef,
         w_value: PyObjectRef,
     ) -> PyObjectRef {
+        // `getitem` hashes the key, so all three by-value words are stale by
+        // the time the store runs — and the default is handed back after the
+        // store, which allocates again.  Slot them and read back at each use.
+        let roots = crate::gc_roots::push_roots();
+        let dict_slot = roots.publish(&[w_dict, w_key, w_value]);
         if let Some(w_result) = self.getitem(w_dict, w_key) {
             return w_result;
         }
-        self.setitem(w_dict, w_key, w_value);
-        w_value
+        self.setitem(
+            roots.get(dict_slot),
+            roots.get(dict_slot + 1),
+            roots.get(dict_slot + 2),
+        );
+        roots.get(dict_slot + 2)
     }
 
     /// `dictmultiobject.py:506-514 w_keys` — collect all keys.
@@ -5618,14 +5726,26 @@ pub trait DictStrategy {
         w_default: Option<PyObjectRef>,
     ) -> Result<PyObjectRef, DictPopError> {
         // dictmultiobject.py:624-634
+        // `getitem` hashes the key and `delitem` allocates, so the receiver,
+        // the key, the default and the fetched value are each stale at their
+        // next use.  A `None` default slots a null word, which the root stack
+        // tolerates.
+        let roots = crate::gc_roots::push_roots();
+        let dict_slot = roots.publish(&[
+            w_dict,
+            w_key,
+            w_default.unwrap_or(std::ptr::null_mut()),
+        ]);
+        let value_slot = dict_slot + 3;
         let w_item = self.getitem(w_dict, w_key);
         if let Some(val) = w_item {
-            if !self.delitem(w_dict, w_key) {
+            roots.pin_root(val);
+            if !self.delitem(roots.get(dict_slot), roots.get(dict_slot + 1)) {
                 return Err(DictPopError);
             }
-            Ok(val)
-        } else if let Some(d) = w_default {
-            Ok(d)
+            Ok(roots.get(value_slot))
+        } else if w_default.is_some() {
+            Ok(roots.get(dict_slot + 2))
         } else {
             Err(DictPopError)
         }
@@ -5642,10 +5762,16 @@ pub trait DictStrategy {
     /// # Safety
     /// `w_dict` must be a valid PyObjectRef.
     unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
+        // `items` and `delitem` both allocate, so the receiver is stale before
+        // the removal and the returned pair is stale after it.
+        let roots = crate::gc_roots::push_roots();
+        let dict_slot = roots.base();
+        roots.pin_root(w_dict);
         let mut items = self.items(w_dict);
         let (w_key, w_value) = items.pop()?;
-        self.delitem(w_dict, w_key);
-        Some((w_key, w_value))
+        let pair_base = roots.publish(&[w_key, w_value]);
+        self.delitem(roots.get(dict_slot), roots.get(pair_base));
+        Some((roots.get(pair_base), roots.get(pair_base + 1)))
     }
 
     /// `dictmultiobject.py:556-557 getiterreversed` — iterate
@@ -5672,11 +5798,25 @@ pub trait DictStrategy {
     /// # Safety
     /// `w_dict` must be a valid PyObjectRef.
     unsafe fn copy(&self, w_dict: PyObjectRef) -> PyObjectRef {
-        let new_dict = crate::dictmultiobject::w_dict_new();
-        for (k, v) in self.items(w_dict) {
-            crate::dictmultiobject::w_dict_store(new_dict, k, v);
+        // The materialised pairs sit in a Rust-heap Vec the collector never
+        // walks and the fresh dict moves under every store, so the whole run
+        // is published before the dict is minted and each word is read back at
+        // the store that consumes it.
+        let roots = crate::gc_roots::push_roots();
+        let pairs_base = roots.base();
+        let items = self.items(w_dict);
+        for &(k, v) in &items {
+            roots.publish(&[k, v]);
         }
-        new_dict
+        let new_slot = roots.publish(&[crate::dictmultiobject::w_dict_new()]);
+        for i in 0..items.len() {
+            crate::dictmultiobject::w_dict_store(
+                roots.get(new_slot),
+                roots.get(pairs_base + 2 * i),
+                roots.get(pairs_base + 2 * i + 1),
+            );
+        }
+        roots.get(new_slot)
     }
 
     /// `dictmultiobject.py:548-552 clear` — reset to EmptyDictStrategy.
@@ -6789,20 +6929,37 @@ impl DictStrategy for UnicodeDictStrategy {
     /// key then dispatches to `setitem`.  UnicodeDictStrategy keeps
     /// str keys on the fast path; no promotion.
     unsafe fn setitem_str(&self, w_dict: PyObjectRef, key: &str, w_value: PyObjectRef) {
-        let dict = &mut *(w_dict as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
-        match dict_entries_index_of_str(entries, key) {
+        // This is the one `setitem_str` that both collects and stores itself:
+        // the membership probe can run a str-subclass `__eq__` (and its no-hook
+        // arm wraps the key), and a miss mints the persistent key.  A dict
+        // header moves, and these parameters are by-value copies of the caller's
+        // words, so the root bracket the entry point holds does not update them
+        // — publish the receiver and the value here and read both slots back
+        // after the probe and after the mint.
+        let roots = crate::gc_roots::push_roots();
+        let dict_slot = roots.publish(&[w_dict, w_value]);
+        let value_slot = dict_slot + 1;
+        let found = dict_entries_index_of_str(w_dict_object_storage(w_dict), key);
+        match found {
             Some(idx) => {
-                let (_, stored_value) = entries.get_index_mut(idx).unwrap();
-                *stored_value = w_value;
+                let w_value = roots.get(value_slot);
+                let entries = w_dict_object_storage_mut(roots.get(dict_slot));
+                *entries.get_index_mut(idx).unwrap().1 = w_value;
             }
             None => {
+                // Mint before reading either slot: call arguments evaluate left
+                // to right, so a slot read written inline with the mint would be
+                // taken before the collection that invalidates it.
                 let stored_key = object_key_for_new_str(key);
+                let w_value = roots.get(value_slot);
+                let dict = &mut *(roots.get(dict_slot) as *mut W_DictObject);
+                let entries =
+                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
                 dict_entries_insert_hashed(entries, stored_key.hash, stored_key.obj, w_value);
                 dict.keys_version = dict.keys_version.wrapping_add(1);
             }
         };
-        dict_write_barrier(w_dict);
+        dict_write_barrier(roots.get(dict_slot));
     }
 
     /// `dictmultiobject.py:1315-1318 getitem_str` override.

--- a/pyre/pyre-object/src/interp_itertools.rs
+++ b/pyre/pyre-object/src/interp_itertools.rs
@@ -1119,17 +1119,21 @@ pub struct W_Cycle {
 /// `w_iterable` must already be an iterator (`cycle`'s registrar applies
 /// `space.iter`).  Allocates an empty `saved` list.
 pub fn w_cycle_new(w_iterable: PyObjectRef) -> PyObjectRef {
-    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).
-    let _roots = crate::gc_roots::push_roots();
-    crate::gc_roots::pin_root(w_iterable);
+    // `gct_fv_gc_malloc` bracket pattern (`framework.py:853-856`).  Minting
+    // `saved` allocates, and a self-iterating `list` subclass reaches here as
+    // a movable header, so `w_iterable` is read back out of its root slot
+    // rather than from the parameter copy that collection left pre-move.
+    let roots = crate::gc_roots::push_roots();
+    let iterable_slot = roots.base();
+    roots.pin_root(w_iterable);
     let saved = crate::listobject::w_list_new(Vec::new());
-    crate::gc_roots::pin_root(saved);
+    roots.pin_root(saved);
     W_Cycle::allocate_stable(W_Cycle {
         ob: PyObject {
             ob_type: std::ptr::null(),
             w_class: std::ptr::null_mut(),
         },
-        w_iterable,
+        w_iterable: roots.get(iterable_slot),
         saved,
         index: 0,
     })

--- a/pyre/pyre-object/src/listobject.rs
+++ b/pyre/pyre-object/src/listobject.rs
@@ -762,15 +762,23 @@ pub unsafe fn switch_to_object_strategy(list: &mut W_ListObject) -> PyObjectRef 
     list.set_object_items_from_vec(seed);
     let obj = crate::gc_roots::shadow_stack_get(obj_slot);
     let list = &mut *(obj as *mut W_ListObject);
+    // Take the strategy together with the block, ahead of the two `install`
+    // calls below.  `list_object_custom_trace` reaches `items` only under the
+    // Object strategy, and `IntArray::install` drops the outgoing storage
+    // through `dealloc_typed_items_block`, whose ownership query is a
+    // safepoint.  `set_object_items_from_vec` closed its own root scope on the
+    // way out, so between its store and this line the fresh block's only
+    // reference is the `items` edge the trace is still skipping — a collection
+    // in that window reclaims it and leaves `items` naming reused nursery.
+    list.strategy = ListStrategy::Object;
+    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
+    let list = &mut *(obj as *mut W_ListObject);
     // Object strategy reads neither typed array again, so drop both to the
     // empty form instead of installing two fresh single-slot blocks.
     list.int_items.install(IntArray::empty());
     let obj = crate::gc_roots::shadow_stack_get(obj_slot);
     let list = &mut *(obj as *mut W_ListObject);
     list.float_items.install(FloatArray::empty());
-    let obj = crate::gc_roots::shadow_stack_get(obj_slot);
-    let list = &mut *(obj as *mut W_ListObject);
-    list.strategy = ListStrategy::Object;
     crate::gc_roots::shadow_stack_get(obj_slot)
 }
 


### PR DESCRIPTION
A `list` or `dict` held in a bare Rust local — or in a by-value parameter, or in
a plain `Vec<PyObjectRef>` filled across a loop — names a pre-move address once
anything allocates: the collector updates its own root slots and never the Rust
word. Being reachable does not help. An instance dict reached through
`getdict_native` stays alive and its *field* is updated while the local copy
goes stale.

### The reproducer this started from

`localeconv_to_dict` held a bare `w_dict_new()` across eighteen insertions, so
both the later insertions and the **returned** dict named a pre-move address,
and `locale.py` calls `localeconv()` constantly.

Same command, same binary modulo that one function, `PYPY_GC_NURSERY=4096`:

| | probe hits | rc | result |
|---|---|---|---|
| before | 20 | 101 (abort) | — |
| after | 0 | 0 | 66 tests OK |

Control runs on unrelated binaries stayed silent.

### The rest

The other sites were reached by a census of `pyre-interpreter` and
`pyre-object`, not by a failing case, and follow the shape `localeconv_to_dict`
established: pin at the mint, read the slot back at every consumer that follows
an allocation, and hoist an allocating value into a local before the slot read,
since call arguments evaluate left to right. A freshly minted object that
nothing else references takes one liveness pin and no read-back.

Notable individual fixes:

- **`UnicodeDictStrategy::setitem_str`** — the one `setitem_str` that both mints
  the persistent key and stores through its own parameters; the bracket its
  entry point holds does not reach them.
- **`reorder_and_add`** — the saved `(map, value)` pairs lived in a plain `Vec`
  and `w_value` in a by-value parameter across a loop in which
  `_mapdict_pop_attribute` collects in either arm. The `Vec` now carries slot
  indices instead of words.
- **`match_signature`** — published `w_kw_defs`, the keyword columns and
  `scope_w`, but not `defaults_w`, which the positional-defaults loop reads
  after the vararg tuple, the `**kwargs` `w_dict_new` and `collect_keyword_args`
  have run.
- **`builtins.rs`** routes four type-namespace closures through a `type_ns_store`
  helper taking the value already built, so the argument-order hazard cannot
  recur across the ~35 insertions.

### One correction, carried in the last commit

Five brackets justified themselves with a collection point that does not exist.
`plain_direct_read` boxes through `box_value` → `w_int_new` / `w_float_new`,
both of which reach `try_gc_alloc_stable_raw`, whose `alloc_in_oldgen` runs no
collection; and `w_str_new` is `std::alloc` behind a GC header, so it moves
nothing either. What those brackets actually cover is **survival**, which
`alloc_typed_items_block` already states: *old-gen birth buys immobility, not
survival*, so a freshly boxed value carries no heap edge and an incremental
major already scanning sweeps it. The comments now say that.

The same finding retired four edits of mine that claimed to be argument-order
defects — the mint on the right must be able to move something, and neither
`w_str_new` nor `w_int_new` can. They were reverted before this branch was
pushed.

### Verification

- `pyre/check.py`: **dynasm 439/439, cranelift 439/439, wasm 432/432, 3/3 backend runs**
- `cargo test --all --features dynasm`: passes, 140 suites
- At `PYPY_GC_NURSERY=4096`: `test_locale` 66 OK, `test_ctypes` 319 OK,
  `test_dict` 120 OK, `test_json` 218 OK, `test_csv` 128 OK

Pre-existing and untouched by this branch — `test_descr` (shadow-stack
`PoisonError` abort), `test_warnings`, `test_io`, `test_sys`, `test_pyexpat` and
`test_importlib` fail with identical counts on control binaries built from
`539ab23b40a` and `2ce63fad8c0`.

### Caveat

Apart from `localeconv`, these sites carry no failing case. A green gate means
no regression, not proof that each site was live.

— *authored by Claude*
