### PR TITLE
jit(cranelift): stop seeding ref-root homes from a LABEL-free trace's entry

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -10053,36 +10053,33 @@ impl CraneliftBackend {
         // The jitframe pointer register (EBP, the pinned register) is reserved
         // and never shares a slot with a value.
         //
-        // The inputarg→ref-root sync must NOT run in this pre-dispatch entry
-        // block when the trace has LABELs: the per-LABEL loaders (the
-        // dispatch_key re-entry path) read each LABEL's carried values from
-        // the dense jitframe slots `JF_FRAME_ITEM0_OFS + i*8`, and when
-        // `max_output_slots < arity` those slots overlap the ref-root region
-        // (`ref_root_base_ofs + slot*8`). Syncing an inputarg to its root slot
-        // here would clobber a carried value before the loader reads it. Defer
-        // the sync to the preamble (key-0 host-entry) path, which is the only
-        // path that needs roots established before the preamble's own ops; the
-        // loader paths reach a LABEL block that re-syncs its carried roots with
-        // no GC in between.
+        // A LABEL trace defers root seeding to the host-entry preamble: the
+        // per-LABEL loaders read their carried values from the dense slots
+        // `JF_FRAME_ITEM0_OFS + i*8`, which overlap the ref-root region when
+        // `max_output_slots < arity`, so seeding here would clobber a carried
+        // value before its loader reads it. A linear entry needs no eager
+        // root-home write at all. A guard's
+        // `allocate_gcmap(&failarg_ref_slots)` contains only dense indices,
+        // while `ref_root_base_ofs` starts at `max_output_slots`, which is at
+        // least `inputargs.len()`, so no guard gcmap can name the ref-root word
+        // such a store would write. Every `emit_push_gcmap` is preceded by
+        // `spill_ref_roots` over the same slot list, and `get_gcmap` uses the
+        // same ref-root predicate as that spill. Its two mark-without-spill
+        // escapes are inert here: demotion requires a LABEL, and
+        // `stale_ref_vars` has no insertion anywhere. The home's first write
+        // is therefore the first spill. Any future path that marks a ref-root
+        // word without a preceding spill is a live GC bug.
         let mut deferred_entry_root_syncs: Vec<(u32, CValue)> = Vec::new();
-        let mut entry_sync_jf_ptr = None;
         let has_labels = !label_indices.is_empty();
+        debug_assert!(
+            demoted_failarg_slots.is_empty(),
+            "entry loop runs before any LABEL seeds a demoted home"
+        );
         for (i, val) in entry_input_vals.iter().copied().enumerate() {
             let slot = inputargs[i].index;
             builder.def_var(var(slot), val);
             if has_labels {
                 deferred_entry_root_syncs.push((slot, val));
-            } else {
-                sync_ref_root_var(
-                    &mut builder,
-                    ptr_type,
-                    &mut entry_sync_jf_ptr,
-                    &ref_root_slots,
-                    slot,
-                    val,
-                    ref_root_base_ofs,
-                    &mut synced_ref_vars,
-                );
             }
         }
 


### PR DESCRIPTION
A trace with no LABELs wrote every Ref inputarg to its ref-root home in the entry block. Every attached bridge is such a trace, and a bridge's entry block runs on every guard exit, so this cost one store per live reference per crossing — 8 to 20 stores in each of fannkuch's 22 bridges, 18 in the hot one.

This is the same shape as #1313's LABEL-header change, at the other `sync_ref_root_var` call site. That audit only looked at the LABEL parameter loop, so the entry loop kept its stores.

### Why nothing observes the word

- A guard's map is `allocate_gcmap(&failarg_ref_slots)` — dense indices only — while `ref_root_base_ofs` is anchored at `max_output_slots`, which is at least `inputargs.len()`. The two ranges are disjoint by construction, so no guard exit can name a ref-root word.
- Every `emit_push_gcmap` is preceded by `spill_ref_roots` over the same slot list, and `get_gcmap` applies that spill's own predicate. A call-site map never names a word the spill on the preceding instruction did not write.
- `get_gcmap`'s two mark-without-spill escapes cannot fire here: the demoted arm requires a LABEL, and `stale_ref_vars` has no insertion anywhere in the workspace.
- `jitframe_trace` visits only the words a map names — there is no range scan — so an unwritten home, including the uninitialised tail a growing `cranelift_realloc_frame` leaves past `old_len`, is never traced.
- `defined_ref_vars` is seeded from `inputargs`, not from the sync, so removing the store does not change gcmap membership.

The home's first write is now the first spill. Any future path that marks a ref-root word without a preceding spill becomes a live GC bug; the comment says so.

### The debug_assert

An earlier revision of this change gated the deletion on `is_demoted_failarg`, mirroring #1313. That gate was dead code: `demoted_failarg_slots` is empty until code emission reaches a LABEL, and this loop runs before the op-emission loop that seeds it. Same expression as #1313's, opposite reachability. The gate is gone and a `debug_assert!` records the invariant instead, so a future change that makes demotion state observable here trips a test rather than silently reproducing an unconditional delete.

### Measurements

`pyre/bench/fannkuch.py`, interleaved CPU medians, 15 rounds:

| arm | median | |
|---|---|---|
| base | 1.584s | |
| this branch | 1.509s | **-4.8%**, ahead in 13/15 paired rounds |
| dynasm, same tree | 0.692s | |

Ratio to dynasm 2.29x to 2.18x. Emitted stores over the whole fannkuch compile: 5924 to 5609. Bridge entry ref-root store runs: 22 of 23 bridge functions drop theirs entirely.

The predicted value was ~5% from the crossing cost model (0.27% of runtime per removed memory instruction, calibrated on #1313's two landed levers); measured -4.8%.

### Gates

`cargo test -p majit-backend-cranelift` and `pyre/check.py --backend cranelift` (439/439) pass. The emitted CLIF is identical before and after the dead gate's removal, which is the direct evidence that the gate was inert.

Five independent adversarial reviews were run against the safety argument, each asked to produce a cited failure sequence (frame reallocation and frame identity, the gcmap/spill correspondence, guard-exit readers, the gate itself, cross-trace lifetime on a shared JITFRAME). None constructed one; the dead-gate finding above came out of that pass.
