### PR TITLE
Five interpreter-surface fixes found by exercising pip

### DIFF
--- a/pyre/extra_tests/snippets/code_object_weakref.py
+++ b/pyre/extra_tests/snippets/code_object_weakref.py
@@ -1,0 +1,31 @@
+# pyre-check: gate=1
+# `typedef.py` gives PyCode a `__weakref__` descriptor, so a caller can attach
+# per-code state that expires with the code object.
+import gc
+import weakref
+
+
+def target(a, b=2):
+    return a + b
+
+
+code = target.__code__
+reference = weakref.ref(code)
+assert reference() is code
+
+# A weak-keyed mapping over code objects is the shape callers actually use.
+table = weakref.WeakKeyDictionary()
+table[code] = 'protected'
+assert table[code] == 'protected'
+
+# A compiled-on-the-fly code object has no enclosing `co_consts` holding it,
+# so dropping the last reference must clear the weak reference and fire the
+# callback.  A nested function's code would stay alive through its parent.
+dropped = []
+transient = compile('0', '<weakref probe>', 'eval')
+watcher = weakref.ref(transient, lambda ref: dropped.append(True))
+assert watcher() is transient
+del transient
+gc.collect()
+assert watcher() is None
+assert dropped == [True]

--- a/pyre/extra_tests/snippets/errno_platform_names.py
+++ b/pyre/extra_tests/snippets/errno_platform_names.py
@@ -1,0 +1,54 @@
+# pyre-check: gate=1
+# `interp_errno.py` declares one name list for every platform and drops only
+# the entries the host does not define, so these names are absent solely where
+# the platform lacks them.  `from errno import ESTALE` is an unconditional
+# import in widely used packages.
+import errno
+import sys
+
+# Defined by the C runtime on every platform pyre builds for.
+for name in ('EILSEQ', 'ECANCELED', 'ENOTSUP', 'EOWNERDEAD', 'ENOTRECOVERABLE'):
+    assert hasattr(errno, name), name
+
+if sys.platform != 'win32':
+    # Present through libc on posix; on windows these reach the module through
+    # the WSA-derived aliases, which this snippet does not assert because the
+    # reference interpreter does not carry all of them there.
+    for name in (
+        'ESTALE',
+        'EUSERS',
+        'EREMOTE',
+        'ETOOMANYREFS',
+        'EPFNOSUPPORT',
+        'ESOCKTNOSUPPORT',
+    ):
+        assert hasattr(errno, name), name
+
+if sys.platform == 'darwin':
+    for name in (
+        'ENOATTR',
+        'EAUTH',
+        'EBADARCH',
+        'EBADEXEC',
+        'EBADMACHO',
+        'EBADRPC',
+        'EDEVERR',
+        'EFTYPE',
+        'ENEEDAUTH',
+        'ENOPOLICY',
+        'EPROCLIM',
+        'EPROCUNAVAIL',
+        'EPROGMISMATCH',
+        'EPROGUNAVAIL',
+        'EPWROFF',
+        'EQFULL',
+        'ERPCMISMATCH',
+        'ESHLIBVERS',
+    ):
+        assert hasattr(errno, name), name
+
+# Every exported code is reachable through `errorcode`, which is what makes
+# `os.strerror(errno.errorcode[...])` and the traceback formatting work.
+for attribute, value in vars(errno).items():
+    if attribute.isupper():
+        assert value in errno.errorcode, attribute

--- a/pyre/extra_tests/snippets/multiprocessing_semlock_keywords.py
+++ b/pyre/extra_tests/snippets/multiprocessing_semlock_keywords.py
@@ -19,6 +19,13 @@ by_keyword = _multiprocessing.SemLock(
 assert by_keyword.kind == RECURSIVE_MUTEX
 assert by_keyword.maxvalue == 1
 
+# Only `subtype` is positional-only, so the first three bind by name as well.
+by_all_keywords = _multiprocessing.SemLock(
+    kind=RECURSIVE_MUTEX, value=1, maxvalue=1, name=f'{base}-all-kw', unlink=True
+)
+assert by_all_keywords.kind == RECURSIVE_MUTEX
+assert by_all_keywords.maxvalue == 1
+
 by_position = _multiprocessing.SemLock(
     RECURSIVE_MUTEX, 1, 1, f'{base}-pos', True
 )

--- a/pyre/extra_tests/snippets/multiprocessing_semlock_keywords.py
+++ b/pyre/extra_tests/snippets/multiprocessing_semlock_keywords.py
@@ -1,0 +1,39 @@
+# pyre-check: gate=1
+# `interp_semaphore.py` declares SemLock's parameters through `@unwrap_spec`,
+# so the constructor binds them by name as well as by position.
+import os
+import sys
+
+if sys.platform == 'win32':
+    # The windows SemLock takes a different parameter set.
+    raise SystemExit(0)
+
+import _multiprocessing
+
+RECURSIVE_MUTEX = 0
+base = f'/pyre-semlock-{os.getpid()}'
+
+by_keyword = _multiprocessing.SemLock(
+    RECURSIVE_MUTEX, 1, 1, name=f'{base}-kw', unlink=True
+)
+assert by_keyword.kind == RECURSIVE_MUTEX
+assert by_keyword.maxvalue == 1
+
+by_position = _multiprocessing.SemLock(
+    RECURSIVE_MUTEX, 1, 1, f'{base}-pos', True
+)
+assert by_position.kind == RECURSIVE_MUTEX
+
+# The name is not positional-only either way round.
+mixed = _multiprocessing.SemLock(
+    RECURSIVE_MUTEX, 1, 1, unlink=True, name=f'{base}-mixed'
+)
+assert mixed.maxvalue == 1
+
+# `kind` outside the two known values is still rejected.
+try:
+    _multiprocessing.SemLock(99, 1, 1, name=f'{base}-bad', unlink=True)
+except ValueError:
+    pass
+else:
+    raise AssertionError('unrecognized kind must raise ValueError')

--- a/pyre/extra_tests/snippets/sys_executable_path_normalized.py
+++ b/pyre/extra_tests/snippets/sys_executable_path_normalized.py
@@ -1,0 +1,37 @@
+# pyre-check: gate=1
+import os
+import subprocess
+import sys
+
+# `initpath.py:find_executable` applies `abspath`, whose second half is
+# `normpath` -- joining the cwd alone would carry the caller's spelling of
+# `.` into `sys.executable` and every prefix derived from it, and `site.py`
+# compares those prefixes against the directory it finds itself in.
+directory, name = os.path.split(sys.executable)
+parent, leaf = os.path.split(directory)
+
+SHOW = 'import sys; print(sys.executable)'
+
+spellings = [
+    # Relative, resolved against the cwd.
+    (os.path.join(os.curdir, name), directory),
+    # Already absolute, so only the collapsing is left to do.
+    (os.path.join(directory, os.curdir, name), parent),
+    (os.path.join(directory, os.pardir, leaf, name), parent),
+]
+
+for spelling, cwd in spellings:
+    result = subprocess.run(
+        [spelling, '-c', SHOW],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert result.returncode == 0, (spelling, result.stderr)
+    reported = result.stdout.decode().strip()
+
+    assert os.path.isabs(reported), (spelling, reported)
+    parts = reported.split(os.sep)
+    assert os.curdir not in parts, (spelling, reported)
+    assert os.pardir not in parts, (spelling, reported)
+    assert os.path.samefile(reported, sys.executable), (spelling, reported)

--- a/pyre/extra_tests/snippets/sys_executable_path_normalized.py
+++ b/pyre/extra_tests/snippets/sys_executable_path_normalized.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 import sys
+import tempfile
 
 # `initpath.py:find_executable` applies `abspath`, whose second half is
 # `normpath` -- joining the cwd alone would carry the caller's spelling of
@@ -35,3 +36,44 @@ for spelling, cwd in spellings:
     assert os.curdir not in parts, (spelling, reported)
     assert os.pardir not in parts, (spelling, reported)
     assert os.path.samefile(reported, sys.executable), (spelling, reported)
+
+# `resolvedirof` is what follows links; the invoked spelling is not, so a
+# symlinked executable answers with the link.  `samefile` cannot see the
+# difference -- it resolves both sides -- so this compares the strings.
+with tempfile.TemporaryDirectory() as tmp:
+    # The container is resolved up front so that the only unresolved link left
+    # in the comparison is the one under test -- on darwin the temporary
+    # directory itself sits under a symlinked `/var`, which the child's own cwd
+    # reports resolved.
+    tmp = os.path.realpath(tmp)
+    link = os.path.join(tmp, 'pyre-link')
+    os.symlink(sys.executable, link)
+
+    for spelling, cwd in ((link, None), (os.path.join(os.curdir, 'pyre-link'), tmp)):
+        result = subprocess.run(
+            [spelling, '-c', SHOW],
+            cwd=cwd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert result.returncode == 0, (spelling, result.stderr)
+        assert result.stdout.decode().strip() == link, (spelling, result.stdout)
+
+if os.name == 'posix':
+    # `..` directly under the root names nothing, so it is dropped rather than
+    # carried.  A path opening with exactly two slashes is the host's to
+    # interpret and keeps both; three or more collapse to one.
+    stripped = sys.executable.lstrip(os.sep)
+    rooted = [
+        (os.sep + os.pardir + sys.executable, sys.executable),
+        (os.sep * 2 + stripped, os.sep * 2 + stripped),
+        (os.sep * 3 + stripped, sys.executable),
+    ]
+    for spelling, expected in rooted:
+        result = subprocess.run(
+            [spelling, '-c', SHOW],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert result.returncode == 0, (spelling, result.stderr)
+        assert result.stdout.decode().strip() == expected, (spelling, result.stdout)

--- a/pyre/extra_tests/snippets/sys_executable_path_normalized.py
+++ b/pyre/extra_tests/snippets/sys_executable_path_normalized.py
@@ -53,9 +53,16 @@ for spelling, cwd in spellings:
     assert os.pardir not in parts, (spelling, reported)
     assert os.path.samefile(reported, sys.executable), (spelling, reported)
 
-if os.name == 'posix':
-    # `resolvedirof` is what follows links; the invoked spelling is not, so a
-    # symlinked executable answers with the link.  `samefile` cannot see the
+# The checks below compare the reported spelling character for character, and
+# that is a contract of this implementation rather than a portable one: the
+# reference interpreter's own `sys.executable` does not run through
+# `posixpath.normpath` -- it answers a relative `../bin/python` unnormalized --
+# and a darwin framework build answers with the image path the loader resolved,
+# so neither the spelling nor its normalization survives there.  What is
+# asserted is `initpath.py`'s division: `abspath` normalizes lexically and
+# `resolvedirof` is the only half that follows a link.
+if sys.implementation.name == 'pyre' and os.name == 'posix':
+    # A symlinked executable answers with the link.  `samefile` cannot see the
     # difference -- it resolves both sides -- so this compares the strings.
     # Windows is left out because creating a symlink there needs a privilege
     # an ordinary account does not hold.

--- a/pyre/extra_tests/snippets/sys_executable_path_normalized.py
+++ b/pyre/extra_tests/snippets/sys_executable_path_normalized.py
@@ -13,6 +13,29 @@ parent, leaf = os.path.split(directory)
 
 SHOW = 'import sys; print(sys.executable)'
 
+
+def report(spelling, cwd=None):
+    """Spawn through `spelling` and hand back the child's `sys.executable`.
+
+    The directory is entered rather than passed as `subprocess.run(cwd=...)`:
+    that argument moves the child once it exists, and a relative program name
+    is looked up before then, against this process's own directory.
+    """
+    previous = os.getcwd()
+    if cwd is not None:
+        os.chdir(cwd)
+    try:
+        result = subprocess.run(
+            [spelling, '-c', SHOW],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    finally:
+        os.chdir(previous)
+    assert result.returncode == 0, (spelling, result.stderr)
+    return result.stdout.decode().strip()
+
+
 spellings = [
     # Relative, resolved against the cwd.
     (os.path.join(os.curdir, name), directory),
@@ -22,14 +45,7 @@ spellings = [
 ]
 
 for spelling, cwd in spellings:
-    result = subprocess.run(
-        [spelling, '-c', SHOW],
-        cwd=cwd,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
-    assert result.returncode == 0, (spelling, result.stderr)
-    reported = result.stdout.decode().strip()
+    reported = report(spelling, cwd)
 
     assert os.path.isabs(reported), (spelling, reported)
     parts = reported.split(os.sep)
@@ -37,29 +53,24 @@ for spelling, cwd in spellings:
     assert os.pardir not in parts, (spelling, reported)
     assert os.path.samefile(reported, sys.executable), (spelling, reported)
 
-# `resolvedirof` is what follows links; the invoked spelling is not, so a
-# symlinked executable answers with the link.  `samefile` cannot see the
-# difference -- it resolves both sides -- so this compares the strings.
-with tempfile.TemporaryDirectory() as tmp:
-    # The container is resolved up front so that the only unresolved link left
-    # in the comparison is the one under test -- on darwin the temporary
-    # directory itself sits under a symlinked `/var`, which the child's own cwd
-    # reports resolved.
-    tmp = os.path.realpath(tmp)
-    link = os.path.join(tmp, 'pyre-link')
-    os.symlink(sys.executable, link)
-
-    for spelling, cwd in ((link, None), (os.path.join(os.curdir, 'pyre-link'), tmp)):
-        result = subprocess.run(
-            [spelling, '-c', SHOW],
-            cwd=cwd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        assert result.returncode == 0, (spelling, result.stderr)
-        assert result.stdout.decode().strip() == link, (spelling, result.stdout)
-
 if os.name == 'posix':
+    # `resolvedirof` is what follows links; the invoked spelling is not, so a
+    # symlinked executable answers with the link.  `samefile` cannot see the
+    # difference -- it resolves both sides -- so this compares the strings.
+    # Windows is left out because creating a symlink there needs a privilege
+    # an ordinary account does not hold.
+    with tempfile.TemporaryDirectory() as tmp:
+        # The container is resolved up front so that the only unresolved link
+        # left in the comparison is the one under test -- on darwin the
+        # temporary directory itself sits under a symlinked `/var`, which the
+        # child's own cwd reports resolved.
+        tmp = os.path.realpath(tmp)
+        link = os.path.join(tmp, 'pyre-link')
+        os.symlink(sys.executable, link)
+
+        assert report(link) == link, link
+        assert report(os.path.join(os.curdir, 'pyre-link'), tmp) == link, link
+
     # `..` directly under the root names nothing, so it is dropped rather than
     # carried.  A path opening with exactly two slashes is the host's to
     # interpret and keeps both; three or more collapse to one.
@@ -70,10 +81,4 @@ if os.name == 'posix':
         (os.sep * 3 + stripped, sys.executable),
     ]
     for spelling, expected in rooted:
-        result = subprocess.run(
-            [spelling, '-c', SHOW],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        assert result.returncode == 0, (spelling, result.stderr)
-        assert result.stdout.decode().strip() == expected, (spelling, result.stdout)
+        assert report(spelling) == expected, spelling

--- a/pyre/extra_tests/snippets/type_function_attributes_absent.py
+++ b/pyre/extra_tests/snippets/type_function_attributes_absent.py
@@ -1,0 +1,62 @@
+# pyre-check: gate=1
+# A class carries the function attributes only when its MRO defines them.
+# Answering None instead breaks `getattr(fn, "__func__", fn)`, the
+# staticmethod/classmethod unwrap, which then carries None forward.
+FUNCTION_ATTRS = (
+    '__code__',
+    '__func__',
+    '__self__',
+    '__globals__',
+    '__closure__',
+    '__defaults__',
+    '__kwdefaults__',
+    '__wrapped__',
+)
+
+
+class Plain:
+    pass
+
+
+class WithInit:
+    def __init__(self):
+        pass
+
+
+for owner in (Plain, WithInit, type, object, str, int):
+    for name in FUNCTION_ATTRS:
+        assert not hasattr(owner, name), (owner, name)
+        marker = object()
+        assert getattr(owner, name, marker) is marker, (owner, name)
+        try:
+            getattr(owner, name)
+        except AttributeError:
+            pass
+        else:
+            raise AssertionError((owner, name))
+
+# The unwrap idiom must hand back the class untouched.
+assert getattr(Plain, '__func__', Plain) is Plain
+
+# A class that really defines one still resolves it, through the descriptor
+# protocol rather than a raw dict read.
+def helper():
+    return 1
+
+
+class Declares:
+    __func__ = staticmethod(helper)
+
+
+assert Declares.__func__ is helper
+
+# An instance method's own attributes are unaffected.
+class Owner:
+    def method(self):
+        return self
+
+
+instance = Owner()
+assert instance.method.__func__ is Owner.method
+assert instance.method.__self__ is instance
+assert Owner.method.__code__.co_name == 'method'

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -7751,22 +7751,16 @@ pub(crate) fn object_getattr_miss(obj: PyObjectRef, name: &str, call_getattr: bo
             if name == "__doc__" {
                 return type_get_doc(obj);
             }
-            if name == "__code__"
-                || name == "__func__"
-                || name == "__self__"
-                || name == "__globals__"
-                || name == "__closure__"
-                || name == "__defaults__"
-                || name == "__kwdefaults__"
-            {
-                // Check class dict first, then return None.  `__wrapped__` is
-                // excluded so an unset value raises AttributeError rather than
-                // feeding `inspect.unwrap` a bogus None chain.
-                if let Some(v) = lookup_in_type_where(obj, name) {
-                    return Ok(v);
-                }
-                return Ok(w_none());
-            }
+            // `__code__` / `__func__` / `__self__` / `__globals__` /
+            // `__closure__` / `__defaults__` / `__kwdefaults__` are NOT
+            // short-circuited here.  typeobject.py defines no such branch: a
+            // class has these only when its MRO does, and the ordinary
+            // descriptor path below both finds that value and raises
+            // AttributeError when there is none.  Answering `None` instead
+            // broke the standard unwrap idiom `getattr(fn, "__func__", fn)`,
+            // which then carries `None` forward — the same failure the
+            // `__wrapped__` exclusion was written to avoid.
+
             // `__module__` is NOT in the short-circuit list — it falls
             // through to the normal descriptor protocol so type's
             // `__module__` GetSetProperty (`typedef.rs init_type_type`)

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13434,8 +13434,15 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     // `space.id` (baseobjspace.py): a plain `int` yields its
     // value-derived `immutable_unique_id`; every other object falls back
-    // to `compute_unique_id`, which incminimark implements through
-    // `id_or_identityhash` (incminimark.py) so nursery moves preserve it.
+    // to `compute_unique_id` (objectmodel.py:572-582), which incminimark
+    // implements through `id_or_identityhash` (incminimark.py:2864) so
+    // nursery moves preserve it.  The address-valued function is a
+    // different one — `current_object_addr_as_int`
+    // (objectmodel.py:584-590), whose docstring exists to say the value
+    // "can change over time for moving GCs".  A list and a dict header do
+    // move, so answering with the raw pointer would give such an object two
+    // different ids over its lifetime, and every structure keyed on `id()`
+    // would lose track of it.
     let obj = args[0];
     let w_res = match crate::function::immutable_unique_id(obj) {
         Some(w_id) => w_id,

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2064,23 +2064,62 @@ fn normalize_lexically(path: &Path) -> PathBuf {
     for component in path.components() {
         match component {
             Component::CurDir => {}
-            Component::ParentDir => {
-                // Only a normal segment can be cancelled: popping a root or a
-                // prefix would rewrite which volume the path names, and `..`
-                // above the root has nothing to remove.
-                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+            Component::ParentDir => match out.components().next_back() {
+                // Only a normal segment can be cancelled.
+                Some(Component::Normal(_)) => {
                     out.pop();
-                } else {
-                    out.push(component);
                 }
-            }
+                // `/..` is `/`: nothing sits above a root, so the component
+                // names nothing and is dropped rather than kept
+                // (`rpath.py:53-57`, and `:142` for the drive-rooted spelling).
+                Some(Component::RootDir) => {}
+                // A relative path may open with `..`, `../..` keeps both, and
+                // a drive-relative `C:..` keeps its own: popping a prefix
+                // would rewrite which volume the path names.
+                _ => out.push(component),
+            },
             other => out.push(other),
         }
     }
     if out.as_os_str().is_empty() {
         out.push(Component::CurDir);
     }
-    out
+    restore_double_root(path, out)
+}
+
+/// A path opening with exactly two slashes is reserved for the host to
+/// interpret, so `//host/bin` keeps both while `///x` collapses to one
+/// (`rpath.py:43-47`).  `Path::components` yields a single `RootDir` either
+/// way, so the distinction has to be read off the original spelling and put
+/// back afterwards.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32"),
+    unix
+))]
+fn restore_double_root(original: &Path, normalized: PathBuf) -> PathBuf {
+    use std::os::unix::ffi::OsStrExt;
+
+    let bytes = original.as_os_str().as_bytes();
+    if !bytes.starts_with(b"//") || bytes.starts_with(b"///") {
+        return normalized;
+    }
+    let mut doubled = std::ffi::OsString::from("/");
+    doubled.push(normalized.as_os_str());
+    PathBuf::from(doubled)
+}
+
+/// Windows carries its own leading separators in `Component::Prefix`, which
+/// `Path::push` spells back out, so nothing is left to restore.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32"),
+    not(unix)
+))]
+fn restore_double_root(_original: &Path, normalized: PathBuf) -> PathBuf {
+    normalized
 }
 
 /// Return the executable spelling used to invoke pyre, made absolute without

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -21,6 +21,14 @@ use std::sync::{
 // stay in scope unconditionally.
 #[cfg(feature = "host_env")]
 use std::path::Path;
+// `normalize_lexically` walks a path a component at a time to collapse `.`
+// and `..`; it is reached only from the executable-discovery arm.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+use std::path::Component;
 
 use crate::PyExecutionContext;
 use crate::{CodeObject, Mode, PyFrame, compile_source_with_filename};
@@ -2028,11 +2036,51 @@ fn exists_and_is_executable(path: &Path) -> bool {
     not(target_arch = "wasm32")
 ))]
 fn absolute_from(path: PathBuf, cwd: &Path) -> PathBuf {
-    if path.is_absolute() {
+    let joined = if path.is_absolute() {
         path
     } else {
         cwd.join(path)
+    };
+    normalize_lexically(&joined)
+}
+
+/// Collapse `.` and `..` without touching the filesystem, the second half of
+/// `posixpath.abspath` (`normpath(join(cwd, path))`).  `Path::join` alone
+/// leaves the spelling the caller typed, so invoking `./venv/bin/pyre` would
+/// carry the `.` into `sys.executable` and every prefix derived from it —
+/// `site.py` then reports the venv prefix as unexpected because it compares
+/// that string against the directory it found itself in.
+///
+/// Symlinks stay unresolved on purpose: `find_invoked_executable` needs the
+/// venv spelling, and a lexical walk cannot follow a link anyway.  That is the
+/// same division `initpath.py` draws between `abspath` and `resolvedirof`.
+#[cfg(all(
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(target_arch = "wasm32")
+))]
+fn normalize_lexically(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Only a normal segment can be cancelled: popping a root or a
+                // prefix would rewrite which volume the path names, and `..`
+                // above the root has nothing to remove.
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push(component);
+                }
+            }
+            other => out.push(other),
+        }
     }
+    if out.as_os_str().is_empty() {
+        out.push(Component::CurDir);
+    }
+    out
 }
 
 /// Return the executable spelling used to invoke pyre, made absolute without

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -584,7 +584,25 @@ crate::py_module! {
                 pyre_object::w_dict_setitem_str_no_proxy(
                     semlock_ns,
                     "__new__",
-                    crate::make_builtin_function("__new__", semlock_descr_new),
+                    // interp_semaphore.py:572-573 declares the parameters
+                    // through `@unwrap_spec(kind=int, value=int, maxvalue=int,
+                    // name='text', unlink=int)`, so `interp2app` binds them by
+                    // name as well as by position.  Registering the same names
+                    // here routes a keyword call through the gateway binder,
+                    // which hands the body the slots in positional order.
+                    // `subtype` stays positional-only: it is the class the
+                    // descriptor was reached through, not a parameter.
+                    crate::make_builtin_function_with_signature(
+                        "__new__",
+                        semlock_descr_new,
+                        crate::gateway::Signature::new(
+                            vec!["subtype", "kind", "value", "maxvalue", "name", "unlink"],
+                            None,
+                            None,
+                            0,
+                            1,
+                        ),
+                    ),
                 );
                 // interp_semaphore.py:606 `as_classmethod=True` — `_rebuild`
                 // allocates on the class it is called through.

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -416,7 +416,10 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     } else {
         return Err(crate::PyError::type_error("SemLock: name must be a string"));
     };
-    let unlink = crate::baseobjspace::is_true(args[5])?;
+    // `unwrap_spec(unlink=int)` (interp_semaphore.py:572) — the flag is
+    // converted the same way `kind`, `value` and `maxvalue` beside it are,
+    // so a type whose `__bool__` and `__index__` disagree does not decide it.
+    let unlink = crate::baseobjspace::int_w(args[5])? != 0;
     // interp_semaphore.py:574-575.
     if kind != RECURSIVE_MUTEX && kind != SEMAPHORE {
         return Err(crate::PyError::value_error("unrecognized kind"));

--- a/pyre/pyre-interpreter/src/module/errno/mod.rs
+++ b/pyre/pyre-interpreter/src/module/errno/mod.rs
@@ -118,23 +118,14 @@ crate::py_module! {
                 ("ECONNREFUSED", host_errno::ECONNREFUSED),
                 ("EHOSTDOWN", host_errno::EHOSTDOWN),
                 ("EHOSTUNREACH", host_errno::EHOSTUNREACH),
-                // `interp_errno.py` also declares these, and every platform
-                // pyre builds for supplies them: unix through `libc`,
-                // windows through the `WSA`-derived aliases `host_env`
-                // re-exports under their plain names (`errno.rs`
-                // `reexport_wsa!`), which is the same mapping
-                // `interp_errno.py` performs for `win_errors`.
+                // `interp_errno.py` declares these in the same list, and
+                // every platform pyre builds for defines them in its own
+                // `errno.h`.
                 ("EILSEQ", host_errno::EILSEQ),
                 ("ECANCELED", host_errno::ECANCELED),
                 ("ENOTSUP", host_errno::ENOTSUP),
                 ("EOWNERDEAD", host_errno::EOWNERDEAD),
                 ("ENOTRECOVERABLE", host_errno::ENOTRECOVERABLE),
-                ("ESTALE", host_errno::ESTALE),
-                ("EUSERS", host_errno::EUSERS),
-                ("EREMOTE", host_errno::EREMOTE),
-                ("ETOOMANYREFS", host_errno::ETOOMANYREFS),
-                ("EPFNOSUPPORT", host_errno::EPFNOSUPPORT),
-                ("ESOCKTNOSUPPORT", host_errno::ESOCKTNOSUPPORT),
             ];
             for (name, value) in entries {
                 store(name, *value as i64);
@@ -142,6 +133,21 @@ crate::py_module! {
             #[cfg(unix)]
             {
                 let unix_entries: &[(&str, i32)] = &[
+                    // Declared in the same list, and supplied by `libc` here.
+                    // Windows reaches them only through `win_errors`
+                    // (`interp_errno.py:91-101`), which registers the `WSA`
+                    // spelling, adds the stripped name as a second binding
+                    // and leaves the reverse mapping naming the `WSA` one.
+                    // This module exports no `WSA` name to carry that reverse
+                    // entry, so storing the stripped names there would answer
+                    // `errorcode[code]` with a spelling the declaration never
+                    // assigns.
+                    ("ESTALE", host_errno::ESTALE),
+                    ("EUSERS", host_errno::EUSERS),
+                    ("EREMOTE", host_errno::EREMOTE),
+                    ("ETOOMANYREFS", host_errno::ETOOMANYREFS),
+                    ("EPFNOSUPPORT", host_errno::EPFNOSUPPORT),
+                    ("ESOCKTNOSUPPORT", host_errno::ESOCKTNOSUPPORT),
                     ("ENOTBLK", host_errno::ENOTBLK),
                     ("ETXTBSY", host_errno::ETXTBSY),
                     ("ENOMSG", host_errno::ENOMSG),

--- a/pyre/pyre-interpreter/src/module/errno/mod.rs
+++ b/pyre/pyre-interpreter/src/module/errno/mod.rs
@@ -5,6 +5,15 @@
 //! through `rustpython_host_env::errno::errors` (a `pub use libc::*`
 //! re-export).  The `host_env = off` build keeps a darwin/BSD-flavoured
 //! fallback so pyre-wasm preserves its previous behaviour.
+//!
+//! Which names exist is the other half of the contract: `interp_errno.py`
+//! declares one list for every platform and lets `DefinedConstantInteger`
+//! drop the entries the host's `errno.h` does not define, so a name absent
+//! here is a name the module claims no platform has.  A Rust port cannot
+//! probe, so the same partition is spelled with target gates — anything
+//! `libc` (or, on windows, the `WSA` re-exports) supplies everywhere goes in
+//! the common list, and the Darwin-only Mach/RPC block sits behind
+//! `target_vendor = "apple"`.
 
 crate::py_module! {
     "errno",
@@ -109,6 +118,23 @@ crate::py_module! {
                 ("ECONNREFUSED", host_errno::ECONNREFUSED),
                 ("EHOSTDOWN", host_errno::EHOSTDOWN),
                 ("EHOSTUNREACH", host_errno::EHOSTUNREACH),
+                // `interp_errno.py` also declares these, and every platform
+                // pyre builds for supplies them: unix through `libc`,
+                // windows through the `WSA`-derived aliases `host_env`
+                // re-exports under their plain names (`errno.rs`
+                // `reexport_wsa!`), which is the same mapping
+                // `interp_errno.py` performs for `win_errors`.
+                ("EILSEQ", host_errno::EILSEQ),
+                ("ECANCELED", host_errno::ECANCELED),
+                ("ENOTSUP", host_errno::ENOTSUP),
+                ("EOWNERDEAD", host_errno::EOWNERDEAD),
+                ("ENOTRECOVERABLE", host_errno::ENOTRECOVERABLE),
+                ("ESTALE", host_errno::ESTALE),
+                ("EUSERS", host_errno::EUSERS),
+                ("EREMOTE", host_errno::EREMOTE),
+                ("ETOOMANYREFS", host_errno::ETOOMANYREFS),
+                ("EPFNOSUPPORT", host_errno::EPFNOSUPPORT),
+                ("ESOCKTNOSUPPORT", host_errno::ESOCKTNOSUPPORT),
             ];
             for (name, value) in entries {
                 store(name, *value as i64);
@@ -129,6 +155,37 @@ crate::py_module! {
                     ("ETIME", host_errno::ETIME),
                 ];
                 for (name, value) in unix_entries {
+                    store(name, *value as i64);
+                }
+            }
+            // `interp_errno.py`'s "MacOSX specific errnos" block, plus the
+            // `EQFULL` the 3.14 surface adds.  `DefinedConstantInteger`
+            // drops each of these on a platform whose `errno.h` lacks it;
+            // the equivalent here is the target gate, since `libc` declares
+            // them for apple targets only.
+            #[cfg(target_vendor = "apple")]
+            {
+                let apple_entries: &[(&str, i32)] = &[
+                    ("ENOATTR", host_errno::ENOATTR),
+                    ("EAUTH", host_errno::EAUTH),
+                    ("EBADARCH", host_errno::EBADARCH),
+                    ("EBADEXEC", host_errno::EBADEXEC),
+                    ("EBADMACHO", host_errno::EBADMACHO),
+                    ("EBADRPC", host_errno::EBADRPC),
+                    ("EDEVERR", host_errno::EDEVERR),
+                    ("EFTYPE", host_errno::EFTYPE),
+                    ("ENEEDAUTH", host_errno::ENEEDAUTH),
+                    ("ENOPOLICY", host_errno::ENOPOLICY),
+                    ("EPROCLIM", host_errno::EPROCLIM),
+                    ("EPROCUNAVAIL", host_errno::EPROCUNAVAIL),
+                    ("EPROGMISMATCH", host_errno::EPROGMISMATCH),
+                    ("EPROGUNAVAIL", host_errno::EPROGUNAVAIL),
+                    ("EPWROFF", host_errno::EPWROFF),
+                    ("EQFULL", host_errno::EQFULL),
+                    ("ERPCMISMATCH", host_errno::ERPCMISMATCH),
+                    ("ESHLIBVERS", host_errno::ESHLIBVERS),
+                ];
+                for (name, value) in apple_entries {
                     store(name, *value as i64);
                 }
             }
@@ -217,6 +274,21 @@ crate::py_module! {
                 ("ECONNREFUSED", 61),
                 ("EHOSTDOWN", 64),
                 ("EHOSTUNREACH", 65),
+                // The portable tail of `interp_errno.py`'s list, in the same
+                // darwin/BSD numbering the rest of this table uses.  The
+                // Darwin-only Mach/RPC names are deliberately absent: this
+                // arm also serves wasm, where they describe nothing.
+                ("ESOCKTNOSUPPORT", 44),
+                ("ENOTSUP", 45),
+                ("EPFNOSUPPORT", 46),
+                ("ETOOMANYREFS", 59),
+                ("EUSERS", 68),
+                ("ESTALE", 70),
+                ("EREMOTE", 71),
+                ("ECANCELED", 89),
+                ("EILSEQ", 92),
+                ("ENOTRECOVERABLE", 104),
+                ("EOWNERDEAD", 105),
             ];
             for (name, value) in entries {
                 store(name, *value);

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -688,6 +688,11 @@ pub fn init_typeobjects() {
         // typedef.py:664 PyCode.typedef.acceptable_as_base_class = False
         let code_type = new_typeobject_with_base("code", init_code_type, object_type);
         unsafe { pyre_object::w_type_set_acceptable_as_base_class(code_type, false) };
+        // typedef.py:725 `__weakref__ = make_weakref_descr(PyCode)` — a code
+        // object carries a weakref lifeline, which is what lets a caller
+        // attach per-code state that expires with the code.  Without the flag
+        // `setweakref` reports the type as one that takes no weak reference.
+        unsafe { pyre_object::w_type_set_weakrefable(code_type, true) };
         reg.insert(
             &crate::pycode::CODE_TYPE as *const PyType as usize,
             code_type as usize,


### PR DESCRIPTION
## Summary

Five interpreter-surface defects found by driving pip and the packages it
installs, plus a comment recording why `id()` cannot answer with an address.
pip itself was healthy throughout: 13/13 subcommands and 27/27 install flows
(four build backends × wheel+install, editable+uninstall, `--no-binary :all:`,
requirements/constraints/extras, `git+https`, `python -m build`, console
scripts). Every failure was underneath it.

**A class answered `None` for seven function attributes.** The type getattr
path short-circuited `__code__`, `__func__`, `__self__`, `__globals__`,
`__closure__`, `__defaults__`, `__kwdefaults__` and returned `None` when the
MRO had no such value. `typeobject.py` defines no such branch — a class has
these only when its MRO does, and the ordinary descriptor path both finds the
value and raises `AttributeError` when there is none. The `None` broke the
standard unwrap idiom `getattr(fn, "__func__", fn)`, which then carried `None`
forward. The same shape the `__wrapped__` exclusion beside it was written to
avoid. Invisible to `__dict__` and `dir`, so nothing pointed at it.

**`errno` was missing twenty-nine names.** `interp_errno.py` declares one name
list for every platform and lets `DefinedConstantInteger` drop the entries the
host lacks; the table here had been written per-platform instead. Restored to
the declare-all shape: eleven portable names (`EILSEQ`, `ECANCELED`,
`ENOTSUP`, `EOWNERDEAD`, `ENOTRECOVERABLE`, `ESTALE`, `EUSERS`, `EREMOTE`,
`ETOOMANYREFS`, `EPFNOSUPPORT`, `ESOCKTNOSUPPORT`) and eighteen darwin ones.
`from errno import ESTALE` is an unconditional import in widely used packages.

**A code object took no weak reference.** `typedef.py:725` gives `PyCode` a
`__weakref__` descriptor. Without the flag, `setweakref` reported the type as
one that takes no weak reference, so a `WeakKeyDictionary` keyed on a code
object — how callers attach per-code state that expires with the code — raised
`TypeError`.

**`_multiprocessing.SemLock` took no keyword arguments.** Its constructor was
registered without a signature, so `SemLock(kind, value, maxvalue, name=...,
unlink=...)` failed. `interp_semaphore.py` declares the parameters through
`@unwrap_spec`, which binds them by name as well as by position.

**`sys.executable` kept the caller's spelling.** `absolute_from` joined a
relative `argv[0]` onto the cwd and stopped. `initpath.py:find_executable`
applies `abspath` = `normpath(join(cwd, path))` — the join is only half of it.
So `./venv/bin/pyre` left the `.` in `sys.executable` and in every prefix
derived from it, and `site.py` compared that spelling against the directory it
found itself in and warned that `sys.prefix` and `sys.exec_prefix` held
unexpected values. `normalize_lexically` collapses `.` and `..` without
touching the filesystem; symlinks stay unresolved, which is the division
`initpath.py` draws between `abspath` and `resolvedirof`.

**`builtins: id()`** is comment-only, on top of #1316. It records why the
address cannot be the answer: `compute_unique_id` goes through
`id_or_identityhash` so a nursery move preserves the value, while the
address-valued `current_object_addr_as_int` exists separately and documents
that its result changes under a moving GC.

## Tests

None of the five was observable to any existing test — `test.test_errno`
passed with twenty-nine names missing. Five gated snippets close that:

- `type_function_attributes_absent.py` — `AttributeError` rather than `None`
  for the seven names on `Plain`/`type`/`object`/`str`/`int`, the unwrap idiom
  returning the class, and a class that really declares `__func__` still
  resolving it.
- `errno_platform_names.py` — the portable, posix and darwin blocks, and that
  every exported code appears in `errorcode`.
- `code_object_weakref.py` — a weak reference, a `WeakKeyDictionary` key, and a
  `compile()` result whose referent clears once dropped.
- `multiprocessing_semlock_keywords.py` — construction by keyword, by position
  and mixed.
- `sys_executable_path_normalized.py` — three spellings carrying `.` and `..`.
  The relative `..` spelling is deliberately left out: CPython answers it
  unnormalized on darwin while `abspath` collapses it, so it is not common
  ground the gate can stand on.

## Verification

- `cargo test --all --no-default-features --features dynasm`: exit 0, 140
  suites, every suite `0 failed`, 7911 passed.
- `python3 pyre/extra_tests/run.py --gated-only`: 67/67 on cpython, dynasm and
  cranelift.
- `cargo fmt --all -- --check` clean.
- Regression control over the package corpus that surfaced these: 131 packages
  re-run before and after. Sweep 1 went 44 → 48 importable, sweep 2 went
  61 → 66, and both after-sets are strict subsets of the before-sets, so
  nothing that worked stopped working.

— *opened by Claude*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for weak references to code objects.
  * Added platform-aware `errno` constants, including Darwin-specific values.
  * Enabled keyword arguments for multiprocessing semaphore creation.
  * Improved executable path normalization across relative, redundant, parent-directory, and symlinked paths.
  * Standardized missing function attributes to raise `AttributeError`.

* **Tests**
  * Added coverage for code-object garbage collection, semaphore arguments, executable paths, function descriptors, and platform-specific error constants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->