### PR TITLE
wasm runner: give each engine configuration its own .cwasm, published by rename

### DIFF
--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -46,9 +46,34 @@ fn run_runtime_program(
     for &(key, value) in envs {
         command.env(key, value);
     }
-    command
+    let output = command
         .output()
-        .unwrap_or_else(|err| panic!("failed to run {}: {err}", binary.display()))
+        .unwrap_or_else(|err| panic!("failed to run {}: {err}", binary.display()));
+    // A child killed by a signal leaves every assertion below nothing to show:
+    // both runtimes report their own failures before exiting — the wasm runner
+    // keeps the run result precisely so a guest trap still prints its JIT
+    // stats — so a failed status next to an empty stderr means the process
+    // never reached any of that. Name the signal and the run that took it
+    // here, once, instead of letting each call site blame output the child
+    // never had the chance to write.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt;
+        if let Some(signal) = output.status.signal() {
+            let env = envs
+                .iter()
+                .map(|(key, value)| format!("{key}={value}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            panic!(
+                "{} died on signal {signal} running {}\nenv: {env}\nstderr:\n{}",
+                binary.display(),
+                script.display(),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+    }
+    output
 }
 
 fn stat_value(stderr: &str, name: &str) -> u64 {

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -2366,8 +2366,8 @@ class Check:
         # Snapshot the wasm-host build to a stable path so a later `web` build of
         # the same crate cannot overwrite the module the runner loads. Copy when
         # the bytes actually changed: rewriting an identical file would bump its
-        # mtime and needlessly invalidate the runner's `<module>.cwasm` compiled
-        # cache (which is keyed by mtime), forcing a ~5s recompile on every run.
+        # mtime, and the runner's `<module>.cwasm` compiled cache is keyed by
+        # the module's content hash, so an identical rewrite buys nothing.
         src_bytes = Path(WASM_BUILD_OUTPUT).read_bytes()
         dst = Path(WASM_MODULE_PATH)
         if not dst.exists() or dst.read_bytes() != src_bytes:
@@ -2385,6 +2385,11 @@ class Check:
         invalidates the cache. Warming it in the build phase moves that fixed
         cost out of every measured benchmark (including the first), so the
         reported times reflect Python execution, not module compilation.
+
+        Fuel metering emits a different module, cached separately as
+        `<module>.fuel.cwasm`, so warm that one too: the wasm runtime codegen
+        regression tests all run under PYRE_WASM_JIT_STATS, and they start six
+        runners at once — without this every one of them recompiles.
         """
         runner = default_binary("wasm")
         if not Path(runner).exists():
@@ -2393,14 +2398,15 @@ class Check:
         env["PYRE_WASM_MODULE"] = str(Path(WASM_MODULE_PATH).resolve())
         env["PYRE_WASM_ENGINE"] = "wasmtime"
         print("Warming wasmtime module cache (.cwasm)...")
-        try:
-            subprocess.run(
-                [runner, "--engine", "wasmtime", os.devnull],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
-                env=env, timeout=120,
-            )
-        except (OSError, subprocess.SubprocessError):
-            pass  # best-effort; a cold first bench just pays the compile once
+        for extra in ({}, {"PYRE_WASM_JIT_STATS": "1"}):
+            try:
+                subprocess.run(
+                    [runner, "--engine", "wasmtime", os.devnull],
+                    stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                    env={**env, **extra}, timeout=120,
+                )
+            except (OSError, subprocess.SubprocessError):
+                pass  # best-effort; a cold first bench just pays the compile once
 
     def _print_cargo_diagnostics(self, cargo_path):
         """Dump the toolchain state when cargo refuses to run.

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -304,12 +304,13 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
     // at https://profiler.firefox.com/. Samples land on epoch checkpoints
     // (function entries / loop back-edges), so call-dense small functions are
     // over-represented and bulk ops (memory.fill) are attributed to the next
-    // checkpoint. Epoch interruption changes main-module codegen, so pair with
-    // PYRE_WASM_NO_CACHE=1 to avoid clobbering the shared .cwasm cache.
+    // checkpoint. Epoch interruption changes main-module codegen, so this mode
+    // caches its module under its own `.cwasm` (see `cache_variant`).
     let guest_profile_out = std::env::var("PYRE_WASM_GUEST_PROFILE").ok();
     if guest_profile_out.is_some() {
         config.epoch_interruption(true);
     }
+    let cache_variant = cache_variant(meter_fuel, guest_profile_out.is_some());
     // Diagnostic: PYRE_WASM_STARTUP_TRACE=1 prints a fixed-startup breakdown
     // (module load/deserialize, main-module instantiate, guest bootstrap+run)
     // so the warmup tax can be attributed to host module-load vs guest
@@ -328,7 +329,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
     let engine = Engine::new(&config)?;
     startup_lap("engine_new");
 
-    let module = load_main_module(&engine, module_path)?;
+    let module = load_main_module(&engine, module_path, cache_variant)?;
     startup_lap("load_module");
 
     let mut store = Store::new(&engine, Host::default());
@@ -1290,13 +1291,16 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
 /// hash. A rebuilt module or a pre-placed `.cwasm` therefore recompiles instead
 /// of running a stale or untrusted artifact. Set `PYRE_WASM_NO_CACHE` to bypass
 /// the cache entirely.
-fn load_main_module(engine: &Engine, module_path: &Path) -> Result<Module> {
+///
+/// `variant` separates the artifacts of engine configurations that emit
+/// different code for the same module; see [`cache_variant`].
+fn load_main_module(engine: &Engine, module_path: &Path, variant: &str) -> Result<Module> {
     let cache_disabled = std::env::var_os("PYRE_WASM_NO_CACHE").is_some();
     let wasm_bytes = std::fs::read(module_path)
         .with_context(|| format!("read wasm module {}", module_path.display()))?;
     let hash = wasm_content_hash(&wasm_bytes);
-    let cache_path = cache_path_for(module_path);
-    let key_path = cache_key_path_for(module_path);
+    let cache_path = cache_path_for(module_path, variant);
+    let key_path = cache_key_path_for(module_path, variant);
 
     if !cache_disabled && cache_key_matches(&key_path, &hash) {
         // SAFETY: the artifact was produced by this runner's own engine via
@@ -1313,28 +1317,61 @@ fn load_main_module(engine: &Engine, module_path: &Path) -> Result<Module> {
     let module = Module::new(engine, &wasm_bytes[..])
         .with_context(|| format!("load wasm module {}", module_path.display()))?;
     if !cache_disabled && let Ok(bytes) = module.serialize() {
-        // Best-effort: a failed cache write only forgoes the speedup. Write
-        // the artifact before the key so an interrupted write never leaves a
-        // key pointing at a half-written `.cwasm`.
-        if std::fs::write(&cache_path, bytes).is_ok() {
-            let _ = std::fs::write(&key_path, &hash);
+        // Best-effort: a failed cache write only forgoes the speedup. Publish
+        // the artifact through a per-process temporary and rename it into
+        // place, then write the key: a rename swaps the directory entry, so a
+        // concurrent run either deserializes the previous artifact whole or
+        // this one whole. Writing the file in place instead would truncate it
+        // under whoever has it mapped, and the key would name a `.cwasm` that
+        // is only half there.
+        let staged = staged_cache_path_for(&cache_path);
+        if std::fs::write(&staged, bytes).is_ok() {
+            if std::fs::rename(&staged, &cache_path).is_ok() {
+                let _ = std::fs::write(&key_path, &hash);
+            } else {
+                let _ = std::fs::remove_file(&staged);
+            }
         }
     }
     Ok(module)
 }
 
-/// `<module>.cwasm` next to the module (full name kept, so
+/// The suffix separating the compiled artifacts of engine configurations that
+/// emit different code for the same module. Both knobs below instrument every
+/// guest instruction, so their modules are neither interchangeable with the
+/// plain one nor with each other; sharing one cache path makes each switch
+/// between modes reject the stored artifact, recompile the whole module and
+/// rewrite the file the other mode just wrote.
+fn cache_variant(meter_fuel: bool, epoch_interruption: bool) -> &'static str {
+    match (meter_fuel, epoch_interruption) {
+        (false, false) => "",
+        (true, false) => ".fuel",
+        (false, true) => ".epoch",
+        (true, true) => ".fuel.epoch",
+    }
+}
+
+/// `<module><variant>.cwasm` next to the module (full name kept, so
 /// `pyre_wasm.wasm-host.wasm` → `pyre_wasm.wasm-host.wasm.cwasm`).
-fn cache_path_for(module_path: &Path) -> PathBuf {
+fn cache_path_for(module_path: &Path, variant: &str) -> PathBuf {
     let mut s = module_path.as_os_str().to_owned();
+    s.push(variant);
     s.push(".cwasm");
     PathBuf::from(s)
 }
 
 /// Sidecar recording the SHA-256 of the `.wasm` its `.cwasm` was compiled from.
-fn cache_key_path_for(module_path: &Path) -> PathBuf {
-    let mut s = module_path.as_os_str().to_owned();
-    s.push(".cwasm.sha256");
+fn cache_key_path_for(module_path: &Path, variant: &str) -> PathBuf {
+    let mut s = cache_path_for(module_path, variant).into_os_string();
+    s.push(".sha256");
+    PathBuf::from(s)
+}
+
+/// Where a `.cwasm` is written before being renamed over the real one. The pid
+/// keeps two runs publishing the same variant from staging onto each other.
+fn staged_cache_path_for(cache_path: &Path) -> PathBuf {
+    let mut s = cache_path.as_os_str().to_owned();
+    s.push(format!(".{}.tmp", std::process::id()));
     PathBuf::from(s)
 }
 


### PR DESCRIPTION
## What

Fuel metering and epoch interruption each emit a different module for the same `.wasm`, and all three configurations shared one `<module>.cwasm`. The cache key is the `.wasm` content hash only, so a run under `PYRE_WASM_JIT_STATS` rejected the artifact a plain run had stored, recompiled the whole module and rewrote the file in place — and the next plain run did the same in the other direction.

Measured on linux/aarch64 against the wasm-host module, one alternating sequence:

| run | before | after |
|---|---|---|
| plain (cold) | 4365ms | 5320ms |
| plain (warm) | 413ms | 407ms |
| `PYRE_WASM_JIT_STATS=1` | 7246ms | 6459ms |
| `PYRE_WASM_JIT_STATS=1` again | 359ms | 342ms |
| plain again | **4710ms** | **374ms** |
| `PYRE_WASM_JIT_STATS=1` again | — | **528ms** |

`.cwasm` and `.fuel.cwasm` now coexist (51.9MB / 60.5MB) instead of overwriting each other.

The artifact is also written to a per-process temporary and renamed into place, so a run that publishes it cannot truncate the file another run has open.

`check.py` warms the fuel variant alongside the plain one: the wasm runtime codegen regression tests all set `PYRE_WASM_JIT_STATS` and start six runners at once, so each of them was paying that recompile — which is why each of those tests takes 42-47s on the Linux CI leg.

## Why the test change

`codegen_test`'s `run_runtime_program` now names the signal when a child dies on one.

The `Run wasm runtime codegen regression tests (Linux only)` step has been failing intermittently since 2026-08-17 — on `main` (runs 31997872223, 32076485389, 32095558286) and on every branch (`perf-exc`, `winapi`, `residual`, `perf/remoce-unsued-trace-plan`), with at least two different victim tests. Every one of them shows `pyre-wasm-runner` exiting non-zero after writing nothing but its `PYRE_SHARED_BUILD` note. No error path of the runner's own produces that: `fatal()` prints, and `run()` deliberately keeps `run_python`'s `Result` so even a guest trap still reaches the `[jit-stats]` readout. So the process is dying on a signal, and the assertions had only an empty stderr to report.

I could **not** reproduce that kill: ~120 runs across macOS/arm64, Linux/arm64 in `container`, and Linux/x86_64 under Rosetta — single, 7-way concurrent, staggered, warm and cold cache — all passed. The concurrent truncate-and-rewrite above is the most plausible remaining source (a slower CI disk widens the write window a lot), but this PR does not prove it. If the step goes red again, the log will now name the signal.

## Verified

- linux/aarch64 container: 21 concurrent runs of all 7 fixtures pass; a step-19-shaped round of all 7 concurrently takes 3.8s with both variants warm
- `cargo fmt --all --check`, `cargo clippy -p pyre-wasm-runner --all-targets` clean, `cargo check -p majit-backend-wasm --tests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebAssembly caching by avoiding unnecessary rewrites and preventing incompatible profiling configurations from sharing cached results.
  - Increased cache reliability by safely staging updates, preserving existing valid caches when a write fails.
  - Added cache warming to improve performance for fuel-metered execution.

- **Diagnostics**
  - Runtime failures caused by Unix signals now provide clearer details, including the signal, executed program, environment, and captured error output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->