### PR TITLE
jit: drop tgt_saveerr from the EffectInfo cache key; emit the builtins.id audit event

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1698,7 +1698,7 @@ impl GcCache {
                 let Some(listed) = sd
                     .all_fielddescrs()
                     .iter()
-                    .find(|f| f.field_key() == fd.field_key)
+                    .find(|f| f.field_key() == fd.field_key())
                 else {
                     continue;
                 };
@@ -1763,10 +1763,10 @@ impl GcCache {
                 continue;
             }
             for fd in cached.values() {
-                if !listed.iter().any(|f| f.field_key() == fd.field_key) {
+                if !listed.iter().any(|f| f.field_key() == fd.field_key()) {
                     orphans.insert(format!(
                         "{}@{}~[{}]",
-                        fd.field_key,
+                        fd.field_key(),
                         fd.offset,
                         listed
                             .iter()
@@ -5131,6 +5131,21 @@ pub use crate::effectinfo::{EffectInfo, ExtraEffect, OopSpecIndex};
 
 // ── Concrete descriptor implementations (descr.py) ──
 
+/// `descr.py:227 name = '%s.%s' % (STRUCT._name, fieldname)` — locate the
+/// external `_cache_field[STRUCT][fieldname]` key inside the display name so
+/// every descriptor does not need a second owned string. Both the struct name
+/// and pyre's synthetic nested-field spelling may contain dots, so deriving the
+/// split from the finished display name would be ambiguous; retain the exact
+/// byte offset supplied while the two inputs are still separate.
+fn field_key_start(name: &str, field_key: &str) -> u32 {
+    let start = name
+        .len()
+        .checked_sub(field_key.len())
+        .filter(|&start| name.get(start..) == Some(field_key))
+        .expect("FieldDescr display name must end with its cache field key");
+    u32::try_from(start).expect("FieldDescr display-name prefix must fit in u32")
+}
+
 /// Simple concrete FieldDescr for use by pyre-jit and tests.
 /// RPython: `FieldDescr(name, offset, size, flag, index_in_parent, is_pure)`.
 #[derive(Debug)]
@@ -5153,10 +5168,12 @@ pub struct SimpleFieldDescr {
     /// `compute_bitstrings` (`effectinfo.py:524-526`).
     ei_index: AtomicU32,
     /// RPython: FieldDescr.name — e.g. "MyStruct.field_name"
-    name: String,
-    /// descr.py:220-233 cache key (`fieldname`), distinct from display
-    /// `name` built at descr.py:227.
-    field_key: String,
+    name: Box<str>,
+    /// Byte offset of `descr.py:220-233`'s external cache key (`fieldname`)
+    /// inside `name`. RPython keeps the key only in `_cache_field`; pyre needs
+    /// to expose it for its descriptor-identity census, so retain a compact
+    /// slice position instead of duplicating the owned string.
+    field_key_start: u32,
     offset: usize,
     field_size: usize,
     field_type: Type,
@@ -5198,7 +5215,7 @@ impl Clone for SimpleFieldDescr {
             descr_index: AtomicI32::new(self.descr_index.load(Ordering::Relaxed)),
             ei_index: AtomicU32::new(self.ei_index.load(Ordering::Relaxed)),
             name: self.name.clone(),
-            field_key: self.field_key.clone(),
+            field_key_start: self.field_key_start,
             offset: self.offset,
             field_size: self.field_size,
             field_type: self.field_type,
@@ -5268,8 +5285,8 @@ impl SimpleFieldDescr {
             index: AtomicU32::new(index),
             descr_index: AtomicI32::new(-1),
             ei_index: AtomicU32::new(u32::MAX),
-            name: String::new(),
-            field_key: String::new(),
+            name: Box::default(),
+            field_key_start: 0,
             offset,
             field_size,
             field_type,
@@ -5300,12 +5317,13 @@ impl SimpleFieldDescr {
         name: String,
         field_key: String,
     ) -> Self {
+        let field_key_start = field_key_start(&name, &field_key);
         SimpleFieldDescr {
             index: AtomicU32::new(index),
             descr_index: AtomicI32::new(-1),
             ei_index: AtomicU32::new(u32::MAX),
-            name,
-            field_key,
+            name: name.into_boxed_str(),
+            field_key_start,
             offset,
             field_size,
             field_type,
@@ -5456,7 +5474,7 @@ impl FieldDescr for SimpleFieldDescr {
         &self.name
     }
     fn field_key(&self) -> &str {
-        &self.field_key
+        &self.name[self.field_key_start as usize..]
     }
     fn index_in_parent(&self) -> usize {
         self.index_in_parent
@@ -5886,12 +5904,13 @@ fn make_simple_descr_group_inner(
         let field_descrs: Vec<Arc<SimpleFieldDescr>> = field_specs
             .iter()
             .map(|spec| {
+                let field_key_start = field_key_start(&spec.name, &spec.field_key);
                 Arc::new(SimpleFieldDescr {
                     index: AtomicU32::new(spec.index),
                     descr_index: AtomicI32::new(-1),
                     ei_index: AtomicU32::new(u32::MAX),
-                    name: spec.name.clone(),
-                    field_key: spec.field_key.clone(),
+                    name: spec.name.clone().into_boxed_str(),
+                    field_key_start,
                     offset: spec.offset,
                     field_size: spec.field_size,
                     field_type: spec.field_type,
@@ -6644,8 +6663,8 @@ pub fn make_vtable_field_descr() -> DescrRef {
                     index: AtomicU32::new(0x6000_0000),
                     descr_index: AtomicI32::new(-1),
                     ei_index: AtomicU32::new(u32::MAX),
-                    name: "object.typeptr".to_string(),
-                    field_key: "typeptr".to_string(),
+                    name: Box::from("object.typeptr"),
+                    field_key_start: field_key_start("object.typeptr", "typeptr"),
                     offset: 0,
                     field_size: std::mem::size_of::<usize>(),
                     field_type: crate::Type::Int,

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -2912,6 +2912,7 @@ pub fn ei_descr_mints_snapshot() -> Vec<DescrMintEntry> {
         .map(|(member, spec)| DescrMintEntry {
             member: member.clone(),
             spec: spec.clone(),
+            ei_index: u32::MAX,
         })
         .collect()
 }

--- a/majit/majit-ir/src/descr_registry.rs
+++ b/majit/majit-ir/src/descr_registry.rs
@@ -166,10 +166,11 @@ pub fn snapshot_all() -> Vec<DescrRef> {
 ///
 /// `MetaInterpStaticData::all_descrs()` is the accessor; nothing else should
 /// reach in here directly.
-static ALL_DESCRS: std::sync::Mutex<Vec<DescrRef>> = std::sync::Mutex::new(Vec::new());
+static ALL_DESCRS: std::sync::LazyLock<std::sync::Mutex<std::sync::Arc<Vec<DescrRef>>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(std::sync::Arc::new(Vec::new())));
 
 /// Handle to the process-wide `all_descrs` list documented on [`ALL_DESCRS`].
-pub fn all_descrs() -> &'static std::sync::Mutex<Vec<DescrRef>> {
+pub fn all_descrs() -> &'static std::sync::Mutex<std::sync::Arc<Vec<DescrRef>>> {
     &ALL_DESCRS
 }
 

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -131,13 +131,16 @@ pub enum DescrMintSpec {
 pub struct DescrMintEntry {
     pub member: DescrSetMember,
     pub spec: DescrMintSpec,
+    /// `effectinfo.py:526 descr.ei_index = mapping.setdefault(...)`, frozen
+    /// by source translation. `u32::MAX` until the build-time partition runs.
+    pub ei_index: u32,
 }
 
 /// `effectinfo.py:128-145 frozenset_or_none`: serializable projection of
 /// the six raw EffectInfo descr sets. The vectors are kept in the same
 /// canonical order as the raw `DescrRef` sets so deserialization can rebuild
 /// the exact object graph before `compute_bitstrings`.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct DescrSetKeys {
     pub readonly_fields: Vec<DescrSetMember>,
     pub write_fields: Vec<DescrSetMember>,
@@ -171,6 +174,19 @@ impl DescrSetKeys {
             readonly_interiorfields: Vec::new(),
             write_interiorfields: Vec::new(),
         }
+    }
+
+    fn canonicalize(&mut self) {
+        fn sort_dedup(members: &mut Vec<DescrSetMember>) {
+            members.sort();
+            members.dedup();
+        }
+        sort_dedup(&mut self.readonly_fields);
+        sort_dedup(&mut self.write_fields);
+        sort_dedup(&mut self.readonly_arrays);
+        sort_dedup(&mut self.write_arrays);
+        sort_dedup(&mut self.readonly_interiorfields);
+        sort_dedup(&mut self.write_interiorfields);
     }
 }
 
@@ -299,6 +315,49 @@ pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
     let canonical = Arc::new(EffectInfoCell::new(effect_info));
     cache.push(canonical.clone());
     canonical
+}
+
+/// Recover the EffectInfo object identity assigned by source translation.
+///
+/// RPython's translated image carries the canonical EffectInfo object itself.
+/// Pyre serializes the image through a build-script process, so references to
+/// that object cross the boundary as a dense id and are rejoined here. The
+/// vector is the direct translated-object table; it is not keyed by descriptor
+/// content and does not duplicate any raw descriptor set.
+fn translated_effect_infos() -> &'static Mutex<Vec<Option<Arc<EffectInfoCell>>>> {
+    static TRANSLATED: LazyLock<Mutex<Vec<Option<Arc<EffectInfoCell>>>>> =
+        LazyLock::new(|| Mutex::new(Vec::new()));
+    &TRANSLATED
+}
+
+pub fn intern_translated_effect_info(
+    translated_id: u32,
+    effect_info: EffectInfo,
+) -> Arc<EffectInfoCell> {
+    let mut translated = translated_effect_infos()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let slot = translated_id as usize;
+    if translated.len() <= slot {
+        translated.resize_with(slot + 1, || None);
+    }
+    if let Some(existing) = &translated[slot] {
+        return existing.clone();
+    }
+    let canonical = Arc::new(EffectInfoCell::new(effect_info));
+    translated[slot] = Some(canonical.clone());
+    canonical
+}
+
+/// Look up an EffectInfo already published from the translated object table.
+/// Call descriptors carry only this dense identity at runtime; the canonical
+/// object itself is loaded once from the frozen EffectInfo artifact.
+pub fn translated_effect_info(translated_id: u32) -> Option<Arc<EffectInfoCell>> {
+    translated_effect_infos()
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(translated_id as usize)
+        .and_then(Clone::clone)
 }
 
 /// effectinfo.py:266-269: frozenset_or_none(x)
@@ -1481,6 +1540,49 @@ struct EiCanonKey {
     call_release_gil: ReleaseGilCacheKey,
 }
 
+/// Address-independent image of [`EiCanonKey`] for source translation.
+///
+/// RPython runs `compute_bitstrings` while translating, so descriptor and
+/// EffectInfo object identity are stable inside the translated image. Pyre's
+/// analyzer and runtime are separate processes; the serializable
+/// [`DescrSetKeys`] are the translated-image names of those same descriptor
+/// objects. This key therefore replaces each raw `DescrRef` frozenset with its
+/// structural member set. It is build-time-only data, not a runtime side table.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct FrozenEiCanonKey {
+    extraeffect: ExtraEffect,
+    oopspecindex: u16,
+    pyre_helper: u8,
+    descr_set_keys: Option<DescrSetKeys>,
+    can_invalidate: bool,
+    can_collect: bool,
+    call_release_gil_site: Option<usize>,
+}
+
+impl FrozenEiCanonKey {
+    fn from_effect_info(ei: &EffectInfo, position: usize) -> Self {
+        Self {
+            extraeffect: ei.extraeffect,
+            oopspecindex: ei.oopspecindex as u16,
+            pyre_helper: ei.pyre_helper as u8,
+            descr_set_keys: ei.descr_set_keys.clone(),
+            can_invalidate: ei.can_invalidate,
+            can_collect: ei.can_collect,
+            // effectinfo.py:144-146 inserts a fresh object into every
+            // release-gil cache key. The stable build-time analogue is the
+            // EI's position in the deterministic descriptor/JitCode walk.
+            call_release_gil_site: (ei.call_release_gil_target.0 != 0).then_some(position),
+        }
+    }
+}
+
+pub struct FrozenBitstringLayout {
+    pub descr_indices: [std::collections::BTreeMap<DescrSetMember, u32>; 3],
+    /// Canonical translated-object identity parallel to the `all_eis` input.
+    /// Ordinary structurally-identical EIs share an id; release-gil EIs do not.
+    pub effect_info_ids: Vec<u32>,
+}
+
 /// Project an Arc-identity raw set to a thin-pointer ptr-id Vec.
 /// Caller's `Vec<DescrRef>` is assumed already canonicalised
 /// (sorted by `Arc::as_ptr`, dedup'd) — the resulting `Vec<usize>`
@@ -1522,6 +1624,164 @@ impl EiCanonKey {
             call_release_gil,
         }
     }
+}
+
+/// Translation-time form of [`compute_bitstrings`] using stable descriptor
+/// keys instead of live `Arc` addresses.
+///
+/// This is the same `effectinfo.py:465-547` partition: for each of fields,
+/// arrays and interior fields, descriptors with identical `(readers, writers)`
+/// membership share one compact `ei_index`, and the most popular classes are
+/// assigned first. The returned maps are the translated-image equivalent of
+/// `descr.ei_index`; a serializer can put each value onto the corresponding
+/// descriptor construction record rather than retaining a runtime side table.
+///
+/// Numeric indices need not match [`compute_bitstrings`]' pointer-address
+/// tie-break. Membership and bit checks do match, while the structural
+/// [`DescrSetMember`] tie-break makes the result reproducible across analyzer
+/// processes.
+pub fn compute_frozen_bitstrings(all_eis: &mut [&mut EffectInfo]) -> FrozenBitstringLayout {
+    use std::collections::{BTreeMap, BTreeSet};
+
+    // `frozenset_or_none`: canonical member order is part of neither
+    // semantics nor identity, so normalize it before forming cache keys.
+    for ei in all_eis.iter_mut() {
+        match ei.descr_set_keys.as_mut() {
+            Some(keys) => keys.canonicalize(),
+            None => {
+                ei.readonly_descrs_fields = None;
+                ei.write_descrs_fields = None;
+                ei.readonly_descrs_arrays = None;
+                ei.write_descrs_arrays = None;
+                ei.readonly_descrs_interiorfields = None;
+                ei.write_descrs_interiorfields = None;
+            }
+        }
+    }
+
+    // `EffectInfo._cache`: structurally identical ordinary EIs denote one
+    // object. Release-gil EIs retain one identity per deterministic mint site.
+    let mut canonical_id_for_position = Vec::with_capacity(all_eis.len());
+    let mut first_position_for_shape: BTreeMap<FrozenEiCanonKey, usize> = BTreeMap::new();
+    for (position, ei) in all_eis.iter().enumerate() {
+        let key = FrozenEiCanonKey::from_effect_info(ei, position);
+        let next = first_position_for_shape.len();
+        let canonical_id = *first_position_for_shape.entry(key).or_insert(next);
+        canonical_id_for_position.push(canonical_id);
+    }
+
+    let mut result: [BTreeMap<DescrSetMember, u32>; 3] = std::array::from_fn(|_| BTreeMap::new());
+    for category in 0..3 {
+        let mut category_members = BTreeSet::new();
+        for ei in all_eis.iter() {
+            let Some(keys) = ei.descr_set_keys.as_ref() else {
+                continue;
+            };
+            let (read, write) = pick_key_category(keys, category);
+            category_members.extend(read.iter().cloned());
+            category_members.extend(write.iter().cloned());
+        }
+
+        let mut memberships = Vec::with_capacity(category_members.len());
+        for member in category_members {
+            assert_member_category(&member, category);
+            let mut readers = Vec::new();
+            let mut writers = Vec::new();
+            for (position, ei) in all_eis.iter().enumerate() {
+                let Some(keys) = ei.descr_set_keys.as_ref() else {
+                    continue;
+                };
+                let canonical_id = canonical_id_for_position[position];
+                let (read, write) = pick_key_category(keys, category);
+                if read.binary_search(&member).is_ok() {
+                    readers.push(canonical_id);
+                }
+                if write.binary_search(&member).is_ok() {
+                    writers.push(canonical_id);
+                }
+            }
+            readers.sort_unstable();
+            readers.dedup();
+            writers.sort_unstable();
+            writers.dedup();
+            memberships.push((member, readers, writers));
+        }
+
+        // effectinfo.py:519-526 popularity ordering + mapping.setdefault.
+        memberships.sort_by(|a, b| {
+            (b.1.len() + b.2.len())
+                .cmp(&(a.1.len() + a.2.len()))
+                .then(a.0.cmp(&b.0))
+        });
+        let mut class_indices: BTreeMap<(Vec<usize>, Vec<usize>), u32> = BTreeMap::new();
+        for (member, readers, writers) in memberships {
+            let next = class_indices.len() as u32;
+            let ei_index = *class_indices.entry((readers, writers)).or_insert(next);
+            result[category].insert(member, ei_index);
+        }
+
+        // effectinfo.py:528-538: bitstrings are encoded from the descriptor's
+        // compact class index, exactly as the live-object path does.
+        for ei in all_eis.iter_mut() {
+            let Some(keys) = ei.descr_set_keys.as_ref() else {
+                continue;
+            };
+            let (read, write) = pick_key_category(keys, category);
+            let read_indices: Vec<u32> = read
+                .iter()
+                .map(|member| {
+                    *result[category]
+                        .get(member)
+                        .expect("frozen bitstrings: read member missing from partition")
+                })
+                .collect();
+            let write_indices: Vec<u32> = write
+                .iter()
+                .map(|member| {
+                    *result[category]
+                        .get(member)
+                        .expect("frozen bitstrings: write member missing from partition")
+                })
+                .collect();
+            store_category_bitstrings(
+                ei,
+                category,
+                Some(crate::bitstring::make_bitstring(&read_indices)),
+                Some(crate::bitstring::make_bitstring(&write_indices)),
+            );
+        }
+    }
+    FrozenBitstringLayout {
+        descr_indices: result,
+        effect_info_ids: canonical_id_for_position
+            .into_iter()
+            .map(|id| u32::try_from(id).expect("too many translated EffectInfo identities"))
+            .collect(),
+    }
+}
+
+fn pick_key_category(
+    keys: &DescrSetKeys,
+    category: usize,
+) -> (&Vec<DescrSetMember>, &Vec<DescrSetMember>) {
+    match category {
+        0 => (&keys.readonly_fields, &keys.write_fields),
+        1 => (&keys.readonly_arrays, &keys.write_arrays),
+        2 => (&keys.readonly_interiorfields, &keys.write_interiorfields),
+        _ => unreachable!("frozen bitstrings: invalid category"),
+    }
+}
+
+fn assert_member_category(member: &DescrSetMember, category: usize) {
+    assert!(
+        matches!(
+            (category, member),
+            (0, DescrSetMember::Field { .. })
+                | (1, DescrSetMember::Array { .. })
+                | (2, DescrSetMember::InteriorField { .. })
+        ),
+        "frozen bitstrings: descriptor member is in the wrong category: {member:?}"
+    );
 }
 
 /// `effectinfo.py:465-547` `compute_bitstrings`.
@@ -2076,5 +2336,144 @@ mod compute_bitstrings_tests {
         // f_a appears only in eisetr, f_b only in eisetw → distinct
         // (eisetr, eisetw) class → distinct ei_index.
         assert_ne!(f_a.get_ei_index(), f_b.get_ei_index());
+    }
+
+    fn field_member(struct_id: u64, field_name: &str) -> DescrSetMember {
+        DescrSetMember::Field {
+            struct_id,
+            field_name: field_name.to_owned(),
+        }
+    }
+
+    #[test]
+    fn frozen_partition_matches_live_membership_semantics() {
+        let f0 = mk_field(0);
+        let f1 = mk_field(1);
+        let f2 = mk_field(2);
+        let k0 = field_member(10, "a");
+        let k1 = field_member(10, "b");
+        let k2 = field_member(20, "c");
+
+        let make_eis = || {
+            vec![
+                EffectInfo {
+                    _readonly_descrs_fields: Some(vec![f0.clone(), f1.clone()]),
+                    _write_descrs_fields: Some(vec![f2.clone()]),
+                    descr_set_keys: Some(DescrSetKeys {
+                        readonly_fields: vec![k0.clone(), k1.clone()],
+                        write_fields: vec![k2.clone()],
+                        ..DescrSetKeys::default()
+                    }),
+                    ..EffectInfo::default()
+                },
+                EffectInfo {
+                    _readonly_descrs_fields: Some(vec![f0.clone()]),
+                    _write_descrs_fields: Some(vec![f1.clone(), f2.clone()]),
+                    descr_set_keys: Some(DescrSetKeys {
+                        readonly_fields: vec![k0.clone()],
+                        write_fields: vec![k1.clone(), k2.clone()],
+                        ..DescrSetKeys::default()
+                    }),
+                    ..EffectInfo::default()
+                },
+            ]
+        };
+
+        let mut live_eis = make_eis();
+        let mut live_refs: Vec<&mut EffectInfo> = live_eis.iter_mut().collect();
+        compute_bitstrings(&[f0.clone(), f1.clone(), f2.clone()], &mut live_refs);
+
+        let mut frozen_eis = make_eis();
+        let mut frozen_refs: Vec<&mut EffectInfo> = frozen_eis.iter_mut().collect();
+        let frozen_indices = compute_frozen_bitstrings(&mut frozen_refs);
+
+        for (live, frozen) in live_eis.iter().zip(&frozen_eis) {
+            for (descr, member) in [(&f0, &k0), (&f1, &k1), (&f2, &k2)] {
+                let live_index = descr.get_ei_index();
+                let frozen_index = frozen_indices.descr_indices[0][member];
+                assert_eq!(
+                    crate::bitstring::bitcheck(
+                        live.readonly_descrs_fields.as_ref().unwrap(),
+                        live_index,
+                    ),
+                    crate::bitstring::bitcheck(
+                        frozen.readonly_descrs_fields.as_ref().unwrap(),
+                        frozen_index,
+                    )
+                );
+                assert_eq!(
+                    crate::bitstring::bitcheck(
+                        live.write_descrs_fields.as_ref().unwrap(),
+                        live_index,
+                    ),
+                    crate::bitstring::bitcheck(
+                        frozen.write_descrs_fields.as_ref().unwrap(),
+                        frozen_index,
+                    )
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn frozen_partition_is_independent_of_member_input_order() {
+        let ka = field_member(1, "a");
+        let kb = field_member(1, "b");
+        let mut ordered = EffectInfo {
+            descr_set_keys: Some(DescrSetKeys {
+                readonly_fields: vec![ka.clone(), kb.clone()],
+                write_fields: vec![kb.clone()],
+                ..DescrSetKeys::default()
+            }),
+            ..EffectInfo::default()
+        };
+        let mut shuffled = EffectInfo {
+            descr_set_keys: Some(DescrSetKeys {
+                readonly_fields: vec![kb.clone(), ka.clone(), kb.clone()],
+                write_fields: vec![kb],
+                ..DescrSetKeys::default()
+            }),
+            ..EffectInfo::default()
+        };
+
+        let ordered_indices = compute_frozen_bitstrings(&mut [&mut ordered]);
+        let shuffled_indices = compute_frozen_bitstrings(&mut [&mut shuffled]);
+        assert_eq!(
+            ordered_indices.descr_indices,
+            shuffled_indices.descr_indices
+        );
+        assert_eq!(
+            ordered.readonly_descrs_fields,
+            shuffled.readonly_descrs_fields
+        );
+        assert_eq!(ordered.write_descrs_fields, shuffled.write_descrs_fields);
+    }
+
+    #[test]
+    fn frozen_partition_keeps_random_effects_wildcard() {
+        let mut random = EffectInfo {
+            extraeffect: ExtraEffect::RandomEffects,
+            descr_set_keys: None,
+            readonly_descrs_fields: Some(vec![0xff]),
+            write_descrs_fields: Some(vec![0xff]),
+            readonly_descrs_arrays: Some(vec![0xff]),
+            write_descrs_arrays: Some(vec![0xff]),
+            readonly_descrs_interiorfields: Some(vec![0xff]),
+            write_descrs_interiorfields: Some(vec![0xff]),
+            ..EffectInfo::default()
+        };
+        let indices = compute_frozen_bitstrings(&mut [&mut random]);
+        assert!(
+            indices
+                .descr_indices
+                .iter()
+                .all(|category| category.is_empty())
+        );
+        assert!(random.readonly_descrs_fields.is_none());
+        assert!(random.write_descrs_fields.is_none());
+        assert!(random.readonly_descrs_arrays.is_none());
+        assert!(random.write_descrs_arrays.is_none());
+        assert!(random.readonly_descrs_interiorfields.is_none());
+        assert!(random.write_descrs_interiorfields.is_none());
     }
 }

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -294,9 +294,25 @@ impl Clone for EffectInfoCell {
 ///
 /// PyPy constructs one canonical EffectInfo object for each structural raw-set
 /// key and the call-descr cache stores that object by identity.  Keep the same
-/// process-global ownership here.  A small insertion-ordered vector is enough
-/// for the translated population and, unlike a second structural key, does not
-/// duplicate all six raw descriptor sets merely to find the canonical cell.
+/// process-global ownership here — `LLType::func_key` keys on this cell's
+/// address for exactly that reason, so anything that splits a cell mints a
+/// distinct call descr.
+///
+/// Upstream's `_cache` is a dict; this is an insertion-ordered vector scanned
+/// linearly, the shape `AGENTS.md`'s container rule allows for a small key
+/// space.  Measured, rather than assumed: the population tops out between 32
+/// and 63 distinct EffectInfos, and the heaviest workload tried (`test_pickle`,
+/// 999 tests) took 6,519 lookups for 44,266 candidate comparisons — about seven
+/// per lookup, most exiting on the first three integer fields.  A keyed map
+/// would have to duplicate all six raw descriptor sets to find the cell it
+/// replaces.
+///
+/// The key is `EffectInfo` equality, which carries `pyre_helper`.  Upstream has
+/// no such field, and it must stay in: the walker matches a helper by that tag
+/// on the descr's EffectInfo because it cannot match by fnaddr (`pyre-jit`'s
+/// `flatten.rs`), so two helpers with identical effect sets but different tags
+/// must not share a cell — one call site would be handed the other's tag and
+/// re-emit the wrong specialization.
 ///
 /// `effectinfo.py:144-146` deliberately bypasses the cache for release-gil
 /// targets by appending a fresh `object()` to the key; those calls receive a
@@ -308,6 +324,18 @@ pub fn intern_effect_info(effect_info: EffectInfo) -> Arc<EffectInfoCell> {
 
     static CACHE: LazyLock<Mutex<Vec<Arc<EffectInfoCell>>>> =
         LazyLock::new(|| Mutex::new(Vec::new()));
+    // `effectinfo.py:143-146` destructures `tgt_func, tgt_saveerr` but appends
+    // the fresh-object breaker only `if tgt_func`, so `tgt_saveerr` never
+    // enters the key, and upstream's only null-target value is
+    // `_NO_CALL_RELEASE_GIL_TARGET = (NULL, 0)`.  The early return above took
+    // every non-null target, so normalise the half no reader can reach from
+    // here: `is_call_release_gil` tests `tgt_func` alone, and the two sites
+    // that do consume the pair assert a resolved address first.  Without this,
+    // a `(0, save_err)` left by an unresolved `resolve_call_release_gil_target`
+    // would key its own cell and mint a call descr upstream would have merged.
+    let mut effect_info = effect_info;
+    effect_info.call_release_gil_target = EffectInfo::_NO_CALL_RELEASE_GIL_TARGET;
+
     let mut cache = CACHE.lock().unwrap_or_else(|e| e.into_inner());
     if let Some(existing) = cache.iter().find(|existing| existing.get() == &effect_info) {
         return existing.clone();
@@ -2157,6 +2185,26 @@ mod compute_bitstrings_tests {
         let first = intern_effect_info(effect_info.clone());
         let second = intern_effect_info(effect_info);
         assert!(!Arc::ptr_eq(&first, &second));
+    }
+
+    /// `effectinfo.py:143-146` reads `tgt_saveerr` out of the pair but never
+    /// puts it in the key, so a null target carrying a stray `save_err` must
+    /// not buy its own canonical cell — and therefore its own call descr.
+    #[test]
+    fn effect_info_cache_ignores_save_err_on_a_null_release_gil_target() {
+        let mut with_save_err = EffectInfo::default();
+        with_save_err.call_release_gil_target = (0, 3);
+        // The premise the normalisation exists for: equality does split on the
+        // pair, so without it the two below would land in separate cells.
+        assert_ne!(with_save_err, EffectInfo::default());
+
+        let plain = intern_effect_info(EffectInfo::default());
+        let stray = intern_effect_info(with_save_err);
+        assert!(Arc::ptr_eq(&plain, &stray));
+        assert_eq!(
+            stray.get().call_release_gil_target,
+            EffectInfo::_NO_CALL_RELEASE_GIL_TARGET,
+        );
     }
 
     /// Two EIs share a fielddescr in their write set; the descr's

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -689,6 +689,31 @@ pub fn make_call_descr_sized_with_effect(
     )
 }
 
+/// Deserialized translated-image variant. `translated_effect_info_id` is the
+/// identity of RPython's canonical EffectInfo object, carried explicitly
+/// because pyre's build script and runtime do not share object addresses.
+pub fn make_call_descr_sized_with_translated_effect(
+    arg_types: &[Type],
+    result_type: Type,
+    result_signed: bool,
+    result_size: usize,
+    translated_effect_info_id: u32,
+) -> DescrRef {
+    let effect_info = majit_ir::effectinfo::translated_effect_info(translated_effect_info_id)
+        .unwrap_or_else(|| {
+            panic!(
+                "translated EffectInfo {translated_effect_info_id} was not published before its CallDescr"
+            )
+        });
+    make_call_descr_sized_with_cell(
+        arg_types,
+        result_type,
+        result_signed,
+        result_size,
+        effect_info,
+    )
+}
+
 fn make_call_descr_sized(
     arg_types: &[Type],
     result_type: Type,
@@ -724,6 +749,22 @@ fn make_call_descr_sized(
     // targets bypass the interner with a fresh cell, matching the `object()`
     // cache breaker at effectinfo.py:144-146.
     let effect_info = majit_ir::effectinfo::intern_effect_info(effect_info);
+    make_call_descr_sized_with_cell(
+        arg_types,
+        result_type,
+        result_signed,
+        result_size,
+        effect_info,
+    )
+}
+
+fn make_call_descr_sized_with_cell(
+    arg_types: &[Type],
+    result_type: Type,
+    result_signed: bool,
+    result_size: usize,
+    effect_info: Arc<majit_ir::effectinfo::EffectInfoCell>,
+) -> DescrRef {
     let key = majit_ir::descr::LLType::func_key(
         arg_types,
         result_type,

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -109,7 +109,8 @@ pub use call_descr::{
     INT_PY_MOD_EFFECT_INFO, LOOPINVARIANT_EFFECT_INFO, cannot_raise_effect_info,
     default_effect_info, effect_info_for_slot, forces_virtual_or_virtualizable_effect_info,
     make_call_assembler_descr, make_call_descr, make_call_descr_from_target_slot,
-    make_call_descr_sized_with_effect, make_call_descr_with_effect, nursery_alloc_effect_info,
+    make_call_descr_sized_with_effect, make_call_descr_sized_with_translated_effect,
+    make_call_descr_with_effect, nursery_alloc_effect_info,
 };
 pub use compile::{
     make_fail_descr, make_fail_descr_typed, make_finish_fail_descr_typed,

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -15,6 +15,7 @@ use crate::optimizeopt::{
 use indexmap::{IndexMap, IndexSet};
 use majit_ir::operand::Operand;
 use majit_ir::{DescrRef, Op, OpCode, OpRef, Type};
+use std::sync::Arc;
 
 use crate::optimizeopt::info::{PtrInfo, PtrInfoExt};
 use crate::optimizeopt::intutils::IntBound;
@@ -316,7 +317,7 @@ pub(crate) struct PendingBridgeRd {
     pub liveboxes: Vec<OpRef>,
     pub livebox_types: Vec<Type>,
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
-    pub all_descrs: Vec<majit_ir::descr::DescrRef>,
+    pub all_descrs: Arc<Vec<majit_ir::descr::DescrRef>>,
     /// `optimizer.cpu` (model.py:39 AbstractCPU) — carried through the
     /// bridge into the retrace `Optimizer.cpu` slot. RPython never sees a
     /// `None` here: `optimizer.cpu` is set at `Optimizer.__init__` time.
@@ -448,7 +449,7 @@ pub struct Optimizer {
     /// Taken from MIStaticData at optimizer construction, returned after.
     /// descr.py:25-47: descriptors get descr_index assigned inline during
     /// collect_optimizer_knowledge_for_resume().
-    pub all_descrs: Vec<DescrRef>,
+    pub all_descrs: Arc<Vec<DescrRef>>,
     /// optimizer.py:787: constant_fold allocator for compile-time object creation.
     pub constant_fold_alloc: Option<crate::optimizeopt::ConstantFoldAllocFn>,
     /// info.py:810-822 `ConstPtrInfo.getstrlen1(mode)` runtime hook —
@@ -1503,7 +1504,7 @@ impl Optimizer {
             final_ctx: None,
             pending_bridge_rd: None,
             building_bridge: false,
-            all_descrs: Vec::new(),
+            all_descrs: Arc::new(Vec::new()),
             constant_fold_alloc: None,
             string_length_resolver: None,
             string_content_resolver: None,
@@ -5400,7 +5401,7 @@ impl Optimizer {
         }
         let new_idx = self.all_descrs.len() as i32;
         descr.set_descr_index(new_idx);
-        self.all_descrs.push(descr.clone());
+        Arc::make_mut(&mut self.all_descrs).push(descr.clone());
         // descr.py:47: assert len(all_descrs) < 2**15
         assert!(
             self.all_descrs.len() < (1 << 15),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -325,7 +325,7 @@ pub struct UnrollOptimizer {
     pub snapshot_frame_pcs: SnapshotFramePcs,
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
     /// Threaded through inner Optimizer instances for inline registration.
-    pub all_descrs: Vec<majit_ir::descr::DescrRef>,
+    pub all_descrs: std::sync::Arc<Vec<majit_ir::descr::DescrRef>>,
     /// compile.py:204-207 / heap.py:807-808 quasi-immutable deps collected
     /// by the phase optimizers for post-compile watcher registration.
     pub quasi_immutable_deps: Vec<(u64, u32)>,
@@ -499,7 +499,7 @@ impl UnrollOptimizer {
             snapshot_vable_boxes: Vec::new(),
             snapshot_vref_boxes: Vec::new(),
             snapshot_frame_pcs: Vec::new(),
-            all_descrs: Vec::new(),
+            all_descrs: std::sync::Arc::new(Vec::new()),
             quasi_immutable_deps: Vec::new(),
             trace_inputargs: Vec::new(),
             phase1_emit_ops: Vec::new(),

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -3633,7 +3633,7 @@ impl<M: Clone> MetaInterp<M> {
     /// the outer `UnrollOptimizer` holding an empty vector, which
     /// `compile_loop` then publishes.  Ignore those instead of invalidating
     /// every `descr_index` already serialized into a compiled bridge.
-    pub(crate) fn take_back_all_descrs(&mut self, all_descrs: Vec<DescrRef>) {
+    pub(crate) fn take_back_all_descrs(&mut self, all_descrs: std::sync::Arc<Vec<DescrRef>>) {
         let mut slot = self.staticdata.all_descrs().lock().unwrap();
         if all_descrs.len() >= slot.len() {
             *slot = all_descrs;
@@ -18245,7 +18245,7 @@ impl MetaInterpStaticData {
     /// backing store is `descr_registry::all_descrs()` because `descr_index`
     /// is stamped off the process-wide `GcCache` — see that static's docs for
     /// why the list cannot be per-instance.
-    pub fn all_descrs(&self) -> &'static std::sync::Mutex<Vec<DescrRef>> {
+    pub fn all_descrs(&self) -> &'static std::sync::Mutex<std::sync::Arc<Vec<DescrRef>>> {
         majit_ir::descr_registry::all_descrs()
     }
 
@@ -18631,6 +18631,19 @@ impl MetaInterpStaticData {
     /// same bitstrings (compute_bitstrings's class assignment is
     /// deterministic for a given EI population).
     pub fn finish_setup_descrs(&self) {
+        self.finish_setup_descrs_impl(false);
+    }
+
+    /// Translated-image variant: descriptor `ei_index` values and EffectInfo
+    /// bitstrings were already produced by source translation, as they are in
+    /// RPython's generated binary. Only publish `all_descrs` and its dense
+    /// `descr_index` stamps; rebuilding translation-only raw frozensets here
+    /// would retain a second object graph with no upstream runtime analogue.
+    pub fn finish_setup_descrs_frozen(&self) {
+        self.finish_setup_descrs_impl(true);
+    }
+
+    fn finish_setup_descrs_impl(&self, frozen_bitstrings: bool) {
         // `warmspot.py:289` runs `finish_setup` once, in one process,
         // before any tracing, so its writes onto the shared descrs have a
         // single writer by construction.  Pyre keeps `MetaInterpStaticData`
@@ -18650,7 +18663,7 @@ impl MetaInterpStaticData {
         // the next sequential `descr_index`.  Pyre's descriptor mint
         // sites publish into the same `GcCache` owner, including
         // metainterp call descrs via `GcCache._cache_call`.
-        let all_descrs = majit_ir::descr_registry::snapshot_all();
+        let all_descrs = std::sync::Arc::new(majit_ir::descr_registry::snapshot_all());
 
         // `descr.py:25-47 setup_descrs` assigns sequential `descr_index`
         // to every cached descr in fixed group order (size, field, array,
@@ -18670,6 +18683,11 @@ impl MetaInterpStaticData {
         // Publish onto staticdata.all_descrs so opencoder / bridgeopt /
         // optimizer reads pick up the same length.
         *self.all_descrs().lock().unwrap() = all_descrs.clone();
+
+        if frozen_bitstrings {
+            majit_ir::effectinfo::mark_compute_bitstrings_ran();
+            return;
+        }
 
         // pyjitpl.py:2290 `effectinfo.compute_bitstrings(self.all_descrs)`.
         // Two-pass mutation: clone each distinct call descr EI for the
@@ -22627,7 +22645,7 @@ mod tests {
             frontend_boxes: vec![11, 22],
             liveboxes: vec![OpRef::input_arg_int(0), OpRef::input_arg_ref(1)],
             livebox_types: vec![Type::Int, Type::Ref],
-            all_descrs: vec![],
+            all_descrs: std::sync::Arc::new(vec![]),
             cpu: crate::cpu::default_cpu(),
         };
 

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -19113,6 +19113,22 @@ mod metainterp_static_data_tests {
             "ordinary structurally-equal EffectInfos must share their canonical cell",
         );
 
+        // The dedup keeps one writeback descr per cell, so `finish_setup_descrs`
+        // publishes `compute_bitstrings`' answer through that representative
+        // only.  Every other descr on the same cell has to observe it, or the
+        // ones that were deduped away would run on unpublished bitstrings.
+        first.as_call_descr().unwrap().set_effect_bitstrings(
+            Some(vec![0b0000_0011]),
+            Some(vec![0b0000_0101]),
+            None,
+            None,
+            None,
+            None,
+        );
+        let observed = second.as_call_descr().unwrap().get_extra_info();
+        assert_eq!(observed.readonly_descrs_fields, Some(vec![0b0000_0011]));
+        assert_eq!(observed.write_descrs_fields, Some(vec![0b0000_0101]));
+
         let (snapshots, writebacks) = unique_effect_info_snapshots(&[first, second]);
 
         assert_eq!(snapshots.len(), 1);

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5980,6 +5980,7 @@ mod tests {
             result_erased: crate::jitcode::CallResultErasedKey::Unsigned,
             void_word_abi: false,
             extra_info: effect.clone(),
+            translated_effect_info_id: None,
         };
         let raw_address = crate::jitcode::BhCallDescr {
             arg_classes: "i".to_string(),
@@ -5989,6 +5990,7 @@ mod tests {
             result_erased: crate::jitcode::CallResultErasedKey::Address,
             void_word_abi: false,
             extra_info: effect,
+            translated_effect_info_id: None,
         };
 
         assert_eq!(single_float.result_type, 'S');

--- a/majit/majit-translate/src/codewriter/call.rs
+++ b/majit/majit-translate/src/codewriter/call.rs
@@ -266,6 +266,7 @@ impl CallDescriptor {
             result_erased: self.result_erased,
             void_word_abi: self.result_type == 'v' && self.result_size == 8,
             extra_info: self.extra_info.clone(),
+            translated_effect_info_id: None,
         }
     }
 

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -932,6 +932,11 @@ pub struct BhCallDescr {
     /// RPython `CallDescr.extrainfo` (`descr.py:453`,
     /// `effectinfo.py:13-263`).
     pub extra_info: majit_ir::descr::EffectInfo,
+    /// Object identity assigned by translation after all EffectInfos are
+    /// known. RPython preserves this directly in the translated image; pyre
+    /// carries the dense id across its analyzer/runtime process boundary.
+    #[serde(default)]
+    pub translated_effect_info_id: Option<u32>,
 }
 
 /// Widest `arg_classes` the blackhole's residual-call dispatch table can build
@@ -1006,6 +1011,7 @@ impl BhCallDescr {
             },
             void_word_abi: result_class == 'v' && result_size == 8,
             extra_info: cd.get_extra_info().clone(),
+            translated_effect_info_id: None,
         }
     }
 
@@ -1024,6 +1030,7 @@ impl BhCallDescr {
             result_erased,
             void_word_abi: false,
             extra_info,
+            translated_effect_info_id: None,
         }
     }
 
@@ -1051,6 +1058,7 @@ impl BhCallDescr {
             ),
             void_word_abi: false,
             extra_info,
+            translated_effect_info_id: None,
         }
     }
 

--- a/pyre/bench/synth/builtin_id_audit_event.cranelift.jitstats
+++ b/pyre/bench/synth/builtin_id_audit_event.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/builtin_id_audit_event.dynasm.jitstats
+++ b/pyre/bench/synth/builtin_id_audit_event.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/builtin_id_audit_event.py
+++ b/pyre/bench/synth/builtin_id_audit_event.py
@@ -1,0 +1,38 @@
+# `id()` emits the `builtins.id` audit event carrying the value it is about to
+# return (`operation.py:84-88`: `w_res = space.id(w_object)`, then
+# `space.audit("builtins.id", [w_res])`).  pyre computed the id and returned it
+# without ever emitting, so `sys.addaudithook` could not observe the call.
+#
+# The hook records a count and the last value, so two things are checked at
+# once: one event per call, and the event's argument being what the call handed
+# back.  Nothing in the hook body calls `id()`, so the count cannot feed itself.
+
+import sys
+
+count = [0]
+last_seen = [0]
+
+
+def hook(event, args):
+    if event == "builtins.id":
+        count[0] += 1
+        last_seen[0] = args[0]
+
+
+obj = [1, 2, 3]
+sys.addaudithook(hook)
+
+N = 2000
+before = count[0]
+last_returned = 0
+for _ in range(N):
+    last_returned = id(obj)
+emitted = count[0] - before
+
+assert emitted == N, "%d events for %d calls" % (emitted, N)
+assert last_seen[0] == last_returned, "event carried %r, call returned %r" % (
+    last_seen[0],
+    last_returned,
+)
+
+print("OK")

--- a/pyre/bench/synth/builtin_id_audit_event.wasm.jitstats
+++ b/pyre/bench/synth/builtin_id_audit_event.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -13405,7 +13405,8 @@ pub(crate) fn builtin_dir(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     Ok(w_list_new(items))
 }
 
-/// `id(obj)` — PyPy: baseobjspace.py id → object identity as int
+/// `operation.py:84-88 id(space, w_object)` — `space.id`, then the
+/// `builtins.id` audit event.
 fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 1 {
         return Err(crate::PyError::type_error(format!(
@@ -13418,10 +13419,22 @@ fn builtin_id(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // to `compute_unique_id`, which incminimark implements through
     // `id_or_identityhash` (incminimark.py) so nursery moves preserve it.
     let obj = args[0];
-    Ok(match crate::function::immutable_unique_id(obj) {
+    let w_res = match crate::function::immutable_unique_id(obj) {
         Some(w_id) => w_id,
         None => w_int_new(pyre_object::gc_hook::gc_identity_hash(obj as usize) as i64),
-    })
+    };
+    // `operation.py:87 space.audit("builtins.id", [w_res])`, emitted after the
+    // id is computed so a hook sees the value the call is about to return.
+    if crate::module::sys::vm::audit_hooks_armed() {
+        // The event-name wrap and the hooks are both collection points, and the
+        // result reaches them only as a copied pointer.  Root it across the
+        // emit and read the answer back out of its slot.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let res_slot = pyre_object::gc_roots::pin_roots(&[w_res]);
+        crate::module::sys::vm::audit("builtins.id", &[w_res])?;
+        return Ok(pyre_object::gc_roots::shadow_stack_get(res_slot));
+    }
+    Ok(w_res)
 }
 
 /// `hash(obj)` — PyPy: `descroperation.py:1006 hash`.

--- a/pyre/pyre-jit-trace/build.rs
+++ b/pyre/pyre-jit-trace/build.rs
@@ -13,7 +13,7 @@ use walkdir::WalkDir;
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v9";
+const CODEGEN_CACHE_VERSION: &str = "pyre-jit-trace-codegen-cache-v11";
 /// Retained cache entries. Each is ~6 MB, and a handful covers the
 /// configurations one checkout switches between (native/wasm × release/dev).
 const CODEGEN_CACHE_MAX_ENTRIES: usize = 8;
@@ -29,6 +29,8 @@ const CODEGEN_OUTPUTS: &[&str] = &[
     "insns.bin",
     "descrs.bin",
     "descrs_index.bin",
+    "effect_infos.bin",
+    "effect_infos_index.bin",
     "ei_descr_mints.bin",
     "ei_descr_mints_index.bin",
     "field_mint_census.bin",
@@ -69,7 +71,8 @@ const CODEGEN_OUTPUTS: &[&str] = &[
 ///
 /// What decides the cross-process verdict after these exclusions:
 /// `jit_trace_gen.rs`, `jitcodes_index.bin`, `jit_drivers.bin`, `insns.bin`,
-/// `descrs_index.bin`, `ei_descr_mints.bin`, `ei_descr_mints_index.bin`,
+/// `descrs_index.bin`, `effect_infos_index.bin`, `ei_descr_mints.bin`,
+/// `ei_descr_mints_index.bin`,
 /// `liveness.bin`.
 /// `jitcodes_index.bin` is the load-bearing one — it holds each jitcode's name
 /// and its byte boundaries in `jitcodes.bin`, and an address is a fixed-width
@@ -88,6 +91,7 @@ const HOST_ADDRESSED_OUTPUTS: &[&str] = &[
     "jitcodes.bin",
     "indirectcalltargets.bin",
     "descrs.bin",
+    "effect_infos.bin",
     "fnaddr_bindings.bin",
     "static_pytype_bindings.bin",
     "static_ref_bindings.bin",
@@ -258,6 +262,12 @@ fn emit_llbc_extraction_placeholders() {
     std::fs::write(
         format!("{out_dir}/descrs_index.bin"),
         bincode::serialize(&(vec![0_u32], Vec::<u8>::new())).unwrap(),
+    )
+    .unwrap();
+    std::fs::write(format!("{out_dir}/effect_infos.bin"), b"").unwrap();
+    std::fs::write(
+        format!("{out_dir}/effect_infos_index.bin"),
+        bincode::serialize(&vec![0_u32]).unwrap(),
     )
     .unwrap();
     std::fs::write(format!("{out_dir}/ei_descr_mints.bin"), b"").unwrap();
@@ -980,8 +990,129 @@ fn real_main() {
 
         std::fs::write(format!("{out_dir}/jit_trace_gen.rs"), &code).unwrap();
 
+        // RPython runs effectinfo.compute_bitstrings during translation and
+        // puts both outputs directly into the translated image: compact
+        // bitstrings on each EffectInfo and `ei_index` on each descriptor.
+        // Pyre's analyzer is a build-script process, so freeze that same
+        // object graph into the serialized image before crossing the process
+        // boundary. Keep the live pipeline untouched: trace-code generation
+        // above consumes its Arc identities, while these clones are solely the
+        // translated constants written below.
+        let mut frozen_descrs = pipeline.descrs.clone();
+        let mut frozen_jitcodes: Vec<std::sync::Arc<majit_translate::jitcode::JitCode>> = pipeline
+            .jitcodes
+            .iter()
+            .map(|jitcode| std::sync::Arc::new((**jitcode).clone()))
+            .collect();
+        let mut frozen_mints = pipeline.ei_descr_mints.clone();
+        let mut call_descrs: Vec<&mut majit_translate::jitcode::BhCallDescr> = Vec::new();
+        for descr in &mut frozen_descrs {
+            match descr {
+                majit_translate::jitcode::BhDescr::Call { calldescr }
+                | majit_translate::jitcode::BhDescr::JitCode { calldescr, .. } => {
+                    call_descrs.push(calldescr)
+                }
+                _ => {}
+            }
+        }
+        for jitcode in &mut frozen_jitcodes {
+            call_descrs.push(
+                &mut std::sync::Arc::get_mut(jitcode)
+                    .expect("fresh frozen JitCode clone is unexpectedly shared")
+                    .body_mut()
+                    .calldescr,
+            );
+        }
+        // `effectinfo.compute_bitstrings(self.cpu.setup_descrs())` sees every
+        // CallDescr in GcCache, not only the subset an opcode or JitCode body
+        // happens to serialize. Include that full call group so descriptors
+        // minted by a non-opcode call still receive their upstream partition.
+        // The serialized BhCallDescr copies below are appended only so their
+        // translated object ids and bitstrings are written in place; ordinary
+        // duplicates collapse through EffectInfo._cache identity.
+        let mut cached_effect_infos: Vec<majit_ir::EffectInfo> = majit_ir::descr::gc_cache()
+            .lock()
+            .unwrap()
+            .snapshot_calls()
+            .into_iter()
+            .filter_map(|descr| {
+                descr.as_call_descr().map(|call| {
+                    let mut effect_info = call.get_extra_info().clone();
+                    // The frozen partition reads `descr_set_keys` plus scalar
+                    // EI metadata. Drop its live-object frozenset projection
+                    // immediately instead of retaining a second cumulative
+                    // Arc graph until codegen ends. Serialized BhCallDescrs
+                    // below keep their own complete values.
+                    effect_info._readonly_descrs_fields = None;
+                    effect_info._write_descrs_fields = None;
+                    effect_info._readonly_descrs_arrays = None;
+                    effect_info._write_descrs_arrays = None;
+                    effect_info._readonly_descrs_interiorfields = None;
+                    effect_info._write_descrs_interiorfields = None;
+                    effect_info.single_write_descr_array = None;
+                    effect_info.extradescrs = None;
+                    effect_info
+                })
+            })
+            .collect();
+        let cached_effect_info_count = cached_effect_infos.len();
+        let frozen_layout = {
+            let mut effect_infos: Vec<&mut majit_ir::EffectInfo> =
+                cached_effect_infos.iter_mut().collect();
+            effect_infos.extend(
+                call_descrs
+                    .iter_mut()
+                    .map(|calldescr| &mut calldescr.extra_info),
+            );
+            majit_ir::effectinfo::compute_frozen_bitstrings(&mut effect_infos)
+        };
+        let serialized_effect_info_ids: Vec<u32> = frozen_layout
+            .effect_info_ids
+            .iter()
+            .copied()
+            .skip(cached_effect_info_count)
+            .collect();
+        assert_eq!(call_descrs.len(), serialized_effect_info_ids.len());
+        let mut frozen_effect_infos = std::collections::BTreeMap::new();
+        for (calldescr, effect_info_id) in call_descrs
+            .into_iter()
+            .zip(serialized_effect_info_ids.into_iter())
+        {
+            calldescr.translated_effect_info_id = Some(effect_info_id);
+            frozen_effect_infos
+                .entry(effect_info_id)
+                .or_insert_with(|| calldescr.extra_info.clone());
+            // The translated image stores one EffectInfo object and lets every
+            // CallDescr point at it. Keep BhCallDescr's host-side field for
+            // codewriter use, but serialize only this inert placeholder once
+            // the dense identity above has been assigned.
+            calldescr.extra_info = majit_ir::EffectInfo::MOST_GENERAL.clone();
+        }
+        for entry in &mut frozen_mints {
+            let category = match &entry.member {
+                majit_ir::effectinfo::DescrSetMember::Field { .. } => 0,
+                majit_ir::effectinfo::DescrSetMember::Array { .. } => 1,
+                majit_ir::effectinfo::DescrSetMember::InteriorField { .. } => 2,
+            };
+            // A descriptor can be minted while write-analysis is still
+            // assembling a concrete EI and then survive in GcCache after a
+            // later unrepresentable member degrades that EI to
+            // EF_RANDOM_EFFECTS. `setup_descrs()` still enumerates it, while
+            // effectinfo.py:496 leaves its `ei_index = sys.maxint` because no
+            // final raw frozenset names it. Preserve that sentinel instead of
+            // pretending the mint log is exactly the final raw-set union.
+            entry.ei_index = frozen_layout.descr_indices[category]
+                .get(&entry.member)
+                .copied()
+                .unwrap_or(u32::MAX);
+        }
+
         // JSON metadata for debugging
-        let json = serde_json::to_string_pretty(&pipeline).unwrap();
+        let mut frozen_pipeline = pipeline.clone();
+        frozen_pipeline.descrs = frozen_descrs.clone();
+        frozen_pipeline.jitcodes = frozen_jitcodes.clone();
+        frozen_pipeline.ei_descr_mints = frozen_mints.clone();
+        let json = serde_json::to_string_pretty(&frozen_pipeline).unwrap();
         std::fs::write(format!("{out_dir}/jit_metadata.json"), &json).unwrap();
 
         // Persist `pipeline.jitcodes` (RPython `all_jitcodes` from
@@ -991,10 +1122,10 @@ fn real_main() {
         // RPython `warmspot.py:281-282` `self.metainterp_sd.jitcodes =
         // codewriter.make_jitcodes()`.
         let mut jitcodes_bin = Vec::new();
-        let mut jitcode_names = Vec::with_capacity(pipeline.jitcodes.len());
-        let mut jitcode_offsets = Vec::with_capacity(pipeline.jitcodes.len() + 1);
+        let mut jitcode_names = Vec::with_capacity(frozen_jitcodes.len());
+        let mut jitcode_offsets = Vec::with_capacity(frozen_jitcodes.len() + 1);
         jitcode_offsets.push(0_u32);
-        for jitcode in &pipeline.jitcodes {
+        for jitcode in &frozen_jitcodes {
             jitcode_names.push(jitcode.name.clone());
             jitcodes_bin.extend(bincode::serialize(jitcode).unwrap());
             jitcode_offsets.push(
@@ -1068,10 +1199,10 @@ fn real_main() {
         // table shape upstream gets from translation-time constants without
         // reconstituting every descriptor in this process.
         let mut descrs_bin = Vec::new();
-        let mut descr_offsets = Vec::with_capacity(pipeline.descrs.len() + 1);
-        let mut descr_kinds = Vec::with_capacity(pipeline.descrs.len());
+        let mut descr_offsets = Vec::with_capacity(frozen_descrs.len() + 1);
+        let mut descr_kinds = Vec::with_capacity(frozen_descrs.len());
         descr_offsets.push(0_u32);
-        for descr in &pipeline.descrs {
+        for descr in &frozen_descrs {
             // `GcCache.setup_descrs` publishes structural descriptors before
             // call descriptors.  Persist that two-pass classification beside
             // the dense offsets so runtime can preserve the ordering without
@@ -1089,14 +1220,37 @@ fn real_main() {
                     .expect("serialized descrs.bin exceeds the u32 offset range"),
             );
         }
-        assert_eq!(descr_offsets.len(), pipeline.descrs.len() + 1);
-        assert_eq!(descr_kinds.len(), pipeline.descrs.len());
+        assert_eq!(descr_offsets.len(), frozen_descrs.len() + 1);
+        assert_eq!(descr_kinds.len(), frozen_descrs.len());
         assert_eq!(descr_offsets.first().copied(), Some(0));
         assert_eq!(descr_offsets.last().copied(), Some(descrs_bin.len() as u32));
         assert!(descr_offsets.windows(2).all(|pair| pair[0] <= pair[1]));
         let descrs_index_bin = bincode::serialize(&(descr_offsets, descr_kinds)).unwrap();
         std::fs::write(format!("{out_dir}/descrs.bin"), &descrs_bin).unwrap();
         std::fs::write(format!("{out_dir}/descrs_index.bin"), &descrs_index_bin).unwrap();
+
+        // RPython's translated constants preserve EffectInfo object identity:
+        // thousands of CallDescrs point at a small canonical object table.
+        // Keep the same ownership instead of repeating each EffectInfo inside
+        // every BhCallDescr wire record. Entries stay independently decodable
+        // so runtime setup drops their structural key strings immediately.
+        let mut effect_infos_bin = Vec::new();
+        let mut effect_info_offsets = Vec::with_capacity(frozen_effect_infos.len() + 1);
+        effect_info_offsets.push(0_u32);
+        for (translated_id, effect_info) in &frozen_effect_infos {
+            effect_infos_bin.extend(bincode::serialize(&(*translated_id, effect_info)).unwrap());
+            effect_info_offsets.push(
+                u32::try_from(effect_infos_bin.len())
+                    .expect("serialized effect_infos.bin exceeds the u32 offset range"),
+            );
+        }
+        let effect_infos_index_bin = bincode::serialize(&effect_info_offsets).unwrap();
+        std::fs::write(format!("{out_dir}/effect_infos.bin"), &effect_infos_bin).unwrap();
+        std::fs::write(
+            format!("{out_dir}/effect_infos_index.bin"),
+            &effect_infos_index_bin,
+        )
+        .unwrap();
 
         // `MAJIT_MINT_INDEX_CENSUS=1`: how many `fielddescrof` mints resolved a
         // slot for `index_in_parent`, and how many carried out the `0` they were
@@ -1131,9 +1285,9 @@ fn real_main() {
         // spec at a time instead of retaining all member/spec strings at the
         // peak of first-JIT setup.
         let mut ei_descr_mints_bin = Vec::new();
-        let mut ei_descr_mint_offsets = Vec::with_capacity(pipeline.ei_descr_mints.len() + 1);
+        let mut ei_descr_mint_offsets = Vec::with_capacity(frozen_mints.len() + 1);
         ei_descr_mint_offsets.push(0_u32);
-        for entry in &pipeline.ei_descr_mints {
+        for entry in &frozen_mints {
             ei_descr_mints_bin.extend(bincode::serialize(entry).unwrap());
             ei_descr_mint_offsets.push(
                 u32::try_from(ei_descr_mints_bin.len())

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -6514,18 +6514,17 @@ pub(crate) fn publish_effect_info_descr_mints(entries: &[majit_ir::effectinfo::D
     use majit_ir::effectinfo::{DescrMintSpec, DescrSetMember};
 
     for entry in entries {
-        match (&entry.member, &entry.spec) {
+        let descr = match (&entry.member, &entry.spec) {
             (
                 DescrSetMember::Field {
                     struct_id,
                     field_name,
                 },
                 spec,
-            ) => {
-                mint_field(LLType::Struct(*struct_id), field_name, spec);
-            }
+            ) => mint_field(LLType::Struct(*struct_id), field_name, spec)
+                .map(|descr| descr as majit_ir::DescrRef),
             (DescrSetMember::Array { array_id }, spec) => {
-                mint_array(LLType::Array(*array_id), spec);
+                mint_array(LLType::Array(*array_id), spec)
             }
             (
                 DescrSetMember::InteriorField { array_id, name },
@@ -6550,21 +6549,28 @@ pub(crate) fn publish_effect_info_descr_mints(entries: &[majit_ir::effectinfo::D
                 else {
                     continue;
                 };
-                let _ = majit_ir::descr::gc_cache()
-                    .lock()
-                    .unwrap()
-                    .get_interiorfield_descr(
-                        array_key,
-                        name.clone(),
-                        String::new(),
-                        array_descr,
-                        field_descr,
-                    );
+                Some(
+                    majit_ir::descr::gc_cache()
+                        .lock()
+                        .unwrap()
+                        .get_interiorfield_descr(
+                            array_key,
+                            name.clone(),
+                            String::new(),
+                            array_descr,
+                            field_descr,
+                        ),
+                )
             }
             // A member paired with a spec of another shape cannot describe its
             // own slot; leaving it unpublished keeps it counted as absent
             // rather than filling the slot with the wrong layout.
-            _ => {}
+            _ => None,
+        };
+        if let Some(descr) = descr
+            && entry.ei_index != u32::MAX
+        {
+            descr.set_ei_index(entry.ei_index);
         }
     }
 }
@@ -6933,6 +6939,77 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
     ei._write_descrs_interiorfields = Some(write_interiorfields);
 }
 
+/// Validate a translated EffectInfo's structural raw-set image without
+/// retaining the rehydrated `Vec<DescrRef>` graph.
+///
+/// RPython discards the six raw frozensets after translation has run
+/// `compute_bitstrings`; the translated object retains the compact bitstrings,
+/// and each descriptor retains `ei_index`. Pyre's earlier runtime rehydration
+/// rebuilt those translation-only frozensets solely because partitioning had
+/// been delayed across the process boundary. Once the build artifact carries
+/// both outputs, resolving every member here is an invariant check, not
+/// runtime state construction. `single_write_descr_array` is the one raw
+/// descriptor reference EffectInfo deliberately keeps after compaction
+/// (`effectinfo.py:201-206`), so that singleton alone remains live.
+pub fn prepare_frozen_effect_info(ei: &mut majit_ir::EffectInfo) {
+    fn degrade(ei: &mut majit_ir::EffectInfo) {
+        ei.extraeffect = majit_ir::ExtraEffect::RandomEffects;
+        ei.can_collect = true;
+        ei.can_invalidate = true;
+        ei.readonly_descrs_fields = None;
+        ei.write_descrs_fields = None;
+        ei.readonly_descrs_arrays = None;
+        ei.write_descrs_arrays = None;
+        ei.readonly_descrs_interiorfields = None;
+        ei.write_descrs_interiorfields = None;
+        ei.single_write_descr_array = None;
+    }
+
+    let Some(keys) = ei.descr_set_keys.take() else {
+        if ei.extraeffect != majit_ir::ExtraEffect::RandomEffects {
+            degrade(ei);
+        }
+        return;
+    };
+    let resolve = |members: &[majit_ir::effectinfo::DescrSetMember]| {
+        let mut out = Vec::with_capacity(members.len());
+        let mut complete = true;
+        for member in members {
+            let looked_up = descr_from_set_member(member);
+            record_set_member_lookup(member, &looked_up);
+            match looked_up {
+                SetMemberLookup::Resolved(descr) => out.push(descr),
+                SetMemberLookup::AbsentContainer | SetMemberLookup::Ambiguous => complete = false,
+            }
+        }
+        complete.then_some(out)
+    };
+    let resolved = (
+        resolve(&keys.readonly_fields),
+        resolve(&keys.write_fields),
+        resolve(&keys.readonly_arrays),
+        resolve(&keys.write_arrays),
+        resolve(&keys.readonly_interiorfields),
+        resolve(&keys.write_interiorfields),
+    );
+    let (
+        Some(_readonly_fields),
+        Some(_write_fields),
+        Some(_readonly_arrays),
+        Some(write_arrays),
+        Some(_readonly_interiorfields),
+        Some(_write_interiorfields),
+    ) = resolved
+    else {
+        degrade(ei);
+        return;
+    };
+    ei.single_write_descr_array = match write_arrays.as_slice() {
+        [only] => Some(only.clone()),
+        _ => None,
+    };
+}
+
 /// `BhCallDescr` -> `CallDescr` adapter. RPython parity: codewriter
 /// `Assembler.descrs` carries the same `CallDescr` instance the
 /// metainterp pulls during op recording. pyre keeps the codewriter-side
@@ -6967,24 +7044,25 @@ pub fn make_call_descr_from_bh(bh: &majit_translate::jitcode::BhCallDescr) -> De
         );
     }
     let result_size = if bh.void_word_abi { 8 } else { bh.result_size };
-    // call.py:320 effectinfo_from_writeanalyze parity: the descr consumed
-    // by pyjitpl/residual-call recording must expose the same EffectInfo
-    // that the codewriter classified for this call site.
-    //
-    // descr.py:524-526 `get_result_type()` parity — preserve the raw
-    // `bh.result_type` char ('i'/'r'/'f'/'v'/'S'/'L') so downstream
-    // consumers (`bhimpl_call_*` dispatch, `is_result_signed`) can
-    // recover the original singlefloat/longlong classification that the
-    // normalized `Type` collapses.
-    majit_ir::descr::make_call_descr_full_with_result_class(
-        u32::MAX,
-        arg_types,
-        result_type,
-        bh.result_type,
-        bh.result_signed,
-        result_size,
-        bh.extra_info.clone(),
-    )
+    if let Some(translated_id) = bh.translated_effect_info_id {
+        majit_metainterp::make_call_descr_sized_with_translated_effect(
+            &arg_types,
+            result_type,
+            bh.result_signed,
+            result_size,
+            translated_id,
+        )
+    } else {
+        majit_ir::descr::make_call_descr_full_with_result_class(
+            u32::MAX,
+            arg_types,
+            result_type,
+            bh.result_type,
+            bh.result_signed,
+            result_size,
+            bh.extra_info.clone(),
+        )
+    }
 }
 
 /// descr.py:384 InteriorFieldDescr for SETINTERIORFIELD_GC.
@@ -7134,6 +7212,7 @@ mod set_member_lookup_tests {
                 is_quasi_immutable: false,
                 index_in_parent: 1,
             },
+            ei_index: u32::MAX,
         }]);
 
         let SetMemberLookup::Resolved(descr) = descr_from_set_member(&member) else {

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -685,6 +685,48 @@ pub fn all_descrs() -> &'static [BhDescr] {
     })
 }
 
+/// Canonical translated EffectInfo objects. RPython embeds each object once
+/// and lets CallDescrs retain references to it; the indexed wire table carries
+/// that identity across pyre's build-script/runtime process boundary.
+fn effect_info_offsets() -> &'static [u32] {
+    static OFFSETS: OnceLock<Box<[u32]>> = OnceLock::new();
+    OFFSETS.get_or_init(|| {
+        const INDEX_BYTES: &[u8] =
+            include_bytes!(concat!(env!("OUT_DIR"), "/effect_infos_index.bin"));
+        const BODY_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/effect_infos.bin"));
+        let offsets: Vec<u32> = bincode::deserialize(INDEX_BYTES).unwrap_or_else(|e| {
+            panic!(
+                "pyre-jit-trace: failed to deserialize effect_infos_index.bin \
+                 ({} bytes): {e}",
+                INDEX_BYTES.len(),
+            )
+        });
+        assert!(!offsets.is_empty());
+        assert_eq!(offsets.first().copied(), Some(0));
+        assert_eq!(offsets.last().copied(), Some(BODY_BYTES.len() as u32));
+        assert!(offsets.windows(2).all(|pair| pair[0] <= pair[1]));
+        offsets.into_boxed_slice()
+    })
+}
+
+fn effect_info_count() -> usize {
+    effect_info_offsets().len() - 1
+}
+
+fn load_effect_info(index: usize) -> (u32, majit_ir::EffectInfo) {
+    const BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/effect_infos.bin"));
+    let offsets = effect_info_offsets();
+    let start = offsets[index] as usize;
+    let end = offsets[index + 1] as usize;
+    bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
+        panic!(
+            "pyre-jit-trace: failed to deserialize effect_infos.bin entry {index} \
+             ({start}..{end} of {} bytes): {e}",
+            BYTES.len(),
+        )
+    })
+}
+
 /// Indexed `pipeline.ei_descr_mints` — gccache slots named only by an
 /// EffectInfo raw set, paired with the arguments their mint took.
 ///
@@ -798,14 +840,13 @@ fn rehydrated_call_descr_ref(bh: majit_translate::jitcode::BhCallDescr) -> majit
     // This BhCallDescr was decoded solely for setup.  Move its EffectInfo
     // into the canonical runtime CallDescr instead of cloning the complete
     // six-set serialization payload and then dropping the source copy.
-    let mut effect_info = bh.extra_info;
-    crate::descr::rehydrate_effect_info(&mut effect_info);
-    majit_metainterp::make_call_descr_sized_with_effect(
+    majit_metainterp::make_call_descr_sized_with_translated_effect(
         &arg_types,
         result_type,
         bh.result_signed,
         bh.result_size,
-        effect_info,
+        bh.translated_effect_info_id
+            .expect("translated BhCallDescr is missing its EffectInfo identity"),
     )
 }
 
@@ -858,6 +899,15 @@ pub fn rehydrate_build_descr_raw_sets() {
         for i in 0..ei_descr_mint_count() {
             let entry = load_ei_descr_mint(i);
             crate::descr::publish_effect_info_descr_mints(std::slice::from_ref(&entry));
+        }
+        // `effectinfo.compute_bitstrings` has already run in the translator.
+        // Resolve the structural spellings once per canonical EffectInfo,
+        // retain only its compact bitstrings/single-write descriptor, and
+        // publish the object table before any CallDescr asks for an id.
+        for i in 0..effect_info_count() {
+            let (translated_id, mut effect_info) = load_effect_info(i);
+            crate::descr::prepare_frozen_effect_info(&mut effect_info);
+            majit_ir::effectinfo::intern_translated_effect_info(translated_id, effect_info);
         }
         for (i, kind) in index.kinds.iter().copied().enumerate() {
             if kind != 1 {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -276,7 +276,7 @@ impl MetaInterpStaticData {
         // (`MetaInterpStaticData::all_descrs`), or `bridgeopt.py:155
         // metainterp_sd.all_descrs[descr_index]` indexes an empty list.
         if !was_done {
-            self.canonical.finish_setup_descrs();
+            self.canonical.finish_setup_descrs_frozen();
         }
     }
 


### PR DESCRIPTION
Four commits on top of `origin/main`, closing the review items left open after #1316 merged.

### `jit: drop tgt_saveerr from the EffectInfo cache key`

`effectinfo.py:143-146` destructures `tgt_func, tgt_saveerr` but appends the fresh-object cache breaker only `if tgt_func`, so `tgt_saveerr` never enters the key; upstream's only null-target value is `_NO_CALL_RELEASE_GIL_TARGET = (NULL, 0)`. `intern_effect_info` compared the whole pair, so a `(0, save_err)` bought its own canonical cell — and since `LLType::func_key` keys on the cell's address, its own call descr.

The `(0, save_err)` reaches the interner through four hops:

```
jitcode/assembler.rs  resolve_call_release_gil_target(ei, target.concrete_ptr, target.save_err)
  -> BhCallDescr::from_signature            (stores extra_info raw, translated_effect_info_id: None)
  -> pyre-jit-trace/src/descr.rs            bh.extra_info.clone()
  -> make_call_descr_full_with_result_class -> SimpleCallDescr::new_with_result_class
  -> intern_effect_info
```

The resolver fires on its `1` sentinel and substitutes both halves verbatim, so a null `concrete_ptr` with a nonzero `save_err` lands as `(0, save_err)`.

Normalising the pair on the cached path is unobservable: `is_call_release_gil` tests `tgt_func` alone, and both sites that consume the pair require a resolved address first — `pyjitpl.rs` early-returns on `!is_call_release_gil()` before reading it, `history.rs` `debug_assert!(realfuncaddr != 0)`. Non-null targets never reach the normalisation; they take the fresh-cell early return, matching the `object()` breaker.

### Review findings resolved

Three of the four came back against the reviewers' recommendation, on evidence rather than argument.

| Finding | Disposition | Basis |
| --- | --- | --- |
| Vec linear scan → HashMap (Codex P1, CodeRabbit Major) | **refuted** | A temporary counter scaffold measured the population: 32-63 distinct EffectInfos; the heaviest workload tried (`test_pickle`, 999 tests) took 6,519 lookups for 44,266 candidate comparisons, ~7 per lookup, most exiting on the first three integer fields. A keyed map would have to duplicate all six raw descriptor sets to find the cell it replaces. |
| `pyre_helper` in the key is a parity regression (Codex §1) | **inverted, kept** | The walker matches a helper by that tag on the descr's EffectInfo because it cannot match by fnaddr (`pyre-jit`'s `flatten.rs`). Two helpers with equal effect sets and different tags sharing a cell would hand one call site the other's tag and re-emit the wrong specialization. |
| `tgt_saveerr` in the key (Codex §1) | **real, fixed** | Above. |
| `setup_snapshots_a_shared_effect_info_once` asserts too little (CodeRabbit) | **real, applied** | Now writes bitstrings through the representative descr and asserts the deduped-away descr observes them — the contract `finish_setup_descrs` relies on. |

The measured numbers and the `pyre_helper` rationale are recorded in the doc comment so the next reviewer does not have to re-derive them.

### `builtins: emit the builtins.id audit event from id()`

`operation.py:84-88` computes `w_res = space.id(w_object)` and then emits `space.audit("builtins.id", [w_res])`. pyre returned the id without ever emitting, so `sys.addaudithook` could not observe the call. The emit follows the house idiom used by `sys._getframe`: the whole block is guarded by `audit_hooks_armed()`, and only inside it are roots pushed — running hooks is a collection point, so the result is pinned across the emit and read back out of its slot.

New fixture `bench/synth/builtin_id_audit_event.py` checks both the event count and that the event's argument is what the call returned. It fails on the pre-fix binary with `0 events for 2000 calls`; PyPy 7.3.20 and CPython 3.14 both print `OK`.

### Verification

- dynasm synthetic suite **431/431**, no jitstats snapshot moved — evidence the normalisation changed no descr population
- `cargo test -p majit-ir` 332+5 passed; `cargo test -p majit-metainterp --features dynasm` clean
- `cargo test -p majit-translate` 3211 passed, which is the only thing that catches a fusion recognizer declining silently
- `cargo fmt --check` clean
- The new interner test asserts its own premise with `assert_ne!` so it cannot pass vacuously
- cranelift and wasm suites were not re-run locally; CI covers them

— *authored by Claude*
