### PR TITLE
test(wasm): report the exit status and stdout of a runtime codegen failure

### DIFF
--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -76,6 +76,25 @@ fn run_runtime_program(
     output
 }
 
+/// Assert a runtime subprocess exited 0, reporting enough to diagnose the
+/// failure from a CI log alone.
+///
+/// `run_runtime_program` has already claimed a death by signal, so what
+/// reaches here is a child that chose its own nonzero status. Which run it
+/// was, what status it chose, and what it had written to stdout are all part
+/// of that answer, and stderr alone carries none of them — a runner that
+/// reports on stdout and exits 1 otherwise fails with an empty message.
+#[track_caller]
+fn assert_ran_ok(label: &str, output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "{label} failed: {}\nstdout:\n{}\nstderr:\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+}
+
 fn stat_value(stderr: &str, name: &str) -> u64 {
     stderr
         .split_whitespace()
@@ -107,11 +126,7 @@ fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
         let bench = "global_reassign.py";
         let script = root.join("pyre/bench/synth").join(bench);
         let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-        assert!(
-            dynasm_run.status.success(),
-            "dynasm failed for {bench}:\n{}",
-            String::from_utf8_lossy(&dynasm_run.stderr)
-        );
+        assert_ran_ok(&format!("dynasm {bench}"), &dynasm_run);
         let wasm_run = run_runtime_program(
             &wasm_runner,
             &script,
@@ -122,10 +137,7 @@ fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
             ],
         );
         let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-        assert!(
-            wasm_run.status.success(),
-            "wasm failed for {bench}:\n{stderr}"
-        );
+        assert_ran_ok(&format!("wasm {bench}"), &wasm_run);
         assert_eq!(
             wasm_run.stdout, dynasm_run.stdout,
             "wasm output diverged from dynasm for {bench}:\n{stderr}"
@@ -160,11 +172,7 @@ fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
     }
 
     let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-    assert!(
-        dynasm_run.status.success(),
-        "dynasm failed:\n{}",
-        String::from_utf8_lossy(&dynasm_run.stderr)
-    );
+    assert_ran_ok("dynasm raise/catch", &dynasm_run);
     let module = wasm_module.to_str().expect("workspace paths must be UTF-8");
     let wasm_run = run_runtime_program(
         &wasm_runner,
@@ -176,7 +184,7 @@ fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
         ],
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-    assert!(wasm_run.status.success(), "wasm failed:\n{stderr}");
+    assert_ran_ok("wasm raise/catch", &wasm_run);
     assert_eq!(
         wasm_run.stdout, dynasm_run.stdout,
         "wasm raise/catch output diverged from dynasm:\n{stderr}"
@@ -205,7 +213,7 @@ fn recursive_call_assembler_does_not_refill_zeroed_nursery_frames() {
         );
     }
     let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-    assert!(dynasm_run.status.success(), "dynasm recursive fib failed");
+    assert_ran_ok("dynasm recursive fib", &dynasm_run);
     let module = wasm_module.to_str().expect("workspace paths must be UTF-8");
     let wasm_run = run_runtime_program(
         &wasm_runner,
@@ -219,10 +227,7 @@ fn recursive_call_assembler_does_not_refill_zeroed_nursery_frames() {
         ],
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-    assert!(
-        wasm_run.status.success(),
-        "wasm recursive fib failed:\n{stderr}"
-    );
+    assert_ran_ok("wasm recursive fib", &wasm_run);
     assert_eq!(
         wasm_run.stdout, dynasm_run.stdout,
         "wasm recursive fib output diverged from dynasm:\n{stderr}"
@@ -259,7 +264,7 @@ fn fannkuch_blackhole_helpers_do_not_reflect_through_the_host() {
     }
 
     let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-    assert!(dynasm_run.status.success(), "dynasm fannkuch failed");
+    assert_ran_ok("dynasm fannkuch", &dynasm_run);
     let module = wasm_module.to_str().expect("workspace paths must be UTF-8");
     let wasm_run = run_runtime_program(
         &wasm_runner,
@@ -271,7 +276,7 @@ fn fannkuch_blackhole_helpers_do_not_reflect_through_the_host() {
         ],
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-    assert!(wasm_run.status.success(), "wasm fannkuch failed:\n{stderr}");
+    assert_ran_ok("wasm fannkuch", &wasm_run);
     assert_eq!(
         wasm_run.stdout, dynasm_run.stdout,
         "wasm fannkuch output diverged from dynasm:\n{stderr}"
@@ -302,11 +307,7 @@ fn terminal_declined_call_assembler_matches_dynasm_at_runtime() {
     }
 
     let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-    assert!(
-        dynasm_run.status.success(),
-        "dynasm failed:\n{}",
-        String::from_utf8_lossy(&dynasm_run.stderr)
-    );
+    assert_ran_ok("dynasm terminal-decline", &dynasm_run);
     let module = wasm_module.to_str().expect("workspace paths must be UTF-8");
     let wasm_run = run_runtime_program(
         &wasm_runner,
@@ -319,7 +320,7 @@ fn terminal_declined_call_assembler_matches_dynasm_at_runtime() {
         ],
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-    assert!(wasm_run.status.success(), "wasm failed:\n{stderr}");
+    assert_ran_ok("wasm terminal-decline", &wasm_run);
     assert_eq!(
         wasm_run.stdout, dynasm_run.stdout,
         "forced terminal-decline wasm output diverged from dynasm\nwasm stderr:\n{stderr}"
@@ -358,7 +359,7 @@ fn wasm_outlier_bridges_stay_compiled_at_runtime() {
     ] {
         let script = root.join("pyre/bench/synth").join(bench);
         let dynasm_run = run_runtime_program(&dynasm, &script, &[]);
-        assert!(dynasm_run.status.success(), "dynasm failed for {bench}");
+        assert_ran_ok(&format!("dynasm {bench}"), &dynasm_run);
         let wasm_run = run_runtime_program(
             &wasm_runner,
             &script,
@@ -369,10 +370,7 @@ fn wasm_outlier_bridges_stay_compiled_at_runtime() {
             ],
         );
         let stderr = String::from_utf8_lossy(&wasm_run.stderr);
-        assert!(
-            wasm_run.status.success(),
-            "wasm failed for {bench}:\n{stderr}"
-        );
+        assert_ran_ok(&format!("wasm {bench}"), &wasm_run);
         assert_eq!(
             wasm_run.stdout, dynasm_run.stdout,
             "wasm output diverged from dynasm for {bench}:\n{stderr}"


### PR DESCRIPTION
Rebased onto `main`; what this branch carried has since landed upstream, and only the piece below is left.

### What is left

`run_runtime_program` names a death by signal since #1330, so what reaches the success assertions in `majit-backend-wasm/tests/codegen_test.rs` is a child that chose its own nonzero status. Those assertions printed stderr alone — not which run it was, not the status it chose, and not what it had written to stdout. A runner that reports on stdout and exits 1 fails with an empty message.

They now go through one `assert_ran_ok` that prints all three. Test-only; no runtime code is touched.

### What was dropped, and why

- **The `CHECK_EXC_MATCH` fold fix.** #1326 landed the same fix, and a stricter one. Both versions drop the `is_class_known` skip on the clause operand and pin the exception's `w_class`, but `check_exc_match_against` reaches the class through `typedef::type`, which falls back to the `ExcKind` registry whenever `w_class` still holds the generic `EXCEPTION_TYPE` stub — every internal raise path (`PyError::value_error` and friends) arrives that way. This branch pinned the stub, which every kind shares, so its guard admitted a different kind and left the defect live for exactly those exceptions; #1326 declines the fold instead. Superseded, not merged.
- **`--test-threads=1` on the CI step.** This branch serialized the leg on the theory that six tests times two interpreter processes were exhausting the runner. #1330 found the actual cause — the three engine configurations shared one `.cwasm`, so concurrent runs truncated each other's artifact — and fixed it with per-configuration artifacts published by rename. Serializing on top of that fix would only slow the leg down and hide a recurrence.

### Gates

`cargo test -p majit-backend-wasm --test codegen_test` builds; `cargo fmt --all --check` is clean. The six `#[ignore]`d runtime tests cannot run on this host: `pyre-dynasm.exe` writes CRLF and `pyre-wasm-runner.exe` writes LF, so their stdout comparisons fail on Windows regardless of the change (82 vs 80 bytes for two lines) — which is why the CI step is `runner.os == 'Linux'`. The Linux leg is the judge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4
