### PR TITLE
gc: root the argument slices two builtins re-read after running Python

### DIFF
--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -14490,9 +14490,15 @@ unsafe fn builtin_iter_override(
     obj: PyObjectRef,
     base: &'static pyre_object::PyType,
 ) -> Result<Option<PyObjectRef>, PyError> {
+    // `lookup_where_pair` walks the MRO and fills the method cache, so the
+    // receiver must survive that step to be the one handed to the override.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
     let Some(method) = (unsafe { builtin_iter_replacement(obj, base) }) else {
         return Ok(None);
     };
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     // descroperation.py:339-341 — an explicit `__iter__ = None` override marks
     // the subclass non-iterable even though the lookup succeeds.
     if unsafe { is_none(method) } {
@@ -14520,6 +14526,17 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             obj
         }
     };
+    // Every builtin arm below asks `builtin_iter_override` whether a heap
+    // subtype replaced `__iter__` before it builds its cursor, and that lookup
+    // allocates — the override arm runs Python outright. The receiver reaches
+    // this frame as a plain argument, so nothing here roots it: a caller that
+    // popped it off its value stack first leaves the collection with no
+    // reference at all, and the cursor is then built over reclaimed memory.
+    // Publish it once for the whole call and read it back where a movable
+    // kind is consumed after that lookup.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
     // `pypy/objspace/std/dictmultiobject.py`
     // `W_BaseDictMultiIterObject` line-by-line port — pyre's
     // `W_BaseDictMultiIterObject`
@@ -14552,7 +14569,9 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             if let Some(w_iter) = builtin_iter_override(obj, &pyre_object::LIST_TYPE)? {
                 return Ok(w_iter);
             }
-            return Ok(pyre_object::w_list_iter_new(obj));
+            return Ok(pyre_object::w_list_iter_new(
+                pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            ));
         }
         if is_tuple(obj) {
             if let Some(w_iter) = builtin_iter_override(obj, &pyre_object::TUPLE_TYPE)? {
@@ -14615,8 +14634,10 @@ pub fn iter(obj: PyObjectRef) -> PyResult {
             if let Some(w_iter) = builtin_iter_override(obj, &pyre_object::DICT_TYPE)? {
                 return Ok(w_iter);
             }
+            // The cursor stores this dict and outlives the frame, so the read
+            // has to name the copy the lookup above may have left behind.
             return Ok(pyre_object::dictmultiobject::w_dict_view_iterator_new(
-                obj,
+                pyre_object::gc_roots::shadow_stack_get(obj_slot),
                 pyre_object::dictmultiobject::DictViewKind::Keys,
             ));
         }

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -1622,16 +1622,33 @@ fn format_render(
     use rustpython_common::format::{
         FieldName, FieldNamePart, FieldType, FormatParseError, FromTemplate,
     };
+    // A gateway hands a builtin its arguments as a native array rebuilt from
+    // root slots immediately before the indirect call
+    // (`call_builtin_code_positional`), so that array is right once and then
+    // frozen. Every field after the first is resolved once this loop has run
+    // `__getattr__` / `__repr__` / `__format__`, and a minor collection there
+    // relocates a young argument while leaving the array holding its pre-move
+    // address. Publish the run and both keyword sources here and read each one
+    // back at its use; the absent source takes a slot too, so the two indices
+    // stay fixed whichever spelling the caller used.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let positional_base = pyre_object::gc_roots::pin_roots(positional);
+    let kwargs_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(kwargs_dict.unwrap_or(pyre_object::PY_NULL));
+    let mapping_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(mapping.unwrap_or(pyre_object::PY_NULL));
     let lookup_kwarg = |name: &str| -> Result<Option<PyObjectRef>, crate::PyError> {
-        if let Some(m) = mapping {
+        if mapping.is_some() {
             // `newformat.format_method(... w_mapping, True)` resolves
             // `{name}` via `space.getitem(mapping, w_key)` per
             // `newformat.py:Template.get_value`; KeyError propagates
             // to the caller (no silent default).
+            let m = pyre_object::gc_roots::shadow_stack_get(mapping_slot);
             let w_key = pyre_object::w_str_new(name);
             return crate::baseobjspace::getitem(m, w_key).map(Some);
         }
-        if let Some(dict) = kwargs_dict {
+        if kwargs_dict.is_some() {
+            let dict = pyre_object::gc_roots::shadow_stack_get(kwargs_slot);
             let v = unsafe { pyre_object::w_dict_getitem_str(dict, name) };
             return Ok(v);
         }
@@ -1695,7 +1712,7 @@ fn format_render(
                 *numbering = Some(true);
                 let idx = *auto_idx;
                 *auto_idx += 1;
-                index_positional(positional, idx)?
+                index_positional(positional_base, positional.len(), idx)?
             }
             FieldType::Index(idx) => {
                 if let Some(true) = *numbering {
@@ -1705,7 +1722,7 @@ fn format_render(
                     ));
                 }
                 *numbering = Some(false);
-                index_positional(positional, idx)?
+                index_positional(positional_base, positional.len(), idx)?
             }
             FieldType::Keyword(name) => {
                 let name_str = name.as_str().unwrap_or("");
@@ -1756,15 +1773,33 @@ fn format_render(
         // A spec containing `{` is itself a template: render it (sharing the
         // numbering state and the recursion budget) before applying it.
         let resolved_spec = if format_spec.as_bytes().contains(&b'{') {
-            format_render(
+            // The chain walk above ran Python, so every argument reachable
+            // only through this frame's native slice is a pre-move copy —
+            // including `val`, which the conversion below still needs. Hand
+            // the nested render the reloaded run (it publishes what it is
+            // given, so passing the stale slice would launder the stale words
+            // into its own roots) and read `val` back once it returns.
+            let inner = pyre_object::gc_roots::push_roots();
+            let val_slot = inner.base();
+            inner.pin_root(val);
+            let reloaded: Vec<PyObjectRef> = (0..positional.len())
+                .map(|i| pyre_object::gc_roots::shadow_stack_get(positional_base + i))
+                .collect();
+            let kwargs_now =
+                kwargs_dict.map(|_| pyre_object::gc_roots::shadow_stack_get(kwargs_slot));
+            let mapping_now =
+                mapping.map(|_| pyre_object::gc_roots::shadow_stack_get(mapping_slot));
+            let spec = format_render(
                 format_spec,
-                positional,
-                kwargs_dict,
-                mapping,
+                &reloaded,
+                kwargs_now,
+                mapping_now,
                 auto_idx,
                 numbering,
                 depth - 1,
-            )?
+            )?;
+            val = inner.get(val_slot);
+            spec
         } else {
             format_spec.clone()
         };
@@ -1933,12 +1968,17 @@ fn parse_format_parts(fmt: &Wtf8) -> Result<Vec<PyPyFormatPart>, crate::PyError>
 
 /// Fetch positional argument `idx`, raising the `str.format` IndexError for
 /// an out-of-range replacement index.
-fn index_positional(positional: &[PyObjectRef], idx: usize) -> Result<PyObjectRef, crate::PyError> {
-    positional.get(idx).copied().ok_or_else(|| {
-        crate::PyError::index_error(format!(
-            "Replacement index {idx} out of range for positional args tuple"
-        ))
-    })
+///
+/// The read goes through the run `format_render` published, so the value is
+/// the one the last collection left behind rather than the address the
+/// gateway's native argument array froze.
+fn index_positional(base: usize, len: usize, idx: usize) -> Result<PyObjectRef, crate::PyError> {
+    if idx < len {
+        return Ok(pyre_object::gc_roots::shadow_stack_get(base + idx));
+    }
+    Err(crate::PyError::index_error(format!(
+        "Replacement index {idx} out of range for positional args tuple"
+    )))
 }
 
 /// Map a template parse error to the matching `str.format` ValueError.


### PR DESCRIPTION
Two more rooting sites of the same family as #1327, found by root-causing a `test_descr` GC abort under `PYPY_GC_NURSERY=4096`.

### `str.format` re-reads its argument slice after running Python

`call_builtin_code_positional` pins `code` and every argument, then rebuilds a **stack array** from those slots immediately before the indirect call. That array is correct at the instant of the call and never again: the `RootScope` keeps the arguments alive for the whole builtin, but a minor that relocates a young argument rewrites the shadow slots, not the array.

`format_render` was the live instance — it indexed that slice once per `{}` field while the loop ran `__getattr__` / `__repr__` / `__format__` between fields, so from the second field on it was reading pre-move addresses. Symptom: `"{} {}".format(...)` raising `requires 'list' received 'list'`.

The fix publishes the positional run and both keyword sources into root slots, reads each back at its use, and hands a *reloaded* run to the nested-spec recursion (a callee that re-publishes would otherwise launder the stale words into its own roots).

Note for anyone reproducing: a JIT-only control has to exceed the compile threshold. A 60-iteration control reads clean here; 6000 iterations fails.

### `space.iter` does not root its receiver

`space.iter` receives the collection as a plain argument and nothing in the frame roots it. `opcode_get_iter` pops the iterable first, and `PyFrame::pop` clears the slot, so on that path the receiver has no reference anywhere while `iter` runs. Every builtin arm then calls `builtin_iter_override`, whose MRO walk allocates and whose override arm runs Python outright.

The receiver is pinned once for the whole call and read back where a movable kind is consumed after that lookup — the list arm's `w_list_iter_new` and the dict arm's `w_dict_view_iterator_new`, both of which store the receiver into a cursor that outlives the frame. `builtin_iter_override` reloads its own receiver after `builtin_iter_replacement` for the same reason.

Only list and dict headers move, so the tuple / set / str / range arms take the liveness pin and no read-back.

### Verification

- `cargo test --all --features dynasm` — 140 suites, rc=0
- `pyre/check.py` — ALL PASSED, dynasm 441/441, cranelift 441/441, wasm 434/434
- `test_dict` / `test_json` / `test_csv` / `test_ctypes` / `test_locale` / `test_importlib` at `PYPY_GC_NURSERY=4096` — OK
- `test_descr` still fails only on its baselined `test_slots` `gc.get_objects()` count row

### Still open, not fixed here

`test_importlib` aborts under `PYPY_GC_NURSERY=4096` (it passes at the default nursery, so no gate covers it). It reproduces identically on sibling controls, so main owns it and it predates this branch.

What is established: the victim is a `dict_keyiterator` whose `w_dict` at offset 16 reads a garbage tid, and a nursery-start ledger shows exactly one phantom per failing run — that same `w_dict` address, which was never handed out as an object start that epoch, with a real live `GcWeakrefBox` starting 8 bytes below it. The dict is traced exactly once, at the fatal minor, never forwarded earlier, and the memory still holds an intact dict, so it died rather than moved. `is_nursery_object_start` is a range check that does not verify the address is an object start, so the stray word gets copied and its forwarding stamp clobbers the neighbour.

Ruled out: `w_dict_view_iterator_new_direction`'s own window, the weakref constructors, the `AutoFlusher` handle list, the remembered-set drain, and `FrameBox::drop`. A return-path bisect pointed at a call's return value, but that signal turned out non-discriminating — it fires identically in passing runs, because JIT inline nursery allocation bypasses the ledger.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating list and dictionary iterators, especially during memory management activity.
  * Fixed potential errors or crashes during string formatting with positional arguments, keyword arguments, and nested format specifications.
  * Improved handling of formatted values and positional field lookups in complex formatting operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->