### PR TITLE
jit: restore the raw result class and the full EffectInfo degrade; drop a dead x86 pass

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -1688,8 +1688,9 @@ impl<'a> AssemblerARM64<'a> {
         self._assemble(true)?;
         self.check_unrelocated_jump_target()?;
 
-        // regalloc sets fail_arg_locs in append_guard_token_with_faillocs.
-        // No allocate_unmapped_fail_arg_slots needed.
+        // regalloc sets fail_arg_locs in append_guard_token_with_faillocs,
+        // which stamps `rd_locs` from them right there
+        // (`llsupport/assembler.py:279`), so no post-regalloc fixup pass runs.
 
         // assembler.py:553 write_pending_failure_recoveries
         let stub_offsets = self.write_pending_failure_recoveries();

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -932,11 +932,6 @@ struct GuardToken {
     /// stored on `Assembler386::fail_descrs` so registration on the owning CLT
     /// keeps it alive while the recovery stub references its address.
     fail_descr: std::sync::Arc<majit_ir::FailDescrCell>,
-    /// Fail argument OpRefs for recovery (to save to sequential output slots).
-    fail_args: Vec<OpRef>,
-    /// regalloc parity: snapshot of opref_to_slot at guard emission time.
-    /// Needed by recovery stubs to read fail_args from correct slots.
-    opref_to_slot_snapshot: IndexMap<OpRef, usize>,
     /// Constants to store in frame during recovery.
     /// Each entry: (frame_slot_index, constant_value).
     const_stores: Vec<(usize, i64)>,
@@ -2340,8 +2335,9 @@ impl<'a> Assembler386<'a> {
         self._assemble(true)?;
         self.check_unrelocated_jump_target()?;
 
-        // regalloc sets fail_arg_locs in append_guard_token_with_faillocs.
-        // No allocate_unmapped_fail_arg_slots needed.
+        // regalloc sets fail_arg_locs in append_guard_token_with_faillocs,
+        // which stamps `rd_locs` from them right there
+        // (`llsupport/assembler.py:279`), so no post-regalloc fixup pass runs.
 
         // assembler.py:553 write_pending_failure_recoveries
         let stub_offsets = self.write_pending_failure_recoveries();
@@ -5221,11 +5217,6 @@ impl<'a> Assembler386<'a> {
         self.pending_guard_tokens.push(GuardToken {
             fail_label,
             fail_descr: cell.clone(),
-            fail_args: op
-                .getfailargs()
-                .map(|fa| fa.iter().map(|a| a.to_opref()).collect())
-                .unwrap_or_default(),
-            opref_to_slot_snapshot: self.opref_to_slot.clone(),
             const_stores,
             gcmap,
             must_save_exception: matches!(
@@ -5237,38 +5228,6 @@ impl<'a> Assembler386<'a> {
             self.finish_gcmap = Some(gcmap);
         }
         self.fail_descrs.push(cell);
-    }
-
-    /// Update `rd_locs` on all pending guard descriptors after the
-    /// regalloc opref→slot map is finalised.  Unmapped (virtual/dead)
-    /// OpRefs and constants get `0xFFFF` — the resume system handles
-    /// them via `rd_numb` TAGVIRTUAL/TAGCONST encoding
-    /// (`resume.py:450-488`).
-    ///
-    /// Parallels the pending_force path of PyPy
-    /// `regalloc.py::store_force_descr → assembler.store_info_on_descr`
-    /// (`llsupport/assembler.py:279 guardtok.faildescr.rd_locs = positions`).
-    fn allocate_unmapped_fail_arg_slots(&mut self) {
-        for gt in &self.pending_guard_tokens {
-            let positions: Vec<u16> = gt
-                .fail_args
-                .iter()
-                .map(|opref| {
-                    if opref.is_none() || opref.is_constant() {
-                        0xFFFFu16
-                    } else {
-                        self.opref_to_slot
-                            .get(opref)
-                            .copied()
-                            .map(|slot| (slot + JITFRAME_FIXED_SIZE) as u16)
-                            .unwrap_or(0xFFFFu16)
-                    }
-                })
-                .collect();
-            if let Some(meta_fd) = gt.fail_descr.as_fail_descr() {
-                meta_fd.set_rd_locs(positions);
-            }
-        }
     }
 
     // assembler.py:652 write_pending_failure_recoveries

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -197,6 +197,11 @@ pub enum LLType {
     Func {
         arg_classes: String,
         result_type: Type,
+        /// `descr.py:665` keys on the RAW result char, so `'S'` (singlefloat)
+        /// and `'L'` do not share a descr with the `'i'`/`'f'` they normalise
+        /// to.  Callers holding only a `Type` pass the char that `Type`
+        /// derives, which leaves their key partition unchanged.
+        result_class: char,
         /// descr.py:664: result_signed = get_type_flag(RESULT) == FLAG_SIGNED
         result_signed: bool,
         /// descr.py:662: result_size = symbolic.get_size(RESULT_ERASED, tsc)
@@ -637,11 +642,24 @@ pub fn strip_generic_args(name: &str) -> std::borrow::Cow<'_, str> {
     }
 }
 
+/// The arg-class char a `Type` derives, for callers that never saw the raw
+/// codewriter char.  `'S'` and `'L'` normalise INTO `Type::Int`/`Type::Float`,
+/// so this direction can only produce the four plain classes.
+pub fn result_class_of(result_type: Type) -> char {
+    match result_type {
+        Type::Int => 'i',
+        Type::Ref => 'r',
+        Type::Float => 'f',
+        Type::Void => 'v',
+    }
+}
+
 impl LLType {
     /// descr.py:665: get_call_descr key tuple.
     pub fn func_key(
         arg_types: &[Type],
         result_type: Type,
+        result_class: char,
         result_signed: bool,
         result_size: usize,
         effect: &Arc<crate::effectinfo::EffectInfoCell>,
@@ -658,6 +676,7 @@ impl LLType {
         LLType::Func {
             arg_classes,
             result_type,
+            result_class,
             result_signed,
             result_size,
             effect_info_identity: Arc::as_ptr(effect) as usize,
@@ -2343,7 +2362,14 @@ impl GcCache {
         effect: EffectInfo,
     ) -> DescrRef {
         let effect = crate::effectinfo::intern_effect_info(effect);
-        let key = LLType::func_key(&arg_types, result_type, result_signed, result_size, &effect);
+        let key = LLType::func_key(
+            &arg_types,
+            result_type,
+            result_class_of(result_type),
+            result_signed,
+            result_size,
+            &effect,
+        );
         // descr.py:667-668: cache hit
         if let Some(descr) = self._cache_call.get(&key) {
             return descr.clone();
@@ -6446,17 +6472,11 @@ impl SimpleCallDescr {
         result_size: usize,
         effect: EffectInfo,
     ) -> Self {
-        let result_class = match result_type {
-            Type::Int => 'i',
-            Type::Ref => 'r',
-            Type::Float => 'f',
-            Type::Void => 'v',
-        };
         Self::new_with_result_class(
             index,
             arg_types,
             result_type,
-            result_class,
+            result_class_of(result_type),
             result_signed,
             result_size,
             effect,
@@ -6491,17 +6511,11 @@ impl SimpleCallDescr {
         result_size: usize,
         effect: Arc<crate::effectinfo::EffectInfoCell>,
     ) -> Self {
-        let result_class = match result_type {
-            Type::Int => 'i',
-            Type::Ref => 'r',
-            Type::Float => 'f',
-            Type::Void => 'v',
-        };
         Self::new_with_effect_cell_and_result_class(
             index,
             arg_types,
             result_type,
-            result_class,
+            result_class_of(result_type),
             result_signed,
             result_size,
             effect,

--- a/majit/majit-metainterp/src/call_descr.rs
+++ b/majit/majit-metainterp/src/call_descr.rs
@@ -26,6 +26,11 @@ struct MetaCallDescr {
     heapcache_index: u32,
     arg_types: Vec<Type>,
     result_type: Type,
+    /// `descr.py:524-526 get_result_type()` returns the RAW char.  Carrying it
+    /// keeps `'S'` (singlefloat) and `'L'` distinguishable from the
+    /// `'i'`/`'f'` they normalise to, which the resume path depends on when it
+    /// rebuilds a `BhCallDescr` off this descr for `bh_call_i`.
+    result_class: char,
     result_signed: bool,
     result_size: usize,
     effect_info: Arc<EffectInfoCell>,
@@ -87,6 +92,11 @@ impl CallDescr for MetaCallDescr {
     }
     fn result_type(&self) -> Type {
         self.result_type
+    }
+    /// `descr.py:524-526 get_result_type()` — the raw char, not the class the
+    /// normalised `result_type` would derive.
+    fn result_class(&self) -> char {
+        self.result_class
     }
     fn result_size(&self) -> usize {
         self.result_size
@@ -695,6 +705,7 @@ pub fn make_call_descr_sized_with_effect(
 pub fn make_call_descr_sized_with_translated_effect(
     arg_types: &[Type],
     result_type: Type,
+    result_class: char,
     result_signed: bool,
     result_size: usize,
     translated_effect_info_id: u32,
@@ -708,6 +719,7 @@ pub fn make_call_descr_sized_with_translated_effect(
     make_call_descr_sized_with_cell(
         arg_types,
         result_type,
+        result_class,
         result_signed,
         result_size,
         effect_info,
@@ -752,6 +764,7 @@ fn make_call_descr_sized(
     make_call_descr_sized_with_cell(
         arg_types,
         result_type,
+        majit_ir::descr::result_class_of(result_type),
         result_signed,
         result_size,
         effect_info,
@@ -761,6 +774,7 @@ fn make_call_descr_sized(
 fn make_call_descr_sized_with_cell(
     arg_types: &[Type],
     result_type: Type,
+    result_class: char,
     result_signed: bool,
     result_size: usize,
     effect_info: Arc<majit_ir::effectinfo::EffectInfoCell>,
@@ -768,6 +782,7 @@ fn make_call_descr_sized_with_cell(
     let key = majit_ir::descr::LLType::func_key(
         arg_types,
         result_type,
+        result_class,
         result_signed,
         result_size,
         &effect_info,
@@ -778,6 +793,7 @@ fn make_call_descr_sized_with_cell(
             heapcache_index: majit_ir::descr::next_call_descr_heapcache_index(),
             arg_types: arg_types.to_vec(),
             result_type,
+            result_class,
             result_signed,
             result_size,
             effect_info,
@@ -1167,5 +1183,67 @@ mod set_effect_bitstrings_tests {
         assert!(unanalyzed._write_descrs_fields.is_none());
         assert_eq!(unanalyzed, default_effect_info());
         assert_ne!(can_raise, unanalyzed);
+    }
+}
+
+#[cfg(test)]
+mod translated_result_class_tests {
+    use super::*;
+    use majit_ir::EffectInfo;
+
+    /// `descr.py:524-526 get_result_type()` returns the raw result char, and
+    /// `descr.py:665` keys the call-descr cache on it.  A descr rehydrated
+    /// from the translated image goes through
+    /// `make_call_descr_sized_with_translated_effect`, which normalises `'S'`
+    /// to `Type::Int` for the IR; the raw char has to survive alongside it,
+    /// because the resume path rebuilds a `BhCallDescr` off this descr
+    /// (`pyre-jit-trace`'s `state.rs`) and hands it to `bh_call_i`.
+    #[test]
+    fn a_translated_descr_keeps_its_raw_result_class() {
+        // Two ids so this test cannot be perturbed by a sibling publishing
+        // over the same dense slot.
+        let cell_id = 4242u32;
+        majit_ir::effectinfo::intern_translated_effect_info(cell_id, EffectInfo::default());
+
+        let singlefloat = make_call_descr_sized_with_translated_effect(
+            &[Type::Int],
+            Type::Int,
+            'S',
+            false,
+            4,
+            cell_id,
+        );
+        assert_eq!(singlefloat.as_call_descr().unwrap().result_class(), 'S');
+        // The normalised view is unchanged — `'S'` is an int-shaped result.
+        assert_eq!(
+            singlefloat.as_call_descr().unwrap().result_type(),
+            Type::Int
+        );
+
+        // Everything the pre-fix key compared is identical here — arg types,
+        // normalised result type, signedness, size, and the EffectInfo cell —
+        // so if the raw char were absent from the key this second mint would
+        // return the descr above and report `'S'`.
+        let plain_int = make_call_descr_sized_with_translated_effect(
+            &[Type::Int],
+            Type::Int,
+            'i',
+            false,
+            4,
+            cell_id,
+        );
+        assert_eq!(plain_int.as_call_descr().unwrap().result_class(), 'i');
+        assert!(!std::sync::Arc::ptr_eq(&singlefloat, &plain_int));
+
+        // Interning still holds for a repeat of the same raw char.
+        let again = make_call_descr_sized_with_translated_effect(
+            &[Type::Int],
+            Type::Int,
+            'S',
+            false,
+            4,
+            cell_id,
+        );
+        assert!(std::sync::Arc::ptr_eq(&singlefloat, &again));
     }
 }

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -6814,40 +6814,51 @@ fn descr_from_set_member(m: &majit_ir::effectinfo::DescrSetMember) -> SetMemberL
 /// whether to clear the bitstrings.  A half-populated EI would clear them
 /// while `extraeffect` still claims concrete effects, and the next
 /// `check_readonly_descr_field` would then read a `None` bitstring.
+/// `effectinfo.py:285-292` wildcard: the shape to fall back to whenever the
+/// concrete sets cannot be rebuilt faithfully.  Conservative in the sound
+/// direction — `has_random_effects()` makes every heap consumer assume the
+/// call touched everything.
+///
+/// Both raw-set families have to be cleared, not just the compacted one.
+/// `EffectInfo::default()` seeds every `_*_descrs_*` with `Some(vec![])` and
+/// serde skips them, so a deserialized EI arrives carrying empty concrete sets;
+/// leaving those behind states "writes nothing" — the bottom of the lattice —
+/// next to an `extraeffect` saying "writes everything".  Readers that consult
+/// the raw set directly (`writes_field_descr_by_identity`, which
+/// `OptHeap::force_from_effectinfo` uses before `compute_bitstrings` has run)
+/// would take the unsound half, and `compute_bitstrings` asserts the
+/// biconditional outright (`effectinfo.py:484-489`).
+fn degrade_to_random_effects(ei: &mut majit_ir::EffectInfo) {
+    ei.extraeffect = majit_ir::ExtraEffect::RandomEffects;
+    // effectinfo.py:364-365 — the wildcard forces can_collect.
+    ei.can_collect = true;
+    // `call.py:284-286` states it outright: "random_effects implies
+    // can_invalidate".  `effectinfo.py:271-273 MOST_GENERAL` is built with
+    // `can_invalidate=True`, and so is pyre's own `EffectInfo::MOST_GENERAL`.
+    // Without this a degraded EI is a shape upstream cannot construct —
+    // random effects with `check_can_invalidate()` still false — and
+    // `check_can_invalidate` is read on a path `has_random_effects()` does not
+    // cover (`heap.py:457-459`; `_seen_guard_not_invalidated` is otherwise only
+    // reset in `__init__`, `heap.py:341`), so a quasi-immutable guard would
+    // survive a call the wildcard says invalidates everything.
+    ei.can_invalidate = true;
+    ei._readonly_descrs_fields = None;
+    ei._write_descrs_fields = None;
+    ei._readonly_descrs_arrays = None;
+    ei._write_descrs_arrays = None;
+    ei._readonly_descrs_interiorfields = None;
+    ei._write_descrs_interiorfields = None;
+    ei.readonly_descrs_fields = None;
+    ei.write_descrs_fields = None;
+    ei.readonly_descrs_arrays = None;
+    ei.write_descrs_arrays = None;
+    ei.readonly_descrs_interiorfields = None;
+    ei.write_descrs_interiorfields = None;
+    ei.single_write_descr_array = None;
+}
+
 pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
-    // `effectinfo.py:285-292` wildcard: the shape to fall back to whenever
-    // the concrete sets cannot be rebuilt faithfully.  Conservative in the
-    // sound direction — `has_random_effects()` makes every heap consumer
-    // assume the call touched everything.
-    fn degrade(ei: &mut majit_ir::EffectInfo) {
-        ei.extraeffect = majit_ir::ExtraEffect::RandomEffects;
-        // effectinfo.py:364-365 — the wildcard forces can_collect.
-        ei.can_collect = true;
-        // `call.py:284-286` states it outright: "random_effects implies
-        // can_invalidate".  `effectinfo.py:271-273 MOST_GENERAL` is built with
-        // `can_invalidate=True`, and so is pyre's own
-        // `EffectInfo::MOST_GENERAL`.  Without this a degraded EI is a shape
-        // upstream cannot construct — random effects with
-        // `check_can_invalidate()` still false — and `check_can_invalidate`
-        // is read on a path `has_random_effects()` does not cover
-        // (`heap.py:457-459`; `_seen_guard_not_invalidated` is otherwise only
-        // reset in `__init__`, `heap.py:341`), so a quasi-immutable guard
-        // would survive a call the wildcard says invalidates everything.
-        ei.can_invalidate = true;
-        ei._readonly_descrs_fields = None;
-        ei._write_descrs_fields = None;
-        ei._readonly_descrs_arrays = None;
-        ei._write_descrs_arrays = None;
-        ei._readonly_descrs_interiorfields = None;
-        ei._write_descrs_interiorfields = None;
-        ei.readonly_descrs_fields = None;
-        ei.write_descrs_fields = None;
-        ei.readonly_descrs_arrays = None;
-        ei.write_descrs_arrays = None;
-        ei.readonly_descrs_interiorfields = None;
-        ei.write_descrs_interiorfields = None;
-        ei.single_write_descr_array = None;
-    }
+    use degrade_to_random_effects as degrade;
 
     // `descr_set_keys` is the build-process -> runtime-process wire channel
     // for the six raw sets skipped by serde.  Consume it here: after the
@@ -6952,18 +6963,11 @@ pub fn rehydrate_effect_info(ei: &mut majit_ir::EffectInfo) {
 /// descriptor reference EffectInfo deliberately keeps after compaction
 /// (`effectinfo.py:201-206`), so that singleton alone remains live.
 pub fn prepare_frozen_effect_info(ei: &mut majit_ir::EffectInfo) {
-    fn degrade(ei: &mut majit_ir::EffectInfo) {
-        ei.extraeffect = majit_ir::ExtraEffect::RandomEffects;
-        ei.can_collect = true;
-        ei.can_invalidate = true;
-        ei.readonly_descrs_fields = None;
-        ei.write_descrs_fields = None;
-        ei.readonly_descrs_arrays = None;
-        ei.write_descrs_arrays = None;
-        ei.readonly_descrs_interiorfields = None;
-        ei.write_descrs_interiorfields = None;
-        ei.single_write_descr_array = None;
-    }
+    // Shared with `rehydrate_effect_info` rather than spelled out again: the
+    // two had drifted, and this one was clearing only the compacted sets while
+    // the six `_*_descrs_*` kept the `Some(vec![])` that `EffectInfo::default()`
+    // seeds and serde skips.
+    use degrade_to_random_effects as degrade;
 
     let Some(keys) = ei.descr_set_keys.take() else {
         if ei.extraeffect != majit_ir::ExtraEffect::RandomEffects {
@@ -7116,6 +7120,62 @@ pub fn make_interior_field_descr(
     ));
     majit_ir::descr_registry::register_interior_field(interior.clone());
     interior
+}
+
+#[cfg(test)]
+mod degrade_shape_tests {
+    use super::*;
+
+    /// `effectinfo.py:149-162` makes the six raw sets `None` **iff** the EI is
+    /// `EF_RANDOM_EFFECTS`, and `compute_bitstrings` (`effectinfo.py:484-489`)
+    /// asserts that biconditional.  Both degrade paths therefore have to clear
+    /// the `_*_descrs_*` family as well as the compacted one — `serde(skip)`
+    /// plus `EffectInfo::default()` means a deserialized EI arrives with
+    /// `Some(vec![])` in all six, and an EI left holding those while
+    /// `extraeffect` says random effects reads as "writes nothing" through
+    /// `writes_field_descr_by_identity`, the unsound direction.
+    #[test]
+    fn both_degrade_paths_clear_the_raw_sets_too() {
+        for (label, prepare) in [
+            (
+                "prepare_frozen_effect_info",
+                prepare_frozen_effect_info as fn(&mut majit_ir::EffectInfo),
+            ),
+            (
+                "rehydrate_effect_info",
+                rehydrate_effect_info as fn(&mut majit_ir::EffectInfo),
+            ),
+        ] {
+            // A concrete classification with no key channel — the shape whose
+            // sets cannot be rebuilt, so it must fall back to the wildcard.
+            let mut ei = majit_ir::EffectInfo {
+                extraeffect: majit_ir::ExtraEffect::CanRaise,
+                descr_set_keys: None,
+                ..majit_ir::EffectInfo::default()
+            };
+            // The premise: `default()` really does seed the raw sets, so
+            // clearing them is not vacuous.
+            assert!(ei._write_descrs_fields.is_some(), "{label}: premise");
+
+            prepare(&mut ei);
+
+            assert_eq!(
+                ei.extraeffect,
+                majit_ir::ExtraEffect::RandomEffects,
+                "{label}"
+            );
+            assert!(ei._readonly_descrs_fields.is_none(), "{label}");
+            assert!(ei._write_descrs_fields.is_none(), "{label}");
+            assert!(ei._readonly_descrs_arrays.is_none(), "{label}");
+            assert!(ei._write_descrs_arrays.is_none(), "{label}");
+            assert!(ei._readonly_descrs_interiorfields.is_none(), "{label}");
+            assert!(ei._write_descrs_interiorfields.is_none(), "{label}");
+            assert!(ei.write_descrs_fields.is_none(), "{label}");
+            assert!(ei.single_write_descr_array.is_none(), "{label}");
+            assert!(ei.can_collect, "{label}");
+            assert!(ei.can_invalidate, "{label}");
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -7048,6 +7048,11 @@ pub fn make_call_descr_from_bh(bh: &majit_translate::jitcode::BhCallDescr) -> De
         majit_metainterp::make_call_descr_sized_with_translated_effect(
             &arg_types,
             result_type,
+            // `descr.py:524-526 get_result_type()` — the raw char, same as the
+            // non-translated arm below.  Dropping it here would collapse `'S'`
+            // onto `'i'` and `'L'` onto `'f'` for every descr that carries a
+            // translated EffectInfo id.
+            bh.result_type,
             bh.result_signed,
             result_size,
             translated_id,

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -843,6 +843,10 @@ fn rehydrated_call_descr_ref(bh: majit_translate::jitcode::BhCallDescr) -> majit
     majit_metainterp::make_call_descr_sized_with_translated_effect(
         &arg_types,
         result_type,
+        // `descr.py:524-526 get_result_type()` keeps the raw char, so a
+        // rehydrated descr reports `'S'`/`'L'` rather than the class its
+        // normalised `result_type` derives.
+        bh.result_type,
         bh.result_signed,
         bh.result_size,
         bh.translated_effect_info_id


### PR DESCRIPTION
Three commits on top of `origin/main`. Two of them fix defects a Codex parity review found in #1331 after it merged; the third removes dead code.

The CI parity review on #1331 reported `pass` but produced no report — its Codex run died on `401 token_invalidated`, and CodeRabbit had hit its review limit. Running the same checked-in prompt (`.github/codex-review-prompt.md`) locally surfaced both findings below.

### `jit: keep the raw result class on a translated call descr`

`make_call_descr_from_bh` normalises `BhCallDescr.result_type` to a `Type`, collapsing `'S'` (singlefloat) onto `Type::Int` and `'L'` onto `Type::Float`. The non-translated arm restores the raw char through `make_call_descr_full_with_result_class`; the arm taken when `translated_effect_info_id` is present did not — `MetaCallDescr` carried no `result_class` field and inherited the default accessor, which derives the char back from the normalised type. Every descr rehydrated from the translated image reported `'i'`/`'f'`.

`descr.py:524-526 get_result_type()` returns the raw char, and the resume path reads it back: `pyre-jit-trace`'s `state.rs` rebuilds a `BhCallDescr::from_arg_classes(cd.arg_classes(), cd.result_class(), …)` and hands it to `bh_call_i`.

The char also goes into `LLType::func_key`. `descr.py:665` keys the call-descr cache on it, and `make_call_descr_sized_with_cell` interns on that key — without it, an `'i'` mint sharing arg types, normalised result type, signedness, size and EffectInfo cell with an earlier `'S'` mint gets handed the `'S'` descr. Callers holding only a `Type` pass the char that `Type` derives, so their key partition is unchanged.

### `jit: clear the raw descr sets when a frozen EffectInfo degrades`

`prepare_frozen_effect_info`'s `degrade` was a near-copy of `rehydrate_effect_info`'s that had lost six lines: it cleared the six compacted `*_descrs_*` sets but left the six `_*_descrs_*` raw sets alone. Those are `serde(skip)` and `EffectInfo::default()` seeds each with `Some(vec![])`, so a deserialized EI keeps empty concrete sets through the degrade.

That is a shape `effectinfo.py:149-162` cannot construct — random effects beside concrete raw sets — and the halves disagree in the unsound direction. `writes_field_descr_by_identity` reads the raw set and answers "does not write this field", which `OptHeap::force_from_effectinfo` consults before `compute_bitstrings` has run, while `has_random_effects()` says the call wrote everything. `compute_bitstrings` does not catch it: its biconditional assert is guarded on `_readonly_descrs_fields.is_none()`, and `Some(vec![])` takes the other branch.

The complete version is hoisted to a shared `degrade_to_random_effects` so the two paths cannot drift apart again.

The review's own framing was that the degrade should be fail-stop rather than a substitution. That was not adopted: the substitution is the documented `effectinfo.py:285-292` wildcard, conservative in the sound direction, and its failures are already counted by the `descr_set_absent` / `descr_set_ambiguous` badness counters that `check.py` gates at zero. The actual defect was that this copy of it was incomplete.

### `jit(dynasm): delete the superseded x86 rd_locs fixup pass`

`allocate_unmapped_fail_arg_slots` had no call site anywhere in the workspace — only its definition and two `assemble_loop` comments saying it was not needed. It is not forgotten wiring but a superseded shape, and calling it would have been **wrong**: the live path stamps `rd_locs` in `append_guard_token_with_faillocs` from the regalloc `faillocs` in registers-first form, while the dead pass recomputed them from `opref_to_slot` as stack slots only (`slot + JITFRAME_FIXED_SIZE`), so it would have overwritten register positions with a stack-only encoding.

Its two feeder fields go with it: `GuardToken.opref_to_slot_snapshot` cloned an `IndexMap<OpRef, usize>` per guard token and was never read anywhere, and `GuardToken.fail_args` was read only inside the dead body. Both writes sat on the compile path. aarch64's `GuardToken` carries neither field, which is why this is x86-only.

### Verification

Each new test was checked against the defect it pins, by disabling one half at a time:

| Probe | Result |
| --- | --- |
| `MetaCallDescr::result_class` accessor override removed | reads `'i'` where `'S'` is expected |
| raw char dropped from `LLType::func_key` | the `'i'` mint comes back as the cached `'S'` descr |
| the six `_*_descrs_*` clears removed from the shared degrade | fails on the `prepare_frozen_effect_info` label alone — the pre-fix split |

`both_degrade_paths_clear_the_raw_sets_too` asserts its own premise (that `default()` really does seed the raw sets) so it cannot pass vacuously.

- `cargo test -p majit-ir -p majit-metainterp --features dynasm` — clean, including the new `a_translated_descr_keeps_its_raw_result_class`
- `cargo test -p majit-backend-dynasm` (native aarch64) 50+14+2 passed; `cargo check -p majit-backend-dynasm --target x86_64-apple-darwin` clean, with no newly-unused symbol from the deletion
- `cargo test -p pyre-jit-trace` for the degrade test was run with `PYRE_LLBC_SKIP_FINGERPRINT_CHECK=1`; the LLBC artefacts are stale on this tree and the test reads no field offsets
- `cargo fmt --check` clean

— *authored by Claude*
