### PR TITLE
check.py: drop the cpython reference on the 21 rows where cpython runs 3x slower than pyre

### DIFF
--- a/pyre/bench/synth/exception_bare_reraise_nested_outer.py
+++ b/pyre/bench/synth/exception_bare_reraise_nested_outer.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=12
+# pyre-check: skip-cpython
+# cpython 2.30s vs pyre 0.42s (5.5x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Bare `raise` inside a nested handler whose re-raise must reach the OUTER
 # handler, exercised under a bridge resume that lands inside the inner handler.
 #

--- a/pyre/bench/synth/fast_local_swap.py
+++ b/pyre/bench/synth/fast_local_swap.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=11
+# pyre-check: skip-cpython
+# cpython 1.33s vs pyre 0.24s (5.5x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.
 N = 6764311

--- a/pyre/bench/synth/global_reassign.py
+++ b/pyre/bench/synth/global_reassign.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=19
+# pyre-check: skip-cpython
+# cpython 2.16s vs pyre 0.25s (8.6x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Exercises JIT global-cache invalidation, for both cell kinds.
 #
 # `run_int` reads a module global reassigned to another int between calls: the

--- a/pyre/bench/synth/if_else_jump_forward.py
+++ b/pyre/bench/synth/if_else_jump_forward.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=11
+# pyre-check: skip-cpython
+# cpython 2.92s vs pyre 0.28s (10.4x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.
 N = 31509157

--- a/pyre/bench/synth/inheritance_dispatch.py
+++ b/pyre/bench/synth/inheritance_dispatch.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=18
+# pyre-check: skip-cpython
+# cpython 1.89s vs pyre 0.37s (5.1x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.
 N = 12693996

--- a/pyre/bench/synth/kept_stack_aliased_swap_boxed.py
+++ b/pyre/bench/synth/kept_stack_aliased_swap_boxed.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=11
+# pyre-check: skip-cpython
+# cpython 2.67s vs pyre 0.23s (11.6x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Two operand-stack temps holding heap ints (>= 256) are swapped across a
 # `goto_if_not` branch guard, a shape a per-jitcode merge-color map is prone
 # to COLLAPSE (alias both slots onto one color).  The flat-free boxed-int

--- a/pyre/bench/synth/kept_stack_boxed_in_handler.py
+++ b/pyre/bench/synth/kept_stack_boxed_in_handler.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=12
+# pyre-check: skip-cpython
+# cpython 1.62s vs pyre 0.21s (7.7x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # A boxed-int conditional-expression keeps a heap int (>= 256) live on the
 # operand stack across a `goto_if_not` branch guard INSIDE an exception
 # handler body.  The kept-stack guard's not-taken arm resumes at a PC the

--- a/pyre/bench/synth/kept_stack_depth_gt1_heap.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1_heap.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=19
+# pyre-check: skip-cpython
+# cpython 2.40s vs pyre 0.64s (3.8x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Depth > 1 kept-stack branch guards whose kept / merge slot is a HEAP int
 # (>= 256, a LOAD_CONST rather than the inline LoadSmallInt).  Sibling of
 # `kept_stack_depth_gt1.py`, which keeps only small-int slots (11, 5, 2); here

--- a/pyre/bench/synth/list_pop_append.py
+++ b/pyre/bench/synth/list_pop_append.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=22
+# pyre-check: skip-cpython
+# cpython 1.72s vs pyre 0.38s (4.5x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Both `append` and `pop` now fold, so this reads 3.2x on dynasm and 4.3x on
 # cranelift where it read 73.5x here before the pop fold -- and the loop that
 # reached 188.0x on windows-latest is the same one. The ceiling is twice the

--- a/pyre/bench/synth/list_setslice.py
+++ b/pyre/bench/synth/list_setslice.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=1.4
+# pyre-check: skip-cpython
+# cpython 1.07s vs pyre 0.15s (7.1x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Re-recorded at twice the slowest native ratio: macOS 0.2x, Ubuntu 0.7x,
 # Windows 0.5x.  The lower ceiling also lowers the derived speed floor.
 # Benchmark: integer list setslice (per-strategy ops)

--- a/pyre/bench/synth/load_fast_check.py
+++ b/pyre/bench/synth/load_fast_check.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=9.5
+# pyre-check: skip-cpython
+# cpython 2.68s vs pyre 0.24s (11.2x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.
 N = 35553509

--- a/pyre/bench/synth/math_log_trig_hot.py
+++ b/pyre/bench/synth/math_log_trig_hot.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=14
+# pyre-check: skip-cpython
+# cpython 1.70s vs pyre 0.46s (3.7x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # RPython lowers the guarded `ll_math_log/cos/sin` bodies to raw float calls.
 # Keep all inputs in their hot domains so the walker emits those CALL_F ops
 # and the temporary W_FloatObject results can virtualize.

--- a/pyre/bench/synth/math_sqrt_hot.py
+++ b/pyre/bench/synth/math_sqrt_hot.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=11
+# pyre-check: skip-cpython
+# cpython 3.46s vs pyre 0.29s (11.9x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # A hot `math.sqrt(x)` loop.  The walker specializes the call
 # (`try_walker_specialize_math_sqrt`) to a domain-guarded pure
 # `CALL_F(sqrt_nonneg_jit)` (ll_math.rs `ll_math_sqrt` -> `sqrt_nonneg`,

--- a/pyre/bench/synth/p2_local_result_bridge.py
+++ b/pyre/bench/synth/p2_local_result_bridge.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=28
+# pyre-check: skip-cpython
+# cpython 2.16s vs pyre 0.50s (4.3x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Regression guard for P2 root result seeding when the residual-call result is
 # stored into a root local slot.  The late type flip forces a guard failure in
 # the inlined callee chain; the root stores the returned value in `x` before

--- a/pyre/bench/synth/raise_bare_class_slot_kinds.py
+++ b/pyre/bench/synth/raise_bare_class_slot_kinds.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=25
+# pyre-check: skip-cpython
+# cpython 4.45s vs pyre 0.21s (21.2x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # A bare `raise X` of an exception kind whose `descr_init` writes flattened
 # slots beyond `args_w` — `interp_exceptions.py:496-499 W_StopIteration`
 # (`value`), `:810-812 W_NameError` and `:1134-1137 W_AttributeError` (`name` /

--- a/pyre/bench/synth/short_circuit_boxed_int_cross_fn.py
+++ b/pyre/bench/synth/short_circuit_boxed_int_cross_fn.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=16
+# pyre-check: skip-cpython
+# cpython 2.26s vs pyre 0.43s (5.3x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Cross-function kept-stack short-circuit where a small-int function is traced
 # BEFORE a structurally-identical heap-int (>= 256) function.
 #

--- a/pyre/bench/synth/short_circuit_value_kept_stack.py
+++ b/pyre/bench/synth/short_circuit_value_kept_stack.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=19
+# pyre-check: skip-cpython
+# cpython 2.57s vs pyre 0.67s (3.8x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Exercises short-circuit `and` / `or` in VALUE context inside a hot loop.
 #
 # `x = (i % 7) and (i + 3)` lowers to `BINARY_OP %; COPY 1; TO_BOOL;

--- a/pyre/bench/synth/short_circuit_value_local_kept.py
+++ b/pyre/bench/synth/short_circuit_value_local_kept.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=20
+# pyre-check: skip-cpython
+# cpython 2.63s vs pyre 0.72s (3.7x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # Depth-1 kept-stack short-circuit with a BARE loop-varying local on the left
 # and a loop-invariant constant on the right.
 #

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -1,4 +1,7 @@
 # pyre-check: max-pypy-ratio=20
+# pyre-check: skip-cpython
+# cpython 4.98s vs pyre 0.29s (17.2x on the ubuntu runner), and it is not
+# gated on — only pypy is.
 # A hot loop FOLLOWED by a try/except whose handler `return`s.  The
 # `return`-from-`except` cleanup compiles to `SWAP 2; POP_EXCEPT;
 # RETURN_VALUE` (the SWAP exchanges the return value with the saved

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -3679,8 +3679,18 @@ def main():
         # 0.13s on the linux and macos runners and 0.39s on the windows one, so
         # pyre reads faster than pypy there. This is the bench that sets the
         # floor divisor's lower bound among the non-synthetic ones.
-        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       1,       5,       1,       5)
-        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       0.5,     5,       1,       5,    wasm_float_tol=True)
+        #
+        # Neither carries a cpython gate, and an absent gate is what stops
+        # cpython being spawned for the row at all. On the ubuntu runner
+        # cpython takes 11.38s against the slowest backend's 0.45s here and
+        # 4.42s against 0.85s on nbody, so the gates they used to carry (1x,
+        # and 0.5x/1x) sat 25x and 3x inside their margin while the 5x pypy
+        # gate beside them reads 1.6x-2.6x: pypy trips on the smaller
+        # regression of the two in both rows. Those two spawns were three
+        # quarters of every cpython second this file spends outside the
+        # synthetic suite.
+        chk.run_bench("spectral_norm",  f"{B}/spectral_norm.py",       15,       None,    5,       None,    5)
+        chk.run_bench("nbody",          f"{B}/nbody.py",               10,       None,    5,       None,    5,    wasm_float_tol=True)
         chk.run_bench("fannkuch",       f"{B}/fannkuch.py",            30,       1,       5,       2,       15)
         # The branchy-inlined-callee guard (gh#343) lives in the synthetic parity
         # suite as bridge_branchy_callee.py, gated against pypy by

--- a/pyre/pyre-jit-trace/src/trace_opcode.rs
+++ b/pyre/pyre-jit-trace/src/trace_opcode.rs
@@ -3469,33 +3469,6 @@ impl MIFrame {
 /// between the int and float fast paths in the retired compare helper,
 /// but reads the ConcreteValue variant directly so the check does not
 /// have to allocate an intermediate w_int/w_float box.
-/// Trace-side mirror of `pyre_interpreter::eval::check_exc_match_against`
-/// (`pyre/pyre-interpreter/src/eval.rs:81-130`).  Kept structurally
-/// identical so the recorded boolean matches the interpreter's
-/// concrete computation — including tuple-of-types, builtin-function
-/// alias, str-named exception kinds, and `is_type` + MRO fallback.
-///
-/// SAFETY: `exc_value` and `exc_type` must be non-null PyObjectRefs
-/// owned by the running interpreter for the duration of this call.
-unsafe fn trace_check_exc_match_against(
-    exc_value: pyre_object::PyObjectRef,
-    exc_type: pyre_object::PyObjectRef,
-) -> bool {
-    // pyopcode.py:1040 — bool-returning mirror of
-    // `pyre_interpreter::eval::check_exc_match_against`. The validity
-    // gate at pyopcode.py:1034-1039 lives in
-    // `pyre_interpreter::eval::validate_check_exc_match_class` and runs
-    // BEFORE this helper in the BC handler, matching the interpreter's
-    // split. PyPy's `@jit.unroll_safe cmp_exc_match` inlines both into
-    // the trace and emits a guard for the `raise oefmt(...)` arm;
-    // pyre's residual-call ABI keeps `bool` so the raise/guard split
-    // lives on the caller side.
-    let Some(w_exc_class) = pyre_interpreter::typedef::r#type(exc_value) else {
-        return false;
-    };
-    pyre_interpreter::baseobjspace::exception_match(w_exc_class.as_ptr(), exc_type)
-}
-
 fn classify_concrete(cv: ConcreteValue) -> (bool, bool) {
     match cv {
         ConcreteValue::Int(_) => (true, false),


### PR DESCRIPTION
Two independent changes.

### 1. `check.py`: stop spawning cpython where it is 3x+ slower than pyre

Parsing the full results table from a green ubuntu `pyre/check.py` run, cpython
is at least 3x slower than the *slowest* pyre backend on **21 of the 399 rows
that run it** — together **62.8s of the 96.7s** the file spends on cpython.

| | rows | cpython s | ratio range |
|---|---|---|---|
| synthetic fixtures | 19 | 46.9s | 3.7x – 21.2x |
| `spectral_norm`, `nbody` | 2 | 15.8s | 5.2x, 25.3x |

**The 19 fixtures** each get a `# pyre-check: skip-cpython` header plus a
one-line note recording the two timings and the ratio, in the same form
`residual_raise_except_resume.py` already uses. None of them was gated against
cpython — only pypy.

**`spectral_norm` and `nbody`** get `None` in both cpython gate columns; an
absent cpython gate is what stops the row spawning cpython at all. The gates
they carried (1x, and 0.5x/1x) sat 25x and 3x inside their margin, while the 5x
pypy gate they keep reads 1.6x–2.6x — pypy trips on the smaller regression of
the two in both rows.

**What is given up.** `skip-cpython` sets `cpython_output = None`, so the 19
fixtures lose the cpython/pypy output cross-check; pypy remains their oracle and
their pypy perf gates are untouched. The two benches lose nothing measurable —
their pypy gate is strictly tighter than the cpython gate that was dropped.

### 2. `jit-trace`: remove the unreferenced `check_exc_match` mirror

`trace_check_exc_match_against` in `trace_opcode.rs` had no callers anywhere in
the workspace, and its doc comment cited a line range that no longer holds the
helper it named. Deleted; the live path is
`pyre_interpreter::eval::check_exc_match_against`.

### Verification

Local, on a rebuilt tree:

| | dynasm | cranelift |
|---|---|---|
| `check.py --synthetic-only` | 430/430 | 430/430 |
| `check.py --no-synthetic` | 10/10 | 10/10 |

All 19 fixtures report `cpython   skip (opt)`; `spectral_norm` and `nbody`
report `-` in the cpython column and still pass their pypy gates.
