### PR TITLE
majit: remove transient allcations from regalloc walk

### DIFF
--- a/majit/majit-backend-dynasm/src/regalloc.rs
+++ b/majit/majit-backend-dynasm/src/regalloc.rs
@@ -2396,6 +2396,8 @@ impl<'a> RegAlloc<'a> {
     pub fn walk_operations(&mut self) -> Vec<RegAllocOp> {
         let operations: &'a [Op] = self.operations;
         let inputargs: &'a [InputArg] = self.inputargs;
+        // Take the lowering plan so dispatch can borrow each LirOp without cloning it.
+        let j2_ops = std::mem::take(&mut self.j2_ops);
         let mut output = Vec::with_capacity(operations.len());
 
         for (i, op) in operations.iter().enumerate() {
@@ -2431,9 +2433,9 @@ impl<'a> RegAlloc<'a> {
             // The dynasm backend now enters through the j2-style lowered
             // operation. The legacy opcode dispatch below is only a guard
             // rail if `_prepare` did not produce a matching plan entry.
-            if let Some(j2_op) = self.j2_ops.get(i).cloned() {
-                self._dispatch_j2(&j2_op, op, i, &mut output);
-                self._free_j2_op_vars(&j2_op, op);
+            if let Some(j2_op) = j2_ops.get(i) {
+                self._dispatch_j2(j2_op, op, i, &mut output);
+                self._free_j2_op_vars(j2_op, op);
             } else {
                 self._dispatch_legacy(op, i, &mut output);
                 self._free_op_vars(op);
@@ -2476,32 +2478,27 @@ impl<'a> RegAlloc<'a> {
         }
     }
 
+    /// Free a lowered operation's uses, fail args, and result in order.
     fn _free_j2_op_vars(&mut self, j2_op: &LirOp, raw_op: &Op) {
-        let mut uses = Vec::new();
-        let mut fail_uses = Vec::new();
-        let mut def = None;
-        let mut def_tp = raw_op.opcode.result_type();
-
-        match j2_op {
+        let (def, def_tp) = match j2_op {
             LirOp::Label { args } | LirOp::Jump { args } | LirOp::Finish { args } => {
-                uses.extend(args.iter().copied());
+                self._possibly_free_j2_vars(args.iter().copied());
+                (None, raw_op.opcode.result_type())
             }
             LirOp::IntBin { dst, lhs, rhs, .. } | LirOp::IntCmp { dst, lhs, rhs, .. } => {
-                uses.push(*lhs);
-                uses.push(*rhs);
-                def = Some(*dst);
-                def_tp = Type::Int;
+                self._possibly_free_j2_vars([*lhs, *rhs].into_iter());
+                (Some(*dst), Type::Int)
             }
             LirOp::IntUnary { dst, arg, .. } => {
-                uses.push(*arg);
-                def = Some(*dst);
-                def_tp = Type::Int;
+                self._possibly_free_j2_vars(std::iter::once(*arg));
+                (Some(*dst), Type::Int)
             }
             LirOp::Guard {
                 args, fail_args, ..
             } => {
-                uses.extend(args.iter().copied());
-                fail_uses.extend(fail_args.iter().copied());
+                self._possibly_free_j2_vars(args.iter().copied());
+                self._possibly_free_j2_vars(fail_args.iter().copied());
+                (None, raw_op.opcode.result_type())
             }
             LirOp::Load {
                 dst,
@@ -2512,12 +2509,14 @@ impl<'a> RegAlloc<'a> {
                 size,
                 ..
             } => {
-                uses.push(*base);
-                uses.extend(offset.iter().copied());
-                uses.extend(index.iter().copied());
-                uses.extend(scale.iter().copied());
-                uses.extend(size.iter().copied());
-                def = Some(*dst);
+                self._possibly_free_j2_vars(
+                    std::iter::once(*base)
+                        .chain(offset.iter().copied())
+                        .chain(index.iter().copied())
+                        .chain(scale.iter().copied())
+                        .chain(size.iter().copied()),
+                );
+                (Some(*dst), raw_op.opcode.result_type())
             }
             LirOp::Store {
                 base,
@@ -2528,16 +2527,19 @@ impl<'a> RegAlloc<'a> {
                 size,
                 ..
             } => {
-                uses.push(*base);
-                uses.extend(offset.iter().copied());
-                uses.extend(index.iter().copied());
-                uses.extend(scale.iter().copied());
-                uses.push(*value);
-                uses.extend(size.iter().copied());
+                self._possibly_free_j2_vars(
+                    std::iter::once(*base)
+                        .chain(offset.iter().copied())
+                        .chain(index.iter().copied())
+                        .chain(scale.iter().copied())
+                        .chain(std::iter::once(*value))
+                        .chain(size.iter().copied()),
+                );
+                (None, raw_op.opcode.result_type())
             }
             LirOp::Call { dst, args, .. } => {
-                uses.extend(args.iter().copied());
-                def = *dst;
+                self._possibly_free_j2_vars(args.iter().copied());
+                (*dst, raw_op.opcode.result_type())
             }
             LirOp::Opcode {
                 dst,
@@ -2545,24 +2547,27 @@ impl<'a> RegAlloc<'a> {
                 fail_args,
                 ..
             } => {
-                uses.extend(args.iter().copied());
-                fail_uses.extend(fail_args.iter().copied());
-                def = *dst;
+                self._possibly_free_j2_vars(args.iter().copied());
+                self._possibly_free_j2_vars(fail_args.iter().copied());
+                (*dst, raw_op.opcode.result_type())
             }
-        }
-
-        for arg in uses.into_iter().chain(fail_uses) {
-            if !arg.is_constant() && !arg.is_none() {
-                let tp = self.tp(arg);
-                self.possibly_free_var(arg, tp);
-            }
-        }
+        };
         if let Some(dst) = def
             && !dst.is_none()
             && !dst.is_constant()
             && def_tp != Type::Void
         {
             self.possibly_free_var(dst, def_tp);
+        }
+    }
+
+    /// Free lowered operands in order without materializing a temporary use list.
+    fn _possibly_free_j2_vars(&mut self, uses: impl Iterator<Item = OpRef>) {
+        for arg in uses {
+            if !arg.is_constant() && !arg.is_none() {
+                let tp = self.tp(arg);
+                self.possibly_free_var(arg, tp);
+            }
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary

Remove avoidable allocations and clones from the register-allocation walk

- Take ownership of `j2_ops` once at the start of `walk_operations`.
- Borrow each `LirOp` during dispatch instead of cloning it.
- Iterate over uses and fail arguments directly in `_free_j2_op_vars`, dropping the temporary `uses` and `fail_uses` vectors.
- Extract the shared operand-freeing logic into `_possibly_free_j2_vars`.
- Preserve the existing use → fail arguments → result freeing order and the register-allocation policy.


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [x] Auto-review section 1 is clear. This check is mandatory.
  - [x] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [ ] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved internal operation processing efficiency by reducing unnecessary data copying.
  * Streamlined variable cleanup while preserving existing behavior across supported operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->