### PR TITLE
interpreter: follow interp___import__ for the cached absolute-import fast path

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -1427,6 +1427,9 @@ fn derive_program_metadata(
                 // bare-leaf fallback) resolve either spelling.
                 let leaf = name.rsplit("::").next().unwrap_or(&name).to_string();
                 let is_rbigint = name == "rbigint::RBigInt" || name.ends_with("::rbigint::RBigInt");
+                let is_tuple_object = leaf == "W_TupleObject"
+                    && (name == "tupleobject::W_TupleObject"
+                        || name.ends_with("::tupleobject::W_TupleObject"));
                 let rows: Vec<(String, String)> = fields
                     .iter()
                     .enumerate()
@@ -1443,6 +1446,16 @@ fn derive_program_metadata(
                         // field offset/size to the backend.
                         let field_ty = if is_rbigint && fname == "_digits" {
                             "[i64]".to_string()
+                        } else if is_tuple_object && fname == "wrappeditems" {
+                            // tupleobject.py:376-390: wrappeditems is the
+                            // immutable `list` / translated
+                            // `GcArray(OBJECTPTR)`. Rust's `*mut ItemsBlock`
+                            // is only its physical storage spelling; exposing
+                            // that wrapper makes getitem dispatch on a
+                            // classdef-less instance. Preserve the upstream
+                            // field shape while Charon's ExactLayout continues
+                            // to provide the real pointer-sized offset.
+                            "[*mut PyObject]".to_string()
                         } else {
                             tyref_to_ast_string(&f.ty, llbc)
                         };
@@ -2148,6 +2161,7 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             || !lo.next_call_results.is_empty()
             || !lo.checked_arith_call_results.is_empty()
             || !lo.option_try_sites.is_empty()
+            || !lo.slice_index_range_sites.is_empty()
             || !lo.slice_index_rangeto_sites.is_empty()
         {
             // The exception-link transforms run on a simplified graph,
@@ -2161,6 +2175,12 @@ fn lower_unstructured_with_static_addrs_and_attrs(
             simplify_lowered_graph(&mut lo.graph, struct_field_attrs, false);
         }
         let mut tail_forwarded_returns = 0usize;
+        if !lo.slice_index_range_sites.is_empty() {
+            crate::front::slice_index::rewire_slice_index_range_sites(
+                &mut lo.graph,
+                &lo.slice_index_range_sites,
+            );
+        }
         if !lo.slice_index_rangeto_sites.is_empty() {
             crate::front::slice_index::rewire_slice_index_rangeto_sites(
                 &mut lo.graph,
@@ -2953,6 +2973,10 @@ struct Lowering<'a> {
     /// recognizer. The end's unsigned coloring is captured from MIR here,
     /// before the operand can become a block inputarg.
     slice_index_rangeto_sites: Vec<crate::front::slice_index::SliceIndexRangeToSite>,
+    /// Full `Range { start, end }` aggregates retained for the orthodox
+    /// `getslice(start, stop)` rewrite.  The same aggregate may also be a
+    /// `range_iter` candidate; both passes are consumer-gated.
+    slice_index_range_sites: Vec<crate::front::slice_index::SliceIndexRangeSite>,
     /// `RangeInclusive::contains(&self, &x)` call sites paired with the
     /// `new` sites above by the `front::range_contains` post-pass (see
     /// [`crate::front::range_contains::RangeContainsSite`]).
@@ -3186,6 +3210,7 @@ impl<'a> Lowering<'a> {
             range_inclusive_new_sites: Vec::new(),
             range_iter_new_sites: Vec::new(),
             slice_index_rangeto_sites: Vec::new(),
+            slice_index_range_sites: Vec::new(),
             range_contains_sites: Vec::new(),
             unwrap_or_sites: Vec::new(),
             unwrap_sites: Vec::new(),
@@ -4924,6 +4949,13 @@ impl<'a> Lowering<'a> {
                             start: arg_vars[0].clone(),
                             end: arg_vars[1].clone(),
                         });
+                    self.slice_index_range_sites.push(
+                        crate::front::slice_index::SliceIndexRangeSite {
+                            range_result: res.clone(),
+                            start: arg_vars[0].clone(),
+                            end: arg_vars[1].clone(),
+                        },
+                    );
                 }
                 if owner_path.as_slice() == ["core", "ops", "range"]
                     && ctor_name == "RangeTo"
@@ -7235,6 +7267,9 @@ impl<'a> Lowering<'a> {
                     && (self.is_workspace_index_call(&reg)
                         || (self.is_vec_index_call(&reg)
                             && (!is_vec_index_mut_regular(&reg, self.llbc)
+                                || add_dest_used_only_as_single_deref(self.body, dest_local)))
+                        || (self.is_slice_scalar_index_call(&reg, second_arg_ty.as_ref())
+                            && (!self.is_slice_scalar_index_mut_call(&reg)
                                 || add_dest_used_only_as_single_deref(self.body, dest_local))))
                 {
                     let res = self
@@ -7920,9 +7955,35 @@ impl<'a> Lowering<'a> {
                 // allocation, not an alias of the source.)
                 let (segments, method_hint) = if args.len() == 1 && is_slice_to_vec(&segments) {
                     (vec!["list".to_string()], None)
+                } else if args.len() == 2
+                    && crate::front::str_find::is_rpython_str_slice_prefix(&segments)
+                {
+                    // PyPy's `name[:dotindex]` reaches ordinary
+                    // `rtype_getslice`.  Rust's core string index body is
+                    // opaque to Charon, so route the exact interpreter
+                    // compatibility helper through the existing marker that
+                    // becomes `getslice(s, 0, stop)` after annotation.
+                    (vec!["__getslice_rangeto".to_string()], None)
                 } else {
                     (segments, method_hint)
                 };
+                // PyPy's `__import__` fast path uses the signed
+                // `str.find` operation directly.  Replace the
+                // interpreter's native compatibility helper with that same
+                // existing RPython method lowering.
+                if crate::front::str_find::is_rpython_str_find_char(&segments) {
+                    let index = crate::front::str_find::emit_rpython_str_find_char(
+                        &mut self.graph,
+                        bb_id,
+                        &args,
+                    )
+                    .map_err(LowerError::Unsupported)?;
+                    self.local_var[dest_local] = Some(index);
+                    let target_bb = self.block_id[target];
+                    let link_args = self.edge_args(mir_bb, target)?;
+                    self.graph.set_goto(bb_id, target_bb, link_args);
+                    return Ok(());
+                }
                 // `vec![e0, …, eN]` lowers to
                 // `box_assume_init_into_vec_unsafe(box [e0, …, eN])`, whose
                 // `box_assume_init` primitive is unregistered, so the legacy
@@ -9797,6 +9858,35 @@ impl<'a> Lowering<'a> {
     /// same gate is shared with the deferred-write liveness pre-pass.
     fn is_vec_index_call(&self, reg: &RegularCall) -> bool {
         is_vec_index_regular(reg, self.llbc)
+    }
+
+    /// `core::slice::index::SliceIndex<usize>::index(_mut)` — scalar slice
+    /// indexing.  RPython represents the same operation directly as
+    /// `getitem` / `setitem`; the Rust trait shim is opaque in Charon and must
+    /// not survive as a residual call.  Range implementations share the same
+    /// name, so accept only the literal `usize` second argument; RangeFrom /
+    /// RangeTo continue through `front::slice_index`'s bounded getslice
+    /// rewrites.
+    fn is_slice_scalar_index_call(&self, reg: &RegularCall, index_ty: Option<&TyRef>) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        let is_index = self.llbc.fn_by_id(*id).is_some_and(|fd| {
+            matches!(
+                fd.item_meta.name_path().as_str(),
+                "core::slice::index::<Impl>::index" | "core::slice::index::<Impl>::index_mut"
+            )
+        });
+        is_index && index_ty.and_then(|ty| self.tyref_literal_uint_atom(ty)) == Some("Usize")
+    }
+
+    fn is_slice_scalar_index_mut_call(&self, reg: &RegularCall) -> bool {
+        let CallKind::Fun(FunId::Regular { id }) = &reg.kind else {
+            return false;
+        };
+        self.llbc
+            .fn_by_id(*id)
+            .is_some_and(|fd| fd.item_meta.name_path() == "core::slice::index::<Impl>::index_mut")
     }
 
     /// `<[T]>::swap(s, a, b)` (`core::slice::<Impl>::swap`) — an
@@ -12693,7 +12783,8 @@ impl<'a> Lowering<'a> {
         Ok(true)
     }
 
-    /// Lower an infallible numeric widening `<i64 as From<u32>>::from(x)`
+    /// Lower an infallible numeric widening `<i64 as From<u32>>::from(x)` or
+    /// `<usize as From<bool>>::from(flag)`
     /// (`core::convert::num::<Impl>::from`, Opaque in the LLBC) to an
     /// identity bind on the destination local.  `From` is implemented in
     /// core only for value-preserving conversions, and a
@@ -12740,13 +12831,17 @@ impl<'a> Lowering<'a> {
         let Some(src) = fd.signature.inputs.first() else {
             return Ok(false);
         };
-        // Only smaller-than-word unsigned sources widen as a
-        // value-preserving identity in the word carrier (the same gate
-        // `try_lower_usize_try_from` uses).
-        if !matches!(
+        // Smaller-than-word unsigned sources widen as a value-preserving
+        // identity in the word carrier (the same gate
+        // `try_lower_usize_try_from` uses). Bool is the RPython BoolRepr
+        // sibling: converting it to Unsigned emits `cast_bool_to_uint`
+        // through the ordinary `r_uint` builtin (`rbool.py:63-74`).
+        let src_is_bool = tyref_to_value_type(src, self.llbc) == ValueType::Bool;
+        let src_is_small_uint = matches!(
             self.tyref_literal_uint_atom(src),
             Some("U8" | "U16" | "U32")
-        ) {
+        );
+        if !src_is_small_uint && !src_is_bool {
             return Ok(false);
         }
         // Destination must be a word-sized integer carrier.  A signed
@@ -12768,7 +12863,25 @@ impl<'a> Lowering<'a> {
         }
         let arg = arg.clone();
         let bb_id = self.block_id[mir_bb];
-        if dest_signed_word {
+        if src_is_bool && dest_unsigned_word {
+            let res = self
+                .graph
+                .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+            self.graph.block_mut(bb_id).operations.push(SpaceOperation {
+                result: Some(res.clone()),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: ["rpython", "rlib", "rarithmetic", "r_uint"]
+                            .into_iter()
+                            .map(str::to_string)
+                            .collect(),
+                    },
+                    args: vec![arg],
+                    result_ty: ValueType::Unsigned,
+                },
+            });
+            self.local_var[dest_local] = Some(res);
+        } else if dest_signed_word {
             let res = self
                 .graph
                 .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -25208,13 +25321,13 @@ mod tests {
         );
     }
 
-    /// The real site is in bounds: its `args: &[PyObjectRef]` is shared and
-    /// therefore cannot change length between the two `ArrayLen` reads. The
-    /// frontend has no shared-reference/immutability notion with which to
-    /// prove that fact, however, so the sound static-length fold declines.
+    /// PyPy carries `call_function` arguments as one dynamic RPython list.
+    /// The Rust interpreter must not reintroduce a fixed-array RangeTo index
+    /// shortcut into this core dispatcher: core's array index body is opaque
+    /// to Charon and blocks the dispatcher from two-phase translation.
     #[test]
     #[ignore]
-    fn call_function_impl_result_declines_residual_array_index() {
+    fn call_function_impl_result_has_no_residual_array_index() {
         use crate::model::OpKind;
         let path = concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -25242,13 +25355,111 @@ mod tests {
         };
         assert_eq!(
             calls_path(&["core", "array", "<Impl>", "index"]),
-            1,
-            "unproved RangeTo array index remains residual"
+            0,
+            "PyPy-shaped dynamic arguments must not leave a fixed-array index"
         );
         assert_eq!(
             calls_path(&["__getslice_rangeto"]),
             0,
             "no RangeTo getslice call is planted without an immutability proof"
+        );
+    }
+
+    /// PyPy's `_match_keywords` indexes its small signature and argument
+    /// lists with ordinary `getitem`.  The Rust `SliceIndex<usize>` shim must
+    /// lower to the same ArrayRead shape instead of remaining an opaque core
+    /// call that prevents the whole builtin-call chain from being annotated.
+    #[test]
+    #[ignore]
+    fn bind_kwargs_scalar_slice_indexes_lower_to_array_reads() {
+        use crate::model::{CallTarget, OpKind};
+        let path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../build/llbc/pyre-interpreter.ullbc"
+        );
+        let llbc = Llbc::load(path).expect("load real LLBC");
+        let graph = super::lower_function(&llbc, "bind_kwargs_to_signature")
+            .expect("lower bind_kwargs_to_signature");
+
+        let residual_scalar_indexes: Vec<_> = graph
+            .blocks
+            .iter()
+            .flat_map(|b| &b.operations)
+            .filter(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[
+                        "core".to_string(),
+                        "slice".to_string(),
+                        "index".to_string(),
+                        "<Impl>".to_string(),
+                        "index".to_string(),
+                    ]
+                )
+            })
+            .collect();
+        assert_eq!(
+            residual_scalar_indexes.len(),
+            0,
+            "scalar SliceIndex<usize> calls must become getitem operations"
+        );
+        assert!(
+            graph
+                .blocks
+                .iter()
+                .flat_map(|b| &b.operations)
+                .any(|op| { matches!(op.kind, OpKind::ArrayRead { .. }) }),
+            "keyword matching should contain the lowered signature getitems"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &["__getslice_range".to_string()]
+                )
+            }),
+            "the proven *args tail Range should use the annotated getslice marker"
+        );
+        assert!(
+            !graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[
+                        "core".to_string(),
+                        "convert".to_string(),
+                        "num".to_string(),
+                        "<Impl>".to_string(),
+                        "from".to_string(),
+                    ]
+                )
+            }),
+            "bool-to-usize offset conversion must not remain an opaque core call"
+        );
+        assert!(
+            graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments == &[
+                        "rpython".to_string(),
+                        "rlib".to_string(),
+                        "rarithmetic".to_string(),
+                        "r_uint".to_string(),
+                    ]
+                )
+            }),
+            "From<bool> for usize should use RPython's cast_bool_to_uint path"
         );
     }
 }

--- a/majit/majit-translate/src/front/mod.rs
+++ b/majit/majit-translate/src/front/mod.rs
@@ -89,6 +89,7 @@ pub(crate) mod saturating_sub;
 pub mod semantic;
 pub(crate) mod slice_first;
 pub(crate) mod slice_index;
+pub(crate) mod str_find;
 pub mod typestr;
 
 pub use semantic::{AstGraphOptions, SemanticFunction, SemanticProgram, StructFieldRegistry};

--- a/majit/majit-translate/src/front/slice_index.rs
+++ b/majit/majit-translate/src/front/slice_index.rs
@@ -103,6 +103,39 @@ pub(crate) struct SliceIndexRangeToSite {
     pub end: Variable,
 }
 
+/// A recognized `Range { start, end }` aggregate feeding a residual scalar
+/// slice-index call.  This is RPython's ordinary `getslice(start, stop)`
+/// shape; bounds are retained separately so the transparent Rust range shell
+/// can be removed after the consumer proof succeeds.
+#[derive(Clone)]
+pub(crate) struct SliceIndexRangeSite {
+    pub range_result: Variable,
+    pub start: Variable,
+    pub end: Variable,
+}
+
+pub(crate) fn rewire_slice_index_range_sites(
+    graph: &mut FunctionGraph,
+    sites: &[SliceIndexRangeSite],
+) -> usize {
+    let mut rewritten = 0;
+    for site in sites {
+        let outcome = rewire_one_slice_index_site(
+            graph,
+            &site.range_result,
+            SliceIndexBounds::Range {
+                start: &site.start,
+                end: &site.end,
+            },
+        );
+        match outcome {
+            Ok(()) => rewritten += 1,
+            Err(_decline) => {}
+        }
+    }
+    rewritten
+}
+
 /// Rewrite every captured `RangeFrom` aggregate that feeds exactly one
 /// residual `slice::index` call into an orthodox `getslice(slice, start,
 /// None)` op. Fail-safe: a site that does not match the expected single-
@@ -152,9 +185,19 @@ pub(crate) fn rewire_slice_index_rangeto_sites(
 
 #[derive(Clone, Copy)]
 enum SliceIndexBounds<'a> {
-    RangeFrom { start: &'a Variable },
-    MinusOne { end: &'a Variable },
-    StaticLength { end: &'a Variable },
+    RangeFrom {
+        start: &'a Variable,
+    },
+    Range {
+        start: &'a Variable,
+        end: &'a Variable,
+    },
+    MinusOne {
+        end: &'a Variable,
+    },
+    StaticLength {
+        end: &'a Variable,
+    },
 }
 
 fn rewire_one_slice_index_rangeto_site(
@@ -232,7 +275,9 @@ fn rewire_one_slice_index_site(
         &index_result,
         matches!(
             bounds,
-            SliceIndexBounds::MinusOne { .. } | SliceIndexBounds::StaticLength { .. }
+            SliceIndexBounds::Range { .. }
+                | SliceIndexBounds::MinusOne { .. }
+                | SliceIndexBounds::StaticLength { .. }
         ),
     ) {
         return Err(format!(
@@ -273,6 +318,21 @@ fn rewire_one_slice_index_site(
                 ));
             }
         }
+        SliceIndexBounds::Range { start, end } => {
+            if !graph_defines(graph, start) || !graph_defines(graph, end) {
+                return Err(format!("{name}: Range bounds are not defined in the graph"));
+            }
+            if !range_end_matches_slice_len(graph, end, &slice) {
+                return Err(format!(
+                    "{name}: Range end is not the indexed slice length — declining"
+                ));
+            }
+            if !range_start_is_bounded_by_end(graph, start, end, &range) {
+                return Err(format!(
+                    "{name}: Range start <= end is not proven at the index — declining"
+                ));
+            }
+        }
         SliceIndexBounds::MinusOne { end } => {
             if !graph_defines(graph, end) {
                 return Err(format!("{name}: MinusOne end is not defined in the graph"));
@@ -299,7 +359,10 @@ fn rewire_one_slice_index_site(
     //    place: the range can be carried by a block link without being read
     //    by an operation, and sweeping its sole defining ctor would orphan
     //    that link-carried value.
-    if matches!(bounds, SliceIndexBounds::RangeFrom { .. }) {
+    if matches!(
+        bounds,
+        SliceIndexBounds::RangeFrom { .. } | SliceIndexBounds::Range { .. }
+    ) {
         for b in &mut graph.blocks {
             b.operations.retain(|op| {
                 let is_field_write =
@@ -333,6 +396,18 @@ fn rewire_one_slice_index_site(
         })
         .ok_or_else(|| format!("{name}: slice::index op vanished before rewrite"))?;
     match bounds {
+        SliceIndexBounds::Range { start, end } => {
+            graph.blocks[rb].operations[ri] = SpaceOperation {
+                result: Some(index_result),
+                kind: OpKind::Call {
+                    target: CallTarget::FunctionPath {
+                        segments: vec!["__getslice_range".to_string()],
+                    },
+                    args: vec![slice, start.clone(), end.clone()],
+                    result_ty: index_result_ty,
+                },
+            };
+        }
         SliceIndexBounds::MinusOne { .. } | SliceIndexBounds::StaticLength { .. } => {
             let (segments, args) = match bounds {
                 SliceIndexBounds::MinusOne { .. } => {
@@ -343,6 +418,7 @@ fn rewire_one_slice_index_site(
                     vec![slice, end.clone()],
                 ),
                 SliceIndexBounds::RangeFrom { .. } => unreachable!(),
+                SliceIndexBounds::Range { .. } => unreachable!(),
             };
             graph.blocks[rb].operations[ri] = SpaceOperation {
                 result: Some(index_result),
@@ -397,9 +473,11 @@ fn resolve_block_alias(graph: &FunctionGraph, var: &Variable) -> Option<Variable
         var: &Variable,
         seen: &mut std::collections::HashSet<Variable>,
         reachable: &std::collections::HashSet<crate::model::BlockId>,
-    ) -> Option<Variable> {
+    ) -> Result<Option<Variable>, ()> {
         if !seen.insert(var.clone()) {
-            return None;
+            // A loop-carried pass-through contributes no new definition.  A
+            // non-cyclic incoming edge must still establish the unique root.
+            return Ok(None);
         }
         // MIR is not strict SSA: an operation result can also be threaded
         // through a later block as an inputarg under the same Variable name.
@@ -411,7 +489,7 @@ fn resolve_block_alias(graph: &FunctionGraph, var: &Variable) -> Option<Variable
             .flat_map(|b| &b.operations)
             .any(|op| op.result.as_ref() == Some(var))
         {
-            return Some(var.clone());
+            return Ok(Some(var.clone()));
         }
         let Some((block_id, arg_index)) = graph.blocks.iter().find_map(|b| {
             b.inputargs
@@ -419,7 +497,7 @@ fn resolve_block_alias(graph: &FunctionGraph, var: &Variable) -> Option<Variable
                 .position(|arg| arg == var)
                 .map(|i| (b.id, i))
         }) else {
-            return Some(var.clone());
+            return Ok(Some(var.clone()));
         };
         let incoming: Option<Vec<Variable>> = graph
             .blocks
@@ -434,15 +512,34 @@ fn resolve_block_alias(graph: &FunctionGraph, var: &Variable) -> Option<Variable
                     .cloned()
             })
             .collect();
-        let incoming: Vec<Variable> = incoming?
+        let incoming: Vec<Variable> = incoming
+            .ok_or(())?
             .into_iter()
             .filter(|candidate| candidate != var)
             .collect();
-        let first = incoming.first()?.clone();
-        if incoming.iter().any(|candidate| candidate != &first) {
-            return None;
+        if incoming.is_empty() {
+            // Function entry arguments are authoritative external roots.
+            return (block_id == graph.startblock)
+                .then(|| var.clone())
+                .map(Some)
+                .ok_or(());
         }
-        visit(graph, &first, seen, reachable)
+        let mut root: Option<Variable> = None;
+        for candidate in incoming {
+            let mut branch_seen = seen.clone();
+            let Some(candidate_root) = visit(graph, &candidate, &mut branch_seen, reachable)?
+            else {
+                continue;
+            };
+            if root
+                .as_ref()
+                .is_some_and(|established| established != &candidate_root)
+            {
+                return Err(());
+            }
+            root = Some(candidate_root);
+        }
+        Ok(root)
     }
     visit(
         graph,
@@ -450,6 +547,8 @@ fn resolve_block_alias(graph: &FunctionGraph, var: &Variable) -> Option<Variable
         &mut std::collections::HashSet::new(),
         &reachable_from_start(graph),
     )
+    .ok()
+    .flatten()
 }
 
 fn const_int_value(graph: &FunctionGraph, var: &Variable) -> Option<i64> {
@@ -910,6 +1009,163 @@ fn minus_one_end_matches(graph: &FunctionGraph, end: &Variable, slice: &Variable
         .flat_map(|b| &b.operations)
         .any(|op| op.result.as_ref() == Some(&rhs) && matches!(&op.kind, OpKind::ConstInt(1)));
     has_len && has_one
+}
+
+/// Prove that the Range stop is exactly `len(slice)`.  Rust's slice index
+/// would reject an oversized stop while RPython's list-slice helper clamps,
+/// so the rewrite is admitted only when both expressions denote the same
+/// length read (following block aliases).
+fn range_end_matches_slice_len(graph: &FunctionGraph, end: &Variable, slice: &Variable) -> bool {
+    let Some(end) = resolve_block_alias(graph, end) else {
+        return false;
+    };
+    let Some(slice) = resolve_block_alias(graph, slice) else {
+        return false;
+    };
+    graph.blocks.iter().flat_map(|b| &b.operations).any(|op| {
+        op.result.as_ref() == Some(&end)
+            && matches!(
+                &op.kind,
+                OpKind::ArrayLen { base, .. }
+                    if resolve_block_alias(graph, base).as_ref() == Some(&slice)
+            )
+    })
+}
+
+/// Prove `start <= end` on the control-flow edge reaching this Range index.
+/// A zero start is immediate because the Range element type is `usize`;
+/// otherwise require a dominating comparison edge.  This preserves Rust's
+/// bounds semantics while lowering the already-proven slice to RPython's
+/// `getslice` operation.
+fn range_start_is_bounded_by_end(
+    graph: &FunctionGraph,
+    start: &Variable,
+    end: &Variable,
+    range: &Variable,
+) -> bool {
+    if const_int_value(graph, start) == Some(0) {
+        return true;
+    }
+    let Some(start_root) = resolve_block_alias(graph, start) else {
+        return false;
+    };
+    let Some(end_root) = resolve_block_alias(graph, end) else {
+        return false;
+    };
+    let Some(index_block) = graph.blocks.iter().find_map(|b| {
+        b.operations.iter().find_map(|op| {
+            (is_slice_range_index_call(&op.kind)
+                && matches!(&op.kind, OpKind::Call { args, .. } if args.get(1) == Some(range)))
+            .then_some(b.id)
+        })
+    }) else {
+        return false;
+    };
+
+    let mut dominators: std::collections::HashMap<
+        crate::model::BlockId,
+        std::collections::HashSet<crate::model::BlockId>,
+    > = graph
+        .blocks
+        .iter()
+        .map(|b| (b.id, graph.blocks.iter().map(|x| x.id).collect()))
+        .collect();
+    dominators.insert(graph.startblock, [graph.startblock].into_iter().collect());
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for block in &graph.blocks {
+            if block.id == graph.startblock {
+                continue;
+            }
+            let preds = graph.predecessors(block.id);
+            if preds.is_empty() {
+                continue;
+            }
+            let mut next: std::collections::HashSet<_> = dominators[&preds[0]].clone();
+            for pred in &preds[1..] {
+                next.retain(|id| dominators[pred].contains(id));
+            }
+            next.insert(block.id);
+            if next != dominators[&block.id] {
+                dominators.insert(block.id, next);
+                changed = true;
+            }
+        }
+    }
+
+    for candidate in &graph.blocks {
+        if candidate.id == index_block || !dominators[&index_block].contains(&candidate.id) {
+            continue;
+        }
+        let Some(crate::model::ExitSwitch::Value(switch)) = &candidate.exitswitch else {
+            continue;
+        };
+        let Some((op, lhs, rhs)) = comparison_variables_for_switch(graph, switch) else {
+            continue;
+        };
+        let Some(lhs) = resolve_block_alias(graph, &lhs) else {
+            continue;
+        };
+        let Some(rhs) = resolve_block_alias(graph, &rhs) else {
+            continue;
+        };
+        let success = match (lhs == start_root, rhs == end_root, op.as_str()) {
+            (true, true, "le" | "lt") => Some(true),
+            (true, true, "gt" | "ge") => Some(false),
+            _ if lhs == end_root && rhs == start_root => match op.as_str() {
+                "ge" | "gt" => Some(true),
+                "lt" | "le" => Some(false),
+                _ => None,
+            },
+            _ => None,
+        };
+        let Some(success) = success else { continue };
+        let mut true_target = None;
+        let mut false_target = None;
+        for link in &candidate.exits {
+            match link.exitcase {
+                Some(crate::model::ExitCase::Bool(true)) => true_target = Some(link.target),
+                Some(crate::model::ExitCase::Bool(false)) => false_target = Some(link.target),
+                _ => {}
+            }
+        }
+        let (Some(true_target), Some(false_target)) = (true_target, false_target) else {
+            continue;
+        };
+        let proving = if success { true_target } else { false_target };
+        let rejecting = if success { false_target } else { true_target };
+        if reaches_without_retesting(graph, proving, index_block, candidate.id)
+            && !reaches_without_retesting(graph, rejecting, index_block, candidate.id)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn comparison_variables_for_switch(
+    graph: &FunctionGraph,
+    switch: &Variable,
+) -> Option<(String, Variable, Variable)> {
+    let switch = resolve_block_alias(graph, switch)?;
+    let (op, lhs, rhs) = graph
+        .blocks
+        .iter()
+        .flat_map(|b| &b.operations)
+        .find_map(|candidate| {
+            if candidate.result.as_ref() != Some(&switch) {
+                return None;
+            }
+            match &candidate.kind {
+                OpKind::BinOp { op, lhs, rhs, .. } => Some((op.clone(), lhs.clone(), rhs.clone())),
+                OpKind::UnaryOp { op, operand, .. } if op == "bool" => {
+                    comparison_variables_for_switch(graph, operand)
+                }
+                _ => None,
+            }
+        })?;
+    Some((op, lhs, rhs))
 }
 
 /// `true` when `kind` is a residual `core::slice::index::<Impl>::index` call —

--- a/majit/majit-translate/src/front/str_find.rs
+++ b/majit/majit-translate/src/front/str_find.rs
@@ -1,0 +1,93 @@
+//! Pyre's signed string-find compatibility call to RPython lowering.
+//!
+//! PyPy reads the dot position as a Signed and slices on it:
+//! `dotindex = name.find(".")` then `name[:dotindex]`
+//! (`pypy/module/_frozen_importlib/interp_import.py:76-79`).
+//! Rust's standard `str::find` returns `Option<usize>` and has no start
+//! argument, so the interpreter exposes an exact native compatibility helper.
+//! During source translation this adapter replaces that helper with the
+//! existing RPython `str.find(char, start) -> Signed` method operation.
+
+use crate::flowspace::model::Variable;
+use crate::model::{CallTarget, FunctionGraph, OpKind, SpaceOperation, ValueType};
+
+pub(crate) fn is_rpython_str_find_char(segments: &[String]) -> bool {
+    segments.ends_with(&["importing".to_string(), "rpython_str_find_char".to_string()])
+}
+
+pub(crate) fn is_rpython_str_slice_prefix(segments: &[String]) -> bool {
+    segments.ends_with(&[
+        "importing".to_string(),
+        "rpython_str_slice_prefix".to_string(),
+    ])
+}
+
+pub(crate) fn emit_rpython_str_find_char(
+    graph: &mut FunctionGraph,
+    block: crate::model::BlockId,
+    args: &[Variable],
+) -> Result<Variable, String> {
+    if args.len() != 3 {
+        return Err(format!(
+            "rpython_str_find_char expected string, char, and start, got {} arguments",
+            args.len()
+        ));
+    }
+    let result = graph.alloc_value_var();
+    graph.block_mut(block).operations.push(SpaceOperation {
+        result: Some(result.clone()),
+        kind: OpKind::Call {
+            target: CallTarget::method("find", None),
+            args: args.to_vec(),
+            result_ty: ValueType::Int,
+        },
+    });
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recognizes_only_the_importing_compatibility_helper() {
+        let path = |parts: &[&str]| parts.iter().map(|s| s.to_string()).collect::<Vec<_>>();
+        assert!(is_rpython_str_find_char(&path(&[
+            "pyre_interpreter",
+            "importing",
+            "rpython_str_find_char"
+        ])));
+        assert!(!is_rpython_str_find_char(&path(&[
+            "core", "str", "<Impl>", "find"
+        ])));
+        assert!(is_rpython_str_slice_prefix(&path(&[
+            "pyre_interpreter",
+            "importing",
+            "rpython_str_slice_prefix"
+        ])));
+    }
+
+    #[test]
+    fn emits_the_existing_signed_rpython_find_method() {
+        let mut graph = FunctionGraph::new("test_rpython_str_find_char");
+        let block = graph.startblock;
+        let haystack = graph
+            .push_op_var(block, OpKind::ConstStr(b"a.b".to_vec()), true)
+            .unwrap();
+        let needle = graph
+            .push_op_var(block, OpKind::ConstStr(b".".to_vec()), true)
+            .unwrap();
+        let start = graph.push_op_var(block, OpKind::ConstInt(1), true).unwrap();
+        let result =
+            emit_rpython_str_find_char(&mut graph, block, &[haystack, needle, start]).unwrap();
+
+        assert!(graph.block(block).operations.iter().any(|op| matches!(
+            &op.kind,
+            OpKind::Call {
+                target: CallTarget::Method { name, .. },
+                result_ty: ValueType::Int,
+                ..
+            } if op.result.as_ref() == Some(&result) && name == "find"
+        )));
+    }
+}

--- a/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
+++ b/majit/majit-translate/src/translator/rtyper/flowspace_adapter.rs
@@ -1641,6 +1641,14 @@ pub fn translate_op(
                             result,
                         )]);
                     }
+                    if segments.as_slice() == ["__getslice_range"] && arg_hls.len() == 3 {
+                        // slice, start, end -> getslice(slice, start, end)
+                        // The frontend plants this marker only after proving
+                        // `0 <= start <= end == len(slice)`, preserving Rust's
+                        // checked Range semantics before entering RPython's
+                        // startstop list-slice lowering.
+                        return Ok(vec![FlowspaceOp::new("getslice", arg_hls, result)]);
+                    }
                     // `[v; N]` array literal.  `front::mir` lowers
                     // `Rvalue::Repeat` to the `__array_repeat` synthetic
                     // carrying `(fill, count)` whenever the count decodes.

--- a/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/lltypesystem/rstr.rs
@@ -49,6 +49,7 @@ use crate::flowspace::model::{
     SpaceOperation, Variable,
 };
 use crate::flowspace::pygraph::PyGraph;
+use crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID;
 use crate::translator::rtyper::error::TyperError;
 use crate::translator::rtyper::lltypesystem::lltype::{
     _ptr, _ptr_obj, Array, ForwardReference, LowLevelType, LowLevelValue, MallocFlavor, Ptr,
@@ -9248,6 +9249,493 @@ pub(crate) fn build_ll_strconcat_helper_graph(
     Ok(helper_pygraph_from_graph(
         graph,
         vec!["s1".to_string(), "s2".to_string()],
+        func,
+    ))
+}
+
+/// `LLHelpers._ll_stringslice` plus the three wrappers selected by
+/// `AbstractStringRepr.rtype_getslice` (`rstr.py:432-437`,
+/// `lltypesystem/rstr.py:844-876`).  The start/stop wrapper preserves the
+/// identity-bearing `jit.we_are_jitted()` branch: the JIT arm clamps
+/// `stop > len`, while the no-JIT arm returns `s1` for `[0:>=len]`.
+pub(crate) fn build_ll_stringslice_helper_graph(
+    rtyper: &crate::translator::rtyper::rtyper::RPythonTyper,
+    name: &str,
+    ptr_lltype: LowLevelType,
+    kind: crate::translator::rtyper::rtyper::SliceKind,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rtyper::SliceKind;
+
+    let core_name = if ptr_lltype == STRPTR.clone() {
+        "_ll_stringslice"
+    } else {
+        "_ll_unicode_slice"
+    };
+    let core_name_owned = core_name.to_string();
+    let ptr_for_core = ptr_lltype.clone();
+    let core = rtyper.lowlevel_helper_function_with_builder(
+        core_name.to_string(),
+        vec![
+            ptr_lltype.clone(),
+            LowLevelType::Signed,
+            LowLevelType::Signed,
+        ],
+        ptr_lltype.clone(),
+        move |_rtyper, _args, _result| {
+            build_ll_stringslice_core_helper_graph(&core_name_owned, ptr_for_core)
+        },
+    )?;
+    let core_ptr = sub_helper_funcptr_constant(rtyper, &core)?;
+
+    let s = variable_with_lltype("s1", ptr_lltype.clone());
+    let start = variable_with_lltype("start", LowLevelType::Signed);
+    let stop = variable_with_lltype("stop", LowLevelType::Signed);
+    let inputargs = match kind {
+        SliceKind::MinusOne => vec![Hlvalue::Variable(s.clone())],
+        SliceKind::StartOnly => vec![
+            Hlvalue::Variable(s.clone()),
+            Hlvalue::Variable(start.clone()),
+        ],
+        SliceKind::StartStop => vec![
+            Hlvalue::Variable(s.clone()),
+            Hlvalue::Variable(start.clone()),
+            Hlvalue::Variable(stop.clone()),
+        ],
+    };
+    let startblock = Block::shared(inputargs);
+    let result = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(result),
+    );
+    let chars_ty = chars_array_ptr_lltype_from_strptr(&ptr_lltype)?;
+    let chars = variable_with_lltype("chars", chars_ty);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getsubstruct",
+        vec![
+            Hlvalue::Variable(s.clone()),
+            constant_with_lltype(ConstValue::byte_str("chars"), LowLevelType::Void),
+        ],
+        Hlvalue::Variable(chars.clone()),
+    ));
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "getarraysize",
+        vec![Hlvalue::Variable(chars)],
+        Hlvalue::Variable(length.clone()),
+    ));
+
+    let signed = |n| constant_with_lltype(ConstValue::Int(n), LowLevelType::Signed);
+    match kind {
+        SliceKind::MinusOne => {
+            let end = variable_with_lltype("end", LowLevelType::Signed);
+            startblock.borrow_mut().operations.push(SpaceOperation::new(
+                "int_sub",
+                vec![Hlvalue::Variable(length), signed(1)],
+                Hlvalue::Variable(end.clone()),
+            ));
+            emit_stringslice_direct_call(
+                &startblock,
+                core_ptr,
+                s,
+                signed(0),
+                Hlvalue::Variable(end),
+                &graph.returnblock,
+                ptr_lltype,
+            );
+        }
+        SliceKind::StartOnly => emit_stringslice_direct_call(
+            &startblock,
+            core_ptr,
+            s,
+            Hlvalue::Variable(start),
+            Hlvalue::Variable(length),
+            &graph.returnblock,
+            ptr_lltype,
+        ),
+        SliceKind::StartStop => {
+            // lltypesystem/rstr.py:862-871 preserves both arms of
+            // `jit.we_are_jitted()`: the JIT arm clamps only `stop > len`,
+            // while the no-JIT arm returns `s1` unchanged for `[0:>=len]`.
+            let call_s = variable_with_lltype("s1", ptr_lltype.clone());
+            let call_start = variable_with_lltype("start", LowLevelType::Signed);
+            let call_stop = variable_with_lltype("stop", LowLevelType::Signed);
+            let call_block = Block::shared(vec![
+                Hlvalue::Variable(call_s.clone()),
+                Hlvalue::Variable(call_start.clone()),
+                Hlvalue::Variable(call_stop.clone()),
+            ]);
+
+            let jit_s = variable_with_lltype("s1", ptr_lltype.clone());
+            let jit_start = variable_with_lltype("start", LowLevelType::Signed);
+            let jit_stop = variable_with_lltype("stop", LowLevelType::Signed);
+            let jit_len = variable_with_lltype("length", LowLevelType::Signed);
+            let jit_block = Block::shared(vec![
+                Hlvalue::Variable(jit_s.clone()),
+                Hlvalue::Variable(jit_start.clone()),
+                Hlvalue::Variable(jit_stop.clone()),
+                Hlvalue::Variable(jit_len.clone()),
+            ]);
+            let jit_too_far = variable_with_lltype("stop_too_far", LowLevelType::Bool);
+            jit_block.borrow_mut().operations.push(SpaceOperation::new(
+                "int_gt",
+                vec![
+                    Hlvalue::Variable(jit_stop.clone()),
+                    Hlvalue::Variable(jit_len.clone()),
+                ],
+                Hlvalue::Variable(jit_too_far.clone()),
+            ));
+            jit_block.borrow_mut().exitswitch = Some(Hlvalue::Variable(jit_too_far));
+            jit_block.closeblock(vec![
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(jit_s.clone()),
+                        Hlvalue::Variable(jit_start.clone()),
+                        Hlvalue::Variable(jit_len),
+                    ],
+                    Some(call_block.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(true),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(jit_s),
+                        Hlvalue::Variable(jit_start),
+                        Hlvalue::Variable(jit_stop),
+                    ],
+                    Some(call_block.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(false),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+            ]);
+
+            let nojit_s = variable_with_lltype("s1", ptr_lltype.clone());
+            let nojit_start = variable_with_lltype("start", LowLevelType::Signed);
+            let nojit_stop = variable_with_lltype("stop", LowLevelType::Signed);
+            let nojit_len = variable_with_lltype("length", LowLevelType::Signed);
+            let nojit_block = Block::shared(vec![
+                Hlvalue::Variable(nojit_s.clone()),
+                Hlvalue::Variable(nojit_start.clone()),
+                Hlvalue::Variable(nojit_stop.clone()),
+                Hlvalue::Variable(nojit_len.clone()),
+            ]);
+            let reaches_end = variable_with_lltype("stop_reaches_end", LowLevelType::Bool);
+            nojit_block
+                .borrow_mut()
+                .operations
+                .push(SpaceOperation::new(
+                    "int_ge",
+                    vec![
+                        Hlvalue::Variable(nojit_stop.clone()),
+                        Hlvalue::Variable(nojit_len.clone()),
+                    ],
+                    Hlvalue::Variable(reaches_end.clone()),
+                ));
+            let full_s = variable_with_lltype("s1", ptr_lltype.clone());
+            let full_start = variable_with_lltype("start", LowLevelType::Signed);
+            let full_len = variable_with_lltype("length", LowLevelType::Signed);
+            let full_block = Block::shared(vec![
+                Hlvalue::Variable(full_s.clone()),
+                Hlvalue::Variable(full_start.clone()),
+                Hlvalue::Variable(full_len.clone()),
+            ]);
+            nojit_block.borrow_mut().exitswitch = Some(Hlvalue::Variable(reaches_end));
+            nojit_block.closeblock(vec![
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(nojit_s.clone()),
+                        Hlvalue::Variable(nojit_start.clone()),
+                        Hlvalue::Variable(nojit_len),
+                    ],
+                    Some(full_block.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(true),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(nojit_s),
+                        Hlvalue::Variable(nojit_start),
+                        Hlvalue::Variable(nojit_stop),
+                    ],
+                    Some(call_block.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(false),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+            ]);
+            let starts_at_zero = variable_with_lltype("starts_at_zero", LowLevelType::Bool);
+            full_block.borrow_mut().operations.push(SpaceOperation::new(
+                "int_eq",
+                vec![Hlvalue::Variable(full_start.clone()), signed(0)],
+                Hlvalue::Variable(starts_at_zero.clone()),
+            ));
+            full_block.borrow_mut().exitswitch = Some(Hlvalue::Variable(starts_at_zero));
+            full_block.closeblock(vec![
+                Link::new(
+                    vec![Hlvalue::Variable(full_s.clone())],
+                    Some(graph.returnblock.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(true),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(full_s),
+                        Hlvalue::Variable(full_start),
+                        Hlvalue::Variable(full_len),
+                    ],
+                    Some(call_block.clone()),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(false),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+            ]);
+
+            startblock.borrow_mut().exitswitch =
+                Some(Hlvalue::Constant(Constant::with_concretetype(
+                    ConstValue::SpecTag(WE_ARE_JITTED_TAG_ID),
+                    LowLevelType::Bool,
+                )));
+            startblock.closeblock(vec![
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(s.clone()),
+                        Hlvalue::Variable(start.clone()),
+                        Hlvalue::Variable(stop.clone()),
+                        Hlvalue::Variable(length.clone()),
+                    ],
+                    Some(jit_block),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(true),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+                Link::new(
+                    vec![
+                        Hlvalue::Variable(s),
+                        Hlvalue::Variable(start),
+                        Hlvalue::Variable(stop),
+                        Hlvalue::Variable(length),
+                    ],
+                    Some(nojit_block),
+                    Some(constant_with_lltype(
+                        ConstValue::Bool(false),
+                        LowLevelType::Bool,
+                    )),
+                )
+                .into_ref(),
+            ]);
+            emit_stringslice_direct_call(
+                &call_block,
+                core_ptr,
+                call_s,
+                Hlvalue::Variable(call_start),
+                Hlvalue::Variable(call_stop),
+                &graph.returnblock,
+                ptr_lltype,
+            );
+        }
+    }
+
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    let args = match kind {
+        SliceKind::MinusOne => vec!["s1"],
+        SliceKind::StartOnly => vec!["s1", "start"],
+        SliceKind::StartStop => vec!["s1", "start", "stop"],
+    };
+    Ok(helper_pygraph_from_graph(
+        graph,
+        args.into_iter().map(str::to_string).collect(),
+        func,
+    ))
+}
+
+fn emit_stringslice_direct_call(
+    block: &crate::flowspace::model::BlockRef,
+    funcptr: Constant,
+    s: Variable,
+    start: Hlvalue,
+    stop: Hlvalue,
+    returnblock: &crate::flowspace::model::BlockRef,
+    ptr_lltype: LowLevelType,
+) {
+    let result = variable_with_lltype("result", ptr_lltype);
+    block.borrow_mut().operations.push(SpaceOperation::new(
+        "direct_call",
+        vec![
+            Hlvalue::Constant(funcptr),
+            Hlvalue::Variable(s),
+            start,
+            stop,
+        ],
+        Hlvalue::Variable(result.clone()),
+    ));
+    block.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(result)],
+            Some(returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+}
+
+fn build_ll_stringslice_core_helper_graph(
+    name: &str,
+    ptr_lltype: LowLevelType,
+) -> Result<PyGraph, TyperError> {
+    use crate::translator::rtyper::rmodel::{gc_flavor_const, lowlevel_type_const};
+
+    let chars_ty = chars_array_ptr_lltype_from_strptr(&ptr_lltype)?;
+    let LowLevelType::Ptr(chars_ptr) = &chars_ty else {
+        return Err(TyperError::message(
+            "stringslice chars must be an array pointer",
+        ));
+    };
+    let PtrTarget::Array(array) = &chars_ptr.TO else {
+        return Err(TyperError::message(
+            "stringslice chars target must be an array",
+        ));
+    };
+    let copy_op = if array.OF == LowLevelType::Char {
+        "copystrcontent"
+    } else {
+        "copyunicodecontent"
+    };
+    let struct_ty = struct_lltype_from_strptr(&ptr_lltype)?;
+    let s = variable_with_lltype("s1", ptr_lltype.clone());
+    let start = variable_with_lltype("start", LowLevelType::Signed);
+    let stop = variable_with_lltype("stop", LowLevelType::Signed);
+    let startblock = Block::shared(vec![
+        Hlvalue::Variable(s.clone()),
+        Hlvalue::Variable(start.clone()),
+        Hlvalue::Variable(stop.clone()),
+    ]);
+    let result = variable_with_lltype("result", ptr_lltype.clone());
+    let mut graph = FunctionGraph::with_return_var(
+        name.to_string(),
+        startblock.clone(),
+        Hlvalue::Variable(result),
+    );
+    let length = variable_with_lltype("length", LowLevelType::Signed);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_sub",
+        vec![Hlvalue::Variable(stop), Hlvalue::Variable(start.clone())],
+        Hlvalue::Variable(length.clone()),
+    ));
+    let negative = variable_with_lltype("negative", LowLevelType::Bool);
+    startblock.borrow_mut().operations.push(SpaceOperation::new(
+        "int_lt",
+        vec![
+            Hlvalue::Variable(length.clone()),
+            constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+        ],
+        Hlvalue::Variable(negative.clone()),
+    ));
+    let alloc_s = variable_with_lltype("s1", ptr_lltype.clone());
+    let alloc_start = variable_with_lltype("start", LowLevelType::Signed);
+    let alloc_len = variable_with_lltype("length", LowLevelType::Signed);
+    let alloc_block = Block::shared(vec![
+        Hlvalue::Variable(alloc_s.clone()),
+        Hlvalue::Variable(alloc_start.clone()),
+        Hlvalue::Variable(alloc_len.clone()),
+    ]);
+    startblock.borrow_mut().exitswitch = Some(Hlvalue::Variable(negative));
+    startblock.closeblock(vec![
+        Link::new(
+            vec![
+                Hlvalue::Variable(s.clone()),
+                Hlvalue::Variable(start.clone()),
+                constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+            ],
+            Some(alloc_block.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(true),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+        Link::new(
+            vec![
+                Hlvalue::Variable(s),
+                Hlvalue::Variable(start),
+                Hlvalue::Variable(length),
+            ],
+            Some(alloc_block.clone()),
+            Some(constant_with_lltype(
+                ConstValue::Bool(false),
+                LowLevelType::Bool,
+            )),
+        )
+        .into_ref(),
+    ]);
+    let newstr = variable_with_lltype("newstr", ptr_lltype.clone());
+    alloc_block
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            "malloc_varsize",
+            vec![
+                lowlevel_type_const(struct_ty),
+                gc_flavor_const()?,
+                Hlvalue::Variable(alloc_len.clone()),
+            ],
+            Hlvalue::Variable(newstr.clone()),
+        ));
+    alloc_block
+        .borrow_mut()
+        .operations
+        .push(SpaceOperation::new(
+            copy_op,
+            vec![
+                Hlvalue::Variable(alloc_s),
+                Hlvalue::Variable(newstr.clone()),
+                Hlvalue::Variable(alloc_start),
+                constant_with_lltype(ConstValue::Int(0), LowLevelType::Signed),
+                Hlvalue::Variable(alloc_len),
+            ],
+            Hlvalue::Constant(Constant::with_concretetype(
+                ConstValue::None,
+                LowLevelType::Void,
+            )),
+        ));
+    alloc_block.closeblock(vec![
+        Link::new(
+            vec![Hlvalue::Variable(newstr)],
+            Some(graph.returnblock.clone()),
+            None,
+        )
+        .into_ref(),
+    ]);
+    let func = GraphFunc::new(
+        name.to_string(),
+        Constant::new(ConstValue::Dict(Default::default())),
+    );
+    graph.func = Some(func.clone());
+    Ok(helper_pygraph_from_graph(
+        graph,
+        vec!["s1".to_string(), "start".to_string(), "stop".to_string()],
         func,
     ))
 }

--- a/majit/majit-translate/src/translator/rtyper/rstr.rs
+++ b/majit/majit-translate/src/translator/rtyper/rstr.rs
@@ -58,10 +58,10 @@ use crate::translator::rtyper::lltypesystem::rstr::{
     build_ll_strconcat_helper_graph, build_ll_streq_helper_graph,
     build_ll_strfasthash_helper_graph, build_ll_strhash_helper_graph,
     build_ll_string_casefold_helper_graph, build_ll_string_isxxx_helper_graph,
-    build_ll_stritem_checked_helper_graph, build_ll_stritem_helper_graph,
-    build_ll_stritem_nonneg_checked_helper_graph, build_ll_stritem_nonneg_helper_graph,
-    build_ll_strlen_helper_graph, build_ll_unichr2str_helper_graph, const_str_cache_llstr,
-    null_str_ptr,
+    build_ll_stringslice_helper_graph, build_ll_stritem_checked_helper_graph,
+    build_ll_stritem_helper_graph, build_ll_stritem_nonneg_checked_helper_graph,
+    build_ll_stritem_nonneg_helper_graph, build_ll_strlen_helper_graph,
+    build_ll_unichr2str_helper_graph, const_str_cache_llstr, null_str_ptr,
 };
 use crate::translator::rtyper::rmodel::{RTypeResult, Repr, ReprState};
 use crate::translator::rtyper::rtyper::{
@@ -265,6 +265,11 @@ impl Repr for StringRepr {
     /// constant `'None'`.
     fn rtype_str(&self, hop: &HighLevelOp) -> RTypeResult {
         rtype_abstract_string_str(self, hop, "ll_str", STRPTR.clone())
+    }
+
+    /// RPython `AbstractStringRepr.rtype_getslice` (`rstr.py:432-437`).
+    fn rtype_getslice(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_abstract_string_getslice(self, hop, "ll_stringslice", STRPTR.clone())
     }
 
     /// RPython `AbstractStringRepr.rtype_method_*` dispatch table
@@ -558,6 +563,12 @@ impl Repr for UnicodeRepr {
     /// the unicode-specialised helper graph.
     fn rtype_int(&self, hop: &HighLevelOp) -> RTypeResult {
         rtype_abstract_string_int(self, hop, "ll_unicode_int", UNICODEPTR.clone())
+    }
+
+    /// Inherited `AbstractStringRepr.rtype_getslice`, specialized to
+    /// `Ptr(UNICODE)` and the unicode helper family.
+    fn rtype_getslice(&self, hop: &HighLevelOp) -> RTypeResult {
+        rtype_abstract_string_getslice(self, hop, "ll_unicode_slice", UNICODEPTR.clone())
     }
 
     /// RPython `AbstractUnicodeRepr.rtype_method_*` dispatch table
@@ -2806,6 +2817,40 @@ fn rtype_abstract_string_method_findlike_char(
     hop.gendirectcall(&helper, vec![v_str, v_ch, v_start, v_end])
 }
 
+/// RPython `AbstractStringRepr.rtype_getslice` (`rstr.py:432-437`).
+fn rtype_abstract_string_getslice(
+    self_repr: &dyn Repr,
+    hop: &HighLevelOp,
+    helper_prefix: &str,
+    ptr_lltype: LowLevelType,
+) -> RTypeResult {
+    use crate::translator::rtyper::rtyper::SliceKind;
+
+    let v_str = hop.inputarg(ConvertedTo::Repr(self_repr), 0)?;
+    let (kind, mut bounds) = hop.decompose_slice_args()?;
+    let suffix = match kind {
+        SliceKind::MinusOne => "minusone",
+        SliceKind::StartOnly => "startonly",
+        SliceKind::StartStop => "startstop",
+    };
+    let helper_name = format!("{helper_prefix}_{suffix}");
+    let mut arg_types = vec![ptr_lltype.clone()];
+    arg_types.extend((0..bounds.len()).map(|_| LowLevelType::Signed));
+    let name_for_builder = helper_name.clone();
+    let ptr_for_builder = ptr_lltype.clone();
+    let helper = hop.rtyper.lowlevel_helper_function_with_builder(
+        helper_name,
+        arg_types,
+        ptr_lltype,
+        move |rtyper, _args, _result| {
+            build_ll_stringslice_helper_graph(rtyper, &name_for_builder, ptr_for_builder, kind)
+        },
+    )?;
+    let mut args = vec![v_str];
+    args.append(&mut bounds);
+    hop.gendirectcall(&helper, args)
+}
+
 // ____________________________________________________________
 // Shared single-cast hash helper synthesizer — used by both CharRepr
 // and UniCharRepr since their helper graphs are structurally identical
@@ -3383,6 +3428,115 @@ fn build_ll_charlike_hash_helper_graph(
 mod tests {
     use super::*;
     use crate::annotator::annrpython::RPythonAnnotator;
+    use crate::translator::backendopt::constfold::WE_ARE_JITTED_TAG_ID;
+
+    /// `AbstractStringRepr.rtype_getslice` (`rstr.py:432-437`) selects the
+    /// start/stop helper and preserves string representation on the result.
+    #[test]
+    fn string_repr_rtype_getslice_emits_stringslice_helpers() {
+        use crate::annotator::model::{SomeInteger, SomeString, SomeValue};
+        use crate::flowspace::model::{Hlvalue, SpaceOperation, Variable};
+        use crate::translator::rtyper::rint::signed_repr;
+        use crate::translator::rtyper::rtyper::LowLevelOpList;
+        use std::cell::RefCell;
+        use std::rc::Rc;
+        use std::sync::Arc;
+
+        let ann = RPythonAnnotator::new(None, None, None, false);
+        let rtyper = Rc::new(RPythonTyper::new(&ann));
+        rtyper
+            .initialize_exceptiondata()
+            .expect("initialize_exceptiondata in test setup");
+        let r_str: Arc<dyn Repr> = string_repr();
+        let r_int: Arc<dyn Repr> = signed_repr();
+        let string = Variable::new();
+        string.set_concretetype(Some(STRPTR.clone()));
+        let start = Variable::new();
+        start.set_concretetype(Some(LowLevelType::Signed));
+        let stop = Variable::new();
+        stop.set_concretetype(Some(LowLevelType::Signed));
+        let result = Variable::new();
+        let args = vec![
+            Hlvalue::Variable(string),
+            Hlvalue::Variable(start),
+            Hlvalue::Variable(stop),
+        ];
+        let llops = Rc::new(RefCell::new(LowLevelOpList::new(rtyper.clone(), None)));
+        let hop = HighLevelOp::new(
+            rtyper.clone(),
+            SpaceOperation::new("getslice", args.clone(), Hlvalue::Variable(result)),
+            Vec::new(),
+            llops,
+        );
+        hop.args_v.borrow_mut().extend(args);
+        hop.args_s.borrow_mut().extend([
+            SomeValue::String(SomeString::new(false, false)),
+            SomeValue::Integer(SomeInteger::new(true, false)),
+            SomeValue::Integer(SomeInteger::new(true, false)),
+        ]);
+        hop.args_r
+            .borrow_mut()
+            .extend([Some(r_str.clone()), Some(r_int.clone()), Some(r_int)]);
+        *hop.r_result.borrow_mut() = Some(r_str);
+
+        rtyper
+            .translate_operation(&hop)
+            .expect("string getslice must rtype")
+            .expect("string getslice returns a variable");
+        assert_eq!(
+            hop.llops
+                .borrow()
+                .ops
+                .iter()
+                .filter(|op| op.opname == "direct_call")
+                .count(),
+            1
+        );
+        let names = ann
+            .translator
+            .graphs
+            .borrow()
+            .iter()
+            .map(|graph| graph.borrow().name.clone())
+            .collect::<Vec<_>>();
+        assert!(names.iter().any(|name| name == "ll_stringslice_startstop"));
+        assert!(names.iter().any(|name| name == "_ll_stringslice"));
+
+        let wrapper = ann
+            .translator
+            .graphs
+            .borrow()
+            .iter()
+            .find(|graph| graph.borrow().name == "ll_stringslice_startstop")
+            .cloned()
+            .expect("startstop wrapper graph");
+        let wrapper = wrapper.borrow();
+        assert!(matches!(
+            wrapper.startblock.borrow().exitswitch,
+            Some(Hlvalue::Constant(ref c))
+                if c.value == ConstValue::SpecTag(WE_ARE_JITTED_TAG_ID)
+        ));
+        let branch_ops = wrapper
+            .startblock
+            .borrow()
+            .exits
+            .iter()
+            .map(|link| {
+                link.borrow()
+                    .target
+                    .as_ref()
+                    .expect("branch target")
+                    .borrow()
+                    .operations
+                    .first()
+                    .expect("branch comparison")
+                    .opname
+                    .clone()
+            })
+            .collect::<Vec<_>>();
+        assert!(branch_ops.contains(&"int_gt".to_string()));
+        assert!(branch_ops.contains(&"int_ge".to_string()));
+    }
 
     #[test]
     fn str_decode_utf8_decodes_valid_utf8_and_rejects_invalid_bytes() {

--- a/majit/majit-translate/tests/test_import_mir.rs
+++ b/majit/majit-translate/tests/test_import_mir.rs
@@ -1,0 +1,65 @@
+use majit_charon_reader::Llbc;
+use majit_translate::{
+    HostStaticAddrs,
+    front::mir::build_semantic_program_from_llbcs_with_static_addrs_and_function_names,
+    model::{CallTarget, OpKind},
+};
+
+const INTERPRETER_LLBC: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc"
+);
+
+#[test]
+fn dunder_import_lowers_rust_string_find_and_slices_to_rpython_ops() {
+    let llbc = Llbc::load(INTERPRETER_LLBC).expect("load pyre-interpreter.ullbc");
+    let program = build_semantic_program_from_llbcs_with_static_addrs_and_function_names(
+        &[llbc],
+        HostStaticAddrs::default(),
+        &["importing"],
+        &["dunder_import"],
+    )
+    .expect("lower importing::dunder_import");
+    let function = program
+        .functions
+        .iter()
+        .find(|f| f.name == "dunder_import")
+        .expect("dunder_import graph");
+
+    assert_eq!(
+        program
+            .struct_fields
+            .field_type("W_TupleObject", "wrappeditems"),
+        Some("[*mut PyObject]"),
+        "PyPy tuple storage must project as GcArray(OBJECTPTR), not ItemsBlock"
+    );
+
+    let ops = function
+        .graph
+        .blocks
+        .iter()
+        .flat_map(|block| &block.operations)
+        .collect::<Vec<_>>();
+    assert!(ops.iter().any(|op| matches!(
+        &op.kind,
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            ..
+        } if segments == &["__getslice_rangeto".to_string()]
+    )));
+    assert!(ops.iter().any(|op| matches!(
+        &op.kind,
+        OpKind::Call {
+            target: CallTarget::Method { name, .. },
+            ..
+        } if name == "find"
+    )));
+    assert!(!ops.iter().any(|op| matches!(
+        &op.kind,
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            ..
+        } if segments.starts_with(&["core".to_string(), "str".to_string()])
+            && matches!(segments.last().map(String::as_str), Some("find" | "index"))
+    )));
+}

--- a/pyre/extra_tests/snippets/import.py
+++ b/pyre/extra_tests/snippets/import.py
@@ -76,3 +76,29 @@ from testutils import assert_raises
 
 with assert_raises(SyntaxError):
     exec("import")
+
+
+# interp_import.py:85-90 hands a cached package's fromlist to importlib's
+# `_handle_fromlist` rather than re-entering `__import__`.  Pyre's slow path is
+# the Python importlib bootstrap, so replacing that entry point makes an
+# accidental fall through observable without depending on timing.
+import importlib
+import importlib._bootstrap as bootstrap
+
+bootstrap_import = bootstrap.__import__
+bootstrap_calls = []
+
+
+def counting_bootstrap_import(*args, **kwargs):
+    bootstrap_calls.append(args[0])
+    return bootstrap_import(*args, **kwargs)
+
+
+bootstrap.__import__ = counting_bootstrap_import
+try:
+    from importlib import import_module as cached_import_module
+
+    assert cached_import_module is importlib.import_module
+    assert bootstrap_calls == []
+finally:
+    bootstrap.__import__ = bootstrap_import

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -6104,9 +6104,12 @@ pub fn getattr(obj: PyObjectRef, w_name: PyObjectRef) -> PyResult {
         )));
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    match name.as_str() {
-        Ok(s) => getattr_str(obj, s),
-        Err(_) => unsafe { getattr_surrogate(obj, w_name, name) },
+    if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(name) } {
+        getattr_str(obj, unsafe {
+            pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name)
+        })
+    } else {
+        unsafe { getattr_surrogate(obj, w_name, name) }
     }
 }
 
@@ -6121,9 +6124,15 @@ pub fn lookup_attr(obj: PyObjectRef, w_name: PyObjectRef) -> PyResult {
         )));
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    match name.as_str() {
-        Ok(s) => getattr_str_impl(obj, s, true, true),
-        Err(_) => unsafe { getattr_surrogate(obj, w_name, name) },
+    if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(name) } {
+        getattr_str_impl(
+            obj,
+            unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name) },
+            true,
+            true,
+        )
+    } else {
+        unsafe { getattr_surrogate(obj, w_name, name) }
     }
 }
 
@@ -6136,9 +6145,14 @@ pub fn setattr(obj: PyObjectRef, w_name: PyObjectRef, value: PyObjectRef) -> PyR
         )));
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    match name.as_str() {
-        Ok(s) => setattr_str(obj, s, value),
-        Err(_) => unsafe { setattr_surrogate(obj, w_name, name, value) },
+    if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(name) } {
+        setattr_str(
+            obj,
+            unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name) },
+            value,
+        )
+    } else {
+        unsafe { setattr_surrogate(obj, w_name, name, value) }
     }
 }
 
@@ -6151,9 +6165,12 @@ pub fn delattr(obj: PyObjectRef, w_name: PyObjectRef) -> PyResult {
         )));
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(w_name) };
-    match name.as_str() {
-        Ok(s) => delattr_str(obj, s),
-        Err(_) => unsafe { delattr_surrogate(obj, w_name, name) },
+    if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(name) } {
+        delattr_str(obj, unsafe {
+            pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(name)
+        })
+    } else {
+        unsafe { delattr_surrogate(obj, w_name, name) }
     }
 }
 

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -3693,7 +3693,12 @@ pub fn install_default_builtins(ns: PyObjectRef) {
         make_module_builtin_function_with_arity("issubclass", builtin_issubclass, 2)
     });
     crate::module_ns_get_or_insert_with(ns, "__import__", || {
-        make_module_builtin_function("__import__", builtin_dunder_import)
+        // `moduledef.py:78-87 startup` — "Copy our __import__ to builtins".
+        // `baseobjspace.py:730` keeps that same object as
+        // `space.w_default_importlib_import`.
+        let w_import = make_module_builtin_function("__import__", builtin_dunder_import);
+        crate::importing::set_default_importlib_import(w_import);
+        w_import
     });
 
     // Descriptor types

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -765,6 +765,7 @@ fn format_unknown_kwds_err(fname: &Wtf8, unmatched: &[Wtf8Buf]) -> Wtf8Buf {
 }
 
 #[cold]
+#[majit_macros::dont_look_inside]
 fn raise_if_posonly_kwds(posonly_kwds: &[String], fname: &Wtf8) -> Result<(), PyError> {
     if posonly_kwds.is_empty() {
         return Ok(());
@@ -776,6 +777,31 @@ fn raise_if_posonly_kwds(posonly_kwds: &[String], fname: &Wtf8) -> Result<(), Py
         posonly_kwds.join(", ")
     ));
     Err(crate::PyError::type_error(msg))
+}
+
+/// Cold `Arguments.parse_obj` keyword-error formatter.
+///
+/// PyPy keeps `oefmt` lazy: the accepted-call trace retains the keyword
+/// matching guards but does not trace construction of an error string.  Keep
+/// pyre's eager `PyError` representation behind the same residual boundary,
+/// as the generated gateway arity helpers above do.  The helper returns the
+/// caller's exact result carrier so the rejected branch can tail-return it.
+#[cold]
+#[majit_macros::dont_look_inside]
+fn builtin_keyword_failure(
+    fname: &str,
+    unmatched: &[Wtf8Buf],
+    takes_no_keywords: bool,
+) -> Result<Vec<PyObjectRef>, PyError> {
+    let msg = if takes_no_keywords {
+        let mut msg = Wtf8Buf::new();
+        msg.push_str(fname);
+        msg.push_str("() takes no keyword arguments");
+        msg
+    } else {
+        format_unknown_kwds_err(Wtf8::new(fname), unmatched)
+    };
+    Err(PyError::type_error(msg))
 }
 
 /// Materialize a Python call frame without retaining the by-value `PyFrame`
@@ -2340,9 +2366,7 @@ pub(crate) fn bind_kwargs_to_signature(
     // rejected with the "takes no keyword arguments" form (e.g. `len`, `abs`).
     if !kwargs.is_empty() && !has_varkw && sig.num_kwonlyargnames() == 0 && posonly == n_pos_params
     {
-        return Err(crate::PyError::type_error(format!(
-            "{fname}() takes no keyword arguments"
-        )));
+        return builtin_keyword_failure(fname, &[], true);
     }
 
     // argument.py:235-236 — flag too many positionals with no `*args` to
@@ -2366,7 +2390,11 @@ pub(crate) fn bind_kwargs_to_signature(
         // A lone-surrogate keyword name (not valid UTF-8) never equals a
         // source-level parameter name, so it falls straight to **kwargs or
         // the unexpected-keyword error below.
-        let key_str = key.as_str().ok();
+        let key_str = if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(key) } {
+            Some(unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(key) })
+        } else {
+            None
+        };
         let mut matched = false;
         for pi in 0..nparams {
             if key_str == Some(sig.argnames[pi]) {
@@ -2417,15 +2445,11 @@ pub(crate) fn bind_kwargs_to_signature(
         // at all (no **kwargs and no keyword-only params). Every BuiltinCode
         // call routes through parse_obj (gateway.py funcrun / funcrun_obj), so
         // the rewrite applies at any arity, not just the single-argument form.
-        let msg = if !has_varkw && sig.num_kwonlyargnames() == 0 {
-            let mut msg = Wtf8Buf::new();
-            msg.push_wtf8(Wtf8::new(fname));
-            msg.push_str("() takes no keyword arguments");
-            msg
-        } else {
-            format_unknown_kwds_err(Wtf8::new(fname), &unmatched_kw_names)
-        };
-        return Err(crate::PyError::type_error(msg));
+        return builtin_keyword_failure(
+            fname,
+            &unmatched_kw_names,
+            !has_varkw && sig.num_kwonlyargnames() == 0,
+        );
     }
 
     // argument.py:289 — too-many-positionals is raised last, after the
@@ -2863,7 +2887,11 @@ fn call_with_kwargs_in_ctx_impl(
                 let value = current_kwarg(kw_index);
                 // A lone-surrogate keyword name never equals a source-level
                 // parameter name; it falls to **kwargs or the error below.
-                let key_str = key.as_str().ok();
+                let key_str = if unsafe { pyre_object::dictmultiobject::wtf8_key_is_utf8(key) } {
+                    Some(unsafe { pyre_object::dictmultiobject::wtf8_key_as_str_unchecked(key) })
+                } else {
+                    None
+                };
                 let mut matched = false;
                 for pi in 0..total_params {
                     if key_str == Some(code.varnames[pi].as_str()) {
@@ -3378,27 +3406,17 @@ pub fn call_function_impl_result(
     crate::stack_check::drain_jit_pending_exception()?;
 
     let callable = _roots.get(root_base);
-    // RPython's GC transform reloads `Arguments.arguments_w` livevars in
-    // place; it does not allocate another list at every ObjSpace call.  Keep
-    // the common small call shape allocation-free and retain a Vec only for
-    // genuinely wide calls.
-    const INLINE_ARGS: usize = 8;
-    let mut inline_args = [PY_NULL; INLINE_ARGS];
-    let mut wide_args = Vec::new();
-    let args = if args.len() <= INLINE_ARGS {
-        // The index loop lowers to `setarrayitem`; iterator adapters are residual calls.
-        #[allow(clippy::needless_range_loop)]
-        for i in 0..args.len() {
-            inline_args[i] = _roots.get(root_base + 1 + i);
-        }
-        &inline_args[..args.len()]
-    } else {
-        wide_args = Vec::with_capacity(args.len());
-        for i in 0..args.len() {
-            wide_args.push(_roots.get(root_base + 1 + i));
-        }
-        wide_args.as_slice()
-    };
+    // `baseobjspace.py:1193-1213 call_function` carries `args_w` as one
+    // RPython list.  Rebuild that same dynamic list from the updated root
+    // slots.  A former fixed `[PY_NULL; 8]` shortcut ended in Rust's opaque
+    // `<[T; N]>::index(&array, ..len)` and prevented the whole call dispatcher
+    // from entering two-phase translation; the meta-tracer can virtualize
+    // this orthodox list on the common fixed-arity paths.
+    let mut rooted_args = Vec::with_capacity(args.len());
+    for i in 0..args.len() {
+        rooted_args.push(_roots.get(root_base + 1 + i));
+    }
+    let args = rooted_args.as_slice();
 
     // Binding an override descriptor below runs `baseobjspace::get`, whose
     // property and general `__get__` arms execute Python.  That updates the

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -4463,6 +4463,87 @@ fn strip_bootstrap_traceback_frames(mut err: crate::PyError) -> crate::PyError {
     err
 }
 
+/// Native counterpart of RPython `str.find(char, start) -> Signed`.
+///
+/// `interp_import.py:76 interp___import__` reads `name.find(".")` as a Signed
+/// with `-1` for "no dot".  Rust's `str::find` returns `Option<usize>` and
+/// takes no start, so the interpreter carries this exact compatibility
+/// function and the translator emits the orthodox RPython string method
+/// instead of tracing this body.  The only caller passes `0`, and an ASCII
+/// dot is always a UTF-8 boundary.
+fn rpython_str_find_char(value: &str, needle: char, start: i64) -> i64 {
+    let Ok(start) = usize::try_from(start) else {
+        return -1;
+    };
+    value
+        .get(start..)
+        .and_then(|tail| tail.find(needle))
+        .and_then(|offset| i64::try_from(start + offset).ok())
+        .unwrap_or(-1)
+}
+
+/// Native counterpart of RPython `s[:stop]`.
+///
+/// `interp_import.py:79` slices the dotted name as `name[:dotindex]`.  The
+/// caller has just proved that `stop` is a non-negative byte index returned by
+/// `rpython_str_find_char`, so translation replaces this exact helper with the
+/// existing post-annotation `getslice(s, 0, stop)` marker.
+fn rpython_str_slice_prefix(value: &str, stop: i64) -> &str {
+    &value[..usize::try_from(stop).expect("find returned a non-negative index")]
+}
+
+/// `interp_import.py:85-90` — hand a cached package's fromlist to importlib.
+///
+/// `space.call_method(w_importlib, "_handle_fromlist", w_mod, w_fromlist,
+/// space.w_default_importlib_import)`.  `_handle_fromlist` imports whichever
+/// names the list adds, so the package case needs no `sys.meta_path` walk of
+/// its own.  Answers `None` while the bootstrap is not installed, which leaves
+/// the caller on the slow path.
+fn handle_fromlist_fast(
+    w_mod: PyObjectRef,
+    w_fromlist: PyObjectRef,
+) -> Result<Option<PyObjectRef>, crate::PyError> {
+    use pyre_object::gc_roots::{pin_root, push_roots, shadow_stack_get, shadow_stack_len};
+
+    let _roots = push_roots();
+    let mod_slot = shadow_stack_len();
+    pin_root(w_mod);
+    let fromlist_slot = shadow_stack_len();
+    pin_root(w_fromlist);
+    let Some(w_bootstrap) = get_sys_module("importlib._bootstrap") else {
+        return Ok(None);
+    };
+    let bootstrap_slot = shadow_stack_len();
+    pin_root(w_bootstrap);
+    let Some(w_handle) = crate::baseobjspace::findattr_result(
+        shadow_stack_get(bootstrap_slot),
+        "_handle_fromlist",
+    )?
+    else {
+        return Ok(None);
+    };
+    let handle_slot = shadow_stack_len();
+    pin_root(w_handle);
+    // `space.w_default_importlib_import` is the importer `_handle_fromlist`
+    // calls for a name the package does not already carry.
+    let Some(w_import) =
+        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")?
+    else {
+        return Ok(None);
+    };
+    let import_slot = shadow_stack_len();
+    pin_root(w_import);
+    crate::call::call_function_impl_result(
+        shadow_stack_get(handle_slot),
+        &[
+            shadow_stack_get(mod_slot),
+            shadow_stack_get(fromlist_slot),
+            shadow_stack_get(import_slot),
+        ],
+    )
+    .map(Some)
+}
+
 /// `builtins.__import__` — `interp___import__`: a fast path answering
 /// absolute imports from initialised `sys.modules` entries, the app-level
 /// `_bootstrap.__import__` (the full `sys.meta_path` / `sys.path_hooks`
@@ -4504,29 +4585,36 @@ pub fn dunder_import(
     });
 
     if level == 0 {
-        // Fast path only for absolute imports (interp_import.py).
-        // A package with a fromlist needs `_handle_fromlist`, which the
-        // slow path runs.
+        // `interp_import.py:66-92` — the fast path is only for absolute
+        // imports.  A fromlist is answered from the cache when the module is
+        // not a package; a package hands its list to `_handle_fromlist`, which
+        // imports whatever the list adds.  No import lock is taken here:
+        // `interp_import.py:19` records that CPython's fast path does not
+        // take one either.
         let have_fromlist =
             !fromlist_missing && crate::baseobjspace::is_true(shadow_stack_get(fromlist_slot))?;
         if let Some(w_mod) = gcd_import_fast(name)? {
             let mod_slot = shadow_stack_len();
             pin_root(w_mod);
             if !have_fromlist {
-                match name.find('.') {
-                    None => return Ok(shadow_stack_get(mod_slot)),
-                    Some(dot) => {
-                        // `import a.b` returns `a`; give up when the
-                        // top-level ancestor is not initialised yet.
-                        if let Some(w_top) = gcd_import_fast(&name[..dot])? {
-                            return Ok(w_top);
-                        }
-                    }
+                let dotindex = rpython_str_find_char(name, '.', 0);
+                if dotindex < 0 {
+                    return Ok(shadow_stack_get(mod_slot));
+                }
+                // `import a.b` answers `a`; give up when the top-level
+                // ancestor is not initialised yet.
+                if let Some(w_top) = gcd_import_fast(rpython_str_slice_prefix(name, dotindex))? {
+                    return Ok(w_top);
                 }
             } else if crate::baseobjspace::findattr_result(shadow_stack_get(mod_slot), "__path__")?
                 .is_none()
             {
                 return Ok(shadow_stack_get(mod_slot));
+            } else if let Some(w_handled) = handle_fromlist_fast(
+                shadow_stack_get(mod_slot),
+                shadow_stack_get(fromlist_slot),
+            )? {
+                return Ok(w_handled);
             }
         }
     }
@@ -5672,5 +5760,14 @@ mod tests {
         assert!(src.contains("def compile"));
         assert!(vfs.read_to_string(&mount.join("re/_nope.py")).is_err());
         assert!(!vfs.is_file(&mount.join("re/_nope.py")));
+    }
+
+    #[test]
+    fn signed_string_find_matches_the_rpython_operation() {
+        assert_eq!(rpython_str_find_char("pkg.child.leaf", '.', 0), 3);
+        assert_eq!(rpython_str_find_char("pkg.child.leaf", '.', 4), 9);
+        assert_eq!(rpython_str_find_char("pkg.child.leaf", '.', 10), -1);
+        assert_eq!(rpython_str_find_char("plain", '.', 0), -1);
+        assert_eq!(rpython_str_slice_prefix("pkg.child", 3), "pkg");
     }
 }

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -405,6 +405,17 @@ static SYS_MODULES: LazyLock<Mutex<HashMap<String, usize>>> =
 static MODULE_DICT_ROOTS: LazyLock<Mutex<std::collections::HashSet<usize>>> =
     LazyLock::new(|| Mutex::new(std::collections::HashSet::new()));
 static SYS_MODULES_DICT: AtomicUsize = AtomicUsize::new(0);
+/// `baseobjspace.py:730` — `self.w_default_importlib_import =
+/// frozen_importlib.w_import`: the interp-level `__import__` gateway, held on
+/// the object space rather than read back out of a namespace, so a later
+/// `builtins.__import__` rebind cannot reach the importer `_handle_fromlist`
+/// is handed.  `moduledef.py:78-87 startup` puts the same object in builtins,
+/// so this cell is filled where that copy is made.
+///
+/// The wrapper is allocated in the movable nursery like any other function
+/// object, so this raw copy is forwarded by `walk_process_import_roots` for
+/// the reason `SYS_MODULES_DICT` is.
+static DEFAULT_IMPORTLIB_IMPORT: AtomicUsize = AtomicUsize::new(0);
 #[cfg(feature = "host_env")]
 static SYS_PATH: LazyLock<Mutex<Vec<PathBuf>>> = LazyLock::new(|| Mutex::new(Vec::new()));
 /// The directory prepended to `sys.path` at startup (`config->sys_path_0`):
@@ -2760,6 +2771,29 @@ unsafe fn walk_bound_module_dicts(visitor: &mut dyn FnMut(&mut PyObjectRef)) {
     }
 }
 
+/// `baseobjspace.py:730` — record the interp-level `__import__` as the space's
+/// default importer.  Called where `builtins.__import__` is bound, which is
+/// what `moduledef.py:87 startup` copies from.
+///
+/// The space captures one importer while it is being set up, so a namespace
+/// built after that keeps the first one: `install_default_builtins` also runs
+/// for a fresh builtins dict, and the module that dict belongs to is not the
+/// one every frame resolves `__import__` through.
+pub fn set_default_importlib_import(w_import: PyObjectRef) {
+    let _ = DEFAULT_IMPORTLIB_IMPORT.compare_exchange(
+        0,
+        w_import as usize,
+        Ordering::AcqRel,
+        Ordering::Acquire,
+    );
+}
+
+/// `space.w_default_importlib_import`, or `None` before builtins is bound.
+fn default_importlib_import() -> Option<PyObjectRef> {
+    let w_import = DEFAULT_IMPORTLIB_IMPORT.load(Ordering::Acquire) as PyObjectRef;
+    (!w_import.is_null()).then_some(w_import)
+}
+
 /// Forward the `sys.modules` dict pointer cached in `SYS_MODULES_DICT`.
 ///
 /// The same dict object is also reachable as `sys.__dict__["modules"]`
@@ -2816,6 +2850,11 @@ pub(crate) unsafe fn walk_process_import_roots(visitor: &mut dyn FnMut(&mut PyOb
     if !dict.is_null() {
         visitor(&mut dict);
         SYS_MODULES_DICT.store(dict as usize, Ordering::Release);
+    }
+    let mut w_import = DEFAULT_IMPORTLIB_IMPORT.load(Ordering::Acquire) as PyObjectRef;
+    if !w_import.is_null() {
+        visitor(&mut w_import);
+        DEFAULT_IMPORTLIB_IMPORT.store(w_import as usize, Ordering::Release);
     }
 }
 
@@ -4515,20 +4554,18 @@ fn handle_fromlist_fast(
     };
     let bootstrap_slot = shadow_stack_len();
     pin_root(w_bootstrap);
-    let Some(w_handle) = crate::baseobjspace::findattr_result(
-        shadow_stack_get(bootstrap_slot),
-        "_handle_fromlist",
-    )?
+    let Some(w_handle) =
+        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "_handle_fromlist")?
     else {
         return Ok(None);
     };
     let handle_slot = shadow_stack_len();
     pin_root(w_handle);
     // `space.w_default_importlib_import` is the importer `_handle_fromlist`
-    // calls for a name the package does not already carry.
-    let Some(w_import) =
-        crate::baseobjspace::findattr_result(shadow_stack_get(bootstrap_slot), "__import__")?
-    else {
+    // calls for a name the package does not already carry.  It is the space's
+    // own captured copy, so rebinding `builtins.__import__` or
+    // `_bootstrap.__import__` cannot redirect it.
+    let Some(w_import) = default_importlib_import() else {
         return Ok(None);
     };
     let import_slot = shadow_stack_len();
@@ -4610,10 +4647,9 @@ pub fn dunder_import(
                 .is_none()
             {
                 return Ok(shadow_stack_get(mod_slot));
-            } else if let Some(w_handled) = handle_fromlist_fast(
-                shadow_stack_get(mod_slot),
-                shadow_stack_get(fromlist_slot),
-            )? {
+            } else if let Some(w_handled) =
+                handle_fromlist_fast(shadow_stack_get(mod_slot), shadow_stack_get(fromlist_slot))?
+            {
                 return Ok(w_handled);
             }
         }


### PR DESCRIPTION
Answers a cached absolute import the way `pypy3.11` does, and gives the two
string operations that path needs their orthodox RPython lowering.

## `interp___import__`, not `absolute_import_try`

The pinned oracle is PyPy 7.3.24 / CPython 3.11, whose `__import__` fast path
is `pypy/module/_frozen_importlib/interp_import.py:66-92`. It calls
`_gcd_import` on the whole name, then for a fromlist-less import reads
`name.find(".")` and `name[:dotindex]`; with a fromlist it probes `__path__`,
answering a non-package directly and handing a package to `_handle_fromlist`
(`interp_import.py:85-90`).

Pyre now follows that shape. The `_handle_fromlist` callback is the part pyre
was missing: a cached package with a satisfied fromlist previously dropped
through to the whole bootstrap `__import__`.

No import lock is taken on this path — `interp_import.py:19` records that
neither PyPy nor CPython takes one there, so `lock_held_by_someone_else` keeps
having no caller.

## Traceable string operations

`str.find(char, start)` and `s[:stop]` are what upstream runs here, but Rust's
`str::find` answers `Option<usize>` and takes no start, and core's string
index body is opaque to Charon. The interpreter carries two exact
compatibility helpers and the translator replaces them with the operations
they stand for:

* `str.find(char, start)` becomes the existing RPython method op;
* the prefix slice becomes the `__getslice_rangeto` marker that annotation
  turns into `getslice(s, 0, stop)`, backed by
  `ll_stringslice_{minusone,startonly,startstop}` graphs built from
  `rstr.py:432-437` and `lltypesystem/rstr.py:844-876` — including the
  `jit.we_are_jitted()` arm whose no-JIT branch returns the receiver for
  `[0:>=len]`.

## Verification

Run on this branch's own base:

| | |
|---|---|
| `extra_tests/snippets/import.py` | pass — asserts `_bootstrap.__import__` is not reached for a cached package import whose fromlist names are already attributes |
| `majit-translate --test test_import_mir` | pass — lowers `dunder_import` and requires a `find` method op and `__getslice_rangeto`, with no residual `core::str` find/index |
| `signed_string_find_matches_the_rpython_operation` | pass |
| `majit-translate --lib str_find` | pass |
| `cargo build --release -p pyrex --bin pyre-dynasm` | clean |

`pyre/check.py` has not been run on this base; the machine was carrying a load
average above 100 for most of the window, which makes its ratio gates
meaningless.
