### PR TITLE
cpyext: the #1334 review findings, and the setdefault they uncovered

### DIFF
--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -3,6 +3,10 @@
  * Written by scripts/cpyext-abi.py generate; do not edit by hand.
  * A declaration here is CPython's own where CPython has one, so an
  * extension's prototypes and pyre's agree by construction.
+ *
+ * An export a hand-written header renames to an inline fast path is
+ * left out: that header declares it ahead of the rename, which a
+ * declaration here would come after.
  */
 #ifndef PYRE_DECL_H
 #define PYRE_DECL_H
@@ -172,9 +176,6 @@ PyAPI_FUNC(Py_ssize_t) PyList_Size(PyObject *);
 PyAPI_FUNC(int) PyList_Sort(PyObject *);
 
 /* cpyext/lock.rs */
-PyAPI_FUNC(int) PyMutex_IsLocked(PyMutex *);
-PyAPI_FUNC(void) PyMutex_Lock(PyMutex *);
-PyAPI_FUNC(void) PyMutex_Unlock(PyMutex *);
 PyAPI_FUNC(int) PyThread_acquire_lock(PyThread_type_lock, int);
 PyAPI_FUNC(PyLockStatus) PyThread_acquire_lock_timed(PyThread_type_lock, PY_TIMEOUT_T, int);
 PyAPI_FUNC(PyThread_type_lock) PyThread_allocate_lock(void);

--- a/pyre/docs/cpyext.md
+++ b/pyre/docs/cpyext.md
@@ -304,9 +304,11 @@ header declaring it wrongly.
 - the conversions at the C boundary (`cpyext/unicodeobject.rs`,
   `cpyext/osmodule.rs`): the named codecs `PyUnicode_Decode` /
   `DecodeASCII` / `DecodeLatin1` / `DecodeUTF8` and `PyUnicode_AsEncodedString`
-  / `AsASCIIString` / `AsLatin1String` / `AsUTF8String`, each reached through
-  `bytes.decode` and `str.encode` so the error handler is the interpreter's
-  own; the `wchar_t` forms `PyUnicode_FromWideChar` / `AsWideChar` /
+  / `AsASCIIString` / `AsLatin1String` / `AsUTF8String`, each running the body
+  `bytes.decode` and `str.encode` run so the codec set and the error handlers
+  are the interpreter's own, and reaching it without the method lookup so that
+  a `str` subclass defining `encode` does not change what these encode; the
+  `wchar_t` forms `PyUnicode_FromWideChar` / `AsWideChar` /
   `AsWideCharString`, whose unit is one code point where a `wchar_t` is four
   bytes and one UTF-16 unit where it is two; and the filesystem encoding
   `PyUnicode_DecodeFSDefault` / `DecodeFSDefaultAndSize` / `EncodeFSDefault`
@@ -360,7 +362,7 @@ header declaring it wrongly.
   `Substring`, `Join`, `FromOrdinal`, `FromObject`, `DecodeUTF8`,
   `InternFromString` / `InternInPlace`, `FindChar`, `Contains`, and the five
   comparisons `Compare` / `CompareWithASCIIString` / `RichCompare` / `Equal` /
-  `EqualToUTF8`. `PyUnicode_DecodeUTF8` decodes through `bytes.decode`, so
+  `EqualToUTF8`. `PyUnicode_DecodeUTF8` runs the body `bytes.decode` runs, so
   every error handler the interpreter has is reachable rather than the three
   a hand-written decoder would name;
 - the `%`-format engine and `PyUnicode_FromFormat` / `FromFormatV` over it

--- a/pyre/docs/cpyext.md
+++ b/pyre/docs/cpyext.md
@@ -44,13 +44,18 @@ per `cpyext` module. `pytypedefs.h` names the shared types once so no
 declaration waits on a definition, and `audit.h` carries the variadic
 `PySys_Audit` the way CPython's own `Include/audit.h` does.
 
-`pyre_decl.h` holds every exported entry point and **is generated** by
+`pyre_decl.h` holds the exported entry points and **is generated** by
 `scripts/cpyext-abi.py` from the `#[unsafe(no_mangle)] extern "C"` functions
 themselves, so a declaration cannot drift from its implementation. It is
 included after the headers that name the types it uses and before the ones
 defining `static inline` functions that call it. `refcount.h` is the first of
 those: `Py_INCREF` expands to the `Py_IncRef` it declares, and `Py_NewRef` is an
 inline function calling that macro.
+
+The exports it leaves out are the three a header renamed. `lock.h` declares
+`PyMutex_Lock` and then, past the inline fast path, `#define`s the name onto
+it; a declaration here would come after that rename and so name the inline
+function rather than the export.
 
 The generator does not spell the declaration from the Rust signature where
 CPython has one of its own. It emits **CPython's** declaration -- `PyLongObject
@@ -120,7 +125,10 @@ the header below. `pyrex/tests/cpyext_dict_subclass.rs`,
 `pyrex/tests/cpyext_type_statics.rs`, `pyrex/tests/cpyext_runtime.rs`,
 `pyrex/tests/cpyext_small.rs`, `pyrex/tests/cpyext_locks.rs` and
 `pyrex/tests/cpyext_writer.rs` take their expectations from CPython 3.14.6
-running the same script against the same fixture.
+running the same script against the same fixture. Every fixture is compiled
+with `-Werror`: it is written against these headers and nothing else, so a
+warning in one is either the fixture calling an entry point wrongly or the
+header declaring it wrongly.
 
 - a pyre-specific Python 3.14 ABI header and extension suffix;
 - `_imp.extension_suffixes()`, `_imp.create_dynamic()` and

--- a/pyre/pyre-interpreter/src/cpyext/bytearrayobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytearrayobject.rs
@@ -46,7 +46,14 @@ pub unsafe extern "C" fn PyByteArray_FromStringAndSize(
     bytes: *const c_char,
     length: isize,
 ) -> *mut CPyObject {
-    let length = length.max(0) as usize;
+    if length < 0 {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "Negative size passed to PyByteArray_FromStringAndSize".to_owned(),
+        ));
+        return std::ptr::null_mut();
+    }
+    let length = length as usize;
     let created = if bytes.is_null() {
         pyre_object::bytearrayobject::w_bytearray_new(length)
     } else {

--- a/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/bytesobject.rs
@@ -139,6 +139,21 @@ pub(super) fn realize_pending(raw: *mut CPyObject) {
     );
 }
 
+/// Give up the reference `pv` holds and leave it naming nothing, which every
+/// failure below does: it is what lets a caller write
+/// `if (_PyBytes_Resize(&v, n) < 0) return NULL;` and owe nothing further.
+///
+/// # Safety
+/// `pv` must be a writable `PyObject *` holding a reference this takes over.
+unsafe fn release_resized(pv: *mut *mut CPyObject) {
+    unsafe {
+        let raw = std::mem::replace(&mut *pv, std::ptr::null_mut());
+        if !raw.is_null() {
+            pyobject::decref(raw);
+        }
+    }
+}
+
 /// `_PyBytes_Resize(&v, newsize)` — give what `*pv` names the new length,
 /// writing back whatever object answers it now.
 ///
@@ -172,13 +187,8 @@ pub unsafe extern "C" fn _PyBytes_Resize(pv: *mut *mut CPyObject, newsize: isize
             .map(|value| unsafe { pyre_object::bytesobject::w_bytes_len(value) }),
     };
     let (Some(current), true) = (current, newsize >= 0) else {
-        // The reference is given up whatever went wrong, which is what lets
-        // the caller write `if (_PyBytes_Resize(&v, n) < 0) return NULL;`.
         unsafe {
-            *pv = std::ptr::null_mut();
-            if !raw.is_null() {
-                pyobject::decref(raw);
-            }
+            release_resized(pv);
             super::pyerrors::PyErr_BadInternalCall();
         }
         return -1;
@@ -191,18 +201,25 @@ pub unsafe extern "C" fn _PyBytes_Resize(pv: *mut *mut CPyObject, newsize: isize
         // No object exists yet, so there is nothing to replace: the block
         // stays and only what C is writing into changes size.
         if unsafe { pyobject::resize_cached_bytes(raw, newsize) }.is_none() {
-            unsafe { super::pyerrors::PyErr_NoMemory() };
+            unsafe {
+                release_resized(pv);
+                super::pyerrors::PyErr_NoMemory();
+            }
             return -1;
         }
         return 0;
     }
     let Some(value) = argument(raw) else {
+        unsafe { release_resized(pv) };
         return -1;
     };
     let data = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
     let mut resized: Vec<u8> = Vec::new();
     if resized.try_reserve_exact(newsize).is_err() {
-        unsafe { super::pyerrors::PyErr_NoMemory() };
+        unsafe {
+            release_resized(pv);
+            super::pyerrors::PyErr_NoMemory();
+        }
         return -1;
     }
     resized.extend_from_slice(&data[..current.min(newsize)]);

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -384,13 +384,6 @@ pub unsafe extern "C" fn PyDict_SetDefaultRef(
     ) else {
         return -1;
     };
-    let present = match crate::baseobjspace::contains(dict, key) {
-        Ok(present) => present,
-        Err(error) => {
-            super::pyerrors::set_pending_error(error);
-            return -1;
-        }
-    };
     let roots = pyre_object::gc_roots::push_roots();
     let dict_slot = pyre_object::gc_roots::shadow_stack_len();
     roots.pin_root(dict);
@@ -398,6 +391,13 @@ pub unsafe extern "C" fn PyDict_SetDefaultRef(
     roots.pin_root(key);
     let default_slot = pyre_object::gc_roots::shadow_stack_len();
     roots.pin_root(default_value);
+    // The key is looked for once, so which of the two things happened is read
+    // off the size either side of it.  Asking the dict whether it holds the key
+    // would run the key's `__hash__` and `__eq__` a second time, and a key that
+    // counts them would see this call as two.
+    let before = unsafe {
+        pyre_object::dictmultiobject::w_dict_len(pyre_object::gc_roots::shadow_stack_get(dict_slot))
+    };
     let key = pyre_object::gc_roots::shadow_stack_get(key_slot);
     let found = unsafe {
         pyre_object::dictmultiobject::w_dict_setdefault_checked(
@@ -410,6 +410,9 @@ pub unsafe extern "C" fn PyDict_SetDefaultRef(
     let Some(found) = trap(found) else {
         return -1;
     };
+    let present = unsafe {
+        pyre_object::dictmultiobject::w_dict_len(pyre_object::gc_roots::shadow_stack_get(dict_slot))
+    } == before;
     if !result.is_null() {
         unsafe { *result = pyobject::make_ref(found) };
     }

--- a/pyre/pyre-interpreter/src/cpyext/pystate.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pystate.rs
@@ -79,10 +79,19 @@ pub unsafe extern "C" fn PyEval_ReleaseThread(_state: *mut CPyThreadState) {
 
 /// `pystate.py:179 PyThreadState_Get`.
 ///
-/// Upstream ends the process with a fatal error when there is no current thread
-/// state.  A thread that reaches here is running pyre code and so has one.
+/// There is no state to answer with while this thread's is not current, and no
+/// way to say so: the return is a state and every caller reads it.  So the
+/// process ends here rather than one dereference later.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyThreadState_Get() -> *mut CPyThreadState {
+    if !STATE_IS_CURRENT.with(|current| current.get()) {
+        super::pyerrors::fatal_error(
+            Some("PyThreadState_Get"),
+            "the function must be called with the GIL held, after Python \
+             initialization and before Python finalization, but the GIL is \
+             released (the current Python thread state is NULL)",
+        );
+    }
     thread_state()
 }
 

--- a/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodeobject.rs
@@ -388,15 +388,23 @@ pub unsafe extern "C" fn PyUnicode_IS_ASCII(object: *mut CPyObject) -> c_uint {
     }
 }
 
+/// The widest code point a representation of this width can hold, which is
+/// what a write to it is measured against.
+fn max_char_value(kind: c_int, ascii: bool) -> c_uint {
+    match (kind, ascii) {
+        (_, true) => 0x7f,
+        (1, _) => 0xff,
+        (2, _) => 0xffff,
+        _ => 0x10ffff,
+    }
+}
+
 /// `PyUnicode_MAX_CHAR_VALUE` — the widest code point the representation can
 /// hold, not the widest it does hold.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyUnicode_MAX_CHAR_VALUE(object: *mut CPyObject) -> c_uint {
     match canonical(object) {
-        Some((_, _, true, _)) => 0x7f,
-        Some((1, _, _, _)) => 0xff,
-        Some((2, _, _, _)) => 0xffff,
-        Some(_) => 0x10ffff,
+        Some((kind, _, ascii, _)) => max_char_value(kind, ascii),
         None => 0,
     }
 }
@@ -405,7 +413,7 @@ pub unsafe extern "C" fn PyUnicode_MAX_CHAR_VALUE(object: *mut CPyObject) -> c_u
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyUnicode_ReadChar(object: *mut CPyObject, index: isize) -> Py_UCS4 {
     let Some((kind, length, _, data)) = canonical(object) else {
-        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        unsafe { super::pyerrors::PyErr_BadArgument() };
         return Py_UCS4::MAX;
     };
     if index < 0 || index as usize >= length {
@@ -428,14 +436,22 @@ pub unsafe extern "C" fn PyUnicode_WriteChar(
     index: isize,
     value: Py_UCS4,
 ) -> c_int {
-    let Some((kind, length, _, data)) = canonical(object) else {
-        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+    let Some((kind, length, ascii, data)) = canonical(object) else {
+        unsafe { super::pyerrors::PyErr_BadArgument() };
         return -1;
     };
     if index < 0 || index as usize >= length {
         super::pyerrors::set_pending_error(crate::PyError::new(
             crate::PyErrorKind::IndexError,
             "string index out of range",
+        ));
+        return -1;
+    }
+    // The width was fixed when the string was made, so a code point wider than
+    // it holds has nowhere to go and the write is refused rather than cut down.
+    if value > max_char_value(kind, ascii) {
+        super::pyerrors::set_pending_error(crate::PyError::value_error(
+            "character out of range".to_owned(),
         ));
         return -1;
     }
@@ -491,33 +507,37 @@ fn error_handler(errors: *const c_char) -> String {
 
 /// The body every `PyUnicode_Decode*` shares.
 ///
-/// The error handler is the interpreter's own, reached by decoding through
-/// `bytes.decode` rather than by naming the handlers this understands.
+/// The codec set and the error handlers are the interpreter's own: this is the
+/// body `bytes.decode` runs, reached without going through the method, so that
+/// nothing an extension decodes depends on an attribute lookup.
 fn decode_through(
     string: *const c_char,
     length: isize,
     encoding: &str,
     errors: *const c_char,
 ) -> *mut CPyObject {
+    if length == 0 {
+        // Nothing to read, so the caller need not have named a buffer at all.
+        return pyobject::make_ref(pyre_object::w_str_new(""));
+    }
     if string.is_null() || length < 0 {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return std::ptr::null_mut();
     }
     let bytes = unsafe { std::slice::from_raw_parts(string as *const u8, length as usize) };
     let handler = error_handler(errors);
-    let w_bytes = pyre_object::bytesobject::w_bytes_from_bytes(bytes);
-    super::object::result(super::object::call_method(
-        w_bytes,
-        "decode",
-        &[
-            pyre_object::w_str_new(encoding),
-            pyre_object::w_str_new(&handler),
-        ],
-    ))
+    super::object::result(
+        crate::typedef::decode_bytes_to_wtf8(bytes, encoding, &handler)
+            .map(pyre_object::w_str_from_wtf8_managed),
+    )
 }
 
-/// The body every `PyUnicode_As*String` shares: `str.encode`, refusing
-/// anything that is not a `str` the way `PyErr_BadArgument` does.
+/// The body every `PyUnicode_As*String` shares, refusing anything that is not a
+/// `str` the way `PyErr_BadArgument` does.
+///
+/// This is the body `str.encode` runs, reached without going through the
+/// method: a subclass that defines `encode` gets the codec its string names
+/// here, not the one its own method would have chosen.
 fn encode_through(object: *mut CPyObject, encoding: &str, errors: *const c_char) -> *mut CPyObject {
     let Some(value) = argument(object) else {
         return std::ptr::null_mut();
@@ -527,14 +547,10 @@ fn encode_through(object: *mut CPyObject, encoding: &str, errors: *const c_char)
         return std::ptr::null_mut();
     }
     let handler = error_handler(errors);
-    super::object::result(super::object::call_method(
-        value,
-        "encode",
-        &[
-            pyre_object::w_str_new(encoding),
-            pyre_object::w_str_new(&handler),
-        ],
-    ))
+    super::object::result(
+        crate::type_methods::encode_object(value, encoding, &handler)
+            .map(|bytes| pyre_object::bytesobject::w_bytes_from_bytes(&bytes)),
+    )
 }
 
 /// The encoding an entry point was given, `utf-8` for a NULL one.
@@ -662,6 +678,10 @@ pub unsafe extern "C" fn PyUnicode_FromWideChar(
     wide: *const wchar_t,
     size: isize,
 ) -> *mut CPyObject {
+    if size == 0 {
+        // Nothing to read, so the caller need not have named a buffer at all.
+        return pyobject::make_ref(pyre_object::w_str_new(""));
+    }
     if wide.is_null() {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return std::ptr::null_mut();
@@ -929,6 +949,19 @@ pub unsafe extern "C" fn PyUnicode_EncodeLocale(
     pyobject::make_ref(pyre_object::bytesobject::w_bytes_from_bytes(&bytes))
 }
 
+/// The `count` units of `T` that `buffer` addresses, empty for a zero count so
+/// that a caller with nothing to hand over need not name a buffer at all.
+///
+/// # Safety
+/// `buffer` must address `count` readable, aligned units of `T` unless `count`
+/// is zero.
+unsafe fn units<'a, T>(buffer: *const std::ffi::c_void, count: usize) -> &'a [T] {
+    match count {
+        0 => &[],
+        count => unsafe { std::slice::from_raw_parts(buffer as *const T, count) },
+    }
+}
+
 /// `PyUnicode_FromKindAndData(kind, buffer, size)` — a string from an array of
 /// code points of one of the three widths.
 ///
@@ -950,15 +983,15 @@ pub unsafe extern "C" fn PyUnicode_FromKindAndData(
     }
     let count = size as usize;
     let points: Vec<u32> = match kind {
-        1 => unsafe { std::slice::from_raw_parts(buffer as *const u8, count) }
+        1 => unsafe { units::<u8>(buffer, count) }
             .iter()
             .map(|&unit| unit as u32)
             .collect(),
-        2 => unsafe { std::slice::from_raw_parts(buffer as *const u16, count) }
+        2 => unsafe { units::<u16>(buffer, count) }
             .iter()
             .map(|&unit| unit as u32)
             .collect(),
-        4 => unsafe { std::slice::from_raw_parts(buffer as *const u32, count) }.to_vec(),
+        4 => unsafe { units::<u32>(buffer, count) }.to_vec(),
         _ => {
             super::pyerrors::set_pending_error(crate::PyError::new(
                 crate::PyErrorKind::SystemError,

--- a/pyre/pyre-interpreter/src/cpyext/unicodewriter.rs
+++ b/pyre/pyre-interpreter/src/cpyext/unicodewriter.rs
@@ -103,6 +103,10 @@ pub unsafe extern "C" fn PyUnicodeWriter_WriteChar(
 /// # Safety
 /// `string` must address `size` readable bytes, or be NUL-terminated.
 unsafe fn sized_bytes<'a>(string: *const c_char, size: isize) -> Option<&'a [u8]> {
+    if size == 0 {
+        // Nothing to read, so the caller need not have named a buffer at all.
+        return Some(&[]);
+    }
     if string.is_null() {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return None;
@@ -185,6 +189,10 @@ pub unsafe extern "C" fn PyUnicodeWriter_WriteWideChar(
     let Some(handle) = (unsafe { writer(handle) }) else {
         return -1;
     };
+    if size == 0 {
+        // Nothing to read, so the caller need not have named a buffer at all.
+        return 0;
+    }
     if string.is_null() {
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return -1;
@@ -286,11 +294,22 @@ pub unsafe extern "C" fn PyUnicodeWriter_WriteStr(
 }
 
 /// `PyUnicodeWriter_WriteRepr(writer, obj)` -- `repr(obj)`.
+///
+/// A NULL object is spelled `<NULL>` rather than refused: the caller reaching
+/// here is often reporting a failure, and there is nothing left to report with
+/// if describing what failed can fail in turn.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyUnicodeWriter_WriteRepr(
     handle: *mut CPyUnicodeWriter,
     object: *mut CPyObject,
 ) -> c_int {
+    if object.is_null() {
+        let Some(handle) = (unsafe { writer(handle) }) else {
+            return -1;
+        };
+        handle.text.push_str("<NULL>");
+        return 0;
+    }
     write_converted(handle, object, crate::display::py_repr_wtf8)
 }
 

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -7020,6 +7020,33 @@ mod dict_method_tests {
     }
 
     #[test]
+    fn dict_setdefault_rejects_unhashable_key_on_a_typed_strategy() {
+        // A dict that already holds one entry is on the strategy that entry's
+        // key type chose, and `DictStrategy.setdefault` there is `getitem`
+        // then `setitem`.  Both answer for a key of another type by switching
+        // to the object strategy and asking again, so the key is hashed on the
+        // way -- and an unhashable one has to be refused there rather than
+        // stored under no hash at all.
+        for (label, key, value) in [
+            ("unicode", w_str_new("a"), w_int_new(1)),
+            ("int", w_int_new(7), w_int_new(1)),
+            (
+                "bytes",
+                pyre_object::bytesobject::w_bytes_from_bytes(b"a"),
+                w_int_new(1),
+            ),
+        ] {
+            init_dict_test_runtime();
+            let dict = w_dict_new();
+            crate::baseobjspace::setitem(dict, key, value).expect("seed the strategy");
+            let unhashable = w_list_new(vec![]);
+
+            assert_type_error(dict_method_setdefault(&[dict, unhashable, w_int_new(9)]));
+            assert_eq!(unsafe { w_dict_len(dict) }, 1, "{label} strategy");
+        }
+    }
+
+    #[test]
     fn dict_pop_empty_returns_default_without_hashing_key() {
         init_dict_test_runtime();
         let dict = w_dict_new();

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3108,11 +3108,22 @@ pub unsafe fn w_dict_setdefault_checked(
         strategy.switch_to_object_strategy(obj);
         return w_dict_setdefault_checked(obj, key, value);
     }
-    let result = strategy.setdefault(obj, key, value);
-    if take_dict_key_error() {
-        return Err(DictKeyError);
+    // `dictmultiobject.py:487-493 DictStrategy.setdefault` is `getitem`
+    // followed by `setitem`.  Both of those are the infallible spellings here,
+    // and a typed strategy answering either for a key of another type reaches
+    // the object strategy through them -- where a key that cannot be hashed
+    // has nowhere to report itself, so the store went ahead on a key with no
+    // hash.  Run the checked pair, which is the same two steps.  The lookup
+    // can run a probing `__eq__`, so the three by-value words are slotted and
+    // read back after it.
+    let roots = crate::gc_roots::push_roots();
+    let dict_slot = roots.publish(&[obj, key, value]);
+    if let Some(existing) = w_dict_lookup_checked(obj, key)? {
+        return Ok(existing);
     }
-    Ok(result)
+    let value = roots.get(dict_slot + 2);
+    w_dict_store_checked(roots.get(dict_slot), roots.get(dict_slot + 1), value)?;
+    Ok(value)
 }
 
 /// `dictmultiobject.py:624-634 DictStrategy.pop` (base) +

--- a/pyre/pyrex/tests/cpyext_conversions.rs
+++ b/pyre/pyrex/tests/cpyext_conversions.rs
@@ -91,6 +91,20 @@ eq('as ascii nonstr', m.as_ascii(b'abc'), BAD)
 eq('as utf8 nonstr', m.as_utf8_string(42), BAD)
 eq('as encoded nonstr', m.as_encoded(42, 'ascii', None), BAD)
 
+# A subclass is still a `str`, and what these encode is the string: they
+# reach the codec directly, so an `encode` of its own is never looked up.
+
+
+class Shouty(str):
+    def encode(self, *arguments, **keywords):
+        raise AssertionError('encode() was looked up')
+
+
+eq('as ascii subclass', m.as_ascii(Shouty('abc')), (b'abc', None))
+eq('as utf8 subclass', m.as_utf8_string(Shouty('a一z')), (b'a\xe4\xb8\x80z', None))
+eq('as latin1 subclass', m.as_latin1(Shouty('a\xe9z')), (b'a\xe9z', None))
+eq('as encoded subclass', m.as_encoded(Shouty('a一z'), 'ascii', 'replace'), (b'a?z', None))
+
 # ── the `wchar_t` forms ────────────────────────────────────────────────
 
 eq('from wide nul terminated', m.from_wide([104, 105], -1), ('hi', None))

--- a/pyre/pyrex/tests/cpyext_fixture/mod.rs
+++ b/pyre/pyrex/tests/cpyext_fixture/mod.rs
@@ -81,7 +81,13 @@ impl Fixtures {
             .arg("-I")
             .arg(&include)
             .arg("-o")
-            .arg(&extension);
+            .arg(&extension)
+            // A fixture is written against these headers and nothing else, so
+            // a warning in one is either the fixture calling an entry point
+            // wrongly or the header declaring it wrongly. Both are what these
+            // tests are for, and a compiler that only mentions them writes to a
+            // stderr this harness reads only when the compile fails.
+            .arg("-Werror");
         if cfg!(target_os = "macos") {
             cc.args(["-bundle", "-undefined", "dynamic_lookup"]);
         } else {

--- a/pyre/pyrex/tests/cpyext_object_families.rs
+++ b/pyre/pyrex/tests/cpyext_object_families.rs
@@ -45,6 +45,15 @@ eq('from_string_and_size', m.ba_from_string_and_size(b'hello', 5), bytearray(b'h
 eq('from_string_and_size, shorter', m.ba_from_string_and_size(b'hello', 2), bytearray(b'he'))
 # A NULL source asks for a buffer of that size; what is in it is not defined.
 eq('from NULL is that long', len(m.ba_from_null(4)), 4)
+eq('from NULL of nothing', m.ba_from_null(0), bytearray())
+# A length below zero is the caller's mistake, not a buffer of no bytes.
+try:
+    m.ba_from_null(-1)
+except SystemError as error:
+    eq('from negative', str(error),
+       'Negative size passed to PyByteArray_FromStringAndSize')
+else:
+    raise AssertionError('PyByteArray_FromStringAndSize accepted a negative size')
 
 eq('from_object(bytes)', m.ba_from_object(b'xy'), bytearray(b'xy'))
 eq('from_object(list)', m.ba_from_object([1, 2, 3]), bytearray(b'\x01\x02\x03'))

--- a/pyre/pyrex/tests/cpyext_small.rs
+++ b/pyre/pyrex/tests/cpyext_small.rs
@@ -145,6 +145,36 @@ eq('setdefault hash raises', raising, (-1, None, ('ValueError', 'boom')))
 refused = m.set_default([], 'a', 1)
 eq('setdefault not a dict', (refused[0], refused[1]), (-1, None))
 eq('setdefault untouched', mapping, {'a': 1, 'b': 2, 'c': 3})
+# Whether the key was there is answered without looking for it a second time,
+# so a key that counts what is asked of it sees one hash either way.
+
+
+class Counted:
+    def __init__(self, name):
+        self.name = name
+        self.hashes = 0
+
+    def __hash__(self):
+        self.hashes += 1
+        return hash(self.name)
+
+    def __eq__(self, other):
+        return isinstance(other, Counted) and other.name == self.name
+
+
+held = Counted('k')
+counted = {held: 'was there'}
+probe = Counted('k')
+eq('setdefault counted present', m.set_default(counted, probe, 'default'),
+   (1, 'was there', None))
+eq('setdefault probes once', probe.hashes, 1)
+fresh = Counted('new')
+eq('setdefault counted absent', m.set_default(counted, fresh, 'default'),
+   (0, 'default', None))
+eq('setdefault probes once inserting', fresh.hashes, 1)
+# The default landing on a key that already maps to an equal value is still
+# the key having been there.
+eq('setdefault same value', m.set_default({'x': 1}, 'x', 1), (1, 1, None))
 
 # ── origin[args] ───────────────────────────────────────────────────────
 

--- a/pyre/pyrex/tests/cpyext_unicode.rs
+++ b/pyre/pyrex/tests/cpyext_unicode.rs
@@ -79,6 +79,36 @@ except TypeError:
 else:
     raise AssertionError('escape() accepted a non-str')
 
+# ── a write is measured against the width the string was made with ─────
+assert u.new_and_write(3, 0x7f, 0x41) == 'Axx'
+assert u.new_and_write(3, 0xff, 0xff) == '\u00ffxx'
+assert u.new_and_write(3, 0xffff, 0xffff) == '\uffffxx'
+assert u.new_and_write(3, 0x10ffff, 0x1f363) == '\U0001f363xx'
+# A surrogate is a code point a str holds, so it is written like any other.
+# The width asked for is the one that holds it: a string wider than its
+# contents need is not the string the same text spells.
+assert u.new_and_write(3, 0xffff, 0xd800) == '\ud800xx'
+for maxchar, value in [
+    (0x7f, 0xff), (0x7f, 0x1f363), (0xff, 0x100),
+    (0xffff, 0x10000), (0x10ffff, 0x110000),
+]:
+    try:
+        u.new_and_write(3, maxchar, value)
+    except ValueError as error:
+        assert str(error) == 'character out of range', (maxchar, value, error)
+    else:
+        raise AssertionError(f'wrote {value:#x} into a string of {maxchar:#x}')
+
+# ── neither accessor takes anything but a string ───────────────────────
+refused = ('TypeError', 'bad argument type for built-in operation')
+assert u.not_a_string(b'abc') == (refused, refused), u.not_a_string(b'abc')
+assert u.not_a_string(3) == (refused, refused)
+
+# ── a count of nothing names no buffer, but the kind is still checked ───
+rows, refused_kind = u.from_nothing()
+assert rows == ['', '', '', ''], rows
+assert refused_kind == ('SystemError', 'invalid kind'), refused_kind
+
 print('cpyext-unicode-ok')
 "#;
 

--- a/pyre/pyrex/tests/cpyext_writer.rs
+++ b/pyre/pyrex/tests/cpyext_writer.rs
@@ -88,6 +88,11 @@ eq('refuse str', m.write_refusals('str', NoText(), 0, 0),
 eq('refuse repr', m.write_refusals('repr', NoText(), 0, 0),
    (-1, ('RuntimeError', 'no repr'), 'keep'))
 
+# A count of nothing names no buffer, so none of the sized writes needs one;
+# `repr` of nothing is spelled rather than refused, which is what a caller
+# already reporting a failure has left to report with.
+eq('write nothing', m.write_nothing(), '<NULL>')
+
 # The substring bounds are in code points, so a character outside the basic
 # plane counts once.
 eq('substring', m.write_substring('h☃llo', 1, 4), ('☃ll', None))

--- a/pyre/pyrex/tests/fixtures/cpyext_unicode.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_unicode.c
@@ -6,6 +6,21 @@
 
 static struct PyModuleDef moduledef;
 
+/* The exception an entry point left behind, as `(type name, message)`. */
+static PyObject *pending(void)
+{
+    PyObject *value = PyErr_GetRaisedException();
+    if (value == NULL) {
+        Py_RETURN_NONE;
+    }
+    PyObject *text = PyObject_Str(value);
+    PyObject *pair = Py_BuildValue("(sO)", Py_TYPE(value)->tp_name,
+                                   text == NULL ? Py_None : text);
+    Py_XDECREF(text);
+    Py_DECREF(value);
+    return pair;
+}
+
 /* The shape a real extension uses: measure the input, allocate a string wide
    enough for it, then fill it through the caller's own pointer. */
 static PyObject *u_escape(PyObject *self, PyObject *arg)
@@ -161,6 +176,85 @@ static PyObject *u_rejects(PyObject *self, PyObject *arg)
     Py_RETURN_TRUE;
 }
 
+/* The width is fixed when the string is made, so a write of a code point
+   wider than it holds is refused rather than cut down.  Both halves happen
+   here: a string is modifiable only while nothing else names it. */
+static PyObject *u_new_and_write(PyObject *self, PyObject *args)
+{
+    (void)self;
+    Py_ssize_t length;
+    unsigned long maxchar;
+    unsigned long value;
+    if (!PyArg_ParseTuple(args, "nkk", &length, &maxchar, &value)) {
+        return NULL;
+    }
+    PyObject *text = PyUnicode_New(length, (Py_UCS4)maxchar);
+    if (text == NULL) {
+        return NULL;
+    }
+    for (Py_ssize_t index = 0; index < length; index++) {
+        Py_UCS4 point = index == 0 ? (Py_UCS4)value : (Py_UCS4)'x';
+        if (PyUnicode_WriteChar(text, index, point) < 0) {
+            Py_DECREF(text);
+            return NULL;
+        }
+    }
+    return text;
+}
+
+/* Neither accessor takes anything but a string, and saying so is what
+   `PyErr_BadArgument` is for. */
+static PyObject *u_not_a_string(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    if (PyUnicode_ReadChar(arg, 0) != (Py_UCS4)-1 || !PyErr_Occurred()) {
+        PyErr_SetString(PyExc_SystemError, "ReadChar accepted something that is not a string");
+        return NULL;
+    }
+    PyObject *read = pending();
+    if (PyUnicode_WriteChar(arg, 0, 'x') != -1 || !PyErr_Occurred()) {
+        Py_XDECREF(read);
+        PyErr_SetString(PyExc_SystemError, "WriteChar accepted something that is not a string");
+        return NULL;
+    }
+    return Py_BuildValue("(NN)", read, pending());
+}
+
+/* A count of nothing names no buffer, so neither builder needs one. */
+static PyObject *u_from_nothing(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    (void)arg;
+    PyObject *wide = PyUnicode_FromWideChar(NULL, 0);
+    if (wide == NULL) {
+        return NULL;
+    }
+    PyObject *rows = PyList_New(0);
+    if (rows == NULL || PyList_Append(rows, wide) < 0) {
+        Py_DECREF(wide);
+        Py_XDECREF(rows);
+        return NULL;
+    }
+    Py_DECREF(wide);
+    int kinds[] = {PyUnicode_1BYTE_KIND, PyUnicode_2BYTE_KIND, PyUnicode_4BYTE_KIND};
+    for (size_t index = 0; index < sizeof(kinds) / sizeof(kinds[0]); index++) {
+        PyObject *text = PyUnicode_FromKindAndData(kinds[index], NULL, 0);
+        if (text == NULL || PyList_Append(rows, text) < 0) {
+            Py_XDECREF(text);
+            Py_DECREF(rows);
+            return NULL;
+        }
+        Py_DECREF(text);
+    }
+    /* The kind is still checked, a count of nothing or not. */
+    if (PyUnicode_FromKindAndData(3, NULL, 0) != NULL || !PyErr_Occurred()) {
+        Py_DECREF(rows);
+        PyErr_SetString(PyExc_SystemError, "PyUnicode_FromKindAndData accepted kind 3");
+        return NULL;
+    }
+    return Py_BuildValue("(NN)", rows, pending());
+}
+
 /* An empty string still allocates, and reads back as ''. */
 static PyObject *u_empty(PyObject *self, PyObject *arg)
 {
@@ -251,6 +345,9 @@ static PyMethodDef methods[] = {
     {"out_of_range", u_out_of_range, METH_NOARGS, "the index checks of the char accessors"},
     {"rejects", u_rejects, METH_NOARGS, "the argument checks of PyUnicode_New"},
     {"empty", u_empty, METH_NOARGS, "PyUnicode_New(0, 0)"},
+    {"new_and_write", u_new_and_write, METH_VARARGS, "PyUnicode_New then PyUnicode_WriteChar"},
+    {"not_a_string", u_not_a_string, METH_O, "the type checks of the char accessors"},
+    {"from_nothing", u_from_nothing, METH_NOARGS, "the builders handed a count of nothing"},
     {NULL, NULL, 0, NULL},
 };
 

--- a/pyre/pyrex/tests/fixtures/cpyext_writer.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_writer.c
@@ -139,6 +139,27 @@ static PyObject *write_refusals(PyObject *self, PyObject *args)
     return Py_BuildValue("(iNN)", written, left, held);
 }
 
+/* Every writer entry point handed a count of nothing, which names no buffer,
+   followed by `repr` of nothing, which is spelled rather than refused. */
+static PyObject *write_nothing(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    (void)arg;
+    PyUnicodeWriter *writer = PyUnicodeWriter_Create(0);
+    if (writer == NULL) {
+        return NULL;
+    }
+    if (PyUnicodeWriter_WriteUTF8(writer, NULL, 0) < 0
+        || PyUnicodeWriter_WriteASCII(writer, NULL, 0) < 0
+        || PyUnicodeWriter_WriteWideChar(writer, NULL, 0) < 0
+        || PyUnicodeWriter_WriteUCS4(writer, NULL, 0) < 0
+        || PyUnicodeWriter_WriteRepr(writer, NULL) < 0) {
+        PyUnicodeWriter_Discard(writer);
+        return NULL;
+    }
+    return PyUnicodeWriter_Finish(writer);
+}
+
 /* The substring cases that work. */
 static PyObject *write_substring(PyObject *self, PyObject *args)
 {
@@ -318,6 +339,7 @@ static PyMethodDef methods[] = {
     {"write_discard", write_discard, METH_NOARGS, NULL},
     {"write_bad_create", write_bad_create, METH_NOARGS, NULL},
     {"write_refusals", write_refusals, METH_VARARGS, NULL},
+    {"write_nothing", write_nothing, METH_NOARGS, NULL},
     {"write_substring", write_substring, METH_VARARGS, NULL},
     {"dict_pop", dict_pop, METH_VARARGS, NULL},
     {"dict_pop_no_result", dict_pop_no_result, METH_VARARGS, NULL},

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -28,6 +28,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[2]
 CPYEXT = ROOT / "pyre/pyre-interpreter/src/cpyext"
 HEADER_DIR = ROOT / "include/pyre3.14t"
 RECORD = pathlib.Path(__file__).resolve().parent / "cpython-abi.txt"
+GENERATED = HEADER_DIR / "pyre_decl.h"
 
 
 # ── reading C ──────────────────────────────────────────────────────────────
@@ -234,6 +235,31 @@ def read_header_inlines():
             params = [param_type(p) for p in split_commas(match.group("params"))]
             ret = tidy(match.group("ret") + " " + match.group("stars"))
             yield path.name, match.group("name"), params or ["void"], ret
+
+
+HAND_DECLARED = re.compile(r"^PyAPI_FUNC\([^)]*\)\s*(?P<name>[A-Za-z_]\w*)\s*\(", re.M)
+RENAME = re.compile(r"^[ \t]*#[ \t]*define[ \t]+(?P<name>[A-Za-z_]\w*)[ \t(]", re.M)
+
+
+def read_renamed_exports():
+    """The exports a hand-written header declares and then renames.
+
+    `lock.h` declares `PyMutex_Lock` and follows the inline fast path with
+    `#define PyMutex_Lock _PyMutex_Lock`, so that a caller reaches the export
+    only on the contended path.  The declaration has to come before that
+    rename, and one after it would name the inline function instead -- a second
+    declaration of a `static inline` already defined, carrying an attribute it
+    did not have.  So a renamed export is declared where it is renamed, and
+    left out of the generated declarations.
+    """
+    for path in sorted(HEADER_DIR.glob("*.h")):
+        if path.name == GENERATED.name:
+            continue
+        text = strip_comments(path.read_text(errors="replace"))
+        declared = {match.group("name") for match in HAND_DECLARED.finditer(text)}
+        for match in RENAME.finditer(text):
+            if match.group("name") in declared:
+                yield match.group("name")
 
 
 STATIC = re.compile(
@@ -466,8 +492,11 @@ def check_data(record, typedefs, misspelled):
 
 def command_generate(args):
     declarations, _, _ = load_record()
+    renamed = set(read_renamed_exports())
     by_module = {}
     for module, name, params, ret in read_exports():
+        if name in renamed:
+            continue
         # CPython's own spelling wherever it has one: `check` has already
         # established the two describe the same call, and the reference
         # spelling is the one an extension's own prototypes agree with.
@@ -482,6 +511,10 @@ def command_generate(args):
         " * Written by scripts/cpyext-abi.py generate; do not edit by hand.",
         " * A declaration here is CPython's own where CPython has one, so an",
         " * extension's prototypes and pyre's agree by construction.",
+        " *",
+        " * An export a hand-written header renames to an inline fast path is",
+        " * left out: that header declares it ahead of the rename, which a",
+        " * declaration here would come after.",
         " */",
         "#ifndef PYRE_DECL_H",
         "#define PYRE_DECL_H",
@@ -499,7 +532,7 @@ def command_generate(args):
     out += ["#ifdef __cplusplus", "}", "#endif", "", "#endif /* !PYRE_DECL_H */"]
 
     text = "\n".join(out) + "\n"
-    target = HEADER_DIR / "pyre_decl.h"
+    target = GENERATED
     if args.check:
         if not target.exists() or target.read_text() != text:
             print(f"{target} is not what `generate` produces; re-run without --check")


### PR DESCRIPTION
Follow-up to #1334, on a branch re-cut off `origin/main`.

## The ten review findings

All ten expectations were measured against CPython 3.14.6 (`python3.14t`) running
the same script against the same fixture, not asserted from the documentation.

- `PyUnicode_ReadChar` / `PyUnicode_WriteChar` refuse a non-string with
  `PyErr_BadArgument`, and `WriteChar` refuses a code point wider than the
  string was made for with `ValueError("character out of range")`.
- `PyUnicode_As*String` and `PyUnicode_Decode*` run the bodies `str.encode` and
  `bytes.decode` run rather than calling the methods, so a `str` subclass
  defining `encode` no longer decides what they encode.
- `PyUnicode_FromWideChar`, `PyUnicode_FromKindAndData`, `decode_through`,
  `PyUnicodeWriter_WriteUTF8` / `WriteASCII` / `WriteWideChar` build an empty
  result for a count of nothing before reading the pointer. They had been
  turning it into a zero-length slice from NULL, which is UB in Rust.
- `PyUnicodeWriter_WriteRepr` writes `<NULL>` for a NULL object.
- `_PyBytes_Resize` gives up the reference `*pv` holds on the two
  `PyErr_NoMemory` paths as well, which its NULL arm already did.
- `PyByteArray_FromStringAndSize` raises `SystemError` for a negative size
  instead of clamping it to zero.
- `PyThreadState_Get` ends the process when this thread's state is not current.
- `PyDict_SetDefaultRef` reads whether the key was there off the dict's size
  instead of probing for it first, so the key's `__hash__` and `__eq__` run once
  — CPython's own count.

New coverage in `cpyext_unicode`, `cpyext_writer`, `cpyext_conversions`,
`cpyext_object_families` and `cpyext_small`, with two new fixture entry points.

## The defect the last of those uncovered

Removing that `contains()` pre-probe exposed what it had been masking.
`w_dict_setdefault_checked` ended in `strategy.setdefault`, which is `getitem`
followed by `setitem` — both the **infallible** spellings. A typed strategy
answers either for a key of another type by switching to the object strategy and
asking again, and the store there had no way to report a key that cannot be
hashed:

| | before | CPython 3.14.6 |
| --- | --- | --- |
| `{'a': 1}.setdefault([], 9)` | returned `9`, no raise, no insert | `TypeError` |
| `{1: 'a'}.setdefault([], 9)` | returned `9`, dict then read back as a misaligned pointer | `TypeError` |
| `{b'a': 1}.setdefault([], 9)` | returned `9`, `capacity overflow` panic on repr | `TypeError` |

It runs `w_dict_lookup_checked` and `w_dict_store_checked` now, which are the
same two steps. All four strategies match CPython.

`lib-python/3/test/test_dict.py::DictTest::test_unhashable_key` makes exactly
this call, but four earlier statements in the same test (`key in d`, `d[key]`,
`d[key] = 2`) each promote `d` to the object strategy on their way to raising,
so the broken arm was unreachable and `baseline.json`'s `test.test_dict: PASS`
was honest. The new regression test in `type_methods.rs` seeds one entry per
strategy and was ablated against the unfixed tail.

## Fixture warnings

`pyre_decl.h` declared `PyMutex_Lock`, `PyMutex_Unlock` and `PyMutex_IsLocked`
after `lock.h` had renamed each onto its inline fast path, so every fixture
compile reported three `-Wignored-attributes` warnings. `generate` now leaves
out an export a hand-written header declares and then renames, and the fixture
harness passes `-Werror` — it reads the compiler's stderr only when the compile
fails, so a warning it wrote was not seen.

## Verification

- `cargo test --all --features dynasm`: 153 binaries, 7917 tests, 0 failures.
- All 17 cpyext fixture binaries pass; `cargo fmt --all --check`,
  `cpyext-abi.py check` and `cpyext-abi.py generate --check` are clean.
- markupsafe rebuilt from its sdist against these headers with `-Werror` and no
  warnings; its own test modules run 39 passed / 1 failed under the C
  `_escape_inner`. The failure is `test_leak.test_markup_leaks`, which is not a
  leak: `gc.get_objects()` goes 7880 → 7804 → 7800 over the run, and the test
  wants fewer than three distinct counts. Pre-existing, unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKvxTiG1M3K7KuKxVVezaX
