### PR TITLE
jit: carry unroll_safe onto methods, and type a range iterator's next as an int

### DIFF
--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -535,6 +535,12 @@ fn rpython_attribute_const_for(
         }
         "look_inside" => &[("_jit_look_inside_", true, false)],
         "jit_loop_invariant" => &[("_jit_loop_invariant_", true, false)],
+        // `rlib/jit.py:151 def unroll_safe` emits no policy fn, so a
+        // sibling const would be rejected in a trait impl — `unroll_safe`
+        // decorates those (`majit-macros/tests/macros.rs` `NameCollider`).
+        // It stays free-fn-only here and reaches methods through the
+        // body-local marker instead, as `jit_elidable` does.
+        "unroll_safe" => &[("_jit_unroll_safe_", true, false)],
         _ => return None,
     };
     let consts: Vec<proc_macro2::TokenStream> = markers
@@ -2055,22 +2061,23 @@ pub fn unroll_safe(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let sig = &func.sig;
     let block = &func.block;
     // RPython attribute-name parity: `rlib/jit.py:159 func._jit_unroll_safe_
-    // = True`.  Emit a module-level `pub const _jit_unroll_safe_<NAME>:
-    // bool = true` next to the wrapper so `rg _jit_unroll_safe_` finds
-    // the parity counterpart in both pyre and PyPy.  Skip for methods
-    // (`self`-receiver) because trait-impl blocks reject foreign
-    // associated items — see `rpython_attribute_const_for`'s receiver
-    // guard for the same reasoning.
-    let unroll_safe_const = if sig.receiver().is_none() {
-        let const_name = format_ident!("_jit_unroll_safe_{}", sig.ident);
-        Some(quote! {
-            #[doc(hidden)]
-            #[allow(non_upper_case_globals)]
-            #vis const #const_name: bool = true;
-        })
-    } else {
-        None
-    };
+    // = True`.  `front/llbc_hints.rs` harvests `_jit_unroll_safe_<NAME>` and
+    // nothing else; the marker this used to leave in the body was spelled
+    // `_MAJIT_UNROLL_SAFE`, carrying neither the prefix nor the function
+    // name, so it was never read — and a method got no sibling const, so a
+    // method got no hint at all.  `@unroll_safe` decorates methods upstream
+    // (`pyframe.py` `fast2locals`, `peekvalues`, `dropvalues`), which is
+    // exactly the shape that was being dropped.
+    //
+    // The body-local spelling is what carries it, as for `jit_elidable`: a
+    // trait impl rejects a foreign associated const, and an attribute macro
+    // cannot tell an inherent impl from a trait impl.  Charon promotes a
+    // body-local const under the method's own path, and
+    // `llbc_hints::marker_path_to_fn_path` already resolves that spelling.
+    // A free function additionally gets the module-level sibling, so
+    // `rg _jit_unroll_safe_` still finds the parity counterpart there.
+    let marker = format_ident!("_jit_unroll_safe_{}", sig.ident);
+    let unroll_safe_const = rpython_attribute_const_for("unroll_safe", sig, vis);
 
     let expanded = quote! {
         #(#attrs)*
@@ -2078,8 +2085,8 @@ pub fn unroll_safe(_attr: TokenStream, item: TokenStream) -> TokenStream {
         #[allow(non_upper_case_globals)]
         #vis #sig {
             #[doc(hidden)]
-            #[allow(dead_code)]
-            const _MAJIT_UNROLL_SAFE: bool = true;
+            #[allow(non_upper_case_globals, dead_code)]
+            const #marker: bool = true;
             #block
         }
 

--- a/majit/majit-macros/tests/macros.rs
+++ b/majit/majit-macros/tests/macros.rs
@@ -676,9 +676,9 @@ mod jit_module {
         assert!(std::hint::black_box(_elidable_function_pure_or_memerror));
         // Methods (`self`-receiver) skip module-level const emission —
         // `rpython_attribute_const_for`'s receiver guard avoids
-        // trait-impl associated-item conflicts.  RPython's
-        // `func._elidable_function_` parity at method scope is left for
-        // a follow-up slice that knows the surrounding `impl` context.
+        // trait-impl associated-item conflicts.  A method reaches the
+        // harvester through the body-local marker instead; see
+        // `test_unroll_safe_marker_reaches_methods`.
 
         // `rlib/jit.py:139 _jit_look_inside_ = False` — both opaque
         // variants share the upstream attribute.
@@ -693,6 +693,56 @@ mod jit_module {
 
         // `rlib/jit.py:159 _jit_unroll_safe_ = True`.
         assert!(std::hint::black_box(_jit_unroll_safe_unrolled_helper));
+    }
+
+    mod unroll_safe_method_module {
+        use majit_macros::unroll_safe;
+
+        pub struct Counter(pub i64);
+
+        impl Counter {
+            /// The marker `unroll_safe` leaves on a method is body-local, so
+            /// the body is the only scope that can name it.  Returning it is
+            /// the assertion: it has to be spelled
+            /// `_jit_unroll_safe_<NAME>` — what `front/llbc_hints.rs`
+            /// harvests — or this does not compile.
+            #[unroll_safe]
+            pub fn bump(&mut self) -> bool {
+                self.0 += 1;
+                _jit_unroll_safe_bump
+            }
+        }
+
+        pub trait Step {
+            fn step(&mut self) -> bool;
+        }
+
+        impl Step for Counter {
+            /// The same marker inside a trait impl, which is what rules out
+            /// a sibling associated const: the trait does not declare one,
+            /// so emitting it here is `error[E0438]`.
+            #[unroll_safe]
+            fn step(&mut self) -> bool {
+                self.0 += 2;
+                _jit_unroll_safe_step
+            }
+        }
+    }
+
+    /// A method carries `unroll_safe` under its own name.
+    ///
+    /// The marker used to be spelled `_MAJIT_UNROLL_SAFE`, carrying neither
+    /// the `_jit_unroll_safe_` prefix nor the function name, so nothing
+    /// harvested it; a free function was covered only by the module-level
+    /// sibling const, which a method never gets.
+    #[test]
+    fn test_unroll_safe_marker_reaches_methods() {
+        use unroll_safe_method_module::{Counter, Step};
+
+        let mut counter = Counter(0);
+        assert!(counter.bump());
+        assert!(counter.step());
+        assert_eq!(counter.0, 3);
     }
 
     mod look_inside_alias_module {

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -1983,9 +1983,18 @@ impl Assembler {
                 // dispatches the `i`-index argcode; a ref/float index is a
                 // kind-flow bug upstream of the codewriter — fail here rather
                 // than emit an unconsumable ref-index (`rrd`/`ird`) shape.
+                //
+                // The array's identity is part of the report: one graph can
+                // hold several `getarrayitem_gc`s and only some of them carry
+                // the bad index, so without it the message names the graph and
+                // leaves the op to be found by bisection.
                 assert_eq!(
                     kc, 'i',
-                    "getarrayitem_gc array index must be int-kind, got {kc:?}",
+                    "getarrayitem_gc array index must be int-kind, got {kc:?} — \
+                     graph {:?}, array_type_id {array_type_id:?}, item_ty \
+                     {item_ty:?}, flatop {:?} (set MAJIT_COVERAGE_PANIC=1 to \
+                     populate the flatop context)",
+                    self.current_graph_name, self.current_flatop_debug,
                 );
                 state.code.push(reg);
                 argcodes.push(kc);

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -125,6 +125,33 @@ fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
 /// discarded; [`iter_next_item_type`] needs it, because the container is the
 /// only thing that separates the two iterator reprs.
 fn iter_op_container(graph: &FunctionGraph, var: &Variable) -> Option<Variable> {
+    walk_back_to_source(graph, var, |op| match &op.kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            args,
+            ..
+        } if is_iter_op_segments(segments) => args.first().cloned(),
+        _ => None,
+    })
+}
+
+/// Walk backwards from `var` to the op that produced it, asking `probe`
+/// about each candidate, and stop at the first `Some`.
+///
+/// Two steps per var: (1) an op whose result is the var — hand it to
+/// `probe`; (2) a block inputarg — trace each predecessor's link arg in
+/// the matching slot, so a loop header's phi resolves through its entry
+/// edge to the pre-loop definition while the back edge re-threads an
+/// already-seen var.
+///
+/// Conservative: a var produced by an op `probe` declines is not followed
+/// any further, so a result is always a positively-confirmed source rather
+/// than the absence of a contrary one.
+fn walk_back_to_source<T>(
+    graph: &FunctionGraph,
+    var: &Variable,
+    probe: impl Fn(&SpaceOperation) -> Option<T>,
+) -> Option<T> {
     let mut visited: Vec<Variable> = Vec::new();
     let mut stack: Vec<Variable> = vec![var.clone()];
     while let Some(v) = stack.pop() {
@@ -132,23 +159,15 @@ fn iter_op_container(graph: &FunctionGraph, var: &Variable) -> Option<Variable> 
             continue;
         }
         visited.push(v.clone());
-        // (1) produced directly by an iter op → confirmed list iterator.
         for b in &graph.blocks {
             for op in &b.operations {
                 if op.result.as_ref() == Some(&v)
-                    && let OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        args,
-                        ..
-                    } = &op.kind
-                    && is_iter_op_segments(segments)
+                    && let Some(found) = probe(op)
                 {
-                    return args.first().cloned();
+                    return Some(found);
                 }
             }
         }
-        // (2) a block inputarg → trace each predecessor's link arg in the
-        // matching slot (the loop-carried iterator phi).
         for b in &graph.blocks {
             if let Some(pos) = b.inputargs.iter().position(|iv| iv == &v) {
                 let target_id = b.id;
@@ -170,9 +189,17 @@ fn iter_op_container(graph: &FunctionGraph, var: &Variable) -> Option<Variable> 
 /// The element type the native `next` op yields for the iterator `var`.
 ///
 /// `ListIteratorRepr::rtype_next` (`rlist.py ll_listnext`) hands back the
-/// list's item repr — a GC reference for every list this fold admits —
-/// while `RangeIteratorRepr::rtype_next` (`rrange.py ll_rangenext_*`) hands
-/// back a `Signed`.  `front::range_iter` reroutes an exclusive int `Range`
+/// list's item repr, while `RangeIteratorRepr::rtype_next`
+/// (`rrange.py ll_rangenext_*`) hands back a `Signed`.
+///
+/// The `Ref` answer is the fold's assumption about every other container,
+/// not a decision: [`is_iter_op_segments`] admits any `core::slice::…::iter`,
+/// including a slice whose items are not GC references (`&[usize]`,
+/// `&[u8]`).  Such a loop would type raw integers into the ref register
+/// bank.  No graph the codewriter looks inside iterates one today — the two
+/// production `#[unroll_safe]` sites iterate a `range` and a
+/// `&[PyObjectRef]` — so closing it needs the container's element type,
+/// which the fold does not consult.  `front::range_iter` reroutes an exclusive int `Range`
 /// for-loop onto the `range()` builtin plus the same `iter` bridge, so both
 /// reprs arrive here behind one `iter` op and only the container that op was
 /// given tells them apart.
@@ -195,24 +222,25 @@ fn iter_next_item_type(graph: &FunctionGraph, iterator: &Variable) -> ValueType 
     }
 }
 
-/// Whether `var` is the result of `front::range_iter`'s reserved
+/// Whether `var` traces back to `front::range_iter`'s reserved
 /// `["__pyre_range"]` call — the `range(a, b)` builtin standing in for an
 /// exclusive int `Range`.
+///
+/// The same backward walk the iterator itself gets.  `range_iter` emits the
+/// `range` call and the `iter` bridge adjacent, so today the container is
+/// that call's direct result; a copy or a block boundary between them would
+/// otherwise flip the answer back to `Ref`, and the failure mode is the
+/// assembler reject [`iter_next_item_type`] exists to prevent rather than a
+/// graceful degrade.
 fn produced_by_range_builtin(graph: &FunctionGraph, var: &Variable) -> bool {
-    graph
-        .blocks
-        .iter()
-        .flat_map(|b| b.operations.iter())
-        .any(|op| {
-            op.result.as_ref() == Some(var)
-                && matches!(
-                    &op.kind,
-                    OpKind::Call {
-                        target: CallTarget::FunctionPath { segments },
-                        ..
-                    } if segments.len() == 1 && segments[0] == "__pyre_range"
-                )
-        })
+    walk_back_to_source(graph, var, |op| match &op.kind {
+        OpKind::Call {
+            target: CallTarget::FunctionPath { segments },
+            ..
+        } if segments.len() == 1 && segments[0] == "__pyre_range" => Some(()),
+        _ => None,
+    })
+    .is_some()
 }
 
 /// Transitive closure of dead forwarded inputarg slots starting from

--- a/majit/majit-translate/src/front/iter_next.rs
+++ b/majit/majit-translate/src/front/iter_next.rs
@@ -117,6 +117,14 @@ fn is_iter_op_segments(segments: &[String]) -> bool {
 /// foreign iterator constructor) is not followed, so the walk returns
 /// `true` only on a positively-confirmed `iter` source.
 fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
+    iter_op_container(graph, var).is_some()
+}
+
+/// The container an `iter` op constructed `var` over, when the backward walk
+/// confirms one.  `originates_from_iter_op` is this with the container
+/// discarded; [`iter_next_item_type`] needs it, because the container is the
+/// only thing that separates the two iterator reprs.
+fn iter_op_container(graph: &FunctionGraph, var: &Variable) -> Option<Variable> {
     let mut visited: Vec<Variable> = Vec::new();
     let mut stack: Vec<Variable> = vec![var.clone()];
     while let Some(v) = stack.pop() {
@@ -130,11 +138,12 @@ fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
                 if op.result.as_ref() == Some(&v)
                     && let OpKind::Call {
                         target: CallTarget::FunctionPath { segments },
+                        args,
                         ..
                     } = &op.kind
                     && is_iter_op_segments(segments)
                 {
-                    return true;
+                    return args.first().cloned();
                 }
             }
         }
@@ -155,7 +164,55 @@ fn originates_from_iter_op(graph: &FunctionGraph, var: &Variable) -> bool {
             }
         }
     }
-    false
+    None
+}
+
+/// The element type the native `next` op yields for the iterator `var`.
+///
+/// `ListIteratorRepr::rtype_next` (`rlist.py ll_listnext`) hands back the
+/// list's item repr — a GC reference for every list this fold admits —
+/// while `RangeIteratorRepr::rtype_next` (`rrange.py ll_rangenext_*`) hands
+/// back a `Signed`.  `front::range_iter` reroutes an exclusive int `Range`
+/// for-loop onto the `range()` builtin plus the same `iter` bridge, so both
+/// reprs arrive here behind one `iter` op and only the container that op was
+/// given tells them apart.
+///
+/// Answering `Ref` for a range is not inert.  The legacy type walker reads
+/// `result_ty` straight off the op (`legacy_annotator`'s `Call` arm returns
+/// it whenever it is not `Unknown`), so the loop's induction variable lands
+/// in the ref register bank, and every `array[i]` in the loop body then
+/// assembles as a `getarrayitem_gc` whose index is ref-kind — which
+/// `assembler.rs` rejects outright.  Graphs containing a loop are normally
+/// residualized rather than looked inside, so this surfaces only on a graph
+/// carrying `@jit.unroll_safe`.
+fn iter_next_item_type(graph: &FunctionGraph, iterator: &Variable) -> ValueType {
+    let over_a_range = iter_op_container(graph, iterator)
+        .is_some_and(|container| produced_by_range_builtin(graph, &container));
+    if over_a_range {
+        ValueType::Int
+    } else {
+        ValueType::Ref(None)
+    }
+}
+
+/// Whether `var` is the result of `front::range_iter`'s reserved
+/// `["__pyre_range"]` call — the `range(a, b)` builtin standing in for an
+/// exclusive int `Range`.
+fn produced_by_range_builtin(graph: &FunctionGraph, var: &Variable) -> bool {
+    graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.operations.iter())
+        .any(|op| {
+            op.result.as_ref() == Some(var)
+                && matches!(
+                    &op.kind,
+                    OpKind::Call {
+                        target: CallTarget::FunctionPath { segments },
+                        ..
+                    } if segments.len() == 1 && segments[0] == "__pyre_range"
+                )
+        })
 }
 
 /// Transitive closure of dead forwarded inputarg slots starting from
@@ -590,6 +647,7 @@ fn rewire_one_next_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(),
     // call (peeled above) are dropped so the native `next` op — which
     // produces the scrutinised `opt` directly — is A's last op and thus the
     // block's `raising_op` under the `LastException` exitswitch below.
+    let item_ty = iter_next_item_type(graph, &iter_arg);
     graph.blocks[a].operations.truncate(next_idx + 1);
     graph.blocks[a].operations[next_idx] = SpaceOperation {
         result: Some(opt.clone()),
@@ -598,7 +656,7 @@ fn rewire_one_next_site(graph: &mut FunctionGraph, opt: &Variable) -> Result<(),
                 segments: next_op_segments(),
             },
             args: vec![iter_arg],
-            result_ty: ValueType::Ref(None),
+            result_ty: item_ty,
         },
     };
 

--- a/majit/majit-translate/tests/test_fast2locals_codewriter.rs
+++ b/majit/majit-translate/tests/test_fast2locals_codewriter.rs
@@ -1,0 +1,222 @@
+//! `PyFrame::fast2locals` driven through the codewriter, against the shipped
+//! interpreter LLBC.
+//!
+//! A graph containing a loop is normally residualized rather than looked
+//! inside (`policy.py:50,61-62 contains_loop`), so nothing in the shipped
+//! build exercises the front-through-assembler path on a looping graph that
+//! reads the frame's locals array.  `fast2locals` is the smallest real graph
+//! with that shape, and driving it here rather than waiting for a policy that
+//! admits it is what surfaced the element-type defect below.
+
+use majit_charon_reader::Llbc;
+use majit_translate::codewriter::call::CallControl;
+use majit_translate::codewriter::codewriter::CodeWriter;
+use majit_translate::codewriter::jitcode::JitCode;
+use majit_translate::front::mir::lower_fun_decl;
+use majit_translate::model::{CallTarget, FunctionGraph, OpKind, ValueType};
+use majit_translate::{CallPath, GraphTransformConfig, VirtualizableFieldDescriptor};
+
+const INTERPRETER_LLBC: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../build/llbc/pyre-interpreter.ullbc"
+);
+
+/// Lower `pyframe::<Impl>::fast2locals` out of the shipped LLBC, or `None`
+/// when the artefact is absent so the tests degrade to a skip.
+fn lower_fast2locals() -> Option<FunctionGraph> {
+    if !std::path::Path::new(INTERPRETER_LLBC).is_file() {
+        eprintln!("skipping: {INTERPRETER_LLBC} is missing");
+        return None;
+    }
+    let llbc = Llbc::load(INTERPRETER_LLBC).expect("load pyre-interpreter.ullbc");
+    let fd = llbc
+        .iter_local_fns()
+        .find(|fd| fd.item_meta.name_path().ends_with("::fast2locals"))
+        .expect("fast2locals present in the shipped LLBC");
+    Some(lower_fun_decl(&llbc, fd).expect("lower fast2locals"))
+}
+
+/// The virtualizable configuration the production pipeline passes
+/// (`pyre-jit-trace/src/virtualizable_spec.rs PYFRAME_VABLE_ARRAYS`).
+fn config() -> GraphTransformConfig {
+    GraphTransformConfig {
+        vable_arrays: vec![VirtualizableFieldDescriptor::new(
+            "locals_cells_stack_w",
+            Some("PyFrame".to_string()),
+            0,
+        )],
+        ..Default::default()
+    }
+}
+
+/// The whole pipeline — jtransform, regalloc, flatten, assemble — runs to
+/// completion on `fast2locals`.
+///
+/// `front::iter_next` typed the `range` iterator's element as a GC
+/// reference, which put the loop counter in the ref register bank and made
+/// every `array[i]` in the body a `getarrayitem_gc` with a ref index.
+/// `assembler.rs` asserts that index kind, so it aborted the build outright
+/// — asserting that this call returns at all is the assertion.
+///
+/// The bare `CallControl` here is not a simplification: the production
+/// pipeline also declines `fast2locals` in the real rtyper's two-phase
+/// prepass and types it with the legacy walker, which is the tier that reads
+/// `result_ty` off the op.
+#[test]
+fn fast2locals_assembles() {
+    let Some(graph) = lower_fast2locals() else {
+        return;
+    };
+    let path = CallPath::from_segments(["pyre_interpreter", "pyframe", "fast2locals"]);
+    let mut callcontrol = CallControl::new();
+    callcontrol.register_function_graph(path.clone(), graph.clone());
+    let mut codewriter = CodeWriter::new();
+    let jitcode = std::sync::Arc::new(JitCode::new("fast2locals"));
+    codewriter.transform_graph_to_jitcode(
+        &graph,
+        &path,
+        &mut callcontrol,
+        &config(),
+        &jitcode,
+        false,
+        0,
+    );
+}
+
+/// A `for i in a..b` loop yields an integer, not a GC reference.
+///
+/// `front::range_iter` reroutes the exclusive int `Range` onto the `range()`
+/// builtin plus the `iter` bridge so the receiver selects upstream's
+/// `RangeIteratorRepr`, whose `rtype_next` (`rrange.py ll_rangenext_*`)
+/// yields a `Signed`.  The `[__iter_next]` marker `front::iter_next` folds
+/// the `next` diamond into has to agree: the legacy type walker reads
+/// `result_ty` straight off the op, and it is the tier `fast2locals` lands
+/// in.
+#[test]
+fn a_range_loops_next_yields_an_int_element() {
+    let Some(graph) = lower_fast2locals() else {
+        return;
+    };
+
+    // The `range()` results, so an `[__iter_next]` can be attributed to a
+    // range rather than to a slice/Vec iterator.
+    let mut range_results = Vec::new();
+    for block in &graph.blocks {
+        for op in &block.operations {
+            if let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                ..
+            } = &op.kind
+                && segments.len() == 1
+                && segments[0] == "__pyre_range"
+                && let Some(result) = &op.result
+            {
+                range_results.push(result.clone());
+            }
+        }
+    }
+    assert!(
+        !range_results.is_empty(),
+        "`fast2locals` has two `for i in 0..n` loops; neither reached \
+         `front::range_iter`, so this test no longer exercises anything"
+    );
+
+    // An iterator built over one of those ranges, threaded to its `next`.
+    let iterators: Vec<_> = graph
+        .blocks
+        .iter()
+        .flat_map(|b| b.operations.iter())
+        .filter_map(|op| match &op.kind {
+            OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                ..
+            } if segments.last().is_some_and(|s| s == "iter")
+                && args.first().is_some_and(|a| range_results.contains(a)) =>
+            {
+                op.result.clone()
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !iterators.is_empty(),
+        "no `iter` op over a `range()` result — the reroute changed shape"
+    );
+
+    let mut checked = 0;
+    for block in &graph.blocks {
+        for op in &block.operations {
+            let OpKind::Call {
+                target: CallTarget::FunctionPath { segments },
+                args,
+                result_ty,
+            } = &op.kind
+            else {
+                continue;
+            };
+            // `front::iter_next`'s marker spelling; the module is
+            // crate-private, so match the reserved segment directly rather
+            // than widening its visibility for a test.
+            if segments.len() != 1 || segments[0] != "__iter_next" {
+                continue;
+            }
+            // The iterator reaches `next` through the loop header's phi, so
+            // match on the value that entered it rather than on the operand.
+            if !args
+                .first()
+                .is_some_and(|a| iterators.contains(a) || reaches(&graph, a, &iterators))
+            {
+                continue;
+            }
+            checked += 1;
+            assert_eq!(
+                result_ty,
+                &ValueType::Int,
+                "the `range` iterator's `next` yields a GC reference, so the \
+                 loop counter lands in the ref register bank",
+            );
+        }
+    }
+    assert!(
+        checked > 0,
+        "no `[__iter_next]` was attributed to a range iterator"
+    );
+}
+
+/// Whether `var` is one of `sources`, following block inputargs back through
+/// every predecessor's link argument in the matching slot.  The loop-carried
+/// iterator arrives at `next` as a phi, not as the `iter` op's result.
+fn reaches(
+    graph: &FunctionGraph,
+    var: &majit_translate::flowspace::model::Variable,
+    sources: &[majit_translate::flowspace::model::Variable],
+) -> bool {
+    let mut visited = Vec::new();
+    let mut stack = vec![var.clone()];
+    while let Some(v) = stack.pop() {
+        if visited.contains(&v) {
+            continue;
+        }
+        if sources.contains(&v) {
+            return true;
+        }
+        visited.push(v.clone());
+        for b in &graph.blocks {
+            let Some(slot) = b.inputargs.iter().position(|iv| iv == &v) else {
+                continue;
+            };
+            for pb in &graph.blocks {
+                for link in &pb.exits {
+                    if link.target == b.id
+                        && let Some(majit_translate::model::LinkArg::Value(src)) =
+                            link.args.get(slot)
+                    {
+                        stack.push(src.clone());
+                    }
+                }
+            }
+        }
+    }
+    false
+}

--- a/majit/majit-translate/tests/test_vable_array_len.rs
+++ b/majit/majit-translate/tests/test_vable_array_len.rs
@@ -237,3 +237,56 @@ fn address_of_the_vable_array_slot_is_marked_not_a_read() {
          anything"
     );
 }
+
+/// Every `locals_w!` read in `fast2locals` is consumed by an array operation
+/// in the block that reads it.
+///
+/// This is the other half of what the virtualizable protocol needs, and it
+/// is checked separately because the two fail independently: an unmarked
+/// read that escapes its block trips `_check_no_vable_array`, and a read
+/// consumed in place but marked `taken_by_address` silently lowers to
+/// `getarrayitem_gc`.  `fast2locals` is the graph a policy that admitted
+/// loops would open first (`pyframe.py:539` decorates it `@jit.unroll_safe`),
+/// so it is where both have to hold.
+#[test]
+fn every_vable_array_read_in_fast2locals_is_consumed_in_its_block() {
+    let Some(graph) = lower_pyframe_method("fast2locals") else {
+        return;
+    };
+
+    let mut checked = 0;
+    for (index, block) in graph.blocks.iter().enumerate() {
+        let reads: Vec<Variable> = block
+            .operations
+            .iter()
+            .filter_map(|op| match &op.kind {
+                OpKind::FieldRead { field, .. } if field.name == "locals_cells_stack_w" => {
+                    op.result.clone()
+                }
+                _ => None,
+            })
+            .collect();
+        for array_var in reads {
+            checked += 1;
+            let consumed = block.operations.iter().any(|op| {
+                matches!(
+                    &op.kind,
+                    OpKind::ArrayRead { base, .. }
+                        | OpKind::ArrayWrite { base, .. }
+                        | OpKind::ArrayLen { base, .. }
+                        if *base == array_var
+                )
+            });
+            assert!(
+                consumed,
+                "the virtualizable array read in block {index} of {:?} has no array \
+                 operation consuming it there",
+                graph.name,
+            );
+        }
+    }
+    assert!(
+        checked > 0,
+        "no read of the virtualizable array in `fast2locals`"
+    );
+}

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2623,12 +2623,32 @@ impl NamespaceOpcodeHandler for PyFrame {
 
 impl StackOpcodeHandler for PyFrame {
     fn swap_values(&mut self, depth: usize) -> Result<(), PyError> {
-        // `localsplus[top], localsplus[other] = localsplus[other], localsplus[top]`
-        // spelled element-wise so the flow lowers to getitem/setitem instead of a
-        // `<[T]>::swap` method call (the localsplus list carries no class row).
-        let top_idx = self.valuestackdepth - 1;
-        let other_idx = self.valuestackdepth - depth;
-        locals_w_mut!(self).swap(top_idx, other_idx);
+        // `pyopcode.py:1844-1852 SWAP`, peek/settop element-wise.  A
+        // `<[T]>::swap` call hands the locals array to a callee, which the
+        // codewriter can only residualize; the element-wise spelling stays
+        // native array operations, and it is what the preceding comment
+        // already claimed this function did.
+        //
+        // `assert oparg >= 2` is upstream's own precondition, and it is what
+        // makes both indices known non-negative to the annotator.
+        assert!(depth >= 2);
+        // Both halves go through the `maybe_none` read: a stack slot holds
+        // NULL while an inlined comprehension runs, where
+        // `LOAD_FAST_AND_CLEAR` pushed an unbound local and cleared its slot.
+        let w_top = self.peekvalue_maybe_none(0);
+        let w_other = self.peekvalue_maybe_none(depth - 1);
+        // The first store overwrites the only stack slot still holding
+        // `w_top`.  `FixedObjectArray::set_ref` roots its receiver and the
+        // value it was handed, and nothing else, across a barrier that can
+        // wait behind a foreign collection — so an unrooted `w_top` would be
+        // stale by the second store.  The GC transform carries every live
+        // variable on the shadow stack across that point; spell the same
+        // thing out here and read `w_top` back.
+        let roots = pyre_object::gc_roots::push_roots();
+        let top_slot = roots.base();
+        roots.pin_root(w_top);
+        self.settopvalue(w_other, 0);
+        self.settopvalue(roots.get(top_slot), depth - 1);
         Ok(())
     }
 }


### PR DESCRIPTION
Three independent defects found while preparing to port
`@jit.unroll_safe` onto `PyFrame::fast2locals`
(`pypy/interpreter/pyframe.py:539`), plus the `swap_values` cleanup that
port needed. **The port itself is deliberately not here** — see the last
section; it cannot land before the virtualizable-array work.

## What was wrong

**1. The `unroll_safe` marker never reached a method.**
`majit-macros`' `unroll_safe` left a body-local const spelled
`_MAJIT_UNROLL_SAFE` — no `_jit_unroll_safe_` prefix, no function name — plus
a module-level sibling const emitted only for a free function.
`front/llbc_hints.rs` harvests `_jit_unroll_safe_<NAME>` and nothing else, so
every method decorated with `#[unroll_safe]` was silently unhinted. The
shipped interpreter LLBC carries exactly one `_jit_unroll_safe_` marker, on a
free function.

Upstream decorates *methods* with it (`pyframe.py` `fast2locals`,
`peekvalues`, `dropvalues`), which is precisely the shape that was dropped.

The fix is the spelling `jit_elidable` already uses: a body-local
`_jit_unroll_safe_<NAME>`. A sibling associated const is not available — a
trait impl rejects a foreign associated const and an attribute macro cannot
tell an inherent impl from a trait impl (`majit-macros/tests/macros.rs`
`NameCollider` is an existing trait impl carrying `#[unroll_safe]`). Charon
promotes a body-local const under the method's own path, and
`llbc_hints::marker_path_to_fn_path` already resolves that spelling.

`test_unroll_safe_marker_reaches_methods` names the marker from inside an
inherent method's body and from inside a trait impl's — the only scope that
can see a body-local const, and the reason the old spelling went unnoticed.

**2. Every `for i in a..b` counter landed in the ref register bank.**
`front::iter_next` hardcoded `result_ty: ValueType::Ref(None)` on the
`[__iter_next]` marker. That is right for `ListIteratorRepr::rtype_next`
(`rpython/rtyper/rlist.py:444-448`, the list's item repr) and wrong for
`RangeIteratorRepr::rtype_next` (`rpython/rtyper/rrange.py:158,210` — a
Signed). `front::range_iter` reroutes an exclusive int `Range` for-loop onto
the `range()` builtin plus the same `iter` bridge, so both reprs arrive
behind one `iter` op; the container that op was given is the only thing
separating them.

The legacy type walker hands back a `Call`'s `result_ty` verbatim whenever it
is not `Unknown`, so this decided the loop counter's register bank. Every
`array[i]` in such a loop body then assembled as a `getarrayitem_gc` with a
ref-kind index, which the assembler rejects.

Nothing in the shipped build reached it: `policy.py:50,61-62` residualizes a
looping graph, so the front-through-assembler path never ran on one that
reads the frame's locals array. `test_fast2locals_codewriter.rs` drives
`PyFrame::fast2locals` — the smallest real graph with that shape — through
`transform_graph_to_jitcode` directly, which is where the defect surfaces
without waiting for a policy that admits the graph.

**3. The assertion that caught it named neither the graph nor the array.**
Its sibling in `Assembler::encode_regorconst_source` already prints
`current_graph_name` and `current_flatop_debug`. One graph can hold several
`getarrayitem_gc`s with only some carrying the bad index, so `array_type_id`
and `item_ty` go in too.

## `swap_values`

Its comment claimed it was spelled element-wise "so the flow lowers to
getitem/setitem instead of a `<[T]>::swap` method call", but the body called
`<[T]>::swap` on the locals array. Spelled out per
`pypy/interpreter/pyopcode.py:1844-1852 SWAP`, including that function's
`assert oparg >= 2` — which is also what makes both indices known
non-negative.

The element-wise spelling introduces a collection point `<[T]>::swap` did not
have, so it also roots the displaced value. `settopvalue` reaches
`FixedObjectArray::set_ref`, whose barrier can wait behind a foreign
collection and which roots its receiver and the value it was handed and
nothing else; the first store overwrites the only stack slot still holding
`w_top`. Without an explicit pin, `w_top` would be live only in an unrooted
Rust local across that point and the second store could write a stale
address. The GC transform carries every live variable on the shadow stack
there; this spells the same thing out.

Both reads go through `peekvalue_maybe_none`: a stack slot holds NULL while
an inlined comprehension runs, where `LOAD_FAST_AND_CLEAR` pushed an unbound
local and cleared its slot.

## Why `@jit.unroll_safe` on `fast2locals` is not in this PR

It was, and was pulled. Applying it is the *arming* step for a defect that
has to be fixed first, and shipping it alone is either wrong or inert:

- `fast2locals` would become the only looping graph in the shipped build
  that reads `PyFrame.locals_cells_stack_w` from inside the codewriter (the
  other production `#[unroll_safe]` site, `builtins.rs`
  `leading_non_null_count`, loops over a plain argument slice).
- `front/mir.rs` classifies a `Rvalue::Ref` / `Rvalue::RawPtr` over any
  `PlaceKind::Projection` as address-of. A deref-then-ref — `&*(*p).f`, what
  every `locals_w!` access lowers to — is a value read.  Marking it
  `taken_by_address` makes `model.rs suppresses_virtualizable()` true, and
  `jtransform.rs` then skips the `vable_arrays` registration, so the read
  lowers to a plain `getarrayitem_gc` rather than a `VableArrayRead`.
- That plain op is not a slower equivalent. The heap array is synchronised
  at JIT entry and at exit / guard failure (`sync_virtualizable_before_jit`,
  `sync_virtualizable_after_jit`, `sync_virtualizable_after_guard_failure`)
  and is not maintained in between, and the optimizer's constant-index
  backstop cannot cover it — `VirtualizableInfo::to_optimizer_config` passes
  `array_lengths: vec![]`, so `optimize_getarrayitem_gc` has nothing seeded
  from the inputargs. Upstream refuses to emit the plain op at all for a
  standard virtualizable: `Transformer.rewrite_op_getfield`'s
  `VirtualizableArrayField` arm drops the `getfield`, and
  `_check_no_vable_array` raises rather than degrading.

So the port belongs with the `front/mir.rs` fix. That fix cannot land alone
either: `Transformer::check_no_vable_array` is a bare `panic!`, and
`pyre-jit-trace/build.rs` calls `generate_into` unguarded with `vable_arrays`
populated from `virtualizable_spec::PYFRAME_VABLE_ARRAYS`, so the
`vable_array_vars.is_empty()` early-return does not spare the production
build — every site that lets a vable array escape its block becomes a build
failure.

The first lever there is not restructuring those sites. Upstream's own hatch
is `jit.hint(access_directly=True, fresh_virtualizable=True)`, consumed by
`Transformer.is_virtualizable_getset`, and `pypy/interpreter/pyframe.py`
`PyFrame.__init__` uses exactly it. pyre already ports the consuming half
(`HintKind::FreshVirtualizable`, `Transformer::is_fresh_virtualizable`,
`majit-metainterp` `hint_fresh_virtualizable`) and has no emitting call site
anywhere in `pyre-interpreter`. Wiring that up comes before counting
restructuring work.
