### PR TITLE
gc: root the operands and receivers the interpreter re-reads after running Python

### DIFF
--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -80,8 +80,10 @@ fn main() {
             .map(|(&id, _)| id)
             .collect();
         if pin_ids.is_empty() {
+            // Not a reason to stop: an artefact that brackets nothing is the
+            // one most likely to hold defects, and the liveness scan below is
+            // exactly what answers for it.
             println!("   (no gc_roots::push_roots in this artefact's name table)");
-            continue;
         }
         let mut bracketed: Vec<u64> = cg
             .callees
@@ -169,8 +171,25 @@ fn main() {
             println!("   (no PyObjectRef type id found — liveness scan skipped)");
             continue;
         }
-        let bracket_set: std::collections::HashSet<u64> = bracketed.iter().copied().collect();
-        let found = liveness::scan(&llbc, &cg, &reach, &bracket_set, &gc_tys);
+        let push_root_ids: std::collections::HashSet<u64> = pin_ids.iter().copied().collect();
+        let (found, stats) = liveness::scan(&llbc, &cg, &reach, &push_root_ids, &gc_tys);
+        println!(
+            "   liveness scan: {} bodies; {} with a terminator this reader could not parse; \
+             {} call(s) withheld as dominated by a push_roots",
+            stats.bodies_scanned, stats.unparsed_terminator_bodies, stats.withheld_under_a_bracket
+        );
+        // The resolved graph is an *under*-approximation of what collects: a
+        // call whose dispatch edge is unresolved is excluded, so a clean
+        // resolved census is not a clean census.  Re-run with the opaque set
+        // folded in and report both, rather than let the difference go unsaid.
+        let mut conservative = reach.clone();
+        conservative.extend(opaque.iter().copied());
+        let (found_conservative, _) =
+            liveness::scan(&llbc, &cg, &conservative, &push_root_ids, &gc_tys);
+        let conservative_fns: std::collections::BTreeSet<&str> = found_conservative
+            .iter()
+            .map(|f| f.func_name.as_str())
+            .collect();
         let mut by_fn: std::collections::BTreeMap<&str, Vec<&liveness::Finding>> =
             Default::default();
         for f in &found {
@@ -185,6 +204,11 @@ fn main() {
             "   unbracketed calls that can collect with a live PyObjectRef: {} in {} fn(s)",
             found.len(),
             by_fn.len()
+        );
+        println!(
+            "       counting unresolved dispatch as collecting too: {} in {} fn(s)",
+            found_conservative.len(),
+            conservative_fns.len()
         );
         println!(
             "       of which hold a NON-ARGUMENT live pointer: {} fn(s)",
@@ -230,6 +254,13 @@ fn main() {
             "       tier 1.5 (live ptr later addressed as list/dict): {} call(s) in {} fn(s)",
             tier15.len(),
             t15_fns.len()
+        );
+        let t15_conservative = found_conservative
+            .iter()
+            .filter(|f| !seeds.contains(&f.callee_id) && !f.movable_use.is_empty())
+            .count();
+        println!(
+            "       tier 1.5 counting unresolved dispatch too: {t15_conservative} call(s)"
         );
         if std::env::var("GC_LIVENESS_TIER15").is_ok() {
             for f in &tier15 {

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -62,7 +62,11 @@ fn main() {
             "   can reach a collection: {} / {} ({}%)",
             reach.len(),
             total,
-            if total == 0 { 0 } else { reach.len() * 100 / total }
+            if total == 0 {
+                0
+            } else {
+                reach.len() * 100 / total
+            }
         );
         println!(
             "   unresolved-callee fns : {} (call through fn-ptr / dyn / unresolved trait)",
@@ -157,7 +161,10 @@ fn main() {
             unjustified.len()
         );
         for id in unjustified.iter().take(40) {
-            println!("           {}", cg.names.get(id).map_or("?", String::as_str));
+            println!(
+                "           {}",
+                cg.names.get(id).map_or("?", String::as_str)
+            );
         }
         if unjustified.len() > 40 {
             println!("           … and {} more", unjustified.len() - 40);
@@ -259,9 +266,7 @@ fn main() {
             .iter()
             .filter(|f| !seeds.contains(&f.callee_id) && !f.movable_use.is_empty())
             .count();
-        println!(
-            "       tier 1.5 counting unresolved dispatch too: {t15_conservative} call(s)"
-        );
+        println!("       tier 1.5 counting unresolved dispatch too: {t15_conservative} call(s)");
         if std::env::var("GC_LIVENESS_TIER15").is_ok() {
             for f in &tier15 {
                 println!(

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -1,0 +1,201 @@
+//! Answer `framework.py`'s question over a charon artefact: which functions can
+//! reach application-level Python, and therefore a collection.
+//!
+//! Usage: `cargo run -p majit-translate --release --example gc-root-reachability -- <file.ullbc>...`
+
+use majit_translate::memory::gctransform::{framework, liveness};
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    if args.is_empty() {
+        eprintln!("usage: gc-root-reachability <file.ullbc>...");
+        std::process::exit(2);
+    }
+    for path in &args {
+        let llbc = match majit_charon_reader::Llbc::load(path) {
+            Ok(l) => l,
+            Err(e) => {
+                eprintln!("{path}: {e:?}");
+                std::process::exit(1);
+            }
+        };
+        let cg = framework::build(&llbc);
+        let total = cg.names.len();
+        println!("== {} ({} fun_decls) ==", llbc.crate_name(), total);
+        // Which crates this artefact actually carries bodies for.  Charon
+        // inlines the dependency graph, so one artefact is usually enough for
+        // a cross-crate answer — but that has to be shown, not assumed.
+        let mut per_crate: std::collections::BTreeMap<&str, usize> = Default::default();
+        for name in cg.names.values() {
+            per_crate
+                .entry(name.split("::").next().unwrap_or("?"))
+                .and_modify(|c| *c += 1)
+                .or_insert(1);
+        }
+        let mut roots: Vec<(&&str, &usize)> = per_crate.iter().collect();
+        roots.sort_by(|a, b| b.1.cmp(a.1));
+        let shown: Vec<String> = roots
+            .iter()
+            .take(6)
+            .map(|(k, v)| format!("{k}={v}"))
+            .collect();
+        println!(
+            "   crates with bodies   : {} ({}{})",
+            per_crate.len(),
+            shown.join(" "),
+            if per_crate.len() > 6 { " …" } else { "" }
+        );
+        println!(
+            "   python-dispatch seeds : {}",
+            cg.seed_report(framework::PYTHON_DISPATCH_SEEDS)
+        );
+        println!(
+            "   collecting-alloc seeds: {}",
+            cg.seed_report(framework::COLLECTING_SEEDS)
+        );
+        let (py, _) = cg.seeds_for(framework::PYTHON_DISPATCH_SEEDS);
+        let (col, _) = cg.seeds_for(framework::COLLECTING_SEEDS);
+        let mut seeds = py;
+        seeds.extend(col);
+        let reach = cg.reaching(&seeds);
+        println!(
+            "   can reach a collection: {} / {} ({}%)",
+            reach.len(),
+            total,
+            if total == 0 { 0 } else { reach.len() * 100 / total }
+        );
+        println!(
+            "   unresolved-callee fns : {} (call through fn-ptr / dyn / unresolved trait)",
+            cg.indirect.len()
+        );
+
+        // Judge the hand-written brackets: a `push_roots()` scope can only be
+        // protecting against a collection if its own function can reach one.
+        // This is a *necessary* condition, so a function that fails it holds a
+        // bracket that nothing in this crate can justify.
+        let pin_ids: Vec<u64> = cg
+            .names
+            .iter()
+            .filter(|(_, n)| n.ends_with("gc_roots::push_roots"))
+            .map(|(&id, _)| id)
+            .collect();
+        if pin_ids.is_empty() {
+            println!("   (no gc_roots::push_roots in this artefact's name table)");
+            continue;
+        }
+        let mut bracketed: Vec<u64> = cg
+            .callees
+            .iter()
+            .filter(|(_, cs)| pin_ids.iter().any(|p| cs.contains(p)))
+            .map(|(&id, _)| id)
+            .collect();
+        bracketed.sort_unstable();
+        // An unresolved callee is undecidable *transitively*: a helper that
+        // dispatches through a `global_hook!` function pointer makes every one
+        // of its callers undecidable too, not just itself.  Without this the
+        // "cannot reach a collection" bucket silently absorbs them.
+        let opaque = cg.reaching(&cg.indirect);
+        let (mut justified, mut undecidable, mut unjustified) = (0usize, 0usize, Vec::new());
+        for id in &bracketed {
+            if reach.contains(id) {
+                justified += 1;
+            } else if opaque.contains(id) {
+                undecidable += 1;
+            } else {
+                unjustified.push(*id);
+            }
+        }
+        println!(
+            "   fns tainted by an unresolved callee (transitive): {} / {}",
+            opaque.len(),
+            total
+        );
+        println!(
+            "   functions holding a push_roots bracket: {}",
+            bracketed.len()
+        );
+        println!("       can reach a collection (justified) : {justified}");
+        println!("       hold an unresolved call (undecided): {undecidable}");
+        println!(
+            "       cannot reach any collection        : {}",
+            unjustified.len()
+        );
+        for id in unjustified.iter().take(40) {
+            println!("           {}", cg.names.get(id).map_or("?", String::as_str));
+        }
+        if unjustified.len() > 40 {
+            println!("           … and {} more", unjustified.len() - 40);
+        }
+
+        // The other direction, and the one that finds defects rather than
+        // overhead: a call that can collect, a GC pointer live across it, and
+        // no bracket anywhere in the function.
+        let gc_tys = liveness::gc_ptr_type_ids(&llbc);
+        if gc_tys.is_empty() {
+            println!("   (no PyObjectRef type id found — liveness scan skipped)");
+            continue;
+        }
+        let bracket_set: std::collections::HashSet<u64> = bracketed.iter().copied().collect();
+        let found = liveness::scan(&llbc, &cg, &reach, &bracket_set, &gc_tys);
+        let mut by_fn: std::collections::BTreeMap<&str, Vec<&liveness::Finding>> =
+            Default::default();
+        for f in &found {
+            by_fn.entry(f.func_name.as_str()).or_default().push(f);
+        }
+        let non_arg_fns: Vec<&&str> = by_fn
+            .iter()
+            .filter(|(_, v)| v.iter().any(|f| !f.live_non_arg.is_empty()))
+            .map(|(k, _)| k)
+            .collect();
+        println!(
+            "   unbracketed calls that can collect with a live PyObjectRef: {} in {} fn(s)",
+            found.len(),
+            by_fn.len()
+        );
+        println!(
+            "       of which hold a NON-ARGUMENT live pointer: {} fn(s)",
+            non_arg_fns.len()
+        );
+        // Tier 1: the callee is *itself* a dispatch seed, so "this call runs
+        // Python" needs no transitive argument.  Tier 2 reaches Python only
+        // through further calls and is far likelier to be a false positive.
+        let mut tier1: Vec<&liveness::Finding> = found
+            .iter()
+            .filter(|f| seeds.contains(&f.callee_id) && !f.live_non_arg.is_empty())
+            .collect();
+        tier1.sort_by(|a, b| a.func_name.cmp(&b.func_name).then(a.line.cmp(&b.line)));
+        let t1_fns: std::collections::BTreeSet<&str> =
+            tier1.iter().map(|f| f.func_name.as_str()).collect();
+        println!(
+            "       tier 1 (callee IS a dispatch seed): {} call(s) in {} fn(s)",
+            tier1.len(),
+            t1_fns.len()
+        );
+        if std::env::var("GC_LIVENESS_TIER1").is_ok() {
+            for f in &tier1 {
+                println!(
+                    "           {}:{}  across {}  live: {:?}",
+                    f.func_name,
+                    f.line,
+                    f.callee_name.rsplit("::").next().unwrap_or(""),
+                    f.live_non_arg
+                );
+            }
+        }
+        let show: usize = std::env::var("GC_LIVENESS_SHOW")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(0);
+        for name in non_arg_fns.iter().take(show) {
+            let v = &by_fn[**name];
+            let f = v.iter().find(|f| !f.live_non_arg.is_empty()).unwrap();
+            println!(
+                "           {}:{}  across {}  live: {:?}",
+                name,
+                f.line,
+                f.callee_name.rsplit("::").next().unwrap_or(""),
+                f.live_non_arg
+            );
+        }
+    }
+}

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -182,6 +182,36 @@ fn main() {
                 );
             }
         }
+        // Tier 1.5: not a direct dispatch seed, but a live pointer that this
+        // body later hands to a `list`/`dict` accessor — the shape both
+        // confirmed defects in `list.index` and `mul` had.
+        let mut tier15: Vec<&liveness::Finding> = found
+            .iter()
+            .filter(|f| !seeds.contains(&f.callee_id) && !f.movable_use.is_empty())
+            .collect();
+        tier15.sort_by(|a, b| a.func_name.cmp(&b.func_name).then(a.line.cmp(&b.line)));
+        let t15_fns: std::collections::BTreeSet<&str> =
+            tier15.iter().map(|f| f.func_name.as_str()).collect();
+        println!(
+            "       tier 1.5 (live ptr later addressed as list/dict): {} call(s) in {} fn(s)",
+            tier15.len(),
+            t15_fns.len()
+        );
+        if std::env::var("GC_LIVENESS_TIER15").is_ok() {
+            for f in &tier15 {
+                println!(
+                    "           {}:{}  across {}  movable-use: {:?}",
+                    f.func_name,
+                    f.line,
+                    f.callee_name.rsplit("::").next().unwrap_or(""),
+                    f.movable_use
+                );
+                match cg.path_to(f.callee_id, &seeds) {
+                    Some(chain) => println!("               path: {}", chain.join(" -> ")),
+                    None => println!("               path: (none — reached only via a seed alias)"),
+                }
+            }
+        }
         let show: usize = std::env::var("GC_LIVENESS_SHOW")
             .ok()
             .and_then(|v| v.parse().ok())

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -105,6 +105,40 @@ fn main() {
                 unjustified.push(*id);
             }
         }
+        let mut traits: Vec<(&String, &usize)> = cg.opaque.dyn_trait.iter().collect();
+        traits.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+        let top: Vec<String> = traits
+            .iter()
+            .take(8)
+            .map(|(n, c)| format!("{}={c}", n.rsplit("::").next().unwrap_or(n)))
+            .collect();
+        println!(
+            "   opaque call census    : dyn-trait={} sites over {} traits, fn-value={}, unknown={}",
+            traits.iter().map(|(_, c)| **c).sum::<usize>(),
+            traits.len(),
+            cg.opaque.fn_value,
+            cg.opaque.unknown
+        );
+        let mut variants: Vec<(&&str, &usize)> = cg.opaque.by_variant.iter().collect();
+        variants.sort_by(|a, b| b.1.cmp(a.1));
+        println!(
+            "       by charon spelling: {}",
+            variants
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        println!("       top traits: {}", top.join(" "));
+        if std::env::var("GC_OPAQUE_SOURCES").is_ok() {
+            let src = framework::dynamic_call_sources(&llbc);
+            let mut rows: Vec<(&String, &usize)> = src.iter().collect();
+            rows.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
+            println!("       fn-value callee sources:");
+            for (label, count) in rows.iter().take(20) {
+                println!("           {count:5}  {label}");
+            }
+        }
         println!(
             "   fns tainted by an unresolved callee (transitive): {} / {}",
             opaque.len(),

--- a/majit/majit-translate/src/lib.rs
+++ b/majit/majit-translate/src/lib.rs
@@ -85,6 +85,7 @@ mod local_crates;
         reason = "the model test spells the exact nested RPython graph shape under test; a one-use alias would conceal rather than simplify that contract"
     )
 )]
+pub mod memory;
 pub mod model;
 pub mod model_ssa;
 pub mod module_path;

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -116,6 +116,47 @@ impl CallGraph {
         out
     }
 
+    /// A shortest call chain from `from` down to one of `seeds`, as names.
+    ///
+    /// A reachability verdict is only as good as the path behind it, and a
+    /// path through an error-formatting helper is a very different claim from
+    /// one through a dunder invocation.  Adjudicating a finding means reading
+    /// this, not trusting the bit.
+    pub fn path_to(&self, from: u64, seeds: &HashSet<u64>) -> Option<Vec<String>> {
+        let mut prev: HashMap<u64, u64> = HashMap::new();
+        let mut seen: HashSet<u64> = HashSet::from([from]);
+        let mut queue: std::collections::VecDeque<u64> = std::collections::VecDeque::from([from]);
+        while let Some(cur) = queue.pop_front() {
+            if seeds.contains(&cur) {
+                let mut chain = vec![cur];
+                let mut walk = cur;
+                while let Some(&up) = prev.get(&walk) {
+                    chain.push(up);
+                    walk = up;
+                }
+                chain.reverse();
+                return Some(
+                    chain
+                        .into_iter()
+                        .map(|id| {
+                            self.names
+                                .get(&id)
+                                .map(|n| n.rsplit("::").take(2).collect::<Vec<_>>().join("::"))
+                                .unwrap_or_else(|| format!("#{id}"))
+                        })
+                        .collect(),
+                );
+            }
+            for &down in self.callees.get(&cur).into_iter().flatten() {
+                if seen.insert(down) {
+                    prev.insert(down, cur);
+                    queue.push_back(down);
+                }
+            }
+        }
+        None
+    }
+
     /// Resolve the configured seed patterns against the real name table.
     pub fn seeds_for(&self, patterns: &[&str]) -> (HashSet<u64>, Vec<String>) {
         let mut ids = HashSet::new();

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -417,14 +417,14 @@ pub fn build(llbc: &majit_charon_reader::Llbc) -> CallGraph {
     let mut note_opaque = |raw: Option<&serde_json::Value>, variant: &'static str| {
         *opaque.by_variant.entry(variant).or_insert(0) += 1;
         match raw.and_then(first_trait_id) {
-        Some(tid) => {
-            let name = llbc
-                .trait_by_id(tid)
-                .map(|t| t.item_meta.name_path())
-                .unwrap_or_else(|| format!("trait#{tid}"));
-            *opaque.dyn_trait.entry(name).or_insert(0) += 1;
-        }
-        None => opaque.fn_value += 1,
+            Some(tid) => {
+                let name = llbc
+                    .trait_by_id(tid)
+                    .map(|t| t.item_meta.name_path())
+                    .unwrap_or_else(|| format!("trait#{tid}"));
+                *opaque.dyn_trait.entry(name).or_insert(0) += 1;
+            }
+            None => opaque.fn_value += 1,
         }
     };
 

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -59,6 +59,77 @@ pub struct CallGraph {
     /// a closure.  Reported rather than dropped: an unresolved edge is exactly
     /// where "can this reach Python" stops being decidable from the graph.
     pub indirect: HashSet<u64>,
+    /// What the unresolved calls actually were.  A taint that swallows a third
+    /// of the graph is only actionable if you know whether it is `dyn Error`
+    /// or something that can reach Python.
+    pub opaque: OpaqueCensus,
+}
+
+/// The unresolved calls, bucketed by what could not be resolved.
+#[derive(Default)]
+pub struct OpaqueCensus {
+    /// `dyn Trait` dispatch, counted per trait name.
+    pub dyn_trait: HashMap<String, usize>,
+    /// A call of a function-typed value whose trait could not be named — a
+    /// `global_hook!` cell read, a function passed in as an argument.
+    pub fn_value: usize,
+    /// The unresolved calls split by which spelling charon used, so a bucket
+    /// is never reasoned about as if it were all one thing.
+    pub by_variant: HashMap<&'static str, usize>,
+    /// Anything else the reader could not classify.
+    pub unknown: usize,
+}
+
+/// Whether a `CallKind::Trait` payload's trait reference is a `dyn` one.
+///
+/// `[trait_ref, method_index, fun_decl_id]` — charon resolves the method and
+/// puts its `FunDeclId` third, so a trait call is a real edge.  The exception
+/// is a `Dyn` trait reference, where the third element names the trait's own
+/// method declaration and the actual body is only known at run time.
+/// The discriminant of a `CallKind::Trait` payload's trait reference.
+pub fn trait_ref_kind(llbc: &majit_charon_reader::Llbc, tref: &serde_json::Value) -> String {
+    let body = if let Some(id) = tref.get("Deduplicated").and_then(|x| x.as_u64()) {
+        match llbc.dedup_body(id) {
+            Some(b) => b,
+            None => return "unresolved-dedup".into(),
+        }
+    } else if let Some(inline) = tref.pointer("/HashConsedValue/1") {
+        inline
+    } else {
+        return "no-body".into();
+    };
+    match body.get("kind") {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Object(m)) => m.keys().next().cloned().unwrap_or_default(),
+        _ => "none".into(),
+    }
+}
+
+/// The first `trait_decl_ref.skip_binder.id` anywhere under `v`.
+///
+/// Both spellings of a virtual call carry the trait the same way — the
+/// `CallKind::Trait` payload and the fat pointer's `DynTrait` type — just at
+/// different depths, so one search answers for both.
+fn first_trait_id(v: &serde_json::Value) -> Option<u64> {
+    if let Some(map) = v.as_object() {
+        if let Some(r) = map.get("trait_decl_ref")
+            && let Some(id) = r.pointer("/skip_binder/id").and_then(|x| x.as_u64())
+        {
+            return Some(id);
+        }
+        for sub in map.values() {
+            if let Some(id) = first_trait_id(sub) {
+                return Some(id);
+            }
+        }
+    } else if let Some(arr) = v.as_array() {
+        for sub in arr {
+            if let Some(id) = first_trait_id(sub) {
+                return Some(id);
+            }
+        }
+    }
+    None
 }
 
 /// The dispatch entry points application-level Python is reached through.
@@ -188,6 +259,143 @@ impl CallGraph {
     }
 }
 
+/// Where each function-pointer call gets its callee from, counted by source.
+///
+/// A count of unresolved calls says how much is opaque; this says *what* is
+/// opaque, which is the part that decides whether modelling it is worth
+/// anything.  The walk is flow-insensitive on purpose — it answers "what kind
+/// of thing lands in this local", not "which value on this path".
+pub fn dynamic_call_sources(llbc: &majit_charon_reader::Llbc) -> HashMap<String, usize> {
+    use majit_charon_reader::ullbc::{
+        CallFunc, CallKind, FunId, Operand, Place, PlaceKind, Rvalue, StmtKind, TermKind,
+    };
+
+    fn root(p: &Place) -> Option<u64> {
+        match &p.kind {
+            PlaceKind::Local(i) => Some(*i),
+            PlaceKind::Projection(b, _) => root(b),
+            _ => None,
+        }
+    }
+    fn op_local(o: &Operand) -> Option<u64> {
+        match o {
+            Operand::Copy(p) | Operand::Move(p) => root(p),
+            Operand::Const(_) => None,
+        }
+    }
+
+    let mut out: HashMap<String, usize> = HashMap::new();
+    for fd in llbc.iter_local_fns() {
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
+        let mut defs: HashMap<u64, Rvalue> = HashMap::new();
+        let mut from_call: HashMap<u64, String> = HashMap::new();
+        let mut projected: HashMap<u64, String> = HashMap::new();
+        for bb in &body.body {
+            for st in &bb.statements {
+                if let Ok(StmtKind::Assign(p, rv)) = st.stmt_kind()
+                    && let Some(l) = root(&p)
+                {
+                    if let Rvalue::Use(Operand::Copy(src) | Operand::Move(src)) = &rv
+                        && let PlaceKind::Projection(_, elem) = &src.kind
+                    {
+                        projected.insert(l, elem.label());
+                    }
+                    defs.insert(l, rv);
+                }
+            }
+            if let Ok(TermKind::Call { call, .. }) = bb.term()
+                && let Some(l) = root(&call.dest)
+                && let CallFunc::Regular(reg) = &call.func
+                && let CallKind::Fun(FunId::Regular { id }) = &reg.kind
+            {
+                let name = llbc
+                    .fn_by_id(*id)
+                    .map(|f| f.item_meta.name_path())
+                    .unwrap_or_default();
+                from_call.insert(l, name.rsplit("::").take(2).collect::<Vec<_>>().join("::"));
+            }
+        }
+        for bb in &body.body {
+            let Ok(TermKind::Call { call, .. }) = bb.term() else {
+                continue;
+            };
+            let CallFunc::Dynamic(op) = &call.func else {
+                continue;
+            };
+            let mut cur = op_local(op);
+            let mut seen: HashSet<u64> = HashSet::new();
+            let label = loop {
+                let Some(l) = cur else {
+                    break "operand is not a local".to_string();
+                };
+                if !seen.insert(l) {
+                    break "cycle".to_string();
+                }
+                if let Some(callee) = from_call.get(&l) {
+                    break format!("<- {callee}");
+                }
+                match defs.get(&l) {
+                    None => {
+                        break if l >= 1 && l <= body.locals.arg_count {
+                            "<- this fn's own parameter".to_string()
+                        } else {
+                            "<- no definition".to_string()
+                        };
+                    }
+                    Some(Rvalue::Use(o) | Rvalue::Cast(_, o, _)) => {
+                        if let Some(nl) = op_local(o) {
+                            cur = Some(nl);
+                            continue;
+                        }
+                        break match projected.get(&l) {
+                            Some(f) => format!("<- field {f}"),
+                            None => "<- constant".to_string(),
+                        };
+                    }
+                    Some(Rvalue::Ref { place, .. } | Rvalue::RawPtr { place, .. }) => {
+                        if let PlaceKind::Projection(_, elem) = &place.kind {
+                            break format!("<- &field {}", elem.label());
+                        }
+                        match root(place) {
+                            Some(nl) if nl != l => {
+                                cur = Some(nl);
+                                continue;
+                            }
+                            _ => break "<- borrow".to_string(),
+                        }
+                    }
+                    Some(other) => {
+                        break format!("<- rvalue {}", rvalue_label(other));
+                    }
+                }
+            };
+            *out.entry(label).or_insert(0) += 1;
+        }
+    }
+    out
+}
+
+fn rvalue_label(r: &majit_charon_reader::ullbc::Rvalue) -> &'static str {
+    use majit_charon_reader::ullbc::Rvalue as R;
+    match r {
+        R::Use(_) => "Use",
+        R::BinaryOp(..) => "BinaryOp",
+        R::UnaryOp(..) => "UnaryOp",
+        R::Ref { .. } => "Ref",
+        R::Aggregate(..) => "Aggregate",
+        R::Discriminant(_) => "Discriminant",
+        R::Cast(..) => "Cast",
+        R::Len(_) => "Len",
+        R::Repeat(..) => "Repeat",
+        R::ShallowInitBox(..) => "ShallowInitBox",
+        R::RawPtr { .. } => "RawPtr",
+        R::NullaryOp(..) => "NullaryOp",
+        R::Unknown => "Unknown",
+    }
+}
+
 /// Build the call graph of one charon artefact.
 ///
 /// Only `Call` terminators contribute edges, and only when charon already
@@ -201,6 +409,20 @@ pub fn build(llbc: &majit_charon_reader::Llbc) -> CallGraph {
     let mut callees: HashMap<u64, HashSet<u64>> = HashMap::new();
     let mut callers: HashMap<u64, HashSet<u64>> = HashMap::new();
     let mut indirect = HashSet::new();
+    let mut opaque = OpaqueCensus::default();
+    let mut note_opaque = |raw: Option<&serde_json::Value>, variant: &'static str| {
+        *opaque.by_variant.entry(variant).or_insert(0) += 1;
+        match raw.and_then(first_trait_id) {
+        Some(tid) => {
+            let name = llbc
+                .trait_by_id(tid)
+                .map(|t| t.item_meta.name_path())
+                .unwrap_or_else(|| format!("trait#{tid}"));
+            *opaque.dyn_trait.entry(name).or_insert(0) += 1;
+        }
+        None => opaque.fn_value += 1,
+        }
+    };
 
     for fd in llbc.iter_local_fns() {
         let id = fd.def_id;
@@ -213,17 +435,68 @@ pub fn build(llbc: &majit_charon_reader::Llbc) -> CallGraph {
             let Ok(TermKind::Call { call, .. }) = bb.term() else {
                 continue;
             };
-            match call.func {
-                CallFunc::Regular(reg) => match reg.kind {
+            match &call.func {
+                CallFunc::Regular(reg) => match &reg.kind {
                     CallKind::Fun(FunId::Regular { id: callee }) => {
-                        entry.insert(callee);
+                        entry.insert(*callee);
                     }
-                    _ => {
+                    CallKind::Fun(FunId::Other(v)) => {
                         indirect.insert(id);
+                        note_opaque(Some(v), "Fun(Other)");
+                    }
+                    CallKind::Trait(v) => {
+                        // `[trait_ref, method_index, fun_decl_id]`.  The third
+                        // element is the **trait's method declaration**, not
+                        // the impl that will run: measured over this artefact,
+                        // 382 of 541 have no body at all, and every trait ref
+                        // is a generic `Clause` / `ParentClause` rather than a
+                        // `TraitImpl`, so the impl is not recoverable here
+                        // without propagating the caller's instantiation.
+                        // Turning this into an edge therefore buys false
+                        // confidence — it retires the caller's undecidability
+                        // by pointing it at a bodyless leaf.
+                        //
+                        // A default body is still real code the call may run,
+                        // so it is added as an edge, which can only widen
+                        // "reaches a collection".  The caller stays opaque
+                        // either way, because an overriding impl is invisible
+                        // from here.
+                        if let Some(c) = v.get(2).and_then(|x| x.as_u64())
+                            && llbc.fn_by_id(c).and_then(|f| f.unstructured()).is_some()
+                        {
+                            entry.insert(c);
+                        }
+                        indirect.insert(id);
+                        note_opaque(Some(v), "Trait");
+                    }
+                    CallKind::Ptr(v) => {
+                        indirect.insert(id);
+                        note_opaque(Some(v), "Ptr");
+                    }
+                    CallKind::Unknown => {
+                        indirect.insert(id);
+                        opaque.unknown += 1;
                     }
                 },
-                _ => {
+                CallFunc::Dynamic(op) => {
                     indirect.insert(id);
+                    // A fat pointer's type is as often a dedup id as an inline
+                    // body; resolving it is what keeps `dyn Trait` out of the
+                    // function-pointer bucket.
+                    let ty = match op {
+                        majit_charon_reader::ullbc::Operand::Copy(p)
+                        | majit_charon_reader::ullbc::Operand::Move(p) => match &p.ty {
+                            majit_charon_reader::ullbc::TyRef::Inline { value: (_, v) } => Some(v),
+                            majit_charon_reader::ullbc::TyRef::Dedup { id } => llbc.dedup_body(*id),
+                            majit_charon_reader::ullbc::TyRef::Other(v) => Some(v),
+                        },
+                        majit_charon_reader::ullbc::Operand::Const(v) => Some(v),
+                    };
+                    note_opaque(ty, "Dynamic");
+                }
+                CallFunc::Unknown => {
+                    indirect.insert(id);
+                    opaque.unknown += 1;
                 }
             }
         }
@@ -233,10 +506,12 @@ pub fn build(llbc: &majit_charon_reader::Llbc) -> CallGraph {
             callers.entry(c).or_default().insert(caller);
         }
     }
+    drop(note_opaque);
     CallGraph {
         names,
         callees,
         callers,
         indirect,
+        opaque,
     }
 }

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -235,7 +235,11 @@ impl CallGraph {
         for pat in patterns {
             let mut any = false;
             for (&id, name) in &self.names {
-                if name.ends_with(pat) {
+                // Anchored on a path separator: an unanchored `ends_with`
+                // would let `fastcall::call_callable` answer for the
+                // `call::call_callable` seed, and an over-matched seed widens
+                // every verdict downstream of `reaching`.
+                if name == pat || name.ends_with(&format!("::{pat}")) {
                     ids.insert(id);
                     any = true;
                 }

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -1,0 +1,201 @@
+//! `rpython/memory/gctransform/framework.py` — which operations can collect.
+//!
+//! Upstream answers this by construction: `BaseFrameworkGCTransformer` has one
+//! `gct_*` handler per operation that can reach the collector, and each of them
+//! brackets its operation with
+//!
+//! ```text
+//! livevars = self.push_roots(hop)
+//! ...
+//! self.pop_roots(hop, livevars)
+//! ```
+//!
+//! (`framework.py:790, 853, 901, 908, 971, 1022, 1050, 1150, …` — about thirty
+//! pairs).  The live set is never written by hand either:
+//! `get_livevars_for_roots` (`framework.py:1501`) takes `hop.livevars_after_op()`
+//! straight off the flow graph, and for a moving GC deliberately drops the
+//! current operation's own arguments — *"moving GCs don't borrow, so the caller
+//! does not need to keep the arguments alive"*.
+//!
+//! pyre has no such rewrite, so the same question has to be answered by
+//! analysis.  It is answered over the *resolved* ULLBC call graph: a Call
+//! terminator names its callee as `Fun::Regular(FunDeclId)`, so closing over
+//! callers cannot be widened by two functions sharing a leaf name.
+//!
+//! # What actually collects
+//!
+//! Settled in source on 2026-08-19, because getting this backwards is what
+//! makes an audit report windows that are not defects:
+//!
+//! - The **host** allocation path does **not** collect.  `try_gc_alloc`
+//!   (`pyre-object/src/gc_hook.rs`) reaches the backend hook
+//!   `dynasm_alloc_nursery_typed` (`majit-backend-dynasm/src/runner.rs`), whose
+//!   own comment states it: *"host-side allocation must not trigger collection:
+//!   the caller holds a raw `*mut u8` on the Rust stack that is NOT registered
+//!   as a GC root."*  It routes to `try_alloc_nursery_no_collect_typed`, which
+//!   bumps the nursery or spills to old-gen, and an object born old while a
+//!   major cycle is marking is born black (`oldgen_birth_flags`).  So neither a
+//!   minor nor a sweep can touch what such a call leaves behind.
+//! - What collects is **application-level Python**: it can reach JIT-compiled
+//!   code, which allocates inline in the nursery and runs a minor when it
+//!   fills.  The explicit collection entry points and the collecting nursery
+//!   hook (`alloc_nursery_collecting_typed`, reserved for the elidable bigint
+//!   payload helpers) are the other two.
+//!
+//! So the seeds below are *dispatch* entry points, never allocators.
+
+use std::collections::{HashMap, HashSet};
+
+/// A resolved ULLBC call graph: which function calls which.
+pub struct CallGraph {
+    /// `def_id -> fully qualified name`
+    pub names: HashMap<u64, String>,
+    /// `def_id -> callees`, from `Fun::Regular` Call terminators only.
+    pub callees: HashMap<u64, HashSet<u64>>,
+    /// `def_id -> callers`, the reverse index.
+    pub callers: HashMap<u64, HashSet<u64>>,
+    /// Functions with at least one Call terminator this pass could not resolve
+    /// to a `FunDeclId` — a call through a function pointer, a trait object or
+    /// a closure.  Reported rather than dropped: an unresolved edge is exactly
+    /// where "can this reach Python" stops being decidable from the graph.
+    pub indirect: HashSet<u64>,
+}
+
+/// The dispatch entry points application-level Python is reached through.
+///
+/// Matched on the trailing path segments so a crate rename cannot silently
+/// empty the seed set; a seed that matches nothing is reported by
+/// [`CallGraph::seed_report`].
+pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
+    // The generic callable dispatchers.
+    "call::call_callable",
+    "call::call_callable_in_ctx",
+    "call::call_callable_with_mode",
+    "call::call_user_function",
+    "call::call_user_function_plain",
+    "call::call_user_function_with_args",
+    "call::call_user_function_resolved_frameless",
+    "call::builtin_code_call_positional",
+    "call::call_builtin_code_positional",
+    // The gateway's indirect call into a builtin's Rust body.
+    "gateway::builtin_code_call",
+    // The frame executors.
+    "eval::eval_frame_plain",
+    "eval::eval_frame_plain_with_operr",
+    "eval::eval_frame_plain_with_resume",
+    "eval::eval_loop",
+    "pyframe::execute_frame",
+    // The space-level helpers most builtins reach Python through.
+    "baseobjspace::call_function",
+    "baseobjspace::call_method",
+    "baseobjspace::call_obj_args",
+    "descroperation::try_call_special",
+];
+
+/// Explicit collection entry points and the one collecting host allocator.
+pub const COLLECTING_SEEDS: &[&str] = &[
+    "gc_hook::try_gc_alloc_collecting",
+    "gc_hook::try_gc_alloc_collecting_rooted",
+];
+
+impl CallGraph {
+    /// Every function that can transitively reach one of `seeds`.
+    pub fn reaching(&self, seeds: &HashSet<u64>) -> HashSet<u64> {
+        let mut out: HashSet<u64> = seeds.clone();
+        let mut work: Vec<u64> = seeds.iter().copied().collect();
+        while let Some(cur) = work.pop() {
+            let Some(ups) = self.callers.get(&cur) else {
+                continue;
+            };
+            for &up in ups {
+                if out.insert(up) {
+                    work.push(up);
+                }
+            }
+        }
+        out
+    }
+
+    /// Resolve the configured seed patterns against the real name table.
+    pub fn seeds_for(&self, patterns: &[&str]) -> (HashSet<u64>, Vec<String>) {
+        let mut ids = HashSet::new();
+        let mut unmatched = Vec::new();
+        for pat in patterns {
+            let mut any = false;
+            for (&id, name) in &self.names {
+                if name.ends_with(pat) {
+                    ids.insert(id);
+                    any = true;
+                }
+            }
+            if !any {
+                unmatched.push((*pat).to_string());
+            }
+        }
+        (ids, unmatched)
+    }
+
+    /// A seed pattern that matches nothing is a silently empty analysis, so
+    /// name them rather than let the closure come back small and look clean.
+    pub fn seed_report(&self, patterns: &[&str]) -> String {
+        let (ids, unmatched) = self.seeds_for(patterns);
+        let mut s = format!("{} seed function(s)", ids.len());
+        if !unmatched.is_empty() {
+            s.push_str(&format!("; UNMATCHED patterns: {unmatched:?}"));
+        }
+        s
+    }
+}
+
+/// Build the call graph of one charon artefact.
+///
+/// Only `Call` terminators contribute edges, and only when charon already
+/// resolved the callee to a `FunDeclId`.  Everything else — `dyn` dispatch, a
+/// function-pointer call, a trait call charon left unresolved — marks the
+/// caller in [`CallGraph::indirect`] instead of inventing an edge.
+pub fn build(llbc: &majit_charon_reader::Llbc) -> CallGraph {
+    use majit_charon_reader::ullbc::{CallFunc, CallKind, FunId, TermKind};
+
+    let mut names = HashMap::new();
+    let mut callees: HashMap<u64, HashSet<u64>> = HashMap::new();
+    let mut callers: HashMap<u64, HashSet<u64>> = HashMap::new();
+    let mut indirect = HashSet::new();
+
+    for fd in llbc.iter_local_fns() {
+        let id = fd.def_id;
+        names.insert(id, fd.item_meta.name_path());
+        let entry = callees.entry(id).or_default();
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
+        for bb in &body.body {
+            let Ok(TermKind::Call { call, .. }) = bb.term() else {
+                continue;
+            };
+            match call.func {
+                CallFunc::Regular(reg) => match reg.kind {
+                    CallKind::Fun(FunId::Regular { id: callee }) => {
+                        entry.insert(callee);
+                    }
+                    _ => {
+                        indirect.insert(id);
+                    }
+                },
+                _ => {
+                    indirect.insert(id);
+                }
+            }
+        }
+    }
+    for (&caller, cs) in &callees {
+        for &c in cs {
+            callers.entry(c).or_default().insert(caller);
+        }
+    }
+    CallGraph {
+        names,
+        callees,
+        callers,
+        indirect,
+    }
+}

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -21,8 +21,8 @@
 use std::collections::{HashMap, HashSet};
 
 use majit_charon_reader::ullbc::{
-    CallFunc, CallKind, FunId, Operand, Place, PlaceKind, Rvalue, StmtKind, SwitchTargets, TermKind,
-    TyRef,
+    CallFunc, CallKind, FunId, Operand, Place, PlaceKind, Rvalue, StmtKind, SwitchTargets,
+    TermKind, TyRef,
 };
 
 /// One call that can collect, with GC pointers live across it and no bracket.
@@ -394,10 +394,10 @@ pub fn scan(
             findings.push(Finding {
                 func: id,
                 func_name: fd.item_meta.name_path(),
-                line: bb.statements.last().map_or(
-                    fd.item_meta.span.data.beg.line,
-                    |s| s.span.data.beg.line,
-                ),
+                line: bb
+                    .statements
+                    .last()
+                    .map_or(fd.item_meta.span.data.beg.line, |s| s.span.data.beg.line),
                 callee_id: *callee,
                 callee_name: cg.names.get(callee).cloned().unwrap_or_default(),
                 live_non_arg: non_arg,

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -45,6 +45,25 @@ pub struct Finding {
     pub movable_use: Vec<String>,
 }
 
+/// What the scan could and could not account for.
+///
+/// A finding count means nothing without these: a body whose terminator the
+/// reader could not parse loses successors, which shrinks every live set
+/// computed from it, and a call sitting downstream of a `push_roots` is
+/// withheld rather than cleared.
+#[derive(Default)]
+pub struct ScanStats {
+    pub bodies_scanned: usize,
+    /// Bodies holding a terminator this reader could not classify.  Their
+    /// liveness is incomplete, so they are reported rather than counted clean.
+    pub unparsed_terminator_bodies: usize,
+    /// Collecting calls withheld because a `push_roots` dominates them.
+    /// Whether that scope is still alive at the call is a drop-placement
+    /// question this pass cannot answer, so they are neither reported nor
+    /// silently dropped.
+    pub withheld_under_a_bracket: usize,
+}
+
 /// Callee names that address a `list` or a `dict` through the pointer.
 fn addresses_movable(name: &str) -> bool {
     const MARKERS: &[&str] = &[
@@ -175,20 +194,24 @@ fn successors(t: &TermKind) -> Vec<u64> {
 
 /// Report every call that can collect and carries an unrooted live GC pointer.
 ///
-/// `bracketed` are the functions that already open a `push_roots` scope; they
-/// are skipped wholesale, because whether *that* scope covers *this* call is a
-/// question about pin/read-back placement, not about liveness.
+/// `push_roots` are the `gc_roots::push_roots` function ids.  Coverage is
+/// judged **per call**, not per function: a call is withheld only when every
+/// path to it runs through a `push_roots`, which is exactly "this block is
+/// unreachable from entry once the bracket blocks are removed".  A function
+/// that brackets one branch and leaves another bare is therefore still
+/// reported on the bare branch.
 pub fn scan(
     llbc: &majit_charon_reader::Llbc,
     cg: &super::framework::CallGraph,
     reach: &HashSet<u64>,
-    bracketed: &HashSet<u64>,
+    push_roots: &HashSet<u64>,
     gc_tys: &HashSet<u64>,
-) -> Vec<Finding> {
+) -> (Vec<Finding>, ScanStats) {
     let mut findings = Vec::new();
+    let mut stats = ScanStats::default();
     for fd in llbc.iter_local_fns() {
         let id = fd.def_id;
-        if bracketed.contains(&id) || !reach.contains(&id) {
+        if !reach.contains(&id) {
             continue;
         }
         let Some(body) = fd.unstructured() else {
@@ -211,8 +234,53 @@ pub fn scan(
             continue;
         }
 
+        stats.bodies_scanned += 1;
         let n = body.body.len();
         let terms: Vec<Option<TermKind>> = body.body.iter().map(|b| b.term().ok()).collect();
+        if terms
+            .iter()
+            .any(|t| t.is_none() || matches!(t, Some(TermKind::Unknown)))
+        {
+            // Successors are unknown for that block, so every live set derived
+            // from it is a lower bound.  Count the body; do not pretend it is
+            // clean.
+            stats.unparsed_terminator_bodies += 1;
+        }
+
+        // Blocks whose terminator opens a root scope, and the blocks that are
+        // still reachable from entry without them — those are the ones no
+        // bracket can dominate.
+        let bracket_blocks: HashSet<usize> = (0..n)
+            .filter(|&b| match &terms[b] {
+                Some(TermKind::Call { call, .. }) => match &call.func {
+                    CallFunc::Regular(reg) => matches!(
+                        &reg.kind,
+                        CallKind::Fun(FunId::Regular { id }) if push_roots.contains(id)
+                    ),
+                    _ => false,
+                },
+                _ => false,
+            })
+            .collect();
+        let unbracketed: HashSet<usize> = if bracket_blocks.is_empty() {
+            (0..n).collect()
+        } else {
+            let mut seen: HashSet<usize> = HashSet::new();
+            let mut work = vec![0usize];
+            while let Some(cur) = work.pop() {
+                if bracket_blocks.contains(&cur) || !seen.insert(cur) {
+                    continue;
+                }
+                if let Some(t) = &terms[cur] {
+                    for s in successors(t) {
+                        if (s as usize) < n {
+                            work.push(s as usize);
+                        }
+                    }
+                }
+            }
+            seen
+        };
         let mut live_in: Vec<HashSet<u64>> = vec![HashSet::new(); n];
         // Backward liveness to a fixed point.  The bodies are small; a plain
         // worklist over predecessors converges in a handful of rounds.
@@ -241,6 +309,27 @@ pub fn scan(
             }
         }
 
+        // Locals this body hands to a `list`/`dict`-addressing callee.  Built
+        // once: it does not depend on which collecting call is being judged.
+        let mut movable_args: HashSet<u64> = HashSet::new();
+        for other in &body.body {
+            let Ok(TermKind::Call { call: c2, .. }) = other.term() else {
+                continue;
+            };
+            let CallFunc::Regular(r2) = &c2.func else {
+                continue;
+            };
+            let CallKind::Fun(FunId::Regular { id: cid }) = &r2.kind else {
+                continue;
+            };
+            if !cg.names.get(cid).is_some_and(|n| addresses_movable(n)) {
+                continue;
+            }
+            for a in &c2.args {
+                use_operand(a, &mut movable_args);
+            }
+        }
+
         // Now re-walk, and at every collecting Call read the live-after set.
         for (b, bb) in body.body.iter().enumerate() {
             let Some(TermKind::Call {
@@ -258,6 +347,10 @@ pub fn scan(
                 continue;
             };
             if !reach.contains(callee) {
+                continue;
+            }
+            if !unbracketed.contains(&b) {
+                stats.withheld_under_a_bracket += 1;
                 continue;
             }
             let mut after: HashSet<u64> = HashSet::new();
@@ -289,34 +382,14 @@ pub fn scan(
                 .collect();
             non_arg.sort();
             in_arg.sort();
-            // Does any live pointer reach a list/dict-addressing callee later
-            // in this body?  Scanning the whole function rather than only the
-            // dominated successors keeps this a ranking signal, not a proof.
-            let mut movable_use: Vec<String> = Vec::new();
-            for other in &body.body {
-                let Ok(TermKind::Call { call: c2, .. }) = other.term() else {
-                    continue;
-                };
-                let CallFunc::Regular(r2) = &c2.func else {
-                    continue;
-                };
-                let CallKind::Fun(FunId::Regular { id: cid }) = &r2.kind else {
-                    continue;
-                };
-                if !cg.names.get(cid).is_some_and(|n| addresses_movable(n)) {
-                    continue;
-                }
-                let mut used = HashSet::new();
-                for a in &c2.args {
-                    use_operand(a, &mut used);
-                }
-                for l in after.iter().filter(|l| used.contains(l)) {
-                    let nm = gc_locals[l].clone();
-                    if !movable_use.contains(&nm) {
-                        movable_use.push(nm);
-                    }
-                }
-            }
+            // Does any live pointer reach a list/dict-addressing callee in this
+            // body?  Anywhere in the body, not only in the dominated
+            // successors — this is a ranking signal, not a proof.
+            let mut movable_use: Vec<String> = after
+                .iter()
+                .filter(|l| movable_args.contains(l))
+                .map(|l| gc_locals[l].clone())
+                .collect();
             movable_use.sort();
             findings.push(Finding {
                 func: id,
@@ -333,7 +406,7 @@ pub fn scan(
             });
         }
     }
-    findings
+    (findings, stats)
 }
 
 fn transfer_stmt(k: &StmtKind, live: &mut HashSet<u64>) {

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -1,0 +1,326 @@
+//! `rpython/memory/gctransform/framework.py:1501 get_livevars_for_roots` —
+//! which GC pointers are live across an operation that can collect.
+//!
+//! Upstream reads the answer straight off the flow graph with
+//! `hop.livevars_after_op()`, then brackets the operation with
+//! `push_roots` / `pop_roots`.  pyre's interpreter is compiled by rustc, so
+//! there is no flow graph to rewrite; this pass computes the same live set over
+//! the ULLBC body and reports the operations where the bracket is *missing*.
+//!
+//! # One deliberate divergence from upstream
+//!
+//! `get_livevars_for_roots` drops the current operation's own arguments for a
+//! moving GC — *"moving GCs don't borrow, so the caller does not need to keep
+//! the arguments alive"*.  That holds upstream because the shadowstack walks
+//! the caller's frame and rewrites its copy in place.  pyre's shadow stack
+//! holds only what was explicitly pinned, so an argument the caller still uses
+//! after the call is just as stale as any other local.  Arguments are therefore
+//! kept in the live set, and reported in a separate column so the two shapes
+//! stay distinguishable.
+
+use std::collections::{HashMap, HashSet};
+
+use majit_charon_reader::ullbc::{
+    CallFunc, CallKind, FunId, Operand, Place, PlaceKind, Rvalue, StmtKind, SwitchTargets, TermKind,
+    TyRef,
+};
+
+/// One call that can collect, with GC pointers live across it and no bracket.
+pub struct Finding {
+    pub func: u64,
+    pub func_name: String,
+    pub line: u64,
+    pub callee_id: u64,
+    pub callee_name: String,
+    /// Live across the call and *not* passed to it — the shape both proven
+    /// defects had.
+    pub live_non_arg: Vec<String>,
+    /// Live across the call because the call itself takes them.
+    pub live_arg: Vec<String>,
+}
+
+fn ty_id(t: &TyRef) -> Option<u64> {
+    match t {
+        TyRef::Dedup { id } => Some(*id),
+        TyRef::Inline { value: (id, _) } => Some(*id),
+        TyRef::Other(_) => None,
+    }
+}
+
+/// The type ids `PyObjectRef` is spelled with in *this* artefact.
+///
+/// Read off signatures pyre already declares in those terms rather than
+/// hard-coded, because a dedup id is artefact-local: `pin_root` takes one and
+/// `shadow_stack_get` returns one.  An empty result means the analysis would
+/// silently find nothing, so callers must report it.
+pub fn gc_ptr_type_ids(llbc: &majit_charon_reader::Llbc) -> HashSet<u64> {
+    let mut out = HashSet::new();
+    for fd in llbc.iter_local_fns() {
+        let name = fd.item_meta.name_path();
+        if name.ends_with("gc_roots::pin_root") {
+            if let Some(t) = fd.signature.inputs.first().and_then(ty_id) {
+                out.insert(t);
+            }
+        } else if name.ends_with("gc_roots::shadow_stack_get") {
+            if let Some(t) = ty_id(&fd.signature.output) {
+                out.insert(t);
+            }
+        }
+    }
+    out
+}
+
+/// The local a place is rooted at, looking through every projection.
+fn place_local(p: &Place) -> Option<u64> {
+    match &p.kind {
+        PlaceKind::Local(i) => Some(*i),
+        PlaceKind::Projection(base, _) => place_local(base),
+        _ => None,
+    }
+}
+
+/// Whether the place names a whole local (so assigning it kills the old value).
+fn bare_local(p: &Place) -> Option<u64> {
+    match &p.kind {
+        PlaceKind::Local(i) => Some(*i),
+        _ => None,
+    }
+}
+
+fn use_operand(o: &Operand, out: &mut HashSet<u64>) {
+    match o {
+        Operand::Copy(p) | Operand::Move(p) => {
+            if let Some(l) = place_local(p) {
+                out.insert(l);
+            }
+        }
+        Operand::Const(_) => {}
+    }
+}
+
+fn use_rvalue(r: &Rvalue, out: &mut HashSet<u64>) {
+    match r {
+        Rvalue::Use(o) | Rvalue::UnaryOp(_, o) => use_operand(o, out),
+        Rvalue::BinaryOp(_, a, b) => {
+            use_operand(a, out);
+            use_operand(b, out);
+        }
+        Rvalue::Ref { place, .. } | Rvalue::RawPtr { place, .. } => {
+            if let Some(l) = place_local(place) {
+                out.insert(l);
+            }
+        }
+        Rvalue::Aggregate(_, ops) => {
+            for o in ops {
+                use_operand(o, out);
+            }
+        }
+        Rvalue::Discriminant(p) | Rvalue::Len(p) => {
+            if let Some(l) = place_local(p) {
+                out.insert(l);
+            }
+        }
+        Rvalue::Cast(_, o, _) | Rvalue::Repeat(o, _, _) | Rvalue::ShallowInitBox(o, _) => {
+            use_operand(o, out)
+        }
+        Rvalue::NullaryOp(_, _) | Rvalue::Unknown => {}
+    }
+}
+
+fn successors(t: &TermKind) -> Vec<u64> {
+    match t {
+        TermKind::Goto { target } => vec![*target],
+        TermKind::Switch { targets, .. } => match targets {
+            SwitchTargets::If(a, b) => vec![*a, *b],
+            SwitchTargets::SwitchInt(_, arms, d) => {
+                let mut v: Vec<u64> = arms.iter().map(|(_, b)| *b).collect();
+                v.push(*d);
+                v
+            }
+        },
+        TermKind::Call {
+            target, on_unwind, ..
+        }
+        | TermKind::Assert {
+            target, on_unwind, ..
+        }
+        | TermKind::Drop {
+            target, on_unwind, ..
+        } => vec![*target, *on_unwind],
+        _ => vec![],
+    }
+}
+
+/// Report every call that can collect and carries an unrooted live GC pointer.
+///
+/// `bracketed` are the functions that already open a `push_roots` scope; they
+/// are skipped wholesale, because whether *that* scope covers *this* call is a
+/// question about pin/read-back placement, not about liveness.
+pub fn scan(
+    llbc: &majit_charon_reader::Llbc,
+    cg: &super::framework::CallGraph,
+    reach: &HashSet<u64>,
+    bracketed: &HashSet<u64>,
+    gc_tys: &HashSet<u64>,
+) -> Vec<Finding> {
+    let mut findings = Vec::new();
+    for fd in llbc.iter_local_fns() {
+        let id = fd.def_id;
+        if bracketed.contains(&id) || !reach.contains(&id) {
+            continue;
+        }
+        let Some(body) = fd.unstructured() else {
+            continue;
+        };
+        // Locals whose static type is a GC pointer.  Nothing else can go stale.
+        let gc_locals: HashMap<u64, String> = body
+            .locals
+            .locals
+            .iter()
+            .filter(|l| ty_id(&l.ty).is_some_and(|t| gc_tys.contains(&t)))
+            .map(|l| {
+                (
+                    l.index,
+                    l.name.clone().unwrap_or_else(|| format!("_{}", l.index)),
+                )
+            })
+            .collect();
+        if gc_locals.is_empty() {
+            continue;
+        }
+
+        let n = body.body.len();
+        let terms: Vec<Option<TermKind>> = body.body.iter().map(|b| b.term().ok()).collect();
+        let mut live_in: Vec<HashSet<u64>> = vec![HashSet::new(); n];
+        // Backward liveness to a fixed point.  The bodies are small; a plain
+        // worklist over predecessors converges in a handful of rounds.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            for b in (0..n).rev() {
+                let Some(t) = &terms[b] else { continue };
+                let mut live: HashSet<u64> = HashSet::new();
+                for s in successors(t) {
+                    if let Some(sl) = live_in.get(s as usize) {
+                        live.extend(sl.iter().copied());
+                    }
+                }
+                transfer_term(t, &mut live);
+                for st in body.body[b].statements.iter().rev() {
+                    if let Ok(k) = st.stmt_kind() {
+                        transfer_stmt(&k, &mut live);
+                    }
+                }
+                live.retain(|l| gc_locals.contains_key(l));
+                if live != live_in[b] {
+                    live_in[b] = live;
+                    changed = true;
+                }
+            }
+        }
+
+        // Now re-walk, and at every collecting Call read the live-after set.
+        for (b, bb) in body.body.iter().enumerate() {
+            let Some(TermKind::Call {
+                call,
+                target,
+                on_unwind,
+            }) = &terms[b]
+            else {
+                continue;
+            };
+            let CallFunc::Regular(reg) = &call.func else {
+                continue;
+            };
+            let CallKind::Fun(FunId::Regular { id: callee }) = &reg.kind else {
+                continue;
+            };
+            if !reach.contains(callee) {
+                continue;
+            }
+            let mut after: HashSet<u64> = HashSet::new();
+            for s in [*target, *on_unwind] {
+                if let Some(sl) = live_in.get(s as usize) {
+                    after.extend(sl.iter().copied());
+                }
+            }
+            if let Some(d) = bare_local(&call.dest) {
+                after.remove(&d);
+            }
+            after.retain(|l| gc_locals.contains_key(l));
+            if after.is_empty() {
+                continue;
+            }
+            let mut args: HashSet<u64> = HashSet::new();
+            for a in &call.args {
+                use_operand(a, &mut args);
+            }
+            let mut non_arg: Vec<String> = after
+                .iter()
+                .filter(|l| !args.contains(l))
+                .map(|l| gc_locals[l].clone())
+                .collect();
+            let mut in_arg: Vec<String> = after
+                .iter()
+                .filter(|l| args.contains(l))
+                .map(|l| gc_locals[l].clone())
+                .collect();
+            non_arg.sort();
+            in_arg.sort();
+            findings.push(Finding {
+                func: id,
+                func_name: fd.item_meta.name_path(),
+                line: bb.statements.last().map_or(
+                    fd.item_meta.span.data.beg.line,
+                    |s| s.span.data.beg.line,
+                ),
+                callee_id: *callee,
+                callee_name: cg.names.get(callee).cloned().unwrap_or_default(),
+                live_non_arg: non_arg,
+                live_arg: in_arg,
+            });
+        }
+    }
+    findings
+}
+
+fn transfer_stmt(k: &StmtKind, live: &mut HashSet<u64>) {
+    match k {
+        StmtKind::Assign(p, r) => {
+            if let Some(d) = bare_local(p) {
+                live.remove(&d);
+            } else if let Some(l) = place_local(p) {
+                live.insert(l);
+            }
+            use_rvalue(r, live);
+        }
+        StmtKind::StorageLive(i) | StmtKind::StorageDead(i) => {
+            live.remove(i);
+        }
+        StmtKind::Assert(a) => use_operand(&a.cond, live),
+        StmtKind::PlaceMention(p) => {
+            if let Some(l) = place_local(p) {
+                live.insert(l);
+            }
+        }
+        StmtKind::Unknown => {}
+    }
+}
+
+fn transfer_term(t: &TermKind, live: &mut HashSet<u64>) {
+    match t {
+        TermKind::Call { call, .. } => {
+            if let Some(d) = bare_local(&call.dest) {
+                live.remove(&d);
+            } else if let Some(l) = place_local(&call.dest) {
+                live.insert(l);
+            }
+            for a in &call.args {
+                use_operand(a, live);
+            }
+        }
+        TermKind::Switch { discr, .. } => use_operand(discr, live),
+        TermKind::Assert { assert, .. } => use_operand(&assert.cond, live),
+        _ => {}
+    }
+}

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -37,6 +37,28 @@ pub struct Finding {
     pub live_non_arg: Vec<String>,
     /// Live across the call because the call itself takes them.
     pub live_arg: Vec<String>,
+    /// Of the live pointers, those the function later hands to a callee whose
+    /// name says it addresses a `list` or a `dict` — the only two kinds whose
+    /// header a minor collection relocates.  A stale pointer that is only
+    /// stored or returned is a different (and rarer) problem; this column is
+    /// where a stale pointer is actually dereferenced as a movable object.
+    pub movable_use: Vec<String>,
+}
+
+/// Callee names that address a `list` or a `dict` through the pointer.
+fn addresses_movable(name: &str) -> bool {
+    const MARKERS: &[&str] = &[
+        "w_list_",
+        "w_dict_",
+        "list_concat",
+        "list_repeat",
+        "sequence_repeat",
+        "require_list",
+        "require_dict",
+        "dict_method_",
+        "list_method_",
+    ];
+    MARKERS.iter().any(|m| name.contains(m))
 }
 
 fn ty_id(t: &TyRef) -> Option<u64> {
@@ -267,6 +289,35 @@ pub fn scan(
                 .collect();
             non_arg.sort();
             in_arg.sort();
+            // Does any live pointer reach a list/dict-addressing callee later
+            // in this body?  Scanning the whole function rather than only the
+            // dominated successors keeps this a ranking signal, not a proof.
+            let mut movable_use: Vec<String> = Vec::new();
+            for other in &body.body {
+                let Ok(TermKind::Call { call: c2, .. }) = other.term() else {
+                    continue;
+                };
+                let CallFunc::Regular(r2) = &c2.func else {
+                    continue;
+                };
+                let CallKind::Fun(FunId::Regular { id: cid }) = &r2.kind else {
+                    continue;
+                };
+                if !cg.names.get(cid).is_some_and(|n| addresses_movable(n)) {
+                    continue;
+                }
+                let mut used = HashSet::new();
+                for a in &c2.args {
+                    use_operand(a, &mut used);
+                }
+                for l in after.iter().filter(|l| used.contains(l)) {
+                    let nm = gc_locals[l].clone();
+                    if !movable_use.contains(&nm) {
+                        movable_use.push(nm);
+                    }
+                }
+            }
+            movable_use.sort();
             findings.push(Finding {
                 func: id,
                 func_name: fd.item_meta.name_path(),
@@ -278,6 +329,7 @@ pub fn scan(
                 callee_name: cg.names.get(callee).cloned().unwrap_or_default(),
                 live_non_arg: non_arg,
                 live_arg: in_arg,
+                movable_use,
             });
         }
     }

--- a/majit/majit-translate/src/memory/gctransform/mod.rs
+++ b/majit/majit-translate/src/memory/gctransform/mod.rs
@@ -14,5 +14,23 @@
 //! *analysis* half: the same questions, answered over the ULLBC charon emits
 //! for those crates, so a hand-written bracket can be checked instead of
 //! trusted.
+//!
+//! # Why not the insertion half
+//!
+//! Upstream's transformer runs inside the translator, between the RTyper and
+//! the backend, and rewrites the graphs it is about to emit.  This crate has
+//! no such position over the interpreter: `majit-translate` lowers LLBC for
+//! the *JIT*, and the interpreter's machine code comes out of rustc, which
+//! this pipeline never sees.  Inserting the bracket automatically would mean
+//! either a rustc MIR pass or LLVM statepoints — a different project with a
+//! different toolchain, not a port of `gctransform`.  The charon artefact is
+//! read-only: it is emitted from the same source rustc compiles, so it can
+//! *answer* `framework.py`'s question about that code, but nothing written
+//! back into it would reach the binary.
+//!
+//! So the hand-written brackets stay, and this module exists to stop them
+//! being taken on trust: `liveness::scan` reports the calls that can collect
+//! with a GC pointer live across them and no bracket, and reports what it had
+//! to withhold rather than counting it clean.
 pub mod framework;
 pub mod liveness;

--- a/majit/majit-translate/src/memory/gctransform/mod.rs
+++ b/majit/majit-translate/src/memory/gctransform/mod.rs
@@ -1,0 +1,18 @@
+//! `rpython/memory/gctransform/` — the GC root transformer.
+//!
+//! Upstream inserts the shadow-stack save/reload bracket automatically:
+//! `framework.py` brackets every collecting operation, `shadowstack.py`
+//! emits the `gc_push_roots` / `gc_pop_roots` pair, `shadowcolor.py` colours
+//! the saves like registers, and `postprocess_double_check` verifies the
+//! placement.  Application code therefore carries no rooting at all —
+//! `pypy/objspace/std/listobject.py descr_index` names its receiver and its
+//! needle as plain locals.
+//!
+//! pyre's interpreter is compiled by rustc, so there is no flow graph for a
+//! `hop.genop` to write into and the bracket is written by hand
+//! (`pyre_object::gc_roots`).  What this module ports is therefore the
+//! *analysis* half: the same questions, answered over the ULLBC charon emits
+//! for those crates, so a hand-written bracket can be checked instead of
+//! trusted.
+pub mod framework;
+pub mod liveness;

--- a/majit/majit-translate/src/memory/mod.rs
+++ b/majit/majit-translate/src/memory/mod.rs
@@ -1,0 +1,8 @@
+//! `rpython/memory/` — the parts that belong to the translation pipeline.
+//!
+//! The collector itself (`rpython/memory/gc/incminimark.py`) lives in
+//! `majit-gc`; what lands here is `rpython/memory/gctransform/`, which is a
+//! *translation* stage: upstream it rewrites the flow graphs after rtyping so
+//! that every operation which can collect is bracketed by
+//! `push_roots` / `pop_roots`.
+pub mod gctransform;

--- a/pyre/extra_tests/parity_tests/binop_notimplemented_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/binop_notimplemented_gc_roots.py
@@ -1,0 +1,67 @@
+# CPython-suite gap: no test returns NotImplemented from a dunder that collects.
+# parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
+
+"""Operand dispatch must survive a dunder that returns ``NotImplemented``.
+
+Both halves of the binary protocol run arbitrary Python before the operands
+are used again: the forward call is tried first, and only when it answers
+``NotImplemented`` does the reflected call — or the error path that names the
+operand types — read them a second time.
+"""
+
+import gc
+
+
+def churn():
+    garbage = [[index, index + 1] for index in range(20000)]
+    assert len(garbage) == 20000
+    gc.collect()
+
+
+class Reflected:
+    """Answers NotImplemented so the reflected method is never the last word."""
+
+    def __radd__(self, other):
+        churn()
+        return NotImplemented
+
+    def __mul__(self, other):
+        churn()
+        return NotImplemented
+
+    def __ror__(self, other):
+        churn()
+        return NotImplemented
+
+
+for _ in range(10):
+    # `list.__iadd__`: the bug-compat branch tries `Reflected.__radd__` first,
+    # so the in-place method is entered with a receiver that has since moved.
+    values = [1, 2, 3]
+    try:
+        values += Reflected()
+    except TypeError as exc:
+        assert "not iterable" in str(exc), exc
+    else:
+        raise AssertionError("list += Reflected() should not succeed")
+    assert values == [1, 2, 3], values
+
+    # `mul`: the forward `Reflected.__mul__` runs, declines, and the sequence
+    # error path then has to name both operand types.
+    values = [1, 2, 3]
+    try:
+        Reflected() * values
+    except TypeError as exc:
+        assert "can't multiply sequence" in str(exc), exc
+    else:
+        raise AssertionError("Reflected() * list should not succeed")
+
+    # The same window with a dict operand, whose header also relocates.
+    mapping = {"a": 1}
+    try:
+        mapping |= Reflected()
+    except TypeError:
+        pass
+    assert mapping == {"a": 1}, mapping
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/list_index_bound_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/list_index_bound_gc_roots.py
@@ -1,0 +1,37 @@
+# CPython-suite gap: list.index is never called with an __index__ bound that collects.
+# parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
+
+"""``list.index`` must survive an ``__index__`` bound that moves the list."""
+
+import gc
+
+
+class Bound:
+    def __init__(self, value):
+        self.value = value
+
+    def __index__(self):
+        # Coercing the start/stop bounds is an arbitrary Python callback, and
+        # it runs after `index` has already read its receiver and its needle.
+        garbage = [[index] for index in range(20000)]
+        assert len(garbage) == 20000
+        gc.collect()
+        return self.value
+
+
+class Payload:
+    pass
+
+
+for _ in range(20):
+    # A `list` needle exercises the search value on the same window as the
+    # receiver: both are kinds whose header a minor collection relocates.
+    needle = [Payload()]
+    values = [[Payload()] for _ in range(8)]
+    values.append(needle)
+
+    assert values.index(needle, Bound(0), Bound(64)) == 8
+    assert values.index(needle, Bound(-9)) == 8
+    assert values.index(needle, Bound(8), Bound(9)) == 8
+
+print("OK")

--- a/pyre/extra_tests/parity_tests/match_keys_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/match_keys_gc_roots.py
@@ -1,0 +1,44 @@
+# CPython-suite gap: no match statement uses a mapping whose `get` runs Python.
+# parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
+
+"""``MATCH_KEYS`` must survive a mapping ``get`` that moves the subject.
+
+The opcode probes the subject once per key pattern, and each probe is an
+arbitrary Python call.  The subject, the seen-key set, the sentinel and every
+value collected so far all have to outlive it.
+"""
+
+import gc
+
+
+def churn():
+    garbage = [[index, index + 1] for index in range(20000)]
+    assert len(garbage) == 20000
+    gc.collect()
+
+
+class Probed(dict):
+    def get(self, key, default=None):
+        churn()
+        return dict.get(self, key, default)
+
+
+def classify(subject):
+    match subject:
+        case {"kind": kind, "left": left, "right": right}:
+            return ("triple", kind, left, right)
+        case {"kind": kind}:
+            return ("single", kind)
+    return ("none",)
+
+
+for _ in range(10):
+    full = Probed(kind=["op"], left=["l"], right=["r"])
+    assert classify(full) == ("triple", ["op"], ["l"], ["r"]), classify(full)
+
+    partial = Probed(kind=["op"])
+    assert classify(partial) == ("single", ["op"]), classify(partial)
+
+    assert classify(Probed(other=1)) == ("none",)
+
+print("OK")

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3212,7 +3212,8 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__add__", "__radd__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
         {
             return Ok(result);
         }
@@ -3235,7 +3236,8 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             // subclass overriding `__add__`/`__radd__` must reach the
             // reflected dispatch; otherwise concat directly.
             if needs_seq_binop_dispatch(a, b, SeqBase::Str, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+                && let Some(result) =
+                    try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3243,7 +3245,8 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         }
         if is_list(a) && is_list(b) {
             if needs_seq_binop_dispatch(a, b, SeqBase::List, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+                && let Some(result) =
+                    try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3251,7 +3254,8 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         }
         if is_tuple(a) && is_tuple(b) {
             if needs_seq_binop_dispatch(a, b, SeqBase::Tuple, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+                && let Some(result) =
+                    try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3266,13 +3270,16 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
                 // a memoryview cannot, so dispatch only when both are bytes-like.
                 if pyre_object::bytesobject::is_bytes_like(b)
                     && needs_bytes_binop_dispatch(a, b, "__add__", "__radd__")
-                    && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+                    && let Some(result) =
+                        try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
                 {
                     return Ok(result);
                 }
                 return bytes_concat(a, b_src);
             }
-            if let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")? {
+            if let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+            {
                 return Ok(result);
             }
             // A non-buffer rhs is rejected with the generic operator TypeError
@@ -3288,7 +3295,8 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         // already implements the reflected-first reordering rule for
         // subclass operands.
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
         {
             return Ok(result);
         }
@@ -3303,7 +3311,9 @@ pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
 
 pub fn matmul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__matmul__", "__rmatmul__")? {
+        if let Some(result) =
+            try_dispatch_binary_special(&mut a, &mut b, "__matmul__", "__rmatmul__")?
+        {
             return Ok(result);
         }
         let a_name = (*ll_type(a)).name;
@@ -3318,13 +3328,15 @@ pub fn sub(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__sub__", "__rsub__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
@@ -3352,7 +3364,8 @@ pub fn sub(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_difference(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
@@ -3368,7 +3381,8 @@ pub fn mul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__mul__", "__rmul__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
             return Ok(result);
         }
@@ -3392,7 +3406,8 @@ pub fn mul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         // list repetition — the same gate the concat branches of `add` apply.
         const MUL_SPECIALS: &[&str] = &["__mul__", "__rmul__"];
         if (seq_repeat_override(a, MUL_SPECIALS) || seq_repeat_override(b, MUL_SPECIALS))
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
             return Ok(result);
         }
@@ -3541,7 +3556,8 @@ pub fn mod_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__mod__", "__rmod__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
         {
             return Ok(result);
         }
@@ -3583,7 +3599,8 @@ pub fn mod_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             };
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
         {
             return Ok(result);
         }
@@ -3607,7 +3624,8 @@ pub fn truediv(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
         {
             return Ok(result);
         }
@@ -3649,7 +3667,8 @@ pub fn truediv(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             return complex_truediv(a, b);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
         {
             return Ok(result);
         }
@@ -4424,7 +4443,8 @@ pub fn divmod(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         numeric_override = needs_numeric_binop_dispatch(a, b, "__divmod__", "__rdivmod__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
         {
             return Ok(result);
         }
@@ -4448,7 +4468,8 @@ pub fn divmod(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         }
     }
     if !numeric_override
-        && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
+        && let Some(result) =
+            try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
     {
         return Ok(result);
     }
@@ -4605,7 +4626,8 @@ pub fn lshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__lshift__", "__rlshift__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
         {
             return Ok(result);
         }
@@ -4618,7 +4640,8 @@ pub fn lshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             }
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
         {
             return Ok(result);
         }
@@ -4636,7 +4659,8 @@ pub fn rshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__rshift__", "__rrshift__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
         {
             return Ok(result);
         }
@@ -4649,7 +4673,8 @@ pub fn rshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             }
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
         {
             return Ok(result);
         }
@@ -4667,13 +4692,15 @@ pub fn and_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__and__", "__rand__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
@@ -4701,7 +4728,8 @@ pub fn and_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_intersection(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
@@ -4758,7 +4786,9 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         {
             return Ok(result);
         }
-        if numeric && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")? {
+        if numeric
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")?
+        {
             return Ok(result);
         }
         // boolobject.py:75 W_BoolObject.descr_or — both operands bool
@@ -4837,13 +4867,15 @@ pub fn xor(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__xor__", "__rxor__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }
@@ -4870,7 +4902,8 @@ pub fn xor(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_symmetric_difference(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
+            && let Some(result) =
+                try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3208,11 +3208,11 @@ unsafe fn try_numeric_unaryop_override(
     Ok(Some(crate::call::call_function_impl_result(method, &[a])?))
 }
 
-pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn add(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__add__", "__radd__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
         {
             return Ok(result);
         }
@@ -3235,7 +3235,7 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             // subclass overriding `__add__`/`__radd__` must reach the
             // reflected dispatch; otherwise concat directly.
             if needs_seq_binop_dispatch(a, b, SeqBase::Str, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3243,7 +3243,7 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
         if is_list(a) && is_list(b) {
             if needs_seq_binop_dispatch(a, b, SeqBase::List, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3251,7 +3251,7 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
         if is_tuple(a) && is_tuple(b) {
             if needs_seq_binop_dispatch(a, b, SeqBase::Tuple, "__add__", "__radd__")
-                && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+                && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
             {
                 return Ok(result);
             }
@@ -3266,13 +3266,13 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 // a memoryview cannot, so dispatch only when both are bytes-like.
                 if pyre_object::bytesobject::is_bytes_like(b)
                     && needs_bytes_binop_dispatch(a, b, "__add__", "__radd__")
-                    && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+                    && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
                 {
                     return Ok(result);
                 }
                 return bytes_concat(a, b_src);
             }
-            if let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")? {
+            if let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")? {
                 return Ok(result);
             }
             // A non-buffer rhs is rejected with the generic operator TypeError
@@ -3288,7 +3288,7 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // already implements the reflected-first reordering rule for
         // subclass operands.
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__add__", "__radd__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__add__", "__radd__")?
         {
             return Ok(result);
         }
@@ -3301,9 +3301,9 @@ pub fn add(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     }
 }
 
-pub fn matmul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn matmul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
-        if let Some(result) = try_dispatch_binary_special(a, b, "__matmul__", "__rmatmul__")? {
+        if let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__matmul__", "__rmatmul__")? {
             return Ok(result);
         }
         let a_name = (*ll_type(a)).name;
@@ -3314,17 +3314,17 @@ pub fn matmul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     }
 }
 
-pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn sub(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__sub__", "__rsub__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__sub__", "__rsub__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__sub__", "__rsub__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
@@ -3352,7 +3352,7 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_difference(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__sub__", "__rsub__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__sub__", "__rsub__")?
         {
             return Ok(result);
         }
@@ -3364,11 +3364,11 @@ pub fn sub(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     }
 }
 
-pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn mul(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__mul__", "__rmul__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__mul__", "__rmul__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
             return Ok(result);
         }
@@ -3392,7 +3392,7 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // list repetition — the same gate the concat branches of `add` apply.
         const MUL_SPECIALS: &[&str] = &["__mul__", "__rmul__"];
         if (seq_repeat_override(a, MUL_SPECIALS) || seq_repeat_override(b, MUL_SPECIALS))
-            && let Some(result) = try_dispatch_binary_special(a, b, "__mul__", "__rmul__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
         {
             return Ok(result);
         }
@@ -3428,6 +3428,13 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // numeric implementation.
         let a_seq = is_repeat_sequence(a);
         let b_seq = is_repeat_sequence(b);
+        // Every arm below can run Python — the two reflected invocations
+        // directly, `try_dispatch_binary_special` through its own — and by
+        // this point either operand may be a list, whose header moves.  Pin
+        // the pair so the error path can name the types, and the repeat path
+        // can address the sequence, at their post-collection addresses.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let operands = pyre_object::gc_roots::pin_roots(&[a, b]);
         let dispatched = match (a_seq, b_seq) {
             (true, true) => None,
             (true, false) => match lookup_type_special(b, "__rmul__") {
@@ -3439,26 +3446,31 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
                 None => None,
             },
             (false, false) if !numeric_override => {
-                try_dispatch_binary_special(a, b, "__mul__", "__rmul__")?
+                try_dispatch_binary_special(&mut a, &mut b, "__mul__", "__rmul__")?
             }
             (false, false) => None,
         };
         if let Some(result) = dispatched {
             return Ok(result);
         }
+        let a = pyre_object::gc_roots::shadow_stack_get(operands);
+        let b = pyre_object::gc_roots::shadow_stack_get(operands + 1);
         let a_name = crate::baseobjspace::object_functionstr_type_name(a);
         let b_name = crate::baseobjspace::object_functionstr_type_name(b);
         // `sequence_repeat`: the count goes through `__index__`, and an
         // operand that has none is reported by its own type — the sequence is
         // never the one named.
         if a_seq || b_seq {
-            let (seq, other, other_name) = if a_seq {
-                (a, b, b_name)
+            let (seq_slot, other, other_name) = if a_seq {
+                (operands, b, b_name)
             } else {
-                (b, a, a_name)
+                (operands + 1, a, a_name)
             };
             if !(a_seq && b_seq) && crate::baseobjspace::lookup(other, "__index__").is_some() {
-                return sequence_repeat(seq, crate::baseobjspace::getindex_repeat(other)?);
+                // `__index__` is Python, so the sequence is addressed again
+                // only after the count is in hand.
+                let count = crate::baseobjspace::getindex_repeat(other)?;
+                return sequence_repeat(pyre_object::gc_roots::shadow_stack_get(seq_slot), count);
             }
             return Err(PyError::type_error(format!(
                 "can't multiply sequence by non-int of type '{other_name}'"
@@ -3470,12 +3482,12 @@ pub fn mul(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     }
 }
 
-pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn floordiv(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__floordiv__", "__rfloordiv__");
         if numeric_override
             && let Some(result) =
-                try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
+                try_dispatch_binary_special(&mut a, &mut b, "__floordiv__", "__rfloordiv__")?
         {
             return Ok(result);
         }
@@ -3492,7 +3504,7 @@ pub fn floordiv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
         if !numeric_override
             && let Some(result) =
-                try_dispatch_binary_special(a, b, "__floordiv__", "__rfloordiv__")?
+                try_dispatch_binary_special(&mut a, &mut b, "__floordiv__", "__rfloordiv__")?
         {
             return Ok(result);
         }
@@ -3525,11 +3537,11 @@ unsafe fn try_subclass_binop_override(
     Ok((!is_not_implemented(result)).then_some(result))
 }
 
-pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn mod_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__mod__", "__rmod__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
         {
             return Ok(result);
         }
@@ -3571,7 +3583,7 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             };
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__mod__", "__rmod__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__mod__", "__rmod__")?
         {
             return Ok(result);
         }
@@ -3591,11 +3603,11 @@ pub fn mod_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 /// longobject.py:62-70 `_truediv` catches OverflowError from
 /// `rbigint.truediv` and reissues it as
 /// "integer division result too large for a float".
-pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn truediv(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__truediv__", "__rtruediv__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
         {
             return Ok(result);
         }
@@ -3637,7 +3649,7 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             return complex_truediv(a, b);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__truediv__", "__rtruediv__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__truediv__", "__rtruediv__")?
         {
             return Ok(result);
         }
@@ -3651,38 +3663,38 @@ pub fn truediv(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// `descroperation.py:425 pow_binary` — return `None` when neither numeric
 /// fast paths nor `__pow__` / `__rpow__` produce a result.
-fn pow_binary(a: PyObjectRef, b: PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
+fn pow_binary(a: &mut PyObjectRef, b: &mut PyObjectRef) -> Result<Option<PyObjectRef>, PyError> {
     unsafe {
-        let numeric_override = needs_numeric_binop_dispatch(a, b, "__pow__", "__rpow__");
+        let numeric_override = needs_numeric_binop_dispatch(*a, *b, "__pow__", "__rpow__");
         if numeric_override {
             if let Some(result) = try_dispatch_binary_special(a, b, "__pow__", "__rpow__")? {
                 return Ok(Some(result));
             }
             return Ok(None);
         }
-        if is_int_like(a) && is_int_like(b) {
-            return int_pow(a, b).map(Some);
+        if is_int_like(*a) && is_int_like(*b) {
+            return int_pow(*a, *b).map(Some);
         }
-        if is_int_or_long(a) && is_int_or_long(b) {
-            return long_pow(a, b).map(Some);
+        if is_int_or_long(*a) && is_int_or_long(*b) {
+            return long_pow(*a, *b).map(Some);
         }
-        if is_float_pair(a, b) {
-            reject_pow_operand_overflow(a)?;
-            reject_pow_operand_overflow(b)?;
-            return float_pow_impl(as_float(a), as_float(b)).map(Some);
+        if is_float_pair(*a, *b) {
+            reject_pow_operand_overflow(*a)?;
+            reject_pow_operand_overflow(*b)?;
+            return float_pow_impl(as_float(*a), as_float(*b)).map(Some);
         }
-        if is_complex_pair(a, b) {
-            reject_pow_operand_overflow(a)?;
-            reject_pow_operand_overflow(b)?;
-            return complex_pow(a, b).map(Some);
+        if is_complex_pair(*a, *b) {
+            reject_pow_operand_overflow(*a)?;
+            reject_pow_operand_overflow(*b)?;
+            return complex_pow(*a, *b).map(Some);
         }
         try_dispatch_binary_special(a, b, "__pow__", "__rpow__")
     }
 }
 
 /// Power operation dispatch (`**` operator).
-pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
-    if let Some(result) = pow_binary(a, b)? {
+pub fn pow(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
+    if let Some(result) = pow_binary(&mut a, &mut b)? {
         return Ok(result);
     }
     let a_name = crate::baseobjspace::object_functionstr_type_name(a);
@@ -3694,11 +3706,11 @@ pub fn pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// `descroperation.py:486-499 inplace_pow` — unlike the generated in-place
 /// binary operations, power has its own fallback error spelling.
-pub fn inplace_pow(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn inplace_pow(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     if let Some(result) = try_inplace_special(a, b, "__ipow__", None, false)? {
         return Ok(result);
     }
-    if let Some(result) = pow_binary(a, b)? {
+    if let Some(result) = pow_binary(&mut a, &mut b)? {
         return Ok(result);
     }
     Err(binary_builtin_type_error("**=", a, b))
@@ -3998,27 +4010,38 @@ pub(crate) fn try_call_special(
 /// `lookup_where`, decide whether to try the reflected operand first by
 /// comparing the two defining classes, then invoke forward-then-reverse.
 pub(crate) fn try_dispatch_binary_special(
-    lhs: PyObjectRef,
-    rhs: PyObjectRef,
+    lhs: &mut PyObjectRef,
+    rhs: &mut PyObjectRef,
     dunder: &str,
     rdunder: &str,
 ) -> Result<Option<PyObjectRef>, PyError> {
     // descroperation.py:687 `seq_bug_compat = (symbol == '+' or symbol == '*')`.
     let seq_bug_compat = dunder == "__add__" || dunder == "__mul__";
     unsafe {
-        let Some(w_typ1) = crate::typedef::r#type(lhs) else {
+        let Some(w_typ1) = crate::typedef::r#type(*lhs) else {
             return Ok(None);
         };
-        let Some(w_typ2) = crate::typedef::r#type(rhs) else {
+        let Some(w_typ2) = crate::typedef::r#type(*rhs) else {
             return Ok(None);
         };
+        // From here on Python can run: `p_abstract_issubclass_w` reaches
+        // `__bases__`, and the two invocations below are Python calls
+        // outright.  Both operands are pinned for the whole span and read
+        // back through `operand`, so neither this frame nor the caller — which
+        // goes on to concatenate, repeat or name them — is left holding a
+        // pre-collection address.  That is why they arrive by `&mut`.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let operands = pyre_object::gc_roots::pin_roots(&[*lhs, *rhs]);
+        let operand = |i: usize| pyre_object::gc_roots::shadow_stack_get(operands + i);
         let (w_left_src, mut w_left_impl) =
             match lookup_where_with_method_cache(w_typ1.as_ptr(), dunder) {
                 Some((src, imp)) => (Some(src), Some(imp)),
                 None => (None, None),
             };
-        let mut w_obj1 = lhs;
-        let mut w_obj2 = rhs;
+        // Which slot the forward call's first operand is read from.  Upstream
+        // swaps the two values; swapping the *index* keeps the pinned copies
+        // authoritative across a collection.
+        let mut swapped = false;
         let mut w_right_impl: Option<PyObjectRef> = None;
         // descroperation.py:652 — same type means the reflected method is
         // never considered.
@@ -4044,24 +4067,33 @@ pub(crate) fn try_dispatch_binary_special(
                     && !p_abstract_issubclass_w(lsrc, rsrc)?
                     && !p_abstract_issubclass_w(w_typ1.as_ptr(), rsrc)?
                 {
-                    std::mem::swap(&mut w_obj1, &mut w_obj2);
+                    swapped = true;
                     std::mem::swap(&mut w_left_impl, &mut w_right_impl);
                 }
             }
         }
+        let (first, second) = if swapped { (1, 0) } else { (0, 1) };
+        // The reflected implementation has to survive the forward call too.
+        let right_slot = w_right_impl.map(|method| {
+            let slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(method);
+            slot
+        });
+        let mut result = None;
         // descroperation.py:676 — _invoke_binop(w_left_impl, w_obj1, w_obj2).
-        if let Some(method) = w_left_impl
-            && let Some(result) = try_call_special(method, &[w_obj1, w_obj2])?
-        {
-            return Ok(Some(result));
+        if let Some(method) = w_left_impl {
+            result = try_call_special(method, &[operand(first), operand(second)])?;
         }
         // descroperation.py:679 — _invoke_binop(w_right_impl, w_obj2, w_obj1).
-        if let Some(method) = w_right_impl
-            && let Some(result) = try_call_special(method, &[w_obj2, w_obj1])?
+        if result.is_none()
+            && let Some(slot) = right_slot
         {
-            return Ok(Some(result));
+            let method = pyre_object::gc_roots::shadow_stack_get(slot);
+            result = try_call_special(method, &[operand(second), operand(first)])?;
         }
-        Ok(None)
+        *lhs = operand(0);
+        *rhs = operand(1);
+        Ok(result)
     }
 }
 
@@ -4071,23 +4103,30 @@ pub(crate) fn try_dispatch_binary_special(
 /// distinct `__rpow__` is tried first, then the base's `__pow__`, then the
 /// reflected method when it has not already been tried.
 fn try_dispatch_ternary_pow_special(
-    base: PyObjectRef,
-    exp: PyObjectRef,
-    modulus: PyObjectRef,
+    base: &mut PyObjectRef,
+    exp: &mut PyObjectRef,
+    modulus: &mut PyObjectRef,
 ) -> Result<Option<PyObjectRef>, PyError> {
     unsafe {
-        let Some(w_base_type) = crate::typedef::r#type(base) else {
+        let Some(w_base_type) = crate::typedef::r#type(*base) else {
             return Ok(None);
         };
-        let Some(w_exp_type) = crate::typedef::r#type(exp) else {
+        let Some(w_exp_type) = crate::typedef::r#type(*exp) else {
             return Ok(None);
         };
+        // Up to three Python invocations follow, and a `list` subclass
+        // defining `__pow__` puts a movable header in an operand slot.  Pin
+        // all three, read them back through `operand`, and hand them out — the
+        // caller spells the error message from them.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let operands = pyre_object::gc_roots::pin_roots(&[*base, *exp, *modulus]);
+        let operand = |i: usize| pyre_object::gc_roots::shadow_stack_get(operands + i);
         let (w_base_src, w_base_impl) =
             match lookup_where_with_method_cache(w_base_type.as_ptr(), "__pow__") {
                 Some((src, imp)) => (Some(src), Some(imp)),
                 None => (None, None),
             };
-        let (w_exp_src, mut w_exp_impl) = if w_base_type != w_exp_type {
+        let (w_exp_src, w_exp_impl) = if w_base_type != w_exp_type {
             match lookup_where_with_method_cache(w_exp_type.as_ptr(), "__rpow__") {
                 Some((src, imp)) => (Some(src), Some(imp)),
                 None => (None, None),
@@ -4095,35 +4134,55 @@ fn try_dispatch_ternary_pow_special(
         } else {
             (None, None)
         };
+        // Each implementation also has to survive the invocations that precede
+        // it.  A class attribute is an arbitrary object, so a `dict` subclass
+        // defining `__call__` puts a movable header in this slot as readily as
+        // in an operand's.
+        let pin = |method: PyObjectRef| {
+            let slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(method);
+            slot
+        };
+        let base_impl_slot = w_base_impl.map(pin);
+        let mut exp_impl_slot = w_exp_impl.map(pin);
 
         // slot_nb_power: a proper exponent subtype whose reflected method is
         // distinct from the base type's definition gets the first chance.
         if issubtype_w(w_exp_type.as_ptr(), w_base_type.as_ptr())
-            && let (Some(exp_src), Some(base_src), Some(exp_impl)) =
-                (w_exp_src, w_base_src, w_exp_impl)
+            && let (Some(exp_src), Some(base_src), Some(slot)) =
+                (w_exp_src, w_base_src, exp_impl_slot)
             && !std::ptr::eq(base_src, exp_src)
             && !p_abstract_issubclass_w(base_src, exp_src)?
             && !p_abstract_issubclass_w(w_base_type.as_ptr(), exp_src)?
         {
-            if let Some(result) = try_call_special(exp_impl, &[exp, base, modulus])? {
+            let exp_impl = pyre_object::gc_roots::shadow_stack_get(slot);
+            if let Some(result) = try_call_special(exp_impl, &[operand(1), operand(0), operand(2)])?
+            {
+                *base = operand(0);
+                *exp = operand(1);
+                *modulus = operand(2);
                 return Ok(Some(result));
             }
             // CPython clears `do_other` after the subtype-first call,
             // including when it returns NotImplemented.
-            w_exp_impl = None;
+            exp_impl_slot = None;
         }
 
-        if let Some(method) = w_base_impl
-            && let Some(result) = try_call_special(method, &[base, exp, modulus])?
-        {
-            return Ok(Some(result));
+        let mut result = None;
+        if let Some(slot) = base_impl_slot {
+            let method = pyre_object::gc_roots::shadow_stack_get(slot);
+            result = try_call_special(method, &[operand(0), operand(1), operand(2)])?;
         }
-        if let Some(method) = w_exp_impl
-            && let Some(result) = try_call_special(method, &[exp, base, modulus])?
+        if result.is_none()
+            && let Some(slot) = exp_impl_slot
         {
-            return Ok(Some(result));
+            let method = pyre_object::gc_roots::shadow_stack_get(slot);
+            result = try_call_special(method, &[operand(1), operand(0), operand(2)])?;
         }
-        Ok(None)
+        *base = operand(0);
+        *exp = operand(1);
+        *modulus = operand(2);
+        Ok(result)
     }
 }
 
@@ -4153,17 +4212,37 @@ pub(crate) fn try_inplace_special(
         // descroperation.py:831 seq_bug_compat — for `+=` / `*=` where the
         // lhs is a builtin sequence and the rhs is not, try the rhs
         // reflected method before the lhs in-place method.
-        if seq_bug_compat
+        let rmethod = if seq_bug_compat
             && let Some(rd) = rdunder
             && let (Some(lhs_type), Some(rhs_type)) =
                 (crate::typedef::r#type(lhs), crate::typedef::r#type(rhs))
             && crate::baseobjspace::flag_sequence_bug_compat(lhs_type.as_ptr())
             && !crate::baseobjspace::flag_sequence_bug_compat(rhs_type.as_ptr())
-            && let Some(rmethod) = unsafe { lookup_type_special(rhs, rd) }
-            && let Some(result) = try_call_special(rmethod, &[rhs, lhs])?
         {
-            return Ok(Some(result));
-        }
+            unsafe { lookup_type_special(rhs, rd) }
+        } else {
+            None
+        };
+        // That reflected call runs Python, and the branch guarding it is
+        // reached precisely when the lhs is a builtin sequence — a list, whose
+        // header moves.  Pin both operands and the in-place method across it
+        // and read them back, or the in-place call below is handed a
+        // pre-collection address.
+        let (lhs, rhs, method) = match rmethod {
+            Some(rmethod) => {
+                let _roots = pyre_object::gc_roots::push_roots();
+                let base = pyre_object::gc_roots::pin_roots(&[lhs, rhs, method]);
+                if let Some(result) = try_call_special(rmethod, &[rhs, lhs])? {
+                    return Ok(Some(result));
+                }
+                (
+                    pyre_object::gc_roots::shadow_stack_get(base),
+                    pyre_object::gc_roots::shadow_stack_get(base + 1),
+                    pyre_object::gc_roots::shadow_stack_get(base + 2),
+                )
+            }
+            None => (lhs, rhs, method),
+        };
         if let Some(result) = try_call_special(method, &[lhs, rhs])? {
             return Ok(Some(result));
         }
@@ -4321,11 +4400,11 @@ pub(crate) fn ternary_builtin_type_error(
 /// `pypy/objspace/descroperation.py:441` tries only the base's `__pow__`;
 /// Python 3.14 changed this to offer the exponent's `__rpow__` the modulus
 /// too (`Objects/typeobject.c:slot_nb_power`).
-pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResult {
+pub fn pow3(mut base: PyObjectRef, mut exp: PyObjectRef, mut modulus: PyObjectRef) -> PyResult {
     if unsafe { is_none(modulus) } {
         return pow(base, exp);
     }
-    if let Some(result) = try_dispatch_ternary_pow_special(base, exp, modulus)? {
+    if let Some(result) = try_dispatch_ternary_pow_special(&mut base, &mut exp, &mut modulus)? {
         return Ok(result);
     }
     Err(ternary_builtin_type_error(
@@ -4340,12 +4419,12 @@ pub fn pow3(base: PyObjectRef, exp: PyObjectRef, modulus: PyObjectRef) -> PyResu
 /// `('divmod', 'divmod', 2, ['__divmod__', '__rdivmod__'])`. Numeric
 /// fast path then forward + reverse special-method dispatch with the
 /// standard NotImplemented fallback.
-pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn divmod(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     let numeric_override;
     unsafe {
         numeric_override = needs_numeric_binop_dispatch(a, b, "__divmod__", "__rdivmod__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__divmod__", "__rdivmod__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
         {
             return Ok(result);
         }
@@ -4369,7 +4448,7 @@ pub fn divmod(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         }
     }
     if !numeric_override
-        && let Some(result) = try_dispatch_binary_special(a, b, "__divmod__", "__rdivmod__")?
+        && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__divmod__", "__rdivmod__")?
     {
         return Ok(result);
     }
@@ -4522,11 +4601,11 @@ fn float_pow_impl(x: f64, y: f64) -> PyResult {
 
 /// Left shift dispatch (`<<` operator).
 
-pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn lshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__lshift__", "__rlshift__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__lshift__", "__rlshift__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
         {
             return Ok(result);
         }
@@ -4539,7 +4618,7 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             }
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__lshift__", "__rlshift__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__lshift__", "__rlshift__")?
         {
             return Ok(result);
         }
@@ -4553,11 +4632,11 @@ pub fn lshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// Right shift dispatch (`>>` operator).
 
-pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn rshift(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__rshift__", "__rrshift__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__rshift__", "__rrshift__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
         {
             return Ok(result);
         }
@@ -4570,7 +4649,7 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             }
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__rshift__", "__rrshift__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__rshift__", "__rrshift__")?
         {
             return Ok(result);
         }
@@ -4584,17 +4663,17 @@ pub fn rshift(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// Bitwise AND dispatch (`&` operator).
 
-pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn and_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__and__", "__rand__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__and__", "__rand__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__and__", "__rand__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
@@ -4622,7 +4701,7 @@ pub fn and_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_intersection(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__and__", "__rand__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__and__", "__rand__")?
         {
             return Ok(result);
         }
@@ -4657,14 +4736,14 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
     // each side so the dict-arm below sees plain dicts and produces
     // the same merge result.  The proxy-on-rhs case mirrors
     // `descr_ror` (proxy wraps the rhs operand inside `__or__`).
-    let a = unsafe {
+    let mut a = unsafe {
         if pyre_object::is_dict_proxy(a) {
             pyre_object::w_dict_proxy_get_mapping(a)
         } else {
             a
         }
     };
-    let b = unsafe {
+    let mut b = unsafe {
         if pyre_object::is_dict_proxy(b) {
             pyre_object::w_dict_proxy_get_mapping(b)
         } else {
@@ -4675,11 +4754,11 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         let set_override = needs_set_binop_dispatch(a, b);
         let numeric = needs_numeric_binop_dispatch(a, b, "__or__", "__ror__");
         if set_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__or__", "__ror__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")?
         {
             return Ok(result);
         }
-        if numeric && let Some(result) = try_dispatch_binary_special(a, b, "__or__", "__ror__")? {
+        if numeric && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")? {
             return Ok(result);
         }
         // boolobject.py:75 W_BoolObject.descr_or — both operands bool
@@ -4731,7 +4810,7 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
         // set-/numeric-subclass override is never re-invoked.
         if !set_override
             && !numeric
-            && let Some(result) = try_dispatch_binary_special(a, b, "__or__", "__ror__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__or__", "__ror__")?
         {
             return Ok(result);
         }
@@ -4754,17 +4833,17 @@ pub fn or_(a: PyObjectRef, b: PyObjectRef) -> PyResult {
 
 /// Bitwise XOR dispatch (`^` operator).
 
-pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
+pub fn xor(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
     unsafe {
         let set_override = needs_set_binop_dispatch(a, b);
         if set_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__xor__", "__rxor__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }
         let numeric_override = needs_numeric_binop_dispatch(a, b, "__xor__", "__rxor__");
         if numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__xor__", "__rxor__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }
@@ -4791,7 +4870,7 @@ pub fn xor(a: PyObjectRef, b: PyObjectRef) -> PyResult {
             return crate::typedef::set_method_symmetric_difference(&[a, b]);
         }
         if !numeric_override
-            && let Some(result) = try_dispatch_binary_special(a, b, "__xor__", "__rxor__")?
+            && let Some(result) = try_dispatch_binary_special(&mut a, &mut b, "__xor__", "__rxor__")?
         {
             return Ok(result);
         }

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -265,7 +265,16 @@ pub fn match_sequence_value(subject: PyObjectRef) -> PyObjectRef {
 /// looked up directly without re-gating (`Python/ceval.c match_keys`).
 pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObjectRef, PyError> {
     let key_items = unsafe { pyre_object::tupleobject::w_tuple_items_copy_as_vec(keys) };
-    let mut values = Vec::with_capacity(key_items.len());
+    // Every round runs `subject.get`, which is application-level Python: it
+    // can relocate the subject and each value already looked up, and it can
+    // reach a collection while the fresh set and sentinel still have no heap
+    // edge.  Hold all of them on the shadow stack and read each back at its
+    // use; the results accumulate in slots rather than in a native `Vec`,
+    // which would keep pre-move addresses.  The keys themselves are hashable,
+    // so no kind that moves reaches `key_items`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let subject_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(subject);
     // pyopcode.py:1797-1818 — a key repeated in the pattern is rejected
     // before it binds anything; track keys already looked up and raise on
     // a duplicate. Each key is looked up with `map.get(key, sentinel)`
@@ -274,12 +283,17 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     // sentinel result means the key is absent.  The sentinel is a fresh
     // `object()` (match_keys `dummy = object()`), so a value present in the
     // subject can never be mistaken for the absent marker.
-    let w_seen = pyre_object::w_set_new();
-    let w_sentinel = pyre_object::w_instance_new(crate::typedef::gettypeobject(
-        &pyre_object::pyobject::INSTANCE_TYPE,
+    let seen_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_set_new());
+    let sentinel_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(
+        crate::typedef::gettypeobject(&pyre_object::pyobject::INSTANCE_TYPE),
     ));
+    let values_base = pyre_object::gc_roots::shadow_stack_len();
+    let mut value_count = 0usize;
     let mut all_match = true;
     for key in key_items {
+        let w_seen = pyre_object::gc_roots::shadow_stack_get(seen_slot);
         if crate::baseobjspace::contains(w_seen, key)? {
             let key_repr = unsafe { crate::display::py_repr_wtf8(key)? };
             return Err(PyError::value_error(crate::display::wtf8_format!(
@@ -288,19 +302,33 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
                 ")"
             )));
         }
-        unsafe { pyre_object::w_set_add(w_seen, key) };
-        let w_value = crate::baseobjspace::call_method(subject, "get", &[key, w_sentinel]);
+        unsafe {
+            pyre_object::w_set_add(pyre_object::gc_roots::shadow_stack_get(seen_slot), key)
+        };
+        let w_sentinel = pyre_object::gc_roots::shadow_stack_get(sentinel_slot);
+        let w_value = crate::baseobjspace::call_method(
+            pyre_object::gc_roots::shadow_stack_get(subject_slot),
+            "get",
+            &[key, w_sentinel],
+        );
         if w_value.is_null() {
             return Err(crate::call::take_call_error()
                 .unwrap_or_else(|| PyError::type_error("mapping pattern lookup failed")));
         }
-        if crate::baseobjspace::is_w(w_value, w_sentinel) {
+        if crate::baseobjspace::is_w(
+            w_value,
+            pyre_object::gc_roots::shadow_stack_get(sentinel_slot),
+        ) {
             all_match = false;
             break;
         }
-        values.push(w_value);
+        pyre_object::gc_roots::pin_root(w_value);
+        value_count += 1;
     }
     Ok(if all_match {
+        let values: Vec<PyObjectRef> = (0..value_count)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(values_base + i))
+            .collect();
         pyre_object::w_tuple_new(values)
     } else {
         pyre_object::w_none()

--- a/pyre/pyre-interpreter/src/opcode_ops.rs
+++ b/pyre/pyre-interpreter/src/opcode_ops.rs
@@ -286,9 +286,9 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
     let seen_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(pyre_object::w_set_new());
     let sentinel_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(
-        crate::typedef::gettypeobject(&pyre_object::pyobject::INSTANCE_TYPE),
-    ));
+    pyre_object::gc_roots::pin_root(pyre_object::w_instance_new(crate::typedef::gettypeobject(
+        &pyre_object::pyobject::INSTANCE_TYPE,
+    )));
     let values_base = pyre_object::gc_roots::shadow_stack_len();
     let mut value_count = 0usize;
     let mut all_match = true;
@@ -302,9 +302,7 @@ pub fn match_keys_value(subject: PyObjectRef, keys: PyObjectRef) -> Result<PyObj
                 ")"
             )));
         }
-        unsafe {
-            pyre_object::w_set_add(pyre_object::gc_roots::shadow_stack_get(seen_slot), key)
-        };
+        unsafe { pyre_object::w_set_add(pyre_object::gc_roots::shadow_stack_get(seen_slot), key) };
         let w_sentinel = pyre_object::gc_roots::shadow_stack_get(sentinel_slot);
         let w_value = crate::baseobjspace::call_method(
             pyre_object::gc_roots::shadow_stack_get(subject_slot),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -851,7 +851,18 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     } else {
         w_int_new(i64::MAX)
     };
+    // An `__index__` on start/stop allocates and may move the list or the
+    // search value across a minor collection.  `w_list_find_or_count` pins
+    // both for its own `eq_w` loop, but it pins whatever address it is
+    // handed, so that scope cannot cover this window — root them here and
+    // reload after the coercion.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let sp = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(list);
+    pyre_object::gc_roots::pin_root(value);
     let (start, stop) = crate::sliceobject::unwrap_start_stop_not_none(size, w_start, w_stop)?;
+    let list = pyre_object::gc_roots::shadow_stack_get(sp);
+    let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
     match crate::listobject::w_list_find_or_count(list, value, start, stop, false)? {
         crate::listobject::FindOrCountResult::Index(i) => Ok(w_int_new(i)),
         crate::listobject::FindOrCountResult::NotFound => {


### PR DESCRIPTION
Two moving-GC root-liveness defects in already-merged code, and the analysis
that found the second one.

## The defect

The binary-operator protocol reads each operand **twice**: the forward special
method is tried first, and only when it answers `NotImplemented` does the
reflected call — or the error path that names the operand types — read them
again. Everything between the two reads is arbitrary Python, so a minor
collection there relocates a `list` or `dict` operand and leaves both the
dispatcher's copies and the caller's pointing at pre-collection addresses.

Two reproductions, each a **deterministic SIGSEGV 5/5** at
`PYPY_GC_NURSERY=4096` and clean at the default nursery:

```python
lst = [1, 2, 3]
lst += R()          # R.__radd__ churns, then returns NotImplemented
                    # -> list.__iadd__ receives a receiver that has moved

L() * [1, 2, 3]     # L.__mul__ churns, then returns NotImplemented
                    # -> the sequence error path names a moved operand
```

Three controls, all clean, which together pin the cause: the dunder returning a
real value (the second read never happens), the list promoted to old gen first
(it cannot move), and no collection inside the dunder.

`try_inplace_special`'s bug-compat branch is the sharpest case — it is reached
*only* when the lhs is a builtin sequence, so the movable operand is guaranteed
rather than incidental.

## The fix

`try_dispatch_binary_special` and `try_dispatch_ternary_pow_special` take their
operands by `&mut`, pin them for the whole Python-running span, and write the
re-read values back. That fixes all **37 call sites** at one point: the
compiler forces every caller to accept the refreshed value, and
`list_concat(a, b)`, `object_functionstr_type_name(a)` and
`sequence_repeat(seq, …)` were all reading post-Python operands. The operand
swap became an index swap so the pinned copies stay authoritative.

Upstream gets this for free — RPython's shadowstack rewrites the *caller's*
frame in place. pyre's shadow stack holds only what was pinned, so the value
has to be handed back explicitly.

Also here: `list.index` holding its receiver and needle across an `__index__`
bound, and `MATCH_KEYS` accumulating `subject.get(key)` results in a native
`Vec` while that call runs Python.

## The analysis

`majit-translate/src/memory/gctransform/` ports the *analysis* half of
`rpython/memory/gctransform/`. Upstream rewrites the flow graph;
pyre's interpreter is compiled by rustc, so there is nothing to rewrite —
`framework::build` builds a call graph over the charon ULLBC, and
`liveness::scan` runs backward liveness and reports calls that can reach a
collection with a `PyObjectRef` live across them and no bracket.

Two things worth knowing about it:

- Seeds are the **Python dispatch** entry points, not the allocators. The host
  allocation path routes to `try_alloc_nursery_no_collect_typed` and does not
  collect; what collects is application-level Python reaching JIT-compiled code
  that allocates inline in the nursery.
- An unresolved callee taints its callers **transitively**. Without that, 134
  functions land in the confident bucket that a `global_hook!` path can reach.

Running it after the fix takes tier 1 (callee is a dispatch seed) from 14 calls
in 10 functions to 8 in 6; every `descroperation` entry is gone and the ones
that remain hold kinds that do not move.

## Review

All seven review findings are answered in the branch: root-bracket coverage is
now judged per call rather than per function, the scan runs a second
conservative pass that includes the transitively-tainted unresolved set, seed
patterns are anchored on a path separator, an artefact with no `push_roots` is
no longer skipped, unparsed terminators are counted and reported instead of
being silently treated as clean, and the movable-argument set is built once per
body. The one declined finding — porting the *insertion* half of `gctransform`
— is answered in the module doc: this crate lowers LLBC for the JIT and never
sees the interpreter's machine code, which rustc produces, so there is no graph
here to insert a bracket into.


## Gate

Rebased onto `2196bac8654`; seven commits.

An eighth commit that reordered the `posix_spawn` env pin was **dropped**: #1305
rewrote that code into `collect_env_entries`, which already publishes the
mapping before the `keys`/`values` calls and reads it back from the slot — the
same ordering, so the commit had become a duplicate and the only merge conflict
on this branch.

Last local gate that completed over an unchanging tree (base `4a4784846ff`,
same interpreter changes):

- three parity regressions × dynasm/cranelift × default/4096 nursery: all pass
- `cargo test --all --features dynasm`: 155 suites, 0 failures
- `cargo fmt --all -- --check`: clean
- `check.py`: wasm 434/434; dynasm and cranelift 440/441 each, the single
  failure being `synth/range_ctor_in_loop` exceeding the 20s wall-clock timeout
  while three other builds shared the machine — a timeout, not an assertion

A re-run on the current base is in flight; the tree was rebased under the
previous attempt, which staled the LLBC artefacts mid-run.

`test_descr::test_slots` fails on this base without these commits too, at the
default nursery as well as at 4096, so it is neither nursery- nor
operand-related. `test_patma` needs `pyperf`, which is not installed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013SXZZhZ24w8JtnFUaEGzjP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection safety during arithmetic, power, sequence operations, and reflected dispatch.
  - Preserved objects correctly when mapping-pattern matching and list index bounds trigger allocation or collection.
  - Fixed handling of operands and values that may move during Python-level calls.

- **Tests**
  - Added regression coverage for `NotImplemented` operations, list indexing, and mapping-pattern matching under repeated garbage collection.

- **Diagnostics**
  - Added tools for analyzing collection reachability and identifying potential live-object hazards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
