### PR TITLE
interpreter, jit: a moving-GC root fix for three math reductions, and the specialised-pair object arm restored

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -19284,6 +19284,126 @@ mod tests {
         assert_eq!(unsafe { *(moved.0 as *const u64) }, 0xD30F_0004);
     }
 
+    /// `demoted_failarg_slots` is trace-global while `loop_phi_keep` is per
+    /// LABEL, so a raw the first LABEL demoted can be a kept block param at a
+    /// later one. For such a raw the home, not the SSA value, is what a guard
+    /// below that LABEL reads, and a loader re-entry refreshes only the dense
+    /// carried slot the param arrives in — so the later LABEL's header has to
+    /// store the param into the home itself.
+    ///
+    /// The second LABEL here carries no back-jump, which is what makes
+    /// `compute_loop_phi_keep` skip it and keep every one of its positions
+    /// while the first LABEL still demotes. Giving it a back-jump of its own
+    /// instead un-demotes the first LABEL through the escape pass.
+    #[test]
+    fn demoted_nonref_header_updates_frame_home_after_bridge_jump() {
+        let mut backend = CraneliftBackend::new();
+        let start_descr = make_label_descr(1706);
+        let body_descr = make_label_descr(1707);
+        let carried = OpRef::int_op(2);
+        let more = OpRef::int_op(4);
+        let next = OpRef::int_op(5);
+        let exit_guard = mk_op(OpCode::GuardTrue, &[more], OpRef::NONE.raw());
+        exit_guard.setfailargs(smallvec::smallvec![
+            rb(carried),
+            rb(OpRef::input_arg_int(1)),
+        ]);
+        let bridge_guard = mk_op(OpCode::GuardFalse, &[OpRef::int_op(103)], OpRef::NONE.raw());
+        bridge_guard.setfailargs(smallvec::smallvec![rb(carried), rb(next)]);
+        let inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
+        let root_ops = vec![
+            mk_op(OpCode::SameAsI, &[OpRef::input_arg_int(0)], carried.raw()),
+            mk_op_with_descr(
+                OpCode::Label,
+                &[carried, OpRef::input_arg_int(1)],
+                OpRef::NONE.raw(),
+                start_descr.clone(),
+            ),
+            mk_op(OpCode::IntAdd, &[OpRef::int_op(100), OpRef::int_op(101)], 3),
+            mk_op_with_descr(
+                OpCode::Label,
+                &[carried, OpRef::input_arg_int(1)],
+                OpRef::NONE.raw(),
+                body_descr.clone(),
+            ),
+            mk_op(
+                OpCode::IntGt,
+                &[OpRef::input_arg_int(1), OpRef::int_op(102)],
+                more.raw(),
+            ),
+            exit_guard,
+            mk_op(
+                OpCode::IntSub,
+                &[OpRef::input_arg_int(1), OpRef::int_op(100)],
+                next.raw(),
+            ),
+            bridge_guard,
+            mk_op_with_descr(
+                OpCode::Jump,
+                &[carried, next],
+                OpRef::NONE.raw(),
+                start_descr,
+            ),
+        ];
+
+        let mut root_constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+        root_constants.insert(100, 1);
+        root_constants.insert(101, 2);
+        root_constants.insert(102, 0);
+        root_constants.insert(103, 1);
+        backend.set_constants(root_constants);
+
+        let token = JitCellToken::new(1706);
+        backend.compile_loop(&inputargs, &root_ops, &token).unwrap();
+
+        let initial_carried = 7;
+        let counter = 2;
+        let failed =
+            backend.execute_token(&token, &[Value::Int(initial_carried), Value::Int(counter)]);
+        let guard_descr =
+            get_latest_descr_from_deadframe(&failed).expect("bridge guard should fail");
+
+        let bridge_inputargs = vec![InputArg::new_int(0), InputArg::new_int(1)];
+        let bridge_increment = 100;
+        let mut bridge_constants: indexmap::IndexMap<u32, i64> = indexmap::IndexMap::new();
+        bridge_constants.insert(100, bridge_increment);
+        backend.set_constants(bridge_constants);
+        let bridge_ops = vec![
+            mk_op(
+                OpCode::IntAdd,
+                &[OpRef::input_arg_int(0), OpRef::int_op(100)],
+                2,
+            ),
+            mk_op_with_descr(
+                OpCode::Jump,
+                &[OpRef::int_op(2), OpRef::input_arg_int(1)],
+                OpRef::NONE.raw(),
+                body_descr,
+            ),
+        ];
+        backend
+            .compile_bridge(
+                guard_descr,
+                &bridge_inputargs,
+                &bridge_ops,
+                &token,
+                &[],
+                None,
+            )
+            .unwrap();
+
+        backend.set_constants(indexmap::IndexMap::new());
+        let frame =
+            backend.execute_token(&token, &[Value::Int(initial_carried), Value::Int(counter)]);
+        // Each of the two bridge trips adds 100 before the counter reaches zero.
+        let expected = initial_carried + counter * bridge_increment;
+        assert_eq!(
+            backend.get_int_value(&frame, 0),
+            expected,
+            "the exit guard published the value the first LABEL seeded, not the one              the bridge carried into the second LABEL's loader"
+        );
+    }
+
     #[test]
     fn loop_phi_keeps_ref_escaping_via_kept_backedge_position() {
         // A deopt-only invariant ref that also flows through a *kept* back-edge

--- a/pyre/extra_tests/parity_tests/math_prod_moving_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/math_prod_moving_gc_roots.py
@@ -1,0 +1,43 @@
+# CPython-suite gap: math tests do not collect while retaining numeric operands.
+# parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
+# parity-env: PYPY_GC_NURSERY=4096
+
+"""Math reductions must keep collected Python numeric operands alive."""
+
+import math
+from decimal import Decimal
+from fractions import Fraction
+
+
+PROD_LIMIT = 1000
+DIST_LIMIT = 300
+SUMPROD_LIMIT = 200
+
+
+expected_product = Decimal(3)
+for factor in map(Decimal, range(1, PROD_LIMIT)):
+    expected_product *= factor
+actual_product = math.prod(
+    map(Decimal, range(1, PROD_LIMIT)),
+    start=Decimal(3),
+)
+assert actual_product == expected_product
+
+
+point = list(map(Decimal, range(DIST_LIMIT)))
+assert math.dist(point, map(Decimal, range(DIST_LIMIT))) == 0.0
+
+
+left_values = range(1, SUMPROD_LIMIT)
+right_values = range(SUMPROD_LIMIT, 1, -1)
+expected_sumprod = 0
+for left, right in zip(map(Fraction, left_values), map(Fraction, right_values)):
+    expected_sumprod += left * right
+actual_sumprod = math.sumprod(
+    map(Fraction, range(1, SUMPROD_LIMIT)),
+    map(Fraction, range(SUMPROD_LIMIT, 1, -1)),
+)
+assert actual_sumprod == expected_sumprod
+
+
+print("OK")

--- a/pyre/pyre-interpreter/src/module/math/interp_math.rs
+++ b/pyre/pyre-interpreter/src/module/math/interp_math.rs
@@ -435,14 +435,23 @@ pub fn dist(args: &[PyObjectRef]) -> PyResult {
             "dist() takes exactly 2 arguments",
         ));
     }
-    let p: Vec<f64> = crate::builtins::collect_iterable(args[0])?
-        .iter()
-        .map(|&a| try_get_double(a))
-        .collect::<Result<Vec<_>, _>>()?;
-    let q: Vec<f64> = crate::builtins::collect_iterable(args[1])?
-        .iter()
-        .map(|&a| try_get_double(a))
-        .collect::<Result<Vec<_>, _>>()?;
+    let collect_coords = |obj: PyObjectRef| -> Result<Vec<f64>, crate::PyError> {
+        let items = crate::builtins::collect_iterable(obj)?;
+        // Conversion can call an element's `__float__`, so publish the whole
+        // materialized sequence before converting any member.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let items_base = pyre_object::gc_roots::shadow_stack_len();
+        for &item in &items {
+            pyre_object::gc_roots::pin_root(item);
+        }
+        (0..items.len())
+            .map(|index| {
+                try_get_double(pyre_object::gc_roots::shadow_stack_get(items_base + index))
+            })
+            .collect()
+    };
+    let p = collect_coords(args[0])?;
+    let q = collect_coords(args[1])?;
     if p.len() != q.len() {
         return Err(crate::PyError::value_error(
             "both points must have the same number of dimensions",
@@ -1207,13 +1216,24 @@ pub fn prod(args: &[PyObjectRef]) -> PyResult {
             "prod() takes at least 1 argument",
         ));
     }
-    let iterable = positional[0];
-    let items = crate::builtins::collect_iterable(iterable)?;
-    let mut acc = start;
-    for item in items {
-        acc = crate::baseobjspace::mul(acc, item)?;
+    let _roots = pyre_object::gc_roots::push_roots();
+    let acc_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(start);
+    let items = crate::builtins::collect_iterable(positional[0])?;
+    let items_base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &items {
+        pyre_object::gc_roots::pin_root(item);
     }
-    Ok(acc)
+    // Multiplication can call `__mul__`; reload both operands after every
+    // collection and keep the running product in its rooted slot.
+    for index in 0..items.len() {
+        let product = crate::baseobjspace::mul(
+            pyre_object::gc_roots::shadow_stack_get(acc_slot),
+            pyre_object::gc_roots::shadow_stack_get(items_base + index),
+        )?;
+        pyre_object::gc_roots::shadow_stack_set(acc_slot, product);
+    }
+    Ok(pyre_object::gc_roots::shadow_stack_get(acc_slot))
 }
 
 /// math.sumprod(p, q) — multiply paired elements, then sum. Added in
@@ -1227,24 +1247,26 @@ pub fn sumprod(args: &[PyObjectRef]) -> PyResult {
         ));
     }
     let p = crate::builtins::collect_iterable(args[0])?;
-    let q = crate::builtins::collect_iterable(args[1])?;
-    if p.len() != q.len() {
-        return Err(crate::PyError::value_error(
-            "Inputs are not the same length",
-        ));
-    }
-    // `mul` and `add` dispatch to the operands' `__mul__` / `__add__`, so a
-    // Decimal or Fraction element makes every turn a collection point.  Both
-    // collected sequences and the running total are native locals no root
-    // walker updates, so publish them and read each operand back per turn.
+    // Collecting the second input runs its iterator, so publish the first
+    // materialized sequence before that call.
     let _roots = pyre_object::gc_roots::push_roots();
     let p_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &p {
         pyre_object::gc_roots::pin_root(item);
     }
+    let q = crate::builtins::collect_iterable(args[1])?;
+    // `mul` and `add` dispatch to the operands' `__mul__` / `__add__`, so a
+    // Decimal or Fraction element makes every turn a collection point.  Both
+    // collected sequences and the running total are native locals no root
+    // walker updates, so publish them and read each operand back per turn.
     let q_base = pyre_object::gc_roots::shadow_stack_len();
     for &item in &q {
         pyre_object::gc_roots::pin_root(item);
+    }
+    if p.len() != q.len() {
+        return Err(crate::PyError::value_error(
+            "Inputs are not the same length",
+        ));
     }
     // The accumulator starts as int 0 so type coercion follows the pure
     // Python `total = 0; total += p_i * q_i` recipe: int stays int, and a

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6406,18 +6406,6 @@ fn try_walker_specialize_subscr_specialised_pair<Sym: WalkSym>(
     dst_bank: char,
 ) -> Result<Option<()>, DispatchError> {
     const TYPELEN: i64 = 2;
-    // The object-slot read is WRONG CODE from here and stays residual until it
-    // is understood.  `test.test_datetime` reaches it through
-    // `self.lt = (array('q', ut), array('q', ut))` read as `self.lt[dt.fold]`,
-    // and the next call in that frame comes out one positional argument short —
-    // `bisect.bisect_right(lt, timestamp)` answers `missing 1 required
-    // positional argument: 'x'`.  Declining only this kind restores the module;
-    // the `ii` / `ff` arms, which share the class guard and the pinned index,
-    // are unaffected, and UNPACK reaches the same slots through
-    // [`walker_emit_specialised_pair_item`] with no index operand and is sound.
-    if pair_kind == SpecialisedPairKind::Object {
-        return Ok(None);
-    }
     // `bool` shares int's `intval`, so it indexes through its own &BOOL_TYPE
     // guard in the unbox below.
     let raw_key = unsafe {


### PR DESCRIPTION
Three follow-ups from the open-defect triage, each verified against a binary built here.

## 1. `math.prod`, `sumprod` and `dist` lost their operands to a moving collection

`collect_iterable` pins its elements onto the shadow stack while collecting them but **drops
those roots before it returns**, so the `Vec<PyObjectRef>` it hands back holds addresses the
next collection invalidates. Three reductions carried such a vector — or a bare local — across a
call that runs Python:

| function | the call it crossed |
|---|---|
| `prod` | `start` was computed before `collect_iterable`, which runs the iterable's `__next__`; then `mul` drove unrooted elements and an unrooted accumulator |
| `sumprod` | collected its first sequence, then ran the second iterable before pinning the first |
| `dist` | converted with `try_get_double`, whose `__float__` call can relocate the elements it has not converted yet |

Each now publishes its operands and reads them back per turn, the loop `sumprod` already used.
`hypot` is deliberately untouched: it maps over the caller's `args` slice rather than a
`collect_iterable` result, and whether that slice is walked is a separate question.

**Repro, 100% of runs in 0.28s, with the JIT off** — `test.test_statistics` corrupted
`_pydecimal`'s `_int` digit string:

```
PYRE_JIT=0 PYPY_GC_NURSERY=4096 ./pyre-dynasm -m test.test_statistics TestGeometricMean.test_basics -v
ValueError: invalid literal for int() with base 10: '\x17('
```

Narrowed to `math.prod(map(Decimal, range(1, 1000)))`; the same value built with a plain
`for` loop was clean, which is what named `prod`.

`math_prod_moving_gc_roots.py` is the regression fixture: **5/5 failures** on the pre-fix binary
(SIGBUS or `ValueError`, JIT on and off alike), 5/5 `OK` after. `test.test_statistics` now runs
400 tests, `OK (skipped=21)`.

The `test.test_statistics` baseline row is left at `IMPORTERROR`. It is wrong, but the module
costs 170s of CPU and the gate runs `--timeout 300` with `--jobs 3` on a 3-core runner, so
promoting it to `PASS` buys a flapping gate rather than coverage. Worth doing separately with a
timeout that fits.

## 2. The object-slot arm of the specialised-pair subscript folds again

`try_walker_specialize_subscr_specialised_pair` declined `SpecialisedPairKind::Object` because
the read made the next call in the frame come out one positional argument short —
`test.test_datetime` answered `bisect_right() missing 1 required positional argument: 'x'`. The
root cause was never found, and the decline was kept after the witness stopped reproducing on
the grounds that its *producer* had gone away rather than the defect.

The producer is back: `try_walker_specialize_newtuple_object` declines arity 2 again, so a
`BUILD_TUPLE` pair is a `makespecialisedtuple2` pair once more. The witness does not return.

Measured with the arm behind a temporary env gate, one binary serving both arms:

| check | result |
|---|---|
| does the fold actually fire? | 1674.93 → **2.85** ns/iter on a two-object pair; 2392.61 → **1459.13** on `datetimetester`'s own shape (two arrays in an attribute, variable index) |
| `test.test_datetime` | 1804 tests, `OK (skipped=29)` — with the arm live *and* declined |
| gated CPython suite, arm live | **207/207, no regressions** |
| `pyre/check.py --backend dynasm`, decline deleted | **441/441**, jitstats unchanged |

## 3. The demoted non-ref home store at a later LABEL header now has a test

That arm shipped without one. Reaching it needs a raw demoted at one LABEL and kept at a later
one, and two shapes do not give it:

- both LABELs sharing a descr demotes the position at *each*, because every test in
  `compute_loop_phi_keep` reads the ops **after** its LABEL and the later one sees a subset;
- distinct descrs need a second JUMP, which is local to the earlier LABEL and un-demotes it
  through the escape pass. Making that JUMP descr-less avoids the un-demote but leaves an op
  after a terminator with no block, and the compile **panics**.

The shape that works gives the later LABEL **no back-jump at all**: `compute_loop_phi_keep`
skips it, so all of its positions stay kept, and the trace keeps its single terminator. A bridge
attached to a guard below it jumps back to that LABEL, entering through its loader, which
refreshes only the dense carried slot the block param arrives in.

Without the store the exit guard publishes **7**, the value the first LABEL seeded, instead of
**207**, what two bridge trips carried in. Verified by deleting the arm and re-running.

## Gates

- `pyre/check.py --backend dynasm` **441/441**.
- `pyre/cpython_tests/run.py --backend dynasm` **207/207, no regressions**.
- `cargo test -p majit-backend-cranelift` 145 + 35 + 1 green; `cargo fmt --check` clean.
- `pyre/check.py --backend cranelift` **440/441**. The one red is
  `synth/generator_tree_recursion`, and it is **not from this branch** — in a correctly
  interleaved gate A/B the arm with change 2 reverted fails too (declined 2/5 rounds, arm live
  3/5), whole-process CPU is flat (+0.9%, paired 4/11 over 11 rounds), the fixture contains no
  two-tuple subscript for change 2 to reach, and dynasm is green on the same commits. This host
  sat at load 24–66 throughout; CI is the place to judge that ratio.
