### PR TITLE
cpython_tests: gate test_venv, whose recorded IMPORTERROR was stale

### DIFF
--- a/lib-python/3/test/test_venv.py
+++ b/lib-python/3/test/test_venv.py
@@ -23,7 +23,8 @@ from test.support import (captured_stdout, captured_stderr,
                           requires_subprocess, is_android, is_apple_mobile,
                           is_wasm32,
                           requires_venv_with_pip, TEST_HOME_DIR,
-                          requires_resource, copy_python_src_ignore)
+                          requires_resource, copy_python_src_ignore,
+                          cpython_only)
 from test.support.os_helper import (can_symlink, EnvironmentVarGuard, rmtree,
                                     TESTFN, FakePath)
 import unittest
@@ -76,7 +77,13 @@ class BaseTest(unittest.TestCase):
             self.include = 'Include'
         else:
             self.bindir = 'bin'
-            self.lib = ('lib', f'python{sysconfig._get_python_version_abi()}')
+            # An implementation keeps its own installation tree rather than
+            # claiming `lib/pythonX.Y`, and `_get_implementation` is what the
+            # install schemes substitute to spell it -- reading it here asks
+            # for the layout the runtime actually builds instead of pinning
+            # one implementation's spelling of it.
+            self.lib = ('lib', f'{sysconfig._get_implementation().lower()}'
+                               f'{sysconfig._get_python_version_abi()}')
             self.include = 'include'
         executable = sys._base_executable
         self.exe = os.path.split(executable)[-1]
@@ -705,6 +712,11 @@ class BasicTest(BaseTest):
 
     @unittest.skipIf(os.name == 'nt', 'not relevant on Windows')
     @requireVenvCreate
+    # The landmark asserted here is `pythonXY[t]` on `sys.path`, put there
+    # whether or not that zip exists.  A stdlib zip reaches `sys.path` here
+    # only when the file is present, and the name is spelled for the running
+    # implementation, so neither half of the assertion can hold.
+    @cpython_only
     def test_zippath_from_non_installed_posix(self):
         """
         Test that when create venv from non-installed python, the zip path

--- a/pyre/cpython_tests/baseline.json
+++ b/pyre/cpython_tests/baseline.json
@@ -1336,7 +1336,7 @@
       "dynasm": "PASS"
     },
     "test.test_venv": {
-      "dynasm": "IMPORTERROR"
+      "dynasm": "PASS"
     },
     "test.test_wait3": {
       "dynasm": "IMPORTERROR"

--- a/pyre/cpython_tests/run.py
+++ b/pyre/cpython_tests/run.py
@@ -569,6 +569,11 @@ SERIAL_MODULES = {
 DEFAULT_RESOURCE_MODULES = {
     "test.test_datetime",
     "test.test_urllibnet",
+    # `EnsurePipTest.test_with_pip` is 115s of this module's 133s, nearly all
+    # of it waiting on two pip bootstraps and two uninstalls in subprocesses.
+    # `pyre/extra_tests/pip/run.py` covers that ground in the same CI job,
+    # offline and in a fraction of the time.
+    "test.test_venv",
     "test.test_zipimport",
 }
 


### PR DESCRIPTION
`test.test_venv` was recorded `IMPORTERROR` and therefore deselected — `run.py` gates only rows recorded `PASS`. The record is stale: the module imports and runs 40 tests. It reported 3 failures and 1 error, all four on one divergence.

## The divergence

`BaseTest.setUp` spelled the venv library directory as a literal:

```python
self.lib = ('lib', f'python{sysconfig._get_python_version_abi()}')
```

The install schemes spell it `lib/{implementation_lower}{version}`, and `sysconfig._get_implementation()` answers `Pyre` here, so a venv holds `lib/pyre3.14t`. Measured:

```
impl      : Pyre
ver+abi   : 3.14t
venv pure : /E/lib/pyre3.14t/site-packages
```

The three `isdir` failures were looking at a directory nothing creates.

**The name cannot come from `_sysconfigdata`**: `sysconfig._init_config_vars` overwrites `implementation_lower` from `_get_implementation()` *after* merging the build vars. `_get_implementation` is the distributor hook the schemes substitute — the same one the reference implementation added for exactly this purpose — and pyre already declares itself through it. So the test is what pinned one implementation's spelling, and the test is what changed. It now reads that same symbol, which leaves the value **identical under the reference interpreter**: `('lib', 'python3.14')` before and after.

## The error

`test_zippath_from_non_installed_posix` asserts a `python{X}{Y}[t]` landmark on the child's `sys.path`. A stdlib zip goes on `sys.path` here only when the file exists, and its name carries the implementation, so neither half can hold. It carries `@cpython_only`, as it does in the reference tree for the same stated reason.

## What the fix newly exposes

With the layout corrected, `_check_output_of_default_create` reaches its later assertions for the first time — the `lib64` symlink arm, the three `pyvenv.cfg` strings (`home`, `executable`, the exact `command` line), and `bin/<exe>`. They hold.

The `lib64` arm is 64-bit non-darwin POSIX only, so it does not run on the machine this was developed on. The symlink is created by implementation-agnostic code in `venv/__init__.py`; the parts that are pyre's were checked directly (`os.symlink` + `os.path.islink` round-trip, `sys.maxsize > 2**32`). **This CI run is the first time that arm executes** — it is the one thing here that local work could not settle.

## Wall time

`EnsurePipTest.test_with_pip` was 115s of the module's 133s, nearly all of it waiting on two pip bootstraps and two uninstalls in subprocesses (16.97s user, 16% cpu). It carries `@requires_resource('cpu')`, so listing the module in `DEFAULT_RESOURCE_MODULES` applies the same empty default resource set libregrtest uses. The gated module is now **47s**. `pyre/extra_tests/pip/run.py` covers that ground in the same job, offline, in 26s.

## Verification

```
$ pyre/cpython_tests/run.py --backend dynasm --jobs 3 --timeout 300 --filter test_venv
  PASS 1 / FAIL 0 / CRASH 0 / TIMEOUT 0
  + test.test_venv: IMPORTERROR -> PASS
```

Direct run: `Ran 40 tests`, `OK (skipped=6)` — the 5 pre-existing decorator skips plus the new `cpython_only`.

Not covered: no cranelift row is created for this module.

— *opened by Claude*