### PR TITLE
Windows: the time, signal, errno and _multiprocessing surfaces, 64-bit seeks, one mmap route, and the _ctypes call surface through COM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,8 @@ CLAUDE.md
 
 # Scratch probes, profiles and baseline binaries (not committed)
 /scratchpad/
+
+# The scratch files `lib-python/3/test` writes into the working directory
+# (`test.support.TESTFN` is `@test_<pid>_tmp<suffix>`), left behind whenever a
+# run dies before its `tearDown`.
+/@test_*_tmp*

--- a/majit/majit-backend-wasm/tests/codegen_test.rs
+++ b/majit/majit-backend-wasm/tests/codegen_test.rs
@@ -32,6 +32,12 @@ fn workspace_root() -> PathBuf {
 /// overwrite each other, so a tree that last built `web` leaves a module there
 /// which loads and runs but is not the one whose counters these tests pin.
 /// `check.py` copies the wasm-host build here for exactly that reason.
+/// A release runtime binary, named the way the host names an executable.
+fn runtime_binary(root: &Path, name: &str) -> PathBuf {
+    root.join("target/release")
+        .join(format!("{name}{}", std::env::consts::EXE_SUFFIX))
+}
+
 fn wasm_host_module(root: &Path) -> PathBuf {
     root.join("target/wasm32-unknown-unknown/release/pyre_wasm.wasm-host.wasm")
 }
@@ -95,6 +101,27 @@ fn assert_ran_ok(label: &str, output: &std::process::Output) {
     );
 }
 
+/// Assert the two runtimes printed the same thing, up to the line ending
+/// their hosts spell a newline with.
+///
+/// What is being compared is what the two backends computed. `pyre-dynasm`
+/// runs on the host, where a text stream translates `\n` on the way out and
+/// Windows spells the result `\r\n`; the wasm guest is its own platform and
+/// spells it `\n`. Comparing the bytes would make every one of these tests
+/// fail on a Windows host over the separator alone.
+#[track_caller]
+fn assert_same_stdout(label: &str, wasm: &std::process::Output, dynasm: &std::process::Output) {
+    fn lines(stdout: &[u8]) -> String {
+        String::from_utf8_lossy(stdout).replace("\r\n", "\n")
+    }
+    assert_eq!(
+        lines(&wasm.stdout),
+        lines(&dynasm.stdout),
+        "{label} output diverged from dynasm:\n{}",
+        String::from_utf8_lossy(&wasm.stderr),
+    );
+}
+
 fn stat_value(stderr: &str, name: &str) -> u64 {
     stderr
         .split_whitespace()
@@ -109,8 +136,8 @@ fn stat_value(stderr: &str, name: &str) -> u64 {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
 
     for artifact in [&dynasm, &wasm_runner, &wasm_module] {
@@ -138,10 +165,7 @@ fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
         );
         let stderr = String::from_utf8_lossy(&wasm_run.stderr);
         assert_ran_ok(&format!("wasm {bench}"), &wasm_run);
-        assert_eq!(
-            wasm_run.stdout, dynasm_run.stdout,
-            "wasm output diverged from dynasm for {bench}:\n{stderr}"
-        );
+        assert_same_stdout(&format!("wasm {bench}"), &wasm_run, &dynasm_run);
         assert!(
             stat_value(&stderr, "compiles") > 1,
             "{bench} did not recompile after its global invalidation:\n{stderr}"
@@ -158,8 +182,8 @@ fn global_reassign_retraces_non_last_label_backedge_at_runtime() {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
     let script = root.join("pyre/bench/raise_catch_loop.py");
 
@@ -185,10 +209,7 @@ fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
     assert_ran_ok("wasm raise/catch", &wasm_run);
-    assert_eq!(
-        wasm_run.stdout, dynasm_run.stdout,
-        "wasm raise/catch output diverged from dynasm:\n{stderr}"
-    );
+    assert_same_stdout("wasm raise/catch", &wasm_run, &dynasm_run);
     assert!(
         stat_value(&stderr, "jit_calls") < 100_000,
         "caught-exception root clearing crossed the host trampoline per iteration:\n{stderr}"
@@ -200,8 +221,8 @@ fn raise_catch_clear_root_does_not_cross_the_host_per_exception() {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn recursive_call_assembler_does_not_refill_zeroed_nursery_frames() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
     let script = root.join("pyre/bench/fib_recursive.py");
 
@@ -228,10 +249,7 @@ fn recursive_call_assembler_does_not_refill_zeroed_nursery_frames() {
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
     assert_ran_ok("wasm recursive fib", &wasm_run);
-    assert_eq!(
-        wasm_run.stdout, dynasm_run.stdout,
-        "wasm recursive fib output diverged from dynasm:\n{stderr}"
-    );
+    assert_same_stdout("wasm recursive fib", &wasm_run, &dynasm_run);
     // `compiles` is the host's module-compile tally, one per loop and one per
     // bridge, and `BRIDGE_OK` counts the bridges the backend accepted — the
     // same event `bridges_compiled` counts, since both are bumped only on the
@@ -251,8 +269,8 @@ fn recursive_call_assembler_does_not_refill_zeroed_nursery_frames() {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn fannkuch_blackhole_helpers_do_not_reflect_through_the_host() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
     let script = root.join("pyre/bench/fannkuch.py");
     for artifact in [&dynasm, &wasm_runner, &wasm_module] {
@@ -277,10 +295,7 @@ fn fannkuch_blackhole_helpers_do_not_reflect_through_the_host() {
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
     assert_ran_ok("wasm fannkuch", &wasm_run);
-    assert_eq!(
-        wasm_run.stdout, dynasm_run.stdout,
-        "wasm fannkuch output diverged from dynasm:\n{stderr}"
-    );
+    assert_same_stdout("wasm fannkuch", &wasm_run, &dynasm_run);
     assert_eq!(stat_value(&stderr, "compiles"), 28);
     assert!(
         stat_value(&stderr, "jit_calls") < 100,
@@ -293,8 +308,8 @@ fn fannkuch_blackhole_helpers_do_not_reflect_through_the_host() {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn terminal_declined_call_assembler_matches_dynasm_at_runtime() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
     let script = root.join("pyre/bench/ca_terminal_decline.py");
 
@@ -321,10 +336,7 @@ fn terminal_declined_call_assembler_matches_dynasm_at_runtime() {
     );
     let stderr = String::from_utf8_lossy(&wasm_run.stderr);
     assert_ran_ok("wasm terminal-decline", &wasm_run);
-    assert_eq!(
-        wasm_run.stdout, dynasm_run.stdout,
-        "forced terminal-decline wasm output diverged from dynasm\nwasm stderr:\n{stderr}"
-    );
+    assert_same_stdout("forced terminal-decline wasm", &wasm_run, &dynasm_run);
     assert!(
         stderr.contains("accepted_ca=") && !stderr.contains("accepted_ca=0"),
         "fixture did not compile its outer CALL_ASSEMBLER trace:\n{stderr}"
@@ -340,8 +352,8 @@ fn terminal_declined_call_assembler_matches_dynasm_at_runtime() {
             run via `cargo test -- --ignored` in the check.py job, which builds them"]
 fn wasm_outlier_bridges_stay_compiled_at_runtime() {
     let root = workspace_root();
-    let dynasm = root.join("target/release/pyre-dynasm");
-    let wasm_runner = root.join("target/release/pyre-wasm-runner");
+    let dynasm = runtime_binary(&root, "pyre-dynasm");
+    let wasm_runner = runtime_binary(&root, "pyre-wasm-runner");
     let wasm_module = wasm_host_module(&root);
 
     for artifact in [&dynasm, &wasm_runner, &wasm_module] {
@@ -371,10 +383,7 @@ fn wasm_outlier_bridges_stay_compiled_at_runtime() {
         );
         let stderr = String::from_utf8_lossy(&wasm_run.stderr);
         assert_ran_ok(&format!("wasm {bench}"), &wasm_run);
-        assert_eq!(
-            wasm_run.stdout, dynasm_run.stdout,
-            "wasm output diverged from dynasm for {bench}:\n{stderr}"
-        );
+        assert_same_stdout(&format!("wasm {bench}"), &wasm_run, &dynasm_run);
         assert!(
             stat_value(&stderr, expected_counter) > 0,
             "{bench} did not compile its formerly-declined bridge:\n{stderr}"

--- a/pyre/bench/synth/pypy_type_surface.py
+++ b/pyre/bench/synth/pypy_type_surface.py
@@ -12,6 +12,16 @@ class Derived(Heap):
     pass
 
 
+# Py_TPFLAGS_IMMUTABLETYPE.  pyre publishes it on every type that is not a
+# heap type and `get_flags` publishes no such bit, so it is the one bit of this
+# word that follows 3.14 rather than PyPy — which makes it the one bit this
+# fixture cannot compare against its oracle.  Masked out below rather than
+# dropped: what it names is asserted directly in
+# `check_exception_group_immutable`, by making the store and failing if it
+# succeeds.
+PYPY_FLAGS = ~(1 << 8)
+
+
 def check_flags():
     # `get_flags`: _HEAPTYPE 1<<9, PATMA_SEQUENCE 1<<5, PATMA_MAPPING 1<<6,
     # _ABSTRACT 1<<20, Py_TPFLAGS_METHOD_DESCRIPTOR 1<<17.  _CPYTYPE marks
@@ -36,8 +46,9 @@ def check_flags():
         Derived: 0x200,
     }
     for cls, want in expected.items():
-        if cls.__flags__ != want:
-            raise AssertionError((cls.__name__, hex(cls.__flags__), hex(want)))
+        got = cls.__flags__ & PYPY_FLAGS
+        if got != want:
+            raise AssertionError((cls.__name__, hex(got), hex(want)))
     return len(expected)
 
 
@@ -53,10 +64,10 @@ def check_exception_group_immutable():
     # `moduledef.py` names `W_ExceptionGroup` under `interpleveldefs`, so
     # `ExceptionGroup` is a static builtin beside `BaseExceptionGroup` rather
     # than a heap type over it.
-    if ExceptionGroup.__flags__ != 0x0 or BaseExceptionGroup.__flags__ != 0x0:
-        raise AssertionError(
-            (hex(ExceptionGroup.__flags__), hex(BaseExceptionGroup.__flags__))
-        )
+    group = ExceptionGroup.__flags__ & PYPY_FLAGS
+    base = BaseExceptionGroup.__flags__ & PYPY_FLAGS
+    if group != 0x0 or base != 0x0:
+        raise AssertionError((hex(group), hex(base)))
     try:
         ExceptionGroup._probe = 1
     except TypeError:

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -320,6 +320,21 @@ def green(s):  return f"\033[32m{s}\033[0m"
 def dim(s):    return f"\033[2m{s}\033[0m"
 def bold(s):   return f"\033[1m{s}\033[0m"
 
+# ── cargo ────────────────────────────────────────────────────────────
+
+def cargo_finished_line(proc):
+    """cargo's `Finished` line, or a stand-in when it printed none.
+
+    Not the last line of the output: cargo ends with its future-incompat
+    `note:`, which says nothing about the build that just ran. `Finished` is
+    the line that names the profile cargo actually produced.
+    """
+    lines = (proc.stdout or "").splitlines() + (proc.stderr or "").splitlines()
+    return next(
+        (line.strip() for line in reversed(lines) if line.strip().startswith("Finished")),
+        "cargo build done",
+    )
+
 # ── Child-process user CPU time and peak RSS ─────────────────────────
 
 # Peak RSS in MiB of the most recent `run_timed` child, or None when the run
@@ -2270,21 +2285,23 @@ class Check:
 
     def build_backend(self, backend):
         # `pyre-jit-trace/build.rs` compares each `build/llbc/*.ullbc` against
-        # what its crate's sources hash to now, and by default reports a
-        # mismatch as a `cargo::warning` — which cargo replays only when it
-        # re-runs the build script, so a run whose crates were cached prints
-        # nothing at all. Every number this script produces is read out of a
-        # binary whose field offsets come from those artefacts, so a stale one
-        # does not fail: it answers, wrongly and quietly. Four measurement runs
-        # on this tree carried the mismatch and none of their logs named it.
+        # what its crate's sources hash to now and fails the build on a
+        # mismatch. Every number this script produces is read out of a binary
+        # whose field offsets come from those artefacts, so a stale one does
+        # not fail: it answers, wrongly and quietly.
         #
-        # `PYRE_LLBC_STRICT=1` is the promotion build.rs already documents "for
-        # callers that want a gate" — the same finding as `cargo::error`. The
-        # cost is that a rebase which moves the LLBC crates makes the next
-        # check.py stop and ask for a multi-minute re-extraction; the
-        # alternative is a green run that measured the wrong bytes. Set here
-        # rather than per-command so the wasm build gets it too.
-        os.environ["PYRE_LLBC_STRICT"] = "1"
+        # This used to set `PYRE_LLBC_STRICT=1` to arm that gate. It was
+        # already armed: `freshness_policy` maps an unset switch and `=1` to
+        # the same `FreshnessMode::Strict`, so the assignment selected no
+        # behaviour build.rs would not have taken anyway — while build.rs
+        # declares `cargo::rerun-if-env-changed=PYRE_LLBC_STRICT`, so it made
+        # every alternation between a cargo invocation that set the variable
+        # and one that did not re-run the build script and recompile
+        # `pyre-jit-trace -> pyre-jit -> pyrex`. Measured on a 16-core Windows
+        # box: 1s to repeat a build at the same value, 123s and 122s to switch
+        # it, 0.4s once nothing sets it. That is a working-tree cost rather
+        # than a CI one — rust-cache cleans workspace crates before saving,
+        # so the CI job rebuilds them either way.
         cfg = CARGO_CONFIG[backend]
         if cfg.get("wasm"):
             return self.build_wasm_backend()
@@ -2295,10 +2312,18 @@ class Check:
         ]
         print("  $ " + " ".join(cmd))
         cargo_path = shutil.which("cargo") or "(not found on PATH)"
-        print(f"  cargo resolved to: {cargo_path}")
+        # `capture_output` holds cargo's progress until it exits and this
+        # script's stdout is block-buffered under a harness, so without the
+        # flush the whole build is one gap with nothing in it. On the Windows
+        # runner it was 2766s of a 3392s step, every build line stamped at the
+        # instant the buffer finally drained; the next largest gap anywhere in
+        # that step was 31s.
+        print(f"  cargo resolved to: {cargo_path}", flush=True)
+        started = time.perf_counter()
         proc = subprocess.run(cmd, capture_output=True, text=True, encoding="utf-8", errors="replace")
+        elapsed = time.perf_counter() - started
         if proc.returncode != 0:
-            print(f"ERROR: cargo build failed (exit {proc.returncode})")
+            print(f"ERROR: cargo build failed (exit {proc.returncode}) after {elapsed:.1f}s")
             if proc.stdout:
                 print("─── cargo stdout ───")
                 print(proc.stdout.rstrip())
@@ -2308,10 +2333,10 @@ class Check:
             print("────────────────────")
             cargo_output = (proc.stderr or "") + (proc.stdout or "")
             if "LLBC STALE" in cargo_output:
-                # `PYRE_LLBC_STRICT=1` above turned build.rs's staleness
-                # warning into the build failure that got us here. It already
-                # printed the exact `extract-llbc.py` line naming the crates
-                # that moved, so repeat the reason rather than the command.
+                # build.rs refuses a stale artefact by default, which is the
+                # failure that got us here. It already printed the exact
+                # `extract-llbc.py` line naming the crates that moved, so
+                # repeat the reason rather than the command.
                 print(red("LLBC artefacts under build/llbc/ are STALE."))
                 print("Field offsets come from them, so a run on this tree "
                       "would measure the wrong bytes.")
@@ -2332,16 +2357,16 @@ class Check:
                 print(red("LLBC artefacts are missing under build/llbc/."))
                 print("Run the extractor first, then re-run this script:")
                 # No crate arguments: extract the full DEFAULT_CRATES set
-                # (pyre-object, pyre-interpreter, pyre-jit). The exact
-                # eval::eval_loop_jit portal lives in pyre-jit.ullbc, so a
-                # production JIT build requires all three artifacts.
+                # (majit-rlib, pyre-object, pyre-interpreter, pyre-jit). The
+                # exact eval::eval_loop_jit portal lives in pyre-jit.ullbc, so
+                # a production JIT build requires all four artifacts.
                 print("    scripts/extract-llbc.py")
             else:
                 self._print_cargo_diagnostics(cargo_path)
             sys.exit(1)
-        lines = (proc.stdout or "").strip().splitlines() + (proc.stderr or "").strip().splitlines()
-        if lines:
-            print(lines[-1])
+        # The wall clock beside cargo's own figure is what makes a build that
+        # recompiled the world distinguishable from a cache hit.
+        print(f"  {cargo_finished_line(proc)} — {elapsed:.1f}s wall", flush=True)
 
     def build_wasm_backend(self):
         """Build the wasm32 `pyre-wasm` module and the native `pyre-wasm-runner`.
@@ -2374,13 +2399,17 @@ class Check:
         ]
         for label, cmd, env in steps:
             print(f"Building {label}...")
-            print("  $ " + " ".join(cmd))
+            # Flushed for the same reason `build_backend` flushes: the command
+            # is the only thing naming the gap it is about to spend.
+            print("  $ " + " ".join(cmd), flush=True)
+            started = time.perf_counter()
             proc = subprocess.run(
                 cmd, capture_output=True, text=True, encoding="utf-8",
                 errors="replace", env=env,
             )
+            elapsed = time.perf_counter() - started
             if proc.returncode != 0:
-                print(f"ERROR: cargo build failed (exit {proc.returncode})")
+                print(f"ERROR: cargo build failed (exit {proc.returncode}) after {elapsed:.1f}s")
                 if proc.stdout:
                     print("─── cargo stdout ───")
                     print(proc.stdout.rstrip())
@@ -2389,9 +2418,7 @@ class Check:
                     print(proc.stderr.rstrip())
                 print("────────────────────")
                 sys.exit(1)
-            lines = (proc.stderr or "").strip().splitlines()
-            if lines:
-                print(lines[-1])
+            print(f"  {cargo_finished_line(proc)} — {elapsed:.1f}s wall", flush=True)
         if not Path(WASM_BUILD_OUTPUT).exists():
             print(f"ERROR: wasm module not produced at {WASM_BUILD_OUTPUT}")
             sys.exit(1)

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -109,6 +109,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_Security",
     "Win32_Security_Cryptography",
     "Win32_System_Diagnostics_Debug",
+    "Win32_System_Com",
     "Win32_System_Environment",
     "Win32_System_IO",
     "Win32_System_LibraryLoader",

--- a/pyre/pyre-interpreter/build.rs
+++ b/pyre/pyre-interpreter/build.rs
@@ -73,6 +73,16 @@ fn main() {
             .compile("pyre_cjkcodecs_jp");
     }
 
+    // `__try`/`__except` is the only thing that reaches a structured exception
+    // and no Rust compiler emits one, so the fence a foreign call is made
+    // inside (`src/module/_ctypes/seh.rs`) is a C translation unit of its own.
+    if target.ends_with("-pc-windows-msvc") {
+        println!("cargo:rerun-if-changed=src/module/_ctypes/seh.c");
+        cc::Build::new()
+            .file("src/module/_ctypes/seh.c")
+            .compile("pyre_ctypes_seh");
+    }
+
     // Only do work for the wasm_vfs feature; native builds need nothing here.
     if std::env::var_os("CARGO_FEATURE_WASM_VFS").is_none() {
         return;

--- a/pyre/pyre-interpreter/build.rs
+++ b/pyre/pyre-interpreter/build.rs
@@ -83,6 +83,20 @@ fn main() {
             .compile("pyre_ctypes_seh");
     }
 
+    // `sys.version` names the C compiler the build used, and on an MSVC target
+    // that name is the `MSC v.<_MSC_VER>` token
+    // (`rpython/rlib/compilerinfo.py:22`).  `ctypes.util._get_build_version`
+    // reads the number back out to decide which C runtime `find_library("c")`
+    // may hand out; with no token at all it assumes MSVC 6 and answers
+    // `msvcrt.dll`, a runtime this build does not share an `errno` with.  The
+    // number comes from the preprocessor rather than a parsed banner: `/EP`
+    // writes the expansion to stdout and nothing else.
+    if target.ends_with("-pc-windows-msvc")
+        && let Some(msc_ver) = msc_ver()
+    {
+        println!("cargo:rustc-env=PYRE_MSC_VER={msc_ver}");
+    }
+
     // Only do work for the wasm_vfs feature; native builds need nothing here.
     if std::env::var_os("CARGO_FEATURE_WASM_VFS").is_none() {
         return;
@@ -114,4 +128,23 @@ fn main() {
     let blob_path = Path::new(&out_dir).join("stdlib_vfs.lz4");
     std::fs::write(&blob_path, &compressed)
         .unwrap_or_else(|e| panic!("wasm_vfs: cannot write {}: {e}", blob_path.display()));
+}
+
+/// `_MSC_VER`, as the compiler itself expands it.  `None` when the probe
+/// cannot be compiled, which leaves `sys.version` naming Rust alone.
+fn msc_ver() -> Option<String> {
+    let out_dir = std::env::var("OUT_DIR").ok()?;
+    let probe = Path::new(&out_dir).join("pyre_msc_ver.c");
+    std::fs::write(&probe, "_MSC_VER\n").ok()?;
+    let output = cc::Build::new()
+        .get_compiler()
+        .to_command()
+        .arg("/nologo")
+        .arg("/EP")
+        .arg(&probe)
+        .output()
+        .ok()?;
+    let expanded = String::from_utf8_lossy(&output.stdout);
+    let digits: String = expanded.chars().filter(char::is_ascii_digit).collect();
+    (!digits.is_empty()).then_some(digits)
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6825,6 +6825,26 @@ macro_rules! crt_call {
 }
 pub(crate) use crt_call;
 
+/// `lseek`, taking and reporting the whole 64-bit file position.
+///
+/// The MSVC runtime's `lseek` is `_lseek`, whose offset and return are a C
+/// `long` — 32 bits there.  A position past 2 GiB therefore arrives as a
+/// negative offset (`1 << 31` fails with `EINVAL`) or as a truncated one
+/// (`1 << 32` seeks to 0), and a position read back off a larger file comes
+/// back wrong.  `_lseeki64` is the one that carries it, and `off_t` is
+/// already 64 bits everywhere else.
+#[cfg(not(feature = "sandbox"))]
+pub(crate) fn crt_lseek(fd: libc::c_int, offset: i64, whence: libc::c_int) -> i64 {
+    #[cfg(windows)]
+    {
+        crt_call!(libc::lseek64(fd, offset, whence))
+    }
+    #[cfg(not(windows))]
+    {
+        crt_call!(libc::lseek(fd, offset as libc::off_t, whence)) as i64
+    }
+}
+
 /// Clear the C runtime errno, so the next `crt_errno` describes the call made
 /// in between rather than whichever one last set the cell.  A caller needs
 /// this wherever the runtime reports through errno on a return value that is
@@ -15242,7 +15262,7 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
                 {
                     #[cfg(not(feature = "sandbox"))]
                     let pos = {
-                        let pos = crt_call!(libc::lseek(fd, offset as libc::off_t, whence));
+                        let pos = crt_lseek(fd, offset, whence);
                         if pos < 0 {
                             return Err(fd_errno_err(crt_errno()));
                         }
@@ -15287,7 +15307,7 @@ pub(crate) fn init_file_wrapper_type(ns: PyObjectRef) {
                     {
                         #[cfg(not(feature = "sandbox"))]
                         let pos = {
-                            let pos = crt_call!(libc::lseek(fd, 0, libc::SEEK_CUR));
+                            let pos = crt_lseek(fd, 0, libc::SEEK_CUR);
                             if pos < 0 {
                                 return Err(fd_errno_err(crt_errno()));
                             }
@@ -15690,7 +15710,7 @@ pub(crate) fn fileio_init(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
             #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
             {
                 #[cfg(not(feature = "sandbox"))]
-                if crt_call!(libc::lseek(fd, 0, libc::SEEK_END)) < 0 {
+                if crt_lseek(fd, 0, libc::SEEK_END) < 0 {
                     // A pipe has no end to seek to, and opening one for append
                     // is legal; only a real seek failure is an error.
                     let errno = crt_errno();
@@ -16106,7 +16126,7 @@ fn file_method_seekable(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         {
             #[cfg(not(feature = "sandbox"))]
             {
-                crt_call!(libc::lseek(fd, 0, libc::SEEK_CUR)) >= 0
+                crt_lseek(fd, 0, libc::SEEK_CUR) >= 0
             }
             #[cfg(feature = "sandbox")]
             {
@@ -16322,8 +16342,8 @@ fn fileio_readall_bufsize(self_obj: PyObjectRef, fd: i32) -> usize {
     if size > 65536 {
         #[cfg(not(feature = "sandbox"))]
         let position = {
-            let position = crt_call!(libc::lseek(fd, 0, libc::SEEK_CUR));
-            (position >= 0).then_some(position as i64)
+            let position = crt_lseek(fd, 0, libc::SEEK_CUR);
+            (position >= 0).then_some(position)
         };
         #[cfg(feature = "sandbox")]
         let position = crate::host_seam::ops::lseek(fd, 0, libc::SEEK_CUR).ok();

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4850,6 +4850,12 @@ pub(crate) fn resolve_pos_or_kw(
 /// is reported against `maxpos`.  The order matters: `list.sort` declares no
 /// positional slot and two keyword-only ones, so one stray positional is a
 /// positional error while three arguments are a total-count error.
+///
+/// The total-count message says "at most" whatever `minargs` is
+/// (`memoryview(b"", 1)` — one required slot — reports "takes at most 1
+/// argument (2 given)"); only the positional message names an exact count,
+/// and only when every positional slot is required (`itertools.batched([], 1,
+/// 2)` reports "takes exactly 2 positional arguments (3 given)").
 pub(crate) fn clinic_arity(
     fn_name: &str,
     npos: usize,
@@ -4861,14 +4867,9 @@ pub(crate) fn clinic_arity(
     let maxargs = maxpos + kwonly;
     if npos + nkw > maxargs {
         return Err(crate::PyError::type_error(format!(
-            "{fn_name}() takes {} {maxargs} {}argument{} ({} given)",
-            if minargs < maxargs {
-                "at most"
-            } else {
-                "exactly"
-            },
+            "{fn_name}() takes at most {maxargs} {}argument{} ({} given)",
             // bpo-31229: a call that passed only keywords names them, so
-            // "takes exactly 1 argument (2 given)" cannot read as a claim
+            // "takes at most 1 argument (2 given)" cannot read as a claim
             // about positional arguments that were never supplied.
             if npos == 0 { "keyword " } else { "" },
             if maxargs == 1 { "" } else { "s" },

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6776,6 +6776,20 @@ macro_rules! crt_call {
 }
 pub(crate) use crt_call;
 
+/// Clear the C runtime errno, so the next `crt_errno` describes the call made
+/// in between rather than whichever one last set the cell.  A caller needs
+/// this wherever the runtime reports through errno on a return value that is
+/// also a legitimate success (`strftime` answering zero for both a rejected
+/// directive and an empty result).  Windows-only, which is where the runtime
+/// keeps a cell of its own that `std::io::Error::last_os_error` does not read.
+#[cfg(windows)]
+pub(crate) fn clear_crt_errno() {
+    #[cfg(feature = "host_env")]
+    {
+        rustpython_host_env::os::clear_errno();
+    }
+}
+
 /// The errno the last C runtime call reported.
 pub(crate) fn crt_errno() -> i32 {
     #[cfg(all(windows, feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -4902,9 +4902,10 @@ pub(crate) fn clinic_arity(
 /// `Arguments._match_signature` (`pypy/interpreter/argument.py`). Each
 /// slot is filled by a positional, then by a keyword of the matching
 /// name; an absent optional slot becomes `PY_NULL` (the generated
-/// `#[pyre_function]` unwrap reads that as "argument omitted"). An absent
-/// required slot, an unknown keyword, a keyword duplicating a positional,
-/// or too many positionals raises `TypeError`.
+/// `#[pyre_function]` unwrap reads that as "argument omitted"), and a
+/// `PY_NULL` arriving in `args` is read the same way. An absent required
+/// slot, an unknown keyword, a keyword duplicating a positional, or too many
+/// positionals raises `TypeError`.
 ///
 /// This is the consumer-side counterpart that lets a builtin resolve
 /// keywords by parameter name without a per-function `Signature`; the
@@ -4917,9 +4918,15 @@ pub(crate) fn bind_builtin_kwargs(
     fn_name: &str,
 ) -> Result<Vec<PyObjectRef>, crate::PyError> {
     let (positional, kwargs) = split_builtin_kwargs(args);
+    // A builtin registered with a `Signature` reaches its body through
+    // `bind_kwargs_to_signature`, which lays out every declared slot and
+    // leaves an omitted one `PY_NULL`; a positional-only registration hands
+    // the body just the arguments the call made. Reading a null slot as an
+    // argument that was not passed makes the two registrations bind alike.
+    let supplied = positional.iter().filter(|v| !v.is_null()).count();
     clinic_arity(
         fn_name,
-        positional.len(),
+        supplied,
         real_kwarg_count(kwargs),
         required.iter().filter(|r| **r).count(),
         names.len(),
@@ -4933,7 +4940,7 @@ pub(crate) fn bind_builtin_kwargs(
     let mut unknown: Option<Wtf8Buf> = None;
     for (i, &v) in positional.iter().enumerate() {
         scope[i] = v;
-        filled[i] = true;
+        filled[i] = !v.is_null();
     }
     if let Some(dict) = kwargs {
         let entries = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) };

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6583,8 +6583,25 @@ fn winerror_derived_errno(w_winerror: PyObjectRef) -> Option<i64> {
 }
 
 /// The POSIX errno a Win32 error code maps to.
+///
+/// A Winsock code is its own errno: the range was built by adding `WSABASEERR`
+/// to the classic numbers, and `errno` publishes the socket names at the
+/// Winsock values, so `errno` and `winerror` agree there and the `OSError`
+/// subclass follows.  The six the table below names are the exception — the
+/// runtime kept its own meaning for those, so they come back down by
+/// `WSABASEERR` to the number they were built from.
 #[cfg(windows)]
 pub(crate) fn winerror_to_errno(code: i64) -> i64 {
+    const WSABASEERR: i64 = 10000;
+    // WSAEINTR, WSAEBADF, WSAEACCES, WSAEFAULT, WSAEINVAL, WSAEMFILE.
+    const WINSOCK_KEEPS_POSIX_ERRNO: &[i64] = &[10004, 10009, 10013, 10014, 10022, 10024];
+    if (WSABASEERR..12000).contains(&code) {
+        return if WINSOCK_KEEPS_POSIX_ERRNO.contains(&code) {
+            code - WSABASEERR
+        } else {
+            code
+        };
+    }
     WINERROR_TO_ERRNO
         .iter()
         .find(|&&(win, _)| win == code)
@@ -6661,18 +6678,28 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
     unsafe { interp_exceptions::w_exception_set_args(exc, args_list) };
 }
 
-/// `ESHUTDOWN` is a POSIX errno absent from the MSVC CRT, so the
-/// `BrokenPipeError` mapping is gated on it being defined (`#ifdef ESHUTDOWN`).
+/// `ESHUTDOWN` is a POSIX errno absent from the MSVC runtime's own `errno.h`,
+/// so the `BrokenPipeError` mapping is gated on it being defined
+/// (`#ifdef ESHUTDOWN`).  Windows has it as the Winsock code, which is the
+/// value a socket reports and the one the `errno` module publishes.
 #[cfg(unix)]
 fn errno_is_eshutdown(e: i32) -> bool {
     e == libc::ESHUTDOWN
+}
+#[cfg(all(windows, feature = "host_env"))]
+fn errno_is_eshutdown(e: i32) -> bool {
+    e == rustpython_host_env::errno::errors::ESHUTDOWN
 }
 /// wasm32 has no libc errnos; match the darwin/BSD numeric value.
 #[cfg(target_arch = "wasm32")]
 fn errno_is_eshutdown(e: i32) -> bool {
     e == 58
 }
-#[cfg(all(not(unix), not(target_arch = "wasm32")))]
+#[cfg(all(
+    not(unix),
+    not(target_arch = "wasm32"),
+    not(all(windows, feature = "host_env"))
+))]
 fn errno_is_eshutdown(_e: i32) -> bool {
     false
 }
@@ -6702,14 +6729,35 @@ mod wasm_errno {
     pub const ETIMEDOUT: i32 = 60;
 }
 
+/// On Windows `ETIMEDOUT` above is the Winsock code, and the runtime's own
+/// `errno.h` has a second value under the same name that a descriptor call
+/// reports; both select `TimeoutError`.
+#[cfg(all(windows, feature = "host_env"))]
+fn errno_is_crt_etimedout(e: i32) -> bool {
+    e == libc::ETIMEDOUT
+}
+#[cfg(not(all(windows, feature = "host_env")))]
+fn errno_is_crt_etimedout(_e: i32) -> bool {
+    false
+}
+
 /// `interp_exceptions.py:1207-1227 ERRNO_MAP` — the OSError subclass the
 /// exact `OSError` constructor selects for a recognised errno, by
 /// registered class name.  Returns `None` for an unmapped errno.
 pub(crate) fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
-    // `ESHUTDOWN` is sourced through `errno_is_eshutdown` (MSVC CRT lacks it);
-    // the rest come from `libc`, or the darwin/BSD `wasm_errno` table on wasm32.
-    #[cfg(not(target_arch = "wasm32"))]
+    // `ESHUTDOWN` is sourced through `errno_is_eshutdown` (the MSVC runtime's
+    // own `errno.h` lacks it); the rest come from the same table the `errno`
+    // module is published from, so `OSError(errno.X)` selects the subclass the
+    // name `X` implies.  On Windows that table answers the socket names with
+    // their Winsock codes, which is what a socket reports.  Failing that
+    // `libc`, or the darwin/BSD `wasm_errno` table on wasm32.
+    #[cfg(all(not(feature = "host_env"), not(target_arch = "wasm32")))]
     use libc::{
+        EACCES, EAGAIN, EALREADY, ECHILD, ECONNABORTED, ECONNREFUSED, ECONNRESET, EEXIST,
+        EINPROGRESS, EINTR, EISDIR, ENOENT, ENOTDIR, EPERM, EPIPE, ESRCH, ETIMEDOUT, EWOULDBLOCK,
+    };
+    #[cfg(all(feature = "host_env", not(target_arch = "wasm32")))]
+    use rustpython_host_env::errno::errors::{
         EACCES, EAGAIN, EALREADY, ECHILD, ECONNABORTED, ECONNREFUSED, ECONNRESET, EEXIST,
         EINPROGRESS, EINTR, EISDIR, ENOENT, ENOTDIR, EPERM, EPIPE, ESRCH, ETIMEDOUT, EWOULDBLOCK,
     };
@@ -6745,7 +6793,7 @@ pub(crate) fn os_error_errno_subclass(errno: i64) -> Option<&'static str> {
         "PermissionError"
     } else if e == ESRCH {
         "ProcessLookupError"
-    } else if e == ETIMEDOUT {
+    } else if e == ETIMEDOUT || errno_is_crt_etimedout(e) {
         "TimeoutError"
     } else {
         return None;

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6833,7 +6833,12 @@ pub(crate) use crt_call;
 /// (`1 << 32` seeks to 0), and a position read back off a larger file comes
 /// back wrong.  `_lseeki64` is the one that carries it, and `off_t` is
 /// already 64 bits everywhere else.
-#[cfg(not(feature = "sandbox"))]
+///
+/// Every caller is a file descriptor operation and so already stops at the
+/// targets whose libc has one; the same condition is spelled here because
+/// `wasm32-unknown-unknown` has no `lseek`, no `off_t` and no `c_int` to
+/// declare this with.
+#[cfg(all(any(unix, windows), not(feature = "sandbox")))]
 pub(crate) fn crt_lseek(fd: libc::c_int, offset: i64, whence: libc::c_int) -> i64 {
     #[cfg(windows)]
     {

--- a/pyre/pyre-interpreter/src/host_seam.rs
+++ b/pyre/pyre-interpreter/src/host_seam.rs
@@ -793,7 +793,7 @@ mod real {
         }
 
         fn lseek(fd: i32, pos: i64, how: i32) -> SeamResult<i64> {
-            let r = unsafe { libc::lseek(fd, pos as libc::off_t, how) };
+            let r = crate::builtins::crt_lseek(fd, pos, how);
             if r < 0 {
                 Err(last_os_error())
             } else {

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -1914,10 +1914,46 @@ fn startup_builtin_module_impl(
 /// shadowing check to compare against absolute module origins.  Under the
 /// sandbox the path is left as given (a virtual path the controller mediates);
 /// `canonicalize` would issue raw host syscalls past the seccomp lockdown.
+/// The extended-length spelling `canonicalize` answers with on Windows, back
+/// as the name everything else uses.
+///
+/// It resolves through `GetFinalPathNameByHandleW`, whose result carries the
+/// `\\?\` prefix — `\\?\Z:\src` for `Z:\src`, `\\?\UNC\host\share` for
+/// `\\host\share`.  A module's `__spec__.origin` is the plain name the
+/// finder joined, so `is_possibly_shadowing` would be comparing two spellings
+/// of the same directory and finding them different.  A prefix with no plain
+/// spelling (`\\?\Volume{...}`) is left as it is.
+#[cfg(all(windows, not(feature = "sandbox")))]
+fn strip_verbatim_prefix(path: PathBuf) -> PathBuf {
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
+
+    const fn wide(s: &str) -> [u16; 4] {
+        let b = s.as_bytes();
+        [b[0] as u16, b[1] as u16, b[2] as u16, b[3] as u16]
+    }
+    const SEP: u16 = b'\\' as u16;
+    let units: Vec<u16> = path.as_os_str().encode_wide().collect();
+    let Some(rest) = units.strip_prefix(&wide(r"\\?\")) else {
+        return path;
+    };
+    let plain = if let Some(unc) = rest.strip_prefix(&wide(r"UNC\")) {
+        [&[SEP, SEP][..], unc].concat()
+    } else if let [_, colon, SEP, ..] = rest
+        && *colon == b':' as u16
+    {
+        rest.to_vec()
+    } else {
+        return path;
+    };
+    PathBuf::from(std::ffi::OsString::from_wide(&plain))
+}
+
 fn canonical_startup_dir(dir: &Path) -> Wtf8Buf {
     #[cfg(not(feature = "sandbox"))]
     if let Ok(abs) = std::path::absolute(dir) {
-        let abs = abs.canonicalize().unwrap_or(abs);
+        let abs = abs.canonicalize().unwrap_or_else(|_| abs.clone());
+        #[cfg(windows)]
+        let abs = strip_verbatim_prefix(abs);
         return crate::gateway::fsdecode_os_str_wtf8(abs.as_os_str());
     }
     crate::gateway::fsdecode_os_str_wtf8(dir.as_os_str())

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1230,20 +1230,69 @@ pub(super) fn invalid_type_code_error() -> crate::PyError {
 
 // ── scalar value ⇄ bytes ──────────────────────────────────────────────
 
+/// `Py_TYPE(value)->tp_name` — the class an instance reports itself as, which
+/// for an instance-layout object is its `w_class` rather than the layout type
+/// its `ob_type` names.
+fn value_type_name(obj: PyObjectRef) -> String {
+    match crate::typedef::r#type(obj) {
+        Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
+        None => unsafe { pyre_object::type_name_of(obj) }.to_string(),
+    }
+}
+
+/// The pointer-width word an `int` names, over the whole unsigned range.
+/// `PyLong_AsVoidPtr` reads the value as a signed word and falls back to the
+/// unsigned conversion when that overflows, so an address with the top bit set
+/// — every Windows pseudo-handle, `GetCurrentProcess()` among them — is an
+/// address like any other rather than an integer too large to be one.
+pub(super) fn pointer_word(obj: PyObjectRef) -> Result<usize, crate::PyError> {
+    match crate::baseobjspace::int_w(obj) {
+        Ok(value) => Ok(value as usize),
+        Err(err) if err.kind == crate::PyErrorKind::OverflowError => {
+            Ok(crate::baseobjspace::uint_w(obj)? as usize)
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// The bytes of a `_SimpleCData` whose own type code is `tc`, which a
+/// destination that takes an *instance* copies byte-for-byte
+/// (`_PyCData_set`, the `PyObject_IsInstance` arm reached when the field
+/// carries no setfunc of its own).
+pub(super) fn same_type_bytes(tc: &str, obj: PyObjectRef) -> Option<Vec<u8>> {
+    if !is_simplecdata_instance(obj) {
+        return None;
+    }
+    let src_cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    (type_code_of(src_cls).as_deref() == Some(tc)).then(|| cdata_bytes(obj).unwrap_or(&[]).to_vec())
+}
+
+/// Store into a destination that takes an instance — a struct field, an array
+/// item, a pointer item.  `_PyCData_set` reaches those with a null field
+/// setfunc, so a same-typed instance is copied and everything else falls to
+/// the type's own setter.  `Simple_init` and the `value` setter call that
+/// setter directly (`Simple_set_value`) and so take no instance at all:
+/// `c_long(c_long(42))` is a TypeError from `PyNumber_Index`.
+pub(super) fn encode_instance_or_value(
+    tc: &str,
+    value: PyObjectRef,
+    dest: PyObjectRef,
+    key: &str,
+) -> Result<Vec<u8>, crate::PyError> {
+    match same_type_bytes(tc, value) {
+        Some(bytes) => Ok(bytes),
+        None => encode_value_into(tc, value, dest, key),
+    }
+}
+
 /// Encode a Python scalar into the native-endian buffer bytes for `tc`.
 ///
-/// A `_SimpleCData` instance of the *same* type code is copied byte-for-byte; a
-/// differently-typed one falls through to normal conversion (which rejects it
-/// unless it is int/float-like), so a larger scalar cannot overwrite a smaller
-/// field with its raw buffer.
+/// This is the type's own setter (`setfunc`), which takes a value and not a
+/// cdata: a `_SimpleCData` instance is converted like anything else, and so
+/// rejected unless it is int/float-like.  A destination that also accepts an
+/// instance of its own type reaches it through `encode_instance_or_value`.
 pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate::PyError> {
     use host_ctypes::SimpleStorageValue as V;
-    if is_simplecdata_instance(obj) {
-        let src_cls = unsafe { pyre_object::w_instance_get_type(obj) };
-        if type_code_of(src_cls).as_deref() == Some(tc) {
-            return Ok(cdata_bytes(obj).unwrap_or(&[]).to_vec());
-        }
-    }
     let val = match tc {
         "c" => {
             if unsafe { pyre_object::is_bytes(obj) } {
@@ -1300,10 +1349,22 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
         "P" | "z" | "Z" => {
             if unsafe { pyre_object::is_none(obj) } {
                 V::Pointer(0)
-            } else if unsafe { pyre_object::is_int(obj) } {
-                V::Pointer(crate::baseobjspace::int_w(obj)? as usize)
+            } else if unsafe { pyre_object::pyobject::is_int_or_long(obj) } {
+                V::Pointer(pointer_word(obj)?)
             } else {
-                return Err(crate::PyError::type_error("cannot be converted to pointer"));
+                // Each of the three says what it takes.  `z_set` and `Z_set`
+                // name the type that was passed instead
+                // (`Py_TYPE(value)->tp_name`, the bare name); `P_set` takes
+                // nothing but an address and says only that.
+                let refused = |what: &str| {
+                    let got = value_type_name(obj);
+                    format!("{what} or integer address expected instead of {got} instance")
+                };
+                return Err(crate::PyError::type_error(match tc {
+                    "z" => refused("bytes"),
+                    "Z" => refused("unicode string"),
+                    _ => "cannot be converted to pointer".to_string(),
+                }));
             }
         }
         "O" => V::ObjectId(obj as usize),

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -81,6 +81,12 @@ fn init_cdata_type(ns: PyObjectRef) {
             ),
         );
     }
+    // What an `out` parameter hands back once the callee has written it.
+    type_ns_store(
+        ns,
+        "__ctypes_from_outparam__",
+        crate::make_builtin_function("__ctypes_from_outparam__", |args| Ok(args[0])),
+    );
 }
 
 pub(super) fn cdata_in_dll(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
@@ -257,6 +263,21 @@ fn init_simplecdata_type(ns: PyObjectRef) {
         ns,
         "__new__",
         crate::typedef::make_new_descr(simplecdata_new),
+    );
+    // A scalar `out` parameter hands back the value rather than the box; one
+    // whose type is a user subclass hands back the instance, because the
+    // subclass is the thing the caller asked for.
+    type_ns_store(
+        ns,
+        "__ctypes_from_outparam__",
+        crate::make_builtin_function("__ctypes_from_outparam__", |args| {
+            let obj = args[0];
+            if super::funcptr::is_simple_subclass(unsafe { pyre_object::w_instance_get_type(obj) })
+            {
+                return Ok(obj);
+            }
+            value_getter(&[pyre_object::PY_NULL, obj])
+        }),
     );
     type_ns_store(
         ns,

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1262,6 +1262,11 @@ pub(super) fn decode_slot(tc: &str, bytes: &[u8]) -> PyObjectRef {
     if tc == "X" {
         return bstr_to_pyobject(bytes);
     }
+    // `P_get` reads a null pointer as `None`, the way `z_get` and `Z_get` read
+    // a null string as one; the host's table answers the address either way.
+    if tc == "P" && host_ctypes::read_pointer_from_buffer(bytes) == 0 {
+        return pyre_object::w_none();
+    }
     decoded_to_pyobject(host_ctypes::decode_type_code(tc, bytes))
 }
 

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1233,7 +1233,7 @@ pub(super) fn invalid_type_code_error() -> crate::PyError {
 /// `Py_TYPE(value)->tp_name` — the class an instance reports itself as, which
 /// for an instance-layout object is its `w_class` rather than the layout type
 /// its `ob_type` names.
-fn value_type_name(obj: PyObjectRef) -> String {
+pub(super) fn value_type_name(obj: PyObjectRef) -> String {
     match crate::typedef::r#type(obj) {
         Some(tp) => unsafe { pyre_object::w_type_get_name(tp.as_ptr()) }.to_string(),
         None => unsafe { pyre_object::type_name_of(obj) }.to_string(),

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -316,10 +316,7 @@ fn simplecdata_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     let value = if tc == "O" {
         host_ctypes::read_pointer_from_buffer(cdata_bytes(obj).unwrap_or(&[])) as PyObjectRef
     } else {
-        decoded_to_pyobject(host_ctypes::decode_type_code(
-            &tc,
-            cdata_bytes(obj).unwrap_or(&[]),
-        ))
+        decode_slot(&tc, cdata_bytes(obj).unwrap_or(&[]))
     };
     let rendered = unsafe { crate::display::py_repr_wtf8(value) }?;
     let name = unsafe { pyre_object::typeobject::w_type_get_name(cls) };
@@ -460,15 +457,19 @@ fn value_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             address as PyObjectRef
         });
     }
+    // A BSTR carries no swapped spelling — `X` has no entry in the byte-order
+    // tables — so it is read before the reversal below could reach it.
+    #[cfg(windows)]
+    if tc == "X" {
+        return Ok(decode_slot(&tc, bytes));
+    }
     let swapped = unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some();
     let owned;
     if swapped {
         owned = bytes.iter().rev().copied().collect::<Vec<_>>();
         bytes = &owned;
     }
-    Ok(decoded_to_pyobject(host_ctypes::decode_type_code(
-        &tc, bytes,
-    )))
+    Ok(decode_slot(&tc, bytes))
 }
 
 /// `_SimpleCData.value` setter — `(descr, instance, value)`.
@@ -483,6 +484,7 @@ fn value_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let value_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(value);
+    release_bstr_slot(&tc, cdata_addr(obj).unwrap_or(0));
     let mut bytes = encode_value_into(&tc, value, obj, "0")?;
     if unsafe { crate::baseobjspace::lookup_in_type(cls, "_swappedbytes_") }.is_some() {
         bytes.reverse();
@@ -1230,6 +1232,61 @@ pub(super) fn invalid_type_code_error() -> crate::PyError {
 
 // ── scalar value ⇄ bytes ──────────────────────────────────────────────
 
+/// The `str` a BSTR slot holds, or `None` for a null one.
+///
+/// `X_get` reads the length out of the string itself (`SysStringLen`) rather
+/// than stopping at the first NUL, because a BSTR may carry one; a null
+/// pointer and a zero-length string are the same value here.
+#[cfg(windows)]
+pub(super) fn bstr_to_pyobject(bytes: &[u8]) -> PyObjectRef {
+    let addr = host_ctypes::read_pointer_from_buffer(bytes);
+    if addr == 0 {
+        return pyre_object::w_none();
+    }
+    let units = unsafe {
+        std::slice::from_raw_parts(
+            addr as *const u16,
+            windows_sys::Win32::Foundation::SysStringLen(addr as *const u16) as usize,
+        )
+    };
+    pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(units))
+}
+
+/// The Python value the bytes of a slot of type code `tc` hold.
+///
+/// The host's decode table answers None for a code it does not know, and it
+/// does not know the BSTR one; `X_get` reads that out of the length the string
+/// itself records.
+pub(super) fn decode_slot(tc: &str, bytes: &[u8]) -> PyObjectRef {
+    #[cfg(windows)]
+    if tc == "X" {
+        return bstr_to_pyobject(bytes);
+    }
+    decoded_to_pyobject(host_ctypes::decode_type_code(tc, bytes))
+}
+
+/// Release the BSTR a slot holds before something else is written over it.
+///
+/// A BSTR is the one value a ctypes buffer owns outright: `SysAllocStringLen`
+/// allocated it, nothing else refers to it, and `X_set` frees the previous
+/// contents on every store.  `addr` is the slot's own address, which is what
+/// every caller has — the object's buffer for a `value` store, that buffer
+/// plus the field offset for a struct or array slot, and the item address for
+/// a pointer store.
+#[cfg(windows)]
+pub(super) fn release_bstr_slot(tc: &str, addr: usize) {
+    if tc != "X" || addr == 0 {
+        return;
+    }
+    let previous = unsafe { (addr as *const usize).read_unaligned() };
+    if previous != 0 {
+        unsafe { windows_sys::Win32::Foundation::SysFreeString(previous as *const u16) };
+    }
+}
+
+#[cfg(not(windows))]
+pub(super) fn release_bstr_slot(_tc: &str, _addr: usize) {}
+
 /// `Py_TYPE(value)->tp_name` — the class an instance reports itself as, which
 /// for an instance-layout object is its `w_class` rather than the layout type
 /// its `ob_type` names.
@@ -1366,6 +1423,36 @@ pub(super) fn encode_value(tc: &str, obj: PyObjectRef) -> Result<Vec<u8>, crate:
                     _ => "cannot be converted to pointer".to_string(),
                 }));
             }
+        }
+        #[cfg(windows)]
+        "X" => {
+            // `X_set` takes a `str` and nothing else — not even the `bytes`
+            // every other pointer code accepts — and allocates the BSTR the
+            // slot will own.  Freeing what the slot held is the caller's,
+            // because only it knows where the slot is.
+            let addr = if unsafe { pyre_object::is_none(obj) } {
+                0
+            } else if unsafe { pyre_object::is_str(obj) } {
+                let units: Vec<u16> = unsafe { pyre_object::w_str_get_wtf8(obj) }
+                    .encode_wide()
+                    .collect();
+                let Ok(len) = u32::try_from(units.len()) else {
+                    return Err(crate::PyError::value_error("String too long for BSTR"));
+                };
+                let bstr = unsafe {
+                    windows_sys::Win32::Foundation::SysAllocStringLen(units.as_ptr(), len)
+                };
+                bstr as usize
+            } else {
+                return Err(crate::PyError::type_error(format!(
+                    "unicode string expected instead of {} instance",
+                    value_type_name(obj)
+                )));
+            };
+            // The host's storage table has no entry for this code and answers
+            // a single zero byte for one it does not know, so the pointer is
+            // written here — `read_pointer_from_buffer` reads it back.
+            return Ok(addr.to_ne_bytes().to_vec());
         }
         "O" => V::ObjectId(obj as usize),
         _ => V::Signed(crate::baseobjspace::int_w(obj)? as i128),

--- a/pyre/pyre-interpreter/src/module/_ctypes/com.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/com.rs
@@ -1,0 +1,271 @@
+//! The COM half of `_CFuncPtr` — a method reached through an interface
+//! pointer's vtable rather than through a symbol.
+//!
+//! Such a method has no address of its own: the constructor is given a vtable
+//! slot number, and the interface pointer the call is made on is what the slot
+//! is read out of, so the first call argument is always that pointer.  When
+//! the constructor was also handed the interface id, a failed status is
+//! reported as a `COMError` carrying whatever the callee's error object says
+//! about it; without one the restype's own `_check_retval_` has the last word.
+
+use super::cdata;
+use pyre_object::PyObjectRef;
+use rustpython_host_env::ctypes as host_ctypes;
+use windows_sys::Win32::System::Com::{CoTaskMemFree, GetErrorInfo, ProgIDFromCLSID};
+
+/// Vtable slots.  Every interface starts with the three `IUnknown` ones, so
+/// the numbering below continues from there for each of the two interfaces an
+/// error is read through.
+const QUERY_INTERFACE: usize = 0;
+const RELEASE: usize = 2;
+/// `ISupportErrorInfo`.
+const INTERFACE_SUPPORTS_ERROR_INFO: usize = 3;
+/// `IErrorInfo`.
+const GET_GUID: usize = 3;
+const GET_SOURCE: usize = 4;
+const GET_DESCRIPTION: usize = 5;
+const GET_HELP_FILE: usize = 6;
+const GET_HELP_CONTEXT: usize = 7;
+
+/// `IID_ISupportErrorInfo` — {DF0B3D60-548F-101B-8E65-08002B2BD119} in the
+/// byte order a `GUID` has in memory.
+static IID_ISUPPORTERRORINFO: [u8; 16] = [
+    0x60, 0x3d, 0x0b, 0xdf, 0x8f, 0x54, 0x1b, 0x10, 0x8e, 0x65, 0x08, 0x00, 0x2b, 0x2b, 0xd1, 0x19,
+];
+
+/// The address in slot `index` of the vtable `this` points at, or 0 when
+/// there is nothing to call there.
+///
+/// A COM method is not an import — there is no name to link against, only a
+/// function pointer the object publishes — so reading the slot and calling it
+/// is the whole calling convention.
+fn slot(this: usize, index: usize) -> usize {
+    match host_ctypes::resolve_com_vtable_entry(this, index) {
+        Ok(entry) => entry.0 as usize,
+        Err(_) => 0,
+    }
+}
+
+/// Call a slot that takes only `this`.  A missing slot answers the failure
+/// every caller here treats as "nothing more to read".
+unsafe fn call1(this: usize, index: usize) -> i32 {
+    let f = slot(this, index);
+    if f == 0 {
+        return -1;
+    }
+    let f: unsafe extern "system" fn(usize) -> i32 = unsafe { std::mem::transmute(f) };
+    unsafe { f(this) }
+}
+
+unsafe fn call2(this: usize, index: usize, a: usize) -> i32 {
+    let f = slot(this, index);
+    if f == 0 {
+        return -1;
+    }
+    let f: unsafe extern "system" fn(usize, usize) -> i32 = unsafe { std::mem::transmute(f) };
+    unsafe { f(this, a) }
+}
+
+unsafe fn call3(this: usize, index: usize, a: usize, b: usize) -> i32 {
+    let f = slot(this, index);
+    if f == 0 {
+        return -1;
+    }
+    let f: unsafe extern "system" fn(usize, usize, usize) -> i32 =
+        unsafe { std::mem::transmute(f) };
+    unsafe { f(this, a, b) }
+}
+
+/// The `this` pointer and the code address a COM method call runs at.
+pub(super) fn call_target(
+    index: i64,
+    inargs: &[PyObjectRef],
+) -> Result<(usize, usize), crate::PyError> {
+    let Some(&this) = inargs.first() else {
+        return Err(crate::PyError::value_error(
+            "native com method call without 'this' parameter",
+        ));
+    };
+    if !cdata::is_cdata_instance(this) {
+        return Err(crate::PyError::type_error(
+            "Expected a COM this pointer as first argument",
+        ));
+    }
+    let this_ptr = host_ctypes::read_pointer_from_buffer(cdata::cdata_bytes(this).unwrap_or(&[]));
+    match host_ctypes::resolve_com_vtable_entry(this_ptr, index.max(0) as usize) {
+        Ok(entry) => Ok((this_ptr, entry.0 as usize)),
+        Err(host_ctypes::ComMethodError::NullComPointer) => {
+            Err(crate::PyError::value_error("NULL COM pointer access"))
+        }
+        Err(host_ctypes::ComMethodError::NullVtablePointer) => Err(crate::PyError::value_error(
+            "COM method call without VTable",
+        )),
+        Err(host_ctypes::ComMethodError::NullFunctionPointer) => {
+            Err(crate::PyError::value_error("NULL function pointer"))
+        }
+    }
+}
+
+/// What the callee's error object says about a failed call.  All-empty when it
+/// has nothing to say, which is also what a callee that carries no error
+/// object at all leaves behind.
+struct ErrorInfo {
+    guid: [u8; 16],
+    description: usize,
+    source: usize,
+    help_file: usize,
+    help_context: u32,
+}
+
+impl Drop for ErrorInfo {
+    fn drop(&mut self) {
+        for bstr in [self.description, self.source, self.help_file] {
+            if bstr != 0 {
+                unsafe { windows_sys::Win32::Foundation::SysFreeString(bstr as *const u16) };
+            }
+        }
+    }
+}
+
+/// An object only carries error info when it answers to `ISupportErrorInfo`
+/// for the very interface the failed call was made on, so both that question
+/// and the interface's own answer come before anything is read.
+fn collect_error_info(this: usize, iid: usize) -> ErrorInfo {
+    let mut info = ErrorInfo {
+        guid: [0; 16],
+        description: 0,
+        source: 0,
+        help_file: 0,
+        help_context: 0,
+    };
+    unsafe {
+        let mut psei = 0usize;
+        if call3(
+            this,
+            QUERY_INTERFACE,
+            IID_ISUPPORTERRORINFO.as_ptr() as usize,
+            std::ptr::addr_of_mut!(psei) as usize,
+        ) < 0
+        {
+            return info;
+        }
+        let supports = call2(psei, INTERFACE_SUPPORTS_ERROR_INFO, iid);
+        call1(psei, RELEASE);
+        if supports < 0 {
+            return info;
+        }
+        let mut pei = std::ptr::null_mut();
+        // `S_FALSE` means the thread has no error object, and only `S_OK` says
+        // one came back.
+        if GetErrorInfo(0, &mut pei) != 0 {
+            return info;
+        }
+        let pei = pei as usize;
+        call2(
+            pei,
+            GET_DESCRIPTION,
+            std::ptr::addr_of_mut!(info.description) as usize,
+        );
+        call2(pei, GET_GUID, info.guid.as_mut_ptr() as usize);
+        call2(
+            pei,
+            GET_HELP_CONTEXT,
+            std::ptr::addr_of_mut!(info.help_context) as usize,
+        );
+        call2(
+            pei,
+            GET_HELP_FILE,
+            std::ptr::addr_of_mut!(info.help_file) as usize,
+        );
+        call2(
+            pei,
+            GET_SOURCE,
+            std::ptr::addr_of_mut!(info.source) as usize,
+        );
+        call1(pei, RELEASE);
+    }
+    info
+}
+
+/// The `str` a BSTR holds, or `None` for a null one.
+fn bstr_str(bstr: usize) -> PyObjectRef {
+    if bstr == 0 {
+        return pyre_object::w_none();
+    }
+    cdata::bstr_to_pyobject(&bstr.to_ne_bytes())
+}
+
+/// The ProgID `guid` is registered under, or `None` when it is registered
+/// under none — which is also what a guid nobody filled in answers.
+fn prog_id(guid: &[u8; 16]) -> PyObjectRef {
+    let mut progid = std::ptr::null_mut();
+    if unsafe { ProgIDFromCLSID(guid.as_ptr() as *const _, &mut progid) } != 0 || progid.is_null() {
+        return pyre_object::w_none();
+    }
+    let mut len = 0;
+    while unsafe { *progid.add(len) } != 0 {
+        len += 1;
+    }
+    let value = pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
+        std::slice::from_raw_parts(progid, len)
+    }));
+    unsafe { CoTaskMemFree(progid as *const _) };
+    value
+}
+
+/// `GetComError` — the `COMError` a failed COM method call raises.
+pub(super) fn error(hresult: i32, iid: usize, this: usize) -> crate::PyError {
+    // Every read below is a COM method call, and a COM method call must not
+    // hold the interpreter: the callee is free to wait on another thread.
+    let info = {
+        let _blocked = crate::module::thread::before_external_block();
+        collect_error_info(this, iid)
+    };
+    // Each value allocates, so each is pinned as it is built rather than
+    // gathered into a list the next allocation could strand.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let details_base = pyre_object::gc_roots::shadow_stack_len();
+    for bstr in [info.description, info.source, info.help_file] {
+        pyre_object::gc_roots::pin_root(bstr_str(bstr));
+    }
+    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(info.help_context as i64));
+    pyre_object::gc_roots::pin_root(prog_id(&info.guid));
+    let details = pyre_object::w_tuple_new(
+        (0..5)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(details_base + i))
+            .collect(),
+    );
+    let details_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(details);
+    let text = match host_ctypes::format_error_message(Some(hresult as u32)) {
+        Some(message) => pyre_object::w_str_new(&message),
+        None => pyre_object::w_none(),
+    };
+    let text_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(text);
+    let hresult_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_int_new(hresult as i64));
+    // Without the class there is nothing to raise but the report the id-less
+    // form would have given, which is the same status by another name.
+    let win32_error = || {
+        crate::PyError::os_error_win32_syscall2(hresult, pyre_object::PY_NULL, pyre_object::PY_NULL)
+    };
+    let Some(cls) = super::interp_ctypes::comerror_type() else {
+        return win32_error();
+    };
+    let args = [
+        pyre_object::gc_roots::shadow_stack_get(hresult_slot),
+        pyre_object::gc_roots::shadow_stack_get(text_slot),
+        pyre_object::gc_roots::shadow_stack_get(details_slot),
+    ];
+    match crate::call::type_call_instantiate(cls, &args) {
+        Ok(instance) => {
+            let instance_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(instance);
+            let mut error = win32_error();
+            error.exc_object = pyre_object::gc_roots::shadow_stack_get(instance_slot);
+            error
+        }
+        Err(error) => error,
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -34,6 +34,7 @@ const PTR_KEY: &str = "_ptr";
 const RESTYPE_KEY: &str = "_restype";
 const ARGTYPES_KEY: &str = "_argtypes";
 pub(super) const CALLABLE_KEY: &str = "_callable";
+const ERRCHECK_KEY: &str = "_errcheck";
 const INTERNAL_CAST_ADDR: usize = 1;
 const INTERNAL_STRING_AT_ADDR: usize = 2;
 const INTERNAL_WSTRING_AT_ADDR: usize = 3;
@@ -85,6 +86,16 @@ fn init_cfuncptr_type(ns: PyObjectRef) {
             crate::make_builtin_function_with_arity("argtypes", argtypes_setter, 3),
             pyre_object::PY_NULL,
             "argtypes",
+        ),
+    );
+    type_ns_store(
+        ns,
+        "errcheck",
+        crate::typedef::make_getset_property_named(
+            crate::make_builtin_function_with_arity("errcheck", errcheck_getter, 2),
+            crate::make_builtin_function_with_arity("errcheck", errcheck_setter, 3),
+            crate::make_builtin_function_with_arity("errcheck", errcheck_deleter, 2),
+            "errcheck",
         ),
     );
 }
@@ -300,6 +311,33 @@ fn argtypes_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     Ok(pyre_object::w_none())
 }
 
+fn errcheck_getter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(instance_get(args[1], ERRCHECK_KEY).unwrap_or_else(pyre_object::w_none))
+}
+
+/// The only thing ever done with an errcheck is calling it, so anything that
+/// cannot be called is refused — `None` included, which is why clearing one is
+/// spelled `del`.
+fn errcheck_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let value = args[2];
+    if !crate::baseobjspace::callable_w(value) {
+        return Err(crate::PyError::type_error(
+            "the errcheck attribute must be callable",
+        ));
+    }
+    instance_set(args[1], ERRCHECK_KEY, value);
+    Ok(pyre_object::w_none())
+}
+
+fn errcheck_deleter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let d = crate::baseobjspace::getdict_native(args[1]);
+    if !d.is_null() {
+        // Deleting one that was never set is not an error.
+        unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(d, ERRCHECK_KEY) };
+    }
+    Ok(pyre_object::w_none())
+}
+
 /// Reject keyword arguments: ctypes foreign calls and `_CFuncPtr(...)` take
 /// only positional arguments, so a stray `fn(x, foo=1)` is an error rather
 /// than a silently dropped `foo`.
@@ -355,6 +393,60 @@ pub(super) fn resolve_restype(obj: PyObjectRef) -> Result<Ret, crate::PyError> {
             Ok(Ret::Code(tc))
         }
     }
+}
+
+/// `restype._check_retval_` — the callable a return value passes through
+/// before the caller sees it.  `HRESULT` declares one so that a failed status
+/// raises `OSError` rather than being handed back as a negative number.
+fn resolve_checker(obj: PyObjectRef) -> Option<PyObjectRef> {
+    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
+    let rt = instance_get(obj, RESTYPE_KEY)
+        .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_restype_") })?;
+    if !unsafe { pyre_object::is_type(rt) } {
+        return None;
+    }
+    unsafe { crate::baseobjspace::lookup_in_type(rt, "_check_retval_") }
+}
+
+/// `errcheck(result, self, arguments)` — the last word on what a call returns.
+/// Handing back the argument tuple unchanged means "nothing to say"; anything
+/// else replaces the result.
+fn apply_errcheck(
+    self_obj: PyObjectRef,
+    result: PyObjectRef,
+    inargs: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let Some(errcheck) = instance_get(self_obj, ERRCHECK_KEY) else {
+        return Ok(result);
+    };
+    // Building the argument tuple allocates, so the three values the call still
+    // needs are read back out of root slots afterwards.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    for value in [self_obj, result, errcheck] {
+        pyre_object::gc_roots::pin_root(value);
+    }
+    let arguments = pyre_object::w_tuple_new(inargs.to_vec());
+    let arguments_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(arguments);
+    let value = crate::call::call_function_impl_result(
+        pyre_object::gc_roots::shadow_stack_get(base + 2),
+        &[
+            pyre_object::gc_roots::shadow_stack_get(base + 1),
+            pyre_object::gc_roots::shadow_stack_get(base),
+            pyre_object::gc_roots::shadow_stack_get(arguments_slot),
+        ],
+    )?;
+    Ok(
+        if std::ptr::eq(
+            value,
+            pyre_object::gc_roots::shadow_stack_get(arguments_slot),
+        ) {
+            pyre_object::gc_roots::shadow_stack_get(base + 1)
+        } else {
+            value
+        },
+    )
 }
 
 /// Wrap a returned pointer value `p` in a fresh instance of pointer type `rt`.
@@ -653,6 +745,19 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `owned` / `keepalive` must outlive the call above.
     drop(keepalive);
     let result = result?.map_err(call_error)?;
+    let value = build_return_value(ret, result)?;
+    let value = match resolve_checker(self_obj) {
+        Some(checker) => crate::call::call_function_impl_result(checker, &[value])?,
+        None => value,
+    };
+    apply_errcheck(self_obj, value, call_args)
+}
+
+/// The Python value a returned `CallValue` becomes under return type `ret`.
+fn build_return_value(
+    ret: Ret,
+    result: host_ctypes::CallValue,
+) -> Result<PyObjectRef, crate::PyError> {
     match ret {
         Ret::Pointer(rt) => {
             let p = match result {

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -40,6 +40,8 @@ const INTERNAL_WSTRING_AT_ADDR: usize = 3;
 const INTERNAL_MEMORYVIEW_AT_ADDR: usize = 4;
 const INTERNAL_PYBYTES_FROMSTRINGANDSIZE: usize = 5;
 const INTERNAL_PYOS_SNPRINTF: usize = 6;
+#[cfg(windows)]
+const INTERNAL_PYERR_SETFROMWINDOWSERR: usize = 7;
 
 static CFUNCPTR_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
@@ -162,6 +164,38 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot))
 }
 
+/// The borrow a marshalled argument is handed to the call as; the borrow ends
+/// with the call, and `owned` outlives it.
+fn owned_arg_as_call_arg(arg: &OwnedArg) -> host_ctypes::CallArg<'_> {
+    match arg {
+        OwnedArg::Typed(code, buf) => host_ctypes::CallArg::Typed {
+            code: code.as_str(),
+            buffer: buf.as_slice(),
+        },
+        OwnedArg::Int(v) => host_ctypes::CallArg::Int(*v),
+        OwnedArg::Double(v) => host_ctypes::CallArg::Double(*v),
+        OwnedArg::Pointer(v) => host_ctypes::CallArg::Pointer(*v),
+        OwnedArg::Aggregate(layout, buf) => host_ctypes::CallArg::Aggregate {
+            layout,
+            buffer: buf.as_slice(),
+        },
+    }
+}
+
+fn call_error(e: host_ctypes::CallError) -> crate::PyError {
+    match e {
+        host_ctypes::CallError::NullFunctionPointer => {
+            crate::PyError::value_error("NULL function pointer")
+        }
+        host_ctypes::CallError::UnknownTypeCode(c) => {
+            crate::PyError::type_error(format!("unsupported type code {c:?}"))
+        }
+        host_ctypes::CallError::BufferTooSmall { expected, got } => crate::PyError::value_error(
+            format!("aggregate argument buffer too small: expected {expected}, got {got}"),
+        ),
+    }
+}
+
 /// `(name, dll)` → resolved symbol address.  `dll._handle` is the integer
 /// library handle; `name` is the symbol string/bytes.
 fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
@@ -188,6 +222,8 @@ fn resolve_from_tuple(t: PyObjectRef) -> Result<usize, crate::PyError> {
     match name_bytes.as_slice() {
         b"PyBytes_FromStringAndSize" => return Ok(INTERNAL_PYBYTES_FROMSTRINGANDSIZE),
         b"PyOS_snprintf" => return Ok(INTERNAL_PYOS_SNPRINTF),
+        #[cfg(windows)]
+        b"PyErr_SetFromWindowsErr" => return Ok(INTERNAL_PYERR_SETFROMWINDOWSERR),
         _ => {}
     }
     super::interp_ctypes::lookup_symbol(handle, &name_bytes).map_err(|e| {
@@ -542,6 +578,10 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         INTERNAL_MEMORYVIEW_AT_ADDR => return internal_memoryview_at(call_args),
         INTERNAL_PYBYTES_FROMSTRINGANDSIZE => return internal_pybytes_fromstringandsize(call_args),
         INTERNAL_PYOS_SNPRINTF => return internal_pyos_snprintf(call_args),
+        #[cfg(windows)]
+        INTERNAL_PYERR_SETFROMWINDOWSERR => {
+            return internal_pyerr_setfromwindowserr(call_args);
+        }
         _ => {}
     }
 
@@ -592,22 +632,7 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
 
     // Borrow the owned data as `CallArg`s; these borrows end with the call.
-    let host_args: Vec<host_ctypes::CallArg> = owned
-        .iter()
-        .map(|o| match o {
-            OwnedArg::Typed(code, buf) => host_ctypes::CallArg::Typed {
-                code: code.as_str(),
-                buffer: buf.as_slice(),
-            },
-            OwnedArg::Int(v) => host_ctypes::CallArg::Int(*v),
-            OwnedArg::Double(v) => host_ctypes::CallArg::Double(*v),
-            OwnedArg::Pointer(v) => host_ctypes::CallArg::Pointer(*v),
-            OwnedArg::Aggregate(layout, buf) => host_ctypes::CallArg::Aggregate {
-                layout,
-                buffer: buf.as_slice(),
-            },
-        })
-        .collect();
+    let host_args: Vec<host_ctypes::CallArg> = owned.iter().map(owned_arg_as_call_arg).collect();
 
     let addr = funcptr_addr(self_obj);
     let flags = funcptr_flags(self_obj);
@@ -627,18 +652,7 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     };
     // `owned` / `keepalive` must outlive the call above.
     drop(keepalive);
-    let result = result?.map_err(|e| match e {
-        host_ctypes::CallError::NullFunctionPointer => {
-            crate::PyError::value_error("NULL function pointer")
-        }
-        host_ctypes::CallError::UnknownTypeCode(c) => {
-            crate::PyError::type_error(format!("unsupported type code {c:?}"))
-        }
-        host_ctypes::CallError::BufferTooSmall { expected, got } => crate::PyError::value_error(
-            format!("aggregate argument buffer too small: expected {expected}, got {got}"),
-        ),
-    });
-    let result = result?;
+    let result = result?.map_err(call_error)?;
     match ret {
         Ret::Pointer(rt) => {
             let p = match result {
@@ -834,6 +848,71 @@ fn internal_pybytes_fromstringandsize(args: &[PyObjectRef]) -> Result<PyObjectRe
     Ok(pyre_object::bytesobject::w_bytes_from_bytes(
         &bytes[..size.min(bytes.len())],
     ))
+}
+
+/// `PyErr_SetFromWindowsErr(ierr)` — raise the OSError a Win32 error code
+/// names, or the one `GetLastError()` names when the code is 0.  The parameter
+/// is a C `int`, so a code with the top bit set arrives as the negative number
+/// `.winerror` reports; a code the system has no message for is spelled
+/// `Windows Error 0x<code>`, which is what `test_windows_message` reads.
+#[cfg(windows)]
+fn internal_pyerr_setfromwindowserr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let code = match args.first() {
+        Some(&arg) => crate::baseobjspace::int_w(arg)? as i32,
+        None => std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
+    };
+    Err(crate::PyError::os_error_win32_syscall2(
+        code,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+    ))
+}
+
+/// `_ctypes.call_function(address, args)` — call an address that carries no
+/// argtypes, no restype and no flags, so every argument converts by the
+/// default rules and the result is read as a C `int`.  `call_cdeclfunction` is
+/// the same call under `FUNCFLAG_CDECL`, which on this architecture is the
+/// only calling convention there is.
+pub(super) fn call_function(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let (Some(&addr), Some(&arguments)) = (args.first(), args.get(1)) else {
+        return Err(crate::PyError::type_error(
+            "call_function() takes exactly 2 arguments",
+        ));
+    };
+    if !unsafe { pyre_object::is_tuple(arguments) } {
+        return Err(crate::PyError::type_error(format!(
+            "argument 2 must be tuple, not {}",
+            cdata::value_type_name(arguments)
+        )));
+    }
+    let addr = cdata::pointer_word(addr)?;
+    let mut keepalive: Vec<Vec<u8>> = Vec::new();
+    let owned = seq_to_vec(arguments)
+        .expect("a tuple")
+        .into_iter()
+        .map(|arg| marshal_default_arg(arg, &mut keepalive))
+        .collect::<Result<Vec<_>, _>>()?;
+    let host_args: Vec<host_ctypes::CallArg> = owned.iter().map(owned_arg_as_call_arg).collect();
+    let result = {
+        let _blocked = crate::module::thread::before_external_block();
+        super::seh::guard(|| {
+            host_ctypes::call(
+                addr,
+                &host_args,
+                host_ctypes::CallRet::Code("i"),
+                host_ctypes::CallOptions::default(),
+            )
+        })
+    };
+    drop(keepalive);
+    let bytes = match result?.map_err(call_error)? {
+        host_ctypes::CallValue::Scalar(b) => b,
+        host_ctypes::CallValue::Pointer(p) => p.to_ne_bytes().to_vec(),
+        _ => Vec::new(),
+    };
+    Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
+        "i", &bytes,
+    )))
 }
 
 fn internal_pyos_snprintf(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -35,6 +35,20 @@ const RESTYPE_KEY: &str = "_restype";
 const ARGTYPES_KEY: &str = "_argtypes";
 pub(super) const CALLABLE_KEY: &str = "_callable";
 const ERRCHECK_KEY: &str = "_errcheck";
+const PARAMFLAGS_KEY: &str = "_paramflags";
+#[cfg(windows)]
+const INDEX_KEY: &str = "_index";
+#[cfg(windows)]
+const IID_KEY: &str = "_iid";
+
+/// `paramflags` direction bits: an argument the caller supplies, one the callee
+/// writes through, and the locale id that always comes from the default.
+const PARAMFLAG_FIN: i64 = 0x1;
+const PARAMFLAG_FOUT: i64 = 0x2;
+const PARAMFLAG_FLCID: i64 = 0x4;
+const PARAMFLAG_DIRECTION: i64 = PARAMFLAG_FIN | PARAMFLAG_FOUT | PARAMFLAG_FLCID;
+const PARAMFLAG_FIN_FLCID: i64 = PARAMFLAG_FIN | PARAMFLAG_FLCID;
+const PARAMFLAG_FIN_FOUT: i64 = PARAMFLAG_FIN | PARAMFLAG_FOUT;
 const INTERNAL_CAST_ADDR: usize = 1;
 const INTERNAL_STRING_AT_ADDR: usize = 2;
 const INTERNAL_WSTRING_AT_ADDR: usize = 3;
@@ -98,6 +112,51 @@ fn init_cfuncptr_type(ns: PyObjectRef) {
             "errcheck",
         ),
     );
+    type_ns_store(
+        ns,
+        "__repr__",
+        crate::make_builtin_function("__repr__", cfuncptr_repr),
+    );
+    type_ns_store(
+        ns,
+        "__bool__",
+        crate::make_builtin_function("__bool__", cfuncptr_bool),
+    );
+}
+
+/// A COM method says which vtable slot it is; everything else reports the
+/// default `<T object at 0x...>`.
+fn cfuncptr_repr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[0];
+    let name = cdata::value_type_name(obj);
+    let address = crate::display::repr_addr(obj as usize);
+    #[cfg(windows)]
+    if let Some(index) = com_index(obj) {
+        return Ok(pyre_object::w_str_new(&format!(
+            "<COM method offset {index}: {name} at {address}>"
+        )));
+    }
+    Ok(pyre_object::w_str_new(&format!(
+        "<{name} object at {address}>"
+    )))
+}
+
+/// A COM method is true whether or not it holds an address, because the vtable
+/// slot it names is all it ever needed.
+fn cfuncptr_bool(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let obj = args[0];
+    #[cfg(windows)]
+    if com_index(obj).is_some() {
+        return Ok(pyre_object::w_bool_from(true));
+    }
+    Ok(pyre_object::w_bool_from(funcptr_addr(obj) != 0))
+}
+
+/// The vtable slot a COM method lives in, or `None` for an ordinary function.
+#[cfg(windows)]
+fn com_index(obj: PyObjectRef) -> Option<i64> {
+    let index = instance_get(obj, INDEX_KEY)?;
+    Some(unsafe { pyre_object::w_int_get_value(index) } - 0x1000)
 }
 
 // ── construction ──────────────────────────────────────────────────────
@@ -116,20 +175,40 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (pos, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     reject_kwargs(kwargs)?;
     let mut callback = pyre_object::PY_NULL;
-    let addr: usize = match pos.last().copied() {
+    let mut paramflags = pyre_object::PY_NULL;
+    #[cfg(windows)]
+    let mut com_index: Option<i64> = None;
+    #[cfg(windows)]
+    let mut com_iid = pyre_object::PY_NULL;
+    let addr: usize = match pos.first().copied() {
         None => 0,
+        // `(name, dll)`, with paramflags allowed after it.
+        Some(a) if unsafe { pyre_object::is_tuple(a) } => {
+            paramflags = pos.get(1).copied().unwrap_or(pyre_object::PY_NULL);
+            resolve_from_tuple(a)?
+        }
+        // `index, name` — a COM method, with paramflags and then the interface
+        // id allowed after it.  It has no address: the vtable of whatever
+        // interface pointer the call is made on is where the method lives.
+        #[cfg(windows)]
+        Some(a) if pos.len() >= 2 && unsafe { pyre_object::is_int(a) } => {
+            if !unsafe { pyre_object::is_str(pos[1]) } {
+                return Err(crate::PyError::type_error(format!(
+                    "argument 2 must be str, not {}",
+                    cdata::value_type_name(pos[1])
+                )));
+            }
+            com_index = Some(unsafe { pyre_object::w_int_get_value(a) });
+            paramflags = pos.get(2).copied().unwrap_or(pyre_object::PY_NULL);
+            com_iid = pos.get(3).copied().unwrap_or(pyre_object::PY_NULL);
+            0
+        }
         Some(a) if unsafe { pyre_object::is_none(a) } => 0,
         Some(a) if unsafe { pyre_object::is_int(a) } => {
             (unsafe { pyre_object::w_int_get_value(a) }) as usize
         }
-        Some(a) if unsafe { pyre_object::is_tuple(a) } => resolve_from_tuple(a)?,
         Some(a) => {
-            let callable = unsafe { crate::function::is_function(a) }
-                || crate::typedef::r#type(a).is_some_and(|ty| {
-                    unsafe { crate::baseobjspace::lookup_in_type(ty.as_ptr(), "__call__") }
-                        .is_some()
-                });
-            if !callable {
+            if !crate::baseobjspace::callable_w(a) {
                 return Err(crate::PyError::type_error(
                     "argument must be callable or integer function address",
                 ));
@@ -138,12 +217,30 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             0
         }
     };
+    let paramflags = validate_paramflags(
+        paramflags,
+        type_argtypes(pyre_object::gc_roots::shadow_stack_get(cls_slot)).as_deref(),
+    )?;
     let callback_slot = if callback.is_null() {
         None
     } else {
         let slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(callback);
         Some(slot)
+    };
+    // Building the instance allocates, so what gets stored on it is read back
+    // out of a root slot once it exists.
+    let paramflags_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(paramflags);
+    #[cfg(windows)]
+    let iid_slot = {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(if com_iid.is_null() {
+            pyre_object::w_none()
+        } else {
+            com_iid
+        });
+        slot
     };
     let obj = cdata::new_cdata_obj_from_bytes(
         pyre_object::gc_roots::shadow_stack_get(cls_slot),
@@ -170,6 +267,31 @@ fn cfuncptr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             super::callbacks::build_thunk(pyre_object::gc_roots::shadow_stack_get(obj_slot))?
         {
             store_funcptr_addr(pyre_object::gc_roots::shadow_stack_get(obj_slot), code)?;
+        }
+    }
+    let paramflags = pyre_object::gc_roots::shadow_stack_get(paramflags_slot);
+    if !unsafe { pyre_object::is_none(paramflags) } {
+        instance_set(
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            PARAMFLAGS_KEY,
+            paramflags,
+        );
+    }
+    #[cfg(windows)]
+    if let Some(index) = com_index {
+        let index = pyre_object::w_int_new(index + 0x1000);
+        instance_set(
+            pyre_object::gc_roots::shadow_stack_get(obj_slot),
+            INDEX_KEY,
+            index,
+        );
+        let iid = pyre_object::gc_roots::shadow_stack_get(iid_slot);
+        if !unsafe { pyre_object::is_none(iid) } {
+            instance_set(
+                pyre_object::gc_roots::shadow_stack_get(obj_slot),
+                IID_KEY,
+                iid,
+            );
         }
     }
     Ok(pyre_object::gc_roots::shadow_stack_get(obj_slot))
@@ -307,6 +429,11 @@ fn argtypes_setter(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             "argtypes must be a sequence of types",
         ));
     }
+    // Paramflags describe the argtypes one for one, so replacing the argtypes
+    // has to leave that description true.
+    if let Some(paramflags) = instance_get(args[1], PARAMFLAGS_KEY) {
+        validate_paramflags(paramflags, argtypes_seq(value).as_deref())?;
+    }
     instance_set(args[1], ARGTYPES_KEY, value);
     Ok(pyre_object::w_none())
 }
@@ -409,15 +536,16 @@ fn resolve_checker(obj: PyObjectRef) -> Option<PyObjectRef> {
 }
 
 /// `errcheck(result, self, arguments)` — the last word on what a call returns.
-/// Handing back the argument tuple unchanged means "nothing to say"; anything
-/// else replaces the result.
+/// Handing back the argument tuple unchanged means "nothing to say", which is
+/// `None` here; anything else replaces the result outright, `out` parameters
+/// included.
 fn apply_errcheck(
     self_obj: PyObjectRef,
     result: PyObjectRef,
     inargs: &[PyObjectRef],
-) -> Result<PyObjectRef, crate::PyError> {
+) -> Result<Option<PyObjectRef>, crate::PyError> {
     let Some(errcheck) = instance_get(self_obj, ERRCHECK_KEY) else {
-        return Ok(result);
+        return Ok(None);
     };
     // Building the argument tuple allocates, so the three values the call still
     // needs are read back out of root slots afterwards.
@@ -437,16 +565,11 @@ fn apply_errcheck(
             pyre_object::gc_roots::shadow_stack_get(arguments_slot),
         ],
     )?;
-    Ok(
-        if std::ptr::eq(
-            value,
-            pyre_object::gc_roots::shadow_stack_get(arguments_slot),
-        ) {
-            pyre_object::gc_roots::shadow_stack_get(base + 1)
-        } else {
-            value
-        },
-    )
+    Ok((!std::ptr::eq(
+        value,
+        pyre_object::gc_roots::shadow_stack_get(arguments_slot),
+    ))
+    .then_some(value))
 }
 
 /// Wrap a returned pointer value `p` in a fresh instance of pointer type `rt`.
@@ -485,13 +608,119 @@ fn wrap_pointer_result(rt: PyObjectRef, p: usize) -> Result<PyObjectRef, crate::
 /// The `_argtypes_` sequence as a Vec, or `None` when unset (ConvParam
 /// defaults apply).
 pub(super) fn resolve_argtypes(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
-    let cls = unsafe { pyre_object::w_instance_get_type(obj) };
-    let at = instance_get(obj, ARGTYPES_KEY)
-        .or_else(|| unsafe { crate::baseobjspace::lookup_in_type(cls, "_argtypes_") })?;
+    match instance_get(obj, ARGTYPES_KEY) {
+        Some(at) => argtypes_seq(at),
+        None => type_argtypes(unsafe { pyre_object::w_instance_get_type(obj) }),
+    }
+}
+
+/// The `_argtypes_` declared on type `cls` — what a constructor has to check
+/// paramflags against, the instance having none of its own yet.
+fn type_argtypes(cls: PyObjectRef) -> Option<Vec<PyObjectRef>> {
+    argtypes_seq(unsafe { crate::baseobjspace::lookup_in_type(cls, "_argtypes_") }?)
+}
+
+/// A settled `argtypes` value as a Vec; `None` means unset.
+fn argtypes_seq(at: PyObjectRef) -> Option<Vec<PyObjectRef>> {
     if unsafe { pyre_object::is_none(at) } {
         return None;
     }
     seq_to_vec(at)
+}
+
+/// The name a type reports, for a message about the type itself rather than
+/// about a value of it.
+fn type_display_name(obj: PyObjectRef) -> String {
+    if unsafe { pyre_object::is_type(obj) } {
+        return unsafe { pyre_object::w_type_get_name(obj) }.to_string();
+    }
+    cdata::value_type_name(obj)
+}
+
+/// `_check_outarg_type` — the callee writes an `out` parameter through the
+/// argument, so the argtype has to be something there is a through: a pointer
+/// or array type, or one of the simple codes that is already an address.
+fn check_outarg_type(at: PyObjectRef, index: usize) -> Result<(), crate::PyError> {
+    if let Some(info) = stginfo::stginfo_of(at)
+        && matches!(
+            stginfo::stginfo_paramfunc(info).as_str(),
+            "pointer" | "array"
+        )
+    {
+        return Ok(());
+    }
+    if matches!(cdata::type_code_of(at).as_deref(), Some("P" | "z" | "Z")) {
+        return Ok(());
+    }
+    Err(crate::PyError::type_error(format!(
+        "'out' parameter {index} must be a pointer type, not {}",
+        type_display_name(at)
+    )))
+}
+
+/// `_validate_paramflags` — one paramflag per argtype, each an
+/// `(int [,string [,value]])` tuple naming a direction that is actually
+/// implemented.  Returns the tuple to store, or `None` for "no paramflags",
+/// which is also what an absent `_argtypes_` leaves the check with nothing to
+/// say about.
+fn validate_paramflags(
+    paramflags: PyObjectRef,
+    argtypes: Option<&[PyObjectRef]>,
+) -> Result<PyObjectRef, crate::PyError> {
+    if paramflags.is_null() || unsafe { pyre_object::is_none(paramflags) } {
+        return Ok(pyre_object::w_none());
+    }
+    if !unsafe { pyre_object::is_tuple(paramflags) } {
+        return Err(crate::PyError::type_error(
+            "paramflags must be a tuple or None",
+        ));
+    }
+    let Some(argtypes) = argtypes else {
+        return Ok(paramflags);
+    };
+    let len = unsafe { pyre_object::w_tuple_len(paramflags) };
+    if len != argtypes.len() {
+        return Err(crate::PyError::value_error(
+            "paramflags must have the same length as argtypes",
+        ));
+    }
+    let malformed = || {
+        crate::PyError::type_error(
+            "paramflags must be a sequence of (int [,string [,value]]) tuples",
+        )
+    };
+    for (i, &at) in argtypes.iter().enumerate() {
+        let item =
+            unsafe { pyre_object::w_tuple_getitem(paramflags, i as i64) }.ok_or_else(malformed)?;
+        if !unsafe { pyre_object::is_tuple(item) } {
+            return Err(malformed());
+        }
+        let item_len = unsafe { pyre_object::w_tuple_len(item) };
+        if !(1..=3).contains(&item_len) {
+            return Err(malformed());
+        }
+        let flag = unsafe { pyre_object::w_tuple_getitem(item, 0) }.ok_or_else(malformed)?;
+        if !unsafe { pyre_object::is_int(flag) } {
+            return Err(malformed());
+        }
+        if item_len > 1 {
+            let name = unsafe { pyre_object::w_tuple_getitem(item, 1) }.ok_or_else(malformed)?;
+            if !unsafe { pyre_object::is_none(name) } && !unsafe { pyre_object::is_str(name) } {
+                return Err(malformed());
+            }
+        }
+        let flag = unsafe { pyre_object::w_int_get_value(flag) };
+        match flag & PARAMFLAG_DIRECTION {
+            PARAMFLAG_FOUT => check_outarg_type(at, i + 1)?,
+            0 | PARAMFLAG_FIN | PARAMFLAG_FIN_FLCID | PARAMFLAG_FIN_FOUT => {}
+            _ => {
+                return Err(crate::PyError::type_error(format!(
+                    "paramflag value {flag} not supported"
+                )));
+            }
+        }
+    }
+    Ok(paramflags)
 }
 
 fn seq_to_vec(obj: PyObjectRef) -> Option<Vec<PyObjectRef>> {
@@ -656,32 +885,51 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         return Err(crate::PyError::type_error("__call__ requires self"));
     }
     let self_obj = args[0];
-    let (call_args, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
-    reject_kwargs(kwargs)?;
+    // A keyword argument only ever names a paramflag, and one that names
+    // nothing is not an error — it simply goes unread.
+    let (inargs, kwargs) = crate::builtins::split_builtin_kwargs(&args[1..]);
     if funcptr_addr(self_obj) == 0 && instance_get(self_obj, CALLABLE_KEY).is_some() {
-        return call_python_callback(self_obj, call_args);
+        return call_python_callback(self_obj, inargs);
     }
     match funcptr_addr(self_obj) {
-        INTERNAL_CAST_ADDR => return internal_cast(call_args),
-        INTERNAL_STRING_AT_ADDR => return internal_string_at(call_args),
-        INTERNAL_WSTRING_AT_ADDR => return internal_wstring_at(call_args),
-        INTERNAL_MEMORYVIEW_AT_ADDR => return internal_memoryview_at(call_args),
-        INTERNAL_PYBYTES_FROMSTRINGANDSIZE => return internal_pybytes_fromstringandsize(call_args),
-        INTERNAL_PYOS_SNPRINTF => return internal_pyos_snprintf(call_args),
+        INTERNAL_CAST_ADDR => return internal_cast(inargs),
+        INTERNAL_STRING_AT_ADDR => return internal_string_at(inargs),
+        INTERNAL_WSTRING_AT_ADDR => return internal_wstring_at(inargs),
+        INTERNAL_MEMORYVIEW_AT_ADDR => return internal_memoryview_at(inargs),
+        INTERNAL_PYBYTES_FROMSTRINGANDSIZE => return internal_pybytes_fromstringandsize(inargs),
+        INTERNAL_PYOS_SNPRINTF => return internal_pyos_snprintf(inargs),
         #[cfg(windows)]
         INTERNAL_PYERR_SETFROMWINDOWSERR => {
-            return internal_pyerr_setfromwindowserr(call_args);
+            return internal_pyerr_setfromwindowserr(inargs);
         }
         _ => {}
     }
 
+    // A COM method has no address of its own: the interface pointer passed as
+    // the first argument is what its vtable is read out of, and that pointer
+    // then leads the call.
+    #[cfg(windows)]
+    let com = match com_index(self_obj) {
+        Some(index) => Some(super::com::call_target(index, inargs)?),
+        None => None,
+    };
+    #[cfg(not(windows))]
+    let com: Option<(usize, usize)> = None;
+
+    let argtypes = resolve_argtypes(self_obj);
+    let callargs = build_callargs(self_obj, argtypes.as_deref(), inargs, kwargs, com.is_some())?;
+    let call_args = callargs.args.as_slice();
+
     // Marshal arguments into owned scalar data.  `keepalive` owns any
     // null-terminated `bytes` copies that pointer args address; `owned` owns
     // the typed buffers.  Both must outlive the borrowed `SimpleArg`s below.
-    let mut owned: Vec<OwnedArg> = Vec::with_capacity(call_args.len());
+    let mut owned: Vec<OwnedArg> = Vec::with_capacity(call_args.len() + 1);
     let mut keepalive: Vec<Vec<u8>> = Vec::new();
+    if let Some((this_ptr, _)) = com {
+        owned.push(OwnedArg::Pointer(this_ptr));
+    }
 
-    match resolve_argtypes(self_obj) {
+    match argtypes {
         Some(argtypes) => {
             for (i, at) in argtypes.iter().enumerate() {
                 let arg = *call_args.get(i).ok_or_else(|| {
@@ -724,7 +972,10 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // Borrow the owned data as `CallArg`s; these borrows end with the call.
     let host_args: Vec<host_ctypes::CallArg> = owned.iter().map(owned_arg_as_call_arg).collect();
 
-    let addr = funcptr_addr(self_obj);
+    let addr = match com {
+        Some((_, method)) => method,
+        None => funcptr_addr(self_obj),
+    };
     let flags = funcptr_flags(self_obj);
     let options = host_ctypes::CallOptions {
         use_errno: flags & FUNCFLAG_USE_ERRNO != 0,
@@ -743,12 +994,239 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `owned` / `keepalive` must outlive the call above.
     drop(keepalive);
     let result = result?.map_err(call_error)?;
-    let value = build_return_value(ret, result)?;
-    let value = match resolve_checker(self_obj) {
-        Some(checker) => crate::call::call_function_impl_result(checker, &[value])?,
-        None => value,
+    // A COM method constructed with an interface id answers the plain status,
+    // and asks the callee what went wrong when that status is a failure; the
+    // restype never gets a look in.
+    let value = match com_error_iid(self_obj, com) {
+        Some((this_ptr, iid)) => {
+            let hresult = scalar_int_result(&result);
+            if hresult < 0 {
+                return Err(super::com::error(hresult, iid, this_ptr));
+            }
+            pyre_object::w_int_new(hresult as i64)
+        }
+        None => {
+            let value = build_return_value(ret, result)?;
+            match resolve_checker(self_obj) {
+                Some(checker) => crate::call::call_function_impl_result(checker, &[value])?,
+                None => value,
+            }
+        }
     };
-    apply_errcheck(self_obj, value, call_args)
+    match apply_errcheck(self_obj, value, call_args)? {
+        Some(forced) => Ok(forced),
+        None => build_result(value, &callargs),
+    }
+}
+
+/// The status word a returned scalar carries.  A COM method answers an
+/// `HRESULT` whatever its declared restype would otherwise make of the bytes.
+fn scalar_int_result(result: &host_ctypes::CallValue) -> i32 {
+    let mut word = [0u8; 4];
+    if let host_ctypes::CallValue::Scalar(bytes) = result {
+        let n = bytes.len().min(word.len());
+        word[..n].copy_from_slice(&bytes[..n]);
+    }
+    i32::from_ne_bytes(word)
+}
+
+/// The `this` pointer and interface id a failed COM call reports through, when
+/// the method was constructed with an id at all.
+#[cfg(windows)]
+fn com_error_iid(obj: PyObjectRef, com: Option<(usize, usize)>) -> Option<(usize, usize)> {
+    let (this_ptr, _) = com?;
+    let iid = instance_get(obj, IID_KEY)?;
+    let (addr, len) = if unsafe { pyre_object::is_bytes(iid) } {
+        let data = unsafe { pyre_object::bytesobject::w_bytes_data(iid) };
+        (data.as_ptr() as usize, data.len())
+    } else {
+        (cdata::cdata_addr(iid)?, cdata::cdata_len(iid)?)
+    };
+    // Anything that is not `GUID`-sized is not an interface id, and is passed
+    // over the way an unrecognised one is.
+    (len == 16).then_some((this_ptr, addr))
+}
+
+#[cfg(not(windows))]
+fn com_error_iid(_obj: PyObjectRef, _com: Option<(usize, usize)>) -> Option<(usize, usize)> {
+    None
+}
+
+/// The arguments a call is made with, and which of them the caller gets back.
+struct CallArgs {
+    args: Vec<PyObjectRef>,
+    /// Arguments the callee alone fills in, by index.
+    outmask: u32,
+    /// Arguments the caller supplies and the callee writes back through.
+    inoutmask: u32,
+    numretvals: u32,
+}
+
+/// `_build_callargs` — with no `paramflags` the call is made with the
+/// arguments the caller passed (less the COM `this`, which leads the call
+/// separately) and nothing comes back through them.  With `paramflags` every
+/// declared argtype gets a value: from the call, from a keyword, from a
+/// default, or from a fresh instance for the callee to write into.
+fn build_callargs(
+    self_obj: PyObjectRef,
+    argtypes: Option<&[PyObjectRef]>,
+    inargs: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+    is_com: bool,
+) -> Result<CallArgs, crate::PyError> {
+    let passed = if is_com { &inargs[1..] } else { inargs };
+    let plain = |args: Vec<PyObjectRef>| CallArgs {
+        args,
+        outmask: 0,
+        inoutmask: 0,
+        numretvals: 0,
+    };
+    let (Some(paramflags), Some(argtypes)) = (instance_get(self_obj, PARAMFLAGS_KEY), argtypes)
+    else {
+        return Ok(plain(passed.to_vec()));
+    };
+    if argtypes.is_empty() || !unsafe { pyre_object::is_tuple(paramflags) } {
+        return Ok(plain(passed.to_vec()));
+    }
+    let mut out = plain(Vec::with_capacity(argtypes.len()));
+    let mut index = 0;
+    for (i, &at) in argtypes.iter().enumerate() {
+        let malformed =
+            || crate::PyError::value_error("paramflags must have the same length as argtypes");
+        let item =
+            unsafe { pyre_object::w_tuple_getitem(paramflags, i as i64) }.ok_or_else(malformed)?;
+        if !unsafe { pyre_object::is_tuple(item) } {
+            return Err(malformed());
+        }
+        let item_len = unsafe { pyre_object::w_tuple_len(item) };
+        let flag = unsafe { pyre_object::w_tuple_getitem(item, 0) }.ok_or_else(malformed)?;
+        let flag = unsafe { pyre_object::w_int_get_value(flag) };
+        let name = (item_len > 1)
+            .then(|| unsafe { pyre_object::w_tuple_getitem(item, 1) })
+            .flatten()
+            .filter(|&n| unsafe { pyre_object::is_str(n) })
+            .map(|n| unsafe { pyre_object::w_str_get_value(n) }.to_string());
+        let defval = if item_len > 2 {
+            unsafe { pyre_object::w_tuple_getitem(item, 2) }
+        } else {
+            None
+        };
+        let value = match flag & PARAMFLAG_DIRECTION {
+            // A locale id never comes from the call.
+            PARAMFLAG_FIN_FLCID => defval.unwrap_or_else(|| pyre_object::w_int_new(0)),
+            PARAMFLAG_FOUT => {
+                out.outmask |= 1 << i;
+                out.numretvals += 1;
+                match defval {
+                    Some(defval) => defval,
+                    None => out_parameter(at)?,
+                }
+            }
+            direction => {
+                if direction == PARAMFLAG_FIN_FOUT {
+                    out.inoutmask |= 1 << i;
+                    out.numretvals += 1;
+                }
+                get_arg(&mut index, name.as_deref(), defval, passed, kwargs)?
+            }
+        };
+        out.args.push(value);
+    }
+    Ok(out)
+}
+
+/// `_get_arg` — the next positional argument, else the keyword of that name,
+/// else the declared default.
+fn get_arg(
+    index: &mut usize,
+    name: Option<&str>,
+    defval: Option<PyObjectRef>,
+    inargs: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    if *index < inargs.len() {
+        let value = inargs[*index];
+        *index += 1;
+        return Ok(value);
+    }
+    if let (Some(kwargs), Some(name)) = (kwargs, name)
+        && let Some(value) = unsafe { pyre_object::w_dict_getitem_str(kwargs, name) }
+    {
+        *index += 1;
+        return Ok(value);
+    }
+    if let Some(defval) = defval {
+        return Ok(defval);
+    }
+    Err(match name {
+        Some(name) => crate::PyError::type_error(format!("required argument '{name}' missing")),
+        None => crate::PyError::type_error("not enough arguments"),
+    })
+}
+
+/// The instance an `out` parameter is given for the callee to write into.  The
+/// argtype points at the thing written, so that is what gets built — an array
+/// type being its own such thing.
+fn out_parameter(at: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let info = stginfo::stginfo_of(at);
+    if info.is_some_and(|info| stginfo::stginfo_paramfunc(info) == "array") {
+        return crate::call::type_call_instantiate(at, &[]);
+    }
+    match info.and_then(stginfo::stginfo_proto) {
+        Some(proto) if unsafe { pyre_object::is_type(proto) } => {
+            crate::call::type_call_instantiate(proto, &[])
+        }
+        // A simple pointer code points at no type there is an instance of.
+        _ => Err(crate::PyError::type_error(format!(
+            "{} 'out' parameter must be passed as default value",
+            type_display_name(at)
+        ))),
+    }
+}
+
+/// `_build_result` — with no `out` parameters the call's own result stands;
+/// with one it is that parameter, and with several a tuple of them.
+fn build_result(result: PyObjectRef, callargs: &CallArgs) -> Result<PyObjectRef, crate::PyError> {
+    if callargs.numretvals == 0 {
+        return Ok(result);
+    }
+    // `__ctypes_from_outparam__` is arbitrary Python and the tuple allocates,
+    // so every value still wanted lives in a root slot across both.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    for &arg in &callargs.args {
+        pyre_object::gc_roots::pin_root(arg);
+    }
+    let returned_base = pyre_object::gc_roots::shadow_stack_len();
+    let mut returned = 0;
+    for i in 0..callargs.args.len().min(u32::BITS as usize) {
+        let bit = 1 << i;
+        let value = if callargs.inoutmask & bit != 0 {
+            pyre_object::gc_roots::shadow_stack_get(base + i)
+        } else if callargs.outmask & bit != 0 {
+            from_outparam(pyre_object::gc_roots::shadow_stack_get(base + i))?
+        } else {
+            continue;
+        };
+        pyre_object::gc_roots::pin_root(value);
+        returned += 1;
+        if returned == callargs.numretvals as usize {
+            break;
+        }
+    }
+    if returned == 1 {
+        return Ok(pyre_object::gc_roots::shadow_stack_get(returned_base));
+    }
+    Ok(pyre_object::w_tuple_new(
+        (0..returned)
+            .map(|i| pyre_object::gc_roots::shadow_stack_get(returned_base + i))
+            .collect(),
+    ))
+}
+
+fn from_outparam(value: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
+    let method = crate::baseobjspace::getattr_str(value, "__ctypes_from_outparam__")?;
+    crate::call::call_function_impl_result(method, &[])
 }
 
 /// The Python value a returned `CallValue` becomes under return type `ret`.
@@ -1239,7 +1717,9 @@ fn marshal_typed_arg(
     keepalive: &mut Vec<Vec<u8>>,
 ) -> Result<OwnedArg, crate::PyError> {
     if argtype_is_pointer_kind(at) {
-        return Ok(OwnedArg::Pointer(resolve_pointer_addr(arg, keepalive)?));
+        return Ok(OwnedArg::Pointer(pointer_argument_addr(
+            arg, at, keepalive,
+        )?));
     }
     // A by-value struct/union argtype.
     if is_aggregate_type(at) {
@@ -1311,6 +1791,28 @@ fn marshal_default_arg(
             "Don't know how to convert parameter",
         ))
     }
+}
+
+/// The address a pointer-kind argtype takes its argument as.
+///
+/// `PyCPointerType.from_param` accepts an instance of the type a `POINTER(T)`
+/// argtype points at by taking its address, which is what lets `f(c_int(5))`
+/// fill in a callee's `int *` — the address of the box, not the number in it.
+fn pointer_argument_addr(
+    arg: PyObjectRef,
+    at: PyObjectRef,
+    keepalive: &mut Vec<Vec<u8>>,
+) -> Result<usize, crate::PyError> {
+    if let Some(info) = stginfo::stginfo_of(at)
+        && stginfo::stginfo_paramfunc(info) == "pointer"
+        && let Some(proto) = stginfo::stginfo_proto(info)
+        && unsafe { pyre_object::is_type(proto) }
+        && unsafe { crate::baseobjspace::isinstance_w(arg, proto) }
+        && let Some(addr) = cdata::cdata_addr(arg)
+    {
+        return Ok(addr);
+    }
+    resolve_pointer_addr(arg, keepalive)
 }
 
 /// Resolve the address a pointer-kind argument lowers to: `byref()` carriers,

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -1059,8 +1059,12 @@ fn marshal_typed_arg(
     }
     let tc = cdata::type_code_of(at)
         .ok_or_else(|| crate::PyError::type_error("argtype has no valid '_type_'"))?;
-    // `encode_value` copies a same-typed cdata's bytes and otherwise converts,
-    // so a mismatched cdata cannot be reinterpreted through the wrong argtype.
+    // `PyCSimpleType.from_param` hands an instance of the argtype itself
+    // straight through and converts anything else, so a mismatched cdata
+    // cannot be reinterpreted through the wrong argtype.
+    if let Some(bytes) = cdata::same_type_bytes(&tc, arg) {
+        return Ok(OwnedArg::Typed(tc, bytes));
+    }
     let buf = cdata::encode_value(&tc, arg)?;
     Ok(OwnedArg::Typed(tc, buf))
 }
@@ -1109,7 +1113,7 @@ fn marshal_default_arg(
     } else if unsafe { pyre_object::is_bytes(arg) } {
         Ok(OwnedArg::Pointer(bytes_pointer_addr(arg, keepalive)))
     } else if unsafe { pyre_object::is_str(arg) } {
-        Err(str_arg_unsupported())
+        Ok(OwnedArg::Pointer(wstr_pointer_addr(arg, keepalive)))
     } else if unsafe { pyre_object::is_float(arg) } {
         Ok(OwnedArg::Double(crate::baseobjspace::float_w(arg)?))
     } else if unsafe { pyre_object::is_int(arg) } {
@@ -1151,12 +1155,12 @@ pub(super) fn resolve_pointer_addr(
     }
     if unsafe { pyre_object::is_none(arg) } {
         Ok(0)
-    } else if unsafe { pyre_object::is_int(arg) } {
-        Ok(crate::baseobjspace::int_w(arg)? as usize)
+    } else if unsafe { pyre_object::pyobject::is_int_or_long(arg) } {
+        Ok(cdata::pointer_word(arg)?)
     } else if unsafe { pyre_object::is_bytes(arg) } {
         Ok(bytes_pointer_addr(arg, keepalive))
     } else if unsafe { pyre_object::is_str(arg) } {
-        Err(str_arg_unsupported())
+        Ok(wstr_pointer_addr(arg, keepalive))
     } else {
         Err(crate::PyError::type_error(
             "expected bytes, integer address, ctypes instance, or None",
@@ -1173,9 +1177,14 @@ fn bytes_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
     keepalive.last().unwrap().as_ptr() as usize
 }
 
-fn str_arg_unsupported() -> crate::PyError {
-    crate::PyError::type_error(
-        "str argument marshalling (wchar_t*) is not implemented in this ctypes slice; \
-         pass bytes for char* arguments",
-    )
+/// Copy a `str` into a NUL-terminated `wchar_t` buffer, keep the copy alive,
+/// and return its address.  `_conv_param` reaches the same place by building
+/// a `c_wchar_p(arg)` and taking its ffi parameter, and `ConvParam` by
+/// `PyUnicode_AsWideCharString` with the buffer held in a capsule for the
+/// duration of the call; `c_wchar_p`'s own setter (`encode_value_into`, the
+/// `Z` arm) spells the copy the same way.
+fn wstr_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
+    let raw = unsafe { pyre_object::w_str_get_wtf8(arg) };
+    keepalive.push(host_ctypes::wchar_null_terminated_bytes(raw));
+    keepalive.last().unwrap().as_ptr() as usize
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -24,6 +24,11 @@ use std::sync::OnceLock;
 /// `_flags_ & FUNCFLAG_USE_ERRNO` — swap the ctypes-local errno around the call.
 pub(super) const FUNCFLAG_USE_ERRNO: i64 = 0x8;
 
+/// `_flags_ & FUNCFLAG_USE_LASTERROR` — swap the ctypes-local last error
+/// around the call, so `ctypes.get_last_error()` reports what the callee set
+/// and no call made since can have overwritten it.
+pub(super) const FUNCFLAG_USE_LASTERROR: i64 = 0x10;
+
 /// Reserved instance-dict keys.
 const PTR_KEY: &str = "_ptr";
 const RESTYPE_KEY: &str = "_restype";
@@ -605,20 +610,24 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         .collect();
 
     let addr = funcptr_addr(self_obj);
-    let use_errno = funcptr_flags(self_obj) & FUNCFLAG_USE_ERRNO != 0;
+    let flags = funcptr_flags(self_obj);
     let options = host_ctypes::CallOptions {
-        use_errno,
-        ..Default::default()
+        use_errno: flags & FUNCFLAG_USE_ERRNO != 0,
+        use_last_error: flags & FUNCFLAG_USE_LASTERROR != 0,
     };
     // `clibffi.py:350-352` declares `ffi_call` with the default
     // `releasegil='auto'`, i.e. released: the callee is arbitrary foreign code
     // and may block on another Python thread's progress.  `owned` / `keepalive`
-    // hold the marshalled buffers across the released window.
+    // hold the marshalled buffers across the released window.  Being arbitrary
+    // foreign code is also why the call goes inside `seh::guard`, which is what
+    // stands between a faulting callee and the process.
     let result = {
         let _blocked = crate::module::thread::before_external_block();
-        host_ctypes::call(addr, &host_args, restype, options)
-    }
-    .map_err(|e| match e {
+        super::seh::guard(|| host_ctypes::call(addr, &host_args, restype, options))
+    };
+    // `owned` / `keepalive` must outlive the call above.
+    drop(keepalive);
+    let result = result?.map_err(|e| match e {
         host_ctypes::CallError::NullFunctionPointer => {
             crate::PyError::value_error("NULL function pointer")
         }
@@ -629,8 +638,6 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             format!("aggregate argument buffer too small: expected {expected}, got {got}"),
         ),
     });
-    // `owned` / `keepalive` must outlive the call above.
-    drop(keepalive);
     let result = result?;
     match ret {
         Ret::Pointer(rt) => {

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -997,14 +997,8 @@ fn cfuncptr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // A COM method constructed with an interface id answers the plain status,
     // and asks the callee what went wrong when that status is a failure; the
     // restype never gets a look in.
-    let value = match com_error_iid(self_obj, com) {
-        Some((this_ptr, iid)) => {
-            let hresult = scalar_int_result(&result);
-            if hresult < 0 {
-                return Err(super::com::error(hresult, iid, this_ptr));
-            }
-            pyre_object::w_int_new(hresult as i64)
-        }
+    let value = match com_status(self_obj, com, &result) {
+        Some(status) => status?,
         None => {
             let value = build_return_value(ret, result)?;
             match resolve_checker(self_obj) {
@@ -1030,6 +1024,37 @@ fn scalar_int_result(result: &host_ctypes::CallValue) -> i32 {
     i32::from_ne_bytes(word)
 }
 
+/// The status a COM method constructed with an interface id answers, and the
+/// callee's own account of a failed one.  `None` for a method without an id
+/// and for every ordinary function, which go through the restype instead.
+///
+/// A COM method only exists on Windows — `_ctypes.c` builds the whole form
+/// under `MS_WIN32` — so off it there is no status to read and `com` is
+/// already `None` at every call.
+#[cfg(windows)]
+fn com_status(
+    obj: PyObjectRef,
+    com: Option<(usize, usize)>,
+    result: &host_ctypes::CallValue,
+) -> Option<Result<PyObjectRef, crate::PyError>> {
+    let (this_ptr, iid) = com_error_iid(obj, com)?;
+    let hresult = scalar_int_result(result);
+    Some(if hresult < 0 {
+        Err(super::com::error(hresult, iid, this_ptr))
+    } else {
+        Ok(pyre_object::w_int_new(hresult as i64))
+    })
+}
+
+#[cfg(not(windows))]
+fn com_status(
+    _obj: PyObjectRef,
+    _com: Option<(usize, usize)>,
+    _result: &host_ctypes::CallValue,
+) -> Option<Result<PyObjectRef, crate::PyError>> {
+    None
+}
+
 /// The `this` pointer and interface id a failed COM call reports through, when
 /// the method was constructed with an id at all.
 #[cfg(windows)]
@@ -1045,11 +1070,6 @@ fn com_error_iid(obj: PyObjectRef, com: Option<(usize, usize)>) -> Option<(usize
     // Anything that is not `GUID`-sized is not an interface id, and is passed
     // over the way an unrecognised one is.
     (len == 16).then_some((this_ptr, addr))
-}
-
-#[cfg(not(windows))]
-fn com_error_iid(_obj: PyObjectRef, _com: Option<(usize, usize)>) -> Option<(usize, usize)> {
-    None
 }
 
 /// The arguments a call is made with, and which of them the caller gets back.

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -619,9 +619,7 @@ pub(super) fn callback_result(
         Ret::Void => Ok(pyre_object::w_none()),
         Ret::Code(code) => {
             let bytes = cdata::encode_value_into(&code, result, obj, "result")?;
-            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
-                &code, &bytes,
-            )))
+            Ok(cdata::decode_slot(&code, &bytes))
         }
         Ret::Pointer(_) | Ret::Aggregate(_) => Ok(result),
     }
@@ -776,18 +774,17 @@ fn build_return_value(
         }
         Ret::Void => Ok(cdata::decoded_to_pyobject(host_ctypes::DecodedValue::None)),
         Ret::Code(c) => {
-            // Reconstruct the raw result bytes and decode exactly as before:
-            // a scalar carries its register image, a pointer-code result its
-            // address bytes.
-            let decoded = match result {
-                host_ctypes::CallValue::Scalar(b) => host_ctypes::decode_type_code(&c, &b),
-                host_ctypes::CallValue::Pointer(p) => {
-                    host_ctypes::decode_type_code(&c, &p.to_ne_bytes())
+            // Reconstruct the raw result bytes and read them as a slot of that
+            // type: a scalar carries its register image, a pointer-code result
+            // its address bytes.
+            let bytes = match result {
+                host_ctypes::CallValue::Void => {
+                    return Ok(cdata::decoded_to_pyobject(host_ctypes::DecodedValue::None));
                 }
-                host_ctypes::CallValue::Void => host_ctypes::DecodedValue::None,
-                host_ctypes::CallValue::Aggregate(b) => host_ctypes::decode_type_code(&c, &b),
+                host_ctypes::CallValue::Scalar(b) | host_ctypes::CallValue::Aggregate(b) => b,
+                host_ctypes::CallValue::Pointer(p) => p.to_ne_bytes().to_vec(),
             };
-            Ok(cdata::decoded_to_pyobject(decoded))
+            Ok(cdata::decode_slot(&c, &bytes))
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -753,17 +753,26 @@ fn register_windows_loader(ns: pyre_object::PyObjectRef) {
     // ── COMError — `args` is the (text, details) tail, not the whole tuple ──
     let w_exception = crate::builtins::lookup_exc_class("Exception")
         .expect("Exception must be installed before _ctypes init");
-    crate::module_ns_store(
-        ns,
+    let comerror = crate::builtins::make_exc_type_with_init(
         "COMError",
-        crate::builtins::make_exc_type_with_init(
-            "COMError",
-            Some("Raised when a COM method call failed."),
-            crate::builtins::exc_exception_new,
-            Some(comerror_init),
-            w_exception,
-        ),
+        Some("Raised when a COM method call failed."),
+        crate::builtins::exc_exception_new,
+        Some(comerror_init),
+        w_exception,
     );
+    let _ = COMERROR_TYPE_OBJ.set(comerror as usize);
+    crate::module_ns_store(ns, "COMError", comerror);
+}
+
+#[cfg(all(windows, feature = "host_env"))]
+static COMERROR_TYPE_OBJ: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
+/// The `COMError` class, once `_ctypes` has been set up.
+#[cfg(all(windows, feature = "host_env"))]
+pub(super) fn comerror_type() -> Option<pyre_object::PyObjectRef> {
+    COMERROR_TYPE_OBJ
+        .get()
+        .map(|&tp| tp as pyre_object::PyObjectRef)
 }
 
 /// `comerror_init` — stamps the three slots and re-points `args` at the tail.
@@ -804,8 +813,10 @@ fn comerror_init(
     crate::baseobjspace::setattr_str(w_self, "hresult", roots.get(args_slot))?;
     crate::baseobjspace::setattr_str(w_self, "text", roots.get(args_slot + 1))?;
     crate::baseobjspace::setattr_str(w_self, "details", roots.get(args_slot + 2))?;
-    // `args = args[1:]`, so the hresult is reachable only through its attribute.
+    // `args` carries all three, hresult included, and `str()`/`repr()` show
+    // all three with it.
     let w_args = pyre_object::tupleobject::w_tuple_new(vec![
+        roots.get(args_slot),
         roots.get(args_slot + 1),
         roots.get(args_slot + 2),
     ]);

--- a/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/interp_ctypes.rs
@@ -414,6 +414,18 @@ fn register_host_ctypes(ns: pyre_object::PyObjectRef) {
         "resize",
         crate::make_builtin_function("resize", ctypes_resize),
     );
+    // `call_function` / `call_cdeclfunction` are the module's own
+    // "so that we can call CFunction instances" pair, described as debugging
+    // only and private; the readline extension `_ctypes` names in that comment
+    // is why they are still here.  The two differ by the calling convention
+    // they pass, which x86-64 has one of.
+    for name in ["call_function", "call_cdeclfunction"] {
+        crate::module_ns_store(
+            ns,
+            name,
+            crate::make_builtin_function_with_arity(name, super::funcptr::call_function, 2),
+        );
+    }
 }
 
 /// Resolve `symbol` in the library a `_handle` names, for `CFuncPtr((name,
@@ -1036,4 +1048,6 @@ fn register_stub_ctypes(ns: pyre_object::PyObjectRef) {
     crate::module_ns_store(ns, "addressof", crate::typedef::w_object());
     crate::module_ns_store(ns, "byref", crate::typedef::w_object());
     crate::module_ns_store(ns, "resize", crate::typedef::w_object());
+    crate::module_ns_store(ns, "call_function", crate::typedef::w_object());
+    crate::module_ns_store(ns, "call_cdeclfunction", crate::typedef::w_object());
 }

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1319,7 +1319,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
                 cdata::cdata_write(obj, offset, &bytes);
                 return Ok(pyre_object::w_none());
             }
-            let mut bytes = cdata::encode_value_into(&tc, value, obj, &index.to_string())?;
+            let mut bytes = cdata::encode_instance_or_value(&tc, value, obj, &index.to_string())?;
             if field_needs_swap(obj, proto, size) {
                 bytes.reverse();
             }
@@ -1958,7 +1958,7 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
         "simple" => {
             let tc = cdata::type_code_of(meta.proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
-            let bytes = cdata::encode_value_into(&tc, value, obj, &idx.to_string())?;
+            let bytes = cdata::encode_instance_or_value(&tc, value, obj, &idx.to_string())?;
             cdata::cdata_write(obj, offset, &bytes);
             if cdata::is_cdata_instance(value) {
                 cdata::keep_ref(obj, &idx.to_string(), value);
@@ -2448,7 +2448,7 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
         "simple" => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
-            let bytes = cdata::encode_value_into(&tc, value, obj, &index.to_string())?;
+            let bytes = cdata::encode_instance_or_value(&tc, value, obj, &index.to_string())?;
             unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
             if cdata::is_cdata_instance(value) {
                 cdata::keep_ref(obj, &index.to_string(), value);

--- a/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/metaclass.rs
@@ -1246,10 +1246,7 @@ fn cfield_get(args: &[PyObjectRef]) -> PyResult {
                 }
                 return Ok(pyre_object::longobject::w_long_new(BigInt::from(raw)));
             }
-            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
-                &tc,
-                &field_bytes,
-            )))
+            Ok(cdata::decode_slot(&tc, &field_bytes))
         }
         "array" => {
             let element = stginfo::stginfo_of(proto).and_then(stginfo::stginfo_proto);
@@ -1319,6 +1316,7 @@ fn cfield_set(args: &[PyObjectRef]) -> PyResult {
                 cdata::cdata_write(obj, offset, &bytes);
                 return Ok(pyre_object::w_none());
             }
+            cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             let mut bytes = cdata::encode_instance_or_value(&tc, value, obj, &index.to_string())?;
             if field_needs_swap(obj, proto, size) {
                 bytes.reverse();
@@ -1919,10 +1917,7 @@ fn array_get_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize) -> PyResult {
                 .ok_or_else(|| crate::PyError::type_error("instance has no buffer"))?;
             let end = (offset + meta.element_size).min(all.len());
             let start = offset.min(end);
-            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
-                &tc,
-                &all[start..end],
-            )))
+            Ok(cdata::decode_slot(&tc, &all[start..end]))
         }
         "struct" | "union" | "array" | "pointer" => Ok(cdata::make_indexed_subview(
             meta.proto,
@@ -1958,6 +1953,7 @@ fn array_set_index(obj: PyObjectRef, meta: &ArrayMeta, idx: usize, value: PyObje
         "simple" => {
             let tc = cdata::type_code_of(meta.proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            cdata::release_bstr_slot(&tc, cdata::cdata_addr(obj).unwrap_or(0) + offset);
             let bytes = cdata::encode_instance_or_value(&tc, value, obj, &idx.to_string())?;
             cdata::cdata_write(obj, offset, &bytes);
             if cdata::is_cdata_instance(value) {
@@ -2421,9 +2417,7 @@ fn pointer_get_index(obj: PyObjectRef, index: isize) -> PyResult {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
             let bytes = unsafe { host_ctypes::borrow_memory(addr as *const u8, element_size) };
-            Ok(cdata::decoded_to_pyobject(host_ctypes::decode_type_code(
-                &tc, bytes,
-            )))
+            Ok(cdata::decode_slot(&tc, bytes))
         }
         _ => Ok(cdata::make_at_address(proto, addr, element_size, obj)),
     }
@@ -2448,6 +2442,7 @@ fn pointer_setitem(args: &[PyObjectRef]) -> PyResult {
         "simple" => {
             let tc = cdata::type_code_of(proto)
                 .ok_or_else(|| crate::PyError::type_error("element has no '_type_'"))?;
+            cdata::release_bstr_slot(&tc, addr);
             let bytes = cdata::encode_instance_or_value(&tc, value, obj, &index.to_string())?;
             unsafe { host_ctypes::copy_bytes_to_address(addr, &bytes, element_size) };
             if cdata::is_cdata_instance(value) {

--- a/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
@@ -21,6 +21,8 @@ fn type_ns_store(ns: pyre_object::PyObjectRef, name: &str, value: pyre_object::P
 pub mod callbacks;
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod cdata;
+#[cfg(all(windows, feature = "host_env"))]
+mod com;
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod funcptr;
 #[cfg(all(any(unix, windows), feature = "host_env"))]

--- a/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/mod.rs
@@ -26,4 +26,6 @@ pub mod funcptr;
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod metaclass;
 #[cfg(all(any(unix, windows), feature = "host_env"))]
+mod seh;
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 pub mod stginfo;

--- a/pyre/pyre-interpreter/src/module/_ctypes/seh.c
+++ b/pyre/pyre-interpreter/src/module/_ctypes/seh.c
@@ -1,0 +1,52 @@
+/* A foreign call can raise a structured exception — an access violation is
+   the usual one — and a structured exception is not a Rust panic or a C++
+   throw.  Nothing written in Rust reaches it; only a frame-based `__except`
+   filter does, and only a compiler that speaks Microsoft SEH emits one.
+   `_ctypes_callproc` wraps `ffi_call` in exactly this (`callproc.c:950-959`),
+   and without it a bad address handed to a foreign function takes the process
+   down where it should have raised OSError.
+
+   The guarded call is written in Rust, so it is passed in rather than
+   inlined here.  `__except` unwinds every frame above this one before the
+   handler runs, so the caller's own frame — and the cell it lends through
+   `arg` — is still standing when `pyre_seh_guard` returns 1. */
+
+#include <windows.h>
+
+typedef struct {
+    unsigned long code;
+    unsigned long long info[2];
+    unsigned long ninfo;
+} pyre_seh_record;
+
+/* `HandleException` (`callproc.c:442-453`): record what was raised and take
+   it, except for a breakpoint — that is how a debugger attaches to a running
+   process, and the handler that wants it is further out. */
+static int pyre_seh_filter(EXCEPTION_POINTERS *ptrs, pyre_seh_record *out)
+{
+    const EXCEPTION_RECORD *rec = ptrs->ExceptionRecord;
+    out->code = rec->ExceptionCode;
+    out->ninfo = (unsigned long)rec->NumberParameters;
+    out->info[0] = rec->NumberParameters > 0
+                 ? (unsigned long long)rec->ExceptionInformation[0] : 0;
+    out->info[1] = rec->NumberParameters > 1
+                 ? (unsigned long long)rec->ExceptionInformation[1] : 0;
+    if (rec->ExceptionCode == EXCEPTION_BREAKPOINT)
+        return EXCEPTION_CONTINUE_SEARCH;
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+int pyre_seh_guard(void (*body)(void *), void *arg, pyre_seh_record *out)
+{
+    out->code = 0;
+    out->ninfo = 0;
+    out->info[0] = 0;
+    out->info[1] = 0;
+    __try {
+        body(arg);
+        return 0;
+    }
+    __except (pyre_seh_filter(GetExceptionInformation(), out)) {
+        return 1;
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_ctypes/seh.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/seh.rs
@@ -1,0 +1,139 @@
+//! Trapping the machine-level exceptions a foreign call raises.
+//!
+//! A structured exception is delivered by the OS through a chain of frame
+//! handlers, not by anything the language runtime unwinds, so a foreign
+//! function that reads address 0x20 does not return an error to its caller —
+//! it takes the process down unless a `__try`/`__except` further out claims
+//! it.  `_ctypes_callproc` has that `__try` around `ffi_call`
+//! (`callproc.c:950-959`); [`guard`] is the same fence with the call it wraps
+//! written in Rust, and [`exception`] is `SetException`.
+//!
+//! Everywhere else the fence is nothing: a POSIX fault arrives as a signal and
+//! the same call raises no structured exception at all.
+
+/// Run `body` inside the fence, reporting a structured exception it raised as
+/// the OSError `SetException` would have set.
+#[cfg(not(all(windows, target_env = "msvc")))]
+pub(super) fn guard<T, F: FnOnce() -> T>(body: F) -> Result<T, crate::PyError> {
+    Ok(body())
+}
+
+#[cfg(all(windows, target_env = "msvc"))]
+pub(super) use msvc::guard;
+
+#[cfg(all(windows, target_env = "msvc"))]
+mod msvc {
+    use std::ffi::c_void;
+
+    /// What the filter in `seh.c` copies out of the `EXCEPTION_RECORD`.
+    #[repr(C)]
+    #[derive(Default)]
+    struct Record {
+        code: u32,
+        info: [u64; 2],
+        ninfo: u32,
+    }
+
+    unsafe extern "C" {
+        /// `seh.c` — `__try { body(arg); } __except (filter) {}`, returning 1
+        /// when the filter took an exception and filling `out` with it.
+        fn pyre_seh_guard(
+            body: extern "C" fn(*mut c_void),
+            arg: *mut c_void,
+            out: *mut Record,
+        ) -> i32;
+    }
+
+    pub(in super::super) fn guard<T, F: FnOnce() -> T>(body: F) -> Result<T, crate::PyError> {
+        // The fence takes one plain function pointer, so the closure and its
+        // result travel in a cell this frame owns.  `__except` unwinds
+        // everything above `pyre_seh_guard` and leaves that frame — and this
+        // one — standing, so the cell is still readable afterwards; what the
+        // unwound frames held is not, which is why nothing is carried out of
+        // the body except through the cell.
+        struct Cell<F, T> {
+            body: Option<F>,
+            out: Option<T>,
+        }
+
+        extern "C" fn trampoline<F: FnOnce() -> T, T>(arg: *mut c_void) {
+            let cell = unsafe { &mut *arg.cast::<Cell<F, T>>() };
+            let body = cell.body.take().expect("the fence calls its body once");
+            cell.out = Some(body());
+        }
+
+        let mut cell = Cell {
+            body: Some(body),
+            out: None,
+        };
+        let mut record = Record::default();
+        let raised = unsafe {
+            pyre_seh_guard(
+                trampoline::<F, T>,
+                std::ptr::from_mut(&mut cell).cast(),
+                &mut record,
+            )
+        };
+        match cell.out {
+            Some(value) if raised == 0 => Ok(value),
+            _ => Err(exception(&record)),
+        }
+    }
+
+    /// `SetException` (`callproc.c:290-441`).  A structured exception code is
+    /// a Win32 error code and most of them are left to
+    /// `PyErr_SetFromWindowsErr`; the ones named here either carry
+    /// information the code alone does not, or describe a fault the system
+    /// message does not.
+    fn exception(record: &Record) -> crate::PyError {
+        use windows_sys::Win32::Foundation as win;
+
+        let code = record.code as i32;
+        let message = match code {
+            win::EXCEPTION_ACCESS_VIOLATION => {
+                // `ExceptionInformation[0]` is the access that faulted and
+                // `[1]` the address it named.  `%p` is ill-defined, so
+                // `PyUnicode_FromFormat` prints it as wide as a pointer and
+                // puts the `0x` in front of it itself.
+                let verb = if record.info[0] == 0 {
+                    "reading"
+                } else {
+                    "writing"
+                };
+                format!(
+                    "exception: access violation {verb} 0x{:0width$x}",
+                    record.info[1],
+                    width = size_of::<usize>() * 2
+                )
+            }
+            win::EXCEPTION_BREAKPOINT => "exception: breakpoint encountered".to_string(),
+            win::EXCEPTION_DATATYPE_MISALIGNMENT => "exception: datatype misalignment".to_string(),
+            win::EXCEPTION_SINGLE_STEP => "exception: single step".to_string(),
+            win::EXCEPTION_ARRAY_BOUNDS_EXCEEDED => "exception: array bounds exceeded".to_string(),
+            win::EXCEPTION_FLT_DENORMAL_OPERAND => {
+                "exception: floating-point operand denormal".to_string()
+            }
+            win::EXCEPTION_FLT_DIVIDE_BY_ZERO => "exception: float divide by zero".to_string(),
+            win::EXCEPTION_FLT_INEXACT_RESULT => "exception: float inexact".to_string(),
+            win::EXCEPTION_FLT_INVALID_OPERATION => {
+                "exception: float invalid operation".to_string()
+            }
+            win::EXCEPTION_FLT_OVERFLOW => "exception: float overflow".to_string(),
+            win::EXCEPTION_FLT_STACK_CHECK => "exception: stack over/underflow".to_string(),
+            win::EXCEPTION_STACK_OVERFLOW => "exception: stack overflow".to_string(),
+            win::EXCEPTION_FLT_UNDERFLOW => "exception: float underflow".to_string(),
+            win::EXCEPTION_INT_DIVIDE_BY_ZERO => "exception: integer divide by zero".to_string(),
+            win::EXCEPTION_INT_OVERFLOW => "exception: integer overflow".to_string(),
+            win::EXCEPTION_PRIV_INSTRUCTION => "exception: privileged instruction".to_string(),
+            win::EXCEPTION_NONCONTINUABLE_EXCEPTION => "exception: nocontinuable".to_string(),
+            _ => {
+                return crate::PyError::os_error_win32_syscall2(
+                    code,
+                    pyre_object::PY_NULL,
+                    pyre_object::PY_NULL,
+                );
+            }
+        };
+        crate::PyError::os_error(message)
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -9,6 +9,57 @@ use crate::host_seam::sys as libc;
 
 /// Raise `_locale.Error` with the supplied message.  Mirrors
 /// `interp_locale.py:15-20 make_error`.
+/// The NUL-terminated buffer a collation call is made with: wide where the
+/// collation is wide, bytes elsewhere.
+///
+/// `PyUnicode_AsWideCharString` raises on an embedded NUL before either
+/// platform's collation sees the argument, so the rejection belongs to the
+/// argument rather than to whichever collation the build ends up calling.
+#[cfg(windows)]
+type CollationArg = Vec<u16>;
+#[cfg(not(windows))]
+type CollationArg = std::ffi::CString;
+
+fn collation_arg(obj: pyre_object::PyObjectRef) -> Result<CollationArg, crate::PyError> {
+    let text = crate::baseobjspace::str_utf8_w(obj)?.to_string();
+    #[cfg(windows)]
+    {
+        if text.contains('\0') {
+            return Err(crate::PyError::value_error("embedded null character"));
+        }
+        Ok(text.encode_utf16().chain([0]).collect())
+    }
+    #[cfg(not(windows))]
+    {
+        std::ffi::CString::new(text.into_bytes())
+            .map_err(|_| crate::PyError::value_error("embedded null character"))
+    }
+}
+
+/// The wide collation the runtime offers.  The narrow pair runs its arguments
+/// through the active code page first, so a character the page cannot spell
+/// collates as whatever replaced it, which puts an accented letter after `b`
+/// instead of before it.
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+unsafe extern "C" {
+    fn wcscoll(s1: *const u16, s2: *const u16) -> i32;
+    fn wcsxfrm(dst: *mut u16, src: *const u16, count: usize) -> usize;
+}
+
+/// Whether the runtime's locale parser would overrun its fixed code page
+/// buffer on this name.  That buffer holds 16 wide characters including the
+/// terminator; a longer encoding is a debug assertion rather than a rejection,
+/// so a composite `LC_ALL` name reaches `setlocale`, comes back reporting
+/// success, and leaves the offending category at "C".  Answer it here instead.
+#[cfg(all(windows, feature = "host_env"))]
+fn windows_encoding_too_long(locale: &str) -> bool {
+    locale.split(';').any(|part| {
+        let name = part.rsplit_once('=').map_or(part, |(_, name)| name);
+        name.split_once('.')
+            .is_some_and(|(_, encoding)| encoding.len() >= 16)
+    })
+}
+
 fn locale_error(message: &str) -> crate::PyError {
     let cls = crate::builtins::lookup_exc_class("_locale.Error")
         .or_else(|| crate::builtins::lookup_exc_class("Exception"))
@@ -320,6 +371,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 if !(libc::LC_ALL..=libc::LC_TIME).contains(&cat) {
                     return Err(locale_error("invalid locale category"));
                 }
+                #[cfg(windows)]
+                if locale_str.as_deref().is_some_and(windows_encoding_too_long) {
+                    return Err(locale_error("unsupported locale setting"));
+                }
                 let c_locale = match locale_str.as_ref() {
                     Some(s) => Some(
                         std::ffi::CString::new(s.as_bytes())
@@ -404,41 +459,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::make_builtin_function_with_arity(
             "strcoll",
             |args| {
-                #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
+                if args.len() < 2
+                    || !unsafe { pyre_object::is_str(args[0]) && pyre_object::is_str(args[1]) }
                 {
-                    if args.len() < 2
-                        || !unsafe { pyre_object::is_str(args[0]) && pyre_object::is_str(args[1]) }
-                    {
-                        return Err(crate::PyError::type_error(
-                            "strcoll: arguments must be strings",
-                        ));
-                    }
-                    let s1 = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
-                    let s2 = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
-                    let c1 = std::ffi::CString::new(s1.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
-                    let c2 = std::ffi::CString::new(s2.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
-                    Ok(pyre_object::w_int_new(
-                        rustpython_host_env::locale::strcoll(&c1, &c2) as i64,
-                    ))
+                    return Err(crate::PyError::type_error(
+                        "strcoll: arguments must be strings",
+                    ));
                 }
-                #[cfg(not(all(unix, feature = "host_env", not(feature = "sandbox"))))]
+                let c1 = collation_arg(args[0])?;
+                let c2 = collation_arg(args[1])?;
+                #[cfg(all(any(unix, windows), feature = "host_env", not(feature = "sandbox")))]
                 {
-                    if args.len() < 2
-                        || !unsafe { pyre_object::is_str(args[0]) && pyre_object::is_str(args[1]) }
-                    {
-                        return Err(crate::PyError::type_error(
-                            "strcoll: arguments must be strings",
-                        ));
-                    }
+                    #[cfg(windows)]
+                    let ord = unsafe { wcscoll(c1.as_ptr(), c2.as_ptr()) } as i64;
+                    #[cfg(not(windows))]
+                    let ord = rustpython_host_env::locale::strcoll(&c1, &c2) as i64;
+                    Ok(pyre_object::w_int_new(ord))
+                }
+                #[cfg(not(all(any(unix, windows), feature = "host_env", not(feature = "sandbox"))))]
+                {
                     // No libc collation available (or sandbox build) — fall back
-                    // to lexical bytewise comparison.  Pure computation, no I/O;
-                    // under sandbox this keeps the fixed "C" collation and never
-                    // calls host libc collation, which would leak host LC_COLLATE.
-                    let s1 = crate::baseobjspace::str_utf8_w(args[0])?.to_string();
-                    let s2 = crate::baseobjspace::str_utf8_w(args[1])?.to_string();
-                    let ord = match s1.as_str().cmp(s2.as_str()) {
+                    // to lexical comparison.  Pure computation, no I/O; under
+                    // sandbox this keeps the fixed "C" collation and never calls
+                    // host libc collation, which would leak host LC_COLLATE.
+                    let ord = match c1.cmp(&c2) {
                         std::cmp::Ordering::Less => -1,
                         std::cmp::Ordering::Equal => 0,
                         std::cmp::Ordering::Greater => 1,
@@ -461,23 +505,40 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         "strxfrm() argument must be str",
                     ));
                 }
+                let c = collation_arg(s)?;
+                #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+                {
+                    // The transform is usually no longer than its argument, so
+                    // start there; a return of `count` or more is the length the
+                    // transform needs, with the buffer left indeterminate.
+                    let mut buf = vec![0u16; c.len()];
+                    let out = loop {
+                        let n = unsafe { wcsxfrm(buf.as_mut_ptr(), c.as_ptr(), buf.len()) };
+                        if n < buf.len() {
+                            buf.truncate(n);
+                            break buf;
+                        }
+                        buf = vec![0u16; n + 1];
+                    };
+                    Ok(pyre_object::w_str_from_wtf8_managed(
+                        rustpython_wtf8::Wtf8Buf::from_wide(&out),
+                    ))
+                }
                 #[cfg(all(unix, feature = "host_env", not(feature = "sandbox")))]
                 {
-                    let sv = crate::baseobjspace::str_utf8_w(s)?.to_string();
-                    let c = std::ffi::CString::new(sv.as_bytes())
-                        .map_err(|_| crate::PyError::value_error("embedded null character"))?;
-                    let out = rustpython_host_env::locale::strxfrm(&c, sv.len() + 1);
+                    let out = rustpython_host_env::locale::strxfrm(&c, c.as_bytes().len() + 1);
                     // `interp_locale.py:139` returns `space.newtext(val)` —
                     // a plain utf-8 decode (lossy), matching `setlocale`;
                     // unlike `localeconv`/`nl_langinfo` it does not apply
                     // surrogateescape.
                     Ok(pyre_object::w_str_new(&String::from_utf8_lossy(&out)))
                 }
-                #[cfg(not(all(unix, feature = "host_env", not(feature = "sandbox"))))]
+                #[cfg(not(all(any(unix, windows), feature = "host_env", not(feature = "sandbox"))))]
                 {
                     // No libc collation available (or sandbox build) — the
                     // transform is identity, keeping the fixed "C" locale and
                     // never reaching host libc strxfrm.
+                    let _ = c;
                     Ok(s)
                 }
             },

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -310,6 +310,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             #[cfg(all(any(unix, windows), feature = "host_env"))]
             {
                 let cat = (unsafe { pyre_object::w_int_get_value(args[0]) }) as i32;
+                // The MSVC runtime reports a category outside its own
+                // `LC_MIN..=LC_MAX` through the invalid parameter handler,
+                // whose default action ends the process before `setlocale`
+                // can return.  Answer the range here so the call raises
+                // instead.  That pair is `LC_ALL..=LC_TIME`, the numbering
+                // the constants above are published from.
+                #[cfg(windows)]
+                if !(libc::LC_ALL..=libc::LC_TIME).contains(&cat) {
+                    return Err(locale_error("invalid locale category"));
+                }
                 let c_locale = match locale_str.as_ref() {
                     Some(s) => Some(
                         std::ffi::CString::new(s.as_bytes())

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -603,26 +603,43 @@ fn semlock_instance(
     Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
 }
 
+/// `_multiprocessing.SemLock.__new__` declares
+/// `kind: int, value: int, maxvalue: int, name: str, unlink: int`, all five
+/// positional-or-keyword, so each binds by name and each converter reports
+/// its own argument.
 #[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    if args.len() != 6 {
+    let Some((&w_subtype, rest)) = args.split_first() else {
         return Err(crate::PyError::type_error(
-            "SemLock() needs (kind, value, maxvalue, name, unlink)",
+            "_multiprocessing.SemLock.__new__(): not enough arguments",
         ));
-    }
-    let w_subtype = args[0];
-    let kind = crate::baseobjspace::int_w(args[1])?;
-    let value = crate::baseobjspace::int_w(args[2])?;
-    let maxvalue = crate::baseobjspace::int_w(args[3])?;
-    let name = if unsafe { is_str(args[4]) } {
-        crate::baseobjspace::str_utf8_w(args[4])?.to_string()
-    } else {
-        return Err(crate::PyError::type_error("SemLock: name must be a string"));
     };
+    let scope = crate::builtins::bind_builtin_kwargs(
+        rest,
+        &["kind", "value", "maxvalue", "name", "unlink"],
+        &[true; 5],
+        "SemLock",
+    )?;
+    let kind = crate::builtins::space_index_w(scope[0])?;
+    let value = crate::builtins::space_index_w(scope[1])?;
+    let maxvalue = crate::builtins::space_index_w(scope[2])?;
+    if !unsafe { is_str(scope[3]) } {
+        // `_PyArg_BadArgument` renders the None singleton as `None` rather
+        // than as its class name.
+        let type_name = if unsafe { is_none(scope[3]) } {
+            "None"
+        } else {
+            unsafe { pyre_object::type_name_of(scope[3]) }
+        };
+        return Err(crate::PyError::type_error(format!(
+            "SemLock() argument 'name' must be str, not {type_name}"
+        )));
+    }
+    let name = crate::baseobjspace::str_utf8_w(scope[3])?.to_string();
     // `unwrap_spec(unlink=int)` (interp_semaphore.py:572) — the flag is
     // converted the same way `kind`, `value` and `maxvalue` beside it are,
     // so a type whose `__bool__` and `__index__` disagree does not decide it.
-    let unlink = crate::baseobjspace::int_w(args[5])? != 0;
+    let unlink = crate::builtins::space_index_w(scope[4])? != 0;
     // interp_semaphore.py:574-575.
     if kind != RECURSIVE_MUTEX && kind != SEMAPHORE {
         return Err(crate::PyError::value_error("unrecognized kind"));

--- a/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_multiprocessing/mod.rs
@@ -1,9 +1,11 @@
 //! _multiprocessing module — PyPy: `pypy/module/_multiprocessing/`.
 //!
 //! Exposes `SemLock(kind, value, maxvalue, name, unlink)` and
-//! `sem_unlink(name)`.  Backed by libc `sem_t` via
-//! `rustpython_host_env::multiprocessing`; unix + host_env only — other
-//! platforms get an empty module so `import _multiprocessing` succeeds.
+//! `sem_unlink(name)`, plus the three socket calls `connection.py` reaches for
+//! on Windows.  Backed by `rustpython_host_env::multiprocessing` — libc
+//! `sem_t` on unix, a `CreateSemaphoreW` handle on Windows; host_env only, so
+//! other platforms get an empty module and `import _multiprocessing`
+//! still succeeds.
 //!
 //! `W_SemLock`'s fields (`interp_semaphore.py:458-466`) live in the instance
 //! dict rather than a typed payload: `handle`, `kind`, `maxvalue` and `name`
@@ -13,17 +15,40 @@
 //! plain attribute, which is wider than the typedef; the alternative — a
 //! handle-keyed side table — has no upstream counterpart.
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 use pyre_object::*;
 
+#[cfg(all(any(unix, windows), feature = "host_env"))]
+use rustpython_host_env::multiprocessing as host_mp;
+
+/// The platform's semaphore, as the instance stores it: an integer `handle`
+/// that `_rebuild` takes back.  Both spellings are raw pointers, so the
+/// round trip through `usize` is the same on either.
+#[cfg(all(unix, feature = "host_env"))]
+type SemRaw = *mut libc::sem_t;
+#[cfg(all(windows, feature = "host_env"))]
+type SemRaw = host_mp::RawHandle;
+
+/// The Win32 code the last call left behind, as an `OSError` carrying it in
+/// `.winerror` (`PyErr_SetExcFromWindowsErr`).
+#[cfg(all(windows, feature = "host_env"))]
+fn last_windows_error() -> crate::PyError {
+    windows_error(std::io::Error::last_os_error().raw_os_error().unwrap_or(0))
+}
+
+#[cfg(all(windows, feature = "host_env"))]
+fn windows_error(winerror: i32) -> crate::PyError {
+    crate::PyError::os_error_win32_syscall2(winerror, PY_NULL, PY_NULL)
+}
+
 /// `interp_semaphore.py:17 RECURSIVE_MUTEX, SEMAPHORE = range(2)`.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 const RECURSIVE_MUTEX: i64 = 0;
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 const SEMAPHORE: i64 = 1;
 
-#[cfg(all(unix, feature = "host_env"))]
-fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
+#[cfg(all(any(unix, windows), feature = "host_env"))]
+fn semlock_get_handle(obj: PyObjectRef) -> SemRaw {
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
         return core::ptr::null_mut();
@@ -31,7 +56,7 @@ fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
     if let Some(v) = unsafe { w_dict_getitem_str(d, "_handle") }
         && unsafe { is_int(v) }
     {
-        return unsafe { w_int_get_value(v) } as usize as *mut libc::sem_t;
+        return unsafe { w_int_get_value(v) } as usize as SemRaw;
     }
     core::ptr::null_mut()
 }
@@ -39,7 +64,7 @@ fn semlock_get_handle(obj: PyObjectRef) -> *mut libc::sem_t {
 /// Read one of the integer fields of `interp_semaphore.py:458-466`.  A missing
 /// or non-int entry reads as 0, which only happens on an instance whose dict a
 /// caller has torn up.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_get_i64(obj: PyObjectRef, key: &str) -> i64 {
     let d = crate::baseobjspace::getdict_native(obj);
     if d.is_null() {
@@ -54,7 +79,7 @@ fn semlock_get_i64(obj: PyObjectRef, key: &str) -> i64 {
 /// Write one of those fields.  Boxing the value and materialising the dict can
 /// both collect, so every operand is published and re-read from the shadow
 /// stack at the store, exactly as `semlock_instance` does.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
     let _roots = pyre_object::gc_roots::push_roots();
     let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
@@ -77,14 +102,14 @@ fn semlock_set_i64(obj: PyObjectRef, key: &str, value: i64) {
 }
 
 /// `interp_semaphore.py:486-487 W_SemLock._ismine`.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_ismine(obj: PyObjectRef) -> bool {
     semlock_get_i64(obj, "count") > 0
         && crate::module::thread::current_ident() == semlock_get_i64(obj, "last_tid")
 }
 
 #[cfg(all(unix, feature = "host_env"))]
-fn semlock_post(handle: *mut libc::sem_t) -> Result<(), crate::PyError> {
+fn semlock_post(handle: SemRaw) -> Result<(), crate::PyError> {
     if unsafe { libc::sem_post(handle) } != 0 {
         return Err(crate::PyError::os_error_with_errno(
             std::io::Error::last_os_error().raw_os_error().unwrap_or(0),
@@ -98,7 +123,7 @@ fn semlock_post(handle: *mut libc::sem_t) -> Result<(), crate::PyError> {
 /// `sem_getvalue` always fails (`HAVE_BROKEN_SEM_GETVALUE`,
 /// `interp_semaphore.py:86-89`) and the `sem_trywait` fallbacks run instead.
 #[cfg(all(unix, feature = "host_env", not(target_vendor = "apple")))]
-fn semlock_getvalue(handle: *mut libc::sem_t) -> Result<i64, crate::PyError> {
+fn semlock_getvalue(handle: SemRaw) -> Result<i64, crate::PyError> {
     let mut val: libc::c_int = 0;
     if unsafe { libc::sem_getvalue(handle, &mut val) } != 0 {
         return Err(crate::PyError::os_error_with_errno(
@@ -113,7 +138,7 @@ fn semlock_getvalue(handle: *mut libc::sem_t) -> Result<i64, crate::PyError> {
 
 /// `interp_semaphore.py:443-455 semlock_iszero`.
 #[cfg(all(unix, feature = "host_env"))]
-fn semlock_iszero(handle: *mut libc::sem_t) -> Result<bool, crate::PyError> {
+fn semlock_iszero(handle: SemRaw) -> Result<bool, crate::PyError> {
     #[cfg(target_vendor = "apple")]
     {
         if unsafe { libc::sem_trywait(handle) } == 0 {
@@ -132,12 +157,194 @@ fn semlock_iszero(handle: *mut libc::sem_t) -> Result<bool, crate::PyError> {
     }
 }
 
+/// The value the semaphore currently holds, for `_get_value`.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_value(handle: SemRaw) -> Result<i64, crate::PyError> {
+    // interp_semaphore.py:432-434.
+    #[cfg(target_vendor = "apple")]
+    {
+        let _ = handle;
+        Err(crate::PyError::not_implemented(
+            "sem_getvalue is not implemented on this system",
+        ))
+    }
+    #[cfg(not(target_vendor = "apple"))]
+    {
+        semlock_getvalue(handle)
+    }
+}
+
+/// `semaphore.c semlock_getvalue`'s Windows arm: take the count down by one
+/// and give it straight back, which is the only way to read it.  A wait that
+/// times out is a semaphore holding nothing.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_value(handle: SemRaw) -> Result<i64, crate::PyError> {
+    host_mp::get_semaphore_value(handle)
+        .map(i64::from)
+        .map_err(|()| last_windows_error())
+}
+
+/// `semaphore.c semlock_iszero`'s Windows arm.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_iszero(handle: SemRaw) -> Result<bool, crate::PyError> {
+    let status = host_mp::wait_for_single_object(handle, 0);
+    if status == host_mp::wait_object_0() {
+        host_mp::release_semaphore(handle).map_err(|code| windows_error(code as i32))?;
+        return Ok(false);
+    }
+    if status == host_mp::wait_timeout() {
+        return Ok(true);
+    }
+    Err(last_windows_error())
+}
+
+/// `semaphore.c semlock_acquire`'s Windows arm, with the recursion
+/// bookkeeping left to the caller as on the POSIX side.
+///
+/// The wait runs in slices rather than as one call: it is the runtime's own
+/// wait, which a Python signal does not interrupt, and the event handshake
+/// `semaphore.c` interrupts it with needs the signal module to own a Win32
+/// event.  Between slices a pending signal is delivered, which is how every
+/// other blocking call in the interpreter answers a Ctrl-C.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_acquire(
+    handle: SemRaw,
+    block: bool,
+    timeout: Option<f64>,
+) -> Result<bool, crate::PyError> {
+    const SLICE_MS: u32 = 100;
+    // `None` waits forever; `Some(0)` is the non-blocking poll.
+    let mut remaining = match (block, timeout) {
+        (false, _) => Some(0),
+        (true, None) => None,
+        (true, Some(seconds)) => {
+            Some((seconds * 1000.0).ceil().clamp(0.0, f64::from(u32::MAX)) as u32)
+        }
+    };
+    loop {
+        let slice = remaining.map_or(SLICE_MS, |left| left.min(SLICE_MS));
+        let status = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_mp::wait_for_single_object(handle, slice)
+        };
+        if status == host_mp::wait_object_0() {
+            crate::module::signal::interp_signal::checksignals_now()?;
+            return Ok(true);
+        }
+        if status != host_mp::wait_timeout() {
+            return Err(last_windows_error());
+        }
+        crate::module::signal::interp_signal::checksignals_now()?;
+        if let Some(left) = &mut remaining {
+            *left -= slice;
+            if *left == 0 {
+                return Ok(false);
+            }
+        }
+    }
+}
+
+/// `semaphore.c semlock_release`'s Windows arm.  Neither the kind nor the
+/// maximum is read: `ReleaseSemaphore` enforces the maximum itself, and the
+/// refusal it reports is the one the POSIX arm makes out of `sem_getvalue`.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_release(handle: SemRaw, kind: i64, maxvalue: i64) -> Result<(), crate::PyError> {
+    let _ = (kind, maxvalue);
+    host_mp::release_semaphore(handle).map_err(|code| {
+        if code == rustpython_host_env::errno::errors::ERROR_TOO_MANY_POSTS {
+            crate::PyError::value_error("semaphore or lock released too many times")
+        } else {
+            windows_error(code as i32)
+        }
+    })
+}
+
+/// The semaphore a `SemLock()` call is built on, and the name the instance
+/// then reports (`None` once it has been unlinked).
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_create(
+    name: &str,
+    value: i64,
+    maxvalue: i64,
+    unlink: bool,
+) -> Result<(SemRaw, Option<String>), crate::PyError> {
+    let _ = maxvalue;
+    let (handle, kept_name) = host_mp::SemHandle::create(name, value as libc::c_uint, unlink)
+        .map_err(|error| {
+            crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+        })?;
+    let raw = handle.as_ptr();
+    // SemHandle::Drop closes the semaphore. Ownership belongs to the Python
+    // W_SemLock until its registered finalizer grows a typed payload.
+    core::mem::forget(handle);
+    Ok((raw, kept_name))
+}
+
+/// A Windows semaphore is anonymous — `CreateSemaphoreW` takes the two counts
+/// and nothing else, and it is the handle that travels to another process —
+/// so the name is only what the instance reports back.  A `value` above
+/// `maxvalue` is the call's own `ERROR_INVALID_PARAMETER`.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_create(
+    name: &str,
+    value: i64,
+    maxvalue: i64,
+    unlink: bool,
+) -> Result<(SemRaw, Option<String>), crate::PyError> {
+    let (Ok(value), Ok(maxvalue)) = (i32::try_from(value), i32::try_from(maxvalue)) else {
+        return Err(crate::PyError::overflow_error(
+            "SemLock() value out of range",
+        ));
+    };
+    let handle = host_mp::SemHandle::create(value, maxvalue)
+        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))?;
+    let raw = handle.as_raw();
+    // As on the POSIX arm: the drop closes the handle, and the Python object
+    // owns it from here.
+    core::mem::forget(handle);
+    Ok((raw, (!unlink).then(|| name.to_owned())))
+}
+
+/// The semaphore `_rebuild` reattaches to.
+#[cfg(all(unix, feature = "host_env"))]
+fn semlock_rebuild_raw(
+    w_handle: PyObjectRef,
+    name: Option<&str>,
+) -> Result<SemRaw, crate::PyError> {
+    match name {
+        // interp_semaphore.py:550-555 — with a name, reopen it and ignore
+        // `w_handle`.
+        Some(name) => {
+            let handle = host_mp::SemHandle::open_existing(name).map_err(|error| {
+                crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
+            })?;
+            let raw = handle.as_ptr();
+            core::mem::forget(handle);
+            Ok(raw)
+        }
+        // interp_semaphore.py:557 `handle = handle_w(space, w_handle)`
+        // (`:223-224`).
+        None => Ok(crate::baseobjspace::int_w(w_handle)? as usize as SemRaw),
+    }
+}
+
+/// There is no name to reopen through on Windows, so the handle is what
+/// `_rebuild` reattaches to whether or not a name came with it.
+#[cfg(all(windows, feature = "host_env"))]
+fn semlock_rebuild_raw(
+    w_handle: PyObjectRef,
+    name: Option<&str>,
+) -> Result<SemRaw, crate::PyError> {
+    let _ = name;
+    Ok(crate::baseobjspace::int_w(w_handle)? as usize as SemRaw)
+}
+
 /// `interp_semaphore.py:357-400 semlock_acquire` — the platform wait alone.
 /// Upstream bumps `self.last_tid`/`self.count` here (`:395-396`); the receiver
 /// stays with the caller instead, which does it on the success return.
 #[cfg(all(unix, feature = "host_env"))]
 fn semlock_acquire(
-    handle: *mut libc::sem_t,
+    handle: SemRaw,
     block: bool,
     timeout: Option<f64>,
 ) -> Result<bool, crate::PyError> {
@@ -240,11 +447,7 @@ fn semlock_acquire(
 
 /// `interp_semaphore.py:403-429 semlock_release`.
 #[cfg(all(unix, feature = "host_env"))]
-fn semlock_release(
-    handle: *mut libc::sem_t,
-    kind: i64,
-    maxvalue: i64,
-) -> Result<(), crate::PyError> {
+fn semlock_release(handle: SemRaw, kind: i64, maxvalue: i64) -> Result<(), crate::PyError> {
     if kind == RECURSIVE_MUTEX {
         return semlock_post(handle);
     }
@@ -283,7 +486,7 @@ fn semlock_release(
 
 /// `interp_semaphore.py:506-523 W_SemLock.acquire` — shared by `acquire` and
 /// `__enter__`, which the class methods cannot reach through each other.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn w_semlock_acquire(
     self_obj: PyObjectRef,
     block: bool,
@@ -321,7 +524,7 @@ fn w_semlock_acquire(
 
 /// `interp_semaphore.py:525-541 W_SemLock.release` — shared by `release` and
 /// `__exit__`.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn w_semlock_release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
     let _roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::pin_roots(&[self_obj]);
@@ -351,10 +554,10 @@ fn w_semlock_release(self_obj: PyObjectRef) -> Result<(), crate::PyError> {
     Ok(())
 }
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_instance(
     w_subtype: PyObjectRef,
-    raw: *mut libc::sem_t,
+    raw: SemRaw,
     kind: i64,
     maxvalue: i64,
     kept_name: Option<String>,
@@ -400,7 +603,7 @@ fn semlock_instance(
     Ok(pyre_object::gc_roots::shadow_stack_get(root_base))
 }
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 6 {
         return Err(crate::PyError::type_error(
@@ -424,24 +627,13 @@ fn semlock_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     if kind != RECURSIVE_MUTEX && kind != SEMAPHORE {
         return Err(crate::PyError::value_error("unrecognized kind"));
     }
-    let (handle, kept_name) = rustpython_host_env::multiprocessing::SemHandle::create(
-        &name,
-        value as libc::c_uint,
-        unlink,
-    )
-    .map_err(|error| {
-        crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
-    })?;
-    let raw = handle.as_ptr();
-    // SemHandle::Drop closes the semaphore. Ownership belongs to the Python
-    // W_SemLock until its registered finalizer grows a typed payload.
-    core::mem::forget(handle);
+    let (raw, kept_name) = semlock_create(&name, value, maxvalue, unlink)?;
     semlock_instance(w_subtype, raw, kind, maxvalue, kept_name)
 }
 
 /// `interp_semaphore.py:547-561 W_SemLock.rebuild`, registered as a
 /// classmethod (`:606`), so `args[0]` is the bound class.
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 fn semlock_rebuild(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() != 5 {
         return Err(crate::PyError::type_error(
@@ -462,26 +654,11 @@ fn semlock_rebuild(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             "_rebuild() argument 'name' must be str or None",
         ));
     };
-    let raw = match &name {
-        // interp_semaphore.py:550-555 — with a name, reopen it and ignore
-        // `w_handle`.
-        Some(name) => {
-            let handle = rustpython_host_env::multiprocessing::SemHandle::open_existing(name)
-                .map_err(|error| {
-                    crate::PyError::os_error_with_errno(error.raw_os_error(), error.description())
-                })?;
-            let raw = handle.as_ptr();
-            core::mem::forget(handle);
-            raw
-        }
-        // interp_semaphore.py:557 `handle = handle_w(space, w_handle)`
-        // (`:223-224`).
-        None => crate::baseobjspace::int_w(args[1])? as usize as *mut libc::sem_t,
-    };
+    let raw = semlock_rebuild_raw(args[1], name.as_deref())?;
     semlock_instance(w_cls, raw, kind, maxvalue, name)
 }
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 crate::py_class! {
     "SemLock",
     methods: {
@@ -528,18 +705,7 @@ crate::py_class! {
             if handle.is_null() {
                 return Err(crate::PyError::value_error("SemLock handle is null"));
             }
-            #[cfg(target_vendor = "apple")]
-            {
-                // interp_semaphore.py:432-434.
-                let _ = handle;
-                Err(crate::PyError::not_implemented(
-                    "sem_getvalue is not implemented on this system",
-                ))
-            }
-            #[cfg(not(target_vendor = "apple"))]
-            {
-                semlock_getvalue(handle)
-            }
+            semlock_value(handle)
         }
         // interp_semaphore.py:563-564 W_SemLock.enter
         fn __enter__(self_obj: PyObjectRef) -> Result<bool, crate::PyError> {
@@ -558,24 +724,69 @@ crate::py_class! {
     }
 }
 
-#[cfg(all(unix, feature = "host_env"))]
+#[cfg(all(any(unix, windows), feature = "host_env"))]
 #[crate::pyre_function]
 fn sem_unlink(name: &str) -> Result<(), crate::PyError> {
-    rustpython_host_env::multiprocessing::sem_unlink(name)
-        .map_err(|_| crate::PyError::os_error("sem_unlink failed"))
+    #[cfg(unix)]
+    {
+        host_mp::sem_unlink(name).map_err(|_| crate::PyError::os_error("sem_unlink failed"))
+    }
+    // A Windows semaphore has no name in the filesystem sense, so there is
+    // nothing to remove and `SEM_UNLINK` is the constant success the call
+    // reads (`semaphore.c`).
+    #[cfg(windows)]
+    {
+        let _ = name;
+        Ok(())
+    }
+}
+
+/// The three socket calls `multiprocessing/connection.py` binds as default
+/// arguments on Windows, where a `Connection` is a socket rather than a
+/// descriptor.  A failure is reported by `WSAGetLastError`, so it carries a
+/// Win32 code rather than an errno.
+#[cfg(all(windows, feature = "host_env"))]
+#[crate::pyre_function]
+fn closesocket(handle: i64) -> Result<(), crate::PyError> {
+    host_mp::close_socket(handle as usize as host_mp::RawSocket)
+        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))
+}
+
+#[cfg(all(windows, feature = "host_env"))]
+#[crate::pyre_function]
+fn recv(handle: i64, size: i64) -> Result<PyObjectRef, crate::PyError> {
+    let size =
+        usize::try_from(size).map_err(|_| crate::PyError::value_error("negative buffer size"))?;
+    let data = host_mp::recv_socket(handle as usize as host_mp::RawSocket, size)
+        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))?;
+    Ok(pyre_object::w_bytes_from_bytes(&data))
+}
+
+#[cfg(all(windows, feature = "host_env"))]
+#[crate::pyre_function]
+fn send(handle: i64, buf: &[u8]) -> Result<i64, crate::PyError> {
+    host_mp::send_socket(handle as usize as host_mp::RawSocket, buf)
+        .map(i64::from)
+        .map_err(|error| windows_error(error.raw_os_error().unwrap_or(0)))
 }
 
 crate::py_module! {
     "_multiprocessing",
     extra_init: |ns| {
-        #[cfg(all(unix, feature = "host_env"))]
+        #[cfg(all(any(unix, windows), feature = "host_env"))]
         {
             let semlock_type = type_object();
             crate::module_ns_store(ns, "SemLock", semlock_type);
             // interp_semaphore.py:593-610 W_SemLock.typedef publishes this
             // constant on the class (the module also exports its own copy).
-            let sem_value_max =
-                w_int_new(rustpython_host_env::multiprocessing::sem_value_max() as i64);
+            // `SEM_VALUE_MAX` is what the platform will count to: the
+            // POSIX limit, or `LONG_MAX` where `CreateSemaphoreW` takes the
+            // maximum as its own argument.
+            #[cfg(unix)]
+            let value_max = i64::from(host_mp::sem_value_max());
+            #[cfg(windows)]
+            let value_max = i64::from(i32::MAX);
+            let sem_value_max = w_int_new(value_max);
             let semlock_ns =
                 unsafe { pyre_object::w_type_get_dict_ptr(semlock_type) } as PyObjectRef;
             unsafe {
@@ -632,6 +843,27 @@ crate::py_module! {
             );
             crate::module_ns_store(ns, "RECURSIVE_MUTEX", w_int_new(RECURSIVE_MUTEX));
             crate::module_ns_store(ns, "SEMAPHORE", w_int_new(SEMAPHORE));
+        }
+        #[cfg(all(windows, feature = "host_env"))]
+        {
+            crate::module_ns_store(
+                ns,
+                "closesocket",
+                crate::make_builtin_function_with_arity("closesocket", closesocket, 1),
+            );
+            crate::module_ns_store(
+                ns,
+                "recv",
+                crate::make_builtin_function_with_arity("recv", recv, 2),
+            );
+            crate::module_ns_store(
+                ns,
+                "send",
+                crate::make_builtin_function_with_arity("send", send, 2),
+            );
+            // `flags` reports the build-time semaphore capabilities the
+            // POSIX build is configured with; this one has none to report.
+            crate::module_ns_store(ns, "flags", pyre_object::w_dict_new());
         }
     }
 }

--- a/pyre/pyre-interpreter/src/module/_socket/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/mod.rs
@@ -10,6 +10,6 @@
 //! nothing that would need a descriptor behind it.
 
 #[cfg(any(unix, windows))]
-mod rsocket_rffi;
+pub(crate) mod rsocket_rffi;
 
 crate::pyre_module_init!(interp_socket);

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -97,6 +97,9 @@ pub const SOL_SOCKET: libc::c_int = ws::SOL_SOCKET;
 pub const SO_TYPE: libc::c_int = ws::SO_TYPE;
 #[cfg(windows)]
 pub const SO_ERROR: libc::c_int = ws::SO_ERROR;
+/// The code a call about a descriptor that is not a socket comes back with.
+#[cfg(windows)]
+pub const WSAENOTSOCK: i32 = ws::WSAENOTSOCK;
 /// The code an expired wait reports, so a timeout this module times itself
 /// reads back the same as one the host produced.
 #[cfg(windows)]

--- a/pyre/pyre-interpreter/src/module/errno/mod.rs
+++ b/pyre/pyre-interpreter/src/module/errno/mod.rs
@@ -130,18 +130,34 @@ crate::py_module! {
             for (name, value) in entries {
                 store(name, *value as i64);
             }
+            // The MSVC runtime carries these under the same names, so they
+            // are not the Unix-only set they were grouped with.
+            #[cfg(any(unix, windows))]
+            {
+                let posix_entries: &[(&str, i32)] = &[
+                    ("ETXTBSY", host_errno::ETXTBSY),
+                    ("ENOMSG", host_errno::ENOMSG),
+                    ("EIDRM", host_errno::EIDRM),
+                    ("EBADMSG", host_errno::EBADMSG),
+                    ("ENODATA", host_errno::ENODATA),
+                    ("ENOLINK", host_errno::ENOLINK),
+                    ("ENOSR", host_errno::ENOSR),
+                    ("ENOSTR", host_errno::ENOSTR),
+                    ("ETIME", host_errno::ETIME),
+                ];
+                for (name, value) in posix_entries {
+                    store(name, *value as i64);
+                }
+            }
             #[cfg(unix)]
             {
                 let unix_entries: &[(&str, i32)] = &[
                     // Declared in the same list, and supplied by `libc` here.
-                    // Windows reaches them only through `win_errors`
+                    // Windows reaches the first six through `win_errors`
                     // (`interp_errno.py:91-101`), which registers the `WSA`
-                    // spelling, adds the stripped name as a second binding
-                    // and leaves the reverse mapping naming the `WSA` one.
-                    // This module exports no `WSA` name to carry that reverse
-                    // entry, so storing the stripped names there would answer
-                    // `errorcode[code]` with a spelling the declaration never
-                    // assigns.
+                    // spelling and adds the stripped name as a second binding
+                    // -- the windows block below stores them in that order, so
+                    // the reverse mapping names the `WSA` one there.
                     ("ESTALE", host_errno::ESTALE),
                     ("EUSERS", host_errno::EUSERS),
                     ("EREMOTE", host_errno::EREMOTE),
@@ -149,16 +165,7 @@ crate::py_module! {
                     ("EPFNOSUPPORT", host_errno::EPFNOSUPPORT),
                     ("ESOCKTNOSUPPORT", host_errno::ESOCKTNOSUPPORT),
                     ("ENOTBLK", host_errno::ENOTBLK),
-                    ("ETXTBSY", host_errno::ETXTBSY),
-                    ("ENOMSG", host_errno::ENOMSG),
-                    ("EIDRM", host_errno::EIDRM),
-                    ("EBADMSG", host_errno::EBADMSG),
                     ("EMULTIHOP", host_errno::EMULTIHOP),
-                    ("ENODATA", host_errno::ENODATA),
-                    ("ENOLINK", host_errno::ENOLINK),
-                    ("ENOSR", host_errno::ENOSR),
-                    ("ENOSTR", host_errno::ENOSTR),
-                    ("ETIME", host_errno::ETIME),
                 ];
                 for (name, value) in unix_entries {
                     store(name, *value as i64);
@@ -197,6 +204,76 @@ crate::py_module! {
                     ("ESHLIBVERS", host_errno::ESHLIBVERS),
                 ];
                 for (name, value) in apple_entries {
+                    store(name, *value as i64);
+                }
+            }
+            // The rest of the runtime's own set, then the Winsock codes.
+            //
+            // A socket reports the Winsock code, so the classic socket names
+            // above already resolve to those and the `WSAE*` spellings share
+            // their values.  They are stored second on purpose: `errorcode`
+            // is keyed by the number, and the name it answers with for a
+            // shared one is the Winsock spelling.
+            #[cfg(windows)]
+            {
+                let windows_entries: &[(&str, i32)] = &[
+                    ("EDEADLOCK", host_errno::EDEADLOCK),
+                    ("ESOCKTNOSUPPORT", host_errno::ESOCKTNOSUPPORT),
+                    ("EPFNOSUPPORT", host_errno::EPFNOSUPPORT),
+                    ("ETOOMANYREFS", host_errno::ETOOMANYREFS),
+                    ("EUSERS", host_errno::EUSERS),
+                    ("ESTALE", host_errno::ESTALE),
+                    ("EREMOTE", host_errno::EREMOTE),
+                    ("WSABASEERR", host_errno::WSABASEERR),
+                    ("WSAEINTR", host_errno::WSAEINTR),
+                    ("WSAEBADF", host_errno::WSAEBADF),
+                    ("WSAEACCES", host_errno::WSAEACCES),
+                    ("WSAEFAULT", host_errno::WSAEFAULT),
+                    ("WSAEINVAL", host_errno::WSAEINVAL),
+                    ("WSAEMFILE", host_errno::WSAEMFILE),
+                    ("WSAEWOULDBLOCK", host_errno::WSAEWOULDBLOCK),
+                    ("WSAEINPROGRESS", host_errno::WSAEINPROGRESS),
+                    ("WSAEALREADY", host_errno::WSAEALREADY),
+                    ("WSAENOTSOCK", host_errno::WSAENOTSOCK),
+                    ("WSAEDESTADDRREQ", host_errno::WSAEDESTADDRREQ),
+                    ("WSAEMSGSIZE", host_errno::WSAEMSGSIZE),
+                    ("WSAEPROTOTYPE", host_errno::WSAEPROTOTYPE),
+                    ("WSAENOPROTOOPT", host_errno::WSAENOPROTOOPT),
+                    ("WSAEPROTONOSUPPORT", host_errno::WSAEPROTONOSUPPORT),
+                    ("WSAESOCKTNOSUPPORT", host_errno::WSAESOCKTNOSUPPORT),
+                    ("WSAEOPNOTSUPP", host_errno::WSAEOPNOTSUPP),
+                    ("WSAEPFNOSUPPORT", host_errno::WSAEPFNOSUPPORT),
+                    ("WSAEAFNOSUPPORT", host_errno::WSAEAFNOSUPPORT),
+                    ("WSAEADDRINUSE", host_errno::WSAEADDRINUSE),
+                    ("WSAEADDRNOTAVAIL", host_errno::WSAEADDRNOTAVAIL),
+                    ("WSAENETDOWN", host_errno::WSAENETDOWN),
+                    ("WSAENETUNREACH", host_errno::WSAENETUNREACH),
+                    ("WSAENETRESET", host_errno::WSAENETRESET),
+                    ("WSAECONNABORTED", host_errno::WSAECONNABORTED),
+                    ("WSAECONNRESET", host_errno::WSAECONNRESET),
+                    ("WSAENOBUFS", host_errno::WSAENOBUFS),
+                    ("WSAEISCONN", host_errno::WSAEISCONN),
+                    ("WSAENOTCONN", host_errno::WSAENOTCONN),
+                    ("WSAESHUTDOWN", host_errno::WSAESHUTDOWN),
+                    ("WSAETOOMANYREFS", host_errno::WSAETOOMANYREFS),
+                    ("WSAETIMEDOUT", host_errno::WSAETIMEDOUT),
+                    ("WSAECONNREFUSED", host_errno::WSAECONNREFUSED),
+                    ("WSAELOOP", host_errno::WSAELOOP),
+                    ("WSAENAMETOOLONG", host_errno::WSAENAMETOOLONG),
+                    ("WSAEHOSTDOWN", host_errno::WSAEHOSTDOWN),
+                    ("WSAEHOSTUNREACH", host_errno::WSAEHOSTUNREACH),
+                    ("WSAENOTEMPTY", host_errno::WSAENOTEMPTY),
+                    ("WSAEPROCLIM", host_errno::WSAEPROCLIM),
+                    ("WSAEUSERS", host_errno::WSAEUSERS),
+                    ("WSAEDQUOT", host_errno::WSAEDQUOT),
+                    ("WSAESTALE", host_errno::WSAESTALE),
+                    ("WSAEREMOTE", host_errno::WSAEREMOTE),
+                    ("WSASYSNOTREADY", host_errno::WSASYSNOTREADY),
+                    ("WSAVERNOTSUPPORTED", host_errno::WSAVERNOTSUPPORTED),
+                    ("WSANOTINITIALISED", host_errno::WSANOTINITIALISED),
+                    ("WSAEDISCON", host_errno::WSAEDISCON),
+                ];
+                for (name, value) in windows_entries {
                     store(name, *value as i64);
                 }
             }

--- a/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
+++ b/pyre/pyre-interpreter/src/module/mmap/interp_mmap.rs
@@ -1466,11 +1466,7 @@ fn mmap_resize_mapping(
         // here until one of the two remaps below puts a mapping back.
         mmap_native(obj)?.mapped = None;
         let remap = |size: usize, reject_existing: bool| {
-            if named {
-                mmap_remap_named(handle, offset, access, size, &tagname, reject_existing)
-            } else {
-                host_mmap::map_handle(handle, offset, size, access).map(MappedObj::Mapped)
-            }
+            mmap_remap_named(handle, offset, access, size, &tagname, reject_existing)
         };
         match host_mmap::extend_file(handle, offset + newsize as i64)
             .and_then(|()| remap(newsize, true))
@@ -1524,10 +1520,12 @@ fn mmap_resize_mapping(
     Ok(())
 }
 
-/// Recreate the Windows mapping object under its original tag name, matching
-/// `rmmap.py:634-645`.  `CreateFileMappingW` reports ERROR_ALREADY_EXISTS when
-/// another mapping still owns the name; a resize surfaces that OS error, while
-/// the recovery remap is allowed to reopen the existing object.
+/// Recreate the Windows mapping object under the name it already had, matching
+/// `rmmap.py:635-636`, which passes `self.tagname` whether or not one was
+/// given.  `CreateFileMappingW` reports ERROR_ALREADY_EXISTS when another
+/// mapping still owns the name; a resize surfaces that OS error, while the
+/// recovery remap is allowed to reopen the existing object.  An untagged
+/// mapping cannot reach it — a zero-length name is not a name.
 #[cfg(windows)]
 fn mmap_remap_named(
     handle: host_mmap::Handle,
@@ -1751,7 +1749,15 @@ fn mmap_construct(
                 if file_size == 0 {
                     return Err(crate::PyError::value_error("cannot mmap an empty file"));
                 }
-                if offset_usize > file_size {
+                // `rmmap.py:757-761` rejects only offset > size, which
+                // leaves an offset landing exactly on EOF asking `mmap(2)` for
+                // a zero-length mapping — EINVAL rather than the ValueError the
+                // caller is told to expect.  `mmapmodule.c new_mmap_object`
+                // refuses it as `if (offset >= status.st_size)` (`:1872`, and
+                // `:2087` for the Windows block) — read at v3.14.6 in the
+                // checkout at Z:/cpython; not executable on the Windows host
+                // this was written on.
+                if offset_usize >= file_size {
                     return Err(crate::PyError::value_error(
                         "mmap offset is greater than file size",
                     ));
@@ -1884,8 +1890,15 @@ fn mmap_construct(
                 if file_len == 0 {
                     return Err(crate::PyError::value_error("cannot mmap an empty file"));
                 }
-                // `rmmap.py:943-945` rejects only offset > size.
-                if offset > file_len {
+                // `rmmap.py:943-945` rejects only offset > size, so an
+                // offset landing exactly on EOF resolves to a zero-length
+                // mapping and asks `MapViewOfFile` for an empty view, which
+                // fails with a Win32 error instead.  `mmapmodule.c
+                // new_mmap_object` refuses the offset one step earlier, `if
+                // (offset >= size)`, in its Windows size block (`:2087`; the
+                // POSIX one spells the same test at `:1872`) — read at v3.14.6
+                // in the checkout at Z:/cpython.
+                if offset >= file_len {
                     return Err(crate::PyError::value_error(
                         "mmap offset is greater than file size",
                     ));
@@ -1895,18 +1908,20 @@ fn mmap_construct(
                 if map_size as i64 != remaining {
                     return Err(crate::PyError::value_error("mmap length is too large"));
                 }
-            } else {
-                // `rmmap.py:949-950` rejects a mapping past EOF rather than
-                // letting `CreateFileMapping` grow the file to fit it.
-                let required = offset
-                    .checked_add(map_size as i64)
-                    .ok_or_else(|| crate::PyError::value_error("mmap length is too large"))?;
-                if required > file_len {
-                    return Err(crate::PyError::value_error(
-                        "mmap length is greater than file size",
-                    ));
-                }
             }
+            // A given length is not measured against the file at all here.
+            // `CreateFileMapping` is asked for `offset + length` and grows the
+            // file to it, so a length past EOF is how the mapping is extended
+            // on this platform.  `rmmap.py:949-950` rejects it with "mmap
+            // length is greater than file size" instead; the run fails on that
+            // at `lib-python/3/test/test_mmap.py:202-209`, which calls
+            // `mmap(fileno(), mapsize + 1)` and, on `sys.platform` starting
+            // with "win", turns a ValueError into
+            // `self.fail("Opening mmap with size+1 should work on Windows.")`.
+            // `pypy/module/mmap/test/test_mmap.py:747-749` concedes the same
+            // point from the other side, skipping its own
+            // `raises(ValueError, ...)` under `os.name == "nt"` with the note
+            // "this should work under windows".
         }
         file_handle = Some(guard);
     }
@@ -1914,10 +1929,17 @@ fn mmap_construct(
     let handle = file_handle
         .as_ref()
         .map_or(host_mmap::INVALID_HANDLE, |guard| guard.0);
-    // A tag names a mapping object other processes can open by the same name,
-    // which memmap2 cannot express, so those go straight through
-    // `CreateFileMappingW`/`MapViewOfFile` (`rmmap.py:999-1004`).
-    let (mapped, owned_handle) = if !tagname.is_empty() {
+    // `rmmap.py:998-1000` reaches every file-backed mapping through one
+    // `CreateFileMapping(m.file_handle, NULL, flProtect, size_hi, size_lo,
+    // m.tagname)`, where the maximum size is `offset + map_size` and the name
+    // is whatever `tagname` holds — the empty string when none was given.  A
+    // zero-length name is not a name: two mappings created with one do not
+    // report ERROR_ALREADY_EXISTS to each other, so the untagged mapping needs
+    // no second route.  memmap2 is the wrong one to give it, because it asks
+    // for a maximum size of 0, which means "the file as it stands" and cannot
+    // extend it, and because it rounds the offset down to the allocation
+    // granularity instead of letting `MapViewOfFile` reject an unaligned one.
+    let (mapped, owned_handle) = if file_handle.is_some() || !tagname.is_empty() {
         let named = host_mmap::create_named_mapping(
             handle,
             tagname,
@@ -1932,14 +1954,6 @@ fn mmap_construct(
             MappedObj::Named(named),
             file_handle.map_or(host_mmap::INVALID_HANDLE, |guard| guard.release()),
         )
-    } else if let Some(guard) = file_handle {
-        let handle = guard.release();
-        let mapped = host_mmap::map_handle(handle, offset, map_size, mmap_access_mode(access))
-            .map_err(|e| {
-                host_mmap::close_handle(handle);
-                mmap_io_err(e, "mmap")
-            })?;
-        (MappedObj::Mapped(mapped), handle)
     } else {
         let mapped = host_mmap::map_anon(map_size).map_err(|e| mmap_io_err(e, "mmap"))?;
         (MappedObj::Mapped(mapped), host_mmap::INVALID_HANDLE)

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -10153,10 +10153,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             ns,
             "symlink",
             crate::make_builtin_function("symlink", |args| {
-                use windows_sys::Win32::Storage::FileSystem::{
-                    CreateSymbolicLinkW, SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE,
-                    SYMBOLIC_LINK_FLAG_DIRECTORY,
-                };
                 let (bound, kwargs) = bind_path_args(
                     args,
                     "symlink",
@@ -10183,37 +10179,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     None => false,
                 };
                 let (wide_src, wide_dst) = (wide_path(&src.as_bytes)?, wide_path(&dst.as_bytes)?);
-                let flags = if target_is_directory {
-                    SYMBOLIC_LINK_FLAG_DIRECTORY
-                } else {
-                    0
-                };
-                // Creating one is a privilege the account may not hold; the
-                // flag asks for the developer-mode path instead, and a Windows
-                // too old to know it rejects the whole call, which is what the
-                // retry without it is for.
-                let mut ok = unsafe {
-                    CreateSymbolicLinkW(
-                        wide_dst.as_ptr(),
-                        wide_src.as_ptr(),
-                        flags | SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE,
-                    )
-                };
-                if !ok
-                    && std::io::Error::last_os_error().raw_os_error()
-                        == Some(windows_sys::Win32::Foundation::ERROR_INVALID_PARAMETER as i32)
-                {
-                    ok =
-                        unsafe { CreateSymbolicLinkW(wide_dst.as_ptr(), wide_src.as_ptr(), flags) };
-                }
-                if !ok {
-                    return Err(fs_err_with_filename2(
-                        std::io::Error::last_os_error(),
-                        0,
-                        src.w_path(),
-                        dst.w_path(),
-                    ));
-                }
+                // The kind is not read off `target_is_directory` alone.
+                // `os_symlink_impl` also asks `_check_dirW`, which resolves a
+                // relative `src` against `dirname(dst)` and reports whether
+                // `GetFileAttributesExW` calls it a directory — so
+                // `os.symlink(os.path.join('a', 'bcd'), 'sym3')` makes a link
+                // that can be walked into rather than a file link nothing can
+                // list.  Creating either is a privilege the account may not
+                // hold, so the call asks for the developer-mode path and
+                // retries without it on the Windows too old to know the flag.
+                // The host wrapper carries both, including the
+                // `windows_has_symlink_unprivileged_flag` latch that stops
+                // paying for the first attempt once it is known to fail.
+                rustpython_host_env::nt::symlink(
+                    &path_from_bytes(&src.as_bytes),
+                    &path_from_bytes(&dst.as_bytes),
+                    &wide_src,
+                    &wide_dst,
+                    target_is_directory,
+                )
+                .map_err(|e| fs_err_with_filename2(e, 0, src.w_path(), dst.w_path()))?;
                 Ok(pyre_object::w_none())
             }),
         );

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2726,18 +2726,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // interp_posix.py:340 `@unwrap_spec(fd=c_int, position=r_longlong,
                 // how=c_int)` — the position is a 64-bit offset, not a C int.
                 let fd = crate::baseobjspace::c_int_w(args[0])? as libc::c_int;
-                let offset = crate::baseobjspace::int_w(args[1])? as libc::off_t;
+                let offset = crate::baseobjspace::int_w(args[1])?;
                 let whence = crate::baseobjspace::c_int_w(args[2])? as libc::c_int;
                 #[cfg(not(feature = "sandbox"))]
                 let ret = {
-                    let ret = crate::builtins::crt_call!(libc::lseek(fd, offset, whence));
+                    let ret = crate::builtins::crt_lseek(fd, offset, whence);
                     if ret < 0 {
                         return Err(errno_err(crate::builtins::crt_errno(), ""));
                     }
-                    ret as i64
+                    ret
                 };
                 #[cfg(feature = "sandbox")]
-                let ret = crate::host_seam::ops::lseek(fd, offset as i64, whence)
+                let ret = crate::host_seam::ops::lseek(fd, offset, whence)
                     .map_err(|e| crate::host_seam::seam_os_err(e, ""))?;
                 Ok(pyre_object::w_int_new(ret))
             },

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -191,6 +191,23 @@ fn check_signum_in_range(signum: i64) -> Result<(), crate::PyError> {
     }
 }
 
+/// Whether the runtime has a signal under this number at all.  `SIGBREAK` is
+/// its own, so the set is spelled out rather than taken from `libc`.
+#[cfg(windows)]
+fn windows_handles_signal(signum: i32) -> bool {
+    const SIGBREAK: i32 = 21;
+    matches!(
+        signum,
+        libc::SIGINT
+            | libc::SIGILL
+            | libc::SIGFPE
+            | libc::SIGSEGV
+            | libc::SIGTERM
+            | SIGBREAK
+            | libc::SIGABRT
+    )
+}
+
 /// interp_signal.py:291-326 `signal(signum, handler) -> previous`.
 fn signal_signal(
     w_signum: PyObjectRef,
@@ -208,6 +225,13 @@ fn signal_signal(
     check_signum_in_range(signum)?;
     // The range check bounds it to `1..NSIG`, so the narrowing is exact.
     let signum = signum as i32;
+    // The runtime handles seven numbers and reports any other through the
+    // invalid parameter handler, so the range check is not the whole answer
+    // here (`signal_signal_impl`).
+    #[cfg(windows)]
+    if !windows_handles_signal(signum) {
+        return Err(crate::PyError::value_error("invalid signal value"));
+    }
 
     // interp_signal.py:313-321 — SIG_DFL / SIG_IGN are the ints 0 / 1;
     // anything else must be callable.  PyPy compares with
@@ -246,6 +270,13 @@ fn signal_getsignal(w_signum: PyObjectRef) -> Result<PyObjectRef, crate::PyError
     let signum = signum_arg(w_signum)?;
     check_signum_in_range(signum)?;
     let signum = signum as i32;
+    // A number the runtime has no signal under was never anyone's to handle,
+    // which `signal_module_exec` records as no handler at all rather than as
+    // the default one.
+    #[cfg(windows)]
+    if !windows_handles_signal(signum) {
+        return Ok(pyre_object::w_none());
+    }
     let h = get_handler(signum);
     Ok(if h.is_null() {
         pyre_object::w_int_new(0)
@@ -494,7 +525,7 @@ pub fn install_signal_handling(ec: &mut ExecutionContext) {
         signalstate::register_ticker(ticker_addr);
 
         // app_main.py:926 — `signal.signal(SIGINT, default_int_handler)`.
-        #[cfg(unix)]
+        #[cfg(any(unix, windows))]
         {
             let sigint = libc::SIGINT;
             if signalstate::pypysig_setflag(sigint) {
@@ -647,7 +678,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                             "raise_signal() missing argument",
                         ));
                     };
-                    match rustpython_host_env::signal::raise_signal(signum) {
+                    // The MSVC runtime reports a signal number it does not
+                    // have through its invalid parameter handler, whose
+                    // default action ends the process before `raise` can
+                    // return.  Silenced, it answers -1 and sets `EINVAL`
+                    // (`signal_raise_signal_impl`).
+                    #[cfg(windows)]
+                    let raised = {
+                        crate::builtins::clear_crt_errno();
+                        if crate::builtins::crt_call!(libc::raise(signum)) == 0 {
+                            Ok(())
+                        } else {
+                            Err(std::io::Error::from_raw_os_error(
+                                crate::builtins::crt_errno(),
+                            ))
+                        }
+                    };
+                    #[cfg(not(windows))]
+                    let raised = rustpython_host_env::signal::raise_signal(signum);
+                    match raised {
                         Ok(()) => {
                             // interp_signal.py:583-584 — the signal may
                             // have been delivered to this thread; run the
@@ -737,23 +786,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             0,
         ),
     );
-    // moduledef.py:17 `'ItimerError': 'interp_signal.get_itimer_error(space)'`
-    // — `signal.new_exception_class("signal.ItimerError", space.w_IOError)`.
-    // An OSError subclass so `setitimer`'s `exception_from_saved_errno`
-    // instance carries errno / strerror.
-    let w_os_error = crate::builtins::lookup_exc_class("OSError")
-        .expect("OSError must be installed before _signal init");
-    crate::module_ns_store(
-        ns,
-        "ItimerError",
-        crate::builtins::make_exc_type(
-            "signal.ItimerError",
-            crate::builtins::exc_os_error_new,
-            w_os_error,
-        ),
-    );
     #[cfg(unix)]
     {
+        // moduledef.py:17 `'ItimerError': 'interp_signal.get_itimer_error(space)'`
+        // — `signal.new_exception_class("signal.ItimerError", space.w_IOError)`.
+        // An OSError subclass so `setitimer`'s `exception_from_saved_errno`
+        // instance carries errno / strerror.  It is published beside the
+        // itimers it reports on, so a platform without them does not carry it.
+        let w_os_error = crate::builtins::lookup_exc_class("OSError")
+            .expect("OSError must be installed before _signal init");
+        crate::module_ns_store(
+            ns,
+            "ItimerError",
+            crate::builtins::make_exc_type(
+                "signal.ItimerError",
+                crate::builtins::exc_os_error_new,
+                w_os_error,
+            ),
+        );
         crate::module_ns_store(
             ns,
             "alarm",
@@ -1266,8 +1316,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
     crate::module_ns_store(ns, "SIG_DFL", pyre_object::w_int_new(0));
     crate::module_ns_store(ns, "SIG_IGN", pyre_object::w_int_new(1));
-    // libc crate doesn't surface NSIG portably; use POSIX 64-signal cap.
-    crate::module_ns_store(ns, "NSIG", pyre_object::w_int_new(64));
+    // libc crate doesn't surface NSIG portably; use POSIX 64-signal cap, or
+    // the count the MSVC runtime defines, one past its highest signal.
+    #[cfg(windows)]
+    const NSIG: i64 = 23;
+    #[cfg(not(windows))]
+    const NSIG: i64 = 64;
+    crate::module_ns_store(ns, "NSIG", pyre_object::w_int_new(NSIG));
     // Common signal numbers (POSIX subset, sourced from libc so numerics
     // match the host — Linux SIGUSR1=10 / macOS SIGUSR1=30, etc.).
     #[cfg(unix)]
@@ -1309,5 +1364,23 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
         crate::module_ns_store(ns, "SIGIO", pyre_object::w_int_new(libc::SIGIO as i64));
         crate::module_ns_store(ns, "SIGSYS", pyre_object::w_int_new(libc::SIGSYS as i64));
+    }
+    // The seven the MSVC runtime defines, and the two console events
+    // `os.kill` sends in place of a signal.  `Lib/signal.py` builds its
+    // `Signals` enum out of exactly these names, so `valid_signals()` and
+    // `Signals(2)` answer from here.
+    #[cfg(windows)]
+    {
+        // `SIGBREAK` is the runtime's own, absent from the libc crate.
+        const SIGBREAK: i64 = 21;
+        crate::module_ns_store(ns, "SIGINT", pyre_object::w_int_new(libc::SIGINT as i64));
+        crate::module_ns_store(ns, "SIGILL", pyre_object::w_int_new(libc::SIGILL as i64));
+        crate::module_ns_store(ns, "SIGFPE", pyre_object::w_int_new(libc::SIGFPE as i64));
+        crate::module_ns_store(ns, "SIGSEGV", pyre_object::w_int_new(libc::SIGSEGV as i64));
+        crate::module_ns_store(ns, "SIGTERM", pyre_object::w_int_new(libc::SIGTERM as i64));
+        crate::module_ns_store(ns, "SIGBREAK", pyre_object::w_int_new(SIGBREAK));
+        crate::module_ns_store(ns, "SIGABRT", pyre_object::w_int_new(libc::SIGABRT as i64));
+        crate::module_ns_store(ns, "CTRL_C_EVENT", pyre_object::w_int_new(0));
+        crate::module_ns_store(ns, "CTRL_BREAK_EVENT", pyre_object::w_int_new(1));
     }
 }

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -179,7 +179,24 @@ pub unsafe fn walk_signal_handler_roots_area(
 /// valid signal in its low 32 bits — `(1 << 32) | SIGINT` — would pass the
 /// check and act on the signal it aliases.
 fn signum_arg(w_signum: PyObjectRef) -> Result<i64, crate::PyError> {
-    crate::baseobjspace::gateway_int_w(w_signum)
+    let signum = crate::baseobjspace::gateway_int_w(w_signum).map_err(|err| {
+        if err.kind == crate::PyErrorKind::OverflowError {
+            c_int_overflow()
+        } else {
+            err
+        }
+    })?;
+    if i32::try_from(signum).is_err() {
+        return Err(c_int_overflow());
+    }
+    Ok(signum)
+}
+
+/// `signalnum: int` lands in a C `int`, so a number too large for one is an
+/// OverflowError from the conversion rather than a signal number out of range
+/// (`PyLong_AsInt`).
+fn c_int_overflow() -> crate::PyError {
+    crate::PyError::overflow_error("Python int too large to convert to C int")
 }
 
 /// interp_signal.py:285-288 `check_signum_in_range`.
@@ -222,16 +239,18 @@ fn signal_signal(
             "signal only works in main thread or with _signals_enabled",
         ));
     }
+    // The runtime handles seven numbers and reports any other through the
+    // invalid parameter handler.  `signal_signal_impl` spells that set out
+    // ahead of the range check, so a number outside it is refused as an
+    // invalid value rather than as one out of range — and the conversion
+    // above has already bounded it to a C `int`.
+    #[cfg(windows)]
+    if !windows_handles_signal(signum as i32) {
+        return Err(crate::PyError::value_error("invalid signal value"));
+    }
     check_signum_in_range(signum)?;
     // The range check bounds it to `1..NSIG`, so the narrowing is exact.
     let signum = signum as i32;
-    // The runtime handles seven numbers and reports any other through the
-    // invalid parameter handler, so the range check is not the whole answer
-    // here (`signal_signal_impl`).
-    #[cfg(windows)]
-    if !windows_handles_signal(signum) {
-        return Err(crate::PyError::value_error("invalid signal value"));
-    }
 
     // interp_signal.py:313-321 — SIG_DFL / SIG_IGN are the ints 0 / 1;
     // anything else must be callable.  PyPy compares with
@@ -774,11 +793,10 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             |args| {
                 #[cfg(feature = "host_env")]
                 {
-                    let signum = if let Some(&a) = args.first() {
-                        unsafe { pyre_object::w_int_get_value(a) }
-                    } else {
+                    let Some(&a) = args.first() else {
                         return Err(crate::PyError::type_error("strsignal() missing argument"));
                     };
+                    let signum = signum_arg(a)?;
                     // interp_signal.py:593-594 spells this bound inline rather
                     // than calling `check_signum_in_range`, and its `signalnum
                     // > NSIG` admits `NSIG` itself.  3.14 rejects it — its own
@@ -1359,13 +1377,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     }
     crate::module_ns_store(ns, "SIG_DFL", pyre_object::w_int_new(0));
     crate::module_ns_store(ns, "SIG_IGN", pyre_object::w_int_new(1));
-    // libc crate doesn't surface NSIG portably; use POSIX 64-signal cap, or
-    // the count the MSVC runtime defines, one past its highest signal.
-    #[cfg(windows)]
-    const NSIG: i64 = 23;
-    #[cfg(not(windows))]
-    const NSIG: i64 = 64;
-    crate::module_ns_store(ns, "NSIG", pyre_object::w_int_new(NSIG));
+    crate::module_ns_store(
+        ns,
+        "NSIG",
+        pyre_object::w_int_new(i64::from(signalstate::NSIG)),
+    );
     // Common signal numbers (POSIX subset, sourced from libc so numerics
     // match the host — Linux SIGUSR1=10 / macOS SIGUSR1=30, etc.).
     #[cfg(unix)]

--- a/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
+++ b/pyre/pyre-interpreter/src/module/signal/interp_signal.rs
@@ -643,7 +643,50 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         )));
                     }
                 }
-                #[cfg(not(unix))]
+                // `getsockopt` is how the descriptor is asked whether it is
+                // a socket (`signal_set_wakeup_fd_impl`).  WinSock answers
+                // every call with `WSANOTINITIALISED` until `WSAStartup` has
+                // run, which is why the import of `_socket` there is not just
+                // for the constants.
+                #[cfg(all(windows, not(feature = "sandbox")))]
+                {
+                    use crate::module::_socket::rsocket_rffi as rffi;
+                    rffi::init();
+                    let mut error: libc::c_int = 0;
+                    let mut len = size_of_val(&error) as rffi::SockLen;
+                    let queried = unsafe {
+                        rffi::getsockopt(
+                            rffi::socket_from_i64(i64::from(fd)),
+                            rffi::SOL_SOCKET,
+                            rffi::SO_ERROR,
+                            (&raw mut error).cast(),
+                            &raw mut len,
+                        )
+                    };
+                    if queried != 0 {
+                        let code = rffi::last_error_code();
+                        // `WSAENOTSOCK` is the descriptor answering that it
+                        // is not a socket, which is not a refusal: a file
+                        // descriptor is taken as well, and `_Py_fstat` is
+                        // what answers for that one — an unopened number
+                        // has no handle behind it.  A descriptor is always
+                        // blocking here, so there is nothing else to check.
+                        if code != rffi::WSAENOTSOCK {
+                            return Err(crate::PyError::os_error_win32_syscall2(
+                                code,
+                                pyre_object::PY_NULL,
+                                pyre_object::PY_NULL,
+                            ));
+                        }
+                        if crate::builtins::crt_call!(libc::get_osfhandle(fd)) == -1 {
+                            return Err(crate::PyError::os_error_syscall(
+                                libc::EBADF,
+                                pyre_object::PY_NULL,
+                            ));
+                        }
+                    }
+                }
+                #[cfg(all(not(unix), any(not(windows), feature = "sandbox")))]
                 if fd < -1 {
                     return Err(crate::PyError::value_error(
                         "set_wakeup_fd(): fd must be -1 or a valid file descriptor",

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -9,8 +9,14 @@
 
 use std::sync::atomic::{AtomicBool, AtomicI32, AtomicI64, AtomicPtr, Ordering};
 
-/// `signals.c:34` — reasonable default cap; the libc crate does not
-/// surface `NSIG` portably.  64 fits a single `i64` bitmask.
+/// `signals.c:34` — one past the highest signal number the platform has,
+/// which is what `Py_NSIG` names and what every range check answers from.
+/// The libc crate does not surface it portably; the POSIX cap is the
+/// reasonable default and fits a single `i64` bitmask, and the MSVC runtime
+/// defines its own, smaller, count.
+#[cfg(windows)]
+pub const NSIG: i32 = 23;
+#[cfg(not(windows))]
 pub const NSIG: i32 = 64;
 
 /// Identity of the signal-driving `ActionFlag` ticker cell (`signals.c:45-49

--- a/pyre/pyre-interpreter/src/module/signal/signalstate.rs
+++ b/pyre/pyre-interpreter/src/module/signal/signalstate.rs
@@ -384,17 +384,59 @@ pub fn block_async_signals_on_origin_thread() {}
 #[cfg(not(unix))]
 pub fn unblock_async_signals_on_interp_thread() {}
 
-#[cfg(not(unix))]
+/// The runtime's own `signal`, which is what stands in for `sigaction` here.
+/// The signal number is one the caller has already answered for, so the
+/// invalid parameter handler has nothing to fire on; it is silenced anyway,
+/// its default action being to end the process.
+#[cfg(windows)]
+fn install_handler(signum: i32, handler: libc::sighandler_t) -> bool {
+    let previous = crate::builtins::crt_call!(libc::signal(signum, handler));
+    previous != libc::SIG_ERR as libc::sighandler_t
+}
+
+/// The OS signal handler.  It flags the signal for the next checkpoint and
+/// puts itself back: the runtime resets a handler to the default before
+/// running it, so a second delivery would otherwise end the process.
+///
+/// The wakeup descriptor the POSIX handler also writes to is a socket here,
+/// which this context cannot write to, so `set_wakeup_fd` stays a record.
+#[cfg(windows)]
+extern "C" fn signal_setflag_handler(signum: libc::c_int) {
+    signal_pushback(signum);
+    install_handler(signum, signal_setflag_handler as *const () as usize);
+}
+
+#[cfg(windows)]
+pub fn pypysig_setflag(signum: i32) -> bool {
+    install_handler(signum, signal_setflag_handler as *const () as usize)
+}
+
+#[cfg(windows)]
+pub fn pypysig_default(signum: i32) -> bool {
+    install_handler(signum, libc::SIG_DFL)
+}
+
+#[cfg(windows)]
+pub fn pypysig_ignore(signum: i32) -> bool {
+    install_handler(signum, libc::SIG_IGN)
+}
+
+/// The handler puts itself back as it runs, so there is nothing left to do
+/// here.
+#[cfg(windows)]
+pub fn pypysig_reinstall(_signum: i32) {}
+
+#[cfg(not(any(unix, windows)))]
 pub fn pypysig_setflag(_signum: i32) -> bool {
     false
 }
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 pub fn pypysig_default(_signum: i32) -> bool {
     false
 }
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 pub fn pypysig_ignore(_signum: i32) -> bool {
     false
 }
-#[cfg(not(unix))]
+#[cfg(not(any(unix, windows)))]
 pub fn pypysig_reinstall(_signum: i32) {}

--- a/pyre/pyre-interpreter/src/module/struct/mod.rs
+++ b/pyre/pyre-interpreter/src/module/struct/mod.rs
@@ -686,7 +686,7 @@ unsafe fn writebuf<'a>(obj: PyObjectRef) -> Result<&'a mut [u8], crate::PyError>
         }
         // `W_MMap.writebuf_w` — the live mapping, unless it was opened
         // read-only.
-        #[cfg(all(unix, not(feature = "sandbox")))]
+        #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
         if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
             let (address, length, readonly) = view?;
             if !readonly {
@@ -1523,7 +1523,7 @@ unsafe fn readbuf<'a>(obj: PyObjectRef) -> Result<&'a [u8], crate::PyError> {
             return Ok(bytesobject::bytes_like_data(obj));
         }
         // `W_MMap.readbuf_w` — the live mapping.
-        #[cfg(all(unix, not(feature = "sandbox")))]
+        #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
         if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
             let (address, length, _readonly) = view?;
             return Ok(std::slice::from_raw_parts(address as *const u8, length));

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1276,17 +1276,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // reads it back out of `sys.version` to answer `win-amd64`/`win-arm64`,
     // and pip turns that answer into the wheel platform tag. Elsewhere the
     // compiler string carries no architecture, so neither does this one.
-    let compiler = if !cfg!(windows) {
-        "Rust"
-    } else if cfg!(target_arch = "x86_64") {
-        "Rust 64 bit (AMD64)"
-    } else if cfg!(target_arch = "aarch64") {
-        "Rust 64 bit (ARM64)"
-    } else if cfg!(target_arch = "arm") {
-        "Rust 32 bit (ARM)"
-    } else {
-        "Rust 32 bit (Intel)"
+    //
+    // The name itself is the compiler that built the C the interpreter
+    // carries, which is what `compilerinfo.py:20-27` publishes: `MSC v.` and
+    // `_MSC_VER` on an MSVC build, the compiler's own name elsewhere.
+    // `ctypes.util._get_build_version` reads that number back out to decide
+    // which C runtime `find_library("c")` may hand out, and with no token at
+    // all it assumes MSVC 6 and answers `msvcrt.dll` — a runtime this build
+    // links none of, and whose `errno` is therefore not the one `use_errno`
+    // reports.
+    let name = match option_env!("PYRE_MSC_VER") {
+        Some(msc_ver) => format!("MSC v.{msc_ver}"),
+        None => "Rust".to_string(),
     };
+    let arch = if !cfg!(windows) {
+        ""
+    } else if cfg!(target_arch = "x86_64") {
+        " 64 bit (AMD64)"
+    } else if cfg!(target_arch = "aarch64") {
+        " 64 bit (ARM64)"
+    } else if cfg!(target_arch = "arm") {
+        " 32 bit (ARM)"
+    } else {
+        " 32 bit (Intel)"
+    };
+    let compiler = format!("{name}{arch}");
     module_ns_store(
         ns,
         "version",

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1954,28 +1954,44 @@ fn stack_size(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_int_new(old as i64))
 }
 
+/// The message `PyLong_AsLong` reports a number that does not fit with.
+fn c_long_overflow() -> crate::PyError {
+    crate::PyError::overflow_error("Python int too large to convert to C long")
+}
+
 fn interrupt_main(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if args.len() > 1 {
         return Err(crate::PyError::type_error(
             "interrupt_main() takes at most 1 argument",
         ));
     }
+    // `PyArg_ParseTuple("|i:interrupt_main")` reads the argument as a C
+    // `long`, so a non-integer is a TypeError and a number too large for one
+    // an OverflowError.  Reading the payload word of whatever was passed
+    // instead takes `(1 << 32) | SIGINT` for `SIGINT` and interrupts the main
+    // thread over a number that is not a signal at all.
+    let signum = match args.first() {
+        Some(&arg) => {
+            let value = crate::baseobjspace::int_w(crate::baseobjspace::space_index(arg)?)
+                .map_err(|err| {
+                    if err.kind == crate::PyErrorKind::OverflowError {
+                        c_long_overflow()
+                    } else {
+                        err
+                    }
+                })?;
+            i32::try_from(value).map_err(|_| c_long_overflow())?
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        None => libc::SIGINT,
+        #[cfg(target_arch = "wasm32")]
+        None => 2,
+    };
     #[cfg(not(target_arch = "wasm32"))]
-    let signum = args
-        .first()
-        .map(|&arg| unsafe { w_int_get_value(arg) as i32 })
-        .unwrap_or(libc::SIGINT);
+    let nsig = crate::module::signal::signalstate::NSIG;
     #[cfg(target_arch = "wasm32")]
-    let signum = args
-        .first()
-        .map(|&arg| unsafe { w_int_get_value(arg) as i32 })
-        .unwrap_or(2);
-    #[cfg(not(target_arch = "wasm32"))]
-    if !(1..crate::module::signal::signalstate::NSIG).contains(&signum) {
-        return Err(crate::PyError::value_error("signal number out of range"));
-    }
-    #[cfg(target_arch = "wasm32")]
-    if !(1..65).contains(&signum) {
+    let nsig = 65;
+    if !(1..nsig).contains(&signum) {
         return Err(crate::PyError::value_error("signal number out of range"));
     }
     let ec = crate::call::getexecutioncontext();

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -17,12 +17,11 @@ use std::time::Instant;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Number of fields in `time.struct_time` as seen by C extensions.
-/// `interp_time.py:290` uses 9, raised to 11 when `struct tm` carries
-/// `tm_zone`/`tm_gmtoff` — true on every Unix target pyre builds for.
-#[cfg(unix)]
+/// `interp_time.py:290` uses 9 plus `tm_zone`/`tm_gmtoff`.  The Unix
+/// `struct tm` carries that pair; the MSVC one does not, and `localtime`
+/// derives it from the host zone rather than dropping the fields, so the
+/// count is the same everywhere.
 pub const STRUCT_TM_ITEMS: i64 = 11;
-#[cfg(not(unix))]
-pub const STRUCT_TM_ITEMS: i64 = 9;
 
 /// Process-start `Instant` used as the monotonic-clock origin whenever
 /// `clock_gettime(CLOCK_MONOTONIC)` is unavailable.  Keeping a single
@@ -287,6 +286,20 @@ pub fn get_time_info(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     }
     let name = unsafe { pyre_object::w_str_get_wtf8(name_obj) };
     let name_str = name.as_str().unwrap_or_default();
+    // Each name reports the call the corresponding function is actually made
+    // of, so the Windows table is its own — none of the five is a
+    // `clock_gettime` there.  `time` is `SystemTime::now`, `monotonic` and
+    // `perf_counter` are `Instant`, and the two CPU clocks are the
+    // `Get*Times` pair `process_time_nanos` / `thread_time_nanos` read.
+    #[cfg(windows)]
+    let (implementation, monotonic, adjustable) = match name_str {
+        "time" => ("GetSystemTimePreciseAsFileTime()", false, true),
+        "monotonic" | "perf_counter" => ("QueryPerformanceCounter()", true, false),
+        "process_time" => ("GetProcessTimes()", true, false),
+        "thread_time" => ("GetThreadTimes()", true, false),
+        _ => return Err(crate::PyError::value_error("unknown clock")),
+    };
+    #[cfg(not(windows))]
     let (implementation, monotonic, adjustable) = match name_str {
         "time" => ("clock_gettime(CLOCK_REALTIME)", false, true),
         "monotonic" | "perf_counter" => {
@@ -401,9 +414,27 @@ fn get_clock_info_resolution(name: &str) -> f64 {
         .unwrap_or(1.0e-9)
 }
 
+/// Windows has no `clock_getres`; each clock's resolution is a property of
+/// the call behind it.  `QueryPerformanceFrequency` answers for the two
+/// `Instant` clocks, and the other three are counted in the 100ns unit both
+/// `FILETIME` and `Get*Times` use.
+#[cfg(all(windows, feature = "host_env"))]
+fn get_clock_info_resolution(name: &str) -> f64 {
+    const FILETIME_TICK_SECONDS: f64 = 1.0e-7;
+    match name {
+        "monotonic" | "perf_counter" => host_time::query_performance_frequency()
+            .filter(|&frequency| frequency > 0)
+            .map_or(FILETIME_TICK_SECONDS, |frequency| 1.0 / frequency as f64),
+        _ => FILETIME_TICK_SECONDS,
+    }
+}
+
 /// Without a host `clock_getres` (non-Unix, no `host_env`, or redox), report the
 /// nanosecond representation resolution every pyre clock carries internally.
-#[cfg(not(all(unix, feature = "host_env", not(target_os = "redox"))))]
+#[cfg(not(any(
+    all(unix, feature = "host_env", not(target_os = "redox")),
+    all(windows, feature = "host_env")
+)))]
 fn get_clock_info_resolution(_name: &str) -> f64 {
     1.0e-9
 }
@@ -440,11 +471,50 @@ fn process_time_nanos() -> Result<i128, crate::PyError> {
     }
 }
 
-#[cfg(not(all(unix, feature = "host_env")))]
+/// `GetProcessTimes`' kernel + user total, the pair `_PyTime_GetProcessTime`
+/// reads on this platform.  The monotonic fallback below would count a sleep,
+/// which is the one thing process time must not do.
+#[cfg(all(windows, feature = "host_env"))]
+fn process_time_nanos() -> Result<i128, crate::PyError> {
+    host_time::get_process_time_100ns()
+        .map(|hundred_ns| i128::from(hundred_ns) * 100)
+        .ok_or_else(|| {
+            crate::PyError::runtime_error(
+                "the processor time used is not available or its value cannot be represented",
+            )
+        })
+}
+
+#[cfg(not(any(all(unix, feature = "host_env"), all(windows, feature = "host_env"))))]
 fn process_time_nanos() -> Result<i128, crate::PyError> {
     // No host clock available; fall back to the monotonic baseline so
     // the value is still non-decreasing.
     Ok(monotonic_baseline().elapsed().as_nanos() as i128)
+}
+
+/// `GetThreadTimes`' kernel + user total for the calling thread — the
+/// `_PyTime_GetThreadTime` counterpart of the `CLOCK_THREAD_CPUTIME_ID` read
+/// below.  As there, an unreadable clock raises rather than reporting a
+/// process-wide figure in its place.
+#[cfg(all(windows, feature = "host_env"))]
+fn thread_time_nanos() -> Result<i128, crate::PyError> {
+    host_time::get_thread_time_100ns()
+        .map(|hundred_ns| i128::from(hundred_ns) * 100)
+        .ok_or_else(|| crate::PyError::os_error("the thread time used is not available"))
+}
+
+/// time.thread_time() → float
+#[cfg(all(windows, feature = "host_env"))]
+pub fn thread_time(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let _ = args;
+    Ok(floatobject::w_float_new(thread_time_nanos()? as f64 * 1e-9))
+}
+
+/// time.thread_time_ns() → int
+#[cfg(all(windows, feature = "host_env"))]
+pub fn thread_time_ns(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let _ = args;
+    Ok(w_int_new(thread_time_nanos()? as i64))
 }
 
 /// time.process_time() → float
@@ -920,6 +990,81 @@ pub fn tzset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
 // ── Windows helpers ─────────────────────────────────────────────────
 
+/// Days from 1970-01-01 to a proleptic-Gregorian date, for a `timegm` the
+/// MSVC runtime does not offer under a portable name.  Civil-from-days in
+/// reverse, with March as the first month so a leap day lands last.
+#[cfg(windows)]
+fn windows_days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+    let year = if month <= 2 { year - 1 } else { year };
+    let era = if year >= 0 { year } else { year - 399 } / 400;
+    let year_of_era = year - era * 400;
+    let month_of_year = (month + 9) % 12;
+    let day_of_year = (153 * month_of_year + 2) / 5 + day - 1;
+    let day_of_era = year_of_era * 365 + year_of_era / 4 - year_of_era / 100 + day_of_year;
+    era * 146097 + day_of_era - 719468
+}
+
+/// `time_localtime`'s `#else` arm, which supplies the two fields the MSVC
+/// `struct tm` lacks: the zone name for this timestamp, and the offset as
+/// `timegm(local) - when`.
+///
+/// The name comes from the host zone rather than `strftime("%Z")` — the two
+/// agree, and reading it directly keeps the string out of the runtime's
+/// locale encoding, which cannot spell a zone named outside its code page.
+#[cfg(windows)]
+fn windows_fill_local_zone(tm: &mut c_tm, when: time_t) {
+    let info = host_time::get_tz_info();
+    tm.tm_zone = if tm.tm_isdst > 0 {
+        info.daylight_name
+    } else {
+        info.standard_name
+    };
+    let days = windows_days_from_civil(
+        i64::from(tm.tm_year) + 1900,
+        i64::from(tm.tm_mon) + 1,
+        i64::from(tm.tm_mday),
+    );
+    let as_utc = days * 86400
+        + i64::from(tm.tm_hour) * 3600
+        + i64::from(tm.tm_min) * 60
+        + i64::from(tm.tm_sec);
+    tm.tm_gmtoff = as_utc - when as i64;
+}
+
+/// `_init_timezone`'s Windows arm.  The runtime derives `_timezone` /
+/// `_daylight` / `_tzname` from the same zone record `GetTimeZoneInformation`
+/// reports, and reading the record is what keeps the two names as text rather
+/// than bytes in whichever code page the runtime is set to.
+///
+/// `Bias` is minutes to add to local time to reach UTC, which is the sign
+/// `time.timezone` already uses.  `altzone` is `timezone - 3600` — the value
+/// the module publishes on this platform, not a second reading of the record.
+/// `daylight` says the zone observes DST at all, which is what the runtime
+/// reports and what a January/July pair shows.
+#[cfg(windows)]
+pub(crate) fn init_timezone(ns: PyObjectRef) {
+    const YEAR: i64 = (365 * 24 + 6) * 3600;
+    let info = host_time::get_tz_info();
+    let timezone = i64::from(info.bias + info.standard_bias) * 60;
+    let start = duration_since_epoch().as_secs() as i64 / YEAR * YEAR;
+    let observes_dst = [start, start + YEAR / 2]
+        .iter()
+        .filter_map(|&when| _c_localtime(when).ok())
+        .any(|tm| tm.tm_isdst > 0);
+
+    crate::module_ns_store(ns, "timezone", w_int_new(timezone));
+    crate::module_ns_store(ns, "altzone", w_int_new(timezone - 3600));
+    crate::module_ns_store(ns, "daylight", w_int_new(i64::from(observes_dst)));
+    crate::module_ns_store(
+        ns,
+        "tzname",
+        w_tuple_new(vec![
+            w_str_new(&info.standard_name),
+            w_str_new(&info.daylight_name),
+        ]),
+    );
+}
+
 #[cfg(windows)]
 #[repr(C)]
 #[allow(non_camel_case_types)]
@@ -970,8 +1115,8 @@ fn c_tm_to_msvc_tm(tm: &c_tm) -> MsvcTm {
 
 /// `app_time.py:5-23 class struct_time(metaclass=structseqtype)` —
 /// process-wide cached subclass-of-tuple type.  The 9-field positional
-/// core; on Unix (`HAS_TM_ZONE`) `tm_zone` / `tm_gmtoff` are named-only
-/// extras so `n_fields == _STRUCT_TM_ITEMS == 11`.
+/// core, with `tm_zone` / `tm_gmtoff` as named-only extras so
+/// `n_fields == _STRUCT_TM_ITEMS == 11`.
 static STRUCT_TIME_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
 
 pub(crate) fn struct_time_type() -> PyObjectRef {
@@ -980,18 +1125,11 @@ pub(crate) fn struct_time_type() -> PyObjectRef {
         "tm_isdst",
     ];
     *STRUCT_TIME_TYPE.get_or_init(|| {
-        #[cfg(unix)]
-        {
-            crate::_structseq::make_struct_seq_with_extra(
-                "time.struct_time",
-                SEQ,
-                &["tm_zone", "tm_gmtoff"],
-            ) as usize
-        }
-        #[cfg(not(unix))]
-        {
-            crate::_structseq::make_struct_seq("time.struct_time", SEQ) as usize
-        }
+        crate::_structseq::make_struct_seq_with_extra(
+            "time.struct_time",
+            SEQ,
+            &["tm_zone", "tm_gmtoff"],
+        ) as usize
     }) as PyObjectRef
 }
 
@@ -1008,19 +1146,11 @@ fn _tm_to_tuple(tm: &c_tm) -> PyObjectRef {
         w_int_new((tm.tm_yday + 1) as i64),
         w_int_new(tm.tm_isdst as i64),
     ];
-    // `_tm_to_tuple` — on Unix the zone fields are exposed as extras.
-    #[cfg(unix)]
-    {
-        let extras = vec![
-            ("tm_zone", pyre_object::w_str_new(&tm.tm_zone)),
-            ("tm_gmtoff", w_int_new(tm.tm_gmtoff)),
-        ];
-        crate::_structseq::new_instance_with_extra(struct_time_type(), seq, extras)
-    }
-    #[cfg(not(unix))]
-    {
-        crate::_structseq::new_instance(struct_time_type(), seq)
-    }
+    let extras = vec![
+        ("tm_zone", pyre_object::w_str_new(&tm.tm_zone)),
+        ("tm_gmtoff", w_int_new(tm.tm_gmtoff)),
+    ];
+    crate::_structseq::new_instance_with_extra(struct_time_type(), seq, extras)
 }
 
 /// `interp_time.py:738-758 _get_inttime` — extract integral epoch seconds
@@ -1152,14 +1282,25 @@ fn _gettmarg(args: &[PyObjectRef], default_now: bool) -> Result<c_tm, crate::PyE
 /// time.localtime([seconds]) — interp_time.localtime
 pub fn localtime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let seconds = _get_seconds(args)?;
-    let tm = _c_localtime(seconds)?;
+    #[cfg_attr(not(windows), expect(unused_mut))]
+    let mut tm = _c_localtime(seconds)?;
+    #[cfg(windows)]
+    windows_fill_local_zone(&mut tm, seconds);
     Ok(_tm_to_tuple(&tm))
 }
 
 /// time.gmtime([seconds]) — interp_time.gmtime
 pub fn gmtime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let seconds = _get_seconds(args)?;
-    let tm = _c_gmtime(seconds)?;
+    #[cfg_attr(not(windows), expect(unused_mut))]
+    let mut tm = _c_gmtime(seconds)?;
+    // The Unix `struct tm` names UTC itself; the MSVC one has no zone fields
+    // at all, so the pair `gmtime` always answers is set here.
+    #[cfg(windows)]
+    {
+        tm.tm_zone = "UTC".to_string();
+        tm.tm_gmtoff = 0;
+    }
     Ok(_tm_to_tuple(&tm))
 }
 
@@ -1394,21 +1535,30 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         };
         Ok(result)
     }
+    // The wide runtime call, which is what `format_time` resolves to here.
+    // The narrow one goes through the active code page, so it can neither be
+    // handed a format outside that page — an astral character comes back as
+    // nothing — nor return a `%Z` zone name that the page cannot spell.
+    // UTF-16 is what pyre's own strings already are: `encode_wide` carries a
+    // lone surrogate as itself, and `from_wide` carries it back.
     #[cfg(windows)]
     {
         unsafe extern "C" {
-            fn strftime(
-                buf: *mut libc::c_char,
+            fn wcsftime(
+                buf: *mut u16,
                 maxsize: usize,
-                format: *const libc::c_char,
+                format: *const u16,
                 timeptr: *const MsvcTm,
             ) -> usize;
         }
-        let c_fmt = std::ffi::CString::new(fmt_wtf8.as_bytes())
-            .map_err(|_| crate::PyError::value_error("embedded null in format string"))?;
         let msvc_tm = c_tm_to_msvc_tm(&tm);
-        let mut buf = vec![0u8; 256];
-        unsafe {
+        let render_segment = |segment: &[u16]| -> Result<Vec<u16>, crate::PyError> {
+            if segment.is_empty() {
+                return Ok(Vec::new());
+            }
+            let mut c_fmt = segment.to_vec();
+            c_fmt.push(0);
+            let mut buf = vec![0u16; 256];
             loop {
                 // A directive the runtime does not accept reaches its invalid
                 // parameter handler, which ends the process unless it is
@@ -1416,35 +1566,58 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
                 // instead.  The cell has to start clear for that read to
                 // describe this call rather than an earlier one.
                 crate::builtins::clear_crt_errno();
-                let n = crate::builtins::crt_call!(strftime(
-                    buf.as_mut_ptr() as *mut libc::c_char,
-                    buf.len(),
-                    c_fmt.as_ptr(),
-                    &msvc_tm,
-                ));
+                let n = unsafe {
+                    crate::builtins::crt_call!(wcsftime(
+                        buf.as_mut_ptr(),
+                        buf.len(),
+                        c_fmt.as_ptr(),
+                        &msvc_tm,
+                    ))
+                };
                 // A rejected directive is neither a buffer too small for the
                 // result nor the empty-result case below.
                 if n == 0 && crate::builtins::crt_errno() == libc::EINVAL {
                     return Err(crate::PyError::value_error("Invalid format string"));
                 }
                 if n != 0 {
-                    // The same recovery as the unix arm above: unrecognised
-                    // directive bytes are echoed verbatim, so a format that is
-                    // a lone surrogate's WTF-8 encoding comes back unchanged,
-                    // and genuinely undecodable locale output takes
-                    // surrogateescape rather than raising.
-                    let rendered = buf[..n].to_vec();
-                    return Ok(match rustpython_wtf8::Wtf8Buf::from_bytes(rendered) {
-                        Ok(wtf8) => w_str_from_wtf8_managed(wtf8),
-                        Err(bytes) => crate::typedef::charp2uni(&bytes),
-                    });
+                    return Ok(buf[..n].to_vec());
                 }
-                if buf.len() > 16384 {
-                    return Ok(w_str_new(""));
+                // A buffer 256 times the format length is not failing for lack
+                // of room: the format simply yields an empty result, e.g. `%Z`
+                // when the timezone is unknown.
+                if buf.len() >= 256 * format_len.max(1) {
+                    return Ok(Vec::new());
                 }
                 buf.resize(buf.len() * 2, 0);
             }
+        };
+
+        // gh-124531 and gh-78662: an embedded NUL is literal data rather than
+        // the end of the format, and so is every character outside ASCII.  The
+        // runtime can carry neither — its format argument ends at the first
+        // NUL, and letting a non-ASCII character make the round trip would fuse
+        // an adjacent surrogate pair back into the one character it spells.  So
+        // the runtime renders the ASCII runs and the rest is copied verbatim,
+        // which also makes `%` immediately before such a character the
+        // incomplete directive it is.
+        let mut result = rustpython_wtf8::Wtf8Buf::new();
+        let mut segment: Vec<u16> = Vec::new();
+        // The trailing `None` renders the last run without repeating the call.
+        for code_point in fmt_wtf8.code_points().map(Some).chain([None]) {
+            let unit = code_point.map_or(0, rustpython_wtf8::CodePoint::to_u32);
+            if (1..=0x7f).contains(&unit) {
+                segment.push(unit as u16);
+                continue;
+            }
+            result.push_wtf8(&rustpython_wtf8::Wtf8Buf::from_wide(&render_segment(
+                &segment,
+            )?));
+            segment.clear();
+            if let Some(literal) = code_point {
+                result.push(literal);
+            }
         }
+        Ok(w_str_from_wtf8_managed(result))
     }
 }
 

--- a/pyre/pyre-interpreter/src/module/time/interp_time.rs
+++ b/pyre/pyre-interpreter/src/module/time/interp_time.rs
@@ -1292,6 +1292,17 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let tm = _gettmarg(&args[1..], true)?;
     _checktm(&tm)?;
 
+    // The MSVC runtime accepts only [1; 9999] here and reports anything else
+    // through its invalid parameter handler, whose default action ends the
+    // process before the caller can see a return value.  `tm_year + 1900` is
+    // the year `_gettmarg` was given, so this cannot overflow.
+    #[cfg(windows)]
+    if tm.tm_year + 1900 < 1 || 9999 < tm.tm_year + 1900 {
+        return Err(crate::PyError::value_error(
+            "strftime() requires year in [1; 9999]",
+        ));
+    }
+
     let fmt_wtf8 = unsafe {
         if !is_str(fmt) {
             return Err(crate::PyError::type_error(
@@ -1399,12 +1410,23 @@ pub fn strftime(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let mut buf = vec![0u8; 256];
         unsafe {
             loop {
-                let n = strftime(
+                // A directive the runtime does not accept reaches its invalid
+                // parameter handler, which ends the process unless it is
+                // silenced; silenced, the call returns zero and sets `EINVAL`
+                // instead.  The cell has to start clear for that read to
+                // describe this call rather than an earlier one.
+                crate::builtins::clear_crt_errno();
+                let n = crate::builtins::crt_call!(strftime(
                     buf.as_mut_ptr() as *mut libc::c_char,
                     buf.len(),
                     c_fmt.as_ptr(),
                     &msvc_tm,
-                );
+                ));
+                // A rejected directive is neither a buffer too small for the
+                // result nor the empty-result case below.
+                if n == 0 && crate::builtins::crt_errno() == libc::EINVAL {
+                    return Err(crate::PyError::value_error("Invalid format string"));
+                }
                 if n != 0 {
                     // The same recovery as the unix arm above: unrecognised
                     // directive bytes are echoed verbatim, so a format that is

--- a/pyre/pyre-interpreter/src/module/time/mod.rs
+++ b/pyre/pyre-interpreter/src/module/time/mod.rs
@@ -114,6 +114,20 @@ crate::py_module! {
                 crate::make_builtin_function_with_arity("tzset", t::tzset, 0),
             );
         }
+        // Windows reads the same four attributes off the host zone record.
+        // `tzset` stays absent: it is the POSIX call that rereads `$TZ`, and
+        // the MSVC runtime's `_tzset` is not exposed under that name either.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            t::init_timezone(ns);
+            // `GetThreadTimes` is unconditional on Windows, so `thread_time`
+            // is published there for the same reason the Unix arm publishes
+            // it wherever `CLOCK_THREAD_CPUTIME_ID` exists.
+            crate::module_ns_store(ns, "thread_time",
+                crate::make_builtin_function_with_arity("thread_time", t::thread_time, 0));
+            crate::module_ns_store(ns, "thread_time_ns",
+                crate::make_builtin_function_with_arity("thread_time_ns", t::thread_time_ns, 0));
+        }
         // localtime/mktime/ctime/strftime consult $TZ + /etc/localtime (and
         // the LC_TIME locale DB), reading host state outside the controller;
         // gmtime (UTC) and asctime (fixed C format) stay pure.

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21889,7 +21889,7 @@ pub(crate) fn buffer_as_bytes_like(
     // `W_MMap.readbuf_w` — the mapping is a bytes-like source in its own
     // right, so `bytes(m)` / `bytearray(m)` copy it here instead of falling
     // through to the iterable path.
-    #[cfg(all(unix, not(feature = "sandbox")))]
+    #[cfg(all(any(unix, windows), not(feature = "sandbox")))]
     if let Some(view) = crate::module::mmap::interp_mmap::mmap_buffer_view(obj) {
         let (address, length, _readonly) = view?;
         let data = unsafe { std::slice::from_raw_parts(address as *const u8, length) };

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -1352,6 +1352,7 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
         return 0;
     }
     const HEAPTYPE: i64 = 1 << 9; // copy_reg._HEAPTYPE
+    const IMMUTABLETYPE: i64 = 1 << 8;
     const ABSTRACT: i64 = 1 << 20;
     const PATMA_SEQUENCE: i64 = 1 << 5;
     const PATMA_MAPPING: i64 = 1 << 6;
@@ -1361,6 +1362,18 @@ pub unsafe fn w_type_get_flags(obj: PyObjectRef) -> i64 {
     let mut flags = 0;
     if t.flag_heaptype {
         flags |= HEAPTYPE;
+    } else {
+        // `Py_TPFLAGS_IMMUTABLETYPE` (`object.h`, read at v3.14.6): a type
+        // whose attributes cannot be set.  `get_flags` publishes no such bit
+        // — it reports the heap flag and stops — while every type pyre builds
+        // itself already answers "cannot set 'x' attribute of immutable type"
+        // to a store, so the flag names something already true here rather
+        // than changing what any of them does.  Measured over 39 builtins on
+        // 3.14: the bit is set on exactly the types that are not heap types,
+        // and those are exactly the ones that refuse the store, in both
+        // interpreters.  `test_ctypes/_support.py` spells the constant and
+        // `test_win32.py:81` reads it back off `COMError`.
+        flags |= IMMUTABLETYPE;
     }
     // typeobject.py `flag_cpytype` marks cpyext-defined static types; pyre has
     // no equivalent type owner, so its bit is always absent.

--- a/scripts/llbc_extract.py
+++ b/scripts/llbc_extract.py
@@ -1320,7 +1320,11 @@ def write_readfiles(path: Path, by_crate: dict[str, set[Path]]) -> None:
         {item for crate_files in by_crate.values() for item in crate_files},
         key=lambda item: item.as_posix(),
     )
-    path.write_text("".join(f"{item.as_posix()}\n" for item in files), encoding="utf-8")
+    path.write_text(
+        "".join(f"{item.as_posix()}\n" for item in files),
+        encoding="utf-8",
+        newline="\n",
+    )
 
 
 def assert_readfiles_resolve(root: Path, dest: Path, by_crate: dict[str, set[Path]]) -> None:
@@ -2285,7 +2289,13 @@ def extract(eng: Engine, args: argparse.Namespace) -> None:
                 f" unstamped — reported as freshness UNKNOWN, not as fresh."
             )
             continue
-        stamp_path.write_text(current_stamp + "\n")
+        # The line ending is pinned, not left to the platform: the stamp is
+        # compared against a string built in memory with "\n", so a writer
+        # that translates makes the artefact describe the same tree
+        # differently on Windows than everywhere else.
+        stamp_path.write_text(
+            current_stamp + "\n", encoding="utf-8", newline="\n"
+        )
         print(f"    wrote {dest} ({dest.stat().st_size} bytes)")
 
     print()
@@ -2414,7 +2424,14 @@ def check(eng: Engine, args: argparse.Namespace) -> None:
                 f"records no source digest, so it cannot match the tree"
             )
             continue
-        text = stamp_bytes.decode("utf-8", errors="replace")
+        # Bytes and not `read_text`, so a truncated or foreign stamp is seen
+        # as it is — but a stamp written before the writer above pinned its
+        # line endings holds CRLF on Windows, and comparing that against an
+        # LF string reports every one of them as carrying content this
+        # engine did not write.
+        text = stamp_bytes.decode("utf-8", errors="replace").replace(
+            "\r\n", "\n"
+        )
         if not text.strip():
             stale.append(
                 f"{crate}: fingerprint stamp {stamp_path} holds only whitespace"


### PR DESCRIPTION
## Summary

The Windows halves of several modules, plus the `_ctypes` call surface up to
COM vtable methods. Every behaviour below was measured against CPython 3.14 on
Windows unless stated otherwise.

**The invalid parameter handler.** `time.strftime` and `_locale.setlocale`
passed their arguments to the C runtime unchecked. The runtime reports a
rejected argument through its invalid parameter handler, whose default action
is `__fastfail`: the process exits `0xC0000409` having written nothing to
either stream, so no traceback and no test report survives. Both check their
arguments first now.

**`time` / `_locale`.** `struct_time` carried 9 fields on Windows,
`timezone` / `altzone` / `daylight` / `tzname` stayed at the UTC interplevel
defaults, `thread_time` was absent, `get_clock_info` named clocks the platform
does not have, and `strftime`, `strcoll` and `strxfrm` ran through the narrow
runtime calls, which convert their arguments through the active code page.

**`errno`, `signal`, `_multiprocessing`.** 69 errno names were absent — the
whole `WSAE*` set, the six classic names bound to a Winsock value, and nine the
runtime carries under the same name as POSIX; `errorcode` went from 67 entries
to the 101 CPython has. `os_error_errno_subclass` read the numbers out of
`libc` while `errno` published the socket names at their Winsock values, so
`OSError(errno.EWOULDBLOCK)` was a bare `OSError`, and `winerror_to_errno` sent
the whole 10000..12000 range to `EINVAL`. `_multiprocessing` was gated to unix,
so `multiprocessing/connection.py` died on `_multiprocessing.closesocket` at
import; the platform seam is now four functions with the bookkeeping shared.
`signal` published no `SIG*` name, so `Lib/signal.py` built an empty `Signals`
enum and `multiprocessing.resource_tracker` could not import.

`SemLock.__new__` accepted six positional arguments and nothing else, so
`SemLock(kind=1, ...)` was a TypeError and every ill-formed call answered with
the same message. It binds by name now. Separately, a builtin registered with
a `Signature` reaches its body through `bind_kwargs_to_signature`, which leaves
an omitted slot `PY_NULL`; `bind_builtin_kwargs` counted those as arguments
that were passed, so `SemLock(1, 1, 1)` reached `is_str` on a null and ended
the process. A null positional is read as an omitted argument now, which is
what makes the two registrations bind alike.

**`signal`, `_thread`.** `set_wakeup_fd` only rejected a number below -1, so it
took a closed socket and an unopened descriptor alike; it asks
`getsockopt(SOL_SOCKET, SO_ERROR)` whether the descriptor is a socket now, and
sends `WSAENOTSOCK` on to the fstat path. `NSIG` was 64 everywhere while
`signal.signal` refused everything above 22, so `getsignal(30)`,
`strsignal(30)` and `_thread.interrupt_main(30)` answered as though the number
were a signal; it is 23 there now.

**`_io`, `posix`.** The MSVC runtime's `lseek` takes a 32-bit `long`, so every
seek past 2 GiB was truncated: `os.lseek(fd, 1 << 31, 0)` raised `EINVAL`,
`1 << 32` seeked to the start, and `f.seek(0x14FFFFFFF)` landed at
`0x4FFFFFFF`. The whole 64-bit position travels now.

**`mmap`.** `rmmap.py:998-1000` reaches every file-backed Windows mapping
through one `CreateFileMapping`; pyre took that route only for a tagged
mapping and sent an untagged one through memmap2, which asks for a maximum
size of 0 and so cannot extend the file. One route now, and a length past EOF
grows the file.

**`posix`, `importing`.** `os.symlink(os.path.join('a', 'bcd'), 'sym3')` — the
two-argument call — produced a link that could not be walked into, because
`os_symlink_impl` reads the link kind off `target_is_directory` *or*
`_check_dirW`. And `is_possibly_shadowing` compared a `canonicalize`d anchor
against the name the finder joined, which on Windows differ by the
`GetFinalPathNameByHandleW` prefix, so the two never matched; the anchor is
spelled the way module origins are now.

**`_ctypes`.** A `str` argument raised "not implemented in this ctypes slice";
it is copied into a NUL-terminated `wchar_t` buffer held for the duration of
the call. `kernel32.GetModuleHandleA(32)` read address 0x20 and took the
process down with it — a structured exception is not a Rust panic, so the call
is fenced the way `_ctypes_callproc` fences `ffi_call`. `call_function` /
`call_cdeclfunction` and the `BSTR` type code were absent.

A return type may declare `_check_retval_`, and `HRESULT` is the one that
does, so every `oledll` function was handing back a failed status as a negative
number instead of raising. `errcheck` was absent altogether — assigning one
landed in the instance dict and was never read.

`proto(index, name[, paramflags[, iid]])` raised `TypeError: argument must be
callable or integer function address`: the constructor read its last argument
rather than dispatching on the first, so the COM form was never reached. It
dispatches on the first now — a tuple is the dll form, an integer followed by a
name is a COM method, a lone integer is an address. A COM method has no address
of its own: the interface pointer passed as its first argument is what its
vtable is read out of, and with an interface id a failed status asks the
callee's `ISupportErrorInfo` / `IErrorInfo` what went wrong and raises
`COMError` with the answer. With `paramflags`, each declared argtype gets its
value from the call, from a keyword of that name, from a declared default, or —
for an `out` parameter — from a fresh instance of the type the argtype points
at, which the caller gets back instead of the call's own result.
`POINTER(T)` handed a `T` instance now passes its address rather than reading a
pointer out of it, and a null `c_void_p` reads as `None` the way a null string
already did.

Measured over `IPersist` on a ShellLink: construction in all three forms,
`repr`, `bool`, `GetClassID` by reference and as an `out` parameter,
`AddRef`/`Release` counts, `QueryInterface` succeeding and failing, the
`COMError` a failed one raises, and — on plain `kernel32` functions — a named
argument, a default, one `out`, two `out`, an `inout` and what `errcheck` is
handed. Every line identical but the addresses.

**Also.** `sys.version` said `[Rust 64 bit (AMD64)]` where the token names the
C compiler, which `ctypes.util._get_build_version` reads back to decide which
C runtime `find_library("c")` may hand out; it is `MSC v.<_MSC_VER>` on an MSVC
build now. `__flags__` published the heap bit and stopped, so every builtin
type read as `Py_TPFLAGS_IMMUTABLETYPE`-clear. `crt_lseek` was declared for
every non-sandbox target although `wasm32-unknown-unknown`'s libc has none of
its four names. `extract-llbc --check` wrote its fingerprint stamp through
`Path.write_text`, so on Windows the stamp held CRLF while the comparison
built LF and every crate reported stale on a clean tree. And the wasm runtime
codegen tests spelled their artifact paths without an executable suffix.

## Test status

`cargo test --all --features dynasm`: 7954 passed, 0 failed.
`pyre/cpython_tests/run.py` on Windows: 198 PASS / 3 FAIL / 0 CRASH.
`test_ctypes` (325 tests) passes in full; it was failing before this branch.

The three reds are platform artifacts rather than interpreter defects, each
root-caused:

- `test_import` — `test_dll_dependency_import` is guarded only by
  `skipUnless(sys.platform == "win32")` and needs `sys.dllhandle` plus a
  `.pyd`-backed `_sqlite3`, so `find_spec` answers `None` on a static build.
- `test_mmap` — 40 errors, one cascade. `test_access_parameter` opens an
  `ACCESS_READ` mmap and never closes it; CPython's refcount closes it when `m`
  is rebound, and Windows refuses `SetEndOfFile` on a file that still has a
  mapping view, so `f.truncate` raises `EACCES` and every later `setUp`'s
  `os.unlink` fails `WinError 32`.
- `test_importlib` — the same shape around a temp `zipped modules.zip`.

The suite compares against `baseline.json` with no `win32-AMD64` overlay, so
`test_fork1`, `test_openpty`, `test_syslog`, `test_tty` and `test_file_eintr`
also read as `PASS -> SKIP`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014svTHUbS67NLQwtPQMuyH4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded Windows compatibility for `ctypes`, including COM calls, callbacks, wide strings, output parameters, and error handling.
  - Added Windows support for multiprocessing semaphores, socket helpers, signals, CPU clocks, timezone data, and locale operations.
  - Improved Windows memory mapping, symlink creation, file positioning, and path handling.

- **Bug Fixes**
  - Corrected argument validation, pointer conversion, signal overflow handling, mmap boundaries, and `struct_time` metadata.
  - Improved build progress reporting and runtime output comparisons across platforms.

- **Chores**
  - Added safeguards for temporary test files and normalized generated file line endings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->