### PR TITLE
jit: read a deref-last projection as a value, and put fast2locals on the virtualizable protocol

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -4664,7 +4664,7 @@ impl<'a> Lowering<'a> {
             // itself. Aliasing the dest local to the referent Variable
             // keeps the IR small, treating `&x` as a same-Variable copy.
             Rvalue::Ref { place, .. } => {
-                let projection = matches!(&place.kind, PlaceKind::Projection(..));
+                let projection = Self::place_ref_is_address_of(&place);
                 let before = self.graph.block(self.block_id[mir_bb]).operations.len();
                 let v = self.resolve_place(mir_bb, place)?;
                 self.mark_place_address_of(mir_bb, projection, before, &v);
@@ -4675,7 +4675,7 @@ impl<'a> Lowering<'a> {
             // and references identically at the IR level (lifetime
             // tracking lives outside the JIT).
             Rvalue::RawPtr { place, .. } => {
-                let projection = matches!(&place.kind, PlaceKind::Projection(..));
+                let projection = Self::place_ref_is_address_of(&place);
                 let before = self.graph.block(self.block_id[mir_bb]).operations.len();
                 let v = self.resolve_place(mir_bb, place)?;
                 self.mark_place_address_of(mir_bb, projection, before, &v);
@@ -5373,6 +5373,24 @@ impl<'a> Lowering<'a> {
             kind: op,
         });
         Ok(var)
+    }
+
+    /// Whether `&<place>` / `&raw [mut] <place>` takes the address of a
+    /// place, as opposed to reading the value one holds.
+    ///
+    /// `&*(*p).f` — a projection whose outermost element is `Deref` — yields
+    /// the value the pointer in `(*p).f` holds, so the underlying read stays
+    /// a value read and keeps its lowering.  `&(*p).f`, Field-last, is the
+    /// real place-address and stays marked.
+    ///
+    /// The `Deref` test is spelled as `resolve_place` and
+    /// `emit_projection_write` already spell it, applied one level out.
+    fn place_ref_is_address_of(place: &Place) -> bool {
+        match &place.kind {
+            PlaceKind::Projection(_, ProjectionElem::Atom(s)) if s == "Deref" => false,
+            PlaceKind::Projection(..) => true,
+            _ => false,
+        }
     }
 
     /// Record that the `Variable` just resolved for a place is the
@@ -21724,6 +21742,67 @@ mod tests {
         assert_eq!(resolve_to_producer_op(&graph, &x), Some((a, 0)));
         // An unrelated free Variable has no producer.
         assert_eq!(resolve_to_producer_op(&graph, &Variable::new()), None);
+    }
+
+    /// `&*(*p).f` reads the value the field holds; `&(*p).f` names the
+    /// field's address.
+    ///
+    /// Both reach `build_rvalue`'s `Ref` / `RawPtr` arms as a
+    /// `PlaceKind::Projection`, so a bare `matches!(.., Projection(..))`
+    /// calls them both an address-of.  On `locals_cells_stack_w` the false
+    /// mark is not inert: `rewrite_op_getfield` reads
+    /// `suppresses_virtualizable` and skips the `vable_array_vars`
+    /// registration, so the read leaves the protocol and becomes a plain
+    /// `getarrayitem_gc` against a heap array that is only synchronised at
+    /// the three `sync_virtualizable_*` points — a stale read, not a slow
+    /// equivalent.  `locals_w!` expands to the deref-then-ref spelling, so
+    /// every one of its readers took that path.
+    #[test]
+    fn a_deref_last_projection_reads_a_value_rather_than_naming_an_address() {
+        use super::Lowering;
+        use majit_charon_reader::ullbc::{Place, PlaceKind, ProjectionElem};
+
+        fn ty() -> TyRef {
+            TyRef::Other(serde_json::Value::Null)
+        }
+        fn place(kind: PlaceKind) -> Place {
+            Place { kind, ty: ty() }
+        }
+        fn field(inner: Place, name: &str) -> Place {
+            place(PlaceKind::Projection(
+                Box::new(inner),
+                ProjectionElem::Tagged(serde_json::json!({ "Field": name })),
+            ))
+        }
+        fn deref(inner: Place) -> Place {
+            place(PlaceKind::Projection(
+                Box::new(inner),
+                ProjectionElem::Atom("Deref".to_string()),
+            ))
+        }
+
+        let local = || place(PlaceKind::Local(0));
+        let is_addr = Lowering::place_ref_is_address_of;
+
+        // `&(*p).f` — the outermost step names a field, so the reference
+        // stands for that field's address and the mark is owed.
+        assert!(is_addr(&field(deref(local()), "locals_cells_stack_w")));
+
+        // `&*(*p).f` — the outermost step dereferences what the field
+        // holds, so the reference stands for the pointee.  The field read
+        // underneath is an ordinary value read.
+        assert!(!is_addr(&deref(field(
+            deref(local()),
+            "locals_cells_stack_w"
+        ))));
+
+        // `&*p`, the same shape one level in, and a bare local: neither
+        // names a field address either.
+        assert!(!is_addr(&deref(local())));
+        assert!(!is_addr(&local()));
+
+        // A nested field is still an address-of at its outermost step.
+        assert!(is_addr(&field(field(deref(local()), "a"), "b")));
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -3485,9 +3485,13 @@ impl OpcodeStepExecutor for PyFrame {
                 "WITH_EXCEPT_START requires five stack values",
             ));
         }
-        let val = locals_w!(self)[depth - 1];
-        let exit_self = locals_w!(self)[depth - 4];
-        let exit_func = locals_w!(self)[depth - 5];
+        // Indices first: a subscript evaluates its receiver before its index
+        // expression, so arithmetic inside the brackets puts the subtraction's
+        // overflow check between the `locals_cells_stack_w` read and its use.
+        let (i_val, i_self, i_func) = (depth - 1, depth - 4, depth - 5);
+        let val = locals_w!(self)[i_val];
+        let exit_self = locals_w!(self)[i_self];
+        let exit_func = locals_w!(self)[i_func];
         let res = with_except_start_values(exit_func, exit_self, val);
         if res.is_null() {
             return Err(crate::call::take_call_error()

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -4155,6 +4155,13 @@ impl PyFrame {
     /// silently dropped).  A function frame with no locals bound yet lazily
     /// allocates a fresh dict (pyframe.py:557 `self.space.newdict(instance=True)`)
     /// and caches it, so `locals() is locals()` holds.  Errors propagate.
+    ///
+    /// `@jit.unroll_safe` (`pyframe.py:572`) cancels `contains_loop` in the
+    /// policy (`codewriter/policy.rs look_inside_graph`), so the slot loop
+    /// below does not keep the codewriter out.  Without it the whole function
+    /// is one residual call, and the `f_locals` read behind it forces the
+    /// virtualizable for the length of that call.
+    #[majit_macros::unroll_safe]
     pub fn fast2locals(&mut self) -> Result<(), crate::PyError> {
         // `space.setitem_str` / `space.delitem` allocate one key per slot and
         // can collect.  RPython's GC transform keeps both the frame and its

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3025,13 +3025,23 @@ impl PyFrame {
 
     #[inline]
     pub fn peek(&self) -> PyObjectRef {
-        locals_w!(self)[self.valuestackdepth - 1]
+        // The index is computed into a local first, as
+        // `pyframe.py:479-484 peekvalue_maybe_none` computes `index` before
+        // its subscript.  A subscript evaluates its receiver before its index
+        // expression, so spelling the arithmetic inside the brackets emits the
+        // `locals_cells_stack_w` read ahead of the subtraction's overflow
+        // check, and that check's branch then carries the array out of the
+        // block on a link — which `_check_no_vable_array` rejects.
+        let index = self.valuestackdepth - 1;
+        locals_w!(self)[index]
     }
 
     #[inline]
     #[allow(dead_code)]
     pub fn peek_at(&self, depth: usize) -> PyObjectRef {
-        locals_w!(self)[self.valuestackdepth - 1 - depth]
+        // Hoisted for the reason given on [`Self::peek`].
+        let index = self.valuestackdepth - 1 - depth;
+        locals_w!(self)[index]
     }
 
     /// Null the locals_cells_stack slots at and above `depth`, the
@@ -3143,7 +3153,8 @@ impl PyFrame {
         let mut idx = n;
         while idx > 0 {
             idx -= 1;
-            values_w[idx] = locals_w!(self)[base + idx];
+            let slot = base + idx;
+            values_w[idx] = locals_w!(self)[slot];
         }
         values_w
     }


### PR DESCRIPTION
`&*(*p).f` was classified as taking the address of `(*p).f`. It reads the
value that field holds. Every `locals_w!` read of the frame's virtualizable
array has that shape, so the classification kept all of them out of the
virtualizable protocol — and that is what stopped `@jit.unroll_safe` from
being portable onto `PyFrame::fast2locals`.

## The defect

`build_rvalue`'s `Rvalue::Ref` and `Rvalue::RawPtr` arms tested
`matches!(&place.kind, PlaceKind::Projection(..))`. That is true for both
`&(*p).f` and `&*(*p).f`; only the first names a field's address.

The mark is not inert. `mark_place_address_of` sets `taken_by_address` on the
descriptor of the last op the projection emitted — the `getfield`.
`rewrite_op_getfield` folds `suppresses_virtualizable()` into
`fresh_virtualizable`, and the `vable_array_vars` insert is gated on
`!fresh_virtualizable`:

```rust
.find(|c| c.matches(field))
.filter(|_| !fresh_virtualizable)
```

So a wrongly marked read is never registered. It stays an ordinary
`getarrayitem_gc` against the heap array — **not a slower equivalent of the
protocol, a stale read**: the heap array is synchronised only at
`sync_virtualizable_before_jit`, `sync_virtualizable_after_jit` and
`sync_virtualizable_after_guard_failure`, and
`VirtualizableInfo::to_optimizer_config` passes `array_lengths: vec![]`, so
the optimizer's const-index backstop is unseeded too.

`locals_w!` expands to `&*$frame.locals_cells_stack_w`. It has **44 call
sites** across `pyframe.rs` (27), `eval.rs` (15) and `builtins.rs` (2).

## The fix

`place_ref_is_address_of` returns false when the outermost projection element
is `Deref`. The test is spelled the way `resolve_place` and
`emit_projection_write` already spell it, applied one level out; `mir.rs` has
five other sites with the identical `PlaceKind::Projection(_,
ProjectionElem::Atom(s)) if s == "Deref"` match.

It is deliberately narrow. `addr_of_mut!(frame.locals_cells_stack_w)` is
Field-last and stays marked — `address_of_the_vable_array_slot_is_marked_not_a_read`
pins exactly that, including its own anti-vacuity guard.

## `@jit.unroll_safe` on `fast2locals`

Upstream `pyframe.py:572` decorates it. `look_inside_graph` cancels
`contains_loop` for a graph carrying the hint (`policy.py:61-62`), so the slot
loop stops keeping the codewriter out.

**Ordering is load-bearing and this PR respects it.** The hint is the arming
switch for the defect, not a consumer of it: it admits `fast2locals` into the
jitcode population, which is what makes the wrongly-classified reads reachable.
Ported alone it is either dead or latently wrong. The defect fix is the first
commit here; the port is the second.

`fresh_virtualizable` is **not** an escape hatch for a reader that trips
`_check_no_vable_array`. Upstream's `is_virtualizable_getset` returns False on
that flag *before* `raise res`, so hinting a reader removes the access from the
protocol rather than fixing it — i.e. it silences the build by shipping the
stale read. `rlib/jit.py:90` documents it as "virtualizable was just
allocated", and upstream's only production use is `PyFrame.__init__`.

## The escape the fix exposed, and why the second commit exists

Applying the first commit alone **breaks the build**. That is not a
speculation — `cargo check -p pyre-jit-trace` died with:

```
A virtualizable array is passed around; it should
only be used immediately after being read.  ...
This is about: vable array field #0
Occurred in: pyre_interpreter::pyframe::<Impl>::peek_at
Escaped via: link argument
```

Registering 44 previously-suppressed reads arms `_check_no_vable_array` for
every graph holding one, and `peek_at` was the first to trip it.

Lowering it says why, and the contrast with a sibling isolates the cause:

```
peek_at                        peekvalue_maybe_none
  bb0 FieldRead locals_...       bb12 FieldRead locals_...
      FieldRead valuestackdepth       ArrayRead
      ConstInt(1), BinOp sub
      -> bb4 (3 link args)
  bb4 BinOp sub
      -> bb5 (2 link args)
  bb5 ArrayRead
```

A subscript evaluates its receiver before its index expression, so
`locals_w!(self)[self.valuestackdepth - 1 - depth]` emits the array read
first and the two subtractions' overflow checks after it; each check branches,
and the array rides the links. `peekvalue_maybe_none` computes the index into
a local first, which is also how `pyframe.py:479-484` spells it, and its read
and use land in one block. The slice bounds check is not the problem — the
front folds it into the `ArrayRead`, which is exactly what that contrast
shows.

Six sites spelled the arithmetic inside the brackets; the other twenty-four
already hoisted it. Loop-shaped readers (`clear_stack_above`, `peekvalues`,
`restore_resume_state_from`, `build_snapshot_frame`) are residualized by
`contains_loop` and never reach the check — which is the same reason the
`unroll_safe` hint is the arming switch for `fast2locals`.

## Verification

`cargo check -p pyre-jit-trace` is the authoritative gate: `build.rs` calls
`generate_into` with no `catch_unwind`, so an escaping graph is a hard build
failure rather than a degraded trace, and CI runs it via `cargo test --all`.

With all three commits applied, against a freshly extracted and stamped set of
all four artefacts (`--check` clean, `window writes: 0 candidate(s)`):

- build **Finished**, no `_check_no_vable_array` panic;
- 2779 jitcodes, and `fast2locals` is among them — the port takes effect;
- `peek_at` and `peek` still in the population, now without escaping.

Tests, all green:

- `a_deref_last_projection_reads_a_value_rather_than_naming_an_address` pins
  the classification on five constructed shapes with no LLBC, so it runs in
  ordinary CI.
- The four pins in `test_vable_array_len.rs`, including
  `address_of_the_vable_array_slot_is_marked_not_a_read` — `addr_of_mut!` is
  Field-last and must stay marked, so this is the over-reach guard for commit
  1 — and `every_vable_array_read_in_fast2locals_is_consumed_in_its_block`,
  which covers exactly the graph commit 3 admits.
- `test_fast2locals_codewriter.rs`, both tests.

## Follow-ups (not in this PR)

- `VirtualizableInfo::to_optimizer_config` passes `array_lengths: vec![]`,
  leaving `optimize_getarrayitem_gc`'s `tracked_array_element` unseeded.
- `baseobjspace.rs:13921` quotes upstream `_unpackiterable_known_length_jitlook`
  *with* its `@jit.unroll_safe` in a doc comment, but carries no attribute.
- `front/iter_next.rs::is_iter_op_segments` admits non-GC slices (`&[usize]`,
  `&[u8]`); narrowing it needs the container's element type.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected address handling for dereferenced fields and nested field access, improving compiler correctness.
  * Added regression coverage for local values, direct fields, dereferenced fields, and nested projections.

* **Performance and Stability**
  * Improved runtime stack access behavior by calculating stack positions before reads.
  * Enabled an optimization that can improve execution efficiency without changing observable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->