### PR TITLE
jit: resolve the #1317 review, drop the unread exit metadata, and remove the dead assembler emitters

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -30,7 +30,7 @@ use majit_backend::{
 };
 use majit_gc::header::{GcHeader, TYPE_ID_MASK};
 use majit_gc::rewrite::GcRewriterImpl;
-use majit_gc::{GcAllocator, GcMap, GcRewriter};
+use majit_gc::{GcAllocator, GcRewriter};
 use majit_ir::{
     AccumInfo, CallDescr, DescrRef, EffectInfo, FailDescr, GcRef, InputArg, OopSpecIndex, Op,
     OpCode, OpRc, OpRef, OpTypeIndex, Type, Value,
@@ -7471,21 +7471,6 @@ impl CompiledLoop {
     }
 }
 
-/// `assembler.py:write_failure_recovery_description` parity —
-/// derive the GC-map classification on demand from `fail_arg_types`
-/// and the per-emission `force_token_slots`.  Takes `&dyn FailDescr`
-/// so callers can invoke it on the bare metainterp `DescrRef`.
-pub(crate) fn fail_descr_gc_map(fd: &dyn FailDescr) -> GcMap {
-    let slots = fd.force_token_slots();
-    let mut gc_map = GcMap::new();
-    for (slot, tp) in fd.fail_arg_types().iter().enumerate() {
-        if *tp == Type::Ref && !slots.contains(&slot) {
-            gc_map.set_ref(slot);
-        }
-    }
-    gc_map
-}
-
 /// Resolve the `ExitRecoveryLayout` for a fail descr via the on-demand
 /// callback.  The cranelift backend no longer caches a
 /// recovery layout — pyre-jit's
@@ -7535,12 +7520,6 @@ fn fail_descr_layout(
         .as_fail_descr()
         .expect("fail_descr_layout requires a Descr that exposes the FailDescr trait");
     let fail_arg_types = fd.fail_arg_types();
-    let gc_map_local = fail_descr_gc_map(fd);
-    let gc_ref_slots = fail_arg_types
-        .iter()
-        .enumerate()
-        .filter_map(|(slot, _)| gc_map_local.is_ref(slot).then_some(slot))
-        .collect();
     let recovery = fail_descr_recovery_layout(descr);
     let frame_stack = recovery.as_ref().map(|r| r.frames.clone());
     majit_backend::FailDescrLayout {
@@ -7551,8 +7530,6 @@ fn fail_descr_layout(
         fail_arg_types: fail_arg_types.to_vec(),
         is_finish: fd.is_finish(),
         is_exception_exit: fd.is_exit_frame_with_exception(),
-        gc_ref_slots,
-        force_token_slots: fd.force_token_slots(),
         recovery_layout: recovery,
         frame_stack,
         rd_numb: fd.rd_numb().map(|s| s.to_vec()),
@@ -9418,7 +9395,6 @@ impl CraneliftBackend {
         collect_guards(
             ops,
             inputargs,
-            &force_tokens,
             &mut fail_descrs,
             &mut fail_descr_cells,
             &mut guard_infos,
@@ -9440,7 +9416,6 @@ impl CraneliftBackend {
         let terminal_exit_layouts = collect_terminal_exit_layouts(
             ops,
             inputargs,
-            &force_tokens,
             trace_id,
             header_pc,
             source_guard,
@@ -15624,7 +15599,6 @@ fn precompute_max_output_slots(inputargs: &[InputArg], ops: &[Op]) -> usize {
 fn collect_guards(
     ops: &[Op],
     inputargs: &[InputArg],
-    force_tokens: &IndexSet<u32>,
     fail_descrs: &mut Vec<DescrRef>,
     fail_descr_cells: &mut Vec<Arc<majit_ir::FailDescrCell>>,
     guard_infos: &mut Vec<GuardInfo>,
@@ -15750,20 +15724,6 @@ fn collect_guards(
         if n > *max_output_slots {
             *max_output_slots = n;
         }
-
-        let force_token_slots: Vec<usize> = fail_arg_refs
-            .iter()
-            .enumerate()
-            // Const operands carry value inline (history.py:227/268/314)
-            // — never force-token slots which live in the body namespace.
-            .filter_map(|(slot, opref)| {
-                if opref.is_constant() {
-                    None
-                } else {
-                    force_tokens.contains(&opref.raw()).then_some(slot)
-                }
-            })
-            .collect();
 
         // RPython resume.py:396: on guard failure the resume PC is taken
         // from the rebuilt top frame (`RebuiltFrame.pc`). rd_numb/rd_consts
@@ -16130,6 +16090,9 @@ fn collect_guards(
         //     also contain Const (handled by regalloc.py:1192-1193 in the same
         //     loop). majit groups external JUMP with FINISH for fail_args
         //     bookkeeping; treat their gcmap the same way.
+        // `compute_gcmap` marks every REF failarg and narrows nothing: a
+        // force token is REF too (`FORCE_TOKEN/0/r` returns the jitframe, a
+        // moving GC object), so its slot is marked like any other.
         let failarg_ref_slots = {
             let mut slots = Vec::new();
             for (i, tp) in fail_arg_types.iter().enumerate() {
@@ -16226,8 +16189,7 @@ fn collect_guards(
                 // op.descr for external JUMP is the TargetToken (already
                 // captured in external_jump_target above) — not a
                 // FailDescr.  Synthesize a `ResumeGuardDescr` so the
-                // meta-side slots for `force_token_slots` and
-                // `external_jump_target` are reachable.
+                // meta-side slot for `external_jump_target` is reachable.
                 majit_backend::make_resume_guard_descr_typed(fail_arg_types.to_vec())
             } else if let Some(d) = op.getdescr() {
                 // Preserve `op.descr` identity for every guard that carries
@@ -16269,15 +16231,13 @@ fn collect_guards(
                     fd.set_fail_arg_types(fail_arg_types.to_vec());
                 }
             }
-            // Per-emission setters publish into ResumeGuardDescr slots
-            // reached directly off `descr` (source_op_index,
-            // force_token_slots).  Gate on Resume-family
+            // The per-emission setter publishes into a ResumeGuardDescr
+            // slot reached directly off `descr`.  Gate on Resume-family
             // ownership — non-Resume descrs (PropagateExceptionDescr
-            // attached via compile_tmp_callback, etc.) carry neither
-            // slot and the trait-default panic would fire otherwise.
+            // attached via compile_tmp_callback, etc.) carry no such slot
+            // and the trait-default panic would fire otherwise.
             if descr.is_resume_guard() || descr.is_resume_guard_copied() {
                 as_fd(&descr).set_source_op_index(op_idx);
-                as_fd(&descr).set_force_token_slots(force_token_slots);
             }
             // Backend no longer caches an `ExitRecoveryLayout` per descr;
             // `fail_descr_recovery_layout` reads on demand via
@@ -16430,7 +16390,6 @@ fn collect_guards(
 fn collect_terminal_exit_layouts(
     ops: &[Op],
     inputargs: &[InputArg],
-    force_tokens: &IndexSet<u32>,
     trace_id: u64,
     header_pc: u64,
     source_guard: Option<(u64, u32)>,
@@ -16450,27 +16409,6 @@ fn collect_terminal_exit_layouts(
             let arg_oprefs: Vec<OpRef> = op.getarglist().iter().map(|a| a.to_opref()).collect();
             let exit_types =
                 infer_fail_arg_types(&arg_oprefs, &type_index, &type_overrides, op_index)?;
-            let force_token_slots: Vec<usize> = op
-                .getarglist()
-                .iter()
-                .enumerate()
-                .filter_map(|(slot, opref)| {
-                    if opref.is_constant() {
-                        None
-                    } else {
-                        force_tokens
-                            .contains(&opref.to_opref().raw())
-                            .then_some(slot)
-                    }
-                })
-                .collect();
-            let gc_ref_slots = exit_types
-                .iter()
-                .enumerate()
-                .filter_map(|(slot, tp)| {
-                    (*tp == Type::Ref && !force_token_slots.contains(&slot)).then_some(slot)
-                })
-                .collect();
             let recovery_layout = (is_jump || is_finish).then(|| {
                 identity_recovery_layout(
                     trace_id,
@@ -16498,8 +16436,6 @@ fn collect_terminal_exit_layouts(
                     .as_ref()
                     .and_then(|d| d.as_fail_descr())
                     .is_some_and(|fd| fd.is_exit_frame_with_exception()),
-                gc_ref_slots,
-                force_token_slots,
                 recovery_layout,
                 // Terminal exits (FINISH/JUMP) don't carry per-guard resume
                 // data — RPython's jitdriver dispatches them via a separate
@@ -17219,7 +17155,6 @@ impl majit_backend::Backend for CraneliftBackend {
                     outputs: result,
                     typed_outputs: typed_result,
                     exit_layout,
-                    force_token_slots: descr.force_token_slots().to_vec(),
                     savedata,
                     exception_value,
                     fail_index: descr.fail_index(),
@@ -17312,7 +17247,6 @@ impl majit_backend::Backend for CraneliftBackend {
                     outputs,
                     typed_outputs,
                     exit_layout: Some(fail_descr_layout(&fail_descr_ref, fail_index, trace_id)),
-                    force_token_slots: fail_descr_fd.force_token_slots().to_vec(),
                     savedata,
                     exception_value: exception,
                     fail_index,
@@ -17373,7 +17307,6 @@ impl majit_backend::Backend for CraneliftBackend {
                 outputs,
                 typed_outputs,
                 exit_layout: Some(fail_descr_layout(&fail_descr_ref, fail_index, trace_id)),
-                force_token_slots: fail_descr_fd.force_token_slots().to_vec(),
                 savedata,
                 exception_value: exception,
                 fail_index,
@@ -19918,8 +19851,6 @@ mod tests {
         assert_eq!(layout.fail_index, u32::MAX);
         assert_eq!(layout.exit_types, vec![Type::Ref, Type::Int]);
         assert!(!layout.is_finish);
-        assert_eq!(layout.gc_ref_slots, vec![0]);
-        assert!(layout.force_token_slots.is_empty());
         let recovery = layout
             .recovery_layout
             .as_ref()
@@ -19974,8 +19905,6 @@ mod tests {
         assert_eq!(layout.fail_index, 0);
         assert_eq!(layout.exit_types, vec![Type::Ref, Type::Float]);
         assert!(layout.is_finish);
-        assert_eq!(layout.gc_ref_slots, vec![0]);
-        assert!(layout.force_token_slots.is_empty());
         let recovery = layout
             .recovery_layout
             .as_ref()
@@ -23237,63 +23166,6 @@ mod tests {
         assert_eq!(descr.fail_index(), 0);
         assert_eq!(backend.get_float_value(&frame, 0), 9.25);
         assert_eq!(backend.get_ref_value(&frame, 1), GcRef(0xBEEF));
-    }
-
-    #[test]
-    fn test_fail_descr_gc_map_tracks_ref_slots() {
-        let mut backend = CraneliftBackend::new();
-
-        let inputargs = vec![
-            InputArg::new_int(0),
-            InputArg::new_ref(1),
-            InputArg::new_float(2),
-            InputArg::new_ref(3),
-        ];
-        let guard_op = mk_op(
-            OpCode::GuardTrue,
-            &[OpRef::input_arg_int(0)],
-            OpRef::NONE.raw(),
-        );
-        guard_op.setfailargs(smallvec::smallvec![
-            rb(OpRef::input_arg_int(0)),
-            rb(OpRef::input_arg_ref(1)),
-            rb(OpRef::input_arg_float(2)),
-            rb(OpRef::input_arg_ref(3)),
-        ]);
-        let ops = vec![
-            mk_op(
-                OpCode::Label,
-                &[
-                    OpRef::input_arg_int(0),
-                    OpRef::input_arg_ref(1),
-                    OpRef::input_arg_float(2),
-                    OpRef::input_arg_ref(3),
-                ],
-                OpRef::NONE.raw(),
-            ),
-            guard_op,
-            mk_op(
-                OpCode::Finish,
-                &[OpRef::input_arg_int(0)],
-                OpRef::NONE.raw(),
-            ),
-        ];
-
-        let token = JitCellToken::new(1005);
-        backend.compile_loop(&inputargs, &ops, &token).unwrap();
-
-        let compiled = token
-            .compiled
-            .get()
-            .unwrap()
-            .downcast_ref::<CompiledLoop>()
-            .unwrap();
-        let descr = &compiled.fail_descrs[0];
-        let gc_map = fail_descr_gc_map(as_fd(descr));
-        assert!(!gc_map.is_ref(0));
-        assert!(gc_map.is_ref(1));
-        assert!(!gc_map.is_ref(2));
-        assert!(gc_map.is_ref(3));
     }
 
     #[test]

--- a/majit/majit-backend-cranelift/src/guard.rs
+++ b/majit/majit-backend-cranelift/src/guard.rs
@@ -11,7 +11,7 @@
 //
 // Per-descr backend state slots (source_op_index, recovery_layout,
 // trace_info, external_jump_target, fail_count, bridge caches,
-// bridge_dispatch_cell, force_token_slots) live on the metainterp
+// bridge_dispatch_cell) live on the metainterp
 // `ResumeGuardDescr` (Slices 7-Tβ6..12) — see `majit-backend::
 // resume_guard_descr`.  PyPy `AbstractFailDescr._attrs_` (history.py:132)
 // carries none of these; Pyre's metainterp descr is the single source

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -1579,6 +1579,10 @@ impl<'a> AssemblerARM64<'a> {
         }
     }
 
+    /// `llsupport/assembler.py:46-64 GuardToken.compute_gcmap`: every
+    /// `REF`-typed failarg is marked and nothing narrows it further.  That
+    /// includes a force token — `resoperation.py FORCE_TOKEN/0/r` returns
+    /// the jitframe, itself a moving GC object.
     fn guard_gcmap_from_faillocs(
         &self,
         fail_arg_types: &[Type],
@@ -1600,23 +1604,6 @@ impl<'a> AssemblerARM64<'a> {
                     gcmap_set_bit(gcmap, f.position + JITFRAME_FIXED_SIZE);
                 }
                 _ => {}
-            }
-        }
-        gcmap
-    }
-
-    fn gcmap_from_fail_arg_locs(
-        &self,
-        fail_arg_types: &[Type],
-        fail_arg_locs: &[Option<usize>],
-    ) -> *mut usize {
-        let frame_depth = self.frame_depth.saturating_sub(JITFRAME_FIXED_SIZE);
-        let gcmap = allocate_gcmap(frame_depth, JITFRAME_FIXED_SIZE);
-        for (tp, loc) in fail_arg_types.iter().zip(fail_arg_locs.iter()) {
-            if *tp == Type::Ref
-                && let Some(position) = loc
-            {
-                gcmap_set_bit(gcmap, *position);
             }
         }
         gcmap
@@ -4770,11 +4757,11 @@ impl<'a> AssemblerARM64<'a> {
                             // `Type::Void` is the "hole" sentinel — value
                             // comes from the resume snapshot, not the
                             // deadframe, so downstream consumers
-                            // (`gc_ref_slots`, `guard_gcmap_from_faillocs`,
-                            // `typed_outputs` reconstruction) must skip
-                            // these slots. Earlier code used `Type::Ref`
-                            // which silently leaked a NULL `GcRef` into
-                            // `gc_ref_slots` and the shadow stack.
+                            // (`guard_gcmap_from_faillocs`, `typed_outputs`
+                            // reconstruction) must skip these slots. Earlier
+                            // code used `Type::Ref`, which silently leaked a
+                            // NULL `GcRef` into the gcmap and the shadow
+                            // stack.
                             Type::Void
                         } else {
                             self.opref_type_at(opref.to_opref(), op_index).unwrap_or_else(|| {

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -11,7 +11,6 @@
 ///   redirect_call_assembler — assembler.py:1138
 use crate::regloc::ebp_loc_pat;
 use indexmap::IndexMap;
-use majit_ir::IndexMapExt;
 use std::sync::Arc;
 
 // aarch64/assembler.py parity: aarch64-only backend.
@@ -505,16 +504,15 @@ pub struct CompiledCode {
     pub source_guard: Option<(u64, u32)>,
 }
 
-#[allow(dead_code)]
+/// The `genop_*` methods here are line-by-line ports of the RPython emitters
+/// (`aarch64/assembler.py` / `x86/assembler.py` `genop_*`).  Emission runs
+/// through `regalloc_perform`, which works from regalloc `arglocs`, so the
+/// ports whose opcode that dispatch reaches by another route carry
+/// `#[allow(dead_code)]` individually.  They are annotated rather than
+/// deleted so the upstream method boundary stays where a later porter looks
+/// for it; the attribute is per method so the lint still reports anything
+/// else in this `impl` that stops being reached.
 impl<'a> AssemblerARM64<'a> {
-    /// rpython/jit/metainterp/history.py:220 `box.type` parity.
-    /// Single source of truth: `op.type_` for ops, `inputarg.tp` for
-    /// inputargs, the `Const` variant tag for constants.
-    #[inline]
-    fn opref_type(&self, opref: OpRef) -> Option<Type> {
-        self.opref_type_at(opref, None)
-    }
-
     #[inline]
     fn opref_type_at(&self, opref: OpRef, at_op_index: Option<usize>) -> Option<Type> {
         let type_index = OpTypeIndex::from_parts(
@@ -872,46 +870,6 @@ impl<'a> AssemblerARM64<'a> {
             }
             OpCode::IntXor => {
                 dynasm!(self.mc ; .arch aarch64 ; eor X(d), X(l), X(s));
-            }
-            _ => {}
-        }
-    }
-
-    /// Emit: ADD/SUB/AND/OR/XOR reg, loc
-    fn emit_binop_reg_loc(&mut self, opcode: OpCode, dst_reg: u8, src: &Loc) {
-        // aarch64: load src to x16 scratch if not in register
-        let src_reg = match src {
-            Loc::Reg(s) => s.value,
-            Loc::Frame(f) => {
-                self.emit_ldr_fp(16, f.ebp_loc.value);
-                16
-            }
-            Loc::Immed(i) => {
-                self.emit_mov_imm64(16, i.value);
-                16
-            }
-            _ => return,
-        };
-        let d = dst_reg;
-        let s = src_reg as u8;
-        match opcode {
-            OpCode::IntAdd | OpCode::IntAddOvf | OpCode::NurseryPtrIncrement => {
-                dynasm!(self.mc ; .arch aarch64 ; add X(d), X(d), X(s));
-            }
-            OpCode::IntSub | OpCode::IntSubOvf => {
-                dynasm!(self.mc ; .arch aarch64 ; sub X(d), X(d), X(s));
-            }
-            OpCode::IntMul | OpCode::IntMulOvf => {
-                dynasm!(self.mc ; .arch aarch64 ; mul X(d), X(d), X(s));
-            }
-            OpCode::IntAnd => {
-                dynasm!(self.mc ; .arch aarch64 ; and X(d), X(d), X(s));
-            }
-            OpCode::IntOr => {
-                dynasm!(self.mc ; .arch aarch64 ; orr X(d), X(d), X(s));
-            }
-            OpCode::IntXor => {
-                dynasm!(self.mc ; .arch aarch64 ; eor X(d), X(d), X(s));
             }
             _ => {}
         }
@@ -1951,10 +1909,12 @@ impl<'a> AssemblerARM64<'a> {
             input_slot_depth.max(JITFRAME_FIXED_SIZE + ra.get_final_frame_depth());
         self.frame_depth = self.frame_depth.max(frame_slot_depth);
 
-        // Sync regalloc frame positions to opref_to_slot for backward
-        // compatibility with genop_call/genop_call_assembler which still
-        // use resolve_opref. When regalloc spills a value to a frame slot,
-        // that slot's position must be visible to resolve_opref.
+        // Sync regalloc frame positions to opref_to_slot for the emitters that
+        // still read resolve_opref instead of arglocs: emit_call,
+        // genop_discard_setfield, genop_cond_call_value, genop_alloc_varsize
+        // and genop_discard_zero_array reach it through load_arg_to_rax /
+        // load_arg_to_rcx. When regalloc spills a value to a frame slot, that
+        // slot's position must be visible to resolve_opref.
         // opref_to_slot stores ABSOLUTE jitframe slots (user position +
         // JITFRAME_FIXED_SIZE) so slot_offset(slot) gives the correct byte
         // offset without further adjustment.
@@ -3705,15 +3665,6 @@ impl<'a> AssemblerARM64<'a> {
         dynasm!(self.mc ; .arch aarch64 ; str xzr, [x16]);
     }
 
-    /// aarch64/opassembler.py:720-724 `emit_op_guard_no_exception`.
-    fn emit_cmp_no_exception(&mut self) {
-        self.emit_mov_imm64(16, crate::jit_exc_type_addr() as i64);
-        dynasm!(self.mc ; .arch aarch64
-            ; ldr x16, [x16]
-            ; cmp x16, xzr
-        );
-    }
-
     /// Emit SETcc into a register (zero-extend to 64-bit).
     fn emit_setcc(&mut self, cc: u8, dst_reg: u8) {
         match cc {
@@ -4384,6 +4335,7 @@ impl<'a> AssemblerARM64<'a> {
     // ----------------------------------------------------------------
 
     /// INT_ADD: result = arg0 + arg1
+    #[allow(dead_code)]
     fn genop_int_add(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4394,6 +4346,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_SUB: result = arg0 - arg1
+    #[allow(dead_code)]
     fn genop_int_sub(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4404,6 +4357,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_MUL: result = arg0 * arg1
+    #[allow(dead_code)]
     fn genop_int_mul(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4414,6 +4368,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_AND: result = arg0 & arg1
+    #[allow(dead_code)]
     fn genop_int_and(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4424,6 +4379,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_OR: result = arg0 | arg1
+    #[allow(dead_code)]
     fn genop_int_or(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4434,6 +4390,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_XOR: result = arg0 ^ arg1
+    #[allow(dead_code)]
     fn genop_int_xor(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4444,6 +4401,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_NEG: result = -arg0
+    #[allow(dead_code)]
     fn genop_int_neg(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -4453,6 +4411,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_INVERT: result = ~arg0
+    #[allow(dead_code)]
     fn genop_int_invert(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -4462,6 +4421,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_LSHIFT: result = arg0 << arg1
+    #[allow(dead_code)]
     fn genop_int_lshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4472,6 +4432,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_RSHIFT: result = arg0 >> arg1 (arithmetic/signed)
+    #[allow(dead_code)]
     fn genop_int_rshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4482,6 +4443,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// UINT_RSHIFT: result = arg0 >> arg1 (logical/unsigned)
+    #[allow(dead_code)]
     fn genop_uint_rshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4497,6 +4459,7 @@ impl<'a> AssemblerARM64<'a> {
 
     /// assembler.py:1856 genop_int_add_ovf — delegates to genop_int_add,
     /// then sets guard_success_cc = 'NO'. On x86, ADD always sets OF.
+    #[allow(dead_code)]
     fn genop_int_add_ovf(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4506,6 +4469,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// assembler.py:1860 genop_int_sub_ovf.
+    #[allow(dead_code)]
     fn genop_int_sub_ovf(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -4515,6 +4479,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// assembler.py:1864 genop_int_mul_ovf.
+    #[allow(dead_code)]
     fn genop_int_mul_ovf(&mut self, op: &Op) {
         // aarch64/opassembler.py multiplies, computes SMULH, and then
         // compares the high word against the sign-extension of the low
@@ -4537,30 +4502,10 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — comparisons
     // ----------------------------------------------------------------
 
-    /// INT_LT/LE/GT/GE/EQ/NE/UINT_*: CMP arg0, arg1 then store CC.
-    /// If the next op is a guard, guard_success_cc is set and consumed.
-    /// Otherwise, materialize the boolean result via SETcc/CSET.
-    fn genop_int_cmp(&mut self, op: &Op) {
-        let cc = Self::opcode_to_cc(op.opcode);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64
-            ; cmp x0, x1
-        );
-
-        // Store the CC for a following guard to consume.
-        self.guard_success_cc = Some(cc);
-
-        // Also materialize the boolean result for non-guard consumers.
-        if !op.pos.get().is_none() {
-            self.emit_setcc_to_result(cc, op.pos.get());
-        }
-    }
-
     /// Emit SETcc/CSET to materialize a boolean result.
     /// x64: SETcc AL; MOVZX EAX, AL
     /// aarch64: CSET X0, cc
+    #[allow(dead_code)]
     fn emit_setcc_to_result(&mut self, cc: u8, result_opref: OpRef) {
         // CSET Xd, cc — sets Xd to 1 if condition is true, 0 otherwise.
         // Note: CSET Xd, cc is an alias for CSINC Xd, XZR, XZR, invert(cc).
@@ -4583,6 +4528,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_IS_TRUE: result = (arg0 != 0)
+    #[allow(dead_code)]
     fn genop_int_is_true(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -4595,6 +4541,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_IS_ZERO: result = (arg0 == 0)
+    #[allow(dead_code)]
     fn genop_int_is_zero(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -4909,201 +4856,8 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — control flow
     // ----------------------------------------------------------------
 
-    /// LABEL: define the back-edge target for JUMP.
-    ///
-    /// RPython: LABEL does NOT emit code. The regalloc establishes
-    /// the slot mapping. JUMP handles slot remapping.
-    ///
-    /// In our frame-slot model: preamble values may be in non-canonical
-    /// slots. We emit copies from old→canonical slots BEFORE the
-    /// LABEL binding, so they execute only on first entry from the
-    /// preamble. JUMP writes directly to canonical slots and jumps
-    /// to the LABEL, skipping the copies.
-    fn genop_label(&mut self, op: &Op) {
-        // Emit preamble→canonical copies BEFORE the label.
-        // Two-pass push/pop: safely handles slot overlaps.
-        let n_label = op.num_args();
-        // Pass 1: push source values
-        for i in 0..n_label {
-            let arg_ref = op.arg(i).to_opref();
-            if arg_ref.is_none() {
-                let dst = Self::slot_offset(i);
-                self.emit_ldr_fp(0, dst);
-                dynasm!(self.mc ; .arch aarch64 ; str x0, [sp, #-16]!);
-            } else if arg_ref.is_constant() {
-                let val = arg_ref.inline_const_bits().unwrap_or_else(|| {
-                    self.constants
-                        .get(&arg_ref.raw())
-                        .map(|c| c.as_raw_i64())
-                        .unwrap_or(0)
-                });
-                self.emit_mov_imm64(0, val);
-                dynasm!(self.mc ; .arch aarch64 ; str x0, [sp, #-16]!);
-            } else if let Some(&old_slot) = self.opref_to_slot.get(&arg_ref) {
-                let src = Self::slot_offset(old_slot);
-                self.emit_ldr_fp(0, src);
-                dynasm!(self.mc ; .arch aarch64 ; str x0, [sp, #-16]!);
-            } else {
-                dynasm!(self.mc ; .arch aarch64 ; str xzr, [sp, #-16]!);
-            }
-        }
-        // Pass 2: pop in reverse into canonical slots
-        for i in (0..n_label).rev() {
-            let dst = Self::slot_offset(i);
-            dynasm!(self.mc ; .arch aarch64 ; ldr x0, [sp], #16);
-            self.emit_str_fp(0, dst);
-        }
-
-        // Bind the LABEL — JUMP targets here (after the copies).
-        let label = self.mc.new_dynamic_label();
-        dynasm!(self.mc ; .arch aarch64 ; =>label);
-        let descr_arc = op.getdescr();
-        if let Some(descr) = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr()) {
-            descr.set_ll_loop_code(self.mc.offset().0);
-            if let Some(id) = loop_target_id(op) {
-                self.target_tokens_currently_compiling.insert(id, label);
-            }
-            if let Some(descr_ref) = op.getdescr() {
-                self.compiled_target_tokens.push(descr_ref.clone());
-            }
-        }
-
-        // Remap: Label's arg[i] → canonical slot i
-        for (i, arg_ref) in op.getarglist().iter().enumerate() {
-            if !arg_ref.is_none() {
-                self.opref_to_slot.insert(arg_ref.to_opref(), i);
-            }
-        }
-        self.next_slot = self.next_slot.max(op.num_args());
-    }
-
-    /// jump.py:66 _move: emit a single slot-to-slot or const-to-slot move.
-    fn emit_slot_move(&mut self, src: i32, dst: i32, is_const: bool, val: i64) {
-        if is_const {
-            self.emit_mov_imm64(0, val);
-            self.emit_str_fp(0, dst);
-        } else if src != dst {
-            self.emit_ldr_fp(0, src);
-            self.emit_str_fp(0, dst);
-        }
-    }
-
-    /// JUMP: unconditional branch to the loop label.
-    /// jump.py:1 remap_frame_layout parity: parallel move algorithm
-    /// to handle cyclic slot dependencies.
-    fn genop_jump(&mut self, op: &Op) {
-        // Build src→dst move list.
-        // Each entry: (src_offset_or_const, dst_offset, is_const, const_val)
-        let n = op.num_args();
-        let mut moves: Vec<(i32, i32, bool, i64)> = Vec::with_capacity(n);
-        for (i, arg_ref) in op.getarglist().iter().enumerate() {
-            let dst = Self::slot_offset(i);
-            match self.resolve_opref(arg_ref.to_opref()) {
-                ResolvedArg::Slot(src) => moves.push((src, dst, false, 0)),
-                ResolvedArg::Const(val) => moves.push((0, dst, true, val)),
-            }
-        }
-
-        // jump.py:1-64 remap_frame_layout: topological order with
-        // cycle breaking via push/pop.
-        // srccount[dst] = number of times dst appears as a src
-        let mut srccount: IndexMap<i32, i32> = IndexMap::new();
-        for m in &moves {
-            srccount.entry_or_default(m.1); // ensure dst exists
-        }
-        let mut pending = n as i32;
-        for (i, m) in moves.iter().enumerate() {
-            if m.2 {
-                continue;
-            } // constant → no src dependency
-            let src = m.0;
-            if let Some(cnt) = srccount.get_mut(&src) {
-                if src == moves[i].1 {
-                    // self-move: skip
-                    *cnt = -(n as i32) - 1;
-                    pending -= 1;
-                } else {
-                    *cnt += 1;
-                }
-            }
-        }
-
-        while pending > 0 {
-            let mut progress = false;
-            for &(src, dst, is_const, const_val) in moves.iter().take(n) {
-                if srccount.get(&dst).copied().unwrap_or(-1) == 0 {
-                    *srccount.get_mut(&dst).unwrap() = -1; // done
-                    pending -= 1;
-                    if !is_const && let Some(cnt) = srccount.get_mut(&src) {
-                        *cnt -= 1;
-                    }
-                    self.emit_slot_move(src, dst, is_const, const_val);
-                    progress = true;
-                }
-            }
-            if !progress {
-                // Cycle: use push/pop to break it.
-                for i in 0..n {
-                    let dst = moves[i].1;
-                    if srccount.get(&dst).copied().unwrap_or(-1) >= 0 {
-                        // Push first dst in the cycle
-                        self.emit_ldr_fp(0, dst);
-                        dynasm!(self.mc ; .arch aarch64
-                            ; str x0, [sp, #-16]!
-                        );
-                        // Walk the cycle
-                        let mut cur = i;
-                        loop {
-                            let cd = moves[cur].1;
-                            *srccount.get_mut(&cd).unwrap() = -1;
-                            pending -= 1;
-                            // Find the move whose dst is this src
-                            let src = moves[cur].0;
-                            let next = moves.iter().position(|m| m.1 == src);
-                            if let Some(ni) = next {
-                                if srccount.get(&moves[ni].1).copied().unwrap_or(-1) < 0 {
-                                    // End of cycle: pop into this slot
-                                    dynasm!(self.mc ; .arch aarch64
-                                        ; ldr x0, [sp], #16
-                                    );
-                                    self.emit_str_fp(0, cd);
-                                    break;
-                                }
-                                self.emit_slot_move(src, cd, false, 0);
-                                cur = ni;
-                            } else {
-                                // No cycle found — emit move and break
-                                self.emit_slot_move(moves[cur].0, cd, moves[cur].2, moves[cur].3);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let descr_arc = op.getdescr();
-        let jump_descr = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr());
-        if let Some(label) =
-            loop_target_id(op).and_then(|k| self.target_tokens_currently_compiling.get(&k).copied())
-        {
-            // Same-buffer jump (loop body)
-            dynasm!(self.mc ; .arch aarch64 ; b =>label);
-        } else if let Some(target) = jump_descr.map(|descr| descr.ll_loop_code()) {
-            // assembler.py closing_jump parity: bridge jumps back to
-            // the original loop's LABEL via absolute address.
-            // assembler.py:1167-1171 `_assemble`: record the target loop's
-            // frame depth so this trace's frame grows to fit it.
-            if let Some(descr) = jump_descr {
-                self.jump_target_frame_depth =
-                    self.jump_target_frame_depth.max(descr.target_frame_depth());
-            }
-            self.emit_mov_imm64(0, target as i64);
-            dynasm!(self.mc ; .arch aarch64 ; br x0);
-        }
-    }
-
     /// FINISH: store result (if any), store descr ptr, return jf_ptr.
+    #[allow(dead_code)]
     fn genop_finish(&mut self, op: &Op, _fail_index: u32) {
         // compiler.rs:9667-9681 parity: trust explicit FINISH types only when
         // they match the actual result arity; otherwise infer from the op args.
@@ -5194,25 +4948,13 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — type conversions
     // ----------------------------------------------------------------
 
-    /// SAME_AS: result = arg0 (copy value)
-    /// SAME_AS: result = arg0 (identity).
-    /// regalloc.py parity: no code emitted — just alias the slot.
-    fn genop_same_as(&mut self, op: &Op) {
-        let arg = op.arg(0).to_opref();
-        if let Some(&slot) = self.opref_to_slot.get(&arg) {
-            self.opref_to_slot.insert(op.pos.get(), slot);
-        } else {
-            self.load_arg_to_rax(arg);
-            self.store_rax_to_result(op.pos.get());
-        }
-    }
-
     // ----------------------------------------------------------------
     // Float helpers
     // ----------------------------------------------------------------
 
     /// Load a float value from `opref` into XMM0 (x64) / D0 (aarch64).
     /// Float values are stored as bit-cast i64 in frame slots.
+    #[allow(dead_code)]
     fn load_float_arg_to_d0(&mut self, opref: OpRef) {
         match self.resolve_opref(opref) {
             ResolvedArg::Slot(offset) => {
@@ -5229,6 +4971,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// Load a float value from `opref` into XMM1 (x64) / D1 (aarch64).
+    #[allow(dead_code)]
     fn load_float_arg_to_d1(&mut self, opref: OpRef) {
         match self.resolve_opref(opref) {
             ResolvedArg::Slot(offset) => {
@@ -5257,6 +5000,7 @@ impl<'a> AssemblerARM64<'a> {
     // ----------------------------------------------------------------
 
     /// FLOAT_ADD: result = arg0 + arg1
+    #[allow(dead_code)]
     fn genop_float_add(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -5267,6 +5011,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// FLOAT_SUB: result = arg0 - arg1
+    #[allow(dead_code)]
     fn genop_float_sub(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -5277,6 +5022,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// FLOAT_MUL: result = arg0 * arg1
+    #[allow(dead_code)]
     fn genop_float_mul(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -5287,6 +5033,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// FLOAT_TRUEDIV: result = arg0 / arg1
+    #[allow(dead_code)]
     fn genop_float_truediv(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -5299,6 +5046,7 @@ impl<'a> AssemblerARM64<'a> {
     /// FLOAT_NEG: result = -arg0
     /// x64: XOR with sign-bit mask (0x8000000000000000).
     /// aarch64: FNEG d0, d0.
+    #[allow(dead_code)]
     fn genop_float_neg(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -5308,6 +5056,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// CAST_INT_TO_FLOAT: result = (f64)arg0
+    #[allow(dead_code)]
     fn genop_cast_int_to_float(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -5317,6 +5066,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// CAST_FLOAT_TO_INT: result = (i64)arg0 (truncation)
+    #[allow(dead_code)]
     fn genop_cast_float_to_int(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -5342,35 +5092,6 @@ impl<'a> AssemblerARM64<'a> {
         op.with_field_descr(|fd| fd.field_size()).unwrap_or(8)
     }
 
-    /// GETFIELD_GC_*: result = [arg0 + offset]
-    /// The offset comes from the op's FieldDescr.
-    fn genop_getfield(&mut self, op: &Op) {
-        let offset = Self::field_offset_from_descr(op);
-        let size = Self::field_size_from_descr(op);
-
-        // Load the object pointer from arg0.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        // Load the field value at [rax + offset] into rax/x0.
-
-        match size {
-            1 => dynasm!(self.mc ; .arch aarch64
-                ; ldrb w0, [x0, offset as u32]
-            ),
-            2 => dynasm!(self.mc ; .arch aarch64
-                ; ldrh w0, [x0, offset as u32]
-            ),
-            4 => dynasm!(self.mc ; .arch aarch64
-                ; ldr w0, [x0, offset as u32]
-            ),
-            _ => dynasm!(self.mc ; .arch aarch64
-                ; ldr x0, [x0, offset as u32]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
     /// SETFIELD_GC: [arg0 + offset] = arg1
     fn genop_discard_setfield(&mut self, op: &Op) {
         let offset = Self::field_offset_from_descr(op);
@@ -5394,126 +5115,6 @@ impl<'a> AssemblerARM64<'a> {
                 ; str x1, [x0, offset as u32]
             ),
         }
-    }
-
-    /// GETARRAYITEM_GC_*: result = array[index]
-    /// arg0 = array pointer, arg1 = index.
-    /// The base_size and item_size come from the op's ArrayDescr.
-    fn genop_getarrayitem(&mut self, op: &Op) {
-        let (base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((8, 8));
-
-        // Load array pointer and index.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        // Compute address: rax = rax + base_size + rcx * item_size
-
-        // x1 = x1 * item_size; x0 = x0 + base_size + x1
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64); // x2 = item_size
-            dynasm!(self.mc ; .arch aarch64
-                ; mul x1, x1, x2
-            );
-        }
-        if base_size != 0 {
-            dynasm!(self.mc ; .arch aarch64
-                ; add x0, x0, base_size as u32
-            );
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, x1
-        );
-        match item_size {
-            1 => dynasm!(self.mc ; .arch aarch64
-                ; ldrb w0, [x0]
-            ),
-            2 => dynasm!(self.mc ; .arch aarch64
-                ; ldrh w0, [x0]
-            ),
-            4 => dynasm!(self.mc ; .arch aarch64
-                ; ldr w0, [x0]
-            ),
-            _ => dynasm!(self.mc ; .arch aarch64
-                ; ldr x0, [x0]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// SETARRAYITEM_GC: array[index] = value
-    /// arg0 = array pointer, arg1 = index, arg2 = value.
-    fn genop_discard_setarrayitem(&mut self, op: &Op) {
-        let (base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((8, 8));
-
-        // Load array pointer.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        // Load index.
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        // Compute element address: rax = rax + base_size + rcx * item_size
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64);
-            dynasm!(self.mc ; .arch aarch64
-                ; mul x1, x1, x2
-            );
-        }
-        if base_size != 0 {
-            dynasm!(self.mc ; .arch aarch64
-                ; add x0, x0, base_size as u32
-            );
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, x1
-        );
-
-        // Now load value from arg2 and store it.
-        // We need a third register: use rcx/x1 again for the value
-        // (the address is in rax/x0).
-        // Save rax/x0 (element address) before loading value.
-
-        // Save x0 (element address) in x2, load value into x1.
-        dynasm!(self.mc ; .arch aarch64
-            ; mov x2, x0
-        );
-        self.load_arg_to_rcx(op.arg(2).to_opref()); // loads into x1
-        match item_size {
-            1 => dynasm!(self.mc ; .arch aarch64
-                ; strb w1, [x2]
-            ),
-            2 => dynasm!(self.mc ; .arch aarch64
-                ; strh w1, [x2]
-            ),
-            4 => dynasm!(self.mc ; .arch aarch64
-                ; str w1, [x2]
-            ),
-            _ => dynasm!(self.mc ; .arch aarch64
-                ; str x1, [x2]
-            ),
-        }
-    }
-
-    /// ARRAYLEN_GC: result = array.length
-    /// The length field location comes from the ArrayDescr's len_descr().
-    fn genop_arraylen(&mut self, op: &Op) {
-        let len_offset = op
-            .with_array_descr(|ad| ad.len_descr().map(|ld| ld.offset() as i32))
-            .flatten()
-            .unwrap_or(0); // Default: length at offset 0 in array header
-
-        // Load array pointer.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        // Load length from [array + len_offset].
-        dynasm!(self.mc ; .arch aarch64
-            ; ldr x0, [x0, len_offset as u32]
-        );
-
-        self.store_rax_to_result(op.pos.get());
     }
 
     // ----------------------------------------------------------------
@@ -5761,19 +5362,6 @@ impl<'a> AssemblerARM64<'a> {
         self.emit_call_from_arglocs(arglocs, func_index);
         if op.opcode.result_type() == Type::Int {
             self.ensure_call_result_bit_extension(arglocs);
-        }
-    }
-
-    /// assembler.py:2169-2174 _genop_real_call.
-    /// genop_call_i = genop_call_r = genop_call_f = genop_call_n
-    fn genop_call(&mut self, op: &Op) {
-        self._genop_call(op);
-        if !op.pos.get().is_none() {
-            if op.opcode.result_type() == Type::Float {
-                self.store_d0_to_result(op.pos.get());
-            } else {
-                self.store_rax_to_result(op.pos.get());
-            }
         }
     }
 
@@ -6661,88 +6249,6 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — misc
     // ----------------------------------------------------------------
 
-    /// FORCE_TOKEN: return the jitframe pointer itself.
-    /// x86/assembler.py genop_force_token: mov resloc, ebp
-    fn genop_force_token(&mut self, op: &Op) {
-        // The frame pointer is the force token.
-        dynasm!(self.mc ; .arch aarch64
-            ; mov x0, x29
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// STRLEN / UNICODELEN: result = string.length
-    /// Load the length field from the string/unicode object header.
-    /// arg0 = string pointer. The length is at a fixed offset in the
-    /// RPython string representation. For RPython strings, the length
-    /// is typically at offset 8 (after the GC header / hash field).
-    fn genop_strlen(&mut self, op: &Op) {
-        // rewrite.py:273-282 parity — the length field offset comes from
-        // `get_array_token(rstr.STR/UNICODE, ...)` → `ArrayDescr.lendescr`
-        // in the JIT descr model.  Upstream emits `GC_LOAD_I` reading
-        // `ArrayDescr.lendescr.offset`; the direct path mirrors that.
-        let offset = op
-            .with_array_descr(|ad| ad.len_descr().map(|ld| ld.offset() as i32))
-            .flatten()
-            .unwrap_or_else(|| Self::field_offset_from_descr(op));
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        dynasm!(self.mc ; .arch aarch64
-            ; ldr x0, [x0, offset as u32]
-        );
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// STRGETITEM / UNICODEGETITEM: result = string[index]
-    /// arg0 = string pointer, arg1 = index.
-    /// Address = base + (basesize - extra_null) + index * itemsize, per
-    /// `rewrite.py:295-306` — STR has `extra_item_after_alloc=1` so the
-    /// token basesize overshoots the first char by 1.
-    fn genop_strgetitem(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((17, 1)); // rstr.STR token defaults (basesize=17, itemsize=1)
-        if op.opcode == OpCode::Strgetitem {
-            debug_assert_eq!(item_size, 1, "STRGETITEM itemsize must be 1");
-            base_size -= 1; // rewrite.py:299 — skip the extra null character
-        }
-
-        self.load_arg_to_rax(op.arg(0).to_opref()); // string pointer
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // index
-
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64);
-            dynasm!(self.mc ; .arch aarch64
-                ; mul x1, x1, x2
-            );
-        }
-        if base_size != 0 {
-            dynasm!(self.mc ; .arch aarch64
-                ; add x0, x0, base_size as u32
-            );
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, x1
-        );
-        match item_size {
-            1 => dynasm!(self.mc ; .arch aarch64
-                ; ldrb w0, [x0]
-            ),
-            2 => dynasm!(self.mc ; .arch aarch64
-                ; ldrh w0, [x0]
-            ),
-            4 => dynasm!(self.mc ; .arch aarch64
-                ; ldr w0, [x0]
-            ),
-            _ => dynasm!(self.mc ; .arch aarch64
-                ; ldr x0, [x0]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
     // ================================================================
     // assembler.py:1817 genop_save_exc_class / genop_save_exception
     // ================================================================
@@ -6793,28 +6299,8 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — extended integer arithmetic
     // ================================================================
 
-    /// INT_FLOORDIV: result = arg0 / arg1 (signed)
-    fn genop_int_floordiv(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64
-            ; sdiv x0, x0, x1
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// INT_MOD: result = arg0 % arg1 (signed)
-    fn genop_int_mod(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64
-            ; sdiv x2, x0, x1
-            ; msub x0, x2, x1, x0
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
     /// UINT_MUL_HIGH: upper 64 bits of unsigned multiply
+    #[allow(dead_code)]
     fn genop_uint_mul_high(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -6825,6 +6311,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// INT_SIGNEXT: sign-extend from num_bytes width to 64 bits.
+    #[allow(dead_code)]
     fn genop_int_signext(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         let num_bytes = match self.resolve_opref(op.arg(1).to_opref()) {
@@ -6847,6 +6334,7 @@ impl<'a> AssemblerARM64<'a> {
     // ================================================================
 
     /// FLOAT_ABS: result = |arg0|
+    #[allow(dead_code)]
     fn genop_float_abs(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -6855,44 +6343,8 @@ impl<'a> AssemblerARM64<'a> {
         self.store_d0_to_result(op.pos.get());
     }
 
-    /// FLOAT_LT/LE/EQ/NE/GT/GE: float comparison.
-    /// For lt/le, swap operands so JA/JAE handles NaN correctly.
-    fn genop_float_cmp(&mut self, op: &Op) {
-        let swap = matches!(op.opcode, OpCode::FloatLt | OpCode::FloatLe);
-        if swap {
-            self.load_float_arg_to_d0(op.arg(1).to_opref());
-            self.load_float_arg_to_d1(op.arg(0).to_opref());
-        } else {
-            self.load_float_arg_to_d0(op.arg(0).to_opref());
-            self.load_float_arg_to_d1(op.arg(1).to_opref());
-        }
-
-        dynasm!(self.mc ; .arch aarch64 ; fcmp d0, d1);
-        match op.opcode {
-            OpCode::FloatLt | OpCode::FloatGt => {
-                dynasm!(self.mc ; .arch aarch64 ; cset x0, gt);
-            }
-            OpCode::FloatLe | OpCode::FloatGe => {
-                dynasm!(self.mc ; .arch aarch64 ; cset x0, ge);
-            }
-            OpCode::FloatEq => {
-                dynasm!(self.mc ; .arch aarch64 ; cset x0, eq);
-            }
-            OpCode::FloatNe => {
-                dynasm!(self.mc ; .arch aarch64 ; cset x0, ne);
-            }
-            _ => {
-                dynasm!(self.mc ; .arch aarch64 ; cset x0, eq);
-            }
-        }
-        dynasm!(self.mc ; .arch aarch64 ; cmp x0, 0);
-        self.guard_success_cc = Some(CC_NE);
-        if !op.pos.get().is_none() {
-            self.store_rax_to_result(op.pos.get());
-        }
-    }
-
     /// CAST_FLOAT_TO_SINGLEFLOAT: f64 → f32 (bits in lower 32 of i64)
+    #[allow(dead_code)]
     fn genop_cast_float_to_singlefloat(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -6903,6 +6355,7 @@ impl<'a> AssemblerARM64<'a> {
     }
 
     /// CAST_SINGLEFLOAT_TO_FLOAT: f32 (bits in lower 32) → f64
+    #[allow(dead_code)]
     fn genop_cast_singlefloat_to_float(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch aarch64
@@ -6916,23 +6369,8 @@ impl<'a> AssemblerARM64<'a> {
     // genop_* — GC memory operations
     // ================================================================
 
-    /// Emit a sized load from [rax]/[x0]. Positive size = zero-extend,
-    /// negative = sign-extend.
-    fn emit_load_from_rax_sized(&mut self, itemsize: i32) {
-        let abs_size = itemsize.unsigned_abs() as usize;
-        let signed = itemsize < 0;
-        match (abs_size, signed) {
-            (1, true) => dynasm!(self.mc ; .arch aarch64 ; ldrsb x0, [x0]),
-            (2, true) => dynasm!(self.mc ; .arch aarch64 ; ldrsh x0, [x0]),
-            (4, true) => dynasm!(self.mc ; .arch aarch64 ; ldrsw x0, [x0]),
-            (1, false) => dynasm!(self.mc ; .arch aarch64 ; ldrb w0, [x0]),
-            (2, false) => dynasm!(self.mc ; .arch aarch64 ; ldrh w0, [x0]),
-            (4, false) => dynasm!(self.mc ; .arch aarch64 ; ldr w0, [x0]),
-            _ => dynasm!(self.mc ; .arch aarch64 ; ldr x0, [x0]),
-        }
-    }
-
     /// Emit a sized store of rcx/x1 to [rax]/[x0].
+    #[allow(dead_code)]
     fn emit_store_to_rax_sized(&mut self, size: usize) {
         match size {
             1 => dynasm!(self.mc ; .arch aarch64 ; strb w1, [x0]),
@@ -6950,43 +6388,9 @@ impl<'a> AssemblerARM64<'a> {
         }
     }
 
-    /// GC_LOAD_I/R/F: load from base + offset with given itemsize.
-    /// arg(0) = base, arg(1) = offset, arg(2) = itemsize.
-    fn genop_gc_load(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-
-        let itemsize = self.resolve_const_or(op.arg(2).to_opref(), 8) as i32;
-        self.emit_load_from_rax_sized(itemsize);
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// GC_LOAD_INDEXED_I/R/F: load from base + base_offset + index * scale.
-    /// arg(0)=base, arg(1)=index, arg(2)=scale, arg(3)=base_offset, arg(4)=itemsize.
-    fn genop_gc_load_indexed(&mut self, op: &Op) {
-        let scale = self.resolve_const_or(op.arg(2).to_opref(), 1) as i32;
-        let base_offset = self.resolve_const_or(op.arg(3).to_opref(), 0) as i32;
-        let itemsize = self.resolve_const_or(op.arg(4).to_opref(), 8) as i32;
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        if scale != 1 {
-            self.emit_mov_imm64(2, scale as i64);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-        if base_offset != 0 {
-            dynasm!(self.mc ; .arch aarch64 ; add x0, x0, base_offset as u32);
-        }
-
-        self.emit_load_from_rax_sized(itemsize);
-        self.store_rax_to_result(op.pos.get());
-    }
-
     /// GC_STORE: store value to base + offset.
     /// 4-arg form: arg(0)=base, arg(1)=offset, arg(2)=value, arg(3)=itemsize.
+    #[allow(dead_code)]
     fn genop_discard_gc_store(&mut self, op: &Op) {
         if op.num_args() < 4 {
             return; // 3-arg GC rewrite form — skip for now
@@ -7007,6 +6411,7 @@ impl<'a> AssemblerARM64<'a> {
     /// GC_STORE_INDEXED: store to base + base_offset + index * scale.
     /// arg(0)=base, arg(1)=index, arg(2)=value, arg(3)=scale,
     /// arg(4)=base_offset, arg(5)=itemsize.
+    #[allow(dead_code)]
     fn genop_discard_gc_store_indexed(&mut self, op: &Op) {
         let scale = self.resolve_const_or(op.arg(3).to_opref(), 1) as i32;
         let base_offset = self.resolve_const_or(op.arg(4).to_opref(), 0) as i32;
@@ -7030,102 +6435,9 @@ impl<'a> AssemblerARM64<'a> {
         self.emit_store_to_rax_sized(itemsize);
     }
 
-    /// RAW_LOAD_I/F: load from base + offset using descriptor.
-    fn genop_raw_load(&mut self, op: &Op) {
-        let offset = Self::field_offset_from_descr(op);
-        let size = Self::field_size_from_descr(op);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-
-        self.emit_load_from_rax_sized(size as i32);
-        let _ = offset; // offset is in the descriptor, not used for raw_load
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// RAW_STORE: store value to base + offset using descriptor.
-    fn genop_discard_raw_store(&mut self, op: &Op) {
-        let size = Self::field_size_from_descr(op);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-        dynasm!(self.mc ; .arch aarch64 ; mov x2, x0);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; mov x0, x2);
-        self.emit_store_to_rax_sized(size);
-    }
-
     // ================================================================
     // genop_* — interior field operations
     // ================================================================
-
-    /// GETINTERIORFIELD_GC_I/R/F: load field from array-of-structs element.
-    fn genop_getinteriorfield(&mut self, op: &Op) {
-        let (base_size, item_size, field_offset, field_size) = op
-            .with_interior_field_descr(|id| {
-                let ad = id.array_descr();
-                let fd = id.field_descr();
-                (
-                    ad.base_size() as i32,
-                    ad.item_size() as i32,
-                    fd.offset() as i32,
-                    fd.field_size(),
-                )
-            })
-            .unwrap_or((8, 8, 0, 8));
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        let total_offset = base_size + field_offset;
-
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        if total_offset != 0 {
-            dynasm!(self.mc ; .arch aarch64 ; add x0, x0, total_offset as u32);
-        }
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-
-        self.emit_load_from_rax_sized(field_size as i32);
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// SETINTERIORFIELD_GC/RAW: write field in array-of-structs element.
-    fn genop_discard_setinteriorfield(&mut self, op: &Op) {
-        let (base_size, item_size, field_offset, field_size) = op
-            .with_interior_field_descr(|id| {
-                let ad = id.array_descr();
-                let fd = id.field_descr();
-                (
-                    ad.base_size() as i32,
-                    ad.item_size() as i32,
-                    fd.offset() as i32,
-                    fd.field_size(),
-                )
-            })
-            .unwrap_or((8, 8, 0, 8));
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        let total_offset = base_size + field_offset;
-
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        if total_offset != 0 {
-            dynasm!(self.mc ; .arch aarch64 ; add x0, x0, total_offset as u32);
-        }
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-        dynasm!(self.mc ; .arch aarch64 ; mov x2, x0);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; mov x0, x2);
-
-        self.emit_store_to_rax_sized(field_size);
-    }
 
     // ================================================================
     // genop_* — call variants
@@ -7213,104 +6525,6 @@ impl<'a> AssemblerARM64<'a> {
     // ================================================================
     // genop_* — string/array operations
     // ================================================================
-
-    /// STRSETITEM / UNICODESETITEM: string[index] = value.
-    /// Address = base + (basesize - extra_null) + index * itemsize, per
-    /// `rewrite.py:307-318` — STR has `extra_item_after_alloc=1` so the
-    /// token basesize overshoots the first char by 1; UNICODE does not.
-    fn genop_discard_strsetitem(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((17, 1));
-        if op.opcode == OpCode::Strsetitem {
-            debug_assert_eq!(item_size, 1, "STRSETITEM itemsize must be 1");
-            base_size -= 1; // rewrite.py:311 — skip the extra null character
-        }
-
-        self.load_arg_to_rax(op.arg(0).to_opref()); // string
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // index
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size as i64);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, base_size as u32
-            ; add x0, x0, x1
-        );
-        dynasm!(self.mc ; .arch aarch64 ; mov x2, x0);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch aarch64 ; mov x0, x2);
-        self.emit_store_to_rax_sized(item_size as usize);
-    }
-
-    /// COPYSTRCONTENT / COPYUNICODECONTENT: copy substring.
-    /// arg(0)=src, arg(1)=dst, arg(2)=src_start, arg(3)=dst_start, arg(4)=length.
-    ///
-    /// Fallback emitter for the no-rewriter path.  When the GC rewriter is
-    /// present (production), `rewrite.py:1045-1080
-    /// rewrite_copy_str_content` replaces this op with
-    /// LOAD_EFFECTIVE_ADDRESS × 2 + CALL_N(memcpy, …) before assembly, so
-    /// this function is never reached.  Kept for tests that run the
-    /// backend directly on un-rewritten ops.  Mirrors upstream's basesize
-    /// handling (`rewrite.py:1049-1053`).
-    fn genop_discard_copystrcontent(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i64, ad.item_size() as i64))
-            .unwrap_or((16, 1));
-        // rewrite.py:1049-1053 `rewrite_copy_str_content` — COPYSTRCONTENT
-        // uses `str_descr.basesize - 1` to skip the `extra_item_after_alloc`
-        // null terminator carried by `rstr.STR.chars` (`rstr.py:1226-1228`).
-        // COPYUNICODECONTENT's unicode_descr has no extra item.  Mirrors the
-        // same correction `strgetsetitem_token` applies for STR{GET,SET}ITEM.
-        if op.opcode == OpCode::Copystrcontent {
-            debug_assert_eq!(item_size, 1, "COPYSTRCONTENT itemsize must be 1");
-            base_size -= 1;
-        }
-
-        // Compute byte_count = length * item_size
-        self.load_arg_to_rax(op.arg(4).to_opref());
-        if item_size != 1 {
-            self.emit_mov_imm64(1, item_size);
-            dynasm!(self.mc ; .arch aarch64 ; mul x0, x0, x1);
-        }
-        dynasm!(self.mc ; .arch aarch64 ; str x0, [sp, #-16]!); // byte_count
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, base_size as u32
-            ; add x0, x0, x1
-            ; str x0, [sp, #-16]!  // src_addr
-        );
-
-        self.load_arg_to_rax(op.arg(1).to_opref());
-        self.load_arg_to_rcx(op.arg(3).to_opref());
-        if item_size != 1 {
-            self.emit_mov_imm64(2, item_size);
-            dynasm!(self.mc ; .arch aarch64 ; mul x1, x1, x2);
-        }
-        dynasm!(self.mc ; .arch aarch64
-            ; add x0, x0, base_size as u32
-            ; add x0, x0, x1
-        );
-
-        let memmove_ptr = libc::memmove as *const () as i64;
-        dynasm!(self.mc ; .arch aarch64
-            ; ldr x1, [sp], #16  // src
-            ; ldr x2, [sp], #16  // count
-        );
-        // x0 = dst already
-        dynasm!(self.mc ; .arch aarch64 ; stp x29, x30, [sp, #-16]!);
-        self.emit_mov_imm64(3, memmove_ptr);
-        dynasm!(self.mc ; .arch aarch64
-            ; blr x3
-            ; ldp x29, x30, [sp], #16
-        );
-    }
 
     /// NEWSTR: allocate a byte string of given length.
     /// `base_size` / `item_size` come from the injected ArrayDescr
@@ -7513,29 +6727,6 @@ impl<'a> AssemblerARM64<'a> {
     // ================================================================
     // genop_* — address computation
     // ================================================================
-
-    /// LOAD_EFFECTIVE_ADDRESS: result = base + (index << shift) + baseofs.
-    /// resoperation.py:1052-1054 — `[v_gcptr, v_index, c_baseofs, c_shift]`.
-    /// arg(0)=base, arg(1)=index, arg(2)=baseofs, arg(3)=shift.
-    fn genop_load_effective_address(&mut self, op: &Op) {
-        let baseofs = self.resolve_const_or(op.arg(2).to_opref(), 0) as i32;
-        let shift = self.resolve_const_or(op.arg(3).to_opref(), 0) as i32;
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        if shift != 0 {
-            // add x0, x0, x1, lsl #shift fuses << and + in one insn;
-            // opencode via a scratch shift to keep store_rax_to_result in rax.
-            dynasm!(self.mc ; .arch aarch64 ; lsl x1, x1, shift as u32);
-        }
-        dynasm!(self.mc ; .arch aarch64 ; add x0, x0, x1);
-        if baseofs != 0 {
-            dynasm!(self.mc ; .arch aarch64 ; add x0, x0, baseofs as u32);
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
 }
 
 /// Flush icache — aarch64 only.

--- a/majit/majit-backend-dynasm/src/guard.rs
+++ b/majit/majit-backend-dynasm/src/guard.rs
@@ -94,9 +94,6 @@ pub fn layout_for_fail_descr(
         is_exception_exit: fd.is_exit_frame_with_exception(),
         trace_id,
         source_op_index: fd.source_op_index(),
-        // Classified from the descr's own force-token list, so a descr
-        // that suppresses force-token producer slots from GC
-        // classification contributes correct metadata to the layout.
         frame_stack: None,
         // Backend no longer caches recovery_layout.  The
         // metainterp `pyjitpl.rs:6322` falls back to

--- a/majit/majit-backend-dynasm/src/guard.rs
+++ b/majit/majit-backend-dynasm/src/guard.rs
@@ -94,14 +94,9 @@ pub fn layout_for_fail_descr(
         is_exception_exit: fd.is_exit_frame_with_exception(),
         trace_id,
         source_op_index: fd.source_op_index(),
-        // Forward through `FailDescr::is_gc_ref_slot` / `force_token_slots`
-        // so concrete descrs that override these (e.g. cranelift descrs
-        // that suppress force-token producer slots from GC classification)
-        // contribute correct metadata to the layout.
-        gc_ref_slots: (0..fail_arg_types.len())
-            .filter(|&i| fd.is_gc_ref_slot(i))
-            .collect(),
-        force_token_slots: fd.force_token_slots(),
+        // Classified from the descr's own force-token list, so a descr
+        // that suppresses force-token producer slots from GC
+        // classification contributes correct metadata to the layout.
         frame_stack: None,
         // Backend no longer caches recovery_layout.  The
         // metainterp `pyjitpl.rs:6322` falls back to

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -756,12 +756,12 @@ fn handle_fail_resume_guard(
     // leave in it (`blackhole.py:1782-1796` ends `deadframe`'s live range at
     // `_prepare_resume_from_failure`, before `_run_forever`).
     //
-    // `is_gc_ref_slot` rather than a bare `Type::Ref` test: a force-token slot
-    // is typed `Ref` but carries an opaque virtualizable handle, so it is not a
-    // pointer to hand the collector.
+    // The rooted set is `compute_gcmap`'s: every `Ref`-typed exit slot, force
+    // tokens included — one is the jitframe pointer, and the jitframe moves.
     let ref_roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    let fail_arg_types = descr.fail_arg_types();
     for slot in 0..raw_values.len() {
-        if descr.is_gc_ref_slot(slot) {
+        if matches!(fail_arg_types.get(slot), Some(majit_ir::Type::Ref)) {
             // SAFETY: `slot` indexes `raw_values`, which outlives the pop below
             // and is not resized while the roots are registered.
             unsafe {

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -737,12 +737,49 @@ fn handle_fail_resume_guard(
         unsafe { majit_gc::gc_add_root(&mut guard_exc_root as *mut majit_ir::GcRef) };
     }
 
+    // `raw_values` is a host copy of the jitframe slots, and only the jitframe
+    // itself is walked (`jitframe_trace`).  The bridge hook below traces and
+    // compiles, so it allocates: a moving collection forwards the frame's own
+    // slots and leaves this copy naming the addresses the objects have left,
+    // which the blackhole call further down then reads.  Register the copy's
+    // GC slots for the hook's duration so the collector writes the forwarded
+    // addresses back through them.
+    //
+    // `pyre-jit`'s other guard-failure path already does this around its own
+    // bridge decision (`DeadFrameRefRoots::enter`, `eval.rs handle_fail`); that
+    // type sits behind `majit-metainterp`, which this crate does not depend on,
+    // so the same shadow-stack primitives are used directly here.
+    //
+    // The scope ends before the blackhole call rather than wrapping it: the
+    // blackhole receiver registers the same buffer itself, and a slot left
+    // registered across the resumed run pins whatever the guard happened to
+    // leave in it (`blackhole.py:1782-1796` ends `deadframe`'s live range at
+    // `_prepare_resume_from_failure`, before `_run_forever`).
+    //
+    // `is_gc_ref_slot` rather than a bare `Type::Ref` test: a force-token slot
+    // is typed `Ref` but carries an opaque virtualizable handle, so it is not a
+    // pointer to hand the collector.
+    let ref_roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    for slot in 0..raw_values.len() {
+        if descr.is_gc_ref_slot(slot) {
+            // SAFETY: `slot` indexes `raw_values`, which outlives the pop below
+            // and is not resized while the roots are registered.
+            unsafe {
+                majit_gc::shadow_stack::push_resume_ref_roots(std::slice::from_raw_parts_mut(
+                    raw_values.as_mut_ptr().add(slot),
+                    1,
+                ));
+            }
+        }
+    }
+
     // compile.py:704-709 `_trace_and_compile_from_bridge`.
     // The hook compiles+attaches; it does NOT re-enter the bridge.
     // Skipped on giveup (None).
     if let (Some(_jct), Some(bridge_fn)) = (owning_jct.as_ref(), CA_BRIDGE_FN.get()) {
         bridge_fn(raw_values.as_ptr(), raw_values.len(), descr_raw);
     }
+    majit_gc::shadow_stack::pop_resume_ref_roots_to(ref_roots_depth);
 
     // compile.py:710-716 `resume_in_blackhole(descr, deadframe)`: the
     // descr is the sole identity carrier; the receiver derives green_key /

--- a/majit/majit-backend-dynasm/src/lib.rs
+++ b/majit/majit-backend-dynasm/src/lib.rs
@@ -406,6 +406,32 @@ pub fn stack_check_addresses() -> Option<StackCheckAddresses> {
 /// Output: the int interpretation of the handled result (the caller
 ///         re-casts to the portal's return type).
 ///
+/// Removes a `gc_add_root` registration on every exit path.
+///
+/// The rooted cell is a local of the trampoline below, and the hooks it calls
+/// trace, compile and run Python — any of which can unwind. An unwind past a
+/// bare `gc_remove_root` frees the cell while the registration still names it,
+/// leaving the collector writing through freed stack.
+struct GcRootScope(*mut majit_ir::GcRef);
+
+impl Drop for GcRootScope {
+    fn drop(&mut self) {
+        majit_gc::gc_remove_root(self.0);
+    }
+}
+
+/// Restores the resume-root stack depth on every exit path.
+///
+/// Same hazard as [`GcRootScope`]: the registered slots point into the
+/// trampoline's `raw_values`, which an unwind frees.
+struct ResumeRefRootScope(usize);
+
+impl Drop for ResumeRefRootScope {
+    fn drop(&mut self) {
+        majit_gc::shadow_stack::pop_resume_ref_roots_to(self.0);
+    }
+}
+
 /// The callee jitframe is GC-managed by the rewriter's
 /// `handle_call_assembler` path, so the helper must not free it here.
 #[expect(
@@ -732,10 +758,11 @@ fn handle_fail_resume_guard(
     // depend on `majit-metainterp`, and `BridgeFn` does not carry the
     // exception, so the bridge hook cannot park a value it never receives.
     // Either fix costs more machinery than the root pair it would delete.
-    let guard_exc_rooted = guard_exc_root.0 != 0;
-    if guard_exc_rooted {
-        unsafe { majit_gc::gc_add_root(&mut guard_exc_root as *mut majit_ir::GcRef) };
-    }
+    let _guard_exc_scope = (guard_exc_root.0 != 0).then(|| {
+        let slot = &mut guard_exc_root as *mut majit_ir::GcRef;
+        unsafe { majit_gc::gc_add_root(slot) };
+        GcRootScope(slot)
+    });
 
     // `raw_values` is a host copy of the jitframe slots, and only the jitframe
     // itself is walked (`jitframe_trace`).  The bridge hook below traces and
@@ -758,7 +785,7 @@ fn handle_fail_resume_guard(
     //
     // The rooted set is `compute_gcmap`'s: every `Ref`-typed exit slot, force
     // tokens included — one is the jitframe pointer, and the jitframe moves.
-    let ref_roots_depth = majit_gc::shadow_stack::resume_ref_roots_depth();
+    let resume_ref_roots = ResumeRefRootScope(majit_gc::shadow_stack::resume_ref_roots_depth());
     let fail_arg_types = descr.fail_arg_types();
     for slot in 0..raw_values.len() {
         if matches!(fail_arg_types.get(slot), Some(majit_ir::Type::Ref)) {
@@ -779,7 +806,7 @@ fn handle_fail_resume_guard(
     if let (Some(_jct), Some(bridge_fn)) = (owning_jct.as_ref(), CA_BRIDGE_FN.get()) {
         bridge_fn(raw_values.as_ptr(), raw_values.len(), descr_raw);
     }
-    majit_gc::shadow_stack::pop_resume_ref_roots_to(ref_roots_depth);
+    drop(resume_ref_roots);
 
     // compile.py:710-716 `resume_in_blackhole(descr, deadframe)`: the
     // descr is the sole identity carrier; the receiver derives green_key /
@@ -801,9 +828,6 @@ fn handle_fail_resume_guard(
             guard_exc_root.0 as i64,
         )
     });
-    if guard_exc_rooted {
-        majit_gc::gc_remove_root(&mut guard_exc_root as *mut majit_ir::GcRef);
-    }
     if let Some(bh_result) = bh_result {
         if majit_log_enabled() {
             eprintln!(

--- a/majit/majit-backend-dynasm/src/runner.rs
+++ b/majit/majit-backend-dynasm/src/runner.rs
@@ -3119,9 +3119,9 @@ impl Backend for DynasmBackend {
                 // `Type::Void` is the resume.py:411-417 hole sentinel —
                 // the slot's value is reconstructed from the resume
                 // snapshot (TAGCONST/TAGVIRTUAL), not from the deadframe.
-                // Surfacing `Value::Void` keeps `gc_ref_slots` and
-                // downstream type-tag dispatchers from misclassifying
-                // it as a live `Ref` and leaking a NULL `GcRef`.
+                // Surfacing `Value::Void` keeps the gcmap and downstream
+                // type-tag dispatchers from misclassifying it as a live
+                // `Ref` and leaking a NULL `GcRef`.
                 Type::Void => Value::Void,
                 Type::Int => Value::Int(raw),
             });
@@ -3144,7 +3144,6 @@ impl Backend for DynasmBackend {
             outputs,
             typed_outputs,
             exit_layout,
-            force_token_slots: Vec::new(),
             savedata: None,
             exception_value,
             fail_index: descr_fd.fail_index_per_trace(),

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -17,18 +17,15 @@ use std::sync::Arc;
 use dynasmrt::x64::Assembler;
 use dynasmrt::{AssemblyOffset, DynamicLabel, DynasmApi, DynasmLabelApi, dynasm};
 
-use majit_backend::{
-    AsmMemoryManager, BackendError, ExitFrameLayout, ExitRecoveryLayout, ExitValueSourceLayout,
-    JitCellToken,
-};
-use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRc, OpRef, OpTypeIndex, TargetArgLoc, Type};
+use majit_backend::{AsmMemoryManager, BackendError, JitCellToken};
+use majit_ir::{FailDescr, InputArg, Op, OpCode, OpRef, OpTypeIndex, TargetArgLoc, Type};
 
 use crate::arch::*;
 use crate::codebuf;
 use crate::gcmap::{allocate_gcmap, gcmap_set_bit};
 use crate::jitframe::{
-    FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FORWARD_OFS, JF_FRAME_OFS,
-    JF_GCMAP_OFS, JF_GUARD_EXC_OFS,
+    FIRST_ITEM_OFFSET, JF_DESCR_OFS, JF_FORCE_DESCR_OFS, JF_FRAME_OFS, JF_GCMAP_OFS,
+    JF_GUARD_EXC_OFS,
 };
 use crate::jump::RegallocMoves;
 use crate::regalloc::{RegAlloc, RegAllocOp};
@@ -976,6 +973,14 @@ pub struct CompiledCode {
     pub source_guard: Option<(u64, u32)>,
 }
 
+/// The `genop_*` methods here are line-by-line ports of the RPython emitters
+/// (`x86/assembler.py` `genop_*`).  Emission runs through `regalloc_perform`,
+/// which works from regalloc `arglocs`, so the ports whose opcode that
+/// dispatch reaches by another route carry `#[allow(dead_code)]`
+/// individually.  They are annotated rather than deleted so the upstream
+/// method boundary stays where a later porter looks for it; the attribute is
+/// per method so the lint still reports anything else in this `impl` that
+/// stops being reached.
 impl<'a> Assembler386<'a> {
     /// rpython/jit/metainterp/history.py:220 `box.type` parity.
     /// Single source of truth: `op.type_` for ops, `inputarg.tp` for
@@ -1776,6 +1781,9 @@ impl<'a> Assembler386<'a> {
         self.emit_abi_arg_from_imm(Self::abi_int_arg(idx), val, Type::Int);
     }
 
+    // Both call sites are `#[cfg(windows)]`, so every other host reads this
+    // as unreached.
+    #[allow(dead_code)]
     fn emit_win64_call_adjust(extra_pushes: usize) -> i32 {
         // Body rsp is 0-mod-16 (per `_call_header`'s padding-slot SUB).
         // With 0 extra pushes, only the 32-byte shadow space is needed
@@ -2129,6 +2137,7 @@ impl<'a> Assembler386<'a> {
     ///
     /// One in-memory subtract — no need to load the current top into a
     /// register, decrement, and store back.
+    #[allow(dead_code)]
     fn gen_footer_shadowstack(&mut self) {
         emit_footer_shadowstack_raw(&mut self.mc);
     }
@@ -2579,10 +2588,12 @@ impl<'a> Assembler386<'a> {
             input_slot_depth.max(JITFRAME_FIXED_SIZE + ra.get_final_frame_depth());
         self.frame_depth = self.frame_depth.max(frame_slot_depth);
 
-        // Sync regalloc frame positions to opref_to_slot for backward
-        // compatibility with genop_call/genop_call_assembler which still
-        // use resolve_opref. When regalloc spills a value to a frame slot,
-        // that slot's position must be visible to resolve_opref.
+        // Sync regalloc frame positions to opref_to_slot for the emitters that
+        // still read resolve_opref instead of arglocs: emit_call,
+        // genop_discard_setfield, genop_cond_call_value, genop_alloc_varsize
+        // and genop_discard_zero_array reach it through load_arg_to_rax /
+        // load_arg_to_rcx. When regalloc spills a value to a frame slot, that
+        // slot's position must be visible to resolve_opref.
         // opref_to_slot stores ABSOLUTE jitframe slots (user position +
         // JITFRAME_FIXED_SIZE) so slot_offset(slot) gives the correct byte
         // offset without further adjustment.
@@ -4856,16 +4867,6 @@ impl<'a> Assembler386<'a> {
         );
     }
 
-    /// x86/assembler.py:1797-1801 `generate_guard_no_exception`.
-    fn emit_cmp_no_exception(&mut self) {
-        let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
-        let exc_type_addr = crate::jit_exc_type_addr() as i64;
-        dynasm!(self.mc ; .arch x64
-            ; mov Rq(scratch), QWORD exc_type_addr
-            ; cmp QWORD [Rq(scratch)], 0
-        );
-    }
-
     /// Emit SETcc into a register (zero-extend to 64-bit).
     fn emit_setcc(&mut self, cc: u8, dst_reg: u8) {
         match cc {
@@ -5442,6 +5443,7 @@ impl<'a> Assembler386<'a> {
     // genop_* — integer arithmetic
 
     /// INT_ADD: result = arg0 + arg1
+    #[allow(dead_code)]
     fn genop_int_add(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5453,6 +5455,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_SUB: result = arg0 - arg1
+    #[allow(dead_code)]
     fn genop_int_sub(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5464,6 +5467,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_MUL: result = arg0 * arg1
+    #[allow(dead_code)]
     fn genop_int_mul(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5475,6 +5479,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_AND: result = arg0 & arg1
+    #[allow(dead_code)]
     fn genop_int_and(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5486,6 +5491,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_OR: result = arg0 | arg1
+    #[allow(dead_code)]
     fn genop_int_or(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5497,6 +5503,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_XOR: result = arg0 ^ arg1
+    #[allow(dead_code)]
     fn genop_int_xor(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5508,6 +5515,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_NEG: result = -arg0
+    #[allow(dead_code)]
     fn genop_int_neg(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc
@@ -5518,6 +5526,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_INVERT: result = ~arg0
+    #[allow(dead_code)]
     fn genop_int_invert(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc
@@ -5528,6 +5537,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_LSHIFT: result = arg0 << arg1
+    #[allow(dead_code)]
     fn genop_int_lshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5539,6 +5549,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_RSHIFT: result = arg0 >> arg1 (arithmetic/signed)
+    #[allow(dead_code)]
     fn genop_int_rshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5550,6 +5561,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// UINT_RSHIFT: result = arg0 >> arg1 (logical/unsigned)
+    #[allow(dead_code)]
     fn genop_uint_rshift(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -5564,18 +5576,21 @@ impl<'a> Assembler386<'a> {
 
     /// assembler.py:1856 genop_int_add_ovf — delegates to genop_int_add,
     /// then sets guard_success_cc = 'NO'. On x86, ADD always sets OF.
+    #[allow(dead_code)]
     fn genop_int_add_ovf(&mut self, op: &Op) {
         self.genop_int_add(op); // ADD sets OF on x86
         self.guard_success_cc = Some(CC_NO);
     }
 
     /// assembler.py:1860 genop_int_sub_ovf.
+    #[allow(dead_code)]
     fn genop_int_sub_ovf(&mut self, op: &Op) {
         self.genop_int_sub(op);
         self.guard_success_cc = Some(CC_NO);
     }
 
     /// assembler.py:1864 genop_int_mul_ovf.
+    #[allow(dead_code)]
     fn genop_int_mul_ovf(&mut self, op: &Op) {
         self.genop_int_mul(op); // IMUL sets OF on x86
         self.guard_success_cc = Some(CC_NO);
@@ -5583,31 +5598,10 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — comparisons
 
-    /// INT_LT/LE/GT/GE/EQ/NE/UINT_*: CMP arg0, arg1 then store CC.
-    /// If the next op is a guard, guard_success_cc is set and consumed.
-    /// Otherwise, materialize the boolean result via SETcc/CSET.
-    fn genop_int_cmp(&mut self, op: &Op) {
-        let cc = Self::opcode_to_cc(op.opcode);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc
-            ; .arch x64
-            ; cmp rax, rcx
-        );
-
-        // Store the CC for a following guard to consume.
-        self.guard_success_cc = Some(cc);
-
-        // Also materialize the boolean result for non-guard consumers.
-        if !op.pos.get().is_none() {
-            self.emit_setcc_to_result(cc, op.pos.get());
-        }
-    }
-
     /// Emit SETcc/CSET to materialize a boolean result.
     /// x64: SETcc AL; MOVZX EAX, AL
     /// aarch64: CSET X0, cc
+    #[allow(dead_code)]
     fn emit_setcc_to_result(&mut self, cc: u8, result_opref: OpRef) {
         match cc {
             CC_L => dynasm!(self.mc ; .arch x64 ; setl al),
@@ -5632,6 +5626,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_IS_TRUE: result = (arg0 != 0)
+    #[allow(dead_code)]
     fn genop_int_is_true(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc
@@ -5645,6 +5640,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_IS_ZERO: result = (arg0 == 0)
+    #[allow(dead_code)]
     fn genop_int_is_zero(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc
@@ -5924,210 +5920,8 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — control flow
 
-    /// LABEL: define the back-edge target for JUMP.
-    ///
-    /// RPython: LABEL does NOT emit code. The regalloc establishes
-    /// the slot mapping. JUMP handles slot remapping.
-    ///
-    /// In our frame-slot model: preamble values may be in non-canonical
-    /// slots. We emit copies from old→canonical slots BEFORE the
-    /// LABEL binding, so they execute only on first entry from the
-    /// preamble. JUMP writes directly to canonical slots and jumps
-    /// to the LABEL, skipping the copies.
-    fn genop_label(&mut self, op: &Op) {
-        // Emit preamble→canonical copies BEFORE the label.
-        // Two-pass push/pop: safely handles slot overlaps.
-        let n_label = op.num_args();
-        // Pass 1: push source values
-        for i in 0..n_label {
-            let arg_ref = op.arg(i).to_opref();
-            if arg_ref.is_none() {
-                let dst = Self::slot_offset(i);
-                dynasm!(self.mc ; .arch x64 ; push QWORD [rbp + dst]);
-            } else if arg_ref.is_constant() {
-                let val = arg_ref.inline_const_bits().unwrap_or_else(|| {
-                    self.constants
-                        .get(&arg_ref.raw())
-                        .map(|c| c.as_raw_i64())
-                        .unwrap_or(0)
-                });
-                dynasm!(self.mc ; .arch x64 ; mov rax, QWORD val as i64 ; push rax);
-            } else if let Some(&old_slot) = self.opref_to_slot.get(&arg_ref) {
-                let src = Self::slot_offset(old_slot);
-                dynasm!(self.mc ; .arch x64 ; push QWORD [rbp + src]);
-            } else {
-                dynasm!(self.mc ; .arch x64 ; push 0);
-            }
-        }
-        // Pass 2: pop in reverse into canonical slots
-        for i in (0..n_label).rev() {
-            let dst = Self::slot_offset(i);
-            dynasm!(self.mc ; .arch x64 ; pop QWORD [rbp + dst]);
-        }
-
-        // Bind the LABEL — JUMP targets here (after the copies).
-        let label = self.mc.new_dynamic_label();
-        dynasm!(self.mc ; .arch x64 ; =>label);
-        let descr_arc = op.getdescr();
-        if let Some(descr) = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr()) {
-            descr.set_ll_loop_code(self.mc.offset().0);
-            if let Some(id) = descr_arc.as_ref().map(majit_ir::descr_identity) {
-                self.target_tokens_currently_compiling.insert(id, label);
-            }
-            if let Some(descr_ref) = descr_arc.as_ref() {
-                self.compiled_target_tokens.push(descr_ref.clone());
-            }
-        }
-
-        // Remap: Label's arg[i] → canonical slot i
-        for (i, arg_ref) in op.getarglist().iter().enumerate() {
-            if !arg_ref.is_none() {
-                self.opref_to_slot.insert(arg_ref.to_opref(), i);
-            }
-        }
-        self.next_slot = self.next_slot.max(op.num_args());
-    }
-
-    /// jump.py:66 _move: emit a single slot-to-slot or const-to-slot move.
-    fn emit_slot_move(&mut self, src: i32, dst: i32, is_const: bool, val: i64) {
-        if is_const {
-            dynasm!(self.mc ; .arch x64
-                ; mov rax, QWORD val
-                ; mov [rbp + dst], rax
-            );
-        } else if src != dst {
-            dynasm!(self.mc ; .arch x64
-                ; mov rax, [rbp + src]
-                ; mov [rbp + dst], rax
-            );
-        }
-    }
-
-    /// JUMP: unconditional branch to the loop label.
-    /// jump.py:1 remap_frame_layout parity: parallel move algorithm
-    /// to handle cyclic slot dependencies.
-    fn genop_jump(&mut self, op: &Op) {
-        // Build src→dst move list.
-        // Each entry: (src_offset_or_const, dst_offset, is_const, const_val)
-        let n = op.num_args();
-        let mut moves: Vec<(i32, i32, bool, i64)> = Vec::with_capacity(n);
-        for (i, arg_ref) in op.getarglist().iter().enumerate() {
-            let dst = Self::slot_offset(i);
-            match self.resolve_opref(arg_ref.to_opref()) {
-                ResolvedArg::Slot(src) => moves.push((src, dst, false, 0)),
-                ResolvedArg::Const(val) => moves.push((0, dst, true, val)),
-            }
-        }
-
-        // jump.py:1-64 remap_frame_layout: topological order with
-        // cycle breaking via push/pop.
-        // srccount[dst] = number of times dst appears as a src
-        let mut srccount: IndexMap<i32, i32> = IndexMap::new();
-        for m in &moves {
-            if !srccount.contains_key(&m.1) {
-                srccount.insert(m.1, 0); // ensure dst exists
-            }
-        }
-        let mut pending = n as i32;
-        for (i, m) in moves.iter().enumerate() {
-            if m.2 {
-                continue;
-            } // constant → no src dependency
-            let src = m.0;
-            if let Some(cnt) = srccount.get_mut(&src) {
-                if src == moves[i].1 {
-                    // self-move: skip
-                    *cnt = -(n as i32) - 1;
-                    pending -= 1;
-                } else {
-                    *cnt += 1;
-                }
-            }
-        }
-
-        while pending > 0 {
-            let mut progress = false;
-            for i in 0..n {
-                let dst = moves[i].1;
-                if srccount.get(&dst).copied().unwrap_or(-1) == 0 {
-                    *srccount.get_mut(&dst).unwrap() = -1; // done
-                    pending -= 1;
-                    if !moves[i].2 {
-                        let src = moves[i].0;
-                        if let Some(cnt) = srccount.get_mut(&src) {
-                            *cnt -= 1;
-                        }
-                    }
-                    self.emit_slot_move(moves[i].0, dst, moves[i].2, moves[i].3);
-                    progress = true;
-                }
-            }
-            if !progress {
-                // Cycle: use push/pop to break it.
-                for i in 0..n {
-                    let dst = moves[i].1;
-                    if srccount.get(&dst).copied().unwrap_or(-1) >= 0 {
-                        // Push first dst in the cycle
-                        dynasm!(self.mc ; .arch x64 ; push QWORD [rbp + dst]);
-                        // Walk the cycle
-                        let mut cur = i;
-                        loop {
-                            let cd = moves[cur].1;
-                            *srccount.get_mut(&cd).unwrap() = -1;
-                            pending -= 1;
-                            // Find the move whose dst is this src
-                            let src = moves[cur].0;
-                            let next = moves.iter().position(|m| m.1 == src);
-                            if let Some(ni) = next {
-                                if srccount.get(&moves[ni].1).copied().unwrap_or(-1) < 0 {
-                                    // End of cycle: pop into this slot
-                                    dynasm!(self.mc ; .arch x64 ; pop QWORD [rbp + cd]);
-                                    break;
-                                }
-                                self.emit_slot_move(src, cd, false, 0);
-                                cur = ni;
-                            } else {
-                                // No cycle found — emit move and break
-                                self.emit_slot_move(moves[cur].0, cd, moves[cur].2, moves[cur].3);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        let descr_arc = op.getdescr();
-        let jump_descr = descr_arc.as_ref().and_then(|d| d.as_loop_target_descr());
-        if let Some(label) = descr_arc
-            .as_ref()
-            .map(majit_ir::descr_identity)
-            .and_then(|k| self.target_tokens_currently_compiling.get(&k).copied())
-        {
-            // Same-buffer jump (loop body)
-            dynasm!(self.mc ; .arch x64 ; jmp =>label);
-        } else if let Some(target) = jump_descr.map(|descr| descr.ll_loop_code()) {
-            // assembler.py closing_jump parity: bridge jumps back to
-            // the original loop's LABEL via absolute address. PyPy
-            // stages the 64-bit target through `X86_64_SCRATCH_REG`
-            // (r11), never RAX — using RAX here would clobber the
-            // loop-carried Ref the regalloc bound to it.
-            // assembler.py:1003-1008 `_assemble`: record the target loop's
-            // frame depth so this trace's frame grows to fit it.
-            if let Some(descr) = jump_descr {
-                self.jump_target_frame_depth =
-                    self.jump_target_frame_depth.max(descr.target_frame_depth());
-            }
-            let addr = target as i64;
-            let scratch = crate::regloc::X86_64_SCRATCH_REG.value;
-            dynasm!(self.mc ; .arch x64
-                ; mov Rq(scratch), QWORD addr
-                ; jmp Rq(scratch)
-            );
-        }
-    }
-
     /// FINISH: store result (if any), store descr ptr, return jf_ptr.
+    #[allow(dead_code)]
     fn genop_finish(&mut self, op: &Op, fail_index: u32) {
         // compiler.rs:9667-9681 parity: trust explicit FINISH types only when
         // they match the actual result arity; otherwise infer from the op args.
@@ -6219,23 +6013,11 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — type conversions
 
-    /// SAME_AS: result = arg0 (copy value)
-    /// SAME_AS: result = arg0 (identity).
-    /// regalloc.py parity: no code emitted — just alias the slot.
-    fn genop_same_as(&mut self, op: &Op) {
-        let arg = op.arg(0).to_opref();
-        if let Some(&slot) = self.opref_to_slot.get(&arg) {
-            self.opref_to_slot.insert(op.pos.get(), slot);
-        } else {
-            self.load_arg_to_rax(arg);
-            self.store_rax_to_result(op.pos.get());
-        }
-    }
-
     // Float helpers
 
     /// Load a float value from `opref` into XMM0 (x64) / D0 (aarch64).
     /// Float values are stored as bit-cast i64 in frame slots.
+    #[allow(dead_code)]
     fn load_float_arg_to_d0(&mut self, opref: OpRef) {
         match self.resolve_opref(opref) {
             ResolvedArg::Slot(offset) => {
@@ -6256,6 +6038,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// Load a float value from `opref` into XMM1 (x64) / D1 (aarch64).
+    #[allow(dead_code)]
     fn load_float_arg_to_d1(&mut self, opref: OpRef) {
         match self.resolve_opref(opref) {
             ResolvedArg::Slot(offset) => {
@@ -6275,6 +6058,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// Store XMM0 (x64) / D0 (aarch64) to the frame slot for `result_opref`.
+    #[allow(dead_code)]
     fn store_d0_to_result(&mut self, result_opref: OpRef) {
         let slot = self.allocate_slot(result_opref);
         let offset = Self::slot_offset(slot);
@@ -6289,6 +6073,7 @@ impl<'a> Assembler386<'a> {
     // aarch64/assembler.py float equivalents
 
     /// FLOAT_ADD: result = arg0 + arg1
+    #[allow(dead_code)]
     fn genop_float_add(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -6300,6 +6085,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// FLOAT_SUB: result = arg0 - arg1
+    #[allow(dead_code)]
     fn genop_float_sub(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -6311,6 +6097,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// FLOAT_MUL: result = arg0 * arg1
+    #[allow(dead_code)]
     fn genop_float_mul(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -6322,6 +6109,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// FLOAT_TRUEDIV: result = arg0 / arg1
+    #[allow(dead_code)]
     fn genop_float_truediv(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         self.load_float_arg_to_d1(op.arg(1).to_opref());
@@ -6335,6 +6123,7 @@ impl<'a> Assembler386<'a> {
     /// FLOAT_NEG: result = -arg0
     /// x64: XOR with sign-bit mask (0x8000000000000000).
     /// aarch64: FNEG d0, d0.
+    #[allow(dead_code)]
     fn genop_float_neg(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         // Load the sign-bit mask (0x8000_0000_0000_0000) into XMM1
@@ -6350,6 +6139,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// CAST_INT_TO_FLOAT: result = (f64)arg0
+    #[allow(dead_code)]
     fn genop_cast_int_to_float(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         // Break cvtsi2sd's false dependency on the destination's prior value
@@ -6363,6 +6153,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// CAST_FLOAT_TO_INT: result = (i64)arg0 (truncation)
+    #[allow(dead_code)]
     fn genop_cast_float_to_int(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc
@@ -6385,38 +6176,6 @@ impl<'a> Assembler386<'a> {
     /// Returns 8 (WORD) if no field descriptor is present.
     fn field_size_from_descr(op: &Op) -> usize {
         op.with_field_descr(|fd| fd.field_size()).unwrap_or(8)
-    }
-
-    /// GETFIELD_GC_*: result = [arg0 + offset]
-    /// The offset comes from the op's FieldDescr.
-    fn genop_getfield(&mut self, op: &Op) {
-        let offset = Self::field_offset_from_descr(op);
-        let size = Self::field_size_from_descr(op);
-
-        // Load the object pointer from arg0.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        // Load the field value at [rax + offset] into rax/x0.
-        match size {
-            1 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, BYTE [rax + offset]
-            ),
-            2 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, WORD [rax + offset]
-            ),
-            4 => dynasm!(self.mc
-                ; .arch x64
-                ; mov eax, [rax + offset]
-            ),
-            _ => dynasm!(self.mc
-                ; .arch x64
-                ; mov rax, [rax + offset]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
     }
 
     /// x86/assembler.py:1746 genop_discard_setfield — sized store via regalloc.
@@ -6733,137 +6492,6 @@ impl<'a> Assembler386<'a> {
         }
     }
 
-    /// GETARRAYITEM_GC_*: result = array[index]
-    /// arg0 = array pointer, arg1 = index.
-    /// The base_size and item_size come from the op's ArrayDescr.
-    fn genop_getarrayitem(&mut self, op: &Op) {
-        let (base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((8, 8));
-
-        // Load array pointer and index.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        // Compute address: rax = rax + base_size + rcx * item_size
-        // rcx = rcx * item_size
-        if item_size != 1 {
-            dynasm!(self.mc
-                ; .arch x64
-                ; imul rcx, rcx, item_size
-            );
-        }
-        // rax = rax + base_size + rcx
-        dynasm!(self.mc
-            ; .arch x64
-            ; add rax, base_size
-            ; add rax, rcx
-        );
-        match item_size {
-            1 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, BYTE [rax]
-            ),
-            2 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, WORD [rax]
-            ),
-            4 => dynasm!(self.mc
-                ; .arch x64
-                ; mov eax, [rax]
-            ),
-            _ => dynasm!(self.mc
-                ; .arch x64
-                ; mov rax, [rax]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// SETARRAYITEM_GC: array[index] = value
-    /// arg0 = array pointer, arg1 = index, arg2 = value.
-    fn genop_discard_setarrayitem(&mut self, op: &Op) {
-        let (base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((8, 8));
-
-        // Load array pointer.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        // Load index.
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        // Compute element address: rax = rax + base_size + rcx * item_size
-        if item_size != 1 {
-            dynasm!(self.mc
-                ; .arch x64
-                ; imul rcx, rcx, item_size
-            );
-        }
-        dynasm!(self.mc
-            ; .arch x64
-            ; add rax, base_size
-            ; add rax, rcx
-        );
-
-        // Now load value from arg2 and store it.
-        // We need a third register: use rcx/x1 again for the value
-        // (the address is in rax/x0).
-        // Save rax/x0 (element address) before loading value.
-        // Push address, load value into rcx, pop address into rax.
-        dynasm!(self.mc
-            ; .arch x64
-            ; push rax
-        );
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc
-            ; .arch x64
-            ; pop rax
-        );
-
-        match item_size {
-            1 => dynasm!(self.mc
-                ; .arch x64
-                ; mov [rax], cl
-            ),
-            2 => dynasm!(self.mc
-                ; .arch x64
-                ; mov [rax], cx
-            ),
-            4 => dynasm!(self.mc
-                ; .arch x64
-                ; mov [rax], ecx
-            ),
-            _ => dynasm!(self.mc
-                ; .arch x64
-                ; mov [rax], rcx
-            ),
-        }
-    }
-
-    /// ARRAYLEN_GC: result = array.length
-    /// The length field location comes from the ArrayDescr's len_descr().
-    fn genop_arraylen(&mut self, op: &Op) {
-        let descr_arc = op.getdescr();
-        let len_offset = descr_arc
-            .as_ref()
-            .and_then(|d| d.as_array_descr())
-            .and_then(|ad| ad.len_descr())
-            .map(|ld| ld.offset() as i32)
-            .unwrap_or(0); // Default: length at offset 0 in array header
-
-        // Load array pointer.
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        // Load length from [array + len_offset].
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rax, [rax + len_offset]
-        );
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
     // genop_* — calls
     // x86/assembler.py:2230 _genop_call
 
@@ -7079,15 +6707,6 @@ impl<'a> Assembler386<'a> {
         self.emit_call_from_arglocs(op, arglocs, func_index);
         if op.opcode.result_type() == Type::Int {
             self.ensure_call_result_bit_extension(arglocs);
-        }
-    }
-
-    /// assembler.py:2169-2174 _genop_real_call.
-    /// genop_call_i = genop_call_r = genop_call_f = genop_call_n
-    fn genop_call(&mut self, op: &Op) {
-        self._genop_call(op);
-        if !op.pos.get().is_none() {
-            self.store_rax_to_result(op.pos.get());
         }
     }
 
@@ -7946,85 +7565,6 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — misc
 
-    /// FORCE_TOKEN: return the jitframe pointer itself.
-    /// x86/assembler.py genop_force_token: mov resloc, ebp
-    fn genop_force_token(&mut self, op: &Op) {
-        // The frame pointer is the force token.
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rax, rbp
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// STRLEN / UNICODELEN: result = string.length
-    /// Load the length field from the string/unicode object header.
-    /// arg0 = string pointer. The length is at a fixed offset in the
-    /// RPython string representation. For RPython strings, the length
-    /// is typically at offset 8 (after the GC header / hash field).
-    fn genop_strlen(&mut self, op: &Op) {
-        let offset = Self::field_offset_from_descr(op);
-        self.load_arg_to_rax(op.arg(0).to_opref());
-
-        dynasm!(self.mc
-            ; .arch x64
-            ; mov rax, [rax + offset]
-        );
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// STRGETITEM / UNICODEGETITEM: result = string[index]
-    /// arg0 = string pointer, arg1 = index.
-    /// Address = base + (basesize - extra_null) + index * itemsize, per
-    /// `rewrite.py:295-306` — STR has `extra_item_after_alloc=1` so the
-    /// token basesize overshoots the first char by 1; UNICODE does not.
-    fn genop_strgetitem(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((17, 1)); // rstr.STR token defaults (basesize=17, itemsize=1)
-        if op.opcode == OpCode::Strgetitem {
-            debug_assert_eq!(item_size, 1, "STRGETITEM itemsize must be 1");
-            base_size -= 1; // rewrite.py:299 — skip the extra null character
-        }
-
-        self.load_arg_to_rax(op.arg(0).to_opref()); // string pointer
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // index
-
-        // Address = rax + base_size + rcx * item_size
-        if item_size != 1 {
-            dynasm!(self.mc
-                ; .arch x64
-                ; imul rcx, rcx, item_size
-            );
-        }
-        dynasm!(self.mc
-            ; .arch x64
-            ; add rax, base_size
-            ; add rax, rcx
-        );
-        match item_size {
-            1 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, BYTE [rax]
-            ),
-            2 => dynasm!(self.mc
-                ; .arch x64
-                ; movzx eax, WORD [rax]
-            ),
-            4 => dynasm!(self.mc
-                ; .arch x64
-                ; mov eax, [rax]
-            ),
-            _ => dynasm!(self.mc
-                ; .arch x64
-                ; mov rax, [rax]
-            ),
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
-
     // assembler.py:1817 genop_save_exc_class / genop_save_exception
 
     /// assembler.py:1817-1818 genop_save_exc_class:
@@ -8091,30 +7631,8 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — extended integer arithmetic
 
-    /// INT_FLOORDIV: result = arg0 / arg1 (signed)
-    fn genop_int_floordiv(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch x64
-            ; cqo
-            ; idiv rcx
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// INT_MOD: result = arg0 % arg1 (signed)
-    fn genop_int_mod(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch x64
-            ; cqo
-            ; idiv rcx
-            ; mov rax, rdx
-        );
-        self.store_rax_to_result(op.pos.get());
-    }
-
     /// UINT_MUL_HIGH: upper 64 bits of unsigned multiply
+    #[allow(dead_code)]
     fn genop_uint_mul_high(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         self.load_arg_to_rcx(op.arg(1).to_opref());
@@ -8126,6 +7644,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// INT_SIGNEXT: sign-extend from num_bytes width to 64 bits.
+    #[allow(dead_code)]
     fn genop_int_signext(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         let num_bytes = match self.resolve_opref(op.arg(1).to_opref()) {
@@ -8146,6 +7665,7 @@ impl<'a> Assembler386<'a> {
     // genop_* — extended float operations
 
     /// FLOAT_ABS: result = |arg0|
+    #[allow(dead_code)]
     fn genop_float_abs(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         let mask: i64 = i64::MAX; // 0x7FFF_FFFF_FFFF_FFFF
@@ -8157,48 +7677,8 @@ impl<'a> Assembler386<'a> {
         self.store_d0_to_result(op.pos.get());
     }
 
-    /// FLOAT_LT/LE/EQ/NE/GT/GE: float comparison.
-    /// For lt/le, swap operands so JA/JAE handles NaN correctly.
-    fn genop_float_cmp(&mut self, op: &Op) {
-        let swap = matches!(op.opcode, OpCode::FloatLt | OpCode::FloatLe);
-        if swap {
-            self.load_float_arg_to_d0(op.arg(1).to_opref());
-            self.load_float_arg_to_d1(op.arg(0).to_opref());
-        } else {
-            self.load_float_arg_to_d0(op.arg(0).to_opref());
-            self.load_float_arg_to_d1(op.arg(1).to_opref());
-        }
-
-        dynasm!(self.mc ; .arch x64 ; ucomisd xmm0, xmm1);
-        match op.opcode {
-            OpCode::FloatLt | OpCode::FloatGt => {
-                dynasm!(self.mc ; .arch x64 ; seta al ; movzx eax, al);
-            }
-            OpCode::FloatLe | OpCode::FloatGe => {
-                dynasm!(self.mc ; .arch x64 ; setae al ; movzx eax, al);
-            }
-            OpCode::FloatEq => {
-                dynasm!(self.mc ; .arch x64
-                    ; sete al ; setnp cl ; and al, cl ; movzx eax, al
-                );
-            }
-            OpCode::FloatNe => {
-                dynasm!(self.mc ; .arch x64
-                    ; setne al ; setp cl ; or al, cl ; movzx eax, al
-                );
-            }
-            _ => {
-                dynasm!(self.mc ; .arch x64 ; sete al ; movzx eax, al);
-            }
-        }
-        dynasm!(self.mc ; .arch x64 ; test rax, rax);
-        self.guard_success_cc = Some(CC_NE);
-        if !op.pos.get().is_none() {
-            self.store_rax_to_result(op.pos.get());
-        }
-    }
-
     /// CAST_FLOAT_TO_SINGLEFLOAT: f64 → f32 (bits in lower 32 of i64)
+    #[allow(dead_code)]
     fn genop_cast_float_to_singlefloat(&mut self, op: &Op) {
         self.load_float_arg_to_d0(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch x64
@@ -8209,6 +7689,7 @@ impl<'a> Assembler386<'a> {
     }
 
     /// CAST_SINGLEFLOAT_TO_FLOAT: f32 (bits in lower 32) → f64
+    #[allow(dead_code)]
     fn genop_cast_singlefloat_to_float(&mut self, op: &Op) {
         self.load_arg_to_rax(op.arg(0).to_opref());
         dynasm!(self.mc ; .arch x64
@@ -8220,26 +7701,8 @@ impl<'a> Assembler386<'a> {
 
     // genop_* — GC memory operations
 
-    /// Emit a sized load from [rax]/[x0]. Positive size = zero-extend,
-    /// negative = sign-extend.
-    fn emit_load_from_rax_sized(&mut self, itemsize: i32) {
-        let abs_size = itemsize.unsigned_abs() as usize;
-        let signed = itemsize < 0;
-        match (abs_size, signed) {
-            (1, true) => dynasm!(self.mc ; .arch x64 ; movsx rax, BYTE [rax]),
-            (2, true) => dynasm!(self.mc ; .arch x64 ; movsx rax, WORD [rax]),
-            (4, true) => dynasm!(self.mc ; .arch x64
-                ; mov eax, [rax]
-                ; cdqe
-            ),
-            (1, false) => dynasm!(self.mc ; .arch x64 ; movzx eax, BYTE [rax]),
-            (2, false) => dynasm!(self.mc ; .arch x64 ; movzx eax, WORD [rax]),
-            (4, false) => dynasm!(self.mc ; .arch x64 ; mov eax, [rax]),
-            _ => dynasm!(self.mc ; .arch x64 ; mov rax, [rax]),
-        }
-    }
-
     /// Emit a sized store of rcx/x1 to [rax]/[x0].
+    #[allow(dead_code)]
     fn emit_store_to_rax_sized(&mut self, size: usize) {
         match size {
             1 => dynasm!(self.mc ; .arch x64 ; mov [rax], cl),
@@ -8257,42 +7720,9 @@ impl<'a> Assembler386<'a> {
         }
     }
 
-    /// GC_LOAD_I/R/F: load from base + offset with given itemsize.
-    /// arg(0) = base, arg(1) = offset, arg(2) = itemsize.
-    fn genop_gc_load(&mut self, op: &Op) {
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch x64 ; add rax, rcx);
-
-        let itemsize = self.resolve_const_or(op.arg(2).to_opref(), 8) as i32;
-        self.emit_load_from_rax_sized(itemsize);
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// GC_LOAD_INDEXED_I/R/F: load from base + base_offset + index * scale.
-    /// arg(0)=base, arg(1)=index, arg(2)=scale, arg(3)=base_offset, arg(4)=itemsize.
-    fn genop_gc_load_indexed(&mut self, op: &Op) {
-        let scale = self.resolve_const_or(op.arg(2).to_opref(), 1) as i32;
-        let base_offset = self.resolve_const_or(op.arg(3).to_opref(), 0) as i32;
-        let itemsize = self.resolve_const_or(op.arg(4).to_opref(), 8) as i32;
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        if scale != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rcx, rcx, scale);
-        }
-        dynasm!(self.mc ; .arch x64 ; add rax, rcx);
-        if base_offset != 0 {
-            dynasm!(self.mc ; .arch x64 ; add rax, base_offset);
-        }
-
-        self.emit_load_from_rax_sized(itemsize);
-        self.store_rax_to_result(op.pos.get());
-    }
-
     /// GC_STORE: store value to base + offset.
     /// 4-arg form: arg(0)=base, arg(1)=offset, arg(2)=value, arg(3)=itemsize.
+    #[allow(dead_code)]
     fn genop_discard_gc_store(&mut self, op: &Op) {
         if op.num_args() < 4 {
             return; // 3-arg GC rewrite form — skip for now
@@ -8313,6 +7743,7 @@ impl<'a> Assembler386<'a> {
     /// GC_STORE_INDEXED: store to base + base_offset + index * scale.
     /// arg(0)=base, arg(1)=index, arg(2)=value, arg(3)=scale,
     /// arg(4)=base_offset, arg(5)=itemsize.
+    #[allow(dead_code)]
     fn genop_discard_gc_store_indexed(&mut self, op: &Op) {
         let scale = self.resolve_const_or(op.arg(3).to_opref(), 1) as i32;
         let base_offset = self.resolve_const_or(op.arg(4).to_opref(), 0) as i32;
@@ -8335,104 +7766,7 @@ impl<'a> Assembler386<'a> {
         self.emit_store_to_rax_sized(itemsize);
     }
 
-    /// RAW_LOAD_I/F: load from base + offset using descriptor.
-    fn genop_raw_load(&mut self, op: &Op) {
-        let offset = Self::field_offset_from_descr(op);
-        let size = Self::field_size_from_descr(op);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch x64 ; add rax, rcx);
-
-        self.emit_load_from_rax_sized(size as i32);
-        let _ = offset; // offset is in the descriptor, not used for raw_load
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// RAW_STORE: store value to base + offset using descriptor.
-    fn genop_discard_raw_store(&mut self, op: &Op) {
-        let size = Self::field_size_from_descr(op);
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        dynasm!(self.mc ; .arch x64 ; add rax, rcx);
-        dynasm!(self.mc ; .arch x64 ; push rax);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch x64 ; pop rax);
-        self.emit_store_to_rax_sized(size);
-    }
-
     // genop_* — interior field operations
-
-    /// GETINTERIORFIELD_GC_I/R/F: load field from array-of-structs element.
-    fn genop_getinteriorfield(&mut self, op: &Op) {
-        let descr_arc = op.getdescr();
-        let (base_size, item_size, field_offset, field_size) = descr_arc
-            .as_ref()
-            .and_then(|d| d.as_interior_field_descr())
-            .map(|id| {
-                let ad = id.array_descr();
-                let fd = id.field_descr();
-                (
-                    ad.base_size() as i32,
-                    ad.item_size() as i32,
-                    fd.offset() as i32,
-                    fd.field_size(),
-                )
-            })
-            .unwrap_or((8, 8, 0, 8));
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        let total_offset = base_size + field_offset;
-
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rcx, rcx, item_size);
-        }
-        dynasm!(self.mc ; .arch x64
-            ; add rax, total_offset
-            ; add rax, rcx
-        );
-
-        self.emit_load_from_rax_sized(field_size as i32);
-        self.store_rax_to_result(op.pos.get());
-    }
-
-    /// SETINTERIORFIELD_GC/RAW: write field in array-of-structs element.
-    fn genop_discard_setinteriorfield(&mut self, op: &Op) {
-        let descr_arc = op.getdescr();
-        let (base_size, item_size, field_offset, field_size) = descr_arc
-            .as_ref()
-            .and_then(|d| d.as_interior_field_descr())
-            .map(|id| {
-                let ad = id.array_descr();
-                let fd = id.field_descr();
-                (
-                    ad.base_size() as i32,
-                    ad.item_size() as i32,
-                    fd.offset() as i32,
-                    fd.field_size(),
-                )
-            })
-            .unwrap_or((8, 8, 0, 8));
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-        let total_offset = base_size + field_offset;
-
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rcx, rcx, item_size);
-        }
-        dynasm!(self.mc ; .arch x64
-            ; add rax, total_offset
-            ; add rax, rcx
-        );
-        dynasm!(self.mc ; .arch x64 ; push rax);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch x64 ; pop rax);
-
-        self.emit_store_to_rax_sized(field_size);
-    }
 
     // genop_* — call variants
 
@@ -8492,109 +7826,6 @@ impl<'a> Assembler386<'a> {
     }
 
     // genop_* — string/array operations
-
-    /// STRSETITEM / UNICODESETITEM: string[index] = value.
-    /// Address = base + (basesize - extra_null) + index * itemsize, per
-    /// `rewrite.py:307-318` — STR has `extra_item_after_alloc=1` so the
-    /// token basesize overshoots the first char by 1; UNICODE does not.
-    fn genop_discard_strsetitem(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i32, ad.item_size() as i32))
-            .unwrap_or((17, 1));
-        if op.opcode == OpCode::Strsetitem {
-            debug_assert_eq!(item_size, 1, "STRSETITEM itemsize must be 1");
-            base_size -= 1; // rewrite.py:311 — skip the extra null character
-        }
-
-        self.load_arg_to_rax(op.arg(0).to_opref()); // string
-        self.load_arg_to_rcx(op.arg(1).to_opref()); // index
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64 ; imul rcx, rcx, item_size);
-        }
-        dynasm!(self.mc ; .arch x64 ; add rax, base_size ; add rax, rcx);
-        dynasm!(self.mc ; .arch x64 ; push rax);
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        dynasm!(self.mc ; .arch x64 ; pop rax);
-        self.emit_store_to_rax_sized(item_size as usize);
-    }
-
-    /// COPYSTRCONTENT / COPYUNICODECONTENT: copy substring.
-    /// arg(0)=src, arg(1)=dst, arg(2)=src_start, arg(3)=dst_start, arg(4)=length.
-    ///
-    /// Fallback emitter for the no-rewriter path.  When the GC rewriter is
-    /// present (production), `rewrite.py:1045-1080
-    /// rewrite_copy_str_content` replaces this op with
-    /// LOAD_EFFECTIVE_ADDRESS × 2 + CALL_N(memcpy, …) before assembly, so
-    /// this function is never reached.  Kept for tests that run the
-    /// backend directly on un-rewritten ops.  Mirrors upstream's basesize
-    /// handling (`rewrite.py:1049-1053`).
-    fn genop_discard_copystrcontent(&mut self, op: &Op) {
-        let (mut base_size, item_size) = op
-            .with_array_descr(|ad| (ad.base_size() as i64, ad.item_size() as i64))
-            .unwrap_or((16, 1));
-        // rewrite.py:1049-1053 `rewrite_copy_str_content` — COPYSTRCONTENT
-        // uses `str_descr.basesize - 1` to skip the `extra_item_after_alloc`
-        // null terminator carried by `rstr.STR.chars` (`rstr.py:1226-1228`).
-        // COPYUNICODECONTENT's unicode_descr has no extra item.  Mirrors the
-        // same correction `strgetsetitem_token` applies for STR{GET,SET}ITEM.
-        if op.opcode == OpCode::Copystrcontent {
-            debug_assert_eq!(item_size, 1, "COPYSTRCONTENT itemsize must be 1");
-            base_size -= 1;
-        }
-
-        // Compute byte_count = length * item_size
-        self.load_arg_to_rax(op.arg(4).to_opref());
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64
-                ; mov rcx, QWORD item_size
-                ; imul rax, rcx
-            );
-        }
-        dynasm!(self.mc ; .arch x64 ; push rax); // [rsp] = byte_count
-
-        // Compute src_addr = src + base_size + src_start * item_size
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(2).to_opref());
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64
-                ; mov rdx, QWORD item_size
-                ; imul rcx, rdx
-            );
-        }
-        dynasm!(self.mc ; .arch x64
-            ; add rax, DWORD base_size as i32
-            ; add rax, rcx
-            ; push rax  // [rsp] = src_addr
-        );
-
-        // Compute dst_addr = dst + base_size + dst_start * item_size
-        self.load_arg_to_rax(op.arg(1).to_opref());
-        self.load_arg_to_rcx(op.arg(3).to_opref());
-        if item_size != 1 {
-            dynasm!(self.mc ; .arch x64
-                ; mov rdx, QWORD item_size
-                ; imul rcx, rdx
-            );
-        }
-        dynasm!(self.mc ; .arch x64
-            ; add rax, DWORD base_size as i32
-            ; add rax, rcx
-        );
-
-        // memmove(dst_addr, src_addr, byte_count)
-        let memmove_ptr = libc::memmove as *const () as i64;
-        dynasm!(self.mc ; .arch x64
-            ; pop rsi        // src
-            ; pop rdx        // count
-            ; push rbp
-        );
-        self.emit_abi_int_arg_from_reg(2, 2); // count
-        self.emit_abi_int_arg_from_reg(1, 6); // src
-        self.emit_abi_int_arg_from_reg(0, 0); // dst
-        dynasm!(self.mc ; .arch x64 ; mov rax, QWORD memmove_ptr);
-        self.emit_abi_call_rax_after_one_push();
-        dynasm!(self.mc ; .arch x64 ; pop rbp);
-    }
 
     /// NEWSTR: allocate a byte string of given length.
     /// `base_size` / `item_size` come from the injected ArrayDescr
@@ -8762,27 +7993,6 @@ impl<'a> Assembler386<'a> {
     }
 
     // genop_* — address computation
-
-    /// LOAD_EFFECTIVE_ADDRESS: result = base + (index << shift) + baseofs.
-    /// resoperation.py:1052-1054 — `[v_gcptr, v_index, c_baseofs, c_shift]`.
-    /// arg(0)=base, arg(1)=index, arg(2)=baseofs, arg(3)=shift.
-    fn genop_load_effective_address(&mut self, op: &Op) {
-        let baseofs = self.resolve_const_or(op.arg(2).to_opref(), 0) as i32;
-        let shift = self.resolve_const_or(op.arg(3).to_opref(), 0) as i32;
-
-        self.load_arg_to_rax(op.arg(0).to_opref());
-        self.load_arg_to_rcx(op.arg(1).to_opref());
-
-        if shift != 0 {
-            dynasm!(self.mc ; .arch x64 ; shl rcx, BYTE shift as i8);
-        }
-        dynasm!(self.mc ; .arch x64 ; add rax, rcx);
-        if baseofs != 0 {
-            dynasm!(self.mc ; .arch x64 ; add rax, baseofs);
-        }
-
-        self.store_rax_to_result(op.pos.get());
-    }
 }
 
 /// `jump.py`'s three primitives. The parallel-move algorithm that drives

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2228,6 +2228,10 @@ impl<'a> Assembler386<'a> {
         }
     }
 
+    /// `llsupport/assembler.py:46-64 GuardToken.compute_gcmap`: every
+    /// `REF`-typed failarg is marked and nothing narrows it further.  That
+    /// includes a force token — `resoperation.py FORCE_TOKEN/0/r` returns
+    /// the jitframe, itself a moving GC object.
     fn guard_gcmap_from_faillocs(
         &self,
         fail_arg_types: &[Type],
@@ -2249,23 +2253,6 @@ impl<'a> Assembler386<'a> {
                     gcmap_set_bit(gcmap, f.position + JITFRAME_FIXED_SIZE);
                 }
                 _ => {}
-            }
-        }
-        gcmap
-    }
-
-    fn gcmap_from_fail_arg_locs(
-        &self,
-        fail_arg_types: &[Type],
-        fail_arg_locs: &[Option<usize>],
-    ) -> *mut usize {
-        let frame_depth = self.frame_depth.saturating_sub(JITFRAME_FIXED_SIZE);
-        let gcmap = allocate_gcmap(frame_depth, JITFRAME_FIXED_SIZE);
-        for (tp, loc) in fail_arg_types.iter().zip(fail_arg_locs.iter()) {
-            if *tp == Type::Ref {
-                if let Some(position) = loc {
-                    gcmap_set_bit(gcmap, *position);
-                }
             }
         }
         gcmap
@@ -5786,11 +5773,11 @@ impl<'a> Assembler386<'a> {
                             // `Type::Void` is the "hole" sentinel — value
                             // comes from the resume snapshot, not the
                             // deadframe, so downstream consumers
-                            // (`gc_ref_slots`, `guard_gcmap_from_faillocs`,
-                            // `typed_outputs` reconstruction) must skip
-                            // these slots. Earlier code used `Type::Ref`
-                            // which silently leaked a NULL `GcRef` into
-                            // `gc_ref_slots` and the shadow stack.
+                            // (`guard_gcmap_from_faillocs`, `typed_outputs`
+                            // reconstruction) must skip these slots. Earlier
+                            // code used `Type::Ref`, which silently leaked a
+                            // NULL `GcRef` into the gcmap and the shadow
+                            // stack.
                             Type::Void
                         } else {
                             self.opref_type_at(opref.to_opref(), op_index).unwrap_or_else(|| {

--- a/majit/majit-backend-dynasm/src/x86/reghint.rs
+++ b/majit/majit-backend-dynasm/src/x86/reghint.rs
@@ -8,7 +8,7 @@ use crate::regalloc::LifetimeManager;
 use crate::regloc::{EAX, ECX, EDX, RegLoc};
 use crate::x86::callbuilder::{ARGUMENTS_GPR, ARGUMENTS_XMM};
 use indexmap::IndexMap;
-use majit_ir::{Op, OpCode, OpRc, OpRef, Type};
+use majit_ir::{Op, OpCode, OpRef, Type};
 
 /// regalloc.py:26-28.
 pub const SAVE_DEFAULT_REGS: u8 = 0;

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -3770,8 +3770,6 @@ impl majit_backend::Backend for WasmBackend {
                     is_exception_exit: meta
                         .map(|fd| fd.is_exit_frame_with_exception())
                         .unwrap_or(false),
-                    gc_ref_slots: Vec::new(),
-                    force_token_slots: Vec::new(),
                     recovery_layout: None,
                     frame_stack: None,
                     rd_numb: meta.and_then(|fd| fd.rd_numb().map(|s| s.to_vec())),
@@ -3853,8 +3851,6 @@ impl majit_backend::Backend for WasmBackend {
                     is_exception_exit: meta
                         .map(|fd| fd.is_exit_frame_with_exception())
                         .unwrap_or(false),
-                    gc_ref_slots: Vec::new(),
-                    force_token_slots: Vec::new(),
                     recovery_layout: None,
                     frame_stack: None,
                     rd_numb: meta.and_then(|fd| fd.rd_numb().map(|s| s.to_vec())),

--- a/majit/majit-backend/src/lib.rs
+++ b/majit/majit-backend/src/lib.rs
@@ -109,7 +109,6 @@ pub struct RawExecResult {
     /// Backend-origin static metadata for this exit, when available.
     pub exit_layout: Option<FailDescrLayout>,
     /// Output slots that carry opaque force tokens instead of GC refs.
-    pub force_token_slots: Vec<usize>,
     /// Optional saved-data GC ref captured by this exit.
     pub savedata: Option<GcRef>,
     /// Pending exception value captured by this exit (`GcRef::NULL` = none).
@@ -766,9 +765,7 @@ pub struct FailDescrLayout {
     /// correct `_DoneWithThisFrameDescr` subclass.
     pub is_exception_exit: bool,
     /// Exit slot indices that hold rooted GC references.
-    pub gc_ref_slots: Vec<usize>,
     /// Exit slot indices that carry opaque FORCE_TOKEN handles.
-    pub force_token_slots: Vec<usize>,
     /// Optional backend-origin recovery layout for this exit.
     pub recovery_layout: Option<ExitRecoveryLayout>,
     /// Complete frame stack from innermost (this guard's frame) to outermost.
@@ -810,9 +807,7 @@ pub struct TerminalExitLayout {
     /// see `FailDescrLayout::is_exception_exit`.
     pub is_exception_exit: bool,
     /// Exit slot indices that hold rooted GC references.
-    pub gc_ref_slots: Vec<usize>,
     /// Exit slot indices that carry opaque FORCE_TOKEN handles.
-    pub force_token_slots: Vec<usize>,
     /// Optional backend-origin recovery layout for this terminal exit.
     pub recovery_layout: Option<ExitRecoveryLayout>,
     /// resume.py:450 — compact resume numbering (terminal exits rarely need
@@ -2587,7 +2582,6 @@ pub trait Backend: Send {
             outputs,
             typed_outputs,
             exit_layout,
-            force_token_slots: descr.force_token_slots().to_vec(),
             savedata,
             exception_value,
             fail_index: descr.fail_index(),
@@ -2697,13 +2691,6 @@ pub trait Backend: Send {
             fail_arg_types: descr.fail_arg_types().to_vec(),
             is_finish: descr.is_finish(),
             is_exception_exit: descr.is_exit_frame_with_exception(),
-            gc_ref_slots: descr
-                .fail_arg_types()
-                .iter()
-                .enumerate()
-                .filter_map(|(slot, _)| descr.is_gc_ref_slot(slot).then_some(slot))
-                .collect(),
-            force_token_slots: descr.force_token_slots().to_vec(),
             recovery_layout: None,
             frame_stack: None,
             rd_numb: None,

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -159,13 +159,6 @@ pub struct ResumeGuardDescr {
     /// the meta Arc is the single source of truth.  `None` for synthetic
     /// FINISH / external-JUMP descrs that have no associated trace op.
     pub source_op_index: UnsafeCell<Option<usize>>,
-    /// Force-token slot positions for runtime GC-root filtering.
-    /// PyPy encodes the same information into the machine code's
-    /// GC-map immediates (`assembler.py` handles force-token slot
-    /// produce/consume inline); cranelift IR has no equivalent inline
-    /// encoding so the vector lives on the descr.  Migrated here from
-    /// the meta Arc is the single source of truth.  Sorted and deduped
-    /// at write time so a reader can `binary_search` it.
     /// This guard is the eval-breaker word's back-edge poll, not a check on
     /// traced values.  Stamped once per emission by the optimizer, which is
     /// where the guard's condition chain is still in hand; read by the

--- a/majit/majit-backend/src/resume_guard_descr.rs
+++ b/majit/majit-backend/src/resume_guard_descr.rs
@@ -165,8 +165,7 @@ pub struct ResumeGuardDescr {
     /// produce/consume inline); cranelift IR has no equivalent inline
     /// encoding so the vector lives on the descr.  Migrated here from
     /// the meta Arc is the single source of truth.  Sorted and deduped
-    /// at write time so `is_force_token_slot` can use `binary_search`.
-    pub force_token_slots: UnsafeCell<Vec<usize>>,
+    /// at write time so a reader can `binary_search` it.
     /// This guard is the eval-breaker word's back-edge poll, not a check on
     /// traced values.  Stamped once per emission by the optimizer, which is
     /// where the guard's condition chain is still in hand; read by the
@@ -318,7 +317,6 @@ impl Descr for ResumeGuardDescr {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -474,16 +472,6 @@ impl FailDescr for ResumeGuardDescr {
     fn set_back_edge_poll(&self) {
         self.back_edge_poll.store(true, Ordering::Relaxed);
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        // Safety: single-threaded JIT.
-        unsafe { (&*self.force_token_slots.get()).clone() }
-    }
-    fn set_force_token_slots(&self, mut slots: Vec<usize>) {
-        slots.sort_unstable();
-        slots.dedup();
-        // Safety: single-threaded JIT.
-        unsafe { *self.force_token_slots.get() = slots };
-    }
     fn fail_count(&self) -> u32 {
         self.fail_count.load(Ordering::Relaxed)
     }
@@ -604,7 +592,6 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         trace_id: AtomicU64::new(0),
         fail_index_per_trace: AtomicU32::new(0),
         source_op_index: UnsafeCell::new(None),
-        force_token_slots: UnsafeCell::new(Vec::new()),
         back_edge_poll: AtomicBool::new(false),
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -631,25 +618,6 @@ impl ResumeGuardDescr {
     pub fn set_source_op_index(&self, source_op_index: usize) {
         // Safety: single-threaded JIT.
         unsafe { *self.source_op_index.get() = Some(source_op_index) };
-    }
-
-    /// Read the codegen-time `force_token_slots`.
-    /// Returns `&[]` when codegen has not stamped any slots (the
-    /// common case for guards that do not produce force tokens).
-    pub fn force_token_slots(&self) -> &[usize] {
-        // Safety: single-threaded JIT.
-        unsafe { &*self.force_token_slots.get() }
-    }
-
-    /// Write the codegen-time `force_token_slots`.
-    /// Sorts + dedups so the stored vector satisfies the
-    /// `binary_search` invariant used by
-    /// `CraneliftFailDescr::is_force_token_slot`.
-    pub fn set_force_token_slots(&self, mut slots: Vec<usize>) {
-        slots.sort_unstable();
-        slots.dedup();
-        // Safety: single-threaded JIT.
-        unsafe { *self.force_token_slots.get() = slots };
     }
 
     /// Increment the per-descr `fail_count`.  Returns

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3990,55 +3990,6 @@ pub trait FailDescr: Descr {
         );
     }
 
-    /// Whether the given exit slot should be treated as a real GC root.
-    ///
-    /// Backends may override this to distinguish rooted refs from opaque
-    /// handles that reuse `Type::Ref`, such as FORCE_TOKEN values.
-    fn is_gc_ref_slot(&self, slot: usize) -> bool {
-        if !matches!(self.fail_arg_types().get(slot), Some(Type::Ref)) {
-            return false;
-        }
-        // Exclude force-token positions: their Type::Ref typing is
-        // synthetic — they carry opaque virtualizable handles (FORCE_TOKEN
-        // op output), not real GC pointers.  The retired
-        // `CraneliftFailDescr` wrapper performed this exclusion explicitly
-        // before computing `fail_descr_gc_map`; the metainterp
-        // `ResumeGuardDescr` now owns the slot list directly, so the
-        // exclusion moves to this trait default and is inherited by every
-        // Resume-family impl that overrides `force_token_slots()`.
-        !self.force_token_slots().contains(&slot)
-    }
-
-    /// Exit slot indices that carry opaque force-token handles.
-    ///
-    /// Returns owned `Vec<usize>` (cloned per call) — the
-    /// the cranelift implementation to `FORCE_TOKEN_SLOTS_TABLE`, a
-    /// backend-static side-table that cannot hand out a borrow under a
-    /// lock.
-    fn force_token_slots(&self) -> Vec<usize> {
-        Vec::new()
-    }
-
-    /// Pyre-only per-emission write of the force-token slot list.
-    /// `assembler.py:write_failure_recovery_description` bakes the
-    /// equivalent GC map into machine code at codegen time per
-    /// emission; the slot list is the cranelift analog and follows
-    /// the same per-emission classification as `rd_locs`
-    /// (`assembler.py:279`).
-    ///
-    /// Default panics — only `ResumeGuardDescr`-family carries the
-    /// slot.  Callers must gate by `is_resume_guard() ||
-    /// is_resume_guard_copied()` before invoking, mirroring
-    /// `set_trace_id` / `set_rd_*` / `set_adr_jump_offset`.
-    /// Implementations must sort+dedup so consumers can `binary_search`.
-    fn set_force_token_slots(&self, _slots: Vec<usize>) {
-        panic!(
-            "set_force_token_slots invoked on a FailDescr that does not \
-             carry the per-emission force_token_slots slot (only \
-             ResumeGuardDescr / ResumeGuardCopiedDescr own it)"
-        );
-    }
-
     /// Pyre-only per-emission failure counter.  PyPy carries the
     /// equivalent jitcounter hash in the per-descr `status` slot
     /// (`compile.py:683` `AbstractResumeGuardDescr._attrs_ =
@@ -4219,11 +4170,6 @@ pub trait FailDescr: Descr {
     /// `compile.py:790-795` `done_compiling — self.status &=
     /// ~ST_BUSY_FLAG`.
     fn done_compiling(&self) {}
-
-    /// `compile.py:750` check `ST_BUSY_FLAG`.
-    fn is_compiling(&self) -> bool {
-        false
-    }
 
     /// `compile.py:826-830` `store_hash(metainterp_sd)` — write the
     /// jitcounter hash bits (status with `ST_SHIFT_MASK` applied).
@@ -8358,10 +8304,6 @@ mod tests {
         assert_eq!(fd.fail_arg_types(), &[Type::Int, Type::Ref]);
         assert!(!fd.is_finish());
         assert_eq!(fd.trace_id(), 0);
-        // Ref slot is a GC ref
-        assert!(fd.is_gc_ref_slot(1));
-        // Int slot is not
-        assert!(!fd.is_gc_ref_slot(0));
     }
 
     #[test]

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -1141,8 +1141,6 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             })
         };
 
-        // Empty because this path classifies no force-token slots; the
-        // predicate still reads it, so the two stay one fact.
         exit_layouts.insert(
             fail_index,
             StoredExitLayout {

--- a/majit/majit-metainterp/src/compile.rs
+++ b/majit/majit-metainterp/src/compile.rs
@@ -175,8 +175,6 @@ pub struct CompiledExitLayout {
     /// `make_finish_fail_descr_typed` routes a `[Type::Ref]` exit to the
     /// correct `_DoneWithThisFrameDescr` subclass.
     pub is_exception_exit: bool,
-    pub gc_ref_slots: Vec<usize>,
-    pub force_token_slots: Vec<usize>,
     /// Held behind a pointer, not inline. Both this and [`Self::resume_layout`]
     /// describe how to REBUILD interpreter state after a guard failed, so both
     /// are `None` on the two exits the steady path actually takes — a FINISH
@@ -196,6 +194,23 @@ pub struct CompiledExitLayout {
     /// compile.py:853 `ResumeGuardDescr` storage handle — shared
     /// pool with rd_numb / rd_consts / rd_virtuals / rd_pendingfields.
     pub storage: Option<std::sync::Arc<crate::resume::ResumeStorage>>,
+}
+
+impl CompiledExitLayout {
+    /// Whether the collector traces exit slot `slot`.
+    ///
+    /// The rule `llsupport/assembler.py compute_gcmap` applies: every
+    /// `REF`-typed failarg is marked, and nothing narrows it further.  A
+    /// force token is included, because `resoperation.py FORCE_TOKEN/0/r`
+    /// is REF upstream as well — it returns the jitframe, itself a GC
+    /// object that moves — and both emitted gcmaps
+    /// (`guard_gcmap_from_faillocs`, `collect_guards`) mark it.
+    ///
+    /// Do not narrow it by force-token position: that would stop rooting a
+    /// live jitframe pointer.
+    pub fn is_traced_ref_slot(&self, slot: usize) -> bool {
+        self.exit_types.get(slot) == Some(&Type::Ref)
+    }
 }
 
 /// Typed result from running compiled code.
@@ -1126,16 +1141,12 @@ pub(crate) fn build_guard_metadata<T: AsRef<majit_ir::Op>>(
             })
         };
 
+        // Empty because this path classifies no force-token slots; the
+        // predicate still reads it, so the two stay one fact.
         exit_layouts.insert(
             fail_index,
             StoredExitLayout {
                 source_op_index: Some(op_idx),
-                gc_ref_slots: exit_types
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(slot, tp)| (*tp == Type::Ref).then_some(slot))
-                    .collect(),
-                force_token_slots: Vec::new(),
                 recovery_layout,
                 resume_layout,
                 storage,
@@ -1204,8 +1215,6 @@ pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
                 .entry(layout.fail_index)
                 .or_insert_with(|| StoredExitLayout {
                     source_op_index: layout.source_op_index,
-                    gc_ref_slots: layout.gc_ref_slots.clone(),
-                    force_token_slots: layout.force_token_slots.clone(),
                     recovery_layout: layout.recovery_layout.clone(),
                     resume_layout: None,
                     storage: storage_from_backend.clone(),
@@ -1220,8 +1229,6 @@ pub(crate) fn merge_backend_exit_layouts<T: AsRef<majit_ir::Op>>(
         if entry.descr.is_none() {
             entry.descr = descr_from_op;
         }
-        entry.gc_ref_slots = layout.gc_ref_slots.clone();
-        entry.force_token_slots = layout.force_token_slots.clone();
         // Merge recovery_layout: preserve header_pc from the frontend's
         // rd_numb-based layout when the backend doesn't provide it.
         // The frontend populates header_pc from the guard's snapshot
@@ -1510,8 +1517,6 @@ pub(crate) fn merge_backend_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
             .entry(layout.op_index)
             .or_insert_with(|| StoredExitLayout {
                 source_op_index: Some(layout.op_index),
-                gc_ref_slots: layout.gc_ref_slots.clone(),
-                force_token_slots: layout.force_token_slots.clone(),
                 recovery_layout: layout.recovery_layout.clone(),
                 resume_layout: None,
                 storage: None,
@@ -1519,8 +1524,6 @@ pub(crate) fn merge_backend_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
                 op_arg_types_for_jump: op_arg_types_for_jump.clone(),
             });
         entry.source_op_index = Some(layout.op_index);
-        entry.gc_ref_slots = layout.gc_ref_slots.clone();
-        entry.force_token_slots = layout.force_token_slots.clone();
         entry.recovery_layout = layout.recovery_layout.clone();
         if entry.descr.is_none() {
             entry.descr = descr_from_op;
@@ -1629,34 +1632,15 @@ pub(crate) fn infer_terminal_exit_layout<T: AsRef<majit_ir::Op>>(
         .iter()
         .map(|opref| {
             // `OpRef::NONE` represents a null-ref placeholder per
-            // `fail_arg_type`; preserve `Type::Ref` so downstream
-            // `gc_ref_slots` + `decode_values_with_layout` see the same
-            // null-Ref typing the rest of the resume path uses.
+            // `fail_arg_type`; preserve `Type::Ref` so the gcmap and
+            // `decode_values_with_layout` see the same null-Ref typing the
+            // rest of the resume path uses.
             if opref.is_none() {
                 return Type::Ref;
             }
             type_index
                 .opref_type_at(opref.to_opref(), op_index)
                 .unwrap_or(Type::Int)
-        })
-        .collect();
-    let force_token_slots: Vec<usize> = op
-        .getarglist()
-        .iter()
-        .enumerate()
-        .filter_map(|(slot, opref)| {
-            type_index
-                .op_at(opref.to_opref())
-                .map(|op| op.opcode)
-                .filter(|opcode| *opcode == OpCode::ForceToken)
-                .map(|_| slot)
-        })
-        .collect();
-    let gc_ref_slots: Vec<usize> = exit_types
-        .iter()
-        .enumerate()
-        .filter_map(|(slot, tp)| {
-            (*tp == Type::Ref && !force_token_slots.contains(&slot)).then_some(slot)
         })
         .collect();
     let is_exception_exit = op
@@ -1672,8 +1656,6 @@ pub(crate) fn infer_terminal_exit_layout<T: AsRef<majit_ir::Op>>(
         exit_types,
         is_finish,
         is_exception_exit,
-        gc_ref_slots,
-        force_token_slots,
         recovery_layout: None,
         resume_layout: None,
         storage: None,
@@ -1704,8 +1686,6 @@ pub(crate) fn build_terminal_exit_layouts<T: AsRef<majit_ir::Op>>(
                 op_index,
                 StoredExitLayout {
                     source_op_index: Some(op_index),
-                    gc_ref_slots: layout.gc_ref_slots,
-                    force_token_slots: layout.force_token_slots,
                     recovery_layout: None,
                     resume_layout: None,
                     storage: None,
@@ -2731,6 +2711,31 @@ mod tests {
     use crate::resume::{ResumeDataLoopMemo, SimpleBoxEnv, Snapshot, SnapshotFrame};
     use majit_ir::{ArrayFlag, Op, OpCode, OpRef};
 
+    /// The deadframe rooting in `handle_fail` reaches the layout, not the
+    /// descr it came from, so the layout answers from its own types.  A
+    /// force-token slot is traced like any other ref — `compute_gcmap`
+    /// marks every REF failarg.
+    #[test]
+    fn exit_layout_traces_every_ref_slot_including_force_tokens() {
+        let layout = CompiledExitLayout {
+            rd_loop_token: 0,
+            trace_id: 0,
+            fail_index: 0,
+            source_op_index: None,
+            exit_types: ExitTypes::from_slice(&[Type::Ref, Type::Int, Type::Ref]),
+            is_finish: false,
+            is_exception_exit: false,
+            recovery_layout: None,
+            resume_layout: None,
+            storage: None,
+        };
+
+        assert!(layout.is_traced_ref_slot(0));
+        assert!(!layout.is_traced_ref_slot(1));
+        assert!(layout.is_traced_ref_slot(2));
+        assert!(!layout.is_traced_ref_slot(3));
+    }
+
     // history.py:227 ConstInt.value inline — SimpleBoxEnv.get_const
     // reads inline-Const directly without the legacy raw-u32 side table.
     #[test]
@@ -3232,7 +3237,6 @@ pub fn make_fail_descr_with_index(fail_index: u32, num_live: usize) -> DescrRef 
         trace_id: AtomicU64::new(0),
         fail_index_per_trace: AtomicU32::new(0),
         source_op_index: UnsafeCell::new(None),
-        force_token_slots: UnsafeCell::new(Vec::new()),
         back_edge_poll: std::sync::atomic::AtomicBool::new(false),
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -3326,7 +3330,6 @@ pub fn make_resume_guard_descr_typed(types: Vec<Type>) -> DescrRef {
         trace_id: AtomicU64::new(0),
         fail_index_per_trace: AtomicU32::new(0),
         source_op_index: UnsafeCell::new(None),
-        force_token_slots: UnsafeCell::new(Vec::new()),
         back_edge_poll: std::sync::atomic::AtomicBool::new(false),
         fail_count: AtomicU32::new(0),
         trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -3587,12 +3590,6 @@ impl FailDescr for ResumeAtPositionDescr {
     fn set_source_op_index(&self, source_op_index: usize) {
         FailDescr::set_source_op_index(&self.inner, source_op_index);
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        FailDescr::force_token_slots(&self.inner)
-    }
-    fn set_force_token_slots(&self, slots: Vec<usize>) {
-        FailDescr::set_force_token_slots(&self.inner, slots);
-    }
     fn fail_count(&self) -> u32 {
         FailDescr::fail_count(&self.inner)
     }
@@ -3654,7 +3651,6 @@ pub fn make_resume_at_position_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -3868,12 +3864,6 @@ impl FailDescr for ResumeGuardForcedDescr {
     fn set_source_op_index(&self, source_op_index: usize) {
         FailDescr::set_source_op_index(&self.inner, source_op_index);
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        FailDescr::force_token_slots(&self.inner)
-    }
-    fn set_force_token_slots(&self, slots: Vec<usize>) {
-        FailDescr::set_force_token_slots(&self.inner, slots);
-    }
     fn fail_count(&self) -> u32 {
         FailDescr::fail_count(&self.inner)
     }
@@ -3935,7 +3925,6 @@ pub fn make_resume_guard_forced_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -4130,12 +4119,6 @@ impl FailDescr for ResumeGuardExcDescr {
     fn set_source_op_index(&self, source_op_index: usize) {
         FailDescr::set_source_op_index(&self.inner, source_op_index);
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        FailDescr::force_token_slots(&self.inner)
-    }
-    fn set_force_token_slots(&self, slots: Vec<usize>) {
-        FailDescr::set_force_token_slots(&self.inner, slots);
-    }
     fn fail_count(&self) -> u32 {
         FailDescr::fail_count(&self.inner)
     }
@@ -4197,7 +4180,6 @@ pub fn make_resume_guard_exc_descr_typed(types: Vec<Type>) -> DescrRef {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -4289,7 +4271,6 @@ pub struct ResumeGuardCopiedDescr {
     /// per emission; cranelift has no inline encoding so the slot list
     /// lives on the descr.  Same per-emission scoping as
     /// `source_op_index` / `rd_locs` — owned per copied descr.
-    force_token_slots: UnsafeCell<Vec<usize>>,
     /// Pyre-only per-emission slot: this guard is the eval-breaker word's
     /// back-edge poll.  Same per-emission scoping as `source_op_index`; a
     /// copy guards the same back edge as its donor, so the optimizer stamps
@@ -4440,7 +4421,6 @@ impl majit_ir::Descr for ResumeGuardCopiedDescr {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
@@ -4620,7 +4600,7 @@ impl FailDescr for ResumeGuardCopiedDescr {
     fn set_source_op_index(&self, source_op_index: usize) {
         unsafe { *self.source_op_index.get() = Some(source_op_index) };
     }
-    /// Per-emission like `force_token_slots` below, and deliberately NOT
+    /// Per-emission, and deliberately NOT
     /// chased through `prev`: the classification describes this guard's own
     /// condition chain, which a sharer does not inherit from its donor.  A
     /// copied descr always answers `false`, and that is correct twice over.
@@ -4639,19 +4619,6 @@ impl FailDescr for ResumeGuardCopiedDescr {
     fn set_back_edge_poll(&self) {
         self.back_edge_poll
             .store(true, std::sync::atomic::Ordering::Relaxed);
-    }
-    /// Per-emission `force_token_slots` (see field comment).  Owned
-    /// per copied descr so each emission's GC-root classification
-    /// stays distinct — PyPy bakes the equivalent map inline per
-    /// emission via `assembler.py:write_failure_recovery_description`,
-    /// no sharing through `prev`.
-    fn force_token_slots(&self) -> Vec<usize> {
-        unsafe { (&*self.force_token_slots.get()).clone() }
-    }
-    fn set_force_token_slots(&self, mut slots: Vec<usize>) {
-        slots.sort_unstable();
-        slots.dedup();
-        unsafe { *self.force_token_slots.get() = slots };
     }
     /// Per-emission `fail_count` (see field comment).  Owned per
     /// copied descr — PyPy parity with per-descr `status` jitcounter
@@ -4777,7 +4744,6 @@ impl majit_ir::Descr for ResumeGuardCopiedExcDescr {
                 trace_id: AtomicU64::new(0),
                 fail_index_per_trace: AtomicU32::new(0),
                 source_op_index: UnsafeCell::new(None),
-                force_token_slots: UnsafeCell::new(Vec::new()),
                 back_edge_poll: std::sync::atomic::AtomicBool::new(false),
                 fail_count: AtomicU32::new(0),
                 trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
@@ -4906,12 +4872,6 @@ impl FailDescr for ResumeGuardCopiedExcDescr {
     fn set_back_edge_poll(&self) {
         self.inner.set_back_edge_poll();
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        self.inner.force_token_slots()
-    }
-    fn set_force_token_slots(&self, slots: Vec<usize>) {
-        self.inner.set_force_token_slots(slots);
-    }
     fn fail_count(&self) -> u32 {
         self.inner.fail_count()
     }
@@ -4988,7 +4948,6 @@ pub fn make_resume_guard_copied_descr(prev: DescrRef) -> DescrRef {
         trace_id: AtomicU64::new(0),
         fail_index_per_trace: AtomicU32::new(0),
         source_op_index: UnsafeCell::new(None),
-        force_token_slots: UnsafeCell::new(Vec::new()),
         back_edge_poll: std::sync::atomic::AtomicBool::new(false),
         fail_count: AtomicU32::new(0),
         trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
@@ -5029,7 +4988,6 @@ pub fn make_resume_guard_copied_exc_descr(prev: DescrRef) -> DescrRef {
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: std::sync::atomic::AtomicPtr::new(std::ptr::null_mut()),
@@ -5143,7 +5101,7 @@ pub fn copy_all_attributes_from(my_descr: &DescrRef, donor_descr: &DescrRef) {
 /// Modeled as a newtype wrapping `ResumeGuardDescr` so the subclass
 /// inherits the full `_attrs_` slot set (adr_jump_offset, rd_locs,
 /// status, rd_loop_token, plus the pyre-side per-emission cells:
-/// source_op_index, force_token_slots, trace_info, fail_count,
+/// source_op_index, trace_info, fail_count,
 /// external_jump_target, bridge_*) the cranelift codegen path reads
 /// off every guard descr at `collect_guards` / dispatch emission.
 /// Same shape as `ResumeAtPositionDescr` (compile.py:892).
@@ -5194,7 +5152,6 @@ impl majit_ir::Descr for CompileLoopVersionDescr {
                 trace_id: AtomicU64::new(0),
                 fail_index_per_trace: AtomicU32::new(0),
                 source_op_index: UnsafeCell::new(None),
-                force_token_slots: UnsafeCell::new(Vec::new()),
                 back_edge_poll: std::sync::atomic::AtomicBool::new(false),
                 fail_count: AtomicU32::new(0),
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -5351,12 +5308,6 @@ impl FailDescr for CompileLoopVersionDescr {
     fn set_source_op_index(&self, source_op_index: usize) {
         FailDescr::set_source_op_index(&self.inner, source_op_index);
     }
-    fn force_token_slots(&self) -> Vec<usize> {
-        FailDescr::force_token_slots(&self.inner)
-    }
-    fn set_force_token_slots(&self, slots: Vec<usize>) {
-        FailDescr::set_force_token_slots(&self.inner, slots);
-    }
     fn fail_count(&self) -> u32 {
         FailDescr::fail_count(&self.inner)
     }
@@ -5416,7 +5367,6 @@ fn make_compile_loop_version_descr_with_payload(types: Vec<Type>, payload: RdPay
             trace_id: AtomicU64::new(0),
             fail_index_per_trace: AtomicU32::new(0),
             source_op_index: UnsafeCell::new(None),
-            force_token_slots: UnsafeCell::new(Vec::new()),
             back_edge_poll: std::sync::atomic::AtomicBool::new(false),
             fail_count: AtomicU32::new(0),
             trace_info: AtomicPtr::new(std::ptr::null_mut()),
@@ -5938,7 +5888,6 @@ mod fail_descr_tests {
                 trace_id: AtomicU64::new(0),
                 fail_index_per_trace: AtomicU32::new(0),
                 source_op_index: UnsafeCell::new(None),
-                force_token_slots: UnsafeCell::new(Vec::new()),
                 back_edge_poll: std::sync::atomic::AtomicBool::new(false),
                 fail_count: AtomicU32::new(0),
                 trace_info: AtomicPtr::new(std::ptr::null_mut()),

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -14164,9 +14164,6 @@ impl<M: Clone> MetaInterp<M> {
                     let exit_types: ExitTypes = typed_fail_values
                         .map(|values| values.iter().map(Value::get_type).collect())
                         .unwrap_or_default();
-                    // Empty because this path classifies no force-token
-                    // slots; the predicate still reads it, so the two stay
-                    // one fact.
                     CompiledExitLayout {
                         rd_loop_token: green_key, // from trace context
                         trace_id,

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -309,8 +309,6 @@ pub(crate) struct CompiledTrace {
 #[derive(Debug, Clone)]
 pub(crate) struct StoredExitLayout {
     pub(crate) source_op_index: Option<usize>,
-    pub(crate) gc_ref_slots: Vec<usize>,
-    pub(crate) force_token_slots: Vec<usize>,
     pub(crate) recovery_layout: Option<ExitRecoveryLayout>,
     pub(crate) resume_layout: Option<ResumeLayoutSummary>,
     /// compile.py:853 `ResumeGuardDescr` storage — single guard-owned
@@ -361,8 +359,6 @@ impl StoredExitLayout {
             exit_types: ExitTypes::from_slice(self.resolve_exit_types()),
             is_finish: self.resolve_is_finish(),
             is_exception_exit: self.resolve_is_exception_exit(),
-            gc_ref_slots: self.gc_ref_slots.clone(),
-            force_token_slots: self.force_token_slots.clone(),
             recovery_layout: self.recovery_layout.clone().map(Box::new),
             resume_layout: self.resume_layout.clone().map(Box::new),
             storage: self.storage.clone(),
@@ -2683,12 +2679,6 @@ impl<M: Clone> MetaInterp<M> {
         let is_finish = descr.is_finish();
         let is_exit_frame_with_exception = descr.is_exit_frame_with_exception();
         let exit_types = ExitTypes::from_slice(descr.fail_arg_types());
-        let gc_ref_slots: Vec<usize> = exit_types
-            .iter()
-            .enumerate()
-            .filter_map(|(slot, _)| descr.is_gc_ref_slot(slot).then_some(slot))
-            .collect();
-        let force_token_slots = descr.force_token_slots().to_vec();
         let rd_loop_token = majit_backend::descr_owning_jct(descr).map(|jct| jct.green_key());
 
         let default_layout = || CompiledExitLayout {
@@ -2699,8 +2689,6 @@ impl<M: Clone> MetaInterp<M> {
             exit_types: exit_types.clone(),
             is_finish,
             is_exception_exit: is_exit_frame_with_exception,
-            gc_ref_slots: gc_ref_slots.clone(),
-            force_token_slots: force_token_slots.clone(),
             recovery_layout: None,
             resume_layout: None,
             storage: None,
@@ -2889,15 +2877,6 @@ impl<M: Clone> MetaInterp<M> {
                 } else {
                     layout.fail_arg_types
                 });
-                let gc_ref_slots = if layout.gc_ref_slots.is_empty() {
-                    exit_types
-                        .iter()
-                        .enumerate()
-                        .filter_map(|(idx, ty)| (*ty == Type::Ref).then_some(idx))
-                        .collect()
-                } else {
-                    layout.gc_ref_slots
-                };
                 CompiledExitLayout {
                     rd_loop_token: owning_key, // compile.py:186
                     trace_id,
@@ -2906,8 +2885,6 @@ impl<M: Clone> MetaInterp<M> {
                     exit_types,
                     is_finish: layout.is_finish,
                     is_exception_exit: layout.is_exception_exit,
-                    gc_ref_slots,
-                    force_token_slots: layout.force_token_slots,
                     recovery_layout: layout.recovery_layout.map(Box::new),
                     resume_layout: None,
                     storage,
@@ -2931,8 +2908,6 @@ impl<M: Clone> MetaInterp<M> {
                 exit_types: ExitTypes::from_vec(layout.exit_types),
                 is_finish: layout.is_finish,
                 is_exception_exit: layout.is_exception_exit,
-                gc_ref_slots: layout.gc_ref_slots,
-                force_token_slots: layout.force_token_slots,
                 recovery_layout: layout.recovery_layout.map(Box::new),
                 resume_layout: None,
                 storage: None,
@@ -2978,8 +2953,6 @@ impl<M: Clone> MetaInterp<M> {
                         exit_types: ExitTypes::from_vec(layout.fail_arg_types),
                         is_finish: layout.is_finish,
                         is_exception_exit: layout.is_exception_exit,
-                        gc_ref_slots: layout.gc_ref_slots,
-                        force_token_slots: layout.force_token_slots,
                         recovery_layout: layout.recovery_layout.map(Box::new),
                         resume_layout: merged
                             .get(&layout.fail_index)
@@ -3034,8 +3007,6 @@ impl<M: Clone> MetaInterp<M> {
                             exit_types: ExitTypes::from_vec(layout.exit_types),
                             is_finish: layout.is_finish,
                             is_exception_exit: layout.is_exception_exit,
-                            gc_ref_slots: layout.gc_ref_slots,
-                            force_token_slots: layout.force_token_slots,
                             recovery_layout: layout.recovery_layout.map(Box::new),
                             resume_layout: merged
                                 .get(&layout.op_index)
@@ -10446,8 +10417,6 @@ impl<M: Clone> MetaInterp<M> {
                     exit_types: ExitTypes::from_vec(layout.fail_arg_types),
                     is_finish: layout.is_finish,
                     is_exception_exit: layout.is_exception_exit,
-                    gc_ref_slots: layout.gc_ref_slots,
-                    force_token_slots: layout.force_token_slots,
                     recovery_layout: layout.recovery_layout.map(Box::new).or_else(|| {
                         trace_layout_ref.and_then(|layout| layout.recovery_layout.clone())
                     }),
@@ -10456,24 +10425,21 @@ impl<M: Clone> MetaInterp<M> {
                 }
             })
             .or(trace_layout)
-            .unwrap_or_else(|| CompiledExitLayout {
-                rd_loop_token: green_key, // from trace context
-                trace_id,
-                fail_index,
-                source_op_index: None,
-                exit_types: result.typed_outputs.iter().map(Value::get_type).collect(),
-                is_finish: result.is_finish,
-                is_exception_exit: result.is_exit_frame_with_exception,
-                gc_ref_slots: result
-                    .typed_outputs
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(slot, value)| (value.get_type() == Type::Ref).then_some(slot))
-                    .collect(),
-                force_token_slots: result.force_token_slots.clone(),
-                recovery_layout: None,
-                resume_layout: None,
-                storage: None,
+            .unwrap_or_else(|| {
+                let exit_types: ExitTypes =
+                    result.typed_outputs.iter().map(Value::get_type).collect();
+                CompiledExitLayout {
+                    rd_loop_token: green_key, // from trace context
+                    trace_id,
+                    fail_index,
+                    source_op_index: None,
+                    exit_types,
+                    is_finish: result.is_finish,
+                    is_exception_exit: result.is_exit_frame_with_exception,
+                    recovery_layout: None,
+                    resume_layout: None,
+                    storage: None,
+                }
             });
         let effective_is_finish = result.is_finish || exit_layout.is_finish;
         if crate::majit_log_enabled() {
@@ -10561,12 +10527,6 @@ impl<M: Clone> MetaInterp<M> {
         // `run_compiled_detailed_with_values_at_dispatch_key` for why the copy
         // does not belong on a path every entry takes.
         let exit_types: &[Type] = descr.fail_arg_types();
-        let gc_ref_slots: Vec<usize> = exit_types
-            .iter()
-            .enumerate()
-            .filter_map(|(slot, _)| descr.is_gc_ref_slot(slot).then_some(slot))
-            .collect();
-        let force_token_slots = descr.force_token_slots().to_vec();
         let status = descr.get_status();
         // compile.py:186 `descr.rd_loop_token` — owning loop's clt,
         // stamped at compile time.  Walk the chain
@@ -10604,8 +10564,6 @@ impl<M: Clone> MetaInterp<M> {
                 exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
-                gc_ref_slots,
-                force_token_slots,
                 recovery_layout: None,
                 resume_layout: None,
                 storage: None,
@@ -10633,8 +10591,6 @@ impl<M: Clone> MetaInterp<M> {
                     exit_types: ExitTypes::from_slice(exit_types),
                     is_finish,
                     is_exception_exit: is_exit_frame_with_exception,
-                    gc_ref_slots,
-                    force_token_slots,
                     recovery_layout: None,
                     resume_layout: None,
                     // The green-key index no longer holds this trace, but the
@@ -10861,8 +10817,6 @@ impl<M: Clone> MetaInterp<M> {
                 exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
-                gc_ref_slots: Vec::new(),
-                force_token_slots: Vec::new(),
                 recovery_layout: None,
                 resume_layout: None,
                 storage: None,
@@ -10887,12 +10841,6 @@ impl<M: Clone> MetaInterp<M> {
             });
         }
 
-        let gc_ref_slots: Vec<usize> = exit_types
-            .iter()
-            .enumerate()
-            .filter_map(|(slot, _)| descr.is_gc_ref_slot(slot).then_some(slot))
-            .collect();
-        let force_token_slots = descr.force_token_slots().to_vec();
         let status = descr.get_status();
         // compile.py:186 `descr.rd_loop_token` — see `run_compiled_detailed`.
         let rd_loop_token = majit_backend::descr_owning_jct(descr).map(|jct| jct.green_key());
@@ -10933,8 +10881,6 @@ impl<M: Clone> MetaInterp<M> {
                 exit_types: ExitTypes::from_slice(exit_types),
                 is_finish,
                 is_exception_exit: is_exit_frame_with_exception,
-                gc_ref_slots,
-                force_token_slots,
                 recovery_layout: None,
                 resume_layout: None,
                 // The green-key index no longer holds this trace, but the
@@ -14214,31 +14160,25 @@ impl<M: Clone> MetaInterp<M> {
                         compiled, green_key, trace_id, fail_index,
                     )
                 })
-                .unwrap_or_else(|| CompiledExitLayout {
-                    rd_loop_token: green_key, // from trace context
-                    trace_id,
-                    fail_index,
-                    source_op_index: None,
-                    exit_types: typed_fail_values
+                .unwrap_or_else(|| {
+                    let exit_types: ExitTypes = typed_fail_values
                         .map(|values| values.iter().map(Value::get_type).collect())
-                        .unwrap_or_default(),
-                    is_finish: false,
-                    is_exception_exit: false,
-                    gc_ref_slots: typed_fail_values
-                        .map(|values| {
-                            values
-                                .iter()
-                                .enumerate()
-                                .filter_map(|(slot, value)| {
-                                    (value.get_type() == Type::Ref).then_some(slot)
-                                })
-                                .collect()
-                        })
-                        .unwrap_or_default(),
-                    force_token_slots: Vec::new(),
-                    recovery_layout: None,
-                    resume_layout: None,
-                    storage: None,
+                        .unwrap_or_default();
+                    // Empty because this path classifies no force-token
+                    // slots; the predicate still reads it, so the two stay
+                    // one fact.
+                    CompiledExitLayout {
+                        rd_loop_token: green_key, // from trace context
+                        trace_id,
+                        fail_index,
+                        source_op_index: None,
+                        is_finish: false,
+                        is_exception_exit: false,
+                        exit_types,
+                        recovery_layout: None,
+                        resume_layout: None,
+                        storage: None,
+                    }
                 });
         // pyjitpl.py:3277-3288 initialize_state_from_guard_failure:
         // guard failure rebuild is stack-critical code — must not be
@@ -23202,8 +23142,6 @@ mod tests {
             fail_index,
             StoredExitLayout {
                 source_op_index: Some(0),
-                gc_ref_slots: vec![0],
-                force_token_slots: vec![],
                 recovery_layout: Some(recovery_layout),
                 resume_layout: None,
                 storage: Some(crate::resume::ResumeStorage::new(
@@ -23292,8 +23230,6 @@ mod tests {
             fail_index,
             StoredExitLayout {
                 source_op_index: Some(0),
-                gc_ref_slots: vec![],
-                force_token_slots: vec![],
                 recovery_layout: None,
                 resume_layout: None,
                 storage: Some(crate::resume::ResumeStorage::new(

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -188,6 +188,24 @@ pub struct JitCode {
     /// like `jitcode.code` continue to work via `Deref<Target=JitCodeBody>`.
     #[serde(with = "oncelock_body_serde")]
     body: OnceLock<JitCodeBody>,
+    /// Memoized verdicts derived from `body`, not assembled into it, so they
+    /// are recomputed rather than serialized. Each is a static property of the
+    /// body: one answer serves every call site and every thread, which is why
+    /// it lives on the shared jitcode instead of a per-thread cache.
+    #[serde(skip)]
+    derived: DerivedBodyFacts,
+}
+
+/// Answers computed on demand from an assembled [`JitCode`] body.
+///
+/// Cloned along with the body they describe: a clone carries the same `code`,
+/// so an answer already computed for the original holds for it too.
+#[derive(Debug, Default, Clone)]
+pub struct DerivedBodyFacts {
+    /// Whether descending into this body can reach a residual call whose
+    /// funcbox is an un-lowered helper's symbolic hash. Read through
+    /// [`JitCode::descent_reaches_unlowered_helper_call`].
+    descent_reaches_unlowered_helper_call: OnceLock<bool>,
 }
 
 mod oncelock_usize_serde {
@@ -256,6 +274,7 @@ impl JitCode {
             index: OnceLock::new(),
             _called_from: None,
             body: OnceLock::new(),
+            derived: DerivedBodyFacts::default(),
         }
     }
 
@@ -288,6 +307,18 @@ impl JitCode {
         self.body
             .get_mut()
             .expect("JitCode body not yet set — call set_body() before body_mut()")
+    }
+
+    /// Whether descending into this body can reach a residual call whose
+    /// funcbox is an un-lowered helper's symbolic hash, computing the answer
+    /// with `compute` the first time it is asked. The property is fixed by the
+    /// assembled body, so the first answer is the only one; every later caller
+    /// on any thread reads it back.
+    pub fn descent_reaches_unlowered_helper_call(&self, compute: impl FnOnce() -> bool) -> bool {
+        *self
+            .derived
+            .descent_reaches_unlowered_helper_call
+            .get_or_init(compute)
     }
 
     /// Commit the body once assembly has produced it. Panics on second
@@ -625,6 +656,7 @@ impl Clone for JitCode {
             index: self.index.clone(),
             _called_from: self._called_from.clone(),
             body: self.body.clone(),
+            derived: self.derived.clone(),
         }
     }
 }

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -190,8 +190,11 @@ pub struct JitCode {
     body: OnceLock<JitCodeBody>,
     /// Memoized verdicts derived from `body`, not assembled into it, so they
     /// are recomputed rather than serialized. Each is a static property of the
-    /// body: one answer serves every call site and every thread, which is why
-    /// it lives on the shared jitcode instead of a per-thread cache.
+    /// body, so the memo travels with the body it describes instead of sitting
+    /// in a map keyed beside it. It is not shared across threads: the runtime
+    /// jitcode table is itself per-thread (`jitcode_runtime.rs JITCODE_CELLS`,
+    /// which cites the GIL for that shape), so a thread that decodes its own
+    /// `JitCode` computes its own answer.
     #[serde(skip)]
     derived: DerivedBodyFacts,
 }
@@ -312,8 +315,9 @@ impl JitCode {
     /// Whether descending into this body can reach a residual call whose
     /// funcbox is an un-lowered helper's symbolic hash, computing the answer
     /// with `compute` the first time it is asked. The property is fixed by the
-    /// assembled body, so the first answer is the only one; every later caller
-    /// on any thread reads it back.
+    /// assembled body, so the first answer is the only one this instance gives:
+    /// `body_mut` needs `&mut self`, which `runtime_fnaddr_patch` can only take
+    /// before the jitcode is published behind an `Arc`.
     pub fn descent_reaches_unlowered_helper_call(&self, compute: impl FnOnce() -> bool) -> bool {
         *self
             .derived

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3640,6 +3640,53 @@ mod tests {
     /// apart, so a registry that passes here can still feed
     /// `runtime_fnaddr_patch` an ambiguous build address — that direction is
     /// what its own assertion catches.
+    /// Whether two registered paths are two spellings of one item, which is
+    /// the only legitimate reason for them to share an address.
+    ///
+    /// The shape every real pair has: a crate-root re-export
+    /// (`pyre_interpreter::acquire_buffered_lock`) beside the defining path
+    /// (`pyre_interpreter::module::_io::acquire_buffered_lock`). Neither is a
+    /// suffix of the other — the crate segment leads both — so drop that
+    /// segment first, after which one is a `::`-boundary suffix of the other.
+    ///
+    /// Comparing only the last segment would accept far more than this: two
+    /// genuinely different items ending in the same name, `module::a::
+    /// type_object` and `module::b::type_object`, would read as aliases while
+    /// address-keyed patching between them stays ambiguous. Those are related
+    /// by no suffix under this rule and are reported.
+    fn are_alias_spellings(a: &str, b: &str) -> bool {
+        fn spellings(path: &str) -> [&str; 2] {
+            [path, path.split_once("::").map_or(path, |(_, rest)| rest)]
+        }
+        spellings(a).into_iter().any(|x| {
+            spellings(b).into_iter().any(|y| {
+                let (short, long) = if x.len() > y.len() { (y, x) } else { (x, y) };
+                long == short
+                    || long
+                        .strip_suffix(short)
+                        .is_some_and(|prefix| prefix.ends_with("::"))
+            })
+        })
+    }
+
+    #[test]
+    fn two_distinct_items_sharing_an_address_are_not_alias_spellings() {
+        // The pair the leaf-name grouping used to accept.
+        assert!(!are_alias_spellings(
+            "pyre_interpreter::module::a::type_object",
+            "pyre_interpreter::module::b::type_object",
+        ));
+        // Both shapes the registry actually produces.
+        assert!(are_alias_spellings(
+            "pyre_interpreter::acquire_buffered_lock",
+            "pyre_interpreter::module::_io::acquire_buffered_lock",
+        ));
+        assert!(are_alias_spellings(
+            "module::_io::stringio::type_object",
+            "pyre_interpreter::module::_io::stringio::type_object",
+        ));
+    }
+
     #[test]
     fn registered_paths_sharing_an_address_are_alias_spellings() {
         let mut by_addr: HashMap<i64, Vec<&'static str>> = HashMap::new();
@@ -3652,12 +3699,17 @@ mod tests {
         // names a different pair.
         let mut collisions: Vec<String> = Vec::new();
         for (addr, paths) in &by_addr {
-            let leaves: std::collections::BTreeSet<&str> = paths
-                .iter()
-                .map(|p| p.rsplit("::").next().unwrap_or(p))
-                .collect();
-            if leaves.len() > 1 {
-                collisions.push(format!("{addr:#x} {leaves:?}"));
+            let mut unrelated: Vec<(&str, &str)> = Vec::new();
+            for (i, a) in paths.iter().enumerate() {
+                for b in &paths[i + 1..] {
+                    if !are_alias_spellings(a, b) {
+                        unrelated.push((a, b));
+                    }
+                }
+            }
+            if !unrelated.is_empty() {
+                unrelated.sort_unstable();
+                collisions.push(format!("{addr:#x} {unrelated:?}"));
             }
         }
         collisions.sort();

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -3642,31 +3642,42 @@ mod tests {
     /// what its own assertion catches.
     /// Whether two registered paths are two spellings of one item, which is
     /// the only legitimate reason for them to share an address.
-    ///
-    /// The shape every real pair has: a crate-root re-export
-    /// (`pyre_interpreter::acquire_buffered_lock`) beside the defining path
-    /// (`pyre_interpreter::module::_io::acquire_buffered_lock`). Neither is a
-    /// suffix of the other — the crate segment leads both — so drop that
-    /// segment first, after which one is a `::`-boundary suffix of the other.
-    ///
-    /// Comparing only the last segment would accept far more than this: two
-    /// genuinely different items ending in the same name, `module::a::
-    /// type_object` and `module::b::type_object`, would read as aliases while
-    /// address-keyed patching between them stays ambiguous. Those are related
-    /// by no suffix under this rule and are reported.
     fn are_alias_spellings(a: &str, b: &str) -> bool {
-        fn spellings(path: &str) -> [&str; 2] {
-            [path, path.split_once("::").map_or(path, |(_, rest)| rest)]
+        /// One path is the other with more leading segments, on a `::`
+        /// boundary — the shape a registry entry recorded with its crate
+        /// segment has against the same entry recorded without one.
+        fn extends(a: &str, b: &str) -> bool {
+            let (short, long) = if a.len() > b.len() { (b, a) } else { (a, b) };
+            long == short
+                || long
+                    .strip_suffix(short)
+                    .is_some_and(|prefix| prefix.ends_with("::"))
         }
-        spellings(a).into_iter().any(|x| {
-            spellings(b).into_iter().any(|y| {
-                let (short, long) = if x.len() > y.len() { (y, x) } else { (x, y) };
-                long == short
-                    || long
-                        .strip_suffix(short)
-                        .is_some_and(|prefix| prefix.ends_with("::"))
-            })
-        })
+        fn split_head(path: &str) -> Option<(&str, &str)> {
+            path.split_once("::")
+        }
+        // A crate-root re-export (`pyre_interpreter::acquire_buffered_lock`)
+        // beside its defining path (`pyre_interpreter::module::_io::
+        // acquire_buffered_lock`) is related by neither suffix while the crate
+        // segment leads both, so drop that segment — but only when the two
+        // paths lead with the same one. No crate re-exports another crate's
+        // item, so `pyre_object::module::x::f` and
+        // `pyre_interpreter::module::x::f` are two functions whose modules are
+        // spelled alike, and comparing their tails would call them one.
+        //
+        // Comparing only the last segment would accept far more than either
+        // rule: `module::a::type_object` and `module::b::type_object` would
+        // read as aliases while address-keyed patching between them stays
+        // ambiguous. Those are related by no suffix here and are reported.
+        if extends(a, b) {
+            return true;
+        }
+        match (split_head(a), split_head(b)) {
+            (Some((head_a, rest_a)), Some((head_b, rest_b))) => {
+                head_a == head_b && extends(rest_a, rest_b)
+            }
+            _ => false,
+        }
     }
 
     #[test]
@@ -3684,6 +3695,12 @@ mod tests {
         assert!(are_alias_spellings(
             "module::_io::stringio::type_object",
             "pyre_interpreter::module::_io::stringio::type_object",
+        ));
+        // Two crates cannot re-export one another's item, so identical module
+        // paths under different crates are two functions, not two spellings.
+        assert!(!are_alias_spellings(
+            "pyre_object::module::x::type_object",
+            "pyre_interpreter::module::x::type_object",
         ));
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -593,40 +593,19 @@ pub(crate) fn exception_string_override_straight_line(body_code: &[u8]) -> bool 
 /// enter, because the abort propagates from any depth.  A body already on the
 /// scan stack is a cycle and answers `false`: the occurrence that opened it
 /// decides.
-/// Whether descending into this jitcode body can reach a residual call whose
-/// funcbox is an un-lowered helper's symbolic hash.
 ///
-/// [`try_execute_residual_call_via_executor`] refuses to record such a call
-/// while inlining a sub-jitcode — the hash is not a code address, so a
-/// compiled trace would branch to it — and raises
-/// `OrthodoxSubWalkTraceUnsupported` at that call.  By then the descent has
-/// executed every earlier op for real, including residual calls that advance
-/// a generator's internal state, and the abort resumes the enclosing frame at
-/// its own `CALL`.  The Python call therefore runs a second time and the first
-/// result is discarded: `random.random()` in a loop advances the Mersenne
-/// Twister once per aborted descent without producing a value for it
-/// (`gen.random()` drew 4003 times for 4000 appends).
-///
-/// The funcbox is a jitcode constant, so whether a body holds such a call is a
-/// static property of the body.  Answering it before the descent starts turns
-/// the mid-descent abort into an ordinary residual call, which applies the
-/// effect exactly once.
-///
-/// The scan follows `inline_call_*` into the callee bodies the descent would
-/// enter, because the abort propagates from any depth.  A body already on the
-/// scan stack is a cycle and answers `false`: the occurrence that opened it
-/// decides.
+/// The answer is memoized on the jitcode itself, so the scan runs once per
+/// body rather than once per call site.  Only this entry point memoizes: the
+/// `false` a cycle produces belongs to the occurrence that opened it, not to
+/// the body, so [`scan_body_for_unlowered_helper_call`] caches nothing.
 fn descent_reaches_unlowered_helper_call(jitcode_index: usize) -> bool {
-    thread_local! {
-        static VERDICTS: std::cell::RefCell<std::collections::HashMap<usize, bool>> =
-            std::cell::RefCell::new(std::collections::HashMap::new());
-    }
-    if let Some(cached) = VERDICTS.with(|v| v.borrow().get(&jitcode_index).copied()) {
-        return cached;
-    }
-    let verdict = scan_body_for_unlowered_helper_call(jitcode_index, &mut Vec::new());
-    VERDICTS.with(|v| v.borrow_mut().insert(jitcode_index, verdict));
-    verdict
+    let Some(jitcode) = crate::jitcode_runtime::get_jitcode_ref_by_index(jitcode_index) else {
+        // Same condition the caller declines on; nothing to answer for.
+        return false;
+    };
+    jitcode.descent_reaches_unlowered_helper_call(|| {
+        scan_body_for_unlowered_helper_call(jitcode_index, &mut Vec::new())
+    })
 }
 
 /// Recursive worker of [`descent_reaches_unlowered_helper_call`].  `seen` is

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -9396,12 +9396,12 @@ fn handle_fail(
     let _guard_exc_root = majit_metainterp::blackhole::GuardExcRoot::park(guard_exc);
     // The exit values are a host copy of the JITFRAME slots; the JITFRAME's
     // own gcmap rooting ended when `execute_token` returned. Bridge tracing
-    // below allocates, so root the Ref slots for this whole call
-    // (`DeadFrameRefRoots`).
+    // below allocates, so root the traced Ref slots for this whole call
+    // (`DeadFrameRefRoots`), the set `compute_gcmap` marks — force tokens
+    // included, since one is a jitframe pointer and the jitframe moves.
     let _deadframe_roots = unsafe {
         majit_metainterp::resume::DeadFrameRefRoots::enter(raw_values, |index| {
-            exit_layout.exit_types.get(index) == Some(&majit_ir::Type::Ref)
-                || exit_layout.gc_ref_slots.contains(&index)
+            exit_layout.is_traced_ref_slot(index)
         })
     };
 
@@ -9605,9 +9605,8 @@ fn forced_guard_cache_owner(
 /// surfaces the running frame instead, so the cache is keyed by the frame the
 /// force ran against (`force_pyframe`) and taken back here by the same frame.
 ///
-/// The jitframe address is not usable as the key: only cranelift populates
-/// `FailDescr::force_token_slots`, so on dynasm the failing exit does not name
-/// its own force token at all.
+/// The jitframe address is not usable as the key: the failing exit does not
+/// name which of its slots holds the force token.
 ///
 /// A miss returns `None`, which resumes the ordinary way. Upstream instead
 /// substitutes an empty `VirtualCache` (`compile.py:959-960`) and still runs
@@ -9658,8 +9657,7 @@ pub(crate) fn resume_in_blackhole_from_exit_layout(
     // live range at `_prepare_resume_from_failure`, before `_run_forever`.
     let deadframe_roots = unsafe {
         majit_metainterp::resume::DeadFrameRefRoots::enter(raw_values, |index| {
-            exit_layout.exit_types.get(index) == Some(&majit_ir::Type::Ref)
-                || exit_layout.gc_ref_slots.contains(&index)
+            exit_layout.is_traced_ref_slot(index)
         })
     };
     if majit_metainterp::majit_log_enabled() {


### PR DESCRIPTION
Follow-up to #1317, which merged before its review was resolved. Three commits:

### 1. The #1317 review findings

Four findings, verified against the code rather than applied as written.

- **`descent_reaches_unlowered_helper_call` kept its verdict in a `thread_local!` HashMap.** The verdict is a static property of a jitcode body, so every thread recomputed the same scan and held its own answer. `JitCode` grows a `DerivedBodyFacts` cell beside the `OnceLock`s it already carries; a clone inherits the verdict along with the body it describes. Only the entry point memoizes, so the `false` a cycle produces stays with the occurrence that opened it. Its doc comment was also duplicated in full; one copy remains.

- **`registered_paths_sharing_an_address_are_alias_spellings` grouped paths by their last `::` segment**, so `module::a::type_object` and `module::b::type_object` read as aliases of each other. Measured first: 335 addresses carry more than one registered path, and every one is a crate-root re-export beside its defining path. Neither is a plain suffix of the other, so the rule drops the leading crate segment before comparing — all 335 pass, and the same-leaf case above does not. A second test pins the rule.

- **`handle_fail_resume_guard` left its deadframe copy unrooted across the bridge hook.** The hook traces and compiles, so it allocates; only the jitframe is walked, so a moving collection forwards its slots and leaves the copy naming addresses the objects have left. `pyre-jit`'s other guard-failure path already roots its copy across the same decision; the CALL_ASSEMBLER twin rooted only `guard_exc`. It now registers the copy's GC slots for the hook's duration.

- **The Codex P1 on register colouring is rebutted**, not applied: the prescribed port of `rpython/tool/algo/regalloc.py` is already in-tree (`majit/majit-translate/src/tool/algo/regalloc.rs`, 704 lines, plus `cleanup_registers` / `release_interp`).

### 2. Dropping the `gc_ref_slots` / `force_token_slots` exit metadata

The rooting fix above needed "which exit slot holds a real GC pointer". `FailDescr::is_gc_ref_slot` answered "typed `Ref` and not a force-token position", and **eleven producers re-derived that rule by hand** — twice verbatim, five times as a per-slot loop over the accessor, four times without the force-token clause. Unifying them turned up the reason the divergence never showed: **the answer is not read anywhere.**

It is not the rule that decides what the collector traces, either. `llsupport/assembler.py:46-64 GuardToken.compute_gcmap` marks every `REF`-typed failarg and narrows nothing, and `resoperation.py:1090 FORCE_TOKEN/0/r` is REF upstream too — the token is the jitframe, itself a GC object that moves. Both emitted gcmaps already follow that rule: dynasm's `guard_gcmap_from_faillocs` and the cranelift `collect_guards` mark force-token slots.

The narrowing reached exactly one place: the `gc_ref_slots` field of `CompiledExitLayout` / `FailDescrLayout` / `StoredExitLayout`, written by every backend and read by no consumer — only copied between those structs and asserted in two backend tests. `force_token_slots` existed to feed it. Upstream carries neither field; `AbstractFailDescr._attrs_` (history.py:132) has no such slot and the gcmap is computed at emission.

Both are removed, along with the trait methods (`is_gc_ref_slot`, `force_token_slots`, `set_force_token_slots`), their impls and forwarders, the `ResumeGuardDescr` cells behind them, cranelift's `fail_descr_gc_map`, and the now-unused `force_tokens` parameter of `collect_guards` / `collect_terminal_exit_layouts`. Net **−380 lines**.

**No behaviour change to what gets rooted.** The two `DeadFrameRefRoots::enter` callbacks in `eval.rs` spelled the tracing rule `exit_types[i] == Ref || gc_ref_slots.contains(&i)`; every producer built `gc_ref_slots` as a subset of the `Ref` slots, so the second clause never added an index and the predicate was the type test alone. Both now call `CompiledExitLayout::is_traced_ref_slot`, which is that test under a name that says which question it answers. `handle_fail_resume_guard`, whose rooting arrives in commit 1, roots by the same rule.

`FailDescr::is_compiling` goes too — a trait default `-> false` with no override and no caller; `must_compile` reads the busy bit through `get_status()`, as `compile.py:750` does inline.

`gcmap_from_fail_arg_locs` is removed from both dynasm assemblers: an unused duplicate of `guard_gcmap_from_faillocs`, carried in two copies whose bodies had drifted apart. Comments citing `FORCE_TOKEN_SLOTS_TABLE` and `CraneliftFailDescr::is_force_token_slot` go too — neither symbol exists.

### 3. The unreached emitter methods behind the assemblers' `allow(dead_code)`

The duplicate above was not alone, and the reason it survived is structural: `impl<'a> AssemblerARM64<'a>` carries a blanket `#[allow(dead_code)]`, and `x86/` is `#[cfg(target_arch = "x86_64")]`, so on an aarch64 machine neither assembler's dead-code warnings are visible. Behind them, **64 private methods on ARM64 and 65 on x86 had no call site left**.

Most are the `genop_*` layer that predates the arglocs/regalloc dispatch — `genop_int_and` shuffles operands through rax/rcx while the live path emits `and X(d), X(l), X(s)` from allocated registers. The rest name opcodes the backend never sees: the rewrite pass turns getfield/getarrayitem/strlen/strgetitem into `gc_load`/`gc_store` before it runs, exactly as upstream's backend has `genop_gc_load` and no `genop_getfield`. Removal iterates to a fixpoint — dropping `genop_int_add_ovf` orphans the `genop_int_add` it called.

The blanket `allow(dead_code)` goes with them, so the lint covers the ARM64 assembler again; `cargo check` for both `aarch64-apple-darwin` and `x86_64-apple-darwin` is then free of dead-code and unused-import warnings from these files. Five imports the x86 files had already stopped using are removed as well.

`relocation_guard`'s corpus floor asserted `bodies > 1000` and the scan now reads 902. The assertion catches a parse that stopped finding bodies — which returns zero or a handful — so it is restated as `bodies > 100`: a bound that separates a broken scan from a working one without tracking how large the emitter happens to be.

Net **−2,739 lines**.

### Verification

`cargo test --all --features dynasm`, `cargo fmt --all --check`, and `python3 pyre/check.py` across all three backends, on a freshly re-extracted LLBC.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved garbage-collection reference tracking during guard failures, resumptions, and blackhole recovery.
  - Strengthened cleanup behavior during exceptional execution paths.
  - Improved validation and reporting for conflicting native function addresses.
  - Corrected handling of missing or void failure arguments.

- **Performance**
  - Added memoization for repeated JIT code analysis, reducing redundant computation.

- **Refactor**
  - Simplified exit and recovery metadata handling across native and WebAssembly execution backends.
  - Consolidated register-based code generation paths for improved consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->