### PR TITLE
co_names_w, what a wrapped code object retains, and the name-key hash memo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "rustpython-codegen"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "bitflags 2.13.0",
  "indexmap",
@@ -3261,7 +3261,7 @@ dependencies = [
 [[package]]
 name = "rustpython-common"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "ascii",
  "bitflags 2.13.0",
@@ -3284,7 +3284,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "rustpython-codegen",
  "rustpython-compiler-core",
@@ -3298,7 +3298,7 @@ dependencies = [
 [[package]]
 name = "rustpython-compiler-core"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "bitflags 2.13.0",
  "bitflagset",
@@ -3314,7 +3314,7 @@ dependencies = [
 [[package]]
 name = "rustpython-host_env"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "bitflags 2.13.0",
  "cc",
@@ -3348,7 +3348,7 @@ dependencies = [
 [[package]]
 name = "rustpython-literal"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "hexf-parse",
  "is-macro",
@@ -3427,7 +3427,7 @@ dependencies = [
 [[package]]
 name = "rustpython-sre_engine"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "bitflags 2.13.0",
  "num_enum",
@@ -3439,7 +3439,7 @@ dependencies = [
 [[package]]
 name = "rustpython-unicode"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "icu_casemap",
  "icu_locale",
@@ -3453,7 +3453,7 @@ dependencies = [
 [[package]]
 name = "rustpython-wtf8"
 version = "0.5.0"
-source = "git+https://github.com/RustPython/RustPython.git?rev=d0baa1c5c1937c5dfed13a983c76fe6323d36572#d0baa1c5c1937c5dfed13a983c76fe6323d36572"
+source = "git+https://github.com/RustPython/RustPython.git?rev=91a725fe833dbc06912a2619e0c39fffa0c61232#91a725fe833dbc06912a2619e0c39fffa0c61232"
 dependencies = [
  "ascii",
  "bstr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,18 +64,19 @@ pyre-jit-trace = { version = "0.0.2", path = "pyre/pyre-jit-trace" }
 pyre-wasm = { version = "0.0.2", path = "pyre/pyre-wasm" }
 pyrex = { version = "0.0.2", path = "pyre/pyrex" }
 
-# Pinned to upstream main after the pyre compatibility fixes from #8390 and
-# the future-annotation block fix from #8506 merged.
-rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
+# Pinned to upstream main after the `Constants` mutable-access impls from
+# #8557 merged; `fix_code_filenames` needs `IndexMut` to edit nested code
+# constants in place.
+rustpython-common = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+rustpython-literal = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+rustpython-compiler = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+rustpython-compiler-core = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
 ruff-text-size = { package = "rustpython-ruff_text_size", git = "https://github.com/RustPython/ruff.git", tag = "0.15.19-rustpython" }
 num-complex = "0.4"
-rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
-sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "d0baa1c5c1937c5dfed13a983c76fe6323d36572" }
+rustpython-host_env = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+rustpython-wtf8 = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+rustpython-unicode = { git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
+sre-engine = { package = "rustpython-sre_engine", git = "https://github.com/RustPython/RustPython.git", rev = "91a725fe833dbc06912a2619e0c39fffa0c61232" }
 
 # majit JIT framework
 majit = { version = "0.0.2", path = "majit/majit" }

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -1936,17 +1936,21 @@ impl WasmBackend {
         }
 
         inputs.fail_index_base = fail_descr_base();
-        let merged_guard_count = codegen::guard_exit_count(&inputs.inputargs, &inputs.ops)
-            + inputs
-                .inlined_bridges
-                .iter()
-                .map(|region| codegen::guard_exit_count(&region.inputargs, &region.ops))
-                .sum::<usize>();
+        // `guard_exit_count` walks the whole op list it is handed, so each
+        // count is taken once here: the exit loop below needs the per-region
+        // counts for every one of its exits, and re-deriving them there would
+        // walk every appended region once per guard.
+        let own_guard_count = codegen::guard_exit_count(&inputs.inputargs, &inputs.ops);
+        let region_guard_counts: Vec<usize> = inputs
+            .inlined_bridges
+            .iter()
+            .map(|region| codegen::guard_exit_count(&region.inputargs, &region.ops))
+            .collect();
+        let merged_guard_count = own_guard_count + region_guard_counts.iter().sum::<usize>();
         let (new_cells_base, new_cells_owner) = codegen::alloc_bridge_cells(merged_guard_count);
         inputs.bridge_cells_base = new_cells_base;
         let (wasm_bytes, guard_exits, _) = codegen::build_wasm_module(&inputs)?;
         let code_size = wasm_bytes.len();
-        let own_guard_count = codegen::guard_exit_count(&inputs.inputargs, &inputs.ops);
         let descrs: Vec<Arc<WasmFailDescr>> = guard_exits
             .iter()
             .enumerate()
@@ -1955,8 +1959,8 @@ impl WasmBackend {
                 let trace_id = inputs
                     .inlined_bridges
                     .iter()
-                    .find_map(|region| {
-                        let count = codegen::guard_exit_count(&region.inputargs, &region.ops);
+                    .zip(&region_guard_counts)
+                    .find_map(|(region, &count)| {
                         let contains = (region_start..region_start + count).contains(&index);
                         region_start += count;
                         contains.then_some(region.trace_id)

--- a/majit/majit-translate/src/model.rs
+++ b/majit/majit-translate/src/model.rs
@@ -5205,6 +5205,7 @@ impl FuncEffects {
         }
         self.cannot_collect |= other.cannot_collect;
         self.random_effects_on_gcobjs |= other.random_effects_on_gcobjs;
+        self.canmallocgc |= other.canmallocgc;
         self.cannot_raise_assertion |= other.cannot_raise_assertion;
         self.memerror_only_assertion |= other.memerror_only_assertion;
         self.elidable |= other.elidable;
@@ -6442,6 +6443,44 @@ impl FunctionGraph {
 
 #[cfg(test)]
 mod tests {
+
+    /// `merge_from`'s contract is that every set flag in `other` wins and that
+    /// registration order does not matter. Each boolean is folded by hand, so
+    /// a field added to `FuncEffects` without a matching `|=` is silently
+    /// dropped — which is how `canmallocgc` was first written.
+    ///
+    /// The two directions are the two callers: `insert_function_graph_indexed`
+    /// folds a pending `external_funcobjs` record into a graph registered
+    /// later, and `GraphStore::insert` folds two aliases of one graph. A flag
+    /// that survives only one direction still loses metadata in the other.
+    #[test]
+    fn merge_from_folds_every_effect_flag_in_both_directions() {
+        let set = FuncEffects {
+            cannot_collect: true,
+            random_effects_on_gcobjs: true,
+            canmallocgc: true,
+            cannot_raise_assertion: true,
+            memerror_only_assertion: true,
+            elidable: true,
+            loop_invariant: true,
+            close_stack: true,
+            ..FuncEffects::default()
+        };
+
+        let mut into_default = FuncEffects::default();
+        into_default.merge_from(&set);
+        assert_eq!(
+            into_default, set,
+            "a set flag in `other` must win over a cleared `self`"
+        );
+
+        let mut from_default = set.clone();
+        from_default.merge_from(&FuncEffects::default());
+        assert_eq!(
+            from_default, set,
+            "a cleared flag in `other` must never unset `self`"
+        );
+    }
     use super::*;
 
     /// `CallTarget::SyntheticTransparentCtor::path_segments()` must

--- a/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=0
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0

--- a/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
+++ b/pyre/bench/synth/class_body_exec_hot_loop.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=0
+bridges_compiled=1
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -313,7 +313,7 @@ pub fn do_combine_starstarargs_wrapped(
             // own storage directly.
             //
             // Pyre adaptation: dict subclasses are
-            // `W_ObjectObject` with a `__dict_data__` backing dict
+            // `W_ObjectObject` with a reserved-slot backing dict
             // (`typedef.rs`'s `dict_descr_new`).  Route through
             // `type_methods::resolve_dict_backing` to recover the
             // backing `W_DictObject`, then perform the same direct

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -5182,7 +5182,7 @@ pub fn setdict(obj: PyObjectRef, w_dict: PyObjectRef) -> Result<(), PyError> {
 /// `getdict` result.  Upstream dict-subclass instances are dict-layout
 /// `W_DictMultiObject`, so `finditem_str`/`setitem_str` strategy
 /// dispatch works on them directly; pyre dict-subclass instances are
-/// `__dict_data__`-composed W_ObjectObject (typedef.rs
+/// slot-composed W_ObjectObject (typedef.rs
 /// dict_descr_new), so the `w_dict_*` layout accessors must target the
 /// backing dict.  Plain dicts, module dicts and mapdict views pass
 /// through unchanged.  The `__dict__` getter keeps returning the

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4335,11 +4335,38 @@ unsafe fn setitem_instance(obj: PyObjectRef, index: PyObjectRef, value: PyObject
 /// Take the `_checked` variant so that surfaces as an error rather than a
 /// miss; only that path wraps the key, to name it in a 3.14 hash-error.
 pub fn finditem_str(obj: PyObjectRef, key: &str) -> Result<Option<PyObjectRef>, PyError> {
+    finditem_str_named(obj, key, pyre_object::PY_NULL, 0)
+}
+
+/// [`finditem_str`] for a caller that can name the key without allocating — a
+/// `(code object, name index)` pair addressing a `co_names_w` slot
+/// (`pycode.py:127-129`), as `pyopcode.py:965` reaches its varname.
+///
+/// The pair is resolved only on the arm that consumes a wrapped key, so a
+/// shortcut dict answers from the borrowed `&str` without touching the slot.
+/// That laziness is the point: reading it is a `dont_look_inside` call the JIT
+/// residualises, and the shortcut is the arm that already allocated nothing.
+///
+/// A `PY_NULL` `pycode` addresses no slot, which is also what a wrapper with no
+/// name table resolves to, so [`finditem_str`] and a nameless code object land
+/// on the same mint.
+pub fn finditem_str_named(
+    obj: PyObjectRef,
+    key: &str,
+    pycode: PyObjectRef,
+    nameindex: usize,
+) -> Result<Option<PyObjectRef>, PyError> {
     if is_shortcut_dict(obj) {
         return unsafe { pyre_object::dictmultiobject::w_dict_getitem_str_checked(obj, key) }
-            .map_err(|_| take_pending_dict_key_error(w_str_new(key)));
+            .map_err(|_| take_pending_dict_key_error(wrapped_key(key, pycode, nameindex)));
     }
-    finditem(obj, w_str_new(key))
+    finditem(obj, wrapped_key(key, pycode, nameindex))
+}
+
+/// The wrapped lookup key: the code object's shared name when the caller named
+/// one, otherwise a freshly minted `w_str`.
+fn wrapped_key(key: &str, pycode: PyObjectRef, nameindex: usize) -> PyObjectRef {
+    unsafe { crate::pycode::w_code_getname_w_or_new(pycode, nameindex, key) }
 }
 
 /// PyPy-compatible identity check returning a raw boolean value.

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -4357,8 +4357,11 @@ pub fn finditem_str_named(
     nameindex: usize,
 ) -> Result<Option<PyObjectRef>, PyError> {
     if is_shortcut_dict(obj) {
-        return unsafe { pyre_object::dictmultiobject::w_dict_getitem_str_checked(obj, key) }
-            .map_err(|_| take_pending_dict_key_error(wrapped_key(key, pycode, nameindex)));
+        let hash = named_key_hash(key, pycode, nameindex);
+        return unsafe {
+            pyre_object::dictmultiobject::w_dict_getitem_str_checked_hashed(obj, key, hash)
+        }
+        .map_err(|_| take_pending_dict_key_error(wrapped_key(key, pycode, nameindex)));
     }
     finditem(obj, wrapped_key(key, pycode, nameindex))
 }
@@ -4367,6 +4370,31 @@ pub fn finditem_str_named(
 /// one, otherwise a freshly minted `w_str`.
 fn wrapped_key(key: &str, pycode: PyObjectRef, nameindex: usize) -> PyObjectRef {
     unsafe { crate::pycode::w_code_getname_w_or_new(pycode, nameindex, key) }
+}
+
+/// `rstr.py:402-412 ll_strhash` for a key the caller named through a
+/// `co_names_w` slot (`pycode.py:127-129`): the digest is memoized in that
+/// shared name string, so each name is hashed once per string rather than once
+/// per opcode that reads it.  Zero when the caller named no slot — the probe
+/// then hashes the borrowed bytes itself, as it always has.
+///
+/// Unlike [`wrapped_key`] this never mints: a slot that has not been realized
+/// yet is realized (one interned string per name value), and a caller holding
+/// no code object gets zero.
+pub(crate) fn named_key_hash(key: &str, pycode: PyObjectRef, nameindex: usize) -> i64 {
+    let w_name = unsafe { crate::pycode::w_code_getname_w(pycode, nameindex) };
+    if w_name.is_null() {
+        return 0;
+    }
+    // The digest answers for `key`'s bytes, so the slot must be the name the
+    // caller borrowed `key` from — the same pairing [`wrapped_key`] already
+    // stores under.  A mismatch would probe a bucket the key is not in.
+    debug_assert_eq!(
+        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) },
+        key,
+        "co_names_w slot names a different key than the opcode borrowed"
+    );
+    unsafe { pyre_object::unicodeobject::w_str_hash_memoized(w_name) }
 }
 
 /// PyPy-compatible identity check returning a raw boolean value.

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -4520,7 +4520,7 @@ fn build_class_inner(
                 unsafe { pyre_object::w_dict_setitem_wtf8_no_proxy(class_ns, &key, value) };
             }
         }
-        // dict subclass instance (e.g. EnumDict): backing dict via __dict_data__
+        // dict subclass instance (e.g. EnumDict): resolve the mapping payload
         let w_prepared_dict = pyre_object::gc_roots::shadow_stack_get(w_namespace_root);
         if unsafe { pyre_object::is_instance(w_prepared_dict) } {
             let backing = crate::type_methods::resolve_dict_backing(w_prepared_dict);
@@ -5629,11 +5629,11 @@ pub unsafe fn create_all_slots(
 
         // PyPy dict subclasses are W_DictMultiObject instances, so their
         // mapping payload is an intrinsic field independent of whether the
-        // Python class requests an instance __dict__.  Pyre composes that
-        // payload as `__dict_data__`; reserve it as an inherited layout slot
-        // rather than an ordinary mapdict attribute.  Otherwise a slotted
-        // dict subclass (PyPy's defaultdict shape) has nowhere to store its
-        // mapping and dict operations recurse through the missing backing.
+        // Python class requests an instance __dict__.  Reserve a layout slot
+        // for it rather than an ordinary mapdict attribute.  Otherwise a
+        // slotted dict subclass (PyPy's defaultdict shape) has nowhere to
+        // store its mapping and dict operations recurse through the missing
+        // backing.
         let dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
         let is_dict_subclass = !dict_type.is_null()
             && !std::ptr::eq(w_type, dict_type)
@@ -5644,24 +5644,17 @@ pub unsafe fn create_all_slots(
             if (*ancestor_layout)
                 .newslotnames
                 .iter()
-                .any(|name| name == "__dict_data__")
+                .any(|name| name == crate::type_methods::DICT_DATA_SLOT)
             {
                 inherited_dict_data = true;
                 break;
             }
             ancestor_layout = (*ancestor_layout).base_layout;
         }
-        if is_dict_subclass
-            && !inherited_dict_data
-            && !newslotnames.iter().any(|name| name == "__dict_data__")
-        {
-            let slot_index = base_nslots + newslotnames.len() as u32;
-            if crate::type_dict_has_storage(w_type) {
-                let member =
-                    pyre_object::w_member_new(slot_index, "__dict_data__".to_string(), w_type);
-                crate::type_dict_store(w_type, "__dict_data__", member);
-            }
-            newslotnames.push("__dict_data__".to_string());
+        if is_dict_subclass && !inherited_dict_data {
+            // No Member is stored for this: it is interpreter storage, not an
+            // attribute the subclass exposes.
+            newslotnames.push(crate::type_methods::DICT_DATA_SLOT.to_string());
         }
 
         // `W_WeakrefBase`/`W_Weakref` keep `w_obj_weak`, `w_callable` and

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -2960,7 +2960,7 @@ fn write_traceback_chain_from_tb<W: Write>(
                 let code = unsafe { &*code_obj };
                 let location = usize::try_from(lasti)
                     .ok()
-                    .and_then(|index| code.locations.get(index))
+                    .and_then(|index| crate::pycode::code_locations(code).get(index))
                     .map(|(start, end)| {
                         (
                             start.line.get(),

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2523,7 +2523,17 @@ impl NamespaceOpcodeHandler for PyFrame {
                 // shortcut exists for. `finditem_str` keeps a dict subclass on
                 // the generic path, where a `__getitem__` or `__missing__`
                 // override still runs.
-                if let Some(value) = crate::baseobjspace::finditem_str(w_locals, name)? {
+                // `pyopcode.py:965 w_varname = self.getname_w(nameindex)`:
+                // the generic arm names its key through `co_names_w`, so a
+                // namespace that cannot use the borrowed-key shortcut — a
+                // `dict` subclass, a non-dict mapping — wraps no key of its own
+                // per execution either.
+                if let Some(value) = crate::baseobjspace::finditem_str_named(
+                    w_locals,
+                    name,
+                    self.pycode as PyObjectRef,
+                    nameindex,
+                )? {
                     return Ok(value);
                 }
                 // pyopcode.py:972 — a missing locals entry falls through to
@@ -2538,6 +2548,10 @@ impl NamespaceOpcodeHandler for PyFrame {
     /// pyopcode.py:855-859 STORE_NAME —
     /// `space.setitem_str(self.getorcreatedebug().w_locals, varname, w_value)`.
     ///
+    /// `nameindex` addresses the `co_names_w` slot naming the key on the
+    /// non-dict-mapping arm below; callers holding no index pass
+    /// [`crate::pyopcode::NO_NAMEINDEX`].
+    ///
     /// Writes straight to `w_locals` (the class namespace, or — at module
     /// scope — the globals dict). It must NOT route through `getdictscope`:
     /// that runs `fast2locals`, which would erase a module frame's
@@ -2546,24 +2560,16 @@ impl NamespaceOpcodeHandler for PyFrame {
     fn store_name_value(
         &mut self,
         name: &str,
-        _nameindex: usize,
+        nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
         let w_locals = self.get_or_create_w_locals();
-        // pyopcode.py:855-859 `space.setitem_str(w_locals, varname, w_value)`:
-        // a plain dict stores by str key through its strategy without
-        // materializing a throwaway `w_str` (an overwrite reuses the stored
-        // key; only a new name allocates one). This is the raw mapping store,
-        // not `__setitem__`, exactly as the object-keyed `setitem` resolves a
-        // dict below. A non-dict mapping (`exec(src, g, mapping)`) keeps the
-        // object-keyed path.
-        if unsafe { pyre_object::is_dict(w_locals) } {
-            unsafe {
-                pyre_object::dictmultiobject::w_dict_setitem_str(w_locals, name, value);
-            }
+        if store_name_into_dict(w_locals, name, value) {
             return Ok(());
         }
-        let key = unsafe { pyre_object::w_str_new(name) };
+        let key = unsafe {
+            crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
+        };
         crate::baseobjspace::setitem(w_locals, key, value)?;
         Ok(())
     }
@@ -2571,28 +2577,21 @@ impl NamespaceOpcodeHandler for PyFrame {
     /// pypy/interpreter/pyopcode.py:567 STORE_GLOBAL — bypasses w_locals
     /// and writes directly into w_globals so `exec("global x; x = 1", g, l)`
     /// lands `x` in `g` even when `l != g`.
+    ///
+    /// `nameindex` names the key through `co_names_w` on the dict-subclass arm;
+    /// callers holding no index pass [`crate::pyopcode::NO_NAMEINDEX`].
     fn store_global_value(
         &mut self,
         name: &str,
-        _nameindex: usize,
+        nameindex: usize,
         value: Self::Value,
     ) -> Result<(), PyError> {
         let w_globals = self.get_w_globals();
-        if !w_globals.is_null() {
-            // A real W_DictObject / W_ModuleDictObject can use the borrowed
-            // string strategy path.  Dict subclasses are ordinary instance
-            // objects in pyre, however, and must retain their mapping object
-            // identity just as PyPy's `space.setitem_str(w_globals, ...)`
-            // does.  Casting such an instance to W_DictObject corrupts the
-            // layout and also skips an overridden `__setitem__`.
-            if unsafe { pyre_object::is_dict(w_globals) } {
-                unsafe {
-                    pyre_object::dictmultiobject::w_dict_setitem_str(w_globals, name, value);
-                }
-            } else {
-                let key = unsafe { pyre_object::w_str_new(name) };
-                crate::baseobjspace::setitem(w_globals, key, value)?;
-            }
+        if !w_globals.is_null() && !store_name_into_dict(w_globals, name, value) {
+            let key = unsafe {
+                crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
+            };
+            crate::baseobjspace::setitem(w_globals, key, value)?;
         }
         Ok(())
     }
@@ -2613,7 +2612,12 @@ impl NamespaceOpcodeHandler for PyFrame {
         // instead of being swallowed as a miss.
         let w_globals = self.get_w_globals();
         if !w_globals.is_null()
-            && let Some(value) = crate::baseobjspace::finditem_str(w_globals, name)?
+            && let Some(value) = crate::baseobjspace::finditem_str_named(
+                w_globals,
+                name,
+                self.pycode as PyObjectRef,
+                nameindex,
+            )?
         {
             return Ok(value);
         }
@@ -2753,6 +2757,68 @@ pub unsafe fn load_global_via_cache_extern(
         Ok(v) => v,
         Err(_) => None,
     }
+}
+
+/// `pyopcode.py:855-859 space.setitem_str(w_ns, varname, w_value)` on a real
+/// `W_DictObject` / `W_ModuleDictObject`: stores by borrowed `&str` through the
+/// strategy without materializing a throwaway `w_str` (an overwrite reuses the
+/// stored key; only a new name allocates one).  This is the raw mapping store,
+/// not `__setitem__`, exactly as the object-keyed `setitem` resolves a dict.
+///
+/// Answers `false` when `w_ns` is not a dict, leaving the caller on the
+/// object-keyed path: a dict subclass is an ordinary instance in pyre and must
+/// keep its mapping identity and any `__setitem__` override, and a non-dict
+/// mapping (`exec(src, g, mapping)`) has no strategy to store into.
+fn store_name_into_dict(w_ns: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+    if !unsafe { pyre_object::is_dict(w_ns) } {
+        return false;
+    }
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str(w_ns, name, value);
+    }
+    true
+}
+
+/// STORE_NAME for a caller holding the wrapped name rather than a `co_names_w`
+/// index — the JIT's `bh_store_name_fn`, whose `w_name` operand is the trace's
+/// own `box_str_constant`.
+///
+/// Naming the key from that constant is what keeps the mapping arm from minting
+/// an immortal `w_str` per execution, the job `co_names_w` (`pycode.py:127-129`)
+/// does for the interpreter; the residual carries no index to reach a slot with.
+///
+/// # Safety
+/// `w_name` must point to a valid `str` object.
+pub unsafe fn store_name_value_w(
+    frame: &mut PyFrame,
+    w_name: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<(), PyError> {
+    let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+    let w_locals = frame.get_or_create_w_locals();
+    if store_name_into_dict(w_locals, name, value) {
+        return Ok(());
+    }
+    crate::baseobjspace::setitem(w_locals, w_name, value)?;
+    Ok(())
+}
+
+/// STORE_GLOBAL counterpart of [`store_name_value_w`], for the JIT's
+/// `bh_store_global_fn`.  `pyopcode.py:567` writes straight into `w_globals`.
+///
+/// # Safety
+/// `w_name` must point to a valid `str` object.
+pub unsafe fn store_global_value_w(
+    frame: &mut PyFrame,
+    w_name: PyObjectRef,
+    value: PyObjectRef,
+) -> Result<(), PyError> {
+    let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+    let w_globals = frame.get_w_globals();
+    if !w_globals.is_null() && !store_name_into_dict(w_globals, name, value) {
+        crate::baseobjspace::setitem(w_globals, w_name, value)?;
+    }
+    Ok(())
 }
 
 /// `celldict.py:279-329 _LOAD_GLOBAL_cached`.  When `pycode` is
@@ -3640,7 +3706,7 @@ impl OpcodeStepExecutor for PyFrame {
         // The pinned RustPython compiler emits STORE_DEREF for that assignment;
         // normalize its semantics at the opcode boundary.
         if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
-            return self.store_name_value("__class__", 0, value);
+            return self.store_name_value("__class__", crate::pyopcode::NO_NAMEINDEX, value);
         }
         let slot = locals_w!(self)[idx];
         if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
@@ -4216,7 +4282,9 @@ impl OpcodeStepExecutor for PyFrame {
     // CPython 3.13: LOAD_FROM_DICT_OR_GLOBALS — try TOS dict first, then globals
     fn load_from_dict_or_globals(&mut self, name: &str, nameindex: usize) -> Result<(), PyError> {
         let mapping = self.pop();
-        let key = pyre_object::w_str_new(name);
+        let key = unsafe {
+            crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
+        };
         let anchor = FrameAnchor::new(self);
         match crate::baseobjspace::getitem(mapping, key) {
             Ok(value) => {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2564,7 +2564,8 @@ impl NamespaceOpcodeHandler for PyFrame {
         value: Self::Value,
     ) -> Result<(), PyError> {
         let w_locals = self.get_or_create_w_locals();
-        if store_name_into_dict(w_locals, name, value) {
+        let hash = crate::baseobjspace::named_key_hash(name, self.pycode as PyObjectRef, nameindex);
+        if store_name_into_dict(w_locals, name, hash, value) {
             return Ok(());
         }
         let key = unsafe {
@@ -2587,7 +2588,8 @@ impl NamespaceOpcodeHandler for PyFrame {
         value: Self::Value,
     ) -> Result<(), PyError> {
         let w_globals = self.get_w_globals();
-        if !w_globals.is_null() && !store_name_into_dict(w_globals, name, value) {
+        let hash = crate::baseobjspace::named_key_hash(name, self.pycode as PyObjectRef, nameindex);
+        if !w_globals.is_null() && !store_name_into_dict(w_globals, name, hash, value) {
             let key = unsafe {
                 crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
             };
@@ -2769,12 +2771,18 @@ pub unsafe fn load_global_via_cache_extern(
 /// object-keyed path: a dict subclass is an ordinary instance in pyre and must
 /// keep its mapping identity and any `__setitem__` override, and a non-dict
 /// mapping (`exec(src, g, mapping)`) has no strategy to store into.
-fn store_name_into_dict(w_ns: PyObjectRef, name: &str, value: PyObjectRef) -> bool {
+///
+/// `hash` is `name`'s digest when the caller holds it — the memo
+/// `rstr.py:402-412 ll_strhash` keeps in the shared `co_names_w` string
+/// (`crate::baseobjspace::named_key_hash`), so a stored name is hashed once per
+/// string rather than once per opcode.  Zero leaves the strategy to hash the
+/// borrowed bytes.
+fn store_name_into_dict(w_ns: PyObjectRef, name: &str, hash: i64, value: PyObjectRef) -> bool {
     if !unsafe { pyre_object::is_dict(w_ns) } {
         return false;
     }
     unsafe {
-        pyre_object::dictmultiobject::w_dict_setitem_str(w_ns, name, value);
+        pyre_object::dictmultiobject::w_dict_setitem_str_hashed(w_ns, name, hash, value);
     }
     true
 }
@@ -2795,8 +2803,12 @@ pub unsafe fn store_name_value_w(
     value: PyObjectRef,
 ) -> Result<(), PyError> {
     let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+    // The trace's own `box_str_constant` names the key, so it is the same
+    // string object on every execution — `rstr.py:402-412 ll_strhash`'s memo
+    // makes it hashed once rather than once per store.
+    let hash = unsafe { pyre_object::unicodeobject::w_str_hash_memoized(w_name) };
     let w_locals = frame.get_or_create_w_locals();
-    if store_name_into_dict(w_locals, name, value) {
+    if store_name_into_dict(w_locals, name, hash, value) {
         return Ok(());
     }
     crate::baseobjspace::setitem(w_locals, w_name, value)?;
@@ -2814,8 +2826,9 @@ pub unsafe fn store_global_value_w(
     value: PyObjectRef,
 ) -> Result<(), PyError> {
     let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+    let hash = unsafe { pyre_object::unicodeobject::w_str_hash_memoized(w_name) };
     let w_globals = frame.get_w_globals();
-    if !w_globals.is_null() && !store_name_into_dict(w_globals, name, value) {
+    if !w_globals.is_null() && !store_name_into_dict(w_globals, name, hash, value) {
         crate::baseobjspace::setitem(w_globals, w_name, value)?;
     }
     Ok(())

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2513,16 +2513,21 @@ impl NamespaceOpcodeHandler for PyFrame {
             // the globals dict borrow-based via `getitem_str` + the cell cache).
             let w_globals = self.get_w_globals();
             if !std::ptr::eq(w_locals, w_globals) {
-                let key = unsafe { pyre_object::w_str_new(name) };
-                match crate::baseobjspace::getitem(w_locals, key) {
-                    Ok(value) => return Ok(value),
-                    Err(err) if matches!(err.kind, PyErrorKind::KeyError) => {
-                        // pyopcode.py:LOAD_NAME `if not w_value: w_value =
-                        // ec.space.finditem_str(self.w_globals, name)` —
-                        // a missing locals entry falls through to globals.
-                    }
-                    Err(err) => return Err(err),
+                // pyopcode.py:967-968 `w_value = space.finditem_str(
+                // self.getorcreatedebug().w_locals, varname)`. The probe is
+                // `finditem_str`, not `getitem`: an exact dict answers from its
+                // strategy with the borrowed key, so neither the wrapped key nor
+                // a KeyError is built. A class body reads every one of its names
+                // through here, and the names it does not bind itself — a module
+                // global, a builtin — miss on every pass, which is the miss that
+                // shortcut exists for. `finditem_str` keeps a dict subclass on
+                // the generic path, where a `__getitem__` or `__missing__`
+                // override still runs.
+                if let Some(value) = crate::baseobjspace::finditem_str(w_locals, name)? {
+                    return Ok(value);
                 }
+                // pyopcode.py:972 — a missing locals entry falls through to
+                // `LOAD_GLOBAL_cached`.
             }
             return self.load_global_value(name, nameindex);
         }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2815,6 +2815,24 @@ pub unsafe fn store_name_value_w(
     Ok(())
 }
 
+/// DELETE_NAME counterpart of [`store_name_value_w`], for the JIT's
+/// `bh_delete_name_fn`.  The trace already holds the key object, so it deletes
+/// through that rather than naming the key again.
+///
+/// # Safety
+/// `w_name` must point to a valid `str` object.
+pub unsafe fn delete_name_w(frame: &mut PyFrame, w_name: PyObjectRef) -> Result<(), PyError> {
+    let w_locals = frame.get_or_create_w_locals();
+    crate::baseobjspace::delitem(w_locals, w_name).map_err(|err| {
+        if matches!(err.kind, PyErrorKind::KeyError) {
+            let name = unsafe { pyre_object::unicodeobject::w_str_get_value(w_name) };
+            PyError::name_error_with_name(format!("name '{name}' is not defined"), name)
+        } else {
+            err
+        }
+    })
+}
+
 /// STORE_GLOBAL counterpart of [`store_name_value_w`], for the JIT's
 /// `bh_store_global_fn`.  `pyopcode.py:567` writes straight into `w_globals`.
 ///
@@ -3764,7 +3782,7 @@ impl OpcodeStepExecutor for PyFrame {
 
     fn delete_deref(&mut self, idx: usize) -> Result<(), PyError> {
         if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
-            return self.delete_name("__class__");
+            return self.delete_name("__class__", crate::pyopcode::NO_NAMEINDEX);
         }
         // `pyopcode.py:580 DELETE_DEREF`: fetch the cell, raise if empty, then
         // `cell.set(None)` — clear the cell *contents* (PY_NULL is the empty
@@ -4317,7 +4335,10 @@ impl OpcodeStepExecutor for PyFrame {
     // back to the cell / free variable at `idx`.
     fn load_from_dict_or_deref(&mut self, idx: usize, name: &str) -> Result<(), PyError> {
         let mapping = self.pop();
-        let key = pyre_object::w_str_new(name);
+        // A localsplus name has no `co_names_w` slot to realize into, so nothing
+        // bounds how often this runs; interning is what keeps an immortal
+        // string per execution from being an immortal string per execution.
+        let key = pyre_object::unicodeobject::intern_str_value(name);
         let anchor = FrameAnchor::new(self);
         match crate::baseobjspace::getitem(mapping, key) {
             Ok(value) => {
@@ -4542,12 +4563,14 @@ impl OpcodeStepExecutor for PyFrame {
 
     // ── delete_name ──
     // pypy/interpreter/pyopcode.py:821 DELETE_NAME — delete from w_locals; KeyError → NameError.
-    fn delete_name(&mut self, name: &str) -> Result<(), PyError> {
+    fn delete_name(&mut self, name: &str, nameindex: usize) -> Result<(), PyError> {
         // `space.delitem(w_locals, w_name)`; at module scope `w_locals` is the
         // globals dict, so a module DELETE_NAME routes through the canonical
         // W_DictObject too.  KeyError → NameError.
         let w_locals = self.get_or_create_w_locals();
-        let key = unsafe { pyre_object::w_str_new(name) };
+        let key = unsafe {
+            crate::pycode::w_code_getname_w_or_new(self.pycode as PyObjectRef, nameindex, name)
+        };
         crate::baseobjspace::delitem(w_locals, key).map_err(|err| {
             if matches!(err.kind, PyErrorKind::KeyError) {
                 PyError::name_error_with_name(format!("name '{name}' is not defined"), name)

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1510,7 +1510,7 @@ pub(super) fn encode_value_into(
     if tc == "z" && unsafe { pyre_object::is_bytes(value) } {
         let raw = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
         let copy =
-            pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::null_terminated_bytes(raw));
+            pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::clone_as_null_terminated(raw));
         // Retain the copy before reading its address, so a GC triggered while
         // inserting the keepalive cannot leave the stored pointer stale.  Until
         // `keep_alive` links it into the root, only this frame holds the copy and
@@ -1530,7 +1530,7 @@ pub(super) fn encode_value_into(
     if tc == "Z" && unsafe { pyre_object::is_str(value) } {
         let raw = unsafe { pyre_object::w_str_get_wtf8(value) };
         let copy =
-            pyre_object::w_bytearray_from_bytes(&host_ctypes::wchar_null_terminated_bytes(raw));
+            pyre_object::w_bytearray_from_bytes(&host_ctypes::clone_wchar_null_terminated(raw));
         let _roots = pyre_object::gc_roots::push_roots();
         pyre_object::gc_roots::pin_root(copy);
         keep_ref(dest, key, value);

--- a/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/cdata.rs
@@ -1509,8 +1509,9 @@ pub(super) fn encode_value_into(
 ) -> Result<Vec<u8>, crate::PyError> {
     if tc == "z" && unsafe { pyre_object::is_bytes(value) } {
         let raw = unsafe { pyre_object::bytesobject::w_bytes_data(value) };
-        let copy =
-            pyre_object::bytesobject::w_bytes_from_bytes(&host_ctypes::clone_as_null_terminated(raw));
+        let copy = pyre_object::bytesobject::w_bytes_from_bytes(
+            &host_ctypes::clone_as_null_terminated(raw),
+        );
         // Retain the copy before reading its address, so a GC triggered while
         // inserting the keepalive cannot leave the stored pointer stale.  Until
         // `keep_alive` links it into the root, only this frame holds the copy and

--- a/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
+++ b/pyre/pyre-interpreter/src/module/_ctypes/funcptr.rs
@@ -1907,7 +1907,7 @@ pub(super) fn resolve_pointer_addr(
 /// address of the copy.
 fn bytes_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
     let raw = unsafe { pyre_object::bytesobject::w_bytes_data(arg) };
-    keepalive.push(host_ctypes::null_terminated_bytes(raw));
+    keepalive.push(host_ctypes::clone_as_null_terminated(raw));
     // The inner Vec's heap buffer is stable even if `keepalive` reallocates.
     keepalive.last().unwrap().as_ptr() as usize
 }
@@ -1920,6 +1920,6 @@ fn bytes_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
 /// `Z` arm) spells the copy the same way.
 fn wstr_pointer_addr(arg: PyObjectRef, keepalive: &mut Vec<Vec<u8>>) -> usize {
     let raw = unsafe { pyre_object::w_str_get_wtf8(arg) };
-    keepalive.push(host_ctypes::wchar_null_terminated_bytes(raw));
+    keepalive.push(host_ctypes::clone_wchar_null_terminated(raw));
     keepalive.last().unwrap().as_ptr() as usize
 }

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -687,7 +687,7 @@ impl wire::MarshalBag for PyreMarshalBag {
     }
 
     fn make_code(&self, code: CodeObject<ConstantData>) -> Result<Rooted, wire::MarshalError> {
-        Ok(Rooted::new(crate::pycode::box_code_constant(&code)))
+        Ok(Rooted::new(crate::pycode::box_code_object(code)))
     }
 
     fn make_stop_iter(&self) -> Result<Rooted, wire::MarshalError> {
@@ -833,8 +833,8 @@ impl wire::MarshalBag for PyreMarshalBag {
         code: CodeObject<ConstantData>,
         constants: Vec<Rooted>,
     ) -> Result<Rooted, wire::MarshalError> {
-        let code = Rooted::new(crate::pycode::box_code_constant(&code));
-        // `box_code_constant` allocates, so read each constant out of its
+        let code = Rooted::new(crate::pycode::box_code_object(code));
+        // `box_code_object` allocates, so read each constant out of its
         // shadow-stack slot only now.  Only the slots the compiler
         // representation cannot reproduce are stored; the rest realize
         // lazily like a fresh compile's.

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -670,9 +670,9 @@ impl wire::MarshalBag for PyreMarshalBag {
     }
 
     fn make_tuple_placeholder(&self, len: usize) -> Result<Option<Rooted>, wire::MarshalError> {
-        Ok(Some(Rooted::new(
-            tupleobject::w_tuple_new_array_backed(vec![PY_NULL; len]),
-        )))
+        Ok(Some(Rooted::new(tupleobject::w_tuple_new_array_backed(
+            vec![PY_NULL; len],
+        ))))
     }
 
     fn set_tuple_item(

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -669,11 +669,10 @@ impl wire::MarshalBag for PyreMarshalBag {
         Rooted::new(w_tuple_new(elements.map(Rooted::get).collect()))
     }
 
-    fn make_tuple_placeholder(&self, len: usize) -> Option<Rooted> {
-        Some(Rooted::new(tupleobject::w_tuple_new_array_backed(vec![
-            PY_NULL;
-            len
-        ])))
+    fn make_tuple_placeholder(&self, len: usize) -> Result<Option<Rooted>, wire::MarshalError> {
+        Ok(Some(Rooted::new(
+            tupleobject::w_tuple_new_array_backed(vec![PY_NULL; len]),
+        )))
     }
 
     fn set_tuple_item(
@@ -687,8 +686,8 @@ impl wire::MarshalBag for PyreMarshalBag {
             .ok_or(wire::MarshalError::BadType)
     }
 
-    fn make_code(&self, code: CodeObject<ConstantData>) -> Rooted {
-        Rooted::new(crate::pycode::box_code_constant(&code))
+    fn make_code(&self, code: CodeObject<ConstantData>) -> Result<Rooted, wire::MarshalError> {
+        Ok(Rooted::new(crate::pycode::box_code_constant(&code)))
     }
 
     fn make_stop_iter(&self) -> Result<Rooted, wire::MarshalError> {
@@ -704,11 +703,11 @@ impl wire::MarshalBag for PyreMarshalBag {
         Ok(Rooted::new(w_list_new(elements.map(Rooted::get).collect())))
     }
 
-    fn make_list_placeholder(&self, len: usize) -> Option<Rooted> {
-        Some(Rooted::new(listobject::w_list_new_object(vec![
+    fn make_list_placeholder(&self, len: usize) -> Result<Option<Rooted>, wire::MarshalError> {
+        Ok(Some(Rooted::new(listobject::w_list_new_object(vec![
             PY_NULL;
             len
-        ])))
+        ]))))
     }
 
     fn set_list_item(
@@ -833,7 +832,7 @@ impl wire::MarshalBag for PyreMarshalBag {
         &self,
         code: CodeObject<ConstantData>,
         constants: Vec<Rooted>,
-    ) -> Rooted {
+    ) -> Result<Rooted, wire::MarshalError> {
         let code = Rooted::new(crate::pycode::box_code_constant(&code));
         // `box_code_constant` allocates, so read each constant out of its
         // shadow-stack slot only now.  Only the slots the compiler
@@ -841,7 +840,7 @@ impl wire::MarshalBag for PyreMarshalBag {
         // lazily like a fresh compile's.
         let constants: Vec<_> = constants.into_iter().map(Rooted::get).collect();
         unsafe { crate::pycode::w_code_fill_wrapped_consts(code.get(), &constants) };
-        code
+        Ok(code)
     }
 
     // `deserialize_code_value_inner` reads a code object's fields as bag

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -821,7 +821,6 @@ fn split_root(path: &rustpython_wtf8::Wtf8) -> (&rustpython_wtf8::Wtf8, &rustpyt
 mod win_nt {
     use pyre_object::PyObjectRef;
     use rustpython_host_env::nt as host_nt;
-    use std::path::Path;
 
     /// Wrap a host-layer `io::Error` as an OSError carrying the offending path.
     /// These calls are Win32 APIs, so the code they report is a Win32 error and
@@ -857,8 +856,7 @@ mod win_nt {
     fn arg_path(
         args: &[PyObjectRef],
         func: &str,
-    ) -> Result<(std::ffi::OsString, bool, crate::gateway::FsEncodedPath), crate::PyError> {
-        use std::os::windows::ffi::OsStringExt;
+    ) -> Result<(widestring::WideCString, bool, crate::gateway::FsEncodedPath), crate::PyError> {
         let Some(&arg) = args.first() else {
             return Err(crate::PyError::type_error(format!(
                 "{func}() missing required argument 'path'"
@@ -875,7 +873,9 @@ mod win_nt {
         let wide: Vec<u16> = crate::gateway::fsdecode_filename_wtf8(&resolved.as_bytes)
             .encode_wide()
             .collect();
-        Ok((std::ffi::OsString::from_wide(&wide), as_bytes, resolved))
+        let path = widestring::WideCString::from_vec(wide)
+            .map_err(|_| crate::PyError::value_error("embedded null character"))?;
+        Ok((path, as_bytes, resolved))
     }
 
     fn wrap_path(s: &std::ffi::OsStr, as_bytes: bool) -> PyObjectRef {
@@ -893,7 +893,7 @@ mod win_nt {
     /// requiring the path to exist.
     pub fn _getfullpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, as_bytes, resolved) = arg_path(args, "_getfullpathname")?;
-        match host_nt::getfullpathname(Path::new(&path)) {
+        match host_nt::getfullpathname(&path) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
@@ -903,10 +903,7 @@ mod win_nt {
     /// backup-semantics handle so directories open too.
     pub fn _getfinalpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, as_bytes, resolved) = arg_path(args, "_getfinalpathname")?;
-        if path.as_encoded_bytes().contains(&0) {
-            return Err(crate::PyError::value_error("embedded null character"));
-        }
-        match host_nt::getfinalpathname(Path::new(&path)) {
+        match host_nt::getfinalpathname(&path) {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
@@ -921,10 +918,7 @@ mod win_nt {
     /// parent off itself.
     pub fn _findfirstfile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, as_bytes, resolved) = arg_path(args, "_findfirstfile")?;
-        if path.as_encoded_bytes().contains(&0) {
-            return Err(crate::PyError::value_error("embedded null character"));
-        }
-        match host_nt::find_first_file_name(Path::new(&path)) {
+        match host_nt::find_first_file_name(&path) {
             Ok(name) => Ok(wrap_path(&name, as_bytes)),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
@@ -960,10 +954,7 @@ mod win_nt {
     /// (ERROR_DIRECTORY).
     pub fn _getdiskusage(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, _, resolved) = arg_path(args, "_getdiskusage")?;
-        if path.as_encoded_bytes().contains(&0) {
-            return Err(crate::PyError::value_error("embedded null character"));
-        }
-        match host_nt::getdiskusage(Path::new(&path)) {
+        match host_nt::getdiskusage(&path) {
             Ok((total, free)) => Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(total as i64),
                 pyre_object::w_int_new(free as i64),
@@ -1007,14 +998,12 @@ mod win_nt {
     /// DLL_DIRECTORY_COOKIE pointer is returned as an int instead. host_env has
     /// no AddDllDirectory wrapper, so call windows-sys directly.
     pub fn _add_dll_directory(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        use std::os::windows::ffi::OsStrExt;
         use windows_sys::Win32::System::LibraryLoader::AddDllDirectory;
         let (path, _, resolved) = arg_path(args, "_add_dll_directory")?;
-        // `encode_wide` re-emits the code units `arg_path` decoded the path
-        // into; going back through a `str` would have no spelling for a lone
-        // surrogate and would address a different directory.
-        let wide: Vec<u16> = path.encode_wide().chain(std::iter::once(0)).collect();
-        let cookie = unsafe { AddDllDirectory(wide.as_ptr()) };
+        // `arg_path` keeps the code units it decoded the path into; going back
+        // through a `str` would have no spelling for a lone surrogate and would
+        // address a different directory.
+        let cookie = unsafe { AddDllDirectory(path.as_ptr()) };
         if cookie.is_null() {
             return Err(io_err_with_filename(
                 &std::io::Error::last_os_error(),
@@ -2907,7 +2896,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // `DeleteFileW`, except on a directory symlink, which `RemoveDirectoryW`
         // unlinks without following (`os_unlink_impl`).
         #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-        rustpython_host_env::nt::remove(path_from_bytes(&path.as_bytes).as_ref())
+        rustpython_host_env::nt::remove(&wide_path(&path.as_bytes)?)
             .map_err(|e| fs_err_with_filename(e, path.w_path()))?;
         #[cfg(all(not(all(windows, feature = "host_env")), not(feature = "sandbox")))]
         {
@@ -4397,8 +4386,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// `entry.inode()` and `os.stat(entry.path).st_ino` disagreeing.
     #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
     fn win_stat_fields(path: &[u8], follow_symlinks: bool) -> std::io::Result<StatFields> {
-        let os_path = os_str_from_bytes(path);
-        rustpython_host_env::nt::win32_xstat(&os_path, follow_symlinks)
+        let wide = widestring::WideCString::from_os_str(&*os_str_from_bytes(path)).map_err(|_| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "embedded null character in path",
+            )
+        })?;
+        rustpython_host_env::nt::win32_xstat(&wide, follow_symlinks)
             .map(|st| stat_fields_from_statstruct(&st))
     }
 
@@ -10632,14 +10626,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     Some(w) => crate::baseobjspace::is_true(w)?,
                     None => true,
                 };
+                let wide = wide_path(&path.as_bytes)?;
                 let result = if follow_symlinks {
-                    host_nt::chmod_follow(&wide_path(&path.as_bytes)?, mode, S_IWRITE)
+                    host_nt::chmod_follow(&wide, mode, S_IWRITE)
                 } else {
                     // `SetFileAttributesW` on the name itself, which is what
                     // "modify the link rather than its target" means where the
                     // mode is one attribute bit.
-                    let name = os_str_from_bytes(&path.as_bytes);
-                    host_nt::win32_lchmod(&name, mode, S_IWRITE)
+                    host_nt::win32_lchmod(&wide, mode, S_IWRITE)
                 };
                 result.map_err(|e| fs_err_with_filename(e, path.w_path()))?;
                 Ok(pyre_object::w_none())
@@ -11097,9 +11091,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let volume = crate::gateway::fsencode_path_w(args[0])?;
-                    name_list(host_nt::listmounts(
-                        path_from_bytes(&volume.as_bytes).as_ref(),
-                    ))
+                    name_list(host_nt::listmounts(&wide_path(&volume.as_bytes)?))
                 },
                 1,
             ),

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -82,7 +82,6 @@ mod imp {
     use majit_rlib::rbigint::RBigInt as BigInt;
     use pyre_object::*;
     use rustpython_host_env::winreg::{self as host_reg, HKEY};
-    use std::ffi::OsStr;
     use widestring::WideCString;
 
     /// A raw handle/pointer value → a Python int (`PyLong_FromVoidPtr`).  The
@@ -475,7 +474,8 @@ mod imp {
         use rustpython_host_env::winreg::QueryStringError;
         let key = key_arg(args, 0)?;
         let sub_key = opt_str(args, 1)?;
-        match host_reg::query_default_value(key, sub_key.as_deref().map(OsStr::new)) {
+        let wide_sub = sub_key.as_deref().map(WideCString::from_str_truncate);
+        match host_reg::query_default_value(key, wide_sub.as_deref()) {
             Ok(value) => Ok(w_str_new(&value)),
             Err(QueryStringError::Code(code)) => Err(win_err(code)),
             Err(QueryStringError::Utf16(_)) => Err(crate::PyError::value_error(
@@ -487,7 +487,7 @@ mod imp {
     fn query_value_ex(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let key = key_arg(args, 0)?;
         let name = opt_str(args, 1)?.unwrap_or_default();
-        match host_reg::query_value_bytes(key, OsStr::new(&name)) {
+        match host_reg::query_value_bytes(key, &WideCString::from_str_truncate(&name)) {
             Ok((data, typ)) => Ok(w_tuple_new(vec![reg2py(&data, typ), w_int_new(typ as i64)])),
             Err(code) => Err(win_err(code)),
         }
@@ -595,9 +595,9 @@ mod imp {
         let value = req_str(args, 3)?;
         check(host_reg::set_default_value(
             key,
-            OsStr::new(&sub_key),
+            &WideCString::from_str_truncate(&sub_key),
             typ,
-            OsStr::new(&value),
+            &widestring::WideString::from_str(&value),
         ))
     }
 
@@ -653,7 +653,7 @@ mod imp {
     fn expand_environment_strings(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         use rustpython_host_env::winreg::ExpandEnvironmentStringsError;
         let input = req_str(args, 0)?;
-        match host_reg::expand_environment_strings(OsStr::new(&input)) {
+        match host_reg::expand_environment_strings(&WideCString::from_str_truncate(&input)) {
             Ok(value) => Ok(w_str_new(&value)),
             Err(ExpandEnvironmentStringsError::Os) => Err(win_err(
                 std::io::Error::last_os_error().raw_os_error().unwrap_or(0) as u32,

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -791,15 +791,9 @@ pub unsafe fn instance_node_getdictvalue_checked(
     ensure_mapdict_initialized(obj);
     let mut inst = mapdict_carrier(obj);
     let map = inst._get_mapdict_map();
-    let w = unsafe { node_read_checked(map, &inst, name, DICT) }?;
-    // mapdict.py:846-847 getdictvalue → read → _direct_read (592-598): lazily
-    // migrate to boxed storage when the read attribute is unboxed and its class
-    // has frozen unboxing.  A raise in `read` unwinds before the migration tail
-    // (846-847 → 58 → 312-313 returns None on the miss path, never reaching
-    // _direct_read), so migration is skipped whenever the read raised;
-    // propagating the read error here mirrors that — and `maybe_migrate_to_boxed`
-    // re-derives the None on the raising path, so it is a no-op there regardless.
-    unsafe { maybe_migrate_to_boxed(map, &mut inst, name, DICT) };
+    // mapdict.py:846-847 getdictvalue → read → _direct_read (592-598): the read
+    // and its lazy migrate-to-boxed tail, off one resolved node.
+    let w = unsafe { node_read_converting(map, &mut inst, name, DICT) }?;
     Ok(w)
 }
 
@@ -942,11 +936,10 @@ pub unsafe fn getslotvalue(obj: PyObjectRef, slotindex: u32) -> Option<PyObjectR
     let mut inst = mapdict_carrier(obj);
     let map = inst._get_mapdict_map();
     let attrkind = SLOTS_STARTING_FROM + slotindex as u16;
-    let w_res = unsafe { node_read(map, &inst, Wtf8::new("slot"), attrkind) };
     // read → _direct_read (mapdict.py:592-598) lazily migrates an unboxed
-    // attribute to boxed storage, as in `instance_node_getdictvalue`.
-    unsafe { maybe_migrate_to_boxed(map, &mut inst, Wtf8::new("slot"), attrkind) };
-    w_res
+    // attribute to boxed storage, as in `instance_node_getdictvalue`; both come
+    // off the one node `node_read_converting` resolves.
+    unsafe { node_read_converting(map, &mut inst, Wtf8::new("slot"), attrkind) }.unwrap_or(None)
 }
 
 /// mapdict.py:770-772 `MapdictSlotsSupport.setslotvalue` —
@@ -1291,10 +1284,12 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &Wtf8, attrkind: u16) -> Op
     let attr_hash = ((product ^ (product << SHIFT1)) >> SHIFT2) as usize;
 
     let mut cache = MAP_ATTR_CACHE.lock().unwrap();
-    if cache.attrs[attr_hash] == self_node
-        && cache.names[attr_hash].as_deref() == Some(name)
-        && cache.indexes[attr_hash] == attrkind
-    {
+    // mapdict.py:104 keeps the name by reference; pyre's slot owns its bytes,
+    // so a fill that lands on a bucket already naming this attribute keeps the
+    // buffer rather than reallocating it.  Which name a bucket holds is fixed
+    // by the hash, so this is the ordinary case for a re-filled bucket.
+    let name_matches = cache.names[attr_hash].as_deref() == Some(name);
+    if name_matches && cache.attrs[attr_hash] == self_node && cache.indexes[attr_hash] == attrkind {
         let cached = cache.cached_attrs[attr_hash];
         return if cached.is_null() { None } else { Some(cached) };
     }
@@ -1306,7 +1301,9 @@ pub unsafe fn find_map_attr(self_node: MapRef, name: &Wtf8, attrkind: u16) -> Op
     // `find_map_attr_chain` directly.
     if crate::baseobjspace::side_effects_ok() {
         cache.attrs[attr_hash] = self_node;
-        cache.names[attr_hash] = Some(name.to_owned());
+        if !name_matches {
+            cache.names[attr_hash] = Some(name.to_owned());
+        }
         cache.indexes[attr_hash] = attrkind;
         cache.cached_attrs[attr_hash] = attr.unwrap_or(std::ptr::null());
     }
@@ -1427,24 +1424,48 @@ unsafe fn mapdict_map_or_null(w_obj: PyObjectRef) -> MapRef {
 /// attribute), then for an unboxed attribute whose class has frozen unboxing
 /// (`terminator.allow_unboxing == False`) migrate the instance off unboxed
 /// storage so the class stops minting unboxed map variants. (Same migration
-/// condition as `maybe_migrate_to_boxed`, evaluated here on the already-resolved
-/// node rather than re-walking the chain.)
+/// condition as `attr_migrates_to_boxed`, on the already-resolved node.)
 ///
 /// # Safety
 /// `attr` must point to a live `PlainAttribute`; `obj` to its live carrier.
 unsafe fn direct_read<O: MapdictObject>(attr: MapRef, obj: &mut O) -> PyObjectRef {
     // mapdict.py:592/600-601 `_prim_direct_read`.
     let w_res = unsafe { plain_direct_read(attr, &*obj) };
+    if !unsafe { attr_migrates_to_boxed(attr) } {
+        return w_res;
+    }
+    // mapdict.py:594-596 `_convert_to_boxed(obj)`.  It rebuilds the carrier
+    // through `node_copy`, which allocates, and the value read above is named
+    // by nothing else — publish it and take it back from the slot.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let value_slot = pyre_object::gc_roots::pin_roots(&[w_res]);
+    unsafe { convert_to_boxed(obj) };
+    pyre_object::gc_roots::shadow_stack_get(value_slot)
+}
+
+/// mapdict.py:593-596 — the migration test of `_direct_read`, on an
+/// already-resolved node: an unboxed attribute whose class has stopped allowing
+/// unboxing migrates the whole instance off unboxed storage.
+///
+/// # Safety
+/// `attr` must point to a live `PlainAttribute`.
+unsafe fn attr_migrates_to_boxed(attr: MapRef) -> bool {
     let p = unsafe { (*attr).as_plain() };
-    if p.unboxed.is_some()
+    p.unboxed.is_some()
         && !unsafe { (*p.terminator).as_terminator() }
             .allow_unboxing
             .get()
-    {
-        // mapdict.py:594-596 `_convert_to_boxed(obj)`.
+}
+
+/// [`direct_read`]'s migration half alone, for a caller that has already taken
+/// the value through `plain_direct_read` off the same node.
+///
+/// # Safety
+/// `attr` must point to a live `PlainAttribute`; `obj` to its live carrier.
+unsafe fn migrate_to_boxed_if_frozen<O: MapdictObject>(attr: MapRef, obj: &mut O) {
+    if unsafe { attr_migrates_to_boxed(attr) } {
         unsafe { convert_to_boxed(obj) };
     }
-    w_res
 }
 
 /// mapdict.py:1461-1477 `_fill_cache`. Store the resolved `(map, attr,
@@ -3429,7 +3450,7 @@ unsafe fn value_has_unbox_type(typ: UnboxType, w_value: PyObjectRef) -> bool {
 /// `_pure_direct_read` variant is applied when the read is JIT-wired.
 /// `unerase_item` is identity. For an `UnboxedPlainAttribute`,
 /// mapdict.py:592-612 gives `_direct_read` the allow-unboxing conversion tail;
-/// pyre places that tail in `maybe_migrate_to_boxed`.
+/// pyre places that tail in `direct_read`.
 ///
 /// # Safety
 /// `attr` must point to a live `PlainAttribute` map node.
@@ -3448,8 +3469,8 @@ pub unsafe fn plain_direct_read<O: MapdictObject>(attr: MapRef, obj: &O) -> PyOb
             // read shared by node_read / copy_attr / reorder_and_add /
             // materialize. `_direct_read`'s lazy migrate-to-boxed side effect
             // (mapdict.py:592-598, when the class has frozen unboxing) lives at
-            // the getattr boundary in `maybe_migrate_to_boxed`, which `&mut`
-            // access permits there; here `&obj` stays pure.
+            // the getattr boundary in `direct_read`, which `&mut` access permits
+            // there; here `&obj` stays pure.
             w_res
         }
     }
@@ -3558,6 +3579,32 @@ pub unsafe fn node_read<O: MapdictObject>(
     unsafe { node_read_checked(self_node, obj, name, attrkind) }.unwrap_or(None)
 }
 
+/// [`node_read_checked`] plus `_direct_read`'s migration tail
+/// (mapdict.py:592-598), both taken off the node this resolves once — the read
+/// the getattr and slot boundaries owe.
+///
+/// Splitting them costs a second `find_map_attr` for the same
+/// `(map, name, attrkind)`, and `find_map_attr`'s cache probe holds a
+/// process-wide lock, so the re-lookup is not the free cache hit it reads as.
+///
+/// A raising terminator probe unwinds before the tail, which is also what
+/// upstream does (`:846-847` → `:58` → `:312-313` returns on the miss path and
+/// never reaches `_direct_read`).
+///
+/// # Safety
+/// `self_node` and its chain must point to live map nodes.
+pub unsafe fn node_read_converting<O: MapdictObject>(
+    self_node: MapRef,
+    obj: &mut O,
+    name: &Wtf8,
+    attrkind: u16,
+) -> Result<Option<PyObjectRef>, PyError> {
+    match unsafe { find_map_attr(self_node, name, attrkind) } {
+        Some(attr) => Ok(Some(unsafe { direct_read(attr, obj) })),
+        None => unsafe { terminator_read_checked((*self_node).terminator(), obj, name, attrkind) },
+    }
+}
+
 /// Fallible [`node_read`], for the callers that can propagate the raising
 /// `__eq__` a devolved terminator's dict probe may reach.
 ///
@@ -3574,47 +3621,9 @@ pub unsafe fn node_read_checked<O: MapdictObject>(
         // attr.ever_mutated` guard selects `_pure_direct_read`
         // (mapdict.py:60-65). The PlainAttribute variants have the same body;
         // UnboxedPlainAttribute._direct_read's conversion tail lives in
-        // `maybe_migrate_to_boxed`.
+        // `direct_read`.
         Some(attr) => Ok(Some(unsafe { plain_direct_read(attr, obj) })),
         None => unsafe { terminator_read_checked((*self_node).terminator(), obj, name, attrkind) },
-    }
-}
-
-/// mapdict.py:592-598 `UnboxedPlainAttribute._direct_read` migration tail.
-/// `node_read` is the shared pure value read (`_prim_direct_read` based, also
-/// used by `copy_attr`/`node_materialize_dict`/`node_set_terminator`); the
-/// getattr `read` path (`getdictvalue`, mapdict.py:846-847 → 55-66) additionally
-/// runs `_direct_read`, which lazily migrates `obj` to boxed storage once the
-/// read attribute is unboxed and its class has frozen unboxing
-/// (`terminator.allow_unboxing` False). A boxed attribute's `_direct_read` is
-/// `_prim_direct_read` (no migration), so this is a no-op for them. The
-/// `find_map_attr` re-lookup hits the per-VM transition cache.
-///
-/// # Safety
-/// `self_node`/its chain must point to live map nodes; `obj` to a live carrier.
-unsafe fn maybe_migrate_to_boxed<O: MapdictObject>(
-    self_node: MapRef,
-    obj: &mut O,
-    name: &Wtf8,
-    attrkind: u16,
-) {
-    let attr = match unsafe { find_map_attr(self_node, name, attrkind) } {
-        Some(a) => a,
-        None => return,
-    };
-    let p = unsafe { (*attr).as_plain() };
-    let migrate = match &p.unboxed {
-        Some(_) => match unsafe { (*p.terminator).as_terminator() }
-            .allow_unboxing
-            .get()
-        {
-            true => false,
-            false => true,
-        },
-        None => false,
-    };
-    if migrate {
-        unsafe { convert_to_boxed(obj) };
     }
 }
 
@@ -5180,7 +5189,7 @@ impl pyre_object::dictmultiobject::DictStrategy for MapDictStrategy {
         // converts the whole instance to boxed storage. `getdictvalue` pairs
         // the two the same way.
         let mut inst = mapdict_carrier(pyre_object::gc_roots::shadow_stack_get(obj_slot));
-        maybe_migrate_to_boxed(map, &mut inst, key, DICT);
+        migrate_to_boxed_if_frozen(curr, &mut inst);
         self.delitem(
             pyre_object::gc_roots::shadow_stack_get(dict_slot),
             pyre_object::gc_roots::shadow_stack_get(key_slot),
@@ -7137,7 +7146,8 @@ mod tests {
             (*term).as_terminator().set_allow_unboxing(false);
             // mapdict.py:592-598 — a read now lazily migrates obj to boxed storage.
             let m = obj._get_mapdict_map();
-            maybe_migrate_to_boxed(m, &mut obj, wn("x"), DICT);
+            let attr = find_map_attr(m, wn("x"), DICT).unwrap();
+            migrate_to_boxed_if_frozen(attr, &mut obj);
             // the rebuilt map's attribute is boxed; the value is preserved.
             assert!((*obj.map).as_plain().unboxed.is_none());
             let m = obj._get_mapdict_map();

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -280,6 +280,27 @@ pub struct PyCode {
     /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
     /// when `code_ptr` is null or unaligned (test fixtures, gateway builtins).
     pub co_consts_w: *mut Vec<std::sync::atomic::AtomicPtr<PyObject>>,
+    /// `pycode.py:127-129 self.co_names_w = [space.new_interned_str(aname) for
+    /// aname in names]` (`_immutable_fields_ co_names_w[*]`, pycode.py:100).
+    /// The realized name objects indexed by name index.  `getname_w(index)`
+    /// (`pyopcode.py:521-522`) returns `co_names_w[index]`, so every opcode
+    /// needing a wrapped name hands back the one object this code object owns
+    /// rather than minting a `W_UnicodeObject` per execution — the identity
+    /// argument of `w_qualname` below, applied per name index.
+    ///
+    /// PyPy interns the whole list in the constructor.  Pyre realizes slots
+    /// lazily at the same wrapped/unwrapped compiler boundary `co_consts_w`
+    /// uses, so a name that never executes costs nothing.
+    ///
+    /// Slots hold `w_str_new` results — `malloc_typed`-immortal, so a published
+    /// pointer is fixed and the table needs no walking: there is nothing to
+    /// forward and nothing whose liveness a trace could decide.  That is also
+    /// why a lost publish race can simply abandon its candidate.
+    ///
+    /// Owned via `Box::into_raw`, sized to `code.names.len()` at construction,
+    /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
+    /// when `code_ptr` is null or unaligned (test fixtures, gateway builtins).
+    pub co_names_w: *mut Vec<std::sync::atomic::AtomicPtr<PyObject>>,
     /// `pycode.py:127 self.co_qualname = qualname` realized as one shared
     /// wrapped object.
     ///
@@ -629,6 +650,19 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         });
         Box::into_raw(Box::new(v))
     };
+    // `pycode.py:127-129 self.co_names_w = [...]` — the realized-name table
+    // sized to the name count, with slots filled lazily by `w_code_getname_w`.
+    let co_names_w = if !code_ptr_aligned {
+        std::ptr::null_mut()
+    } else {
+        let code_ref = unsafe { &*(code_ptr as *const crate::CodeObject) };
+        let names_len = code_ref.names.len();
+        let mut v: Vec<std::sync::atomic::AtomicPtr<PyObject>> = Vec::with_capacity(names_len);
+        v.resize_with(names_len, || {
+            std::sync::atomic::AtomicPtr::new(std::ptr::null_mut())
+        });
+        Box::into_raw(Box::new(v))
+    };
     let npure_cellvars = if !code_ptr_aligned {
         u32::MAX
     } else {
@@ -658,6 +692,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         globals_caches,
         mapdict_caches,
         co_consts_w,
+        co_names_w,
         w_qualname: pyre_object::PY_NULL,
         w_name: pyre_object::PY_NULL,
     };
@@ -2012,6 +2047,80 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
     published
 }
 
+/// `pyopcode.py:521-522 getname_w(index) -> self.getcode().co_names_w[index]`
+/// — the one wrapped name this code object holds at `idx`.
+///
+/// Realized on first demand with `w_str_new`, whose result is
+/// `malloc_typed`-immortal: the published pointer is fixed, so a slot is never
+/// forwarded and a thread losing the publish race abandons its candidate rather
+/// than freeing it.
+///
+/// Returns `PY_NULL` when the enclosing code or the slot cannot be resolved
+/// (test fixtures and gateway builtins carry no name table); callers fall back
+/// to wrapping the key themselves.
+///
+/// # Safety
+/// `w_code_obj` must point to a valid `PyCode`.
+#[majit_macros::dont_look_inside]
+pub unsafe fn w_code_getname_w(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
+    if w_code_obj.is_null() {
+        return pyre_object::pyobject::PY_NULL;
+    }
+    let w_code = unsafe { &*(w_code_obj as *const PyCode) };
+    if w_code.co_names_w.is_null() {
+        return pyre_object::pyobject::PY_NULL;
+    }
+    let slot_table = unsafe { &*w_code.co_names_w };
+    let Some(slot) = slot_table.get(idx) else {
+        return pyre_object::pyobject::PY_NULL;
+    };
+    // PyPy's GIL serializes first access to its already-interned list. Pyre is
+    // free-threaded and realizes this slot lazily, so every reader and writer
+    // uses the AtomicPtr element stored in co_names_w.
+    let existing = slot.load(std::sync::atomic::Ordering::Acquire);
+    if !existing.is_null() {
+        return existing;
+    }
+    // Guard `code_ptr` before dereferencing it — the same null/alignment check
+    // the lazy-cache initializers use.
+    let align_mask = std::mem::align_of::<crate::CodeObject>() as i64 - 1;
+    if w_code.code_ptr.is_null() || (w_code.code_ptr as i64) & align_mask != 0 {
+        return pyre_object::pyobject::PY_NULL;
+    }
+    let code = unsafe { &*(w_code.code_ptr as *const crate::CodeObject) };
+    let Some(name) = code.names.get(idx) else {
+        return pyre_object::pyobject::PY_NULL;
+    };
+    let realized = w_str_new(name);
+    match slot.compare_exchange(
+        std::ptr::null_mut(),
+        realized,
+        std::sync::atomic::Ordering::AcqRel,
+        std::sync::atomic::Ordering::Acquire,
+    ) {
+        Ok(_) => realized,
+        Err(winner) => winner,
+    }
+}
+
+/// [`w_code_getname_w`] with the caller's own fallback folded in: a wrapper
+/// carrying no name table answers `PY_NULL`, and the key is then minted the way
+/// it was before `co_names_w` existed.
+///
+/// # Safety
+/// `w_code_obj` must be null or point to a valid `PyCode`.
+pub unsafe fn w_code_getname_w_or_new(
+    w_code_obj: PyObjectRef,
+    idx: usize,
+    name: &str,
+) -> PyObjectRef {
+    let w_name = unsafe { w_code_getname_w(w_code_obj, idx) };
+    if w_name.is_null() {
+        return w_str_new(name);
+    }
+    w_name
+}
+
 /// pypy/module/__pypy__/interp_magic.py:79
 /// `func.getcode().hidden_applevel = True` — explicit setter for the
 /// `__pypy__.hidden_applevel(func)` builtin marker, plus the
@@ -2297,6 +2406,10 @@ pub unsafe fn pycode_destructor(obj_addr: usize) {
     if !code.co_consts_w.is_null() {
         drop(unsafe { Box::from_raw(code.co_consts_w) });
         code.co_consts_w = std::ptr::null_mut();
+    }
+    if !code.co_names_w.is_null() {
+        drop(unsafe { Box::from_raw(code.co_names_w) });
+        code.co_names_w = std::ptr::null_mut();
     }
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -610,7 +610,7 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
         // to [`code_locations`] to rebuild on the first reader that wants it.
         // `first_line_number` is the value the array was decoded against here;
         // a `co_firstlineno_raw` stamp that cannot be spelled as `OneIndexed`
-        // corrects the record in `box_code_constant_with_firstlineno`.
+        // corrects the record in `box_code_object_with_firstlineno`.
         let firstlineno_raw = unsafe { &*(code_ptr as *const crate::CodeObject) }
             .first_line_number
             .map(|line| line.get() as i32)
@@ -749,25 +749,35 @@ pub unsafe fn w_code_yields_inside_try(w_code: PyObjectRef) -> bool {
     unsafe { (*(w_code as *const PyCode)).fast_natural_arity & YIELDS_INSIDE_TRY_BIT != 0 }
 }
 
-/// Box a cloned compiler code object into a heap Python code wrapper.
+/// Box a compiler code object the caller owns into a heap Python code wrapper.
 ///
 /// PyPy's compiler constructs `PyCode` directly (`pycode.py:115-126`) and
-/// therefore has no foreign compiler-object clone in the translated graph.
-/// Pyre's compiler-core `CodeObject` is a dependency ADT whose derived `Clone`
-/// recursively owns boxed slices and nested constants; it is solely the
-/// serialization/API seam used to reach the interpreter-level `PyCode`.
-/// Residualize that foreign seam so the translated graph retains PyPy's direct
-/// `PyCode` value shape instead of inventing an RPython layout for the opaque
-/// Rust clone. Keep clone, Box ownership transfer, and wrapper publication in
-/// the one boundary.
+/// therefore has no foreign compiler-object in the translated graph. Pyre's
+/// compiler-core `CodeObject` is a dependency ADT that recursively owns boxed
+/// slices and nested constants; it is solely the serialization/API seam used
+/// to reach the interpreter-level `PyCode`. Residualize that foreign seam so
+/// the translated graph retains PyPy's direct `PyCode` value shape instead of
+/// inventing an RPython layout for the opaque Rust value. Keep Box ownership
+/// transfer and wrapper publication in the one boundary.
+///
+/// The object is leaked on purpose: code wrappers are immortal and
+/// `pycode_destructor` never frees `code_ptr`.
 ///
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py:139`): the body
-/// `Box::into_raw`s a cloned `CodeObject` (unlifted raw allocation) before
-/// forwarding to the residualised `w_code_new`.
+/// `Box::into_raw`s a `CodeObject` (unlifted raw allocation) before forwarding
+/// to the residualised `w_code_new`.
+#[majit_macros::dont_look_inside]
+pub fn box_code_object(code: crate::CodeObject) -> PyObjectRef {
+    let code_ptr = Box::into_raw(Box::new(code)) as *const ();
+    w_code_new(code_ptr)
+}
+
+/// [`box_code_object`] for a caller that only has a borrow, which has to copy.
+/// A caller that owns its `CodeObject` should hand it over instead — the copy
+/// is a whole recursive duplicate of the constants graph.
 #[majit_macros::dont_look_inside]
 pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
-    let code_ptr = Box::into_raw(Box::new(code.clone())) as *const ();
-    w_code_new(code_ptr)
+    box_code_object(code.clone())
 }
 
 /// Publish a code wrapper over a `CodeObject` the caller keeps alive, rather
@@ -852,8 +862,8 @@ pub(crate) unsafe fn code_filename_bytes(w_code: PyObjectRef) -> Vec<u8> {
     }
 }
 
-fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32) -> PyObjectRef {
-    let obj = box_code_constant(code);
+fn box_code_object_with_firstlineno(code: crate::CodeObject, firstlineno: i32) -> PyObjectRef {
+    let obj = box_code_object(code);
     unsafe {
         (*(obj as *mut PyCode)).co_firstlineno_raw = firstlineno;
     }
@@ -1256,8 +1266,8 @@ pub unsafe fn code_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
         linetable,
         exceptiontable,
     };
-    let result = box_code_constant_with_firstlineno(
-        &code,
+    let result = box_code_object_with_firstlineno(
+        code,
         first_line.clamp(i32::MIN as i64, i32::MAX as i64) as i32,
     );
     unsafe { set_filename_bytes(result, filename_bytes) };
@@ -1765,7 +1775,7 @@ pub unsafe fn code_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::P
         code.instructions.len(),
     );
 
-    let result = box_code_constant_with_firstlineno(&code, firstlineno_raw);
+    let result = box_code_object_with_firstlineno(code, firstlineno_raw);
     unsafe { set_filename_bytes(result, filename_bytes) };
     unsafe {
         (*(result as *mut PyCode)).filename_inherits_to_nested = filename_inherits_to_nested;

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -8,6 +8,7 @@ use pyre_object::pyobject::*;
 use pyre_object::{
     w_bool_from, w_bool_get_value, w_int_new, w_list_new, w_seq_iter_new, w_str_new, w_tuple_new,
 };
+use rustpython_compiler_core::SourceLocation;
 
 const YIELDS_INSIDE_TRY_BIT: u16 = 0x8000;
 
@@ -292,10 +293,12 @@ pub struct PyCode {
     /// lazily at the same wrapped/unwrapped compiler boundary `co_consts_w`
     /// uses, so a name that never executes costs nothing.
     ///
-    /// Slots hold `w_str_new` results — `malloc_typed`-immortal, so a published
-    /// pointer is fixed and the table needs no walking: there is nothing to
-    /// forward and nothing whose liveness a trace could decide.  That is also
-    /// why a lost publish race can simply abandon its candidate.
+    /// Slots hold `intern_str_value` results — `malloc_typed`-immortal, so a
+    /// published pointer is fixed and the table needs no walking: there is
+    /// nothing to forward and nothing whose liveness a trace could decide.
+    /// Interning is also what keeps the immortality affordable: the canonical
+    /// object is shared by every code object naming the same value, so a lost
+    /// publish race abandons nothing — both racers hold the same object.
     ///
     /// Owned via `Box::into_raw`, sized to `code.names.len()` at construction,
     /// never resized; a `null` slot is unrealized.  The whole pointer is `null`
@@ -602,6 +605,18 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
     // by every field initializer below.
     let align_mask = std::mem::align_of::<crate::CodeObject>() as i64 - 1;
     let code_ptr_aligned = !code_ptr.is_null() && (code_ptr as i64) & align_mask == 0;
+    if code_ptr_aligned {
+        // The expanded `locations` array is redundant with `linetable`; hand it
+        // to [`code_locations`] to rebuild on the first reader that wants it.
+        // `first_line_number` is the value the array was decoded against here;
+        // a `co_firstlineno_raw` stamp that cannot be spelled as `OneIndexed`
+        // corrects the record in `box_code_constant_with_firstlineno`.
+        let firstlineno_raw = unsafe { &*(code_ptr as *const crate::CodeObject) }
+            .first_line_number
+            .map(|line| line.get() as i32)
+            .unwrap_or(1);
+        release_code_locations(code_ptr as *mut crate::CodeObject, firstlineno_raw);
+    }
     let mut fast_natural_arity = if !code_ptr_aligned {
         crate::gateway::HOPELESS
     } else {
@@ -818,6 +833,13 @@ fn box_code_constant_with_firstlineno(code: &crate::CodeObject, firstlineno: i32
     unsafe {
         (*(obj as *mut PyCode)).co_firstlineno_raw = firstlineno;
     }
+    // `w_code_new` recorded `first_line_number`, which drops the zero and
+    // negative values this stamp carries; re-record the exact one so the
+    // released rows decode against what the array was built from.
+    let code_ptr = unsafe { w_code_get_ptr(obj) } as *mut crate::CodeObject;
+    if !code_ptr.is_null() {
+        record_deferred_locations_firstlineno(code_ptr, firstlineno);
+    }
     obj
 }
 
@@ -1000,8 +1022,18 @@ unsafe fn require_code(
     Ok(unsafe { &*ptr })
 }
 
+/// The `co_names` / `co_varnames` / `co_freevars` / `co_cellvars` getters.
+///
+/// Interned for `pycode.py:127-129 space.new_interned_str(aname)`' reason: the
+/// entries name values, so every code object spelling one must hand back the
+/// same object rather than a fresh immortal string per read.
 fn names_tuple(names: &[String]) -> PyObjectRef {
-    w_tuple_new(names.iter().map(|name| w_str_new(name)).collect())
+    w_tuple_new(
+        names
+            .iter()
+            .map(|name| pyre_object::unicodeobject::intern_str_value(name))
+            .collect(),
+    )
 }
 
 fn constants_tuple(obj: PyObjectRef, code: &crate::CodeObject) -> PyObjectRef {
@@ -1039,7 +1071,7 @@ fn legacy_lnotab(code: &crate::CodeObject, firstlineno: i64) -> Vec<u8> {
     let mut out = Vec::new();
     let mut line = firstlineno;
     let mut start_offset = 0usize;
-    for (index, (start, _)) in code.locations.iter().enumerate() {
+    for (index, (start, _)) in code_locations(code).iter().enumerate() {
         let next_line = start.line.get() as i64;
         if next_line != line {
             let offset = index * 2;
@@ -1423,8 +1455,7 @@ pub unsafe fn code_varname_from_oparg(
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let code = unsafe { require_code(obj, "co_positions")? };
-    let rows = code
-        .locations
+    let rows = code_locations(code)
         .iter()
         .map(|(start, end)| {
             w_tuple_new(vec![
@@ -1444,12 +1475,13 @@ pub unsafe fn code_positions(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyE
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn code_lines(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     let code = unsafe { require_code(obj, "co_lines")? };
+    let locations = code_locations(code);
     let mut rows = Vec::new();
     let mut start = 0usize;
-    while start < code.locations.len() {
-        let line = code.locations[start].0.line.get();
+    while start < locations.len() {
+        let line = locations[start].0.line.get();
         let mut end = start + 1;
-        while end < code.locations.len() && code.locations[end].0.line.get() == line {
+        while end < locations.len() && locations[end].0.line.get() == line {
             end += 1;
         }
         rows.push(w_tuple_new(vec![
@@ -2091,7 +2123,9 @@ pub unsafe fn w_code_getname_w(w_code_obj: PyObjectRef, idx: usize) -> PyObjectR
     let Some(name) = code.names.get(idx) else {
         return pyre_object::pyobject::PY_NULL;
     };
-    let realized = w_str_new(name);
+    // `pycode.py:127-129 space.new_interned_str(aname)` — one canonical object
+    // per name value, not one per code object that names it.
+    let realized = pyre_object::unicodeobject::intern_str_value(name);
     match slot.compare_exchange(
         std::ptr::null_mut(),
         realized,
@@ -2116,7 +2150,10 @@ pub unsafe fn w_code_getname_w_or_new(
 ) -> PyObjectRef {
     let w_name = unsafe { w_code_getname_w(w_code_obj, idx) };
     if w_name.is_null() {
-        return w_str_new(name);
+        // No slot to realize into, so nothing bounds how often this runs;
+        // interning is what keeps an immortal string per execution from being
+        // an immortal string per execution.
+        return pyre_object::unicodeobject::intern_str_value(name);
     }
     w_name
 }
@@ -2309,6 +2346,124 @@ pub unsafe fn w_code_frame_stores_global(obj: PyObjectRef, w_globals: PyObjectRe
         return false;
     }
     !std::ptr::eq(code.w_globals, w_globals)
+}
+
+/// The state of a code object's `co_positions` rows once its own `locations`
+/// array has been released.
+///
+/// `Deferred` carries the first line number the rows must be decoded against.
+/// `CodeObject.first_line_number` cannot stand in for it: it is an
+/// `Option<OneIndexed>`, which cannot spell the zero and negative values
+/// `CodeType(...)` accepts and `co_firstlineno_raw` preserves.
+#[derive(Clone, Copy)]
+enum CodeLocations {
+    Deferred(i32),
+    Decoded(&'static [(SourceLocation, SourceLocation)]),
+}
+
+/// Rows released from `CodeObject.locations`, keyed by code object address.
+///
+/// `locations` is not serialized: `marshal.rs:265,951` expand it out of
+/// `linetable` while reading a code object, so a loaded code object carries the
+/// same line information twice — compressed at about 1.5 bytes per instruction
+/// and expanded at 32, since `SourceLocation` is a pair of `NonZeroUsize`.
+/// Nothing but a traceback, a debugger line jump and the `co_positions` /
+/// `co_lines` getters ever reads the expanded form, so [`w_code_new`] releases
+/// it and [`code_locations`] rebuilds it on the first reader — the
+/// realize-once treatment `co_consts_w` and `co_names_w` already get.
+///
+/// Decoded rows are leaked because the `CodeObject` describing them is itself
+/// never released: `pycode_destructor` frees the side tables and leaves
+/// `code_ptr` standing, so an entry can never outlive its key's validity and
+/// never has to be revisited.
+///
+/// Process-global and keyed by `usize` for `LIVE_CODE_WRAPPERS`' reasons: the
+/// rows belong to the shared code object, and a raw `PyObjectRef` is not
+/// `Send`.
+static CODE_LOCATIONS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashMap<usize, CodeLocations>>,
+> = std::sync::OnceLock::new();
+
+fn code_locations_cache()
+-> &'static std::sync::Mutex<std::collections::HashMap<usize, CodeLocations>> {
+    CODE_LOCATIONS.get_or_init(|| std::sync::Mutex::new(std::collections::HashMap::new()))
+}
+
+/// Release a freshly constructed code object's expanded `locations` array,
+/// recording the first line number [`code_locations`] must decode it back
+/// against.
+///
+/// Called before the wrapper is published, so no reader can be holding the
+/// array that is dropped here, and a later call for the same code object (the
+/// `co_firstlineno_raw` stamp that follows `CodeType(...)` and `code.replace`)
+/// simply corrects the recorded line number.
+fn release_code_locations(code_ptr: *mut crate::CodeObject, firstlineno_raw: i32) {
+    // A code object with no instructions has no rows to decode, and a second
+    // wrapper over one already released must keep the record the first made —
+    // re-deferring would abandon rows a reader has since decoded.
+    let code = unsafe { &mut *code_ptr };
+    if code.instructions.is_empty() || code.locations.is_empty() {
+        return;
+    }
+    code.locations = Vec::new().into_boxed_slice();
+    code_locations_cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(code_ptr as usize, CodeLocations::Deferred(firstlineno_raw));
+}
+
+/// Correct the first line number a released array is decoded against, leaving a
+/// code object that still holds its own array alone.
+fn record_deferred_locations_firstlineno(code_ptr: *mut crate::CodeObject, firstlineno_raw: i32) {
+    let mut cache = code_locations_cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(slot @ CodeLocations::Deferred(_)) = cache.get_mut(&(code_ptr as usize)) {
+        *slot = CodeLocations::Deferred(firstlineno_raw);
+    }
+}
+
+/// The `co_positions` rows of `code`, decoding them out of `linetable` on the
+/// first reader when [`release_code_locations`] has taken the array away.
+///
+/// Returns the code object's own array untouched when it still holds one, so a
+/// code object built outside [`w_code_new`] reads exactly as it always did.
+///
+/// An empty array on a code object that has instructions always means the rows
+/// were released: every construction path fills `locations` through
+/// `linetable_to_locations`, which returns one row per instruction. Decoding is
+/// therefore the right answer whether or not the map still knows the object.
+pub fn code_locations(code: &crate::CodeObject) -> &[(SourceLocation, SourceLocation)] {
+    if !code.locations.is_empty() || code.instructions.is_empty() {
+        return &code.locations;
+    }
+    let key = code as *const crate::CodeObject as usize;
+    let mut cache = code_locations_cache()
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let firstlineno_raw = match cache.get(&key) {
+        Some(CodeLocations::Decoded(rows)) => return *rows,
+        Some(CodeLocations::Deferred(firstlineno_raw)) => *firstlineno_raw,
+        // A copy of a released code object: `w_code_fill_consts_from_tuple`
+        // serializes a wrapped constant back into `ConstantData` by copying the
+        // `CodeObject`, so the empty array travels to an address this map has
+        // never seen. `linetable` is the serialized form and travels with it,
+        // which is why it — not the map — is what makes the rows recoverable;
+        // the record only exists to carry a first line number
+        // `Option<OneIndexed>` cannot spell.
+        None => code
+            .first_line_number
+            .map(|line| line.get() as i32)
+            .unwrap_or(1),
+    };
+    let rows: &'static [(SourceLocation, SourceLocation)] =
+        Box::leak(rustpython_compiler_core::marshal::linetable_to_locations(
+            &code.linetable,
+            firstlineno_raw,
+            code.instructions.len(),
+        ));
+    cache.insert(key, CodeLocations::Decoded(rows));
+    rows
 }
 
 /// Registry mapping a raw CodeObject pointer (`PyCode.code_ptr`) to the

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -731,8 +731,10 @@ pub fn w_code_new_with_hidden_applevel(code_ptr: *const (), hidden_applevel: boo
 /// surfaces flip the flag to `True`.
 ///
 /// # Safety
-/// `code_ptr` must be a valid pointer to a `CodeObject` obtained
-/// via `Box::into_raw`.
+/// `code_ptr` must be a valid pointer to a `CodeObject` that is never freed
+/// and never moved. `pycode_destructor` releases the wrapper's side tables
+/// but never `code_ptr`, so a leaked box and a constant reached through one
+/// both qualify.
 pub fn w_code_new(code_ptr: *const ()) -> PyObjectRef {
     w_code_new_with_hidden_applevel(code_ptr, false)
 }
@@ -768,13 +770,35 @@ pub fn box_code_constant(code: &crate::CodeObject) -> PyObjectRef {
     w_code_new(code_ptr)
 }
 
-/// Box a nested compiler constant and inherit the enclosing `PyCode`'s raw
+/// Publish a code wrapper over a `CodeObject` the caller keeps alive, rather
+/// than over a copy of it.
+///
+/// [`box_code_constant`] copies because most callers hold a `CodeObject` on
+/// the stack. A nested compiler constant is not one of those: it sits in its
+/// enclosing `CodeObject`'s constants table behind its own `Box`, that table
+/// is only ever edited in place, and the enclosing object is itself leaked.
+/// So the constant already outlives every wrapper published for it.
+///
+/// # Safety
+/// `code` must point to a `CodeObject` that is never freed and never moved.
+unsafe fn box_code_constant_in_place(code: *const crate::CodeObject) -> PyObjectRef {
+    w_code_new(code as *const ())
+}
+
+/// Wrap a nested compiler constant and inherit the enclosing `PyCode`'s raw
 /// filename when it belongs to the set selected by
 /// `importing.py:379-391 update_code_filenames`' `oldname` guard.
-fn box_code_constant_inheriting_filename(code: &crate::CodeObject, parent: &PyCode) -> PyObjectRef {
-    let obj = box_code_constant(code);
+///
+/// # Safety
+/// `code` must satisfy [`box_code_constant_in_place`], and `parent` must be
+/// the `PyCode` whose constants table holds it.
+unsafe fn box_code_constant_inheriting_filename(
+    code: *const crate::CodeObject,
+    parent: &PyCode,
+) -> PyObjectRef {
+    let obj = unsafe { box_code_constant_in_place(code) };
     if parent.filename_inherits_to_nested
-        && code.source_path
+        && unsafe { &*code }.source_path
             == unsafe { &*(parent.code_ptr as *const crate::CodeObject) }.source_path
         && !parent.filename_bytes.is_null()
     {
@@ -2052,9 +2076,9 @@ pub unsafe fn w_code_const(w_code_obj: PyObjectRef, idx: usize) -> PyObjectRef {
     }
 
     let mut realized = match &constants[idx] {
-        crate::bytecode::ConstantData::Code { code } => {
-            box_code_constant_inheriting_filename(code, w_code)
-        }
+        crate::bytecode::ConstantData::Code { code } => unsafe {
+            box_code_constant_inheriting_filename(&**code as *const crate::CodeObject, w_code)
+        },
         constant => crate::pyframe::pyobject_from_constant(constant),
     };
     // Keep the losing or winning candidate live until the CAS has either
@@ -2190,26 +2214,22 @@ pub unsafe fn w_code_get_ptr(obj: PyObjectRef) -> *const () {
 /// `importing.py:379 update_code_filenames`: set `source_path` on `code` and,
 /// recursively, on every nested code constant whose filename still matches the
 /// root's *original* name (leaving unrelated inlined filenames untouched).
-/// `Constants` exposes no in-place mutation, so the table is rebuilt.
+///
+/// The table is edited through `Constants`' `DerefMut`, so every constant keeps
+/// its address. Nested constants are wrapped in place by
+/// [`box_code_constant_in_place`], and a wrapper published before this runs
+/// reads the new name out of the object it already points at — which is what
+/// `update_code_filenames` mutating already-wrapped nested `PyCode` constants
+/// amounts to.
 fn fix_code_filenames(code: &mut crate::CodeObject, oldname: &str, newname: &str) {
     code.source_path = newname.to_owned();
-    let new_consts: crate::bytecode::Constants<crate::bytecode::ConstantData> = code
-        .constants
-        .iter()
-        .map(|c| match c {
-            crate::bytecode::ConstantData::Code { code: nested }
-                if nested.source_path == oldname =>
-            {
-                let mut nested = (**nested).clone();
-                fix_code_filenames(&mut nested, oldname, newname);
-                crate::bytecode::ConstantData::Code {
-                    code: Box::new(nested),
-                }
-            }
-            other => other.clone(),
-        })
-        .collect();
-    code.constants = new_consts;
+    for constant in code.constants.iter_mut() {
+        if let crate::bytecode::ConstantData::Code { code: nested } = constant
+            && nested.source_path == oldname
+        {
+            fix_code_filenames(nested, oldname, newname);
+        }
+    }
 }
 
 /// `_imp._fix_co_filename(code, path)` (importing.py:158 fix_co_filename):
@@ -2398,18 +2418,28 @@ fn code_locations_cache()
 /// `co_firstlineno_raw` stamp that follows `CodeType(...)` and `code.replace`)
 /// simply corrects the recorded line number.
 fn release_code_locations(code_ptr: *mut crate::CodeObject, firstlineno_raw: i32) {
-    // A code object with no instructions has no rows to decode, and a second
-    // wrapper over one already released must keep the record the first made —
-    // re-deferring would abandon rows a reader has since decoded.
+    // A code object with no instructions has no rows to decode.
     let code = unsafe { &mut *code_ptr };
-    if code.instructions.is_empty() || code.locations.is_empty() {
+    if code.instructions.is_empty() {
         return;
     }
-    code.locations = Vec::new().into_boxed_slice();
-    code_locations_cache()
+    // Nested constants are wrapped in place, so two threads realizing one
+    // `co_consts_w` slot reach the same `CodeObject`. Whoever creates the
+    // record owns the drop; the array is read and written only under this
+    // lock. A second wrapper over an already-released object must keep the
+    // record the first made — re-deferring would abandon rows a reader has
+    // since decoded.
+    let mut cache = code_locations_cache()
         .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner)
-        .insert(code_ptr as usize, CodeLocations::Deferred(firstlineno_raw));
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(code_ptr as usize) else {
+        return;
+    };
+    if code.locations.is_empty() {
+        return;
+    }
+    entry.insert(CodeLocations::Deferred(firstlineno_raw));
+    code.locations = Vec::new().into_boxed_slice();
 }
 
 /// Correct the first line number a released array is decoded against, leaving a

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1906,7 +1906,7 @@ pub fn offset2lineno(code: &CodeObject, stopat: isize) -> usize {
     if stopat < 0 {
         return lineno;
     }
-    code.locations
+    crate::pycode::code_locations(code)
         .get(stopat as usize)
         .map(|(start, _)| start.line.get())
         .unwrap_or(lineno)
@@ -2091,11 +2091,11 @@ fn mark_explain_incompatible_stack(target_stack: i64) -> &'static str {
 fn mark_lines(code: &CodeObject, len: usize) -> Vec<i32> {
     let mut lines = vec![-1i32; len];
     let first = code.first_line_number.map(|n| n.get() as i32).unwrap_or(1);
+    let locations = crate::pycode::code_locations(code);
     let mut last_line = -1i32;
     for i in 0..len {
         // `locations[i].0` is the start SourceLocation of unit `i`.
-        let line = code
-            .locations
+        let line = locations
             .get(i)
             .map(|(start, _)| start.line.get() as i32)
             .unwrap_or(first);
@@ -4022,7 +4022,7 @@ impl PyFrame {
         // marshal reader as repeated zero-width positions on the first line.
         // CPython reports ``frame.f_lineno is None`` for that table rather
         // than manufacturing the code object's first line number.
-        let locations = &self.code().locations;
+        let locations = crate::pycode::code_locations(self.code());
         if !locations.is_empty()
             && locations.iter().all(|(start, end)| {
                 start.character_offset.get() == 1 && end.character_offset.get() == 1

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -1282,7 +1282,7 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
     fn delete_attr(&mut self, _name: &str) -> Result<(), PyError> {
         Err(crate::PyError::type_error("delete_attr not implemented"))
     }
-    fn delete_name(&mut self, _name: &str) -> Result<(), PyError> {
+    fn delete_name(&mut self, _name: &str, _nameindex: usize) -> Result<(), PyError> {
         Err(crate::PyError::type_error("delete_name not implemented"))
     }
     fn delete_global(&mut self, _name: &str) -> Result<(), PyError> {
@@ -3327,7 +3327,8 @@ pub fn execute_delete_name<E: OpcodeStepExecutor>(
     let Instruction::DeleteName { namei } = instruction else {
         unreachable!()
     };
-    executor.delete_name(code.names[u32_as_usize(namei.get(op_arg))].as_ref())?;
+    let nameindex = u32_as_usize(namei.get(op_arg));
+    executor.delete_name(code.names[nameindex].as_ref(), nameindex)?;
     Ok(StepResult::Continue)
 }
 

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -639,6 +639,21 @@ pub fn opcode_store_fast_store_fast<H: LocalOpcodeHandler + ?Sized>(
     handler.store_local_value(idx2, v2)
 }
 
+/// The `nameindex` a caller passes when it addresses no `co_names_w` slot
+/// (`pycode.py:127-129`).
+///
+/// `0` cannot say this — it is a valid index, and naming the first entry of the
+/// name table is exactly the wrong answer.  Out of range for every table, so
+/// `w_code_getname_w` resolves it to `PY_NULL` and the key is minted the way it
+/// was before the table existed.
+///
+/// The caller that needs it is the implicit class-body `__class__` store, whose
+/// name is a literal rather than a `co_names` entry.  (The JIT's
+/// `bh_store_name_fn` / `bh_store_global_fn` residuals also hold no index, but
+/// they are handed an already-wrapped `w_name` and enter through
+/// `eval::store_name_value_w`, which needs no index at all.)
+pub const NO_NAMEINDEX: usize = usize::MAX;
+
 pub fn opcode_store_name<H: NamespaceOpcodeHandler + ?Sized>(
     handler: &mut H,
     name: &str,

--- a/pyre/pyre-interpreter/src/reduce_protocol.rs
+++ b/pyre/pyre-interpreter/src/reduce_protocol.rs
@@ -123,16 +123,6 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
         let dict_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(d);
         if crate::baseobjspace::len_w(pyre_object::gc_roots::shadow_stack_get(dict_slot))? > 0 {
-            // Copy `__dict__`. For a dict subclass, drop the internal
-            // `__dict_data__` key it keeps its mapping payload under: that
-            // payload is reconstructed through `dictitems`, not the instance
-            // state, so an attribute-less dict subclass yields `None` here
-            // (matching the empty instance `__dict__` of a built-in subclass).
-            // A non-dict instance keeps a user attribute of that name.
-            let is_dict_inst = {
-                let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
-                unsafe { crate::baseobjspace::isinstance_w(current_obj(), w_dict_type) }
-            };
             let copy_slot = pyre_object::gc_roots::shadow_stack_len();
             pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
             let items = unsafe {
@@ -147,12 +137,6 @@ pub fn object_getstate_default(w_obj: PyObjectRef) -> PyResult {
             for index in 0..items.len() {
                 let k = pyre_object::gc_roots::shadow_stack_get(items_slot + 2 * index);
                 let v = pyre_object::gc_roots::shadow_stack_get(items_slot + 2 * index + 1);
-                if is_dict_inst
-                    && unsafe { pyre_object::is_str(k) }
-                    && unsafe { pyre_object::w_str_get_value(k) } == "__dict_data__"
-                {
-                    continue;
-                }
                 unsafe {
                     pyre_object::w_dict_store(
                         pyre_object::gc_roots::shadow_stack_get(copy_slot),

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6253,16 +6253,21 @@ pub fn str_method_translate(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::
 
 // ── Dict methods ─────────────────────────────────────────────────────
 
-/// Resolve the actual backing W_DictObject for either a plain dict or
-/// a dict subclass instance (which stores data in `__dict_data__`).
+/// Layout-slot name reserved for a dict subclass's mapping payload, pyre's
+/// object-resident stand-in for the intrinsic `W_DictMultiObject` field a
+/// PyPy dict subclass carries.
 ///
-/// PyPy: W_DictMultiObject subclass instances ARE dicts, so no indirection
-/// is needed. In pyre, dict subclass instances are W_ObjectObject with a
-/// backing dict stored as an attribute.
+/// The name holds a space so no class can declare it: `__slots__` entries are
+/// rejected unless they are identifiers. A spellable name would collide — the
+/// user's member is installed first and the reserved name appended after it,
+/// so `dict_data_slot` would answer with the user's index and the mapping
+/// payload would overwrite their slot.
+pub const DICT_DATA_SLOT: &str = "dict subclass w_dict_data";
+
 /// True when `obj` can be read as a dict — an exact dict, a dict subclass
-/// carrying a `__dict_data__` backing, or a mapping proxy wrapping one.  This
-/// is the receiver test a `dict` method descriptor applies, so an object that
-/// merely claims `__class__ is dict` never reaches the backing lookup.
+/// carrying a mapping payload, or a mapping proxy wrapping one.  This is the
+/// receiver test a `dict` method descriptor applies, so an object that merely
+/// claims `__class__ is dict` never reaches the backing lookup.
 ///
 /// # Safety
 /// `obj` must be a valid, non-null pointer to a `PyObject`.
@@ -6270,11 +6275,7 @@ pub unsafe fn has_dict_backing(obj: PyObjectRef) -> bool {
     !resolve_dict_backing(obj).is_null()
 }
 
-/// Write pyre's object-resident stand-in for a dict subclass's intrinsic
-/// `W_DictMultiObject` payload.  This is a layout-slot operation, not Python
-/// attribute assignment: a subclass may override `__setattr__` with a dict
-/// method before its mapping payload exists.
-/// Absolute layout-slot index of the reserved `__dict_data__` payload for
+/// Absolute layout-slot index of the reserved [`DICT_DATA_SLOT`] payload for
 /// `obj`, walking the layout chain from the object's type toward its base.
 /// `None` when no layout in the chain reserves the slot.
 ///
@@ -6295,7 +6296,7 @@ unsafe fn dict_data_slot(obj: PyObjectRef) -> Option<u32> {
             if let Some(offset) = current
                 .newslotnames
                 .iter()
-                .position(|name| name == "__dict_data__")
+                .position(|name| name == DICT_DATA_SLOT)
             {
                 return Some(first_slot + offset as u32);
             }
@@ -6305,6 +6306,9 @@ unsafe fn dict_data_slot(obj: PyObjectRef) -> Option<u32> {
     }
 }
 
+/// Write the mapping payload of a dict subclass instance.  This is a
+/// layout-slot operation, not Python attribute assignment: a subclass may
+/// override `__setattr__` with a dict method before its payload exists.
 pub fn set_dict_backing(obj: PyObjectRef, backing: PyObjectRef) -> bool {
     unsafe {
         if !is_instance(obj) || !is_dict(backing) {
@@ -6343,9 +6347,7 @@ pub fn resolve_dict_backing(obj: PyObjectRef) -> PyObjectRef {
             }
         }
         if is_instance(obj) {
-            // `__dict_data__` is pyre's object-resident stand-in for the
-            // intrinsic W_DictMultiObject payload of a PyPy dict subclass.
-            // Read that reserved layout slot directly: going through
+            // Read the reserved layout slot directly: going through
             // `getattr_str` would incorrectly expose internal dict operations
             // to a subclass's Python-level `__getattribute__` hook.
             if let Some(slot) = dict_data_slot(obj)

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -1907,7 +1907,7 @@ fn method_owner(type_name: &str) -> Option<&'static crate::gateway::MethodOwner>
         "bool" => pyre_object::is_bool,
         "float" => pyre_object::is_float,
         "complex" => pyre_object::is_complex,
-        // A dict subclass keeps its entries in a `__dict_data__` backing
+        // A dict subclass keeps its entries in a reserved-slot backing
         // rather than the dict layout, and the dict methods already read
         // through to it, so "has a dict backing" is the receiver test.
         "dict" => crate::type_methods::has_dict_backing,
@@ -3607,12 +3607,11 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 
     // PyPy `W_DictMultiObject.allocate_and_init_instance` initializes the
     // mapping payload directly, before any Python-level `__setattr__` can
-    // run.  `__dict_data__` is pyre's reserved layout-slot equivalent, so
-    // write it through object.__setattr__'s terminal path rather than
-    // dispatching a subclass override.
+    // run.  The reserved layout slot is pyre's equivalent, so write it as a
+    // slot rather than dispatching attribute assignment.
     //
     // Nothing references the instance until the backing mapping is installed,
-    // and both that allocation and the attribute store are collection points.
+    // and both that allocation and the slot store are collection points.
     // Its allocation is stable, so the word never moves and needs no read
     // back — the pin is what keeps a major collection from reclaiming it.
     // The mapping is a `dict` and does move, so it is pinned at the mint and
@@ -3622,11 +3621,10 @@ fn dict_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     pyre_object::gc_roots::pin_root(instance);
     let backing_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(pyre_object::w_dict_new());
-    crate::baseobjspace::object_setattr(
+    crate::type_methods::set_dict_backing(
         instance,
-        "__dict_data__",
         pyre_object::gc_roots::shadow_stack_get(backing_slot),
-    )?;
+    );
     Ok(instance)
 }
 /// boolobject.py descr_new — bool.__new__(cls, obj=False)
@@ -6884,7 +6882,7 @@ fn init_dict_type(ns: PyObjectRef) {
                 |args| {
                     crate::type_methods::arity_slot(args, 1)?;
                     // A dict subclass is instance-represented (the mapping lives in
-                    // the `__dict_data__` backing), so `compare` would not see it as
+                    // the reserved-slot backing), so `compare` would not see it as
                     // a dict and would re-dispatch to this `__eq__`, recursing.
                     // Resolve each operand to its backing dict first; exact dicts
                     // and non-dict operands are left unchanged for `compare`.
@@ -11048,10 +11046,10 @@ pub(crate) fn cpython_type_layout(w_type: PyObjectRef) -> Option<(i64, i64)> {
     // per user slot to that same prefix.
     let mut slots = unsafe { pyre_object::w_type_get_nslots(w_type) } as i64;
     // Some composed instances own private Layout slots for a builtin's
-    // intrinsic fields: a dict subclass keeps its mapping payload in
-    // `__dict_data__`, a slotted `weakref.ref` subclass its three
-    // `W_WeakrefBase` fields. CPython keeps both in the fixed struct prefix,
-    // so neither contributes to the public `tp_basicsize` projection.
+    // intrinsic fields: a dict subclass its mapping payload, a slotted
+    // `weakref.ref` subclass its three `W_WeakrefBase` fields. CPython keeps
+    // both in the fixed struct prefix, so neither contributes to the public
+    // `tp_basicsize` projection.
     let mut current = unsafe { pyre_object::w_type_get_layout_ptr(w_type) };
     while !current.is_null() {
         slots -= unsafe { &(*current).newslotnames }
@@ -11066,7 +11064,7 @@ pub(crate) fn cpython_type_layout(w_type: PyObjectRef) -> Option<(i64, i64)> {
 /// Whether `name` is a Layout slot pyre reserves for a builtin's intrinsic
 /// fields rather than for an attribute the class declared.
 fn is_reserved_payload_slot(name: &str) -> bool {
-    name == "__dict_data__"
+    name == crate::type_methods::DICT_DATA_SLOT
         || crate::module::_weakref::interp__weakref::RESERVED_FIELD_SLOTS.contains(&name)
 }
 

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -3876,8 +3876,8 @@ static PYCODE_DESCR_GROUP: LazyLock<majit_ir::descr::SimpleDescrGroup> = LazyLoc
             ArrayFlag::Unsigned,
             false,
         ),
-        // The slot is written once, by `box_code_constant_with_firstlineno`,
-        // onto the object `box_code_constant` has just boxed out of a fresh
+        // The slot is written once, by `box_code_object_with_firstlineno`,
+        // onto the object `box_code_object` has just boxed out of a fresh
         // `Box` — no caching, so nothing can have read it first. `code.replace`
         // reads it and builds a new code object rather than writing this one.
         field(

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -5534,7 +5534,16 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
     // CPython/PyPy LOAD_FROM_DICT_OR_GLOBALS uses mapping subscription, not
     // attribute lookup.  Preserve __getitem__/__missing__ and propagate every
     // exception except the KeyError that selects the globals fallback.
-    let key = pyre_object::w_str_new(varname);
+    // `pycode.py:127-129 co_names_w[idx]` — this residual already resolved the
+    // name through `code.names[idx]`, so it names the key from the same index
+    // instead of minting an immortal `w_str` on every execution.
+    let key = unsafe {
+        pyre_interpreter::pycode::w_code_getname_w_or_new(
+            w_code_ptr as pyre_object::PyObjectRef,
+            idx,
+            varname,
+        )
+    };
     match pyre_interpreter::baseobjspace::getitem(dict, key) {
         Ok(val) => return val as i64,
         Err(err) if matches!(err.kind, pyre_interpreter::PyErrorKind::KeyError) => {}
@@ -6252,7 +6261,9 @@ pub extern "C" fn bh_load_name_fn(frame_ptr: i64, w_name: i64, namei: i64) -> i6
 /// `space.setitem` and module/class namespaces through the dict
 /// strategy.  Same blackhole-only execution contract and `w_name` ABI
 /// as `bh_load_name_fn`.  `STORE_NAME` carries no nameindex-keyed
-/// cache upstream, so the trait's `nameindex` argument is passed as 0.
+/// cache upstream and this residual is handed the wrapped name rather than an
+/// index, so it enters through `store_name_value_w`, which names the key from
+/// that `w_name` instead of resolving a `co_names_w` slot.
 /// Returns 1 on success; on error it sets `BH_LAST_EXC_VALUE` and
 /// returns 0, matching `bh_store_subscr_fn`.
 pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i64 {
@@ -6263,9 +6274,13 @@ pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i
          site must thread portal_frame_reg as the leading ref operand"
     );
     let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
-    let name =
-        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
-    match frame.store_name_value(name, 0, value as pyre_object::PyObjectRef) {
+    match unsafe {
+        pyre_interpreter::eval::store_name_value_w(
+            frame,
+            w_name as pyre_object::PyObjectRef,
+            value as pyre_object::PyObjectRef,
+        )
+    } {
         Ok(()) => 1,
         Err(mut err) => {
             // Publish into both exception cells: STORE_NAME lowers into the
@@ -6286,8 +6301,9 @@ pub extern "C" fn bh_store_name_fn(frame_ptr: i64, w_name: i64, value: i64) -> i
 /// routes through `w_dict_setitem_str` on the eagerly-resolved
 /// `w_globals` (or the back-mirror dict storage when null).  Same
 /// blackhole-only execution contract and `w_name` ABI as
-/// `bh_store_name_fn`.  `STORE_GLOBAL` carries no nameindex-keyed cache,
-/// so the trait's `nameindex` argument is passed as 0.  Returns 1 on
+/// `bh_store_name_fn`.  `STORE_GLOBAL` carries no nameindex-keyed cache
+/// and this residual is handed the wrapped name rather than an index, so it
+/// enters through `store_global_value_w`.  Returns 1 on
 /// success; on error it sets `BH_LAST_EXC_VALUE` and returns 0.
 pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) -> i64 {
     use pyre_interpreter::pyopcode::NamespaceOpcodeHandler;
@@ -6297,9 +6313,13 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
          site must thread portal_frame_reg as the leading ref operand"
     );
     let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
-    let name =
-        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
-    match frame.store_global_value(name, 0, value as pyre_object::PyObjectRef) {
+    match unsafe {
+        pyre_interpreter::eval::store_global_value_w(
+            frame,
+            w_name as pyre_object::PyObjectRef,
+            value as pyre_object::PyObjectRef,
+        )
+    } {
         Ok(()) => 1,
         Err(mut err) => {
             // Publish into both exception cells, matching the STORE_NAME arm.

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -6335,18 +6335,19 @@ pub extern "C" fn bh_store_global_fn(frame_ptr: i64, w_name: i64, value: i64) ->
 
 /// DELETE_NAME residual using the frame receiver and interned-name ABI.
 /// pyopcode.py DELETE_NAME deletes from `w_locals` and raises `NameError`
-/// when the binding is absent.
+/// when the binding is absent.  The trace carries no `co_names` index, so it
+/// enters through `delete_name_w`, which deletes through the key object the
+/// trace already holds.
 pub extern "C" fn bh_delete_name_fn(frame_ptr: i64, w_name: i64) -> i64 {
-    use pyre_interpreter::pyopcode::OpcodeStepExecutor;
     assert!(
         frame_ptr != 0,
         "bh_delete_name_fn requires a non-null PyFrame; every DELETE_NAME emit \
          site must thread portal_frame_reg as the leading ref operand"
     );
     let frame = unsafe { &mut *(frame_ptr as *mut PyFrame) };
-    let name =
-        unsafe { pyre_object::unicodeobject::w_str_get_value(w_name as pyre_object::PyObjectRef) };
-    match frame.delete_name(name) {
+    match unsafe {
+        pyre_interpreter::eval::delete_name_w(frame, w_name as pyre_object::PyObjectRef)
+    } {
         Ok(()) => 1,
         Err(mut err) => {
             publish_residual_call_exception(err.to_exc_object() as i64);

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -5966,8 +5966,7 @@ pub fn get_location(
                         }
                         None => ("<eof>".to_string(), "<eof>".to_string()),
                     };
-                let line = code
-                    .locations
+                let line = pyre_interpreter::pycode::code_locations(code)
                     .get(next_instr)
                     .and_then(|(start, _)| Some(start.line.get() as usize))
                     .unwrap_or_else(|| {

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1083,6 +1083,27 @@ impl ModuleDictStrategy {
         storage.entries.values().map(|v| unsafe { unwrap_cell(*v) })
     }
 
+    /// The name at iteration position `index`, or `None` past the end.
+    ///
+    /// `getiterkeys` walks the whole map; a dict view's integer cursor wants
+    /// one entry, and the storage is an `IndexMap`, so ask it directly.
+    pub fn nth_key<'a>(&self, storage: &'a ModuleDictStorage, index: usize) -> Option<&'a str> {
+        storage.entries.get_index(index).map(|(k, _)| k.as_str())
+    }
+
+    /// [`Self::nth_key`]'s value half, unwrapped the way `getitervalues`
+    /// unwraps (`celldict.py:152-154 values`).
+    pub fn nth_unwrapped_value(
+        &self,
+        storage: &ModuleDictStorage,
+        index: usize,
+    ) -> Option<PyObjectRef> {
+        storage
+            .entries
+            .get_index(index)
+            .map(|(_, v)| unsafe { unwrap_cell(*v) })
+    }
+
     /// GC root walk over every live `GlobalCache.cell` reachable through
     /// this strategy's `caches` registry (`celldict.py:214
     /// get_global_cache`), forwarding the movable value each cell holds.
@@ -1178,12 +1199,11 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
             .collect()
     }
 
-    /// `celldict.py:144-149 values`.
+    /// `celldict.py:144-149 values` — reads the cells and nothing else.
+    /// Routing this through `items` wrapped every name into a
+    /// `W_UnicodeObject` only to drop it.
     unsafe fn values(&self, w_dict: PyObjectRef) -> Vec<PyObjectRef> {
-        crate::dictmultiobject::w_dict_items(w_dict)
-            .into_iter()
-            .map(|(_, v)| v)
-            .collect()
+        crate::dictmultiobject::w_module_dict_values_inner(w_dict)
     }
 
     /// `celldict.py:151-155 items` — branches on `is_object_strategy`
@@ -1191,6 +1211,24 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
     /// via `w_str_new`.
     unsafe fn items(&self, w_dict: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
         crate::dictmultiobject::w_module_dict_items_inner(w_dict)
+    }
+
+    /// A module dict is not one of the tiny strategies the `nth_item`
+    /// default was written for. Taking one entry by materialising `items`
+    /// wrapped every name in the dict — and `w_str_new` never frees — so a
+    /// single walk of a module dict left one immortal `W_UnicodeObject` per
+    /// name per step behind it.
+    unsafe fn nth_item(
+        &self,
+        w_dict: PyObjectRef,
+        index: usize,
+    ) -> Option<(PyObjectRef, PyObjectRef)> {
+        crate::dictmultiobject::w_module_dict_nth_item_inner(w_dict, index)
+    }
+
+    /// The value half of [`Self::nth_item`], which wraps no name at all.
+    unsafe fn nth_value(&self, w_dict: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+        crate::dictmultiobject::w_module_dict_nth_value_inner(w_dict, index)
     }
 
     /// `celldict.py:157-159 clear`.  Branches on

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -560,16 +560,25 @@ pub unsafe fn dict_entries_index_of_object(
 /// required while bootstrapping `str.__hash__` itself: its defining type dict
 /// is already a W_DictObject, so `hash_w(w_str)` would recursively look up
 /// `str.__hash__` in the dict currently being filled.
+///
+/// `hash` is the caller's digest for `key`, or 0 when it holds none.  The
+/// digest is memoized on the new string (`rstr.py:402-412 ll_strhash`), so the
+/// key this dict now owns never hashes its bytes again.
 #[inline]
-unsafe fn object_key_for_new_str(key: &str) -> ObjectKey {
+unsafe fn object_key_for_new_str(key: &str, hash: i64) -> ObjectKey {
     let obj = crate::w_str_new(key);
-    match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
-        Some(hash) => {
-            crate::dict_eq_hook::take_eq_error();
-            ObjectKey { hash, obj }
-        }
-        None => object_key_for(obj),
-    }
+    let hash = match hash {
+        0 => match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
+            Some(hash) => {
+                crate::dict_eq_hook::take_eq_error();
+                hash
+            }
+            None => return object_key_for(obj),
+        },
+        memoized => memoized,
+    };
+    unsafe { crate::unicodeobject::w_str_set_hash(obj, hash) };
+    ObjectKey { hash, obj }
 }
 
 /// Fallible variant of [`object_key_for`].  When the `hash_w` hook
@@ -7166,7 +7175,7 @@ impl DictStrategy for UnicodeDictStrategy {
                 // Mint before reading either slot: call arguments evaluate left
                 // to right, so a slot read written inline with the mint would be
                 // taken before the collection that invalidates it.
-                let stored_key = object_key_for_new_str(key);
+                let stored_key = object_key_for_new_str(key, hash);
                 let w_value = roots.get(value_slot);
                 let dict = &mut *(roots.get(dict_slot) as *mut W_DictObject);
                 let entries =

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -5098,6 +5098,61 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
     }
 }
 
+/// [`w_module_dict_items_inner`] for one iteration position.
+///
+/// The dict view's integer cursor asks for a single entry, and both storage
+/// halves are `IndexMap`s, so this reads that entry rather than building the
+/// whole list. Only the one name is wrapped.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ModuleDictObject`.
+pub unsafe fn w_module_dict_nth_item_inner(
+    obj: PyObjectRef,
+    index: usize,
+) -> Option<(PyObjectRef, PyObjectRef)> {
+    lock_dict_refs!(_module_guard, obj);
+    if let Some(entries) = w_module_dict_object_storage(obj) {
+        return entries.get_index(index).map(|(k, &v)| (k.obj, v));
+    }
+    let strategy = &*w_module_dict_get_strategy(obj);
+    let key = strategy.nth_key(&*w_module_dict_get_storage(obj), index)?;
+    // Wrapping the name allocates, so root the wrapper and read the value
+    // back afterwards — the cell storage keeps it traced.
+    let roots = crate::gc_roots::push_roots();
+    let key_slot = roots.base();
+    roots.pin_root(crate::w_str_new(key));
+    let value = strategy.nth_unwrapped_value(&*w_module_dict_get_storage(obj), index)?;
+    Some((roots.get(key_slot), value))
+}
+
+/// [`w_module_dict_nth_item_inner`]'s value half, which wraps no name.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ModuleDictObject`.
+pub unsafe fn w_module_dict_nth_value_inner(obj: PyObjectRef, index: usize) -> Option<PyObjectRef> {
+    lock_dict_refs!(_module_guard, obj);
+    if let Some(entries) = w_module_dict_object_storage(obj) {
+        return entries.get_index(index).map(|(_, &v)| v);
+    }
+    let strategy = &*w_module_dict_get_strategy(obj);
+    strategy.nth_unwrapped_value(&*w_module_dict_get_storage(obj), index)
+}
+
+/// `celldict.py:144-149 values` — the cells, with no name wrapped.
+///
+/// # Safety
+/// `obj` must point to a valid `W_ModuleDictObject`.
+pub unsafe fn w_module_dict_values_inner(obj: PyObjectRef) -> Vec<PyObjectRef> {
+    lock_dict_refs!(_module_guard, obj);
+    if let Some(entries) = w_module_dict_object_storage(obj) {
+        return entries.values().copied().collect();
+    }
+    let strategy = &*w_module_dict_get_strategy(obj);
+    strategy
+        .getitervalues(&*w_module_dict_get_storage(obj))
+        .collect()
+}
+
 /// Iterate over (key_str, value) pairs. Keys must be str objects.
 ///
 /// Pyre-only convenience wrapper around `w_dict_items` that drops

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -457,12 +457,18 @@ pub unsafe fn dict_entries_pop_last(entries: &mut indexmap::IndexMap<ObjectKey, 
 /// allocating `object_key_for(w_str_new(key))` path when no str hash hook is
 /// installed (pyre-object lib tests without the str hook, pre-init snapshot
 /// tools), preserving today's behavior there.
+///
+/// `hash` is `key`'s digest when the caller already holds it —
+/// [`crate::unicodeobject::w_str_hash_memoized`] on the string object `key` was
+/// borrowed from (`rstr.py:402-412 ll_strhash`).  Zero means the caller has
+/// none and the bytes are hashed here.
 #[inline]
 unsafe fn dict_entries_get_str(
     entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
     key: &str,
+    hash: i64,
 ) -> Option<PyObjectRef> {
-    match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
+    match memoized_or_hashed(key, hash) {
         Some(hash) => {
             // Clear any stale eq flag so a str-subclass comparison in the probe
             // starts clean, matching `object_key_for`'s pre-probe reset (:125).
@@ -473,6 +479,18 @@ unsafe fn dict_entries_get_str(
     }
 }
 
+/// `key`'s digest: the one the caller memoized on the string object it borrowed
+/// `key` from, or — when it holds none — a fresh hash of the borrowed bytes.
+/// `None` when no str hash hook is installed, which puts the caller on its
+/// allocating owned-key arm.
+#[inline]
+fn memoized_or_hashed(key: &str, hash: i64) -> Option<i64> {
+    if hash != 0 {
+        return Some(hash);
+    }
+    crate::dict_eq_hook::try_hash_str(key.as_bytes())
+}
+
 /// Borrow-key membership probe returning the entry index, for str-keyed
 /// `setitem_str`: a re-store to an existing name updates in place and reuses
 /// the stored key, so only a genuinely new key allocates a persistent
@@ -480,12 +498,15 @@ unsafe fn dict_entries_get_str(
 /// inserted key, not an overwrite — `dictmultiobject.py:1220-1221`).  Falls
 /// back to the allocating `object_key_for(w_str_new(key))` probe when no str
 /// hash hook is installed.
+///
+/// `hash` carries a caller-held digest, as in [`dict_entries_get_str`].
 #[inline]
 unsafe fn dict_entries_index_of_str(
     entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
     key: &str,
+    hash: i64,
 ) -> Option<usize> {
-    match crate::dict_eq_hook::try_hash_str(key.as_bytes()) {
+    match memoized_or_hashed(key, hash) {
         Some(hash) => {
             crate::dict_eq_hook::take_eq_error();
             dict_entries_index_of_str_hashed(entries, hash, key)
@@ -2126,7 +2147,7 @@ unsafe fn w_module_dict_setitem_str_internal(obj: PyObjectRef, key: &str, w_valu
         let value_slot = roots.base();
         roots.pin_root(w_value);
         let entries = w_module_dict_object_storage_mut(obj);
-        match dict_entries_index_of_str(entries, key) {
+        match dict_entries_index_of_str(entries, key, 0) {
             Some(idx) => {
                 dict_entries_value_set_at(entries, idx, roots.get(value_slot));
             }
@@ -2166,7 +2187,7 @@ pub unsafe fn w_module_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<P
         // overridden `__eq__`/`__hash__` are reachable from the
         // str-fast-path lookup.  A borrowed `&str` probe avoids the
         // per-lookup throwaway `W_UnicodeObject` (`getitem_str` parity).
-        return dict_entries_get_str(entries, key);
+        return dict_entries_get_str(entries, key, 0);
     }
     {
         let strategy = &*(*(obj as *const W_ModuleDictObject)).mstrategy;
@@ -3483,8 +3504,23 @@ pub unsafe fn w_dict_setitem(obj: PyObjectRef, key: i64, value: PyObjectRef) {
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_dict_getitem_str(obj: PyObjectRef, key: &str) -> Option<PyObjectRef> {
+    w_dict_getitem_str_hashed(obj, key, 0)
+}
+
+/// [`w_dict_getitem_str`] for a caller that already holds `key`'s digest —
+/// [`crate::unicodeobject::w_str_hash_memoized`] on the string object `key` was
+/// borrowed from (`rstr.py:402-412 ll_strhash`).  Zero leaves the strategy to
+/// hash the borrowed bytes, which is what every other caller gets.
+///
+/// # Safety
+/// Same as [`w_dict_getitem_str`].
+pub unsafe fn w_dict_getitem_str_hashed(
+    obj: PyObjectRef,
+    key: &str,
+    hash: i64,
+) -> Option<PyObjectRef> {
     lock_dict_refs!(_dict_guard, obj);
-    w_dict_get_strategy(obj).getitem_str(obj, key)
+    w_dict_get_strategy(obj).getitem_str_hashed(obj, key, hash)
 }
 
 /// Error-propagating sibling of [`w_dict_getitem_str`], the str-keyed
@@ -3503,7 +3539,20 @@ pub unsafe fn w_dict_getitem_str_checked(
     obj: PyObjectRef,
     key: &str,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
-    let hit = w_dict_getitem_str(obj, key);
+    w_dict_getitem_str_checked_hashed(obj, key, 0)
+}
+
+/// [`w_dict_getitem_str_checked`] for a caller that already holds `key`'s
+/// digest, as [`w_dict_getitem_str_hashed`] takes it.
+///
+/// # Safety
+/// `obj` must point to a valid dict.
+pub unsafe fn w_dict_getitem_str_checked_hashed(
+    obj: PyObjectRef,
+    key: &str,
+    hash: i64,
+) -> Result<Option<PyObjectRef>, DictKeyError> {
+    let hit = w_dict_getitem_str_hashed(obj, key, hash);
     if take_dict_key_error() {
         return Err(DictKeyError);
     }
@@ -3523,12 +3572,25 @@ pub unsafe fn w_dict_getitem_str_object_strategy(
     obj: PyObjectRef,
     key: &str,
 ) -> Option<PyObjectRef> {
+    w_dict_getitem_str_object_strategy_hashed(obj, key, 0)
+}
+
+/// [`w_dict_getitem_str_object_strategy`] for a caller that already holds
+/// `key`'s digest (`rstr.py:402-412 ll_strhash`).
+///
+/// # Safety
+/// Same as [`w_dict_getitem_str_object_strategy`].
+pub unsafe fn w_dict_getitem_str_object_strategy_hashed(
+    obj: PyObjectRef,
+    key: &str,
+    hash: i64,
+) -> Option<PyObjectRef> {
     let dict = &*(obj as *const W_DictObject);
     let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
     // Under the `dict_keys_equal` hash/eq pair, str-keyed lookups hash on the
     // str hash and compare on WTF-8 byte equality.  A borrowed `&str` probe
     // avoids the per-lookup throwaway `W_UnicodeObject` (`getitem_str` parity).
-    dict_entries_get_str(entries, key)
+    dict_entries_get_str(entries, key, hash)
 }
 
 /// `pypy/objspace/std/dictmultiobject.py:111-112 W_DictMultiObject.setitem_str`
@@ -3545,8 +3607,24 @@ pub unsafe fn w_dict_getitem_str_object_strategy(
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_dict_setitem_str(obj: PyObjectRef, key: &str, value: PyObjectRef) {
+    w_dict_setitem_str_hashed(obj, key, 0, value)
+}
+
+/// [`w_dict_setitem_str`] for a caller that already holds `key`'s digest, as
+/// [`w_dict_getitem_str_hashed`] takes it.
+///
+/// Residualised for [`w_dict_setitem_str`]'s reason.
+#[majit_macros::dont_look_inside]
+/// # Safety
+/// Same as [`w_dict_setitem_str`].
+pub unsafe fn w_dict_setitem_str_hashed(
+    obj: PyObjectRef,
+    key: &str,
+    hash: i64,
+    value: PyObjectRef,
+) {
     lock_dict_refs!(_dict_guard, obj, value);
-    w_dict_get_strategy(obj).setitem_str(obj, key, value)
+    w_dict_get_strategy(obj).setitem_str_hashed(obj, key, hash, value)
 }
 
 /// Compatibility spelling retained until the remaining callers are collapsed.
@@ -5691,6 +5769,25 @@ pub trait DictStrategy {
         self.getitem(w_dict, w_key)
     }
 
+    /// [`getitem_str`](Self::getitem_str) told `key`'s digest, so a strategy
+    /// whose table is keyed on `space.hash_w` can probe without re-hashing the
+    /// bytes.  The digest is the memo `rstr.py:402-412 ll_strhash` keeps in the
+    /// string object the caller borrowed `key` from; zero means it holds none.
+    /// Only the strategies backed by that table override this — the default
+    /// discards the digest and re-hashes.
+    ///
+    /// # Safety
+    /// `w_dict` must be a valid PyObjectRef.
+    unsafe fn getitem_str_hashed(
+        &self,
+        w_dict: PyObjectRef,
+        key: &str,
+        hash: i64,
+    ) -> Option<PyObjectRef> {
+        let _ = hash;
+        self.getitem_str(w_dict, key)
+    }
+
     /// `dictmultiobject.py:475-476 setitem` — required.
     ///
     /// # Safety
@@ -5705,6 +5802,23 @@ pub trait DictStrategy {
     unsafe fn setitem_str(&self, w_dict: PyObjectRef, key: &str, w_value: PyObjectRef) {
         let w_key = crate::w_str_new(key);
         self.setitem(w_dict, w_key, w_value);
+    }
+
+    /// [`setitem_str`](Self::setitem_str)'s counterpart to
+    /// [`getitem_str_hashed`](Self::getitem_str_hashed), taking `key`'s digest
+    /// the same way.
+    ///
+    /// # Safety
+    /// `w_dict` and `w_value` must be valid PyObjectRef.
+    unsafe fn setitem_str_hashed(
+        &self,
+        w_dict: PyObjectRef,
+        key: &str,
+        hash: i64,
+        w_value: PyObjectRef,
+    ) {
+        let _ = hash;
+        self.setitem_str(w_dict, key, w_value);
     }
 
     /// `dictmultiobject.py:481-482 delitem` — required.
@@ -6642,7 +6756,16 @@ impl DictStrategy for ObjectDictStrategy {
     /// `dictmultiobject.py:1216-1218 ObjectDictStrategy.getitem_str` —
     /// upstream just delegates to `getitem` after wrapping the key.
     unsafe fn getitem_str(&self, w_dict: PyObjectRef, key: &str) -> Option<PyObjectRef> {
-        crate::dictmultiobject::w_dict_getitem_str_object_strategy(w_dict, key)
+        self.getitem_str_hashed(w_dict, key, 0)
+    }
+
+    unsafe fn getitem_str_hashed(
+        &self,
+        w_dict: PyObjectRef,
+        key: &str,
+        hash: i64,
+    ) -> Option<PyObjectRef> {
+        crate::dictmultiobject::w_dict_getitem_str_object_strategy_hashed(w_dict, key, hash)
     }
 
     /// `dictmultiobject.py:1220-1221 setitem_str` — `ObjectDictStrategy`
@@ -7012,6 +7135,16 @@ impl DictStrategy for UnicodeDictStrategy {
     /// key then dispatches to `setitem`.  UnicodeDictStrategy keeps
     /// str keys on the fast path; no promotion.
     unsafe fn setitem_str(&self, w_dict: PyObjectRef, key: &str, w_value: PyObjectRef) {
+        self.setitem_str_hashed(w_dict, key, 0, w_value);
+    }
+
+    unsafe fn setitem_str_hashed(
+        &self,
+        w_dict: PyObjectRef,
+        key: &str,
+        hash: i64,
+        w_value: PyObjectRef,
+    ) {
         // This is the one `setitem_str` that both collects and stores itself:
         // the membership probe can run a str-subclass `__eq__` (and its no-hook
         // arm wraps the key), and a miss mints the persistent key.  A dict
@@ -7022,7 +7155,7 @@ impl DictStrategy for UnicodeDictStrategy {
         let roots = crate::gc_roots::push_roots();
         let dict_slot = roots.publish(&[w_dict, w_value]);
         let value_slot = dict_slot + 1;
-        let found = dict_entries_index_of_str(w_dict_object_storage(w_dict), key);
+        let found = dict_entries_index_of_str(w_dict_object_storage(w_dict), key, hash);
         match found {
             Some(idx) => {
                 let w_value = roots.get(value_slot);
@@ -7047,7 +7180,16 @@ impl DictStrategy for UnicodeDictStrategy {
 
     /// `dictmultiobject.py:1315-1318 getitem_str` override.
     unsafe fn getitem_str(&self, w_dict: PyObjectRef, key: &str) -> Option<PyObjectRef> {
-        crate::dictmultiobject::w_dict_getitem_str_object_strategy(w_dict, key)
+        self.getitem_str_hashed(w_dict, key, 0)
+    }
+
+    unsafe fn getitem_str_hashed(
+        &self,
+        w_dict: PyObjectRef,
+        key: &str,
+        hash: i64,
+    ) -> Option<PyObjectRef> {
+        crate::dictmultiobject::w_dict_getitem_str_object_strategy_hashed(w_dict, key, hash)
     }
 
     /// `dictmultiobject.py:1061-1067 AbstractTypedStrategy.setitem`.

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -754,6 +754,39 @@ pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
     unsafe { (*(obj as *mut W_UnicodeObject)).hash = hash }
 }
 
+/// `rstr.py:402-412 ll_strhash` — read the memo, and compute the digest only
+/// while the slot still reads zero:
+///
+/// ```python
+/// def ll_strhash(s):
+///     if not s:
+///         return 0
+///     x = s.hash
+///     if x == 0:
+///         x = LLHelpers._ll_strhash(s)
+///     return x
+/// ```
+///
+/// The digest is the one [`crate::dict_eq_hook::try_hash_str`] produces, so a
+/// key hashed here lands in the bucket a borrowed-`&str` probe would have
+/// found.  Answers zero when no str-hash hook is installed — callers read that
+/// as "no memo", not as a digest, and hash the borrowed bytes themselves.
+///
+/// # Safety
+/// `obj` must be a `W_UnicodeObject`.
+pub unsafe fn w_str_hash_memoized(obj: PyObjectRef) -> i64 {
+    let cached = unsafe { w_str_get_hash(obj) };
+    if cached != 0 {
+        return cached;
+    }
+    let bytes = unsafe { w_str_get_wtf8(obj) }.as_bytes();
+    let Some(hash) = crate::dict_eq_hook::try_hash_str(bytes) else {
+        return 0;
+    };
+    unsafe { w_str_set_hash(obj, hash) };
+    hash
+}
+
 /// Borrow a known W_UnicodeObject as `&str`, or `None` when it carries a lone
 /// surrogate (so the backing is not valid UTF-8).
 ///

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -578,6 +578,37 @@ pub unsafe fn intern_exact_str(obj: PyObjectRef) -> PyObjectRef {
     obj
 }
 
+/// `objspace.new_interned_str(s)` — the process-wide canonical exact `str` for
+/// `value`, built only when the value is not interned yet.
+///
+/// [`intern_exact_str`] answers the same question for a caller that already
+/// holds an object, and must be handed one even when the table already has the
+/// canonical instance.  A caller that holds only the characters — a code
+/// object realizing `co_names_w` (`pycode.py:127-129`), an attribute name —
+/// would have to build a [`w_str_new`] result to ask, and that result is
+/// `malloc_typed`-immortal: abandoning it on a hit retains it for the process
+/// lifetime.  Interning from the value instead builds nothing on a hit.
+#[majit_macros::dont_look_inside]
+pub fn intern_str_value(value: &str) -> PyObjectRef {
+    let mut table = STRING_INTERN_TABLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let Some(slot) = table.get(Wtf8::new(value)) {
+        return **slot as PyObjectRef;
+    }
+    let obj = w_str_new(value);
+    let mut slot = Box::new(obj as usize);
+    let root_slot = (&mut *slot) as *mut usize as *mut *mut u8;
+    // `w_str_new` is immortal, so this root only has to keep the collector from
+    // rewriting a slot it never owns; the registration matches
+    // [`intern_exact_str`] so both entry points present the table identically.
+    unsafe {
+        crate::gc_hook::try_gc_add_root(root_slot);
+    }
+    table.insert(Wtf8Buf::from_string(value.to_string()), slot);
+    obj
+}
+
 /// CPython 3.14 `PyUnicode_CHECK_INTERNED`: true only when `obj` itself is the
 /// canonical value stored in the process-wide intern table.
 ///


### PR DESCRIPTION
This branch started as `co_names_w` and grew two more strands on the same
surface: what a code object retains after it is wrapped, and how a namespace
key is hashed. Ten commits, three groups.

| | |
|---|---|
| `majit: fold canmallocgc…` | pre-existing, carried along |
| `interpreter: probe LOAD_NAME's locals through finditem_str`<br>`interpreter: add co_names_w and key name lookups from it` | **1. name keys** — below |
| `interpreter: defer code object locations and intern code object names`<br>`deps: move the rustpython pin to 91a725fe833d` + fmt<br>`interpreter: wrap nested code constants in place instead of copying them`<br>`interpreter: hand an owned code object to its wrapper instead of copying it`<br>`object: give ModuleDictStrategy a positional accessor for dict iteration` | **2. code object retention** |
| `object, interpreter: hash a namespace key through the name string's memo` | **3. the name hash memo** |

---

# 1. `co_names_w`

## What

`pycode.py:127-129` builds `co_names_w` from the code object's names, and
`pyopcode.py:521-522 getname_w` hands out its entries. Pyre's `PyCode` carried
`globals_caches`, `mapdict_caches` and `co_consts_w` — every per-name-index
table sized to `code.names.len()` — but not that table itself. So a name-keyed
lookup that could not take a dict's borrowed-`&str` shortcut wrapped a fresh key
with `w_str_new`, whose result is `malloc_typed`-immortal by contract.

Per **execution**, not per name. Nothing reclaims it.

## Measured

`bench/synth/class_body_exec_hot_loop`, peak RSS **941.1 → 122.2 MB** (pypy3
35.8, cpython3 18.0). User CPU 1.65 → 1.33 s, min of 5 (the host was at load
~500, so read the CPU figures as indicative and the RSS as exact).

A class-body loop scaled over 25..400 repeats:

| | 25 | 50 | 100 | 200 | 400 |
|---|---|---|---|---|---|
| before | 103.8 | 131.9 | 187.6 | 297.7 | 521.5 |
| after | 76.0 | 75.1 | 77.0 | 77.9 | **78.8** |

What identifies the removed allocations as off-collector: lowering
`PYPY_GC_MIN` 64-fold moved the *before* figures not at all (521.5 vs 521.4).
Collectable populations in the same runs — `str()`, f-strings, `%`, `join` —
respond to it and are untouched here.

## How

- `co_names_w` as lazily realized `AtomicPtr` slots with CAS publish, plus
  `w_code_getname_w` and a `_or_new` form falling back to `w_str_new` for a
  wrapper carrying no name table. Slots hold `w_str_new` results, which are
  immortal and so never move — no walking, and a lost publish race abandons its
  candidate. That is `w_code_qualname_obj`'s lifetime argument, not
  `w_code_const`'s root-registration dance.
- `finditem_str_named` reads the slot **only on the arm that consumes a wrapped
  key**. Reading it is a `dont_look_inside` call the JIT residualises, and the
  shortcut arm is the one that already allocated nothing.
- Routed: `load_name_value`, `load_global_value`, `store_name_value`,
  `store_global_value`, `load_from_dict_or_globals`, and the
  `bh_load_from_dict_or_globals_fn` residual.

## A latent hazard this closed

`store_name_value` and `store_global_value` had always ignored their
`nameindex`, so three callers passed a literal `0`: the `bh_store_name_fn` and
`bh_store_global_fn` residuals and the implicit class-body `__class__` store.
Giving that parameter meaning would have made all three key from
`co_names_w[0]` — the *first* name in the table.

The residuals now enter through `store_name_value_w` / `store_global_value_w`,
keying from the `w_name` operand they were already being handed and discarding;
`__class__` passes `NO_NAMEINDEX`, out of range for every name table. The dict
arm the three STORE_NAME paths share is factored into `store_name_into_dict`.

## Verification

- A 13-case probe — class-body name resolution, the `__class__` cell and an
  explicit `__class__` shadow, `exec` into a plain dict / a `dict` subclass with
  `__getitem__` / one with `__missing__` / an `OrderedDict`, two-argument `exec`,
  `global`, `del`, PEP 695 type-param scope, per-code name independence — is
  byte-identical to the pre-change binary.
- `test_scope`, `test_class`, `test_super`, `test_descr`, `test_builtin`,
  `test_dict`: identical verdicts before and after.
- `cargo check -p pyrex --no-default-features --features dynasm` clean.

## Not in this PR

The remaining floor is a fixed **~8.5 KB per code object** (cpython 1.1, pypy
2.1, flat across 500/1500/3000 defs and GC-invisible), which is why `import
decimal` costs pyre +55.0 MB against cpython's +1.3. Separate work.

`delete_name` and `load_from_dict_or_deref` still mint — neither carries a name
index in its signature.

---

# 2. What a code object retains

Four allocations a wrapped code object kept that nothing reclaims, found by
attributing a `malloc_history -allBySize` census to **the frame directly above
the allocator** rather than to the nearest pyre frame (aggregating the other way
hides the culprit whenever the allocator itself tops the list).

- **`locations` is pure derived data.** RustPython builds it from `linetable`
  via `codegen/src/ir.rs linetable_to_locations`, the same function
  `code_locations` calls, and both the compile and the marshal path always carry
  `linetable`. Release the expanded array and rebuild it on demand.
- **Code object names** were minted per wrapper; interned now.
- **`box_code_constant` deep-copied the nested `CodeObject`.** A
  `ConstantData::Code { code: Box<CodeObject> }` does not move when the
  enclosing `Vec` moves, and `pycode_destructor` never frees `code_ptr`, so the
  wrapper can borrow the constant in place. `fix_code_filenames` rewrites the
  nested tree through `IndexMut` — which is why the rustpython pin moves to
  `91a725fe833d`, the first upstream commit carrying the `Constants`
  mutable-access impls from RustPython#8557.
- **`make_code` cloned an owned `CodeObject`** into its wrapper; it is handed
  over now.

Retained bytes on a single `import re`: `box_code_constant*` 10.35 → 0.55 MB,
`fix_code_filenames` 4.44 → 0.07 MB.

Then a fifth, of a different kind: `w_str_new` was called **161,382** times on
that same `import re`. `DictStrategy::nth_item`'s default is
`self.items(w_dict).into_iter().nth(index)` — it materialises the whole list to
answer one index, minting a `w_str` per key each time. Fine for the tiny empty
strategies it was written for; quadratic for `ModuleDictStrategy`, which every
module dict uses. `ModuleDictStrategy` gets a positional accessor and overrides
`nth_item` / `nth_value`.

`w_str_new` 7.16 MB / 161,382 calls → **2.68 MB / 60,216**. Peak RSS on a
15-module import **275.4 → 210.4 MB**, reproduced with the arms reversed
(276.4 → 209.6).

---

# 3. The name hash memo

`LOAD_NAME` / `STORE_NAME` reach the locals dict with a borrowed `&str`, so the
entry probe hashed the name's WTF-8 bytes on **every opcode**. The digest
`rstr.py:402-412 ll_strhash` memoizes in the string object was never read there
— `W_UnicodeObject.hash` and its accessors exist, but only `hash_value`
consulted them. Upstream gets this for free because `co_names[i]` is an RPython
string and `ll_strhash` caches in the string itself.

`w_str_hash_memoized` is the read-or-compute half of `ll_strhash`. The two
borrow-key entry probes take a `hash`; `DictStrategy` gains
`getitem_str_hashed` / `setitem_str_hashed` whose defaults discard it, overridden
by the two strategies backed by the `space.hash_w`-keyed table. The name opcodes
source the digest from the `co_names_w` slot naming the key, the JIT's
STORE_NAME / STORE_GLOBAL residuals from the `w_name` they are handed. Zero
means "no memo" and every other caller hashes the bytes as before.

Measured against a **same-base control build** (same HEAD, the four files
reverted, own `extract-llbc` + release build), min of 5 interleaved runs:

| shape | control | with the memo | |
|---|---|---|---|
| class body | 293.4 | 239.9 ns/iter | **−18.2%** |
| `exec` into a plain dict | 281.1 | 228.7 ns/iter | **−18.6%** |
| `exec` into a `dict` subclass | 1342.1 | 1310.1 ns/iter | −2.4% |
| module globals | 318.8 | 311.1 ns/iter | −2.4% |
| function locals | 2.6 | 2.7 ns/iter | — |
| `d["a"] = d["a"] + 1` | 101.2 | 100.7 ns/iter | — |

The two untouched shapes are the internal control: the change is confined to the
borrowed-`&str` name path, and only the shapes on it move.

`bench/synth/class_body_exec_hot_loop` itself moves only −3.5% (1.073 → 1.035 s,
min of 9 interleaved) because two of its four shapes hand `exec` a `dict`
subclass, and those spend ~26% of their time in `resolve_dict_backing` — a
mapdict slot read under a global mutex, done **twice** per `__setitem__`, with no
upstream counterpart (upstream a `dict` subclass *is* a `W_DictMultiObject`, so
`self` is the payload). Identified, not fixed here.

---

# Verification for 2 and 3

- **`cpython_tests` full suite: 210/210 PASS, no regressions** (dynasm, jit on).
- `cargo test -p pyre-object`: 275 passed.
- An 8-case `_fix_co_filename` probe (including `replace` + a shared nested code
  object) and a 9-case module-dict probe (including the object-strategy switch)
  are byte-identical to CPython 3.14.6 and to the pre-change binary.
- `pyre/check.py --backend dynasm` reports 17 jit-stats failures — **all 17
  reproduce byte-identically on the same-base control binary**, including
  `class_body_exec_hot_loop bridges_compiled 0 -> 1`. They are base-owned, not
  from these commits, and no snapshot was re-recorded.

— *commented by Claude*
