### PR TITLE
cpyext: what a Cython module reaches for, and the descriptor-cache order it made visible

### DIFF
--- a/include/pyre3.14t/Python.h
+++ b/include/pyre3.14t/Python.h
@@ -5,8 +5,11 @@
  * from the exports themselves; the rest is the hand-written half --
  * the structs an extension lays out, and the macros it expands.
  */
-#ifndef PYRE_PYTHON_H
-#define PYRE_PYTHON_H
+/* The guard is the name CPython and PyPy both give it: an extension that
+ * wants to know whether it has Python's headers at all tests `Py_PYTHON_H`,
+ * and Cython's generated C refuses to compile without it. */
+#ifndef Py_PYTHON_H
+#define Py_PYTHON_H
 
 #include <assert.h>
 #include <inttypes.h>
@@ -19,8 +22,10 @@
 #include <string.h>
 #include <wchar.h>
 
-#include "patchlevel.h"
+/* `pyport.h` first: `patchlevel.h` declares one object, and `PyAPI_DATA` is
+ * what declares it. */
 #include "pyport.h"
+#include "patchlevel.h"
 #include "pymacro.h"
 #include "pytypedefs.h"
 #include "object.h"
@@ -59,9 +64,12 @@
 #include "sliceobject.h"
 #include "memoryobject.h"
 #include "pycapsule.h"
+#include "code.h"
+#include "funcobject.h"
+#include "traceback.h"
 #include "import.h"
 #include "modsupport.h"
 #include "audit.h"
 #include "abstract.h"
 
-#endif /* !PYRE_PYTHON_H */
+#endif /* !Py_PYTHON_H */

--- a/include/pyre3.14t/code.h
+++ b/include/pyre3.14t/code.h
@@ -1,0 +1,33 @@
+/* The flag bits a code object's `co_flags` is made of.
+ *
+ * One of the headers `Python.h` includes; an extension includes only
+ * `Python.h`. The exported entry points are declared together in
+ * `pyre_decl.h`, which is generated.
+ */
+#ifndef PYRE_CODE_H
+#define PYRE_CODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* Each bit is the one `inspect` publishes under the same name, so a value an
+   extension builds here and a value it reads from Python mean the same thing.
+   A code object itself stays opaque -- `PyCodeObject` is named in
+   `pytypedefs.h` and has no fields an extension may read. */
+#define CO_OPTIMIZED            0x0001
+#define CO_NEWLOCALS            0x0002
+#define CO_VARARGS              0x0004
+#define CO_VARKEYWORDS          0x0008
+#define CO_NESTED               0x0010
+#define CO_GENERATOR            0x0020
+#define CO_COROUTINE            0x0080
+#define CO_ITERABLE_COROUTINE   0x0100
+#define CO_ASYNC_GENERATOR      0x0200
+#define CO_HAS_DOCSTRING        0x4000000
+#define CO_METHOD               0x8000000
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_CODE_H */

--- a/include/pyre3.14t/compile.h
+++ b/include/pyre3.14t/compile.h
@@ -1,0 +1,21 @@
+/* What `Py_CompileString` and its callers name a compilation unit's shape by.
+ *
+ * An extension includes this by name rather than through `Python.h`, which is
+ * where the reference header set puts it too.
+ */
+#ifndef PYRE_COMPILE_H
+#define PYRE_COMPILE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define Py_single_input 256
+#define Py_file_input 257
+#define Py_eval_input 258
+#define Py_func_type_input 345
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_COMPILE_H */

--- a/include/pyre3.14t/frameobject.h
+++ b/include/pyre3.14t/frameobject.h
@@ -1,0 +1,22 @@
+/* Frames.
+ *
+ * An extension includes this by name rather than through `Python.h`, which is
+ * where the reference header set puts it too.
+ */
+#ifndef PYRE_FRAMEOBJECT_H
+#define PYRE_FRAMEOBJECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/* A frame is opaque: nothing outside this runtime reads a field of one, and
+   an extension only ever holds a pointer. */
+typedef struct _frame PyFrameObject;
+
+#define PyFrame_Check(op) Py_IS_TYPE((op), &PyFrame_Type)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_FRAMEOBJECT_H */

--- a/include/pyre3.14t/funcobject.h
+++ b/include/pyre3.14t/funcobject.h
@@ -1,0 +1,25 @@
+/* Bound methods.
+ *
+ * One of the headers `Python.h` includes; an extension includes only
+ * `Python.h`. The exported entry points are declared together in
+ * `pyre_decl.h`, which is generated.
+ */
+#ifndef PYRE_FUNCOBJECT_H
+#define PYRE_FUNCOBJECT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define PyMethod_Check(op) PyObject_TypeCheck((op), &PyMethod_Type)
+
+/* The reference header reads the two members straight out of the struct.  A
+   mirror has no members to read, so each is the call that answers with the
+   same borrowed reference. */
+#define PyMethod_GET_FUNCTION(obj) PyMethod_Function((PyObject *)(obj))
+#define PyMethod_GET_SELF(obj) PyMethod_Self((PyObject *)(obj))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_FUNCOBJECT_H */

--- a/include/pyre3.14t/import.h
+++ b/include/pyre3.14t/import.h
@@ -10,9 +10,10 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-/* Imports.  The borrowed-reference `PyImport_AddModule` and
-   `PyImport_GetModuleDict` are absent: pyre has no container to hang the
-   borrow on, so only the strong-reference forms exist. */
+/* Imports.  The borrowed-reference `PyImport_AddModule` is absent: pyre has no
+   container to hang the borrow on, so only the strong-reference form exists.
+   `PyImport_GetModuleDict` is present because `sys.modules` outlives every
+   caller, which is what makes its borrow sound. */
 
 #ifdef __cplusplus
 }

--- a/include/pyre3.14t/lock.h
+++ b/include/pyre3.14t/lock.h
@@ -53,6 +53,19 @@ _PyMutex_IsLocked(PyMutex *m)
 }
 #define PyMutex_IsLocked _PyMutex_IsLocked
 
+/* A critical section serializes the operations that name the same object.
+   Here every Python thread runs under one global lock, which already gives
+   that ordering, so entering one costs nothing and the macros are the braces
+   that scope the block an extension wrote between them.  `op` is not
+   evaluated: an extension that writes `Py_BEGIN_CRITICAL_SECTION(f(x))` gets
+   no call, the same as when the reference header serializes on the lock. */
+#define Py_BEGIN_CRITICAL_SECTION(op)               {
+#define Py_BEGIN_CRITICAL_SECTION_MUTEX(mutex)      {
+#define Py_END_CRITICAL_SECTION()                   }
+#define Py_BEGIN_CRITICAL_SECTION2(a, b)            {
+#define Py_BEGIN_CRITICAL_SECTION2_MUTEX(m1, m2)    {
+#define Py_END_CRITICAL_SECTION2()                  }
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/pyre3.14t/methodobject.h
+++ b/include/pyre3.14t/methodobject.h
@@ -25,6 +25,49 @@ struct PyMethodDef {
 #define METH_STATIC 0x0020
 #define METH_COEXIST 0x0040
 #define METH_FASTCALL 0x0080
+/* A method that is handed the class defining it beside its receiver, and so
+   carries a `PyCMethodObject` rather than a `PyCFunctionObject`. */
+#define METH_METHOD 0x0200
+
+/* The two layouts a C function carries.
+ *
+ * Nothing pyre makes is read through these: what a `PyMethodDef`-backed
+ * callable holds is reached through the entry points below, which is why they
+ * are calls where the reference header spells them as field reads.  The fields
+ * are declared because an extension defining a type derived from
+ * `PyCFunction_Type` embeds one of these in its own instance layout and writes
+ * them itself -- the block a C-defined type's instance gets is `tp_basicsize`
+ * bytes, so those fields are that instance's own storage. */
+typedef struct {
+    PyObject_HEAD
+    PyMethodDef *m_ml;
+    PyObject *m_self;
+    PyObject *m_module;
+    PyObject *m_weakreflist;
+    vectorcallfunc vectorcall;
+} PyCFunctionObject;
+
+typedef struct {
+    PyCFunctionObject func;
+    PyTypeObject *mm_class;
+} PyCMethodObject;
+
+/* The type an extension's own `PyMethodDef` becomes, and so the base a type
+   derived from it names.  An interpreter builtin such as `len` is a different
+   `builtin_function_or_method` that no symbol here names, and
+   `PyCFunction_Check` answers no for it: it carries no `PyMethodDef`, so
+   `PyCFunction_GetFunction` would have nothing to hand back. */
+PyAPI_DATA(PyTypeObject) PyCFunction_Type;
+
+#define PyCFunction_Check(op) PyObject_TypeCheck((op), &PyCFunction_Type)
+#define PyCFunction_CheckExact(op) Py_IS_TYPE((op), &PyCFunction_Type)
+#define PyCMethod_CheckExact(op) Py_IS_TYPE((op), &PyCMethod_Type)
+#define PyCMethod_Check(op) PyObject_TypeCheck((op), &PyCMethod_Type)
+
+#define PyCFunction_GET_FUNCTION(func) PyCFunction_GetFunction((PyObject *)(func))
+#define PyCFunction_GET_SELF(func) PyCFunction_GetSelf((PyObject *)(func))
+#define PyCFunction_GET_FLAGS(func) PyCFunction_GetFlags((PyObject *)(func))
+#define PyCFunction_GET_CLASS(func) PyCFunction_GetClass((PyObject *)(func))
 
 #ifdef __cplusplus
 }

--- a/include/pyre3.14t/objimpl.h
+++ b/include/pyre3.14t/objimpl.h
@@ -32,6 +32,10 @@ extern "C" {
         }                                                       \
     } while (0)
 
+/* The reference header reads the flag out of the collector's own header word
+   in front of the block; here the answer is a call. */
+#define _PyGC_FINALIZED(o) PyObject_GC_IsFinalized((PyObject *)(o))
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/pyre3.14t/patchlevel.h
+++ b/include/pyre3.14t/patchlevel.h
@@ -26,11 +26,35 @@ extern "C" {
 /* Version as a string */
 #define PY_VERSION "3.14.6"
 
+/* The same four digits packed as `PY_VERSION_HEX` packs them, read at run
+   time: the macros above are what an extension was compiled against, and this
+   is what it is running against. */
+PyAPI_DATA(const unsigned long) Py_Version;
+
 /* Pyre version as a string. Keep in sync with the `pyrex` package version,
    which is what `sys.pyre_version_info` reports; `cpyext_patchlevel.rs`
    compares the two. */
 #define PYRE_VERSION "0.0.2"
 #define PYRE_VERSION_NUM 0x00000200
+
+/* What an extension asks when it wants to know whether the object layouts
+   behind these headers are CPython's.  They are not: pyre's cpyext mirrors
+   `pypy/module/cpyext`, so a `PyObject *` names a block that stands for an
+   interpreter object rather than the object itself, and nothing may read a
+   field of one that is not declared here.
+
+   `PYPY_VERSION` is the name that question is already spelled under -- Cython
+   branches on it, and so does much of the ecosystem -- and the value tracks
+   PyPy's own so that a version gate written for PyPy lands on the same side
+   for pyre.  Code that wants to know which of the two it has reads
+   `PYRE_VERSION` above. */
+#define PYPY_VERSION "8.0.0-alpha0"
+#define PYPY_VERSION_NUM 0x08000000
+
+/* A reference cpyext holds is a regular one: it keeps the interpreter object
+   alive for as long as the block does. */
+#define PYPY_CPYEXT_GC 1
+#define PyPy_Borrow(a, b) ((void)0)
 
 /* Version as a single 4-byte hex number, e.g. 0x030E06F0 == 3.14.6 final.
    Use this for numeric comparisons, e.g. #if PY_VERSION_HEX >= ...

--- a/include/pyre3.14t/pyport.h
+++ b/include/pyre3.14t/pyport.h
@@ -40,6 +40,20 @@ typedef intptr_t Py_ssize_t;
 #define PY_SSIZE_T_MIN (-PY_SSIZE_T_MAX - 1)
 typedef Py_ssize_t Py_hash_t;
 typedef size_t Py_uhash_t;
+/* The widest integer the C compiler offers, under the name an extension
+   spells it by, and the limits `<limits.h>` gives it. */
+#define PY_LONG_LONG long long
+#define PY_LLONG_MIN LLONG_MIN
+#define PY_LLONG_MAX LLONG_MAX
+#define PY_ULLONG_MAX ULLONG_MAX
+
+/* The fixed-width integer names an extension may spell a field or a cast
+   with, alongside the `<stdint.h>` names they stand for. */
+#define PY_UINT32_T uint32_t
+#define PY_UINT64_T uint64_t
+#define PY_INT32_T int32_t
+#define PY_INT64_T int64_t
+
 typedef uint32_t Py_UCS4;
 typedef uint16_t Py_UCS2;
 typedef uint8_t Py_UCS1;

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -105,6 +105,7 @@ PyAPI_FUNC(PyObject *) PyDict_New(void);
 PyAPI_FUNC(int) PyDict_Next(PyObject *, Py_ssize_t *, PyObject **, PyObject **);
 PyAPI_FUNC(int) PyDict_Pop(PyObject *, PyObject *, PyObject **);
 PyAPI_FUNC(int) PyDict_PopString(PyObject *, const char *, PyObject **);
+PyAPI_FUNC(PyObject *) PyDict_SetDefault(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyDict_SetDefaultRef(PyObject *, PyObject *, PyObject *, PyObject **);
 PyAPI_FUNC(int) PyDict_SetItem(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyDict_SetItemString(PyObject *, const char *, PyObject *);
@@ -131,6 +132,11 @@ PyAPI_FUNC(int) PyFloat_Check(PyObject *);
 PyAPI_FUNC(int) PyFloat_CheckExact(PyObject *);
 PyAPI_FUNC(PyObject *) PyFloat_FromDouble(double);
 
+/* cpyext/funcobject.rs */
+PyAPI_FUNC(PyObject *) PyMethod_Function(PyObject *);
+PyAPI_FUNC(PyObject *) PyMethod_New(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) PyMethod_Self(PyObject *);
+
 /* cpyext/gc.rs */
 PyAPI_FUNC(void) PyObject_GC_Track(void *);
 PyAPI_FUNC(void) PyObject_GC_UnTrack(void *);
@@ -141,10 +147,13 @@ PyAPI_FUNC(PyObject *) Py_GenericAlias(PyObject *, PyObject *);
 /* cpyext/import_.rs */
 PyAPI_FUNC(PyObject *) PyImport_AddModuleRef(const char *);
 PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *);
+PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 PyAPI_FUNC(PyObject *) PyImport_Import(PyObject *);
 PyAPI_FUNC(PyObject *) PyImport_ImportModule(const char *);
 PyAPI_FUNC(PyObject *) PyImport_ImportModuleAttr(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyImport_ImportModuleAttrString(const char *, const char *);
+PyAPI_FUNC(PyObject *) PyImport_ImportModuleLevel(const char *, PyObject *, PyObject *, PyObject *, int);
+PyAPI_FUNC(PyObject *) PyImport_ImportModuleLevelObject(PyObject *, PyObject *, PyObject *, PyObject *, int);
 PyAPI_FUNC(PyObject *) PyImport_ImportModuleNoBlock(const char *);
 
 /* cpyext/iterator.rs */
@@ -240,6 +249,13 @@ PyAPI_FUNC(int) PyMapping_SetItemString(PyObject *, const char *, PyObject *);
 PyAPI_FUNC(Py_ssize_t) PyMapping_Size(PyObject *);
 PyAPI_FUNC(PyObject *) PyMapping_Values(PyObject *);
 
+/* cpyext/methodobject.rs */
+PyAPI_FUNC(int) PyCFunction_GetFlags(PyObject *);
+PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
+PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);
+PyAPI_FUNC(PyObject *) PyCFunction_New(PyMethodDef *, PyObject *);
+PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *, PyObject *);
+
 /* cpyext/modsupport.rs */
 PyAPI_FUNC(PyObject *) PyModuleDef_Init(PyModuleDef *);
 PyAPI_FUNC(int) PyModule_Add(PyObject *, const char *, PyObject *);
@@ -309,10 +325,12 @@ PyAPI_FUNC(PyObject *) PyObject_ASCII(PyObject *);
 PyAPI_FUNC(int) PyObject_AsFileDescriptor(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Bytes(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Call(PyObject *, PyObject *, PyObject *);
+PyAPI_FUNC(int) PyObject_CallFinalizerFromDealloc(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_CallNoArgs(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_CallObject(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_CallOneArg(PyObject *, PyObject *);
 PyAPI_FUNC(void *) PyObject_Calloc(size_t, size_t);
+PyAPI_FUNC(void) PyObject_ClearManagedDict(PyObject *);
 PyAPI_FUNC(int) PyObject_DelAttr(PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_DelAttrString(PyObject *, const char *);
 PyAPI_FUNC(int) PyObject_DelItem(PyObject *, PyObject *);
@@ -354,7 +372,9 @@ PyAPI_FUNC(Py_ssize_t) PyObject_Size(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Str(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Type(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Vectorcall(PyObject *, PyObject *const *, size_t, PyObject *);
+PyAPI_FUNC(PyObject *) PyObject_VectorcallDict(PyObject *, PyObject *const *, size_t, PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_VectorcallMethod(PyObject *, PyObject *const *, size_t, PyObject *);
+PyAPI_FUNC(int) PyObject_VisitManagedDict(PyObject *, visitproc, void *);
 PyAPI_FUNC(PyObject *) PyVectorcall_Call(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) Py_GetConstant(unsigned int);
 PyAPI_FUNC(PyObject *) Py_GetConstantBorrowed(unsigned int);
@@ -392,8 +412,10 @@ PyAPI_FUNC(void) PyErr_SetNone(PyObject *);
 PyAPI_FUNC(void) PyErr_SetObject(PyObject *, PyObject *);
 PyAPI_FUNC(void) PyErr_SetRaisedException(PyObject *);
 PyAPI_FUNC(void) PyErr_SetString(PyObject *, const char *);
+PyAPI_FUNC(void) PyErr_WriteUnraisable(PyObject *);
 PyAPI_FUNC(void) _PyErr_BadInternalCall(const char *, int);
 PyAPI_FUNC(void) _PyErr_ChainExceptions1(PyObject *);
+PyAPI_FUNC(void) _PyPyre_WriteUnraisable(PyObject *, PyObject *);
 PyAPI_FUNC(void) _Py_FatalErrorFunc(const char *, const char *);
 
 /* cpyext/pymem.rs */
@@ -420,6 +442,8 @@ PyAPI_FUNC(PyThreadState *) PyEval_SaveThread(void);
 PyAPI_FUNC(int) PyEval_ThreadsInitialized(void);
 PyAPI_FUNC(int) PyGILState_Check(void);
 PyAPI_FUNC(PyThreadState *) PyGILState_GetThisThreadState(void);
+PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Get(void);
+PyAPI_FUNC(int64_t) PyInterpreterState_GetID(PyInterpreterState *);
 PyAPI_FUNC(PyThreadState *) PyThreadState_Get(void);
 PyAPI_FUNC(PyThreadState *) PyThreadState_Swap(PyThreadState *);
 PyAPI_FUNC(PyThreadState *) _PyThreadState_UncheckedGet(void);
@@ -588,6 +612,7 @@ PyAPI_FUNC(int) _PyPyre_WarnExplicitMessage(PyObject *, PyObject *, const char *
 PyAPI_FUNC(int) _PyPyre_WarnUnicode(PyObject *, PyObject *, PyObject *, Py_ssize_t);
 
 /* cpyext/weakrefobject.rs */
+PyAPI_FUNC(void) PyObject_ClearWeakRefs(PyObject *);
 PyAPI_FUNC(int) PyWeakref_Check(PyObject *);
 PyAPI_FUNC(int) PyWeakref_CheckProxy(PyObject *);
 PyAPI_FUNC(int) PyWeakref_CheckRef(PyObject *);

--- a/include/pyre3.14t/pyre_format.h
+++ b/include/pyre3.14t/pyre_format.h
@@ -352,6 +352,20 @@ static inline PyObject *PyErr_Format(PyObject *type, const char *format, ...)
     return NULL;
 }
 
+/* `PyErr_FormatUnraisable` states what was going on where
+   `PyErr_WriteUnraisable` names the object, so the message is built with this
+   engine and handed to the core the two share. */
+static inline void PyErr_FormatUnraisable(const char *format, ...)
+{
+    va_list va;
+    PyObject *message;
+    va_start(va, format);
+    message = PyUnicode_FromFormatV(format, va);
+    va_end(va);
+    _PyPyre_WriteUnraisable(message, NULL);
+    Py_XDECREF(message);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/pyre3.14t/pystate.h
+++ b/include/pyre3.14t/pystate.h
@@ -5,9 +5,10 @@
  * around a blocking call, one to take it before calling in from a thread of
  * its own.
  *
- * `PyThreadState` is opaque here. An extension receives one from
- * `PyEval_SaveThread` and hands it back to `PyEval_RestoreThread`; everything
- * upstream keeps inside the struct is reached through an entry point instead.
+ * An extension receives a `PyThreadState` from `PyEval_SaveThread` and hands it
+ * back to `PyEval_RestoreThread`. `interp` is the one field it reads directly,
+ * which is how it asks which interpreter the thread runs in without a call;
+ * everything else the struct stands for is reached through an entry point.
  */
 #ifndef PYRE_PYSTATE_H
 #define PYRE_PYSTATE_H
@@ -16,7 +17,17 @@
 extern "C" {
 #endif
 
-typedef struct _ts PyThreadState;
+/* The interpreter a thread runs in.  Opaque: an extension compares one handle
+   against another and passes it on, and reaches everything behind it through
+   an entry point. */
+typedef struct _is PyInterpreterState;
+
+typedef struct _ts {
+    PyInterpreterState *interp;
+} PyThreadState;
+
+/* The spelling an extension written before 3.9 uses for the same call. */
+#define PyThreadState_GET() PyThreadState_Get()
 
 typedef enum { PyGILState_LOCKED, PyGILState_UNLOCKED } PyGILState_STATE;
 

--- a/include/pyre3.14t/pytypedefs.h
+++ b/include/pyre3.14t/pytypedefs.h
@@ -43,6 +43,9 @@ typedef void (*PyCapsule_Destructor)(PyObject *);
 /* The buffer a `str` is written into piece by piece.  Opaque: only this
    runtime ever looks inside one. */
 typedef struct PyUnicodeWriter PyUnicodeWriter;
+/* A code object.  Opaque: nothing outside this runtime reads a field of one,
+   and an extension only ever holds a pointer. */
+typedef struct PyCodeObject PyCodeObject;
 
 #ifdef __cplusplus
 }

--- a/include/pyre3.14t/traceback.h
+++ b/include/pyre3.14t/traceback.h
@@ -1,0 +1,19 @@
+/* Tracebacks.
+ *
+ * One of the headers `Python.h` includes; an extension includes only
+ * `Python.h`. The exported entry points are declared together in
+ * `pyre_decl.h`, which is generated.
+ */
+#ifndef PYRE_TRACEBACK_H
+#define PYRE_TRACEBACK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define PyTraceBack_Check(v) Py_IS_TYPE((v), &PyTraceBack_Type)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* !PYRE_TRACEBACK_H */

--- a/pyre/pyre-interpreter/src/cpyext/dictobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/dictobject.rs
@@ -355,6 +355,26 @@ pub unsafe extern "C" fn PyDict_GetItemRef(
     unsafe { get_item_ref(found, result) }
 }
 
+/// `PyDict_SetDefault(dict, key, default)` — the value `key` already had, or
+/// `default` after storing it, borrowed from the dict either way.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyDict_SetDefault(
+    object: *mut CPyObject,
+    key: *mut CPyObject,
+    default_value: *mut CPyObject,
+) -> *mut CPyObject {
+    let mut value = std::ptr::null_mut();
+    if unsafe { PyDict_SetDefaultRef(object, key, default_value, &mut value) } < 0 {
+        return std::ptr::null_mut();
+    }
+    // The strong reference the `Ref` spelling answers with is what makes this
+    // one a borrow: the dict holds the value, and the caller is handed the
+    // dict's reference rather than one of its own.
+    let borrowed = pyobject::borrow_from(object, unsafe { pyobject::from_ref(value) });
+    unsafe { pyobject::decref(value) };
+    borrowed
+}
+
 /// `PyDict_SetDefaultRef(dict, key, default, &result)` — 1 when the key was
 /// already there, 0 when the default was inserted, -1 on failure.
 ///

--- a/pyre/pyre-interpreter/src/cpyext/funcobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/funcobject.rs
@@ -1,0 +1,55 @@
+//! The bound-method entry points -- PyPy `cpyext/funcobject.py`.
+
+use super::object::{argument, result};
+use super::pyobject::{self, CPyObject};
+
+/// `funcobject.py:106 PyMethod_New(func, self)` — bind `receiver` to
+/// `function`, the way an attribute lookup on an instance does.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMethod_New(
+    function: *mut CPyObject,
+    receiver: *mut CPyObject,
+) -> *mut CPyObject {
+    super::object::realize_all([function, receiver]);
+    let (Some(function), Some(receiver)) = (argument(function), argument(receiver)) else {
+        return std::ptr::null_mut();
+    };
+    result(Ok(pyre_object::w_method_new(
+        function,
+        receiver,
+        pyre_object::PY_NULL,
+    )))
+}
+
+/// The member `reader` names on `method`, borrowed, or NULL with a
+/// `SystemError` when `method` is not a bound method.
+///
+/// Borrowed is what both readers answer with: the member is reachable through
+/// the method for as long as the caller holds it.
+unsafe fn method_member(
+    method: *mut CPyObject,
+    reader: unsafe fn(pyre_object::PyObjectRef) -> pyre_object::PyObjectRef,
+) -> *mut CPyObject {
+    let Some(object) = argument(method) else {
+        return std::ptr::null_mut();
+    };
+    if !unsafe { pyre_object::function::is_method(object) } {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    pyobject::borrow_from(method, unsafe { reader(object) })
+}
+
+/// `funcobject.py:114 PyMethod_Function(method)` — the callable the binding
+/// wraps, borrowed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMethod_Function(method: *mut CPyObject) -> *mut CPyObject {
+    unsafe { method_member(method, pyre_object::function::w_method_get_func) }
+}
+
+/// `funcobject.py:120 PyMethod_Self(method)` — the receiver the binding
+/// carries, borrowed.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyMethod_Self(method: *mut CPyObject) -> *mut CPyObject {
+    unsafe { method_member(method, pyre_object::function::w_method_get_self) }
+}

--- a/pyre/pyre-interpreter/src/cpyext/import_.rs
+++ b/pyre/pyre-interpreter/src/cpyext/import_.rs
@@ -106,12 +106,121 @@ pub unsafe extern "C" fn PyImport_ImportModuleAttrString(
     attribute
 }
 
+/// `import_.py:33 PyImport_GetModuleDict()` — `sys.modules`, borrowed.
+///
+/// The borrow is sound where `PyImport_AddModule`'s is not: the modules dict
+/// is made during start-up and lives for as long as the interpreter does, so
+/// the mirror it is handed out through outlives every caller.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyImport_GetModuleDict() -> *mut CPyObject {
+    let modules = crate::importing::sys_modules_dict();
+    if modules.is_null() {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::RuntimeError,
+            "sys.modules is not set",
+        ));
+        return std::ptr::null_mut();
+    }
+    pyobject::borrow_mirror(modules)
+}
+
+/// `import_.py:58 PyImport_ImportModuleLevelObject(name, globals, locals,
+/// fromlist, level)` — `__import__` with each of its arguments.
+///
+/// A NULL stands for the argument's default, which is what an extension that
+/// only wants one of them passes for the rest.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyImport_ImportModuleLevelObject(
+    name: *mut CPyObject,
+    globals: *mut CPyObject,
+    locals: *mut CPyObject,
+    fromlist: *mut CPyObject,
+    level: std::ffi::c_int,
+) -> *mut CPyObject {
+    super::object::realize_all([name, globals, locals, fromlist]);
+    let Some(name) = argument(name) else {
+        return std::ptr::null_mut();
+    };
+    if level < 0 {
+        super::pyerrors::set_pending_error(crate::PyError::value_error(
+            "level must be >= 0".to_owned(),
+        ));
+        return std::ptr::null_mut();
+    }
+    result(import_module_level(
+        name,
+        globals,
+        locals,
+        fromlist,
+        level as i64,
+    ))
+}
+
+/// `PyImport_ImportModuleLevel(name, globals, locals, fromlist, level)` — the
+/// `const char *` spelling of the entry point above.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyImport_ImportModuleLevel(
+    name: *const c_char,
+    globals: *mut CPyObject,
+    locals: *mut CPyObject,
+    fromlist: *mut CPyObject,
+    level: std::ffi::c_int,
+) -> *mut CPyObject {
+    if name.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    let text = unsafe { super::unicodeobject::PyUnicode_FromString(name) };
+    if text.is_null() {
+        return std::ptr::null_mut();
+    }
+    let answer =
+        unsafe { PyImport_ImportModuleLevelObject(text, globals, locals, fromlist, level) };
+    unsafe { pyobject::decref(text) };
+    answer
+}
+
+/// The body of [`PyImport_ImportModuleLevelObject`], with the defaults filled
+/// in and every argument rooted across the allocations the others make.
+fn import_module_level(
+    name: PyObjectRef,
+    globals: *mut CPyObject,
+    locals: *mut CPyObject,
+    fromlist: *mut CPyObject,
+    level: i64,
+) -> Result<PyObjectRef, crate::PyError> {
+    let builtins = crate::importing::get_sys_module("builtins").ok_or_else(|| {
+        crate::PyError::new(crate::PyErrorKind::ImportError, "builtins is not loaded")
+    })?;
+    let import = crate::baseobjspace::getattr_str(builtins, "__import__")?;
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(import);
+    roots.pin_root(name);
+    // Each default allocates, so every argument is on the stack before the
+    // next one is built and all five are read back afterwards.
+    for (raw, default) in [(globals, None), (locals, None), (fromlist, Some(()))] {
+        let given = unsafe { pyobject::from_ref(raw) };
+        let value = if !given.is_null() {
+            given
+        } else if default.is_some() {
+            pyre_object::w_tuple_new_array_backed(Vec::new())
+        } else {
+            pyre_object::w_none()
+        };
+        roots.pin_root(value);
+    }
+    roots.pin_root(pyre_object::w_int_new(level));
+    let at = |index: usize| pyre_object::gc_roots::shadow_stack_get(base + index);
+    crate::call::call_function_impl_result(at(0), &[at(1), at(2), at(3), at(4), at(5)])
+}
+
 /// `PyImport_AddModuleRef` — the module under `name`, created empty when
 /// `sys.modules` does not have it yet.
 ///
-/// The 3.12-and-earlier `PyImport_AddModule` and `PyImport_GetModuleDict`
-/// return *borrowed* references with no container for pyre to hang the borrow
-/// on, so only the strong-reference forms are provided.
+/// The 3.12-and-earlier `PyImport_AddModule` returns a *borrowed* reference
+/// with no container for pyre to hang the borrow on, so only the
+/// strong-reference form is provided.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyImport_AddModuleRef(name: *const c_char) -> *mut CPyObject {
     let Some(name) = name_of(name) else {

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -92,6 +92,13 @@ fn method_def_at(index: i64) -> Option<*mut CPyMethodDef> {
 static PYCFUNCTION_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
 
 /// The carrier type, named as upstream names its typedef.
+///
+/// This is what `PyCFunction_Type` names, and so what `PyCFunction_Check`
+/// answers for.  An interpreter builtin such as `len` is a *different*
+/// `builtin_function_or_method` and answers no: it carries no `PyMethodDef`,
+/// so an entry point that agreed it was one would then have nothing to hand
+/// back from `PyCFunction_GetFunction` but an error, which a caller spelling
+/// the two as one expression does not look for.
 pub fn pycfunction_type() -> PyObjectRef {
     *PYCFUNCTION_TYPE_OBJ.get_or_init(|| {
         let tp = crate::typedef::make_builtin_type("builtin_function_or_method", |ns| {
@@ -111,6 +118,88 @@ pub fn pycfunction_type() -> PyObjectRef {
         unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
         tp as usize
     }) as PyObjectRef
+}
+
+/// The `PyMethodDef` behind `object`, or NULL with a `SystemError` when
+/// nothing is.
+fn checked_method_def(object: *mut CPyObject) -> Option<*mut CPyMethodDef> {
+    let object = unsafe { pyobject::from_ref(object) };
+    let definition = (!object.is_null()).then(|| method_def(object)).flatten();
+    if definition.is_none() {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "bad argument to internal function",
+        ));
+    }
+    definition
+}
+
+/// `methodobject.py:563 PyCFunction_GetFunction(object)` — the C function the
+/// carrier calls.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCFunction_GetFunction(object: *mut CPyObject) -> *mut c_void {
+    match checked_method_def(object) {
+        Some(definition) => (unsafe { (*definition).ml_meth }) as *mut c_void,
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// `PyCFunction_GetFlags(object)` — the `METH_*` set the definition carries.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCFunction_GetFlags(object: *mut CPyObject) -> c_int {
+    match checked_method_def(object) {
+        Some(definition) => unsafe { (*definition).ml_flags },
+        None => -1,
+    }
+}
+
+/// `PyCFunction_GetSelf(object)` — the receiver the carrier was bound to,
+/// borrowed, and NULL for a definition declared `METH_STATIC`.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCFunction_GetSelf(object: *mut CPyObject) -> *mut CPyObject {
+    let Some(definition) = checked_method_def(object) else {
+        return std::ptr::null_mut();
+    };
+    if unsafe { (*definition).ml_flags } & METH_STATIC != 0 {
+        return std::ptr::null_mut();
+    }
+    let carrier = unsafe { pyobject::from_ref(object) };
+    match carrier_get(carrier, SELF_KEY) {
+        Some(receiver) => pyobject::borrow_from(object, receiver),
+        None => std::ptr::null_mut(),
+    }
+}
+
+/// `PyCFunction_New(ml, self)` — the callable a `PyMethodDef` row describes.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCFunction_New(
+    method: *mut CPyMethodDef,
+    receiver: *mut CPyObject,
+) -> *mut CPyObject {
+    unsafe { PyCFunction_NewEx(method, receiver, std::ptr::null_mut()) }
+}
+
+/// `PyCFunction_NewEx(ml, self, module)` — the same, naming the module the
+/// definition came from.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCFunction_NewEx(
+    method: *mut CPyMethodDef,
+    receiver: *mut CPyObject,
+    module: *mut CPyObject,
+) -> *mut CPyObject {
+    if method.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    super::object::realize_all([receiver, module]);
+    let receiver = unsafe { pyobject::from_ref(receiver) };
+    let module = unsafe { pyobject::from_ref(module) };
+    let module = if module.is_null() {
+        pyre_object::w_none()
+    } else {
+        module
+    };
+    super::object::result(new_pycfunction(method, receiver, module))
 }
 
 fn carrier_get(carrier: PyObjectRef, key: &str) -> Option<PyObjectRef> {

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -23,6 +23,7 @@ pub mod complexobject;
 pub mod dictobject;
 pub mod exception;
 pub mod floatobject;
+pub mod funcobject;
 pub mod gc;
 pub mod genericaliasobject;
 pub mod import_;

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -1009,6 +1009,103 @@ pub unsafe extern "C" fn PyObject_GC_IsFinalized(_object: *mut CPyObject) -> c_i
     0
 }
 
+/// `PyObject_CallFinalizerFromDealloc(object)` — run the type's
+/// `tp_finalize` from a deallocator that is about to free the block.
+///
+/// The block is at zero when a deallocator reaches here, and a finalizer may
+/// hand `self` out, so it holds one reference of its own while it runs: a
+/// count above that afterwards is something else having kept the object, and
+/// the caller is told to leave the block alone.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_CallFinalizerFromDealloc(object: *mut CPyObject) -> c_int {
+    if object.is_null() {
+        return 0;
+    }
+    let tp = unsafe { (*object).ob_type };
+    if tp.is_null() {
+        return 0;
+    }
+    let finalize = unsafe { (*tp).tp_finalize };
+    if finalize.is_null() {
+        return 0;
+    }
+    let finalize: unsafe extern "C" fn(*mut CPyObject) = unsafe { std::mem::transmute(finalize) };
+    unsafe { (*object).ob_refcnt = 1 };
+    unsafe { finalize(object) };
+    if unsafe { (*object).ob_refcnt } > 1 {
+        return -1;
+    }
+    unsafe { (*object).ob_refcnt = 0 };
+    0
+}
+
+/// `PyObject_VisitManagedDict(object, visit, arg)` — nothing to visit.
+///
+/// A traversal reports the references the C block holds, and the instance
+/// namespace is not one of them: it hangs off the interpreter object, which
+/// the collector reaches without going through this layer.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_VisitManagedDict(
+    _object: *mut CPyObject,
+    _visit: *const c_void,
+    _arg: *mut c_void,
+) -> c_int {
+    0
+}
+
+/// `PyObject_ClearManagedDict(object)` — empty the instance namespace.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_ClearManagedDict(object: *mut CPyObject) {
+    let Some(object) = argument(object) else {
+        return;
+    };
+    let dict = crate::baseobjspace::getdict_native(object);
+    if !dict.is_null() {
+        unsafe { pyre_object::dictmultiobject::w_dict_clear(dict) };
+    }
+}
+
+/// `PyObject_VectorcallDict(callable, args, nargsf, keywords)` — the vector
+/// call whose keywords arrive as a mapping rather than as names beside the
+/// values.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_VectorcallDict(
+    callable: *mut CPyObject,
+    args: *const *mut CPyObject,
+    nargsf: usize,
+    keywords: *mut CPyObject,
+) -> *mut CPyObject {
+    if keywords.is_null() {
+        return unsafe { PyObject_Vectorcall(callable, args, nargsf, std::ptr::null_mut()) };
+    }
+    let nargs = vectorcall_nargs(nargsf);
+    let positional = unsafe { PyTuple_from_vector(args, nargs) };
+    if positional.is_null() {
+        return std::ptr::null_mut();
+    }
+    let answer = unsafe { PyObject_Call(callable, positional, keywords) };
+    unsafe { pyobject::decref(positional) };
+    answer
+}
+
+/// The `tuple` a vector's first `count` entries make, as a new reference.
+#[allow(non_snake_case)]
+unsafe fn PyTuple_from_vector(args: *const *mut CPyObject, count: usize) -> *mut CPyObject {
+    let tuple = unsafe { super::tupleobject::PyTuple_New(count as isize) };
+    if tuple.is_null() {
+        return std::ptr::null_mut();
+    }
+    for index in 0..count {
+        let item = unsafe { *args.add(index) };
+        unsafe { pyobject::incref(item) };
+        if unsafe { super::tupleobject::PyTuple_SetItem(tuple, index as isize, item) } != 0 {
+            unsafe { pyobject::decref(tuple) };
+            return std::ptr::null_mut();
+        }
+    }
+    tuple
+}
+
 // ── the object allocator ──────────────────────────────────────────────────
 //
 // `PyObject_Free` is the deallocator for all three of these, and for a block

--- a/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyerrors.rs
@@ -827,6 +827,50 @@ pub unsafe extern "C" fn _PyErr_ChainExceptions1(exception: *mut CPyObject) {
     unsafe { PyErr_SetRaisedException(pending) };
 }
 
+/// `write_unraisable` over whatever the indicator holds, which the two
+/// entry points below share.
+///
+/// The indicator is taken first: reporting runs `sys.unraisablehook`, and a
+/// hook that raises has to find the slot free to leave its own error in.
+fn write_unraisable(context: Option<String>, object: *mut CPyObject) {
+    let Some(mut error) = take_pending_error() else {
+        return;
+    };
+    let object = unsafe { pyobject::from_ref(object) };
+    let object = if object.is_null() {
+        pyre_object::w_none()
+    } else {
+        object
+    };
+    let context = context.unwrap_or_default();
+    error.write_unraisable(
+        pyre_object::w_none(),
+        rustpython_wtf8::Wtf8::new(context.as_str()),
+        object,
+    );
+}
+
+/// `PyErr_WriteUnraisable(object)` — report the pending exception through
+/// `sys.unraisablehook` and clear it, naming `object` as what was being
+/// operated on.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyErr_WriteUnraisable(object: *mut CPyObject) {
+    write_unraisable(None, object);
+}
+
+/// The core `PyErr_FormatUnraisable` is built on, whose message states what
+/// was going on rather than leaving the report to name the object.
+///
+/// `message` is a `str`, because the header composes it with the same format
+/// engine every other variadic entry point uses.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn _PyPyre_WriteUnraisable(message: *mut CPyObject, object: *mut CPyObject) {
+    let text = unsafe { pyobject::from_ref(message) };
+    let context = (!text.is_null() && unsafe { pyre_object::unicodeobject::is_str(text) })
+        .then(|| unsafe { pyre_object::w_str_get_wtf8(text) }.to_string());
+    write_unraisable(context, object);
+}
+
 /// End the process, reporting `message` the way a caller that cannot go on
 /// does.
 ///

--- a/pyre/pyre-interpreter/src/cpyext/pystate.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pystate.rs
@@ -16,12 +16,30 @@
 use std::cell::{Cell, UnsafeCell};
 use std::ffi::c_int;
 
+/// The interpreter an extension is handed a pointer to.
+///
+/// Opaque, and for the same reason `CPyThreadState` is: what it stands for is
+/// reached through entry points rather than through the struct.
+#[repr(C)]
+pub struct CPyInterpreterState {
+    _private: u8,
+}
+
+/// The one interpreter, which every thread runs in.
+///
+/// Nothing is kept behind the handle: it exists so that an extension asking
+/// which interpreter it is in gets an answer to compare and to pass on, and
+/// the address of a static gives one that is stable and never NULL.
+static INTERPRETER: CPyInterpreterState = CPyInterpreterState { _private: 0 };
+
 /// The per-thread state an extension is handed a pointer to.
 ///
-/// Opaque: what upstream's `PyThreadState` carries is interpreter bookkeeping
-/// an extension reaches through entry points, not through the struct.
+/// `interp` is the one field an extension reads directly, which is how it asks
+/// which interpreter the thread runs in without a call; everything else this
+/// stands for is reached through an entry point.
 #[repr(C)]
 pub struct CPyThreadState {
+    interp: *mut CPyInterpreterState,
     /// Never read through the pointer; a distinct byte so two threads' states
     /// are distinct addresses.
     _private: u8,
@@ -30,8 +48,10 @@ pub struct CPyThreadState {
 thread_local! {
     /// Stable for as long as the thread lives, which is as long as a
     /// `PyThreadState *` naming it is valid.
-    static THREAD_STATE: UnsafeCell<CPyThreadState> =
-        const { UnsafeCell::new(CPyThreadState { _private: 0 }) };
+    static THREAD_STATE: UnsafeCell<CPyThreadState> = UnsafeCell::new(CPyThreadState {
+        interp: &INTERPRETER as *const CPyInterpreterState as *mut CPyInterpreterState,
+        _private: 0,
+    });
     /// `ec.cpyext_threadstate_is_current`.  Swapping NULL in clears it, which
     /// is how an extension says the thread state it was handed is no longer the
     /// one in force.
@@ -142,6 +162,23 @@ pub unsafe extern "C" fn PyGILState_GetThisThreadState() -> *mut CPyThreadState 
 
 /// `pystate.py:51 PyEval_InitThreads` — threads are always available, so
 /// upstream's `setup_threads` has nothing left to do here.
+/// `PyInterpreterState_Get()` — the interpreter the calling thread runs in.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyInterpreterState_Get() -> *mut CPyInterpreterState {
+    &INTERPRETER as *const CPyInterpreterState as *mut CPyInterpreterState
+}
+
+/// `PyInterpreterState_GetID(interp)` — the identifier an interpreter is
+/// known by, which is 0 for the one pyre runs.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyInterpreterState_GetID(interp: *mut CPyInterpreterState) -> i64 {
+    if interp.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return -1;
+    }
+    0
+}
+
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyEval_InitThreads() {}
 

--- a/pyre/pyre-interpreter/src/cpyext/sysmodule.rs
+++ b/pyre/pyre-interpreter/src/cpyext/sysmodule.rs
@@ -41,6 +41,16 @@ pub unsafe extern "C" fn PySys_AuditTuple(event: *const c_char, args: *mut CPyOb
     }
 }
 
+/// `Py_Version` — the running version, packed the way `PY_VERSION_HEX` packs
+/// it.  An extension reads this when it wants the version it is running
+/// against rather than the one its headers were.
+///
+/// The digits are `sys.version_info`'s, and `patchlevel.h` states the same
+/// four; `PY_RELEASE_LEVEL_FINAL` with serial 0 is the low byte.
+#[unsafe(no_mangle)]
+pub static Py_Version: std::ffi::c_ulong = 0x030e_06f0;
+
 pub(super) fn ensure_linked() {
     std::hint::black_box(PySys_AuditTuple as *const ());
+    std::hint::black_box(&raw const Py_Version);
 }

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -368,10 +368,14 @@ type_mirrors! {
     PyDictItems_Type => builtin_type(&pyre_object::dictmultiobject::DICT_ITEMS_TYPE),
     PyDictKeys_Type => builtin_type(&pyre_object::dictmultiobject::DICT_KEYS_TYPE),
     PyDictValues_Type => builtin_type(&pyre_object::dictmultiobject::DICT_VALUES_TYPE),
-    // Functions, methods and descriptors.  `PyCFunction_Type` is absent: a
-    // method an extension defines carries `methodobject`'s own
-    // `builtin_function_or_method`, not the interpreter's, so one symbol
-    // cannot name the type of both it and `len`.
+    // Functions, methods and descriptors.  `PyCFunction_Type` names
+    // `methodobject`'s own `builtin_function_or_method` -- the type a method
+    // an extension defines carries, and so the one a type derived from it is
+    // derived from.  The interpreter's `len` is the other
+    // `builtin_function_or_method`, which no symbol here names, and
+    // `PyCFunction_Check` answers no for it; `methodobject`'s
+    // `pycfunction_type` says why that is the safe half of the gap.
+    PyCFunction_Type => super::methodobject::pycfunction_type(),
     PyClassMethodDescr_Type => builtin_type(&crate::function::CLASSMETHOD_DESCRIPTOR_TYPE),
     PyClassMethod_Type => builtin_type(&pyre_object::function::CLASSMETHOD_TYPE),
     PyFunction_Type => builtin_type(&crate::function::FUNCTION_TYPE),

--- a/pyre/pyre-interpreter/src/cpyext/weakrefobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/weakrefobject.rs
@@ -174,3 +174,18 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyWeakref_GetRef as *const ());
     std::hint::black_box(PyWeakref_IsDead as *const ());
 }
+
+/// `object.py:141 PyObject_ClearWeakRefs(object)` — break every weak
+/// reference to `object` and run the callbacks they carry.
+///
+/// An object that was never the target of one has no lifeline, and there is
+/// nothing to break.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_ClearWeakRefs(object: *mut CPyObject) {
+    let Some(object) = super::object::argument(object) else {
+        return;
+    };
+    if let Some(lifeline) = crate::baseobjspace::getweakref(object) {
+        crate::module::_weakref::interp__weakref::finalize_weakrefs(lifeline);
+    }
+}

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -5786,6 +5786,142 @@ fn simple_field_spec_from_bh(
 /// never aliases distinct STRUCTs; absent a real identity carrier,
 /// the closest orthodox behaviour is "each call is a distinct
 /// STRUCT" — mint fresh per call.
+/// Every STRUCT this module declares a descriptor group for, by the def path
+/// the group is registered under.
+///
+/// `build_object_descr_group_with_def_path` keys a group as
+/// `path_hash(def_path)`, which is the `GcCache` `(STRUCT, fieldname)`
+/// namespace a serialized `BhDescr` resolves into as well.  The two producers
+/// do not carry the same information: a group spells out `descr.py:229
+/// STRUCT._immutable_field(fieldname)` for each field, while the codewriter's
+/// `immutable_fields_by_struct` is empty for the whole LLBC pipeline, so every
+/// field a `BhDescr` describes reads as plain mutable.  `GcCache` hands the
+/// slot to whoever asks first and returns it unchanged after that, so without
+/// forcing the group here the rank a field ends up carrying is decided by
+/// which of the two reached it first -- and a `BhDescr` that got there first
+/// takes the declaration off every field of the STRUCT at once.
+///
+/// A group that does not reach that namespace is absent from the list:
+/// `PYCODE` and `EC` mint through the unkeyed factory, and `PYTRACEBACK` is
+/// registered under an empty def path, so its key is `path_hash("")` --
+/// none of the three names a STRUCT a `BhDescr` can carry.
+static DECLARED_GROUPS: &[(&str, fn())] = &[
+    ("intobject::W_IntObject", || {
+        LazyLock::force(&W_INT_DESCR_GROUP);
+    }),
+    ("intobject::W_IntObjectUser", || {
+        LazyLock::force(&W_INT_USER_DESCR_GROUP);
+    }),
+    ("floatobject::W_FloatObject", || {
+        LazyLock::force(&W_FLOAT_DESCR_GROUP);
+    }),
+    ("longobject::W_LongObject", || {
+        LazyLock::force(&W_LONG_DESCR_GROUP);
+    }),
+    ("boolobject::W_BoolObject", || {
+        LazyLock::force(&W_BOOL_DESCR_GROUP);
+    }),
+    ("unicodeobject::W_UnicodeObject", || {
+        LazyLock::force(&W_UNICODE_DESCR_GROUP);
+    }),
+    ("unicodeobject::W_UnicodeObjectUser", || {
+        LazyLock::force(&W_UNICODE_USER_DESCR_GROUP);
+    }),
+    ("functional::W_IntRangeIterator", || {
+        LazyLock::force(&RANGE_ITER_DESCR_GROUP);
+    }),
+    ("functional::W_Range", || {
+        LazyLock::force(&RANGE_DESCR_GROUP);
+    }),
+    ("functional::W_Zip", || {
+        LazyLock::force(&W_ZIP_DESCR_GROUP);
+    }),
+    ("iterobject::W_SeqIterObject", || {
+        LazyLock::force(&SEQ_ITER_DESCR_GROUP);
+    }),
+    ("iterobject::W_TupleIterObject", || {
+        LazyLock::force(&TUPLE_ITER_DESCR_GROUP);
+    }),
+    ("function::Function", || {
+        LazyLock::force(&FUNCTION_DESCR_GROUP);
+    }),
+    ("function::Method", || {
+        LazyLock::force(&W_METHOD_DESCR_GROUP);
+    }),
+    ("dictmultiobject::W_DictObject", || {
+        LazyLock::force(&W_DICT_DESCR_GROUP);
+    }),
+    ("celldict::ObjectMutableCell", || {
+        LazyLock::force(&W_OBJECT_MUTABLE_CELL_DESCR_GROUP);
+    }),
+    ("listobject::W_ListObject", || {
+        LazyLock::force(&W_LIST_DESCR_GROUP);
+    }),
+    ("tupleobject::W_TupleObject", || {
+        LazyLock::force(&W_TUPLE_DESCR_GROUP);
+    }),
+    ("tupleobject::W_TupleObjectUser", || {
+        LazyLock::force(&W_TUPLE_USER_DESCR_GROUP);
+    }),
+    (
+        "specialisedtupleobject::W_SpecialisedTupleObject_ii",
+        || {
+            LazyLock::force(&SPECIALISED_TUPLE_II_DESCR_GROUP);
+        },
+    ),
+    (
+        "specialisedtupleobject::W_SpecialisedTupleObject_ff",
+        || {
+            LazyLock::force(&SPECIALISED_TUPLE_FF_DESCR_GROUP);
+        },
+    ),
+    (
+        "specialisedtupleobject::W_SpecialisedTupleObject_oo",
+        || {
+            LazyLock::force(&SPECIALISED_TUPLE_OO_DESCR_GROUP);
+        },
+    ),
+    ("object_array::ItemsBlock", || {
+        LazyLock::force(&ITEMS_BLOCK_DESCR_GROUP);
+    }),
+    ("rbigint::RBigIntPair", || {
+        LazyLock::force(&RBIGINT_PAIR_DESCR_GROUP);
+    }),
+    ("pyframe::FrameDebugData", || {
+        LazyLock::force(&FRAME_DEBUG_DATA_DESCR_GROUP);
+    }),
+    ("pyframe::PyFrame", || {
+        LazyLock::force(&PYFRAME_DESCR_GROUP);
+    }),
+    ("sliceobject::W_SliceObject", || {
+        LazyLock::force(&W_SLICE_DESCR_GROUP);
+    }),
+    ("objectobject::W_ObjectObject", || {
+        LazyLock::force(&W_OBJECT_OBJECT_DESCR_GROUP);
+    }),
+];
+
+/// The [`DECLARED_GROUPS`] rows by the `GcCache` key each one owns.
+static DECLARED_GROUP_BY_KEY: LazyLock<std::collections::HashMap<u64, fn()>> =
+    LazyLock::new(|| {
+        DECLARED_GROUPS
+            .iter()
+            .map(|(def_path, force)| (majit_ir::descr::path_hash(def_path), *force))
+            .collect()
+    });
+
+/// Force this module's own group for `cache_key`, if it declares one, so the
+/// declaration takes the STRUCT's `(STRUCT, fieldname)` slots before a
+/// serialized `BhDescr` can.
+///
+/// Idempotent and cheap after the first call for a STRUCT: the group is a
+/// `LazyLock` and the second force is a load.
+fn force_declared_group(cache_key: u64) {
+    if let Some(force) = DECLARED_GROUP_BY_KEY.get(&cache_key) {
+        force();
+    }
+}
+
 fn simple_descr_group_from_bh_size(
     spec: &majit_translate::jitcode::BhSizeSpec,
 ) -> majit_ir::descr::SimpleDescrGroup {
@@ -5817,6 +5953,14 @@ fn simple_descr_group_from_bh_size(
             &field_specs,
         );
     }
+    // The spec describes every field as plain mutable: the codewriter's
+    // `immutable_fields_by_struct` is empty for the whole LLBC pipeline, so a
+    // serialized `BhDescr` carries no `descr.py:229
+    // STRUCT._immutable_field(fieldname)` rank.  Minting this STRUCT's fields
+    // from it would take that rank off them for every later reader, since the
+    // slot goes to whoever asks first.  Where this module declares the STRUCT,
+    // let the declaration ask first.
+    force_declared_group(spec.type_id);
     // `descr.py:108-118 get_size_descr` + `:218-239 get_field_descr`
     // keyed publish: GcCache is the sole owner/cache for this STRUCT.
     majit_ir::descr::make_simple_descr_group_keyed_with_headerless(
@@ -6390,6 +6534,10 @@ pub fn make_descr_from_bh(bh: &majit_translate::jitcode::BhDescr) -> DescrRef {
             }
             if let Some(parent) = parent {
                 if parent.type_id != 0 {
+                    // Before the lookup, not after it: a declared group that
+                    // has not been forced yet leaves the slot empty, and the
+                    // rebuild below would then fill it from the spec.
+                    force_declared_group(parent.type_id);
                     let key = majit_ir::descr::LLType::Struct(parent.type_id);
                     if let Some(fd) = majit_ir::descr::gc_cache()
                         .lock()

--- a/pyre/pyrex/tests/cpyext_callables.rs
+++ b/pyre/pyrex/tests/cpyext_callables.rs
@@ -1,0 +1,141 @@
+//! The callables an extension makes and asks about: the `PyMethodDef`-backed
+//! function, the bound method, the modules dict, and the reports a call that
+//! cannot raise leaves behind.
+//!
+//! Every expectation was taken from CPython 3.14 running this same script
+//! against this same fixture.
+
+#![cfg(all(
+    feature = "cpyext",
+    not(feature = "sandbox"),
+    any(target_os = "macos", target_os = "linux")
+))]
+
+mod cpyext_fixture;
+
+use cpyext_fixture::Fixtures;
+
+const SCRIPT: &str = r#"
+import sys
+import cpyext_callables as m
+
+
+def eq(name, got, want):
+    assert got == want, '%s: got %r, want %r' % (name, got, want)
+
+
+class Named:
+    def method(self):
+        return self
+
+
+# ── what is backed by a C function ─────────────────────────────────────
+
+eq('c function extension', m.is_c_function(m.probe), 1)
+eq('c function python', m.is_c_function(Named.method), 0)
+eq('c function bound python', m.is_c_function(Named().method), 0)
+eq('c function int', m.is_c_function(7), 0)
+eq('c function type', m.is_c_function(int), 0)
+
+eq('probe is probe', m.is_probe(m.probe), 1)
+eq('probe is not len', m.is_probe(len), 0)
+eq('probe is not a str', m.is_probe('x'), 0)
+
+# METH_O, and the receiver a module-level function carries is its module.
+flags, receiver = m.describe(m.probe)
+eq('probe flags', flags, 8)
+eq('probe receiver', receiver is m, True)
+
+# ── a callable built from a definition ─────────────────────────────────
+
+made = m.make_c_function(m)
+eq('made is a c function', m.is_c_function(made), 1)
+eq('made is probe', m.is_probe(made), 1)
+eq('made calls through', made('through'), 'through')
+eq('made name', made.__name__, 'probe')
+eq('made is fresh', made is m.probe, False)
+
+# ── binding ────────────────────────────────────────────────────────────
+
+subject = Named()
+method, checked, function, bound_self = m.bind(Named.method, subject)
+eq('bind checks', checked, 1)
+eq('bind function', function is Named.method, True)
+eq('bind self', bound_self is subject, True)
+eq('bind calls', method() is subject, True)
+eq('bind equals', method == subject.method, True)
+
+# ── the modules dict ───────────────────────────────────────────────────
+
+eq('modules is sys.modules', m.module_dict() is sys.modules, True)
+eq('modules holds this one', m.module_dict()['cpyext_callables'] is m, True)
+
+# ── __import__ with every argument stated ──────────────────────────────
+
+eq('import top level', m.import_level('sys', None, 0) is sys, True)
+# A fromlist asks for the leaf rather than the package.
+encodings = m.import_level('encodings.utf_8', ['decode'], 0)
+eq('import fromlist', encodings.__name__, 'encodings.utf_8')
+
+# ── the borrowed setdefault ────────────────────────────────────────────
+
+table = {'x': 1}
+eq('setdefault present', m.set_default(table, 'x', 99), 1)
+eq('setdefault absent', m.set_default(table, 'y', 2), 2)
+eq('setdefault stored', table, {'x': 1, 'y': 2})
+
+# ── a call whose keywords are a mapping ────────────────────────────────
+
+def takes(a, b, c=3, *, d=4):
+    return (a, b, c, d)
+
+
+eq('vectorcall dict', m.call_with_dict(takes, (1, 2), {'d': 40}), (1, 2, 3, 40))
+eq('vectorcall dict empty', m.call_with_dict(takes, (1, 2, 3), {}), (1, 2, 3, 4))
+eq('vectorcall dict only kw', m.call_with_dict(takes, (), {'a': 1, 'b': 2}),
+   (1, 2, 3, 4))
+
+# ── what a call that cannot raise reports ──────────────────────────────
+
+reports = []
+previous = sys.unraisablehook
+sys.unraisablehook = reports.append
+try:
+    m.report_unraisable(subject)
+    m.report_unraisable_msg()
+finally:
+    sys.unraisablehook = previous
+
+eq('two reports', len(reports), 2)
+eq('named object', reports[0].object is subject, True)
+eq('named exception', type(reports[0].exc_type), type)
+eq('named exception value', str(reports[0].exc_value), 'boom')
+eq('stated message', reports[1].err_msg,
+   'Exception ignored while doing the thing')
+eq('stated object', reports[1].object, None)
+# Reporting clears the indicator, so nothing is pending afterwards.
+eq('nothing pending', m.probe('still working'), 'still working')
+
+# ── the runtime it is running against ──────────────────────────────────
+
+version, interpreter = m.runtime_identity()
+eq('version', version, sys.hexversion)
+eq('interpreter id', interpreter, 0)
+
+# ── tracebacks ─────────────────────────────────────────────────────────
+
+try:
+    raise ValueError('x')
+except ValueError as error:
+    eq('is a traceback', m.is_traceback(error.__traceback__), 1)
+eq('is not a traceback', m.is_traceback(None), 0)
+
+print('cpyext-callables-ok')
+"#;
+
+#[test]
+fn the_callables_an_extension_makes() {
+    let fixtures = Fixtures::new("cpyext-callables");
+    fixtures.compile("cpyext_callables");
+    fixtures.expect_ok(SCRIPT, &[], "cpyext-callables-ok");
+}

--- a/pyre/pyrex/tests/fixtures/cpyext_callables.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_callables.c
@@ -1,0 +1,202 @@
+/* The callables an extension makes and asks about: the `PyMethodDef`-backed
+   function, the bound method, and the reports a call that cannot raise leaves
+   behind. */
+#include "Python.h"
+
+static PyObject *probe(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    Py_INCREF(arg);
+    return arg;
+}
+
+static PyMethodDef probe_def = {"probe", probe, METH_O, NULL};
+
+/* Whether each argument is backed by a C function. */
+static PyObject *is_c_function(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    return PyLong_FromLong(PyCFunction_Check(arg));
+}
+
+/* Whether `arg` is this module's own `probe`, compared the way an extension
+   recognises one of its own: the C function behind it. */
+static PyObject *is_probe(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    if (!PyCFunction_Check(arg)) {
+        return PyLong_FromLong(0);
+    }
+    return PyLong_FromLong(PyCFunction_GET_FUNCTION(arg) == (PyCFunction)probe);
+}
+
+/* The flags and receiver the carrier holds, beside the name it answers to. */
+static PyObject *describe(PyObject *self, PyObject *arg)
+{
+    PyObject *receiver;
+    (void)self;
+    if (!PyCFunction_Check(arg)) {
+        PyErr_SetString(PyExc_TypeError, "not a C function");
+        return NULL;
+    }
+    receiver = PyCFunction_GET_SELF(arg);
+    if (receiver == NULL) {
+        receiver = Py_None;
+    }
+    return Py_BuildValue("iO", PyCFunction_GET_FLAGS(arg), receiver);
+}
+
+/* A fresh callable over the same definition, bound to `receiver`. */
+static PyObject *make_c_function(PyObject *self, PyObject *receiver)
+{
+    (void)self;
+    return PyCFunction_New(&probe_def, receiver);
+}
+
+/* `func.__get__(receiver)` spelled the way C spells it, then read back. */
+static PyObject *bind(PyObject *self, PyObject *args)
+{
+    PyObject *function;
+    PyObject *receiver;
+    PyObject *method;
+    PyObject *answer;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "OO", &function, &receiver)) {
+        return NULL;
+    }
+    method = PyMethod_New(function, receiver);
+    if (method == NULL) {
+        return NULL;
+    }
+    answer = Py_BuildValue("OiOO", method, PyMethod_Check(method),
+                           PyMethod_GET_FUNCTION(method), PyMethod_GET_SELF(method));
+    Py_DECREF(method);
+    return answer;
+}
+
+/* `sys.modules`, which an extension reaches without importing `sys`. */
+static PyObject *module_dict(PyObject *self, PyObject *unused)
+{
+    PyObject *modules = PyImport_GetModuleDict();
+    (void)self;
+    (void)unused;
+    Py_XINCREF(modules);
+    return modules;
+}
+
+/* `__import__` with every argument stated. */
+static PyObject *import_level(PyObject *self, PyObject *args)
+{
+    const char *name;
+    PyObject *fromlist;
+    int level;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "sOi", &name, &fromlist, &level)) {
+        return NULL;
+    }
+    return PyImport_ImportModuleLevel(name, NULL, NULL, fromlist, level);
+}
+
+/* The borrowed spelling of `setdefault`. */
+static PyObject *set_default(PyObject *self, PyObject *args)
+{
+    PyObject *dict;
+    PyObject *key;
+    PyObject *value;
+    PyObject *answer;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "OOO", &dict, &key, &value)) {
+        return NULL;
+    }
+    answer = PyDict_SetDefault(dict, key, value);
+    if (answer == NULL) {
+        return NULL;
+    }
+    Py_INCREF(answer);
+    return answer;
+}
+
+/* A call whose keywords arrive as a mapping rather than beside the values. */
+static PyObject *call_with_dict(PyObject *self, PyObject *args)
+{
+    PyObject *callable;
+    PyObject *positional;
+    PyObject *keywords;
+    PyObject *vector[3];
+    Py_ssize_t count;
+    Py_ssize_t index;
+    (void)self;
+    if (!PyArg_ParseTuple(args, "OO!O!", &callable, &PyTuple_Type, &positional,
+                          &PyDict_Type, &keywords)) {
+        return NULL;
+    }
+    count = PyTuple_Size(positional);
+    if (count > 3) {
+        PyErr_SetString(PyExc_ValueError, "at most three positional arguments");
+        return NULL;
+    }
+    for (index = 0; index < count; index++) {
+        vector[index] = PyTuple_GetItem(positional, index);
+    }
+    return PyObject_VectorcallDict(callable, vector, (size_t)count, keywords);
+}
+
+/* Report the pending exception the way a caller that cannot raise does. */
+static PyObject *report_unraisable(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    PyErr_SetString(PyExc_ValueError, "boom");
+    PyErr_WriteUnraisable(arg);
+    Py_RETURN_NONE;
+}
+
+/* The same, stating what was going on instead of naming an object. */
+static PyObject *report_unraisable_msg(PyObject *self, PyObject *unused)
+{
+    (void)self;
+    (void)unused;
+    PyErr_SetString(PyExc_ValueError, "boom");
+    PyErr_FormatUnraisable("Exception ignored while doing %s", "the thing");
+    Py_RETURN_NONE;
+}
+
+/* The version the extension is running against, and the interpreter it is in. */
+static PyObject *runtime_identity(PyObject *self, PyObject *unused)
+{
+    (void)self;
+    (void)unused;
+    return Py_BuildValue("kL", Py_Version,
+                         PyInterpreterState_GetID(PyThreadState_Get()->interp));
+}
+
+/* Whether the argument is a traceback. */
+static PyObject *is_traceback(PyObject *self, PyObject *arg)
+{
+    (void)self;
+    return PyLong_FromLong(PyTraceBack_Check(arg));
+}
+
+static PyMethodDef methods[] = {
+    {"is_c_function", is_c_function, METH_O, NULL},
+    {"is_probe", is_probe, METH_O, NULL},
+    {"describe", describe, METH_O, NULL},
+    {"make_c_function", make_c_function, METH_O, NULL},
+    {"probe", probe, METH_O, NULL},
+    {"bind", bind, METH_VARARGS, NULL},
+    {"module_dict", module_dict, METH_NOARGS, NULL},
+    {"import_level", import_level, METH_VARARGS, NULL},
+    {"set_default", set_default, METH_VARARGS, NULL},
+    {"call_with_dict", call_with_dict, METH_VARARGS, NULL},
+    {"report_unraisable", report_unraisable, METH_O, NULL},
+    {"report_unraisable_msg", report_unraisable_msg, METH_NOARGS, NULL},
+    {"runtime_identity", runtime_identity, METH_NOARGS, NULL},
+    {"is_traceback", is_traceback, METH_O, NULL},
+    {NULL, NULL, 0, NULL}};
+
+static struct PyModuleDef def = {PyModuleDef_HEAD_INIT, "cpyext_callables", NULL,
+                                 -1, methods};
+
+PyMODINIT_FUNC PyInit_cpyext_callables(void)
+{
+    return PyModule_Create(&def);
+}

--- a/pyre/scripts/cpyext-abi.py
+++ b/pyre/scripts/cpyext-abi.py
@@ -156,6 +156,7 @@ STRUCTS = {
     "CPyMethodDef": "PyMethodDef", "CPyMemberDef": "PyMemberDef",
     "CPyGetSetDef": "PyGetSetDef", "c_void": "void",
     "CPyThreadState": "PyThreadState", "CPyComplex": "Py_complex",
+    "CPyInterpreterState": "PyInterpreterState",
     "CPyMutex": "PyMutex",
     "CPyUnicodeWriter": "PyUnicodeWriter",
 }


### PR DESCRIPTION
Two commits. The first is the cpyext slice a Cython-generated module needs; the
second is a JIT descriptor-cache fix that slice made visible.

# 1. `cpyext`: the callables, thread state and headers a Cython module reaches for

Cython's generated C takes its `CYTHON_COMPILING_IN_PYPY` branch when
`PYPY_VERSION` is defined, and that branch names entry points and header
spellings this layer did not carry. Against a `cythonize`d module's C, the
compile went from 133 errors to 8, measured after each tier rather than
asserted.

## What an extension can now reach

Bound methods (`PyMethod_New` / `PyMethod_Function` / `PyMethod_Self`, a new
`funcobject.rs`), the `PyMethodDef`-backed callables (`PyCFunction_New` /
`_NewEx` / `_GetFunction` / `_GetFlags` / `_GetSelf`), unraisable-exception
reporting (`PyErr_WriteUnraisable` and the `_PyPyre_WriteUnraisable` core
under `PyErr_FormatUnraisable`), imports (`PyImport_GetModuleDict`,
`PyImport_ImportModuleLevel`, `PyImport_ImportModuleLevelObject`), the object
protocol pieces a `tp_dealloc` and the managed-dict paths call
(`PyObject_CallFinalizerFromDealloc`, `PyObject_VisitManagedDict`,
`PyObject_ClearManagedDict`, `PyObject_VectorcallDict`),
`PyObject_ClearWeakRefs`, `PyDict_SetDefault`, `PyInterpreterState_Get` /
`_GetID`, and the `Py_Version` data symbol.

## `PyCFunction_Type`, and why the check stays narrow

`typeobject.rs` carried a note that `PyCFunction_Type` could not be bound
because pyre has two `builtin_function_or_method` types. It now names
`methodobject`'s own one — the type a method an extension defines carries, and
so the base a type derived from it is derived from.

`PyCFunction_Check` is a header macro over `PyObject_TypeCheck` rather than an
export. The broad PyPy-style check answers yes for the interpreter's `len`,
which carries no `PyMethodDef`, so `PyCFunction_GetFunction` can only set
`SystemError` for it — and Cython's `__Pyx_IsSameCFunction` spells
`PyCFunction_Check(f) && PyCFunction_GET_FUNCTION(f) == c` as one expression
and never looks for an error. Measured: the broad form leaves `SystemError:
cpyext function returned a result with an exception set` on the first call.

## Declarations an extension reads through rather than calls

`PyThreadState` gains its `interp` member — `PyThreadState_Get()->interp` is a
field read — and `PyCFunctionObject` / `PyCMethodObject` are declared so a type
derived from `PyCFunction_Type` can embed one. Nothing pyre makes is read
through those fields; they are declared because a C-defined type's instance
block is `tp_basicsize` bytes, so an extension that embeds one writes its own
storage.

## Headers

New: `code.h` (the eleven `CO_` flags, each checked against the value pyre's
own `inspect` reports), `funcobject.h`, `traceback.h`, `compile.h`,
`frameobject.h`. `pyport.h` gains the `PY_LONG_LONG` / `PY_*INT*_T` spellings,
`lock.h` the critical-section macros (no-ops behind pyre's GIL), `objimpl.h`
`_PyGC_FINALIZED`. `patchlevel.h` moves after `pyport.h` in `Python.h` because
`Py_Version` is declared with `PyAPI_DATA`.

# 2. `jit`: a declared descriptor group takes its fields' cache slots before a serialized `BhDescr` rebuilds them

`GcCache` is keyed by `(STRUCT, fieldname)` and returns the first descriptor
minted for a pair unchanged (`descr.py:220-221`). Two producers reach that
namespace with different information:

- a `*_DESCR_GROUP` in `pyre-jit-trace/src/descr.rs` spells out `descr.py:229
  STRUCT._immutable_field(fieldname)` per field;
- a serialized `BhDescr` does not — the codewriter's
  `immutable_fields_by_struct` is empty for the whole LLBC pipeline, since
  Charon does not carry the declaration, so every field it describes reads as
  plain mutable.

`make_descr_from_bh` rebuilds a `BhDescr`'s whole parent group through
`simple_descr_group_from_bh_size` **before** looking anything up, so one
rehydrated field takes the declaration off every field of that STRUCT.
`get_field_descr` keeps the cached flags when a caller declares nothing, so the
group forced afterwards disagrees with its own slots and trips the identity
assertion:

```
get_field_descr cache hit for code disagrees with the caller:
cached "Function.code" (offset 16, size 8, type Ref, immutable false, quasi false, ...)
vs requested Some("Function.code") (... immutable true, quasi true ...)
```

Reached by importing a C extension and then running a Python `escape` loop hot
(markupsafe 3.0.3 with `_escape_inner` swapped back to `_native`): the
extension changes which jitcode is resolved first, so a body reading a
`Function` field arrives before `FUNCTION_DESCR_GROUP` is forced. Without an
extension loaded the group wins and nothing is visible, which is why this
surfaces only now. In a build without debug assertions the group silently keeps
the stripped flags instead — a lost fold, not a miscompile, since
`is_always_pure` gates on both flags.

`force_declared_group` forces this module's group for the STRUCT about to be
rebuilt, so the declaration takes the slots and both orders agree. **Nothing
already minted is mutated**, so a descriptor a compiled trace holds cannot
change under it; that was chosen over upgrading the cached flags in place,
which would change folding for already-compiled traces. `DECLARED_GROUPS`
lists the twenty-eight groups registered under a def path; the three that are
not (`PYCODE`, `EC`, `PYTRACEBACK`) mint through the unkeyed factory or under
`path_hash("")`, so they name no STRUCT a `BhDescr` resolves into.

This is main-owned: it reproduces on the base without any of the cpyext
changes, which mint no field descriptors.

# Gates

- `cpyext-abi.py check`: 489 exports / 24 header inlines / 123 data objects,
  every entry point matches.
- `cargo test -p pyrex --features cpyext,dynasm --test 'cpyext_*'` — 25 tests
  across 18 files.
- `cpyext_callables` is a new fixture; the same C source and the same script
  were built against CPython 3.14's headers and run on CPython, and give the
  same output there.
- markupsafe 3.0.3's own test modules: panic → 39 passed / 1 failed. The
  remaining failure is `test_leak.test_markup_leaks`, which wants fewer than
  three distinct `gc.get_objects()` counts and gets three — four before this.
- `cargo fmt --all -- --check`.
- `cargo test --all --features dynasm` is re-running locally after the last
  rebuild; every result line it has printed so far is `ok`, and it had not
  reached a failure when it was last interrupted. CI is the verdict here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded CPython C API compatibility for code objects, compilation modes, frames, methods, functions, imports, interpreter state, weak references, and object finalization.
  * Added support for vector calls with keyword mappings, unraisable-exception reporting, dictionary defaults, and module dictionary access.
  * Added runtime version and PyPy compatibility metadata.
  * Improved descriptor handling and added comprehensive C-extension compatibility coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->