### PR TITLE
jit, interpreter: the three #1324 review threads left open at merge

### DIFF
--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -7335,8 +7335,9 @@ impl<'a> Lowering<'a> {
                 // mutable leaf is gated on the [`add_dest_used_only_as_single_deref`]
                 // escape guard (a failing shape stays residual — safe).  The
                 // read leaf (`index`, a value copy) needs no such guard.
+                let workspace_index = self.is_workspace_index_call(&reg);
                 if args.len() == 2
-                    && (self.is_workspace_index_call(&reg)
+                    && (workspace_index
                         || (self.is_vec_index_call(&reg)
                             && (!is_vec_index_mut_regular(&reg, self.llbc)
                                 || add_dest_used_only_as_single_deref(self.body, dest_local)))
@@ -7347,18 +7348,31 @@ impl<'a> Lowering<'a> {
                     let res = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
+                    // `Index::index(_mut)` returns `&T`/`&mut T`, while
+                    // RPython's getarrayitem returns `T`.  Preserve that
+                    // pointee kind: treating the reference wrapper itself as
+                    // the item makes an integer Vec load flow into
+                    // `int_mul/ri>i`.
+                    let item_ty = tyref_deref_value_type(&call.dest.ty, self.llbc);
+                    // The `pyre_`-fenced workspace arm has exactly three
+                    // element banks — `FixedObjectArray` (Ref), `IntArray`,
+                    // `FloatArray` — so a Ref element there IS the
+                    // length-prefixed object block `set_ref` and the `swap`
+                    // decomposition name, and this read has to share their
+                    // descr or a cached element survives their store.  The
+                    // `Vec<T>` and slice legs reach Ref elements that are not
+                    // that block, and they keep the identity-less descr,
+                    // which `arraydescrof_concrete` mints locally without a
+                    // cache publish.
+                    let array_type_id = (workspace_index && matches!(item_ty, ValueType::Ref(_)))
+                        .then(|| PYOBJECT_GCARRAY_TYPE_ID.to_string());
                     self.graph.block_mut(bb_id).operations.push(SpaceOperation {
                         result: Some(res.clone()),
                         kind: OpKind::ArrayRead {
                             base: args[0].clone(),
                             index: args[1].clone(),
-                            // `Index::index(_mut)` returns `&T`/`&mut T`,
-                            // while RPython's getarrayitem returns `T`.
-                            // Preserve that pointee kind: treating the
-                            // reference wrapper itself as the item makes an
-                            // integer Vec load flow into `int_mul/ri>i`.
-                            item_ty: tyref_deref_value_type(&call.dest.ty, self.llbc),
-                            array_type_id: None,
+                            item_ty,
+                            array_type_id: array_type_id.clone(),
                             nolength: false,
                             pure: false,
                         },
@@ -7370,7 +7384,7 @@ impl<'a> Lowering<'a> {
                             base_var: args[0].clone(),
                             index_local: arg_locals.get(1).copied().flatten(),
                             index_var: args[1].clone(),
-                            array_type_id: None,
+                            array_type_id,
                         },
                     );
                     self.local_var[dest_local] = Some(res);
@@ -7511,6 +7525,23 @@ impl<'a> Lowering<'a> {
                     let base = args[0].clone();
                     let idx_a = args[1].clone();
                     let idx_b = args[2].clone();
+                    // The four synthetic ops below name the SLICE's own item
+                    // kind and array identity.  `swap` is matched by name
+                    // alone, and the name reaches four element kinds: the
+                    // `i64` / `f64` / `usize` monomorphizations of
+                    // `listsort::sort_with`, the `array` module's `Vec<u8>`
+                    // byte buffer, and `FixedObjectArray::swap`'s
+                    // `&mut [PyObjectRef]`.  Only the last is the
+                    // length-prefixed object block, whose identity every
+                    // other devirtualized accessor arm spells explicitly;
+                    // leaving it unnamed keeps the swap out of that descr's
+                    // key, so a trace could cache an element through one arm
+                    // and miss the invalidation this store owes it.  The
+                    // unboxed banks must NOT borrow that identity, so the
+                    // name follows the element kind.
+                    let elem_ty = self.slice_swap_elem_value_type(&reg);
+                    let elem_array_type_id = matches!(elem_ty, ValueType::Ref(_))
+                        .then(|| PYOBJECT_GCARRAY_TYPE_ID.to_string());
                     let elem_a = self
                         .graph
                         .alloc_value_var_with_type(crate::model::ConcreteType::Unknown);
@@ -7522,8 +7553,8 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::ArrayRead {
                             base: base.clone(),
                             index: idx_a.clone(),
-                            item_ty: ValueType::Ref(None),
-                            array_type_id: None,
+                            item_ty: elem_ty.clone(),
+                            array_type_id: elem_array_type_id.clone(),
                             nolength: false,
                             pure: false,
                         },
@@ -7533,8 +7564,8 @@ impl<'a> Lowering<'a> {
                         kind: OpKind::ArrayRead {
                             base: base.clone(),
                             index: idx_b.clone(),
-                            item_ty: ValueType::Ref(None),
-                            array_type_id: None,
+                            item_ty: elem_ty.clone(),
+                            array_type_id: elem_array_type_id.clone(),
                             nolength: false,
                             pure: false,
                         },
@@ -7545,8 +7576,8 @@ impl<'a> Lowering<'a> {
                             base: base.clone(),
                             index: idx_a,
                             value: LinkArg::Value(elem_b),
-                            item_ty: ValueType::Ref(None),
-                            array_type_id: None,
+                            item_ty: elem_ty.clone(),
+                            array_type_id: elem_array_type_id.clone(),
                             nolength: false,
                         },
                     });
@@ -7556,8 +7587,8 @@ impl<'a> Lowering<'a> {
                             base,
                             index: idx_b,
                             value: LinkArg::Value(elem_a),
-                            item_ty: ValueType::Ref(None),
-                            array_type_id: None,
+                            item_ty: elem_ty.clone(),
+                            array_type_id: elem_array_type_id.clone(),
                             nolength: false,
                         },
                     });
@@ -9981,6 +10012,25 @@ impl<'a> Lowering<'a> {
         self.llbc
             .fn_by_id(*id)
             .is_some_and(|fd| fd.item_meta.name_path() == "core::slice::<Impl>::swap")
+    }
+
+    /// Element type of a `core::slice::<Impl>::swap` call, read off the
+    /// call's own type arguments (`generics.types[0]`) the way
+    /// [`Self::tyref_adt_type_arg`] reads an ADT's.  The swap decomposition
+    /// synthesizes `ArrayRead`/`ArrayWrite` pairs the MIR never spells, and
+    /// both the item kind and the array identity have to be the SLICE's, not
+    /// a fixed guess: `swap` is matched by name alone, so it also reaches the
+    /// unboxed typed-strategy backings.  Falls back to `Ref(None)` when the
+    /// type argument cannot be read, which is the shape the decomposition
+    /// assumed unconditionally before.
+    fn slice_swap_elem_value_type(&self, reg: &RegularCall) -> ValueType {
+        reg.generics
+            .get("types")
+            .and_then(serde_json::Value::as_array)
+            .and_then(|types| types.first())
+            .and_then(|node| serde_json::from_value::<TyRef>(node.clone()).ok())
+            .map(|ty| tyref_to_value_type(&ty, self.llbc))
+            .unwrap_or(ValueType::Ref(None))
     }
 
     /// `FixedObjectArray::set_ref(self, index, value)` — the GC-published

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1313,34 +1313,22 @@ pub(crate) unsafe fn get_and_call_function(
         ))
     {
         // `DescrOperation.get_and_call_function`'s fast path spells this
-        // `w_descr.funccall(w_obj, *args_w)` — the varargs unpack at
-        // translation time and build no list, so the receiver-prepend must
-        // not become an allocation here either: a
-        // `Vec::with_capacity` is an opaque residual the walker cannot descend
-        // through, and it walls off every `__instancecheck__` /
-        // `__getattr__`-style dunder dispatch that reaches this arm. Keep the
-        // common small arity on a stack array — the same shape and the same
-        // reason as `call::call_function_impl_result`'s own `INLINE_ARGS` —
-        // and retain a `Vec` only for genuinely wide calls.
-        const INLINE_ARGS: usize = 8;
-        let mut inline_full = [pyre_object::PY_NULL; INLINE_ARGS + 1];
-        let mut wide_full;
-        let full: &[PyObjectRef] = if args_w.len() <= INLINE_ARGS {
-            inline_full[0] = w_obj;
-            // The index loop lowers to `setarrayitem`; iterator adapters are
-            // residual calls.
-            #[allow(clippy::needless_range_loop)]
-            for i in 0..args_w.len() {
-                inline_full[i + 1] = args_w[i];
-            }
-            &inline_full[..args_w.len() + 1]
-        } else {
-            wide_full = Vec::with_capacity(args_w.len() + 1);
-            wide_full.push(w_obj);
-            wide_full.extend_from_slice(args_w);
-            &wide_full
-        };
-        return crate::call::call_function_impl_result(w_descr, full);
+        // `w_descr.funccall(w_obj, *args_w)`.  Build the receiver-prepended
+        // positionals as one dynamic list, the shape
+        // `call::call_function_impl_result` itself builds: `Vec::with_capacity`
+        // lowers to `newlist` (`is_vec_ctor_segments`), `push` to the resized
+        // `ListRepr`'s `append`, and `extend_from_slice` to its own method
+        // arm, so the meta-tracer can virtualize it on the fixed-arity paths.
+        // A fixed `[PY_NULL; N]` with a trailing `&full[..len]` is the shape
+        // that dispatcher records as having ended in the opaque
+        // `<[T; N]>::index(&array, ..len)` and kept the whole call dispatcher
+        // out of two-phase translation — which would wall off exactly the
+        // `__instancecheck__` / `__getattr__` dunder dispatch this arm exists
+        // to expose.
+        let mut full = Vec::with_capacity(args_w.len() + 1);
+        full.push(w_obj);
+        full.extend_from_slice(args_w);
+        return crate::call::call_function_impl_result(w_descr, full.as_slice());
     }
     let w_impl = unsafe { get(w_descr, w_obj, w_type) }?.unwrap_or(w_descr);
     crate::call::call_function_impl_result(w_impl, args_w)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -1006,6 +1006,26 @@ mod foriter_delivery_tests {
         fbw_store_journal_reset();
     }
 
+    /// A `PureUnfolded` decline is the one cause that must leave the walk
+    /// unmarked: the call it stands for applies no effect, so there is no
+    /// pending write a replay could be the only carrier of.  Marking it would
+    /// shut every no-replay walk-end road and leave replay — which re-applies
+    /// the already-executed effects — as the only exit.  Guard both flag
+    /// components, not just the aggregate, so a future rewrite of the `match`
+    /// cannot set one of them and still read false through some other path.
+    #[test]
+    fn a_pure_unfolded_decline_leaves_the_walk_unmarked() {
+        fbw_store_journal_reset();
+        assert!(!fbw_has_unjournaled_effect());
+
+        fbw_mark_unjournaled_effect(ResidualDecline::PureUnfolded);
+
+        assert_eq!(fbw_unjournaled_kinds(), (false, false));
+        assert!(!fbw_has_unjournaled_effect());
+
+        fbw_store_journal_reset();
+    }
+
     /// Two FOR_ITERs of one frame can be in flight at once (an outer `list`
     /// loop through the residual leg, a `range` body inside it through the
     /// specialised leg). The deliver site can only push at the header the
@@ -1342,9 +1362,14 @@ pub(crate) fn fbw_journaled_effect_lens() -> (usize, usize, usize) {
 /// cause here and the flag itself keeps no provenance; `PYRE_UNJOURNALED_SITE`
 /// names the caller, in the shape `PYRE_LB_SITE` uses for the callee-inline
 /// declines.
+fn unjournaled_site_enabled() -> bool {
+    static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *ENABLED.get_or_init(|| std::env::var_os("PYRE_UNJOURNALED_SITE").is_some())
+}
+
 #[track_caller]
 pub(crate) fn fbw_mark_unjournaled_effect(cause: ResidualDecline) {
-    if std::env::var_os("PYRE_UNJOURNALED_SITE").is_some() {
+    if unjournaled_site_enabled() {
         let loc = std::panic::Location::caller();
         // Only a `Symbolic` decline records a site, so read the cell only for
         // that cause: on any other one it still holds whichever earlier


### PR DESCRIPTION
Follow-ups to the three review threads left unresolved when #1324 was squash-merged (`40cf01907c6`). Rebased onto current `main`; the anchors all still exist there.

### 1. `front`: name the object GC array on both devirtualized element arms

Codex P1. `ArrayRead`/`ArrayWrite` carry an `array_type_id` that keys both the descriptor cache and the `EffectInfo` descr set, and two arms reaching the length-prefixed `PyObjectRef` block left it `None` — so they did not share a descr with the `set_ref` and items-pointer arms that name `PYOBJECT_GCARRAY_TYPE_ID`.

The `slice::swap` decomposition was also guessing its element kind, and the census came out stronger than the finding assumed. `is_slice_swap_call` matches `core::slice::<Impl>::swap` by name alone, and the name reaches four element kinds:

| site | element |
| --- | --- |
| `listsort::ListSortState::reverse_slice` on `list: &'a mut [T]` in `sort_with<T: Copy, L: SortLt<T>>` | `i64` / `f64` (`builtins::sort_scalars` over `int_items` / `float_items`) and `usize` (the object/key path sorts a `Vec<usize>` permutation) |
| `module::array::array_reverse_method` | `u8` (the `array` module's `Vec<u8>` byte buffer) |
| `object_array::FixedObjectArray::swap` | `PyObjectRef` |

So the fixed `Ref(None)` was wrong on every monomorphization of the sort path, not merely missing an identity. `slice_swap_elem_value_type` reads the element off the call's own `generics.types[0]` through `tyref_to_value_type`, the way `tyref_adt_type_arg` reads an ADT's, and falls back to `Ref(None)` when the type argument cannot be read.

The workspace `Index` arm is named too, but gated: that arm is an `||` of three predicates and only `is_workspace_index_regular` is fenced on the block (a `pyre_`-prefixed path with an `index`/`index_mut` leaf — the tree has exactly three such impls, `FixedObjectArray` (Ref), `IntArray`, `FloatArray`). The `Vec<T>` and slice legs also reach `Ref` elements that are **not** that block and keep `None`. The identity is threaded through `IndexElemAlias.array_type_id`, so the paired `*p = v` write in `emit_projection_write`'s `Deref` arm inherits it.

One correction to the finding's mechanism, which does not change its conclusion: the identity-less legs are not merely unkeyed, they are un-*shared*. `arraydescrof_concrete`'s `None` arm is "no identity carrier — local mint, no cache publish", so each site gets its own descr. That is why leaving the unboxed banks unnamed is safe, and equally why the object-block reads and writes had to be named — two sites that both said `None` were already on two different descrs.

### 2. `interpreter`: build `get_and_call_function`'s receiver-prepend as a dynamic list

Codex P2, confirmed by the callee's own comment. `call::call_function_impl_result` records at its `rooted_args` rebuild that "a former fixed `[PY_NULL; 8]` shortcut ended in Rust's opaque `<[T; N]>::index(&array, ..len)` and prevented the whole call dispatcher from entering two-phase translation". #1324 reintroduced that shape one frame above it and cited that function as the precedent — `INLINE_ARGS` occurs nowhere else in the tree, so the cited precedent did not exist.

The reason the fixed array was reached for is also gone: `flowspace_adapter` routes `vec::Vec::{new,with_capacity}` to `newlist` (`is_vec_ctor_segments`), `Vec::push` to the resized `ListRepr`'s `append`, and `Vec::extend_from_slice` to its own method arm. The arm is rewritten to those three calls — the same shape `call_function_impl_result` builds.

### 3. `jit-trace`: cache the `PYRE_UNJOURNALED_SITE` gate, and cover the `PureUnfolded` arm

CodeRabbit. The env read now goes through a `OnceLock<bool>`, matching `fbw_debug_abort_enabled` and `fbw_inline_diag_enabled` in the same file. The added test asserts a `PureUnfolded` decline leaves `fbw_has_unjournaled_effect()` false and both `fbw_unjournaled_kinds()` components false — the existing sibling test exercises `ResidualDecline::Symbolic` only, so nothing pinned the arm that must not mark.

### Gates

`pyre/check.py` on this rebased base — dynasm 442/442, cranelift 442/442, wasm 435/435, 3/3 backend runs.

`cargo test --all --features dynasm` exit 0, run on the pre-rebase base (the same three commits, parented on `40cf01907c6`'s content); it is re-running on this base now and I will note the result here if it differs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved correctness when reading reference arrays and handling slice element swaps.
  * Fixed certain function-call scenarios to ensure arguments are passed consistently.
  * Corrected residual behavior in JIT tracing so effect tracking remains accurate.
* **Performance**
  * Reduced repeated environment configuration checks during execution.
* **Tests**
  * Added regression coverage for effect tracking after declined trace residuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->