### PR TITLE
check.py: withdraw the startup-drift allowance, and report the margin instead

### DIFF
--- a/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.py
+++ b/pyre/bench/synth/blackhole_inlined_callee_local_after_escape.py
@@ -1,12 +1,9 @@
 # Output guard for an inlined callee whose local is read back after the frame
-# escapes.  This file no longer reaches an adopt of any kind: since the
-# constant-depth `sys._getframe` fold (#1096) its committed baselines read
+# escapes.  This file reaches no adopt of any kind: with the constant-depth
+# `sys._getframe` fold (#1096) its committed baselines read
 # `fbw_blackhole_adopted_single_frame=0`, `loops_aborted=0`, `loops_compiled=2`
-# on all three backends.  Before the fold they read 5 / 5 / 1 -- five
-# SINGLE-frame adopts.  `fbw_blackhole_adopted_multi_frame` is 0 here today and
-# was 0 before the fold too, so despite the wording this file carried for a
-# while, it has never taken the multi-frame arm.  That arm is pinned elsewhere,
-# by `getframe_inline_subwalk_multiframe` and
+# on all three backends.  It does not take the multi-frame arm either; that
+# arm is pinned by `getframe_inline_subwalk_multiframe` and
 # `getframe_while_inlined_callee_subwalk` among others, all recording a nonzero
 # `fbw_blackhole_adopted_multi_frame` on all three backends.
 #

--- a/pyre/bench/synth/bound_method_builtin_fold.py
+++ b/pyre/bench/synth/bound_method_builtin_fold.py
@@ -1,10 +1,7 @@
 # pyre-check: max-pypy-ratio=160
-# The trip count now puts pypy above the startup-subtraction floor, so this
-# ratio is a measurement rather than pyre divided by the floor constant, and
-# the number it reports is larger than the clamped reading it replaces -- a
-# clamped baseline over-states pypy's work and so under-states the ratio. The
-# ceiling is twice the slowest of the three backends observed unclamped
-# (78.5x on wasm); the previous 48 was fitted against the clamp and fails.
+# The trip count puts pypy above the startup-subtraction floor, so this ratio
+# is a measurement rather than pyre divided by the floor constant. The ceiling
+# is twice the slowest of the three backends observed (78.5x on wasm).
 # `lst.append(x)` on a builtin receiver: the name resolves to a builtin-code
 # function on the type, so LOAD_ATTR's method fast path declines (it only
 # pushes `[descr, self]` for `flag_method_descriptor` types) and `getattr`

--- a/pyre/bench/synth/call_kw_hot_loop.py
+++ b/pyre/bench/synth/call_kw_hot_loop.py
@@ -3,10 +3,10 @@
 # callee, unlike call_star_forms_inlined_callee.py).  `g(i, step=2)` lowers to
 # CALL_KW whose `null_or_self` receiver slot (arg index 1) is the PY_NULL
 # sentinel (GcRef(0)) for a plain no-receiver call.  The residual-executor
-# NULL-Ref-arg refusal used to lack the `is_call_kw` receiver-slot exemption
-# that its sibling walker_abort_if_mayforce_null_ref_arg has, so it declined
-# the recording iteration's call to a symbolic op and dropped that one
-# iteration's effect — the hot-loop sum came out exactly one term short.
+# NULL-Ref-arg refusal carries the `is_call_kw` receiver-slot exemption its
+# sibling walker_abort_if_mayforce_null_ref_arg has.  Without it the refusal
+# declines the recording iteration's call to a symbolic op and drops that
+# iteration's effect, leaving the hot-loop sum exactly one term short.
 # The keyword overrides a default (`step=1`) and the result depends on both
 # the positional and the keyword arg so the call cannot be constant-folded
 # away; the exact aggregate makes a single dropped iteration observable.

--- a/pyre/bench/synth/call_loop_local_function.py
+++ b/pyre/bench/synth/call_loop_local_function.py
@@ -19,19 +19,17 @@
 # in the committed `.jitstats` baseline is the signal: it is 1 with the field
 # guards and 9480 with an identity guard, which also compiled 47 bridges here
 # (2497 at N=1000000) before `make_a_counter_per_value` (regalloc.py:496-499)
-# reached the dynasm and wasm backends.  With the identity guard gone this
-# fixture no longer exercises that bucketing — `bridges_compiled` stays 0.
+# reached the dynasm and wasm backends.  Without the identity guard this
+# fixture does not exercise that bucketing — `bridges_compiled` stays 0.
 #
 # `N` is sized by the GATE, not by the loop.  The gate compares
 # startup-subtracted times with the baseline floored at 5ms, so below ~11M
-# iterations pypy lands on that floor.  That used to be the regime this
-# fixture chose deliberately, because a clamped baseline still produced a
-# comparison — a fixed ~45ms budget for pyre.  It no longer does: a clamped
-# baseline now disarms the ratio gate entirely, ceiling and derived floor
-# both, so staying under the floor means being ungated rather than being
-# stably gated.  The trip count is therefore set above it.  The other bound
-# is unchanged — ~195ns/iteration here against pypy's fraction of one, and
-# this fixture must not become the slowest baseline run in the suite.
+# iterations pypy lands on that floor.  A clamped baseline disarms the ratio
+# gate entirely, ceiling and derived floor both, so staying under the floor
+# means being ungated rather than being stably gated: the trip count is set
+# above it.  The other bound is ~195ns/iteration here against pypy's fraction
+# of one, and this fixture must not become the slowest baseline run in the
+# suite.
 N = 72000000
 
 

--- a/pyre/bench/synth/call_star_forms_inlined_callee.py
+++ b/pyre/bench/synth/call_star_forms_inlined_callee.py
@@ -1,8 +1,8 @@
 # pyre-check: max-pypy-ratio=18
 # CALL_KW and CALL_FUNCTION_EX inside a callee that is inlined into the hot
-# loop.  Both opcodes used to emit abort_permanent and decline the callee's
-# jitcode; the residual port lets them compile.  Guards output correctness and
-# the demonstrable inline (loops_aborted drops to 0).
+# loop.  The residual port compiles both opcodes rather than emitting
+# abort_permanent and declining the callee's jitcode.  Guards output
+# correctness and the demonstrable inline (loops_aborted is 0).
 #
 # `call_kw_hot_loop.py` is the contrasting shape: a CALL_KW directly in the
 # hot loop body rather than nested inside an inlined callee.

--- a/pyre/bench/synth/class_attrs_methods.py
+++ b/pyre/bench/synth/class_attrs_methods.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=32
 # The ceiling is twice the slowest ratio observed (15.7x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 N = 600000
 
 

--- a/pyre/bench/synth/class_reassign_hot.py
+++ b/pyre/bench/synth/class_reassign_hot.py
@@ -4,11 +4,11 @@
 # fitted it to a single run's numbers.
 # Reassigning obj.__class__ inside a hot loop must actually re-root the
 # instance's type, so method lookup and type() follow the new class.  The
-# STORE_ATTR mapdict inline cache (store_attr_slowpath) used to classify
+# STORE_ATTR mapdict inline cache (store_attr_slowpath) must not classify
 # `__class__` as an ordinary instance-dict attribute (its data-descriptor role
 # is modelled by object_setattr's special-case, not a getset, so it never
-# surfaces for classify_attr) and stored it into the instance dict, leaving the
-# real type unchanged: obj.kind() kept dispatching through the old class.  The
+# surfaces for classify_attr): storing it into the instance dict leaves the
+# real type unchanged and obj.kind() keeps dispatching through the old class.  The
 # exact aggregate over the loop makes that silent miscompile observable.
 N = 200000
 

--- a/pyre/bench/synth/comprehension_object_append_hot.py
+++ b/pyre/bench/synth/comprehension_object_append_hot.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=102
 # The ceiling is twice the slowest ratio observed (51.0x on the windows runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 # An inlined list comprehension whose LIST_APPEND element lands in a list
 # Object-strategy (tuple / None / str / dict / f-string) folds through the #171
 # orthodox append. Its Object arm stores a GC ref and runs list_write_barrier,

--- a/pyre/bench/synth/defaults_reassigned_midloop.py
+++ b/pyre/bench/synth/defaults_reassigned_midloop.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=36
 # The ceiling is twice the slowest ratio observed (17.8x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 # `__defaults__` replaced part-way through a compiled loop, in the two shapes
 # that break differently from a same-length replacement.
 #

--- a/pyre/bench/synth/del_cellvar_walk_commit.py
+++ b/pyre/bench/synth/del_cellvar_walk_commit.py
@@ -3,11 +3,11 @@
 # sentinel `bh_store_deref_value_fn` hands straight to `w_cell_set` without
 # ever reading it.
 #
-# The walker's NULL-Ref-arg refusal used to decline that residual, which marks
-# the walk as carrying a recorded-but-unexecuted effect.  Every walk over this
-# loop then failed the walk-end flush ("unjournaled effect — legacy replay
-# kept") and handed the region back to a replay that re-ran the residuals the
-# walk had already executed concretely.  `bump` is one of them, so `log` grew
+# The walker's NULL-Ref-arg refusal must not decline that residual: a decline
+# marks the walk as carrying a recorded-but-unexecuted effect, so every walk
+# over this loop fails the walk-end flush ("unjournaled effect — legacy replay
+# kept") and hands the region back to a replay that re-runs the residuals the
+# walk already executed concretely.  `bump` is one of them, so `log` grew
 # by exactly one entry per walk: 20048 instead of 20000, on both backends and
 # at stock thresholds.
 #

--- a/pyre/bench/synth/exception_const_operand_resume.py
+++ b/pyre/bench/synth/exception_const_operand_resume.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=55
 # The ceiling is twice the slowest ratio observed (27.3x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 # Exception-resume bridge (GuardException) with a CONSTANT pre-call operand.
 # Each `try` divides/indexes with a CONSTANT numerator/addend that lives on the
 # operand stack at the raising bytecode. The loop warms up exception-free

--- a/pyre/bench/synth/exception_dict_slot_reject.py
+++ b/pyre/bench/synth/exception_dict_slot_reject.py
@@ -2,7 +2,6 @@
 # `loops_compiled=0` -- so a pypy ratio compares two interpreters' startup
 # rather than any generated code, and reads whatever the host's process
 # spawn cost happens to be that run. The jitstats baselines gate it.
-# rounded up; the gate it replaces was fitted to no measurement.
 # A subclass whose base already carries an instance dict rejects a second
 # `__dict__` slot. BaseException subclasses carry the dict through the native
 # exception slot, so they must reject it too.

--- a/pyre/bench/synth/exception_escape_caller_frame_tb_node.py
+++ b/pyre/bench/synth/exception_escape_caller_frame_tb_node.py
@@ -1,9 +1,9 @@
 # pyre-check: max-pypy-ratio=116
 # An exception escaping a compiled frame that holds a try block it does NOT
-# match used to lose the CALLER's traceback node:
+# match must keep the CALLER's traceback node:
 #
-#   before:  ('d_nonmatching_except', 'mid', 'leaf')
-#   after:   ('<module>', 'd_nonmatching_except', 'mid', 'leaf')
+#   correct:            ('<module>', 'd_nonmatching_except', 'mid', 'leaf')
+#   caller node lost:   ('d_nonmatching_except', 'mid', 'leaf')
 #
 # The non-matching clause falls through to the except-cleanup RERAISE, so the
 # blackhole classified the exiting frame as a bare reraise and cleared

--- a/pyre/bench/synth/exception_reduce.py
+++ b/pyre/bench/synth/exception_reduce.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=65
 # The ceiling is twice the slowest ratio observed (32.5x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 N = 50000
 
 

--- a/pyre/bench/synth/finally_bare_raise.py
+++ b/pyre/bench/synth/finally_bare_raise.py
@@ -5,11 +5,11 @@
 # bare `raise` (RAISE_VARARGS argc==0).  When such a bare re-raise is
 # reached by normal fall-through — no `PUSH_EXC_INFO` seeded the handler
 # exception — the RAISE_VARARGS(0) PC is uncovered and the FrameState
-# carries no `last_exception` pair.  The codewriter previously routed this
-# unconditionally to `emit_reraise!`, whose `exception_edge_extravars`
-# asserts a materialized pair, so `transform_graph_to_jitcode` panicked
-# ("exception edge state missing last_exception pair") while building the
-# jitcode for any hot function shaped like this.  The parity-correct coding
+# carries no `last_exception` pair.  Routing this unconditionally to
+# `emit_reraise!`, whose `exception_edge_extravars` asserts a materialized
+# pair, makes `transform_graph_to_jitcode` panic ("exception edge state
+# missing last_exception pair") while building the jitcode for any hot
+# function shaped like this.  The parity-correct coding
 # is the explicit `raise/r` of the current exception
 # (`get_current_exception()` + raise), as the `Reraise` no-catch arm
 # already does.  This bench pins that such functions compile and run

--- a/pyre/bench/synth/for_iter_select_receiver_swap.py
+++ b/pyre/bench/synth/for_iter_select_receiver_swap.py
@@ -1,6 +1,5 @@
 # pyre-check: max-pypy-ratio=33
-# The ceiling is twice the slowest ratio observed, 16.1x on the linux runner;
-# the gate it replaces sat inside the run-to-run spread.
+# The ceiling is twice the slowest ratio observed, 16.1x on the linux runner.
 # A conditional expression selects one of two loop locals as the receiver
 # (`q = o if cond else p`) whose attribute is then read/written inside a hot
 # `for i in range(...)` loop.  The two arms of the conditional are distinct

--- a/pyre/bench/synth/foriter_body_return.py
+++ b/pyre/bench/synth/foriter_body_return.py
@@ -1,13 +1,13 @@
 # A `return` inside a `FOR_ITER` body — the early-exit search shape
-# (`for x in xs: if pred(x): return x`), which is the single most common
-# reason `for_iter_bodies_all_jit_safe` used to decline a frame on real code:
-# a census over stdlib test modules put `RETURN_VALUE` first at 95 of 223
-# first-rejections, ahead of the documented `LIST_APPEND`-with-`CALL` case.
+# (`for x in xs: if pred(x): return x`), the shape a gate that rejects
+# `RETURN_VALUE` declines most often on real code: a census over stdlib test
+# modules puts it first at 95 of 223 first-rejections, ahead of the documented
+# `LIST_APPEND`-with-`CALL` case.
 #
 # A declined frame runs fully interpreted, so it reports `loops_compiled=0`
 # AND `loops_aborted=0` — the tracer never sees it. That invisibility is why
-# no fixture covered the shape before this one: the decline leaves no counter
-# to notice.
+# the shape needs a fixture of its own: the decline leaves no counter to
+# notice.
 #
 # Both exits are driven. `i % (N + 8)` overshoots the largest element for one
 # probe in five, so the scan returns from inside the loop for the rest and

--- a/pyre/bench/synth/foriter_call_resume_drops_iteration.py
+++ b/pyre/bench/synth/foriter_call_resume_drops_iteration.py
@@ -5,9 +5,9 @@
 # (`LoopBearingCalleeInlineUnsupported`) and resumes the caller forward at the
 # CALL. That resume rebuilds the caller's operand stack from the overrides
 # collected at the CALL, and the `null_or_self` slot a `PUSH_NULL` leaves under
-# it has no box in the walk and no distinguishable shadow value — so it used to
-# be missing, the resume declined, and the legacy rollback+replay refused
-# in-flight FOR_ITER delivery, DROPPING that iteration. The loss is silent: one
+# it has no box in the walk and no distinguishable shadow value.  When that
+# slot goes missing the resume declines, and the legacy rollback+replay
+# refuses in-flight FOR_ITER delivery, DROPPING that iteration. The loss is silent: one
 # iteration's accumulation never happens and the answer is simply too small.
 #
 # All three ingredients are required — with one callee, without the branch

--- a/pyre/bench/synth/foriter_isinstance_class_property_replay.py
+++ b/pyre/bench/synth/foriter_isinstance_class_property_replay.py
@@ -5,9 +5,8 @@
 # `helper` is admitted into the surrounding FOR_ITER body.  The trailing
 # opaque `id` call makes the first inline sub-walk abort and replay `helper`.
 # The property returns `int`, so the same loop also pins the observable
-# `isinstance` semantics formerly covered by a separate, lower-priority parity
-# test: the MRO miss must consult the property, use its result, and invoke it on
-# every call.  If the call is incorrectly marked replay-safe, the first replay
+# `isinstance` semantics: the MRO miss must consult the property, use its
+# result, and invoke it on every call.  If the call is incorrectly marked replay-safe, the first replay
 # invokes the getter twice (N + 1 hits).
 
 N = 5000

--- a/pyre/bench/synth/gc_pypy_frontend.py
+++ b/pyre/bench/synth/gc_pypy_frontend.py
@@ -174,7 +174,20 @@ assert isinstance(public_stats.total_gc_memory, str)
 assert isinstance(public_stats.total_gc_time, int)
 assert repr(public_stats).startswith("Total memory consumed:\n")
 public_copy = type(public_stats)(raw_stats)
-assert public_copy.total_gc_memory == public_stats.total_gc_memory
+# Compare the copy against the snapshot it was built from.  `public_stats`
+# carries a `get_stats()` snapshot taken forty-odd lines earlier and
+# `total_gc_memory` is a formatted size, so comparing the two asserts that no
+# collection ran in between rather than that the constructor converts -- which
+# is false whenever the nursery is small enough to collect there.
+# `app_referents.py:72-76 _format` is the conversion under test.
+raw_total = raw_stats.total_gc_memory
+assert public_copy.total_gc_memory == (
+    "%.1fkB" % (raw_total / 1024.0)
+    if raw_total < 1000000
+    else "%.1fMB" % (raw_total / 1024.0 / 1024.0)
+)
+# `total_gc_time` is the one field the wrapper passes through unformatted.
+assert public_copy.total_gc_time == raw_stats.total_gc_time
 
 # `jit_hooks.stats_asmmemmgr_*` reads the active CPU's assembler memory
 # manager. A hot loop must therefore make both native-code counters visible;

--- a/pyre/bench/synth/getattr_hook_binding.py
+++ b/pyre/bench/synth/getattr_hook_binding.py
@@ -4,12 +4,11 @@
 # being called, exactly like any other special method, so it receives the
 # arguments the descriptor protocol gives it.
 #
-# Each of the three accesses below used to cost one opaque residual holding the
-# whole `object_getattr_miss` walk plus a fresh frame for the hook. Inlining
-# the hook against the version-tag and map pins that make the miss constant
-# dropped the ratio from 48.6x/59.5x (dynasm/wasm) to 7.4x/10.4x/8.7x
-# (dynasm/cranelift/wasm); the bound is twice the slowest of those (10.4x),
-# rounded up to the next multiple of five.
+# The hook inlines against the version-tag and map pins that make the miss
+# constant, instead of costing one opaque residual per access holding the
+# whole `object_getattr_miss` walk plus a fresh frame.  The ratio reads
+# 7.4x/10.4x/8.7x (dynasm/cranelift/wasm); the bound is twice the slowest of
+# those (10.4x), rounded up to the next multiple of five.
 
 
 class ClassmethodGetattr:

--- a/pyre/bench/synth/getattribute_override_no_bind.py
+++ b/pyre/bench/synth/getattribute_override_no_bind.py
@@ -6,8 +6,8 @@
 #    (`type(self).__dict__[name]`), never a bound method, so `c.f(i)` calls
 #    `f(i)` (a single positional, no implicit self).  `compute_load_method_bound`
 #    (shared by the interpreter `load_method` and the blackhole
-#    `bh_load_method_self_fn`) used to infer the binding from MRO shape alone
-#    and wrongly prepend self, making `len(args)` 2 instead of 1.
+#    `bh_load_method_self_fn`) must not infer the binding from MRO shape
+#    alone: that prepends self and makes `len(args)` 2 instead of 1.
 #
 # 2. GC: `type.__dict__` caches its canonical `W_DictObject` in the type
 #    namespace's off-GC `DictStorage.mirror_target`.  The moving collector did

--- a/pyre/bench/synth/getframe_force_cancel_journal.py
+++ b/pyre/bench/synth/getframe_force_cancel_journal.py
@@ -2,7 +2,6 @@
 # `loops_compiled=0` -- so a pypy ratio compares two interpreters' startup
 # rather than any generated code, and reads whatever the host's process
 # spawn cost happens to be that run. The jitstats baselines gate it.
-# rounded up; the gate it replaces was fitted to no measurement.
 # Regression guard: a frame-forcing user @property that forces FIRST (the
 # escape flush commits mid-property) and mutates SECOND (the commit is then
 # withdrawn because the callee entered a user frame). The withdrawal must

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn.py
@@ -25,18 +25,18 @@
 # frame, so the drive read locals one Python iteration stale and accumulated
 # total += 1039 where i was already 1040.
 #
-# All of it is now moot for the reason that matters: the CRN handoff no longer
-# rebuilds the frame from the terminal register banks at all, so there is no
-# NULL to write and nothing left to decline.
+# None of that is reachable here: the CRN handoff does not rebuild the frame
+# from the terminal register banks, so there is no NULL to write and nothing
+# to decline.
 #
-# This file no longer reaches the blackhole at all. The constant-depth
+# This file does not reach the blackhole at all. The constant-depth
 # `sys._getframe` fold (#1096) answers the `_getframe(0)` below out of the portal
 # virtualizable, so nothing escapes, nothing aborts, and the loop simply
 # compiles: the committed baselines record
 # `fbw_blackhole_adopted_single_frame=0`, `loops_aborted=0`, `loops_compiled=1`
-# on all three backends (they read 5 / 5 / 0 before the fold). What it still
-# guards is the output. The pre-fold counters, and with them the CRN machinery
-# described above, are carried by the `_declined` sibling
+# on all three backends. What it guards is the output. The unfolded counters,
+# and with them the CRN machinery described above, are carried by the
+# `_declined` sibling
 # (`getframe_root_loop_force_blackhole_crn_declined`), which repeats this shape
 # at a force the fold declines and records 5 adopts / 5 aborts.
 #

--- a/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_declined.py
+++ b/pyre/bench/synth/getframe_root_loop_force_blackhole_crn_declined.py
@@ -44,10 +44,9 @@
 # frame, so the drive read locals one Python iteration stale and accumulated
 # total += 1039 where i was already 1040.
 #
-# All of it is now moot for the reason that matters: the CRN handoff no longer
-# rebuilds the frame from the terminal register banks at all, so there is no
-# NULL to write and nothing left to decline. The drive runs and this file
-# adopts it five times. Its effects are idempotent, though, which is exactly
+# None of that is reachable here: the CRN handoff does not rebuild the frame
+# from the terminal register banks, so there is no NULL to write and nothing
+# to decline. The drive runs and this file adopts it five times. Its effects are idempotent, though, which is exactly
 # what hid the residual heap half of a post-drive decline — see the
 # `_nonidempotent` sibling.
 import sys

--- a/pyre/bench/synth/global_quasiimmut_invalidation.py
+++ b/pyre/bench/synth/global_quasiimmut_invalidation.py
@@ -1,12 +1,9 @@
 # pyre-check: max-pypy-ratio=26
 # pyre-check: skip-cpython
-# The wasm allowance this carried (`max-wasm-ratio=6`, for the 5.2x and 5.1x
-# reported on ubuntu-24.04) is gone because the ratio came down, not because
-# the ceiling went up: the steady state no longer re-enters the invalidated
-# loop, halving the executed wasm ops, and the ratio reads 2.9x here against
-# 7.8x before.
+# No wasm allowance is needed: the steady state does not re-enter the
+# invalidated loop, and the wasm ratio reads 2.9x.
 # The pypy ceiling is twice the slowest ratio observed, 12.6x on the macos
-# runner; the gate it replaces sat inside the run-to-run spread.
+# runner.
 # cpython 0.21s vs pyre 0.07s (3.0x), and it is not gated on — only pypy is.
 # Nested compiled loop + a conditional loop-carried store to a MODULE
 # GLOBAL that is read after the (untaken) store.  The read-only global
@@ -16,10 +13,10 @@
 # invalidation flag, but the compiled GUARD_NOT_INVALIDATED must re-read
 # that flag at runtime on every iteration so that a re-entry through any
 # path (warm entry, CALL_ASSEMBLER, eval-breaker poll-deopt resume)
-# observes the invalidation.  Previously the guard emitted no runtime
-# code (only the warm-entry lookup filtered invalidated tokens), so after
-# the periodic poll deopt the stale const-folded loop was re-entered and
-# `x` reverted to its pre-store value for the rest of the run.  Function
+# observes the invalidation.  A guard that emits no runtime code (leaving
+# only the warm-entry lookup to filter invalidated tokens) lets the periodic
+# poll deopt re-enter the stale const-folded loop, and `x` reverts to its
+# pre-store value for the rest of the run.  Function
 # scope is unaffected (locals are never const-folded this way); the
 # module-global read path is the one under test.
 K = 5000

--- a/pyre/bench/synth/goto_if_not_same_box.py
+++ b/pyre/bench/synth/goto_if_not_same_box.py
@@ -6,8 +6,8 @@
 # `record_or_fold_fused_guard` mirrors `opimpl_goto_if_not_<cmp>`
 # (pyjitpl.py:547): `if <not float> and b1 is b2:` skips both the compare op
 # and the guard because `x <cmp> x` is statically determined
-# (FASTPATHS_SAME_BOXES: eq/le/ge => True, ne/lt/gt => False). Previously the
-# Rust path recorded an extra always-passing guard for these self-compares.
+# (FASTPATHS_SAME_BOXES: eq/le/ge => True, ne/lt/gt => False). The Rust path
+# must not record an extra always-passing guard for these self-compares.
 #
 # A self-compare reaches the fused branch when both operands colour to the same
 # register (`i == i`, `obj is obj`). The fast path must follow the branch in

--- a/pyre/bench/synth/import_math.py
+++ b/pyre/bench/synth/import_math.py
@@ -4,13 +4,10 @@
 # reference timeout leaves pypy back on the floor, so cpython is dropped
 # deliberately rather than by spending the whole timeout to discover the same
 # drop.
-# The 291 this replaces was never fitted to an observation: pypy's execution
-# sat on the startup-subtraction floor, so the ratio it bounded was pyre's time
-# divided by a constant. With pypy's side now a measurement the loop reads
-# 1.3-1.9x, and 8 is twice the slowest reading from either size. Keeping a
-# ceiling at or above PERF_GATE_FLOOR_DIVISOR would also pin the derived floor
-# to parity, which a fixture running this close to pypy cannot clear on a host
-# where pyre happens to land faster.
+# pypy's side is a measurement at this count and the loop reads 1.3-1.9x, so 8
+# is twice the slowest reading. A ceiling at or above PERF_GATE_FLOOR_DIVISOR
+# would pin the derived floor to parity, which a fixture running this close to
+# pypy cannot clear on a host where pyre happens to land faster.
 import math
 
 # Sized so pypy's own execution clears the measurement floor: below it the

--- a/pyre/bench/synth/inline_freevar_after_mayforce.py
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.py
@@ -2,15 +2,8 @@
 # The ceiling is a function of N, so raising N refits it. pypy's execution here
 # is almost all fixed cost -- doubling N moved it 0.035s to 0.039s -- while this
 # backend pays roughly 27us per iteration, so the ratio tracks N nearly one for
-# one. Going from 32176 to 64000 moved the local cranelift ratio 25.8x to 44.9x,
-# and 49 scaled by that same measured 1.74 is 86: the gate keeps exactly the
-# slack it had before, re-expressed at the new size, rather than being loosened.
-#
-# The 49 it replaces was twice the slowest ratio observed once pypy's side
-# became a measurement. The 25 before that was fitted while pypy's execution was
-# pinned to the startup-subtraction floor, and a pinned denominator
-# over-estimates the work pypy actually did, so every ratio read against it was
-# a lower bound -- this loop was always this far behind, the clamp just hid it.
+# one. At N = 64000 the local cranelift ratio reads 44.9x, and the ceiling sits
+# just under twice it.
 # An inlined closure keeps its freevar cells in MIFrame.registers_r across a
 # may-force call.  The `Fraction` arithmetic in `forward` is that may-force
 # call and invalidates heap-cache facts; the following LOAD_DEREF must recover
@@ -23,8 +16,8 @@
 # failed decode leaves two guards failing on nearly every iteration, while
 # guarding the callee namespace through the portal/root frame compiles an
 # endless chain of equally failing bridges.  With both frame properties
-# preserved, guard failures fall from 16898 to 471 and local native ratios are
-# 10.3x dynasm / 15.9x cranelift versus PyPy (formerly 22-29x on macOS).
+# preserved, guard failures stay at 471 and local native ratios are 10.3x
+# dynasm / 15.9x cranelift versus PyPy.
 from fractions import Fraction
 
 

--- a/pyre/bench/synth/inlined_helper_mutation.py
+++ b/pyre/bench/synth/inlined_helper_mutation.py
@@ -5,11 +5,11 @@
 # The bound is twice the slowest of the three backends (27.7x), rounded up to
 # the next multiple of ten.
 #
-# `push` binds `a.append` inside an inlined callee, and the folds that shape a
-# bound-method load used to decline for the whole of such a sub-walk. They now
-# decline only where a guard would collapse its resume to the caller's CALL,
-# so the binding folds here: the ratio fell from 39.4x/70.2x/60.8x to
-# 15.1x/27.7x/26.4x (dynasm/cranelift/wasm).
+# `push` binds `a.append` inside an inlined callee.  The folds that shape a
+# bound-method load decline only where a guard would collapse its resume to
+# the caller's CALL, rather than for the whole of such a sub-walk, so the
+# binding folds here and the ratio reads 15.1x/27.7x/26.4x
+# (dynasm/cranelift/wasm).
 # Inlined-callee shared-heap mutation parity, in both helper orderings.
 #
 # A tiny helper mutates a caller-owned list/instance inside a hot while-loop,

--- a/pyre/bench/synth/kept_stack_deep_var_nested_call.py
+++ b/pyre/bench/synth/kept_stack_deep_var_nested_call.py
@@ -1,6 +1,5 @@
 # pyre-check: max-pypy-ratio=28
-# The ceiling is twice the slowest ratio observed, 13.9x on the macos runner;
-# the gate it replaces sat inside the run-to-run spread.
+# The ceiling is twice the slowest ratio observed, 13.9x on the macos runner.
 # Deep operand-stack Variables across a nested-call deopt guard.
 # Several computed Variables (x, y, z) sit deep on the stack as arguments being
 # marshalled for `acc(...)` while `mul(i, i)` (a residual call that can guard /

--- a/pyre/bench/synth/kept_stack_depth_gt1.py
+++ b/pyre/bench/synth/kept_stack_depth_gt1.py
@@ -9,8 +9,9 @@
 # Each shape lives in its own minimal loop so the kept-stack guard is the
 # whole trace and a miscompile is not diluted by a multi-shape loop.  Pure
 # arithmetic -> deterministic checksum.  Regression guard for the depth > 1
-# decline removal (`0 < a < b < 9` previously miscompiled 749949 vs 375000,
-# `total + (a + ((i & 1) or 5))` 1837502750500 vs 1275003750000).
+# decline removal: `0 < a < b < 9` must read 375000 (a miscompile gives
+# 749949) and `total + (a + ((i & 1) or 5))` 1275003750000 (miscompile:
+# 1837502750500).
 N = 1500000
 
 

--- a/pyre/bench/synth/list_append_funcentry_helper.py
+++ b/pyre/bench/synth/list_append_funcentry_helper.py
@@ -1,10 +1,7 @@
 # pyre-check: max-pypy-ratio=125
-# The trip count now puts pypy above the startup-subtraction floor, so this
-# ratio is a measurement rather than pyre divided by the floor constant, and
-# it reads higher than the clamped one it replaces -- a baseline pinned to the
-# floor over-states pypy's work and so under-states the ratio. The ceiling is
-# twice the slowest backend observed unclamped (61.9x on cranelift); the
-# previous 61 was fitted against the clamp and sat under that reading.
+# The trip count puts pypy above the startup-subtraction floor, so this ratio
+# is a measurement rather than pyre divided by the floor constant. The ceiling
+# is twice the slowest backend observed (61.9x on cranelift).
 # #171/#34: the orthodox list.append fold fires in function-entry (no-loop)
 # helper traces, not only loop traces.  `push` is a no-loop helper called in a
 # hot loop on two alternating receivers, so it traces from entry (header_pc==0)

--- a/pyre/bench/synth/load_attr_blackhole_resume.py
+++ b/pyre/bench/synth/load_attr_blackhole_resume.py
@@ -1,10 +1,10 @@
 # pyre-check: max-pypy-ratio=12
 # Guard-failure blackhole resume across a LOAD_ATTR (issue #143 guard-12
 # class).  The rare branch fails its guard until the bridge threshold, and
-# each failure resumes the rest of the iteration through `c.v` — the
-# jitcode position that used to carry `abort_permanent` (which crashed the
-# blackhole with an out-of-bounds register read) and is now lowered to the
-# `load_attr_fn` residual call by the canonical splice.
+# each failure resumes the rest of the iteration through `c.v` — a jitcode
+# position the canonical splice lowers to the `load_attr_fn` residual call.
+# An `abort_permanent` there crashes the blackhole with an out-of-bounds
+# register read.
 class C:
     def __init__(self):
         self.v = 3

--- a/pyre/bench/synth/loop_callee_return.py
+++ b/pyre/bench/synth/loop_callee_return.py
@@ -1,6 +1,5 @@
 # pyre-check: max-pypy-ratio=28
-# The ceiling is twice the slowest ratio observed, 13.6x on the macos runner;
-# the gate it replaces sat inside the run-to-run spread.
+# The ceiling is twice the slowest ratio observed, 13.6x on the macos runner.
 # Regression: a loop-bearing callee whose return value is consumed by a hot
 # caller loop. The inline recursive-call-assembler path (opimpl_recursive_call_
 # assembler) reaches the callee's loop back-edge, pops the inline frame, and

--- a/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
+++ b/pyre/bench/synth/loop_exit_empty_dict_local_clobber.py
@@ -1,11 +1,10 @@
 # pyre-check: max-pypy-ratio=19
-# The ceiling is twice the slowest ratio observed, 9.3x on the macos runner;
-# the gate it replaces sat inside the run-to-run spread.
+# The ceiling is twice the slowest ratio observed, 9.3x on the macos runner.
 # A local must not read back as the `for` loop's iterator after the loop.
 #
-# An empty dict literal used to decline in the codewriter, and the decline
-# emitted `abort_permanent`, which closes its block: everything after it -
-# the whole loop - stopped being lowered. The loop header still resolved to a
+# An empty dict literal must not decline in the codewriter: the decline
+# emits `abort_permanent`, which closes its block, so everything after it -
+# the whole loop - stops being lowered. The loop header still resolved to a
 # walk entry, because the resume-marker tables carry an unlowered PC forward
 # onto the last marker that WAS emitted, so the walk entered the prologue
 # instead. Entry seeding fills a region's registers from the live frame by

--- a/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
+++ b/pyre/bench/synth/mapdict_frozen_unboxing_fold.py
@@ -1,7 +1,5 @@
 # pyre-check: max-pypy-ratio=63
-# The ceiling is twice the slowest ratio observed once pypy's side became a
-# measurement; the previous 58 was fitted against a floored denominator, which
-# over-estimates pypy's work and so understated the ratio.
+# The ceiling is twice the slowest ratio observed.
 # A type change on one instance freezes unboxing for the whole class
 # (mapdict.py:623). Instances created before the freeze keep an unboxed slot
 # until something reads it: `_direct_read` migrates them off unboxed storage

--- a/pyre/bench/synth/nested_list_comprehension_hot.py
+++ b/pyre/bench/synth/nested_list_comprehension_hot.py
@@ -2,10 +2,9 @@
 # An inlined list comprehension whose LIST_APPEND element is a non-empty nested
 # list (`[[i] …]` / `[[i, i + 1] …]`). The #171 fold virtualizes the inner list,
 # whose separately allocated backing block (NewArray / NewArrayClear) carries no
-# jitcode-liveness color. Once the trace-time single-executor forks were retired
-# the append body no longer runs under a speculative-replay sub-walk, so the
-# backing block is bound at every guard-exit deopt without an extra resume-data
-# root.
+# jitcode-liveness color. The append body does not run under a
+# speculative-replay sub-walk, so the backing block is bound at every
+# guard-exit deopt without an extra resume-data root.
 #
 # Acceptance repro for that fold: it must print the same total on all three
 # backends (dynasm / cranelift / wasm).

--- a/pyre/bench/synth/pypy_type_surface.py
+++ b/pyre/bench/synth/pypy_type_surface.py
@@ -1,7 +1,7 @@
 # pyre-check: no-cpython
 # Every assertion here is a place where PyPy remains pyre's reference rather
-# than CPython.  CPython 3.14 layout members and `__sizeof__` are now deliberate
-# pyre compatibility surfaces and therefore no longer belong in this fixture.
+# than CPython.  CPython 3.14 layout members and `__sizeof__` are deliberate
+# pyre compatibility surfaces and so do not belong in this fixture.
 N = 20000
 
 class Heap:

--- a/pyre/bench/synth/range_ctor_in_loop.py
+++ b/pyre/bench/synth/range_ctor_in_loop.py
@@ -9,11 +9,11 @@
 # pypy spends 0.10s, clearing the floor even on the platform with the
 # coarsest timer.
 #
-# `main` used to run interpreted end to end. The `try: range(0, 3, 0)` below
-# puts an out-of-line handler after the trailing comprehension, and the loop
-# region that gates the back edge grew across the gap between them and picked
-# up that comprehension's call-bearing `FOR_ITER` -- an opcode this loop never
-# reaches. With the region built from the exception table instead, the while
+# The `try: range(0, 3, 0)` below puts an out-of-line handler after the
+# trailing comprehension. A loop region that gates the back edge by spanning
+# the gap between them picks up that comprehension's call-bearing `FOR_ITER`
+# -- an opcode this loop never reaches -- and `main` then runs interpreted end
+# to end. With the region built from the exception table instead, the while
 # loop and the three `for` loops compile, and this gate's own metric falls
 # from 122x to 23.2x dynasm / 30.2x cranelift / 24.7x wasm. A separate
 # min-of-five interleaved harness reads the same move as 158x to 35.2x /

--- a/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
+++ b/pyre/bench/synth/recursion_past_unroll_bound_from_loop.py
@@ -10,7 +10,7 @@
 # `fib_recursive` and `selfrec_bridge_nontail_promote` do not cover this. There
 # the recursion is itself the hot thing, so the callee owns a compiled loop
 # before any non-inline decision is taken. Here the hot thing is the caller's
-# loop, and the recursion is a callee it reaches; that ordering is what used to
+# loop, and the recursion is a callee it reaches; that ordering is what can
 # leave the call as an interpreter residual for the rest of the run, one frame
 # build and one entry bridge per recursive call. `recursive_call_frame_relocation`
 # holds the neighbouring case, a recursion under a `FOR_ITER` iterator, which

--- a/pyre/bench/synth/residual_raise_except_resume.py
+++ b/pyre/bench/synth/residual_raise_except_resume.py
@@ -7,18 +7,18 @@
 # fails, so the blackhole walks forward and executes the residual call
 # concretely on the resume path.  When that call raises, the exception
 # must be routed to the in-frame `catch_exception` adjacency the
-# codewriter emitted right after the call; previously the catch search
-# started at the call's operand byte (the dispatch loop advances the
-# position only after the handler returns) so the catch was never found
-# and the exception escaped the handler.  This bench pins that a
+# codewriter emitted right after the call.  A catch search that starts at
+# the call's operand byte (the dispatch loop advances the position only
+# after the handler returns) never finds the catch, and the exception
+# escapes the handler.  This bench pins that a
 # residual-call raise caught on the resume path returns byte-identically.
 #
 # `list_extend_resume` additionally builds a heap-local list via
 # LIST_EXTEND (`[*base]`) *after* the loop, so the loop-exit guard
 # failure resumes through the LIST_EXTEND: the walk must execute the
-# `list_extend` residual.  Previously LIST_EXTEND had no walker handler
-# and emitted an abort that, reached on the resume walk, invalidated the
-# live frame and crashed (SIGSEGV) — the residual port fixes that.
+# `list_extend` residual.  Without a walker handler LIST_EXTEND emits an
+# abort that, reached on the resume walk, invalidates the live frame and
+# crashes (SIGSEGV).
 #
 # N is sized so PyPy's startup-subtracted user-CPU stays well clear of its own
 # empty-program startup. The gate divides by that difference, so a workload

--- a/pyre/bench/synth/store_slice_hot.py
+++ b/pyre/bench/synth/store_slice_hot.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=32
 # The ceiling is twice the slowest ratio observed (15.8x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 # STORE_SLICE in a hot loop: `buf[a:b] = [i, i + 1]` with *variable* bounds
 # (a, b are locals, not literals) compiles to the STORE_SLICE opcode every
 # iteration — literal bounds would fold to a const slice + STORE_SUBSCR.  The

--- a/pyre/bench/synth/subscr_user_getitem_stack_index.py
+++ b/pyre/bench/synth/subscr_user_getitem_stack_index.py
@@ -1,9 +1,9 @@
 # A user `__getitem__` inlined inside a `for` body, subscripted with an index
 # produced on the operand stack rather than read from a local.
 #
-# The FOR_ITER admission gate used to accept this inline because it identified
-# "entered from a CALL" by the absence of an `arg_class_guard`, which the
-# subscript route also leaves empty even though it enters from `BINARY_OP`.
+# The FOR_ITER admission gate must not identify "entered from a CALL" by the
+# absence of an `arg_class_guard`: the subscript route also leaves that empty
+# even though it enters from `BINARY_OP`, so the inline is accepted wrongly.
 # The abort rewind has no CALL coordinate there, so the flush resumed with the
 # operand stack one short and the index operand was replaced by an unrelated
 # live reference — the iterator, the iterated list, or a bound method.

--- a/pyre/bench/synth/swap_except_return_resume.py
+++ b/pyre/bench/synth/swap_except_return_resume.py
@@ -8,8 +8,8 @@
 # exception state so POP_EXCEPT can pop the state and leave the value at
 # TOS).  The try/except is reached only after the loop's exit guard fails,
 # so the blackhole walks forward through the SWAP on the resume path.
-# Previously the codewriter emitted `abort_permanent` for SWAP, so the
-# resume walk failed ("call failed" / uncaught escape).  This bench pins
+# An `abort_permanent` for SWAP fails the resume walk ("call failed" /
+# uncaught escape).  This bench pins
 # that the SWAP-bearing handler tail resumes byte-identically.
 # Sized so pypy's own execution clears the measurement floor: below it the
 # ratio gate divides by the floor and reads startup rather than this loop.

--- a/pyre/bench/synth/unary_negative.py
+++ b/pyre/bench/synth/unary_negative.py
@@ -1,22 +1,11 @@
 # pyre-check: max-pypy-ratio=8
 # The trip count puts pypy's execution above the startup-subtraction floor, so
-# this ratio is a measurement. It reads higher than the clamped one it replaces
-# rather than lower: a baseline pinned to the floor over-states pypy's work,
-# so every ratio built on it was an under-estimate. The ceiling is twice the
-# slowest of the backends observed.
-#
-# 220 came from a 109.5x cranelift reading; the loop now runs at parity, so the
-# derived floor is the bound that noticed. A ceiling that far above its
-# measurement is not a loose bound but a disabled one at BOTH ends: the floor is
-# `min(1, ceiling / PERF_GATE_FLOOR_DIVISOR)`, so 220 pinned it at parity, and
-# cranelift reading 0.5x on macos failed it from below.
-#
-# Observations behind 8 -- ubuntu 1.7x / 1.7x / 1.6x (dynasm / cranelift /
-# wasm), macos 1.1x / 0.6x, windows 1.2x / 1.5x, and 2.5x / 3.9x on a loaded
-# dev box where pypy's own execution lands in the thin band and inflates every
-# ratio built on it. Twice the slowest of those puts the floor at 0.2x, which
-# is 2.5x under the fastest reading -- both bounds keep room, which is the
-# whole point of deriving one from the other.
+# this ratio is a measurement. The loop runs at parity: ubuntu 1.7x / 1.7x /
+# 1.6x (dynasm / cranelift / wasm), macos 1.1x / 0.6x, windows 1.2x / 1.5x.
+# The ceiling is twice the slowest of those, which puts the derived floor
+# `min(1, ceiling / PERF_GATE_FLOOR_DIVISOR)` at 0.2x -- 2.5x under the fastest
+# reading, so both bounds keep room. A ceiling far above the measurement would
+# disable the gate at BOTH ends, the floor included.
 N = 38000000
 
 

--- a/pyre/bench/synth/unary_negative.py
+++ b/pyre/bench/synth/unary_negative.py
@@ -1,10 +1,22 @@
-# pyre-check: max-pypy-ratio=220
+# pyre-check: max-pypy-ratio=8
 # The trip count puts pypy's execution above the startup-subtraction floor, so
 # this ratio is a measurement. It reads higher than the clamped one it replaces
 # rather than lower: a baseline pinned to the floor over-states pypy's work,
 # so every ratio built on it was an under-estimate. The ceiling is twice the
-# slowest of the three backends observed (109.5x on cranelift) -- the previous
-# 110 sat on top of that reading and would fail on the run-to-run spread.
+# slowest of the backends observed.
+#
+# 220 came from a 109.5x cranelift reading; the loop now runs at parity, so the
+# derived floor is the bound that noticed. A ceiling that far above its
+# measurement is not a loose bound but a disabled one at BOTH ends: the floor is
+# `min(1, ceiling / PERF_GATE_FLOOR_DIVISOR)`, so 220 pinned it at parity, and
+# cranelift reading 0.5x on macos failed it from below.
+#
+# Observations behind 8 -- ubuntu 1.7x / 1.7x / 1.6x (dynasm / cranelift /
+# wasm), macos 1.1x / 0.6x, windows 1.2x / 1.5x, and 2.5x / 3.9x on a loaded
+# dev box where pypy's own execution lands in the thin band and inflates every
+# ratio built on it. Twice the slowest of those puts the floor at 0.2x, which
+# is 2.5x under the fastest reading -- both bounds keep room, which is the
+# whole point of deriving one from the other.
 N = 38000000
 
 

--- a/pyre/bench/synth/unpack_drain_star_raise.py
+++ b/pyre/bench/synth/unpack_drain_star_raise.py
@@ -1,6 +1,6 @@
 # pyre-check: max-pypy-ratio=106
 # The ceiling is twice the slowest ratio observed (52.7x on the linux runner),
-# rounded up; the gate it replaces was fitted to no measurement.
+# rounded up.
 # Star-unpack of an iterator of unknown length: `f(*it)` is the consumer that
 # routes through `_unpackiterable_unknown_length`, the drain loop jd1
 # (`unpackiterable_driver`) traces and compiles. `a, b, c = it` does NOT reach

--- a/pyre/bench/synth/with_except_start_function_resume.py
+++ b/pyre/bench/synth/with_except_start_function_resume.py
@@ -1,11 +1,10 @@
 # pyre-check: max-pypy-ratio=29
-# The ceiling is twice the slowest ratio observed, 14.2x on the macos runner;
-# the gate it replaces sat inside the run-to-run spread.
+# The ceiling is twice the slowest ratio observed, 14.2x on the macos runner.
 # A function-entry trace records only the early-return arm.  The first true
 # call then fails that guard and blackhole-replays the previously unvisited
 # `with` arm.  WITH_EXCEPT_START must read the live handler stack and call
-# `__exit__`; a disconnected graph result used to treat the caught TypeError
-# as the exit callable and leak another TypeError instead.
+# `__exit__`; a disconnected graph result treats the caught TypeError as the
+# exit callable and leaks another TypeError instead.
 try:
     import pypyjit
 

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -207,23 +207,39 @@ WIN_TIMER_QUANTUM_S = 1.0 / 64
 STARTUP_SAMPLES = 5
 EXEC_TIME_FLOOR_S = WIN_TIMER_QUANTUM_S if sys.platform == "win32" else 0.005
 # `exec` is `bench - startup`, and startup is a measured median rather than a
-# constant.  Between runs of the same job on the same platform, pypy readings
-# moved 0.013s -> 0.031s and 0.019s -> 0.029s, dynasm moved 0.088s -> 0.158s,
-# and cranelift moved 0.084s -> 0.144s (while cpython moved 0.022s -> 0.023s).
-# As a fraction of the larger reading in each pair that is 34%, 58%, 44% and
-# 42%.  Whatever the startup estimate is off by lands whole in `exec`, so the
-# residual error of a startup-subtracted time scales with the startup, not
-# with the timer quantum -- for pypy it is 2-6x EXEC_TIME_FLOOR_S and for the
-# backends more than 10x.  Half the measured startup sits in the middle of the
-# observed range.
-# Consequently the effective ceiling becomes
-# `limit * (1 + STARTUP_DRIFT_FRACTION * startup / exec_baseline)`: a fixture
-# whose baseline is real work is barely affected, while one whose baseline is
-# the same size as its own startup gets several times the slack -- which is
-# what its measurement can actually support.
-# The allowance applies only to the recorded-ratio gates; the wasm/dynasm gate
-# opts out at its call site.
-STARTUP_DRIFT_FRACTION = 0.5
+# constant, so whatever the estimate is off by lands whole in `exec`.  That
+# error is real, but NO allowance is granted for it, and a standing allowance
+# was tried and removed.  It read `0.5 * startup`, added to the baseline on
+# every recorded ceiling and to the measured side on every floor.
+#
+# It was withdrawn because its evidence did not survive being checked against
+# the 234 job logs carrying a startup line across 125 CI runs.  Consecutive
+# same-platform movement |delta|/max has median 0.125 and p90 0.45, putting 0.5
+# near p95 rather than mid-range; on ubuntu and macos only 6 of 432 pairs reach
+# it (ubuntu dynasm median 0.07, macos dynasm 0.14).  What does reach it is
+# windows, where every reading is an exact multiple of WIN_TIMER_QUANTUM_S --
+# cpython reads only 0.000s or 0.016s, so its pairs move by a full 1.0 as pure
+# quantization, which `_compare_buffer` already pays for separately there.  The
+# four pairs the number was fitted on turned out to be two macos lines from
+# different branches four hours apart, with ten macos runs in between reading
+# 0.130 0.077 0.069 0.076 0.072 0.076 0.118 0.092 0.079 0.106 for dynasm: they
+# bracket the range rather than measuring an adjacent step.
+#
+# It was also the wrong shape.  It multiplied the READING, so it grew where the
+# startup was largest rather than where it was least certain, and vanished
+# exactly where the clock is coarsest -- windows cpython measured 0.000s in 17
+# of 56 runs, yielding no allowance at all.  Widening the floor was worse than
+# widening the ceiling: the floor is what reports a fixture that got FASTER
+# than its recorded ceiling, so an allowance there dampens the signal a
+# performance change is supposed to produce.  And it was the only gate
+# adjustment the comparison table could not show, because `_ratio` never
+# applied it.
+#
+# What replaces it is not a threshold.  A failing gate reports how far the
+# startup estimate would have to be wrong to erase the failure, in units of the
+# startup it subtracted (`_gate_fail_detail`), so a red carries its own
+# measurement context and a small one can be told from a real regression
+# without a constant deciding in advance.
 # A floor failure is only trustworthy when the baseline clears the execution
 # floor enough for small relative error: execution time is the difference
 # between two independently measured values.
@@ -2605,11 +2621,15 @@ class Check:
             pyre_times.append(elapsed)
         return statistics.median(pyre_times), statistics.median(baseline_times)
 
-    def _startup_drift(self, key):
-        """Run-to-run error of the startup `_exec_time` subtracted for *key*."""
+    def _subtracted_startup(self, key):
+        """The startup `_exec_time` actually subtracted for *key*.
+
+        The unit a gate failure's margin is reported in: nothing is subtracted
+        under --no-startup-subtract, so there is no error to report against.
+        """
         if self.args.no_startup_subtract:
             return 0.0
-        return STARTUP_DRIFT_FRACTION * self.startup.get(key, 0.0)
+        return self.startup.get(key, 0.0)
 
     def _baseline_exec_time_clamped(self, baseline, baseline_time):
         """Whether startup subtraction pinned a baseline to its floor."""
@@ -2635,16 +2655,12 @@ class Check:
             and EXEC_TIME_FLOOR_S < float(exec_b) < FLOOR_GATE_MIN_BASELINE_S
         )
 
-    def _performance_gate_passed(
-        self, backend, script, timeout, elapsed, limit, baseline_time,
-        baseline_cmd, expected_output, baseline_key, minimum=None,
-        *, allow_startup_drift=True,
-    ):
-        """Check one performance ratio, retrying a failure by median.
+    @staticmethod
+    def _compare_buffer(limit):
+        """Clock granularity the comparison has to absorb, at this *limit*.
 
-        The pass/fail decision compares execution-only (startup-subtracted)
-        times; the returned elapsed/baseline stay raw for reporting. The
-        returned bound is ``ceiling`` or ``floor`` when the gate fails.
+        Shared with `_gate_fail_detail`, which reports a failure's margin and
+        so has to reconstruct the same bound the gate applied.
         """
         # Each execution-only value is a difference between two independently
         # measured quantities (bench - empty-program startup).  On Windows each
@@ -2668,18 +2684,26 @@ class Check:
         # ~2.3s exec, a 0.06s baseline wobbling +-0.004s across the 36x line.
         #
         # That term stays: it is the granularity of the clock, and it is what a
-        # baseline sitting at the floor is worth.  It is not the whole error.
-        # An exec time also carries whatever its startup estimate was off by,
-        # which is a separate quantity of a different size -- see
-        # STARTUP_DRIFT_FRACTION, applied per side below rather than folded in
-        # here, because the two bounds are distorted by opposite sides.
-        compare_buffer = BENCH_COMPARE_BUFFER_S
+        # baseline sitting at the floor is worth.  It is deliberately the ONLY
+        # term -- an exec time also carries whatever its startup estimate was
+        # off by, a separate quantity of a different size, and no allowance is
+        # granted for it.  See the STARTUP_SAMPLES block for what was tried.
+        buf = BENCH_COMPARE_BUFFER_S
         if sys.platform == "win32":
-            compare_buffer += 2 * WIN_TIMER_QUANTUM_S * (1 + limit)
-        else:
-            compare_buffer += limit * EXEC_TIME_FLOOR_S
+            return buf + 2 * WIN_TIMER_QUANTUM_S * (1 + limit)
+        return buf + limit * EXEC_TIME_FLOOR_S
 
-        drift = self._startup_drift if allow_startup_drift else (lambda _key: 0.0)
+    def _performance_gate_passed(
+        self, backend, script, timeout, elapsed, limit, baseline_time,
+        baseline_cmd, expected_output, baseline_key, minimum=None,
+    ):
+        """Check one performance ratio, retrying a failure by median.
+
+        The pass/fail decision compares execution-only (startup-subtracted)
+        times; the returned elapsed/baseline stay raw for reporting. The
+        returned bound is ``ceiling`` or ``floor`` when the gate fails.
+        """
+        compare_buffer = self._compare_buffer(limit)
 
         def failed_bound(measured, baseline_value):
             exec_measured = self._exec_time(backend, measured)
@@ -2715,33 +2739,25 @@ class Check:
             # wants a ratio gate has to give pypy enough work to measure.
             if self._baseline_exec_time_clamped(baseline_key, baseline_value):
                 return None
-            # Each bound is distorted by one side only, so each gets the
-            # allowance on that side. A startup estimate that came out high
-            # under-states every exec derived from it: for the ceiling that
-            # shrinks the DENOMINATOR and inflates the ratio, so the allowance
-            # goes to the baseline; for the floor it shrinks the NUMERATOR and
-            # the fixture reads as having reached parity, so the allowance goes
-            # to the measured side. The opposite side of each bound is left
-            # alone -- an under-stated numerator only makes the ceiling pass,
-            # and a gate is not made honest by relaxing it where it cannot
-            # falsely fire.
-            #
-            # One run demonstrated both at once: pypy startup read 0.029s
-            # against 0.019s on the same base, and dynasm 0.158s against
-            # 0.088s, which failed four ceilings and three floors while every
-            # fixture's own measured time had gone down.
-            if exec_measured > (
-                exec_baseline + drift(baseline_key)
-            ) * limit + compare_buffer:
+            # Each bound is distorted by one side only. A startup estimate that
+            # came out high under-states every exec derived from it: for the
+            # ceiling that shrinks the DENOMINATOR and inflates the ratio, and
+            # for the floor it shrinks the NUMERATOR so the fixture reads as
+            # having reached parity. Both are real and neither is bought off
+            # here. `_gate_fail_detail` reports instead how far the estimate
+            # would have to be wrong to erase the failure, in units of the
+            # startup subtracted on the side that bound is distorted by, so a
+            # small margin is legible as one without a constant deciding in
+            # advance that every fixture gets it.
+            if exec_measured > exec_baseline * limit + compare_buffer:
                 return "ceiling"
             # The measured side enters amplified by `limit / minimum`, so its
-            # error is amplified with it: the allowance belongs inside that
-            # factor, not in the flat buffer.
+            # error is amplified with it -- which is also why the floor's
+            # margin is reported against `limit / minimum`, not flat.
             if (
                 minimum is not None
                 and exec_baseline >= FLOOR_GATE_MIN_BASELINE_S
-                and (exec_measured + drift(backend))
-                * (limit / minimum) + compare_buffer
+                and exec_measured * (limit / minimum) + compare_buffer
                 < exec_baseline * limit
             ):
                 return "floor"
@@ -2776,6 +2792,10 @@ class Check:
         their true measured ratio and the failed gate threshold. Every number
         on the line is arithmetically self-consistent: exec_measured /
         exec_baseline equals the shown ratio, which is outside the shown gate.
+
+        The line closes with what it would take for the startup estimate to be
+        the whole story, since no allowance is granted for that error: see
+        `_startup_error_margin`.
         """
         exec_m = self._exec_time(backend, measured)
         exec_b = self._exec_time(baseline, baseline_time)
@@ -2794,7 +2814,48 @@ class Check:
                 f"exec {exec_m:.2f}s > {baseline} {exec_b:.2f}s  "
                 f"ratio {ratio} > gate {float(limit):g}x"
             )
-        return detail
+        margin = self._startup_error_margin(
+            backend, baseline, exec_m, exec_b, limit, bound, minimum,
+        )
+        return detail + margin if margin else detail
+
+    def _startup_error_margin(
+        self, backend, baseline, exec_m, exec_b, limit, bound, minimum,
+    ):
+        """How wrong the startup estimate has to be for this failure to vanish.
+
+        `exec` is `bench - startup`, so an over-stated startup understates
+        every exec built on it -- shrinking the ceiling's denominator, and the
+        floor's numerator. Solving each bound for the correction that would put
+        it exactly on its threshold gives the size of the startup error the
+        verdict rests on, and dividing by the startup actually subtracted on
+        that side states it in the only unit that travels between hosts.
+
+        `0.05 x` says the run is arguing about a twentieth of an empty-program
+        spawn and should not be believed; `3.0 x` says no plausible mis-reading
+        reaches it. This replaces the withdrawn standing allowance, which
+        answered the same question with one constant for every fixture.
+        """
+        # Nothing was subtracted, so there is no subtraction error to report.
+        side = baseline if bound == "ceiling" else backend
+        startup = self._subtracted_startup(side)
+        if startup <= 0:
+            return ""
+        buffer_s = self._compare_buffer(limit)
+        if bound == "ceiling":
+            # exec_m > (exec_b + d) * limit + buffer  =>  d erases it at
+            needed = (float(exec_m) - buffer_s) / limit - float(exec_b)
+        else:
+            if not minimum:
+                return ""
+            # (exec_m + d) * (limit / minimum) + buffer < exec_b * limit
+            needed = (
+                (float(exec_b) * limit - buffer_s) * minimum / limit
+                - float(exec_m)
+            )
+        if needed <= 0:
+            return ""
+        return f"; needs {needed / startup:.3g}x {side} startup to be noise"
 
     def _run_backend_bench(
         self, backend, name, script, timeout,
@@ -2969,27 +3030,20 @@ class Check:
             ):
                 self.wasm_ratio_ungated.append(name)
             else:
-                # The startup-drift allowance is calibrated on the recorded
-                # per-bench ratios, whose baseline is re-measured on every host
-                # while the ceiling stays fixed at what the fitting run saw.
-                # This gate's failures have not been shown to move that way,
-                # and widening it costs a red that names a real backend gap:
-                # `short_circuit_value_kept_stack` reads 5.3x here against a 4x
-                # ceiling and clears it only with the allowance. The denominator
-                # concern this gate does have is handled above by declining the
-                # gate outright and naming the fixture in the summary, not by
-                # quietly widening the bound.
-                #
-                # This ceiling is also meant to come back down as the backend
-                # closes the gap, so it has to mean the number it states. A
-                # standing allowance underneath it would be re-fitted along with
-                # it, and the tightening would buy less than it says it does.
+                # This ceiling is meant to come back down as the backend closes
+                # the gap, so it has to mean the number it states: a standing
+                # allowance underneath it would be re-fitted along with it, and
+                # the tightening would buy less than it says it does. That is
+                # now true of every ratio gate rather than this one alone, so
+                # the opt-out this call site used to carry is gone. The
+                # denominator concern it does have is handled above, by
+                # declining the gate outright and naming the fixture in the
+                # summary rather than quietly widening the bound.
                 passed, bound, checked_elapsed, checked_baseline, retry_note = (
                     self._performance_gate_passed(
                         backend, script, timeout, elapsed,
                         ceiling, dynasm_elapsed,
                         [self._pyre("dynasm"), script], pypy_output, "dynasm",
-                        allow_startup_drift=False,
                     )
                 )
                 if not passed:

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -139,43 +139,23 @@ pub fn w_pytraceback_new(
     lineno: i64,
     w_code: PyObjectRef,
 ) -> PyObjectRef {
-    let _roots = pyre_object::gc_roots::push_roots();
-    pyre_object::gc_roots::pin_root(w_next);
-    pyre_object::gc_roots::pin_root(w_code);
+    // `frame` is pinned alongside the two managed fields, because the
+    // allocation below can safepoint and a raw `*mut PyFrame` held only in
+    // this function's locals is reachable from no root walker.  Most frames
+    // are allocated non-moving (`FrameBox::new`), which is what lets raw
+    // copies exist elsewhere at all — `FrameBox::deref` reads its raw field
+    // while holding a forwarding-capable `owner_root` it never reads back,
+    // `eval_loop` runs behind a `&mut PyFrame` across a safepoint, and the
+    // blackhole keeps the virtualizable as a bare integer.  It is not every
+    // frame: a compiled trace's inlined-callee frame is a nursery
+    // allocation, so a minor collection triggered by this very allocation
+    // recycles it and any slot built from a pre-allocation copy names freed
+    // bytes for the rest of the node's life.  Upstream needs no bracket
+    // here — a minor relocates the frame and rewrites the slot
+    // (`incminimark.py:2237` / `:2252`).
+    let roots = pyre_object::gc_roots::push_roots();
+    let inputs = pyre_object::gc_roots::pin_roots(&[w_next, w_code, frame as PyObjectRef]);
 
-    let value = PyTraceback {
-        ob_header: PyObject {
-            ob_type: &PYTRACEBACK_TYPE as *const PyType,
-            w_class: get_instantiate(&PYTRACEBACK_TYPE),
-        },
-        frame,
-        lasti,
-        w_next,
-        lineno,
-        w_code,
-    };
-
-    // The rule below cannot be spelled as a `debug_assert!` here: this crate
-    // is extracted to LLBC, so an assertion lands in the JIT's view of this
-    // function and its probe becomes a real call on every traceback the
-    // traced code builds — measurably, on the `getattr_*` gates.  It stays a
-    // stated obligation.
-    //
-    // `frame` was copied into `value` above and is not among the roots
-    // pinned here, so the allocation below — which can safepoint — must
-    // not be able to move it.  Upstream has no such rule: a minor
-    // collection would relocate the frame and rewrite the slot
-    // (`incminimark.py:2237` / `:2252`).  Pyre cannot, because raw
-    // `*mut PyFrame` copies exist that no root walker reaches —
-    // `FrameBox::deref` reads its raw field while holding a
-    // forwarding-capable `owner_root` it never reads back, `eval_loop`
-    // runs behind a `&mut PyFrame` across a safepoint, and the
-    // blackhole keeps the virtualizable as a bare integer.  Frames are
-    // therefore allocated non-moving (`FrameBox::new`), and callers of
-    // `record_application_traceback` owe this function a frame that
-    // stays reachable across the allocation: on the `CURRENT_FRAME` /
-    // `f_backref` chain, or pinned by hand.
-    //
     // This host-side constructor allocates the traceback itself into oldgen:
     // its Rust caller can hold the returned pointer outside a translated
     // GC-map slot before publishing it. JIT-emitted traceback nodes do not
@@ -189,18 +169,41 @@ pub fn w_pytraceback_new(
         PYTRACEBACK_OBJECT_SIZE,
     );
     if !raw.is_null() {
-        let ptr = raw as *mut PyTraceback;
-        unsafe {
-            std::ptr::write(ptr, value);
-        }
-        // The oldgen traceback references the freshly-born `w_next` /
-        // `w_code` (and, once GC-owned, the frame); remember it for the
-        // next minor tracer.
-        pyre_object::gc_hook::try_gc_write_barrier(raw);
-        return ptr as PyObjectRef;
+        // The fresh block is a root before `get_instantiate` below can enter
+        // an allocation of its own, matching `FrameBox::new`'s pin of its own
+        // result.  The block is non-moving, so `raw` stays the address.
+        pyre_object::gc_roots::pin_root(raw as PyObjectRef);
     }
 
-    pyre_object::lltype::malloc_typed(value) as PyObjectRef
+    // Every input is read back through the bracket's own cell rather than
+    // reused from the argument: the allocation above may have moved any of
+    // them.  Before the GC hook is wired nothing moves and each read answers
+    // the address it was given.
+    let value = PyTraceback {
+        ob_header: PyObject {
+            ob_type: &PYTRACEBACK_TYPE as *const PyType,
+            w_class: get_instantiate(&PYTRACEBACK_TYPE),
+        },
+        frame: roots.get(inputs + 2) as *mut crate::pyframe::PyFrame,
+        lasti,
+        w_next: roots.get(inputs),
+        lineno,
+        w_code: roots.get(inputs + 1),
+    };
+
+    if raw.is_null() {
+        return pyre_object::lltype::malloc_typed(value) as PyObjectRef;
+    }
+
+    let ptr = raw as *mut PyTraceback;
+    unsafe {
+        std::ptr::write(ptr, value);
+    }
+    // The oldgen traceback references the freshly-born `w_next` /
+    // `w_code` (and, once GC-owned, the frame); remember it for the
+    // next minor tracer.
+    pyre_object::gc_hook::try_gc_write_barrier(raw);
+    ptr as PyObjectRef
 }
 
 /// # Safety


### PR DESCRIPTION
Removes `STARTUP_DRIFT_FRACTION` from `check.py` and replaces the allowance it granted with a per-failure report of how wrong the startup estimate would have to be.

## Why the constant goes

`check.py` measures child **user CPU** and computes `exec = bench - startup`, so every recorded-ratio gate carries the error of a startup estimate sampled once per run. `STARTUP_DRIFT_FRACTION = 0.5` paid for that error by widening the bound by `0.5 * startup` on whichever side the bound leans. Its stated evidence does not survive being checked.

**The dispersion is not 0.5.** Taking every consecutive same-`(platform, interpreter)` pair of startup readings from the CI job logs and measuring `|delta| / max` — the exact quantity the allowance was meant to cover — over 56 runs / 166 platform rows / 702 pairs:

| platform | pairs | median | p90 | pairs reaching 0.5 |
|---|---|---|---|---|
| ubuntu | 270 | 0.100 | 0.31 | 1 |
| macos | 216 | 0.146 | 0.40 | 5 |
| windows | 216 | 0.113 | **1.00** | 35 |
| **all** | **702** | **0.125** | **0.45** | **41** |

So 0.5 sits near p95 overall, and **6 of 486** ubuntu+macos pairs reach it. What does reach it is windows — 35 of the 41 — and windows is not dispersion. Every reading there is an exact multiple of `WIN_TIMER_QUANTUM_S`, and cpython takes only two values across the whole census, `0.000s` and `0.016s`, so a single quantum step scores movement `1.00`. That is quantization, and the compare buffer already pays for it separately on win32 (`2 * WIN_TIMER_QUANTUM_S * (1 + limit)`). The allowance was sized on an artifact of the coarsest clock and then applied everywhere.

**The four pairs it was fitted on are not a pair.** They are two macos lines from *different branches* four hours apart. The ten macos runs in between read `0.130 0.077 0.069 0.076 0.072 0.076 0.118 0.092 0.079 0.106` for dynasm — the two endpoints were the extremes of that window, not adjacent samples.

**It was the wrong shape three ways.**

- It multiplied the reading, so the allowance grew where startup was *largest*, not where it was *least certain*, and it vanished to zero exactly where the clock is coarsest (windows cpython read `0.000s` in 17 of 56 rows — allowance `0.0`, on the one platform whose readings actually move by half).
- It widened the **floor** as well as the ceiling. The floor gate is what reports a fixture running faster than its recorded ceiling, i.e. the signal that a perf change worked. Damping it makes wins invisible.
- `_ratio` never applied it, so it was the only gate adjustment the comparison table could not display. A gate that passed only because of the allowance printed the same green as one that passed on its numbers.

## What replaces it

Nothing widens. A failing gate now closes with the margin:

```
exec 0.42s > pypy 0.01s  ratio 42.2x > gate 30x; needs 0.205x pypy startup to be noise
```

`needed` is solved from the bound the gate actually applied, and reported in units of the startup that was subtracted on the side that bound leans on. `0.05x` means the failure is arguing over one twentieth of an empty-program launch and should not be trusted; `3x` means no plausible misreading reaches it. The reader decides per fixture instead of one constant deciding for all 352 gated fixtures in advance.

Supporting edits: `_compare_buffer` is factored out of `_performance_gate_passed` so `_gate_fail_detail` reconstructs the *same* bound the gate applied rather than an approximation of it; `_startup_drift` becomes `_subtracted_startup`, which reports the unit rather than an allowance. The wasm/dynasm gate already passed `allow_startup_drift=False`, so it is unaffected — the keyword and its call-site comment go with the allowance, since the opt-out is now the global behaviour.

## Two alternatives measured and rejected

Both were the obvious "estimate the startup better instead" answers. Both are refuted by local measurement, in this repo, at load recorded before and after.

**Warmup / cold-start.** The hypothesis was that the first startup samples pay a page-cache ramp the bench does not. Three cold sibling binaries × 16 samples each: the first sample was at or near the series minimum in all three. There is no ramp to warm away.

**Contemporaneity (measure startup next to each bench).** This only helps if bench and startup share a per-moment multiplicative factor. They do not — pearson `r(startup, bench)` is **-0.55** for pypy and **-0.57** for dynasm over interleaved blocks. The startup estimate does not carry information about the bench's machine state, so re-measuring it next to the bench cancels nothing.

Worth stating explicitly for anyone reaching for a third fix: `_baseline_exec_time_clamped` is a *separate* hazard. When `baseline_raw <= startup + EXEC_TIME_FLOOR_S` the gate returns `None` and is disarmed entirely, unbuffered and independent of regression size (announced as `~` in the table). Raising the startup estimate pushes fixtures *into* that clamp, so "measure startup more aggressively" disarms gates rather than tightening them. Removing the allowance does not touch the clamp.

## Verification

392 `(limit, minimum, measured, baseline)` combinations driven through `_performance_gate_passed` directly:

- every verdict equals the allowance-free arithmetic;
- **10 gates tighten, 0 loosen** — the change is one-directional by construction and by test;
- each of the 178 reported margins sits exactly on its bound's threshold: feeding `needed * 1.05` back in as the old per-side allowance clears the failure, `needed * 0.95` does not.

Expect some previously-green ratio gates to turn red. Each one now states in its own failure line how much startup error would be required to explain it away.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Performance gates no longer automatically allow startup-time drift when evaluating results.
  - Gate failures now report the estimated startup error margin needed to explain the failure.
  - Performance comparisons consistently account for clock-granularity buffering.
  - Startup subtraction behavior is reported accurately when startup adjustment is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->