### PR TITLE
cpyext: the review findings on the callables slice, and the METH_METHOD arm the header advertised

### DIFF
--- a/include/pyre3.14t/Python.h
+++ b/include/pyre3.14t/Python.h
@@ -66,6 +66,7 @@
 #include "pycapsule.h"
 #include "code.h"
 #include "funcobject.h"
+#include "frameobject.h"
 #include "traceback.h"
 #include "import.h"
 #include "modsupport.h"

--- a/include/pyre3.14t/code.h
+++ b/include/pyre3.14t/code.h
@@ -26,6 +26,23 @@ extern "C" {
 #define CO_HAS_DOCSTRING        0x4000000
 #define CO_METHOD               0x8000000
 
+/* The `__future__` bits and the monitoring opt-out share `co_flags` with the
+   set above but are not published by `inspect`: a compiler flag names them,
+   and an extension composing one for a compile call needs the value.  They
+   start at 0x20000 so that the `PyCF_` compiler flags can have the range
+   below them. */
+#define CO_FUTURE_DIVISION          0x20000
+#define CO_FUTURE_ABSOLUTE_IMPORT   0x40000
+#define CO_FUTURE_WITH_STATEMENT    0x80000
+#define CO_FUTURE_PRINT_FUNCTION    0x100000
+#define CO_FUTURE_UNICODE_LITERALS  0x200000
+#define CO_FUTURE_BARRY_AS_BDFL     0x400000
+#define CO_FUTURE_GENERATOR_STOP    0x800000
+#define CO_FUTURE_ANNOTATIONS       0x1000000
+#define CO_NO_MONITORING_EVENTS     0x2000000
+
+#define PyCode_Check(op) Py_IS_TYPE((op), &PyCode_Type)
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/pyre3.14t/frameobject.h
+++ b/include/pyre3.14t/frameobject.h
@@ -1,7 +1,8 @@
 /* Frames.
  *
- * An extension includes this by name rather than through `Python.h`, which is
- * where the reference header set puts it too.
+ * One of the headers `Python.h` includes -- `PyFrame_Check` is reachable from
+ * `Python.h` alone in both reference header sets -- and an extension may also
+ * include it by name, which is the spelling most of them use.
  */
 #ifndef PYRE_FRAMEOBJECT_H
 #define PYRE_FRAMEOBJECT_H

--- a/include/pyre3.14t/funcobject.h
+++ b/include/pyre3.14t/funcobject.h
@@ -10,7 +10,11 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#define PyMethod_Check(op) PyObject_TypeCheck((op), &PyMethod_Type)
+/* Exact, because `method` is not a base a type may derive from and because
+   `PyMethod_Function` / `PyMethod_Self` answer for this type alone: a
+   predicate wider than the accessors' own guard would admit objects they then
+   refuse with a `SystemError` the caller never looks for. */
+#define PyMethod_Check(op) Py_IS_TYPE((op), &PyMethod_Type)
 
 /* The reference header reads the two members straight out of the struct.  A
    mirror has no members to read, so each is the call that answers with the

--- a/include/pyre3.14t/methodobject.h
+++ b/include/pyre3.14t/methodobject.h
@@ -59,6 +59,10 @@ typedef struct {
    `PyCFunction_GetFunction` would have nothing to hand back. */
 PyAPI_DATA(PyTypeObject) PyCFunction_Type;
 
+/* The `METH_METHOD` carrier, which holds the defining class beside everything
+   `PyCFunction_Type` holds and so derives from it. */
+PyAPI_DATA(PyTypeObject) PyCMethod_Type;
+
 #define PyCFunction_Check(op) PyObject_TypeCheck((op), &PyCFunction_Type)
 #define PyCFunction_CheckExact(op) Py_IS_TYPE((op), &PyCFunction_Type)
 #define PyCMethod_CheckExact(op) Py_IS_TYPE((op), &PyCMethod_Type)
@@ -67,7 +71,10 @@ PyAPI_DATA(PyTypeObject) PyCFunction_Type;
 #define PyCFunction_GET_FUNCTION(func) PyCFunction_GetFunction((PyObject *)(func))
 #define PyCFunction_GET_SELF(func) PyCFunction_GetSelf((PyObject *)(func))
 #define PyCFunction_GET_FLAGS(func) PyCFunction_GetFlags((PyObject *)(func))
-#define PyCFunction_GET_CLASS(func) PyCFunction_GetClass((PyObject *)(func))
+/* `PyCMethod_GetClass` is the name the entry point carries; the reference
+   header reaches the same answer by reading `mm_class` behind a `METH_METHOD`
+   test, which a mirror has no field to do. */
+#define PyCFunction_GET_CLASS(func) PyCMethod_GetClass((PyObject *)(func))
 
 #ifdef __cplusplus
 }

--- a/include/pyre3.14t/pyre_decl.h
+++ b/include/pyre3.14t/pyre_decl.h
@@ -255,6 +255,8 @@ PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_GetSelf(PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_New(PyMethodDef *, PyObject *);
 PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *, PyObject *);
+PyAPI_FUNC(PyTypeObject *) PyCMethod_GetClass(PyObject *);
+PyAPI_FUNC(PyObject *) PyCMethod_New(PyMethodDef *, PyObject *, PyObject *, PyTypeObject *);
 
 /* cpyext/modsupport.rs */
 PyAPI_FUNC(PyObject *) PyModuleDef_Init(PyModuleDef *);
@@ -325,6 +327,7 @@ PyAPI_FUNC(PyObject *) PyObject_ASCII(PyObject *);
 PyAPI_FUNC(int) PyObject_AsFileDescriptor(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Bytes(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Call(PyObject *, PyObject *, PyObject *);
+PyAPI_FUNC(void) PyObject_CallFinalizer(PyObject *);
 PyAPI_FUNC(int) PyObject_CallFinalizerFromDealloc(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_CallNoArgs(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_CallObject(PyObject *, PyObject *);

--- a/include/pyre3.14t/pyre_format.h
+++ b/include/pyre3.14t/pyre_format.h
@@ -354,14 +354,30 @@ static inline PyObject *PyErr_Format(PyObject *type, const char *format, ...)
 
 /* `PyErr_FormatUnraisable` states what was going on where
    `PyErr_WriteUnraisable` names the object, so the message is built with this
-   engine and handed to the core the two share. */
+   engine and handed to the core the two share.
+
+   The exception to be reported is already pending when this is called, and
+   building the message can raise: a `%S`/`%R`/`%A` conversion runs Python, a
+   non-ASCII format byte and an out-of-range `%c` each set an error of their
+   own.  So the indicator is held aside across the format and a failure there
+   is dropped -- what gets reported must be the caller's exception, not
+   whatever the message-building hit.  A NULL format is the spelling for "no
+   message": the report then carries the exception alone, with `err_msg` None,
+   and the formatter is never entered. */
 static inline void PyErr_FormatUnraisable(const char *format, ...)
 {
     va_list va;
-    PyObject *message;
-    va_start(va, format);
-    message = PyUnicode_FromFormatV(format, va);
-    va_end(va);
+    PyObject *message = NULL;
+    PyObject *pending = PyErr_GetRaisedException();
+    if (format != NULL) {
+        va_start(va, format);
+        message = PyUnicode_FromFormatV(format, va);
+        va_end(va);
+        if (message == NULL) {
+            PyErr_Clear();
+        }
+    }
+    PyErr_SetRaisedException(pending);
     _PyPyre_WriteUnraisable(message, NULL);
     Py_XDECREF(message);
 }

--- a/include/pyre3.14t/pytypedefs.h
+++ b/include/pyre3.14t/pytypedefs.h
@@ -17,6 +17,8 @@ typedef PyObject *(*PyCFunctionWithKeywords)(PyObject *, PyObject *, PyObject *)
 typedef PyObject *(*_PyCFunctionFast)(PyObject *, PyObject *const *, Py_ssize_t);
 typedef PyObject *(*_PyCFunctionFastWithKeywords)(PyObject *, PyObject *const *,
                                                   Py_ssize_t, PyObject *);
+typedef PyObject *(*PyCMethod)(PyObject *, PyTypeObject *, PyObject *const *,
+                               Py_ssize_t, PyObject *);
 typedef int (*visitproc)(PyObject *, void *);
 typedef int (*traverseproc)(PyObject *, visitproc, void *);
 typedef int (*inquiry)(PyObject *);

--- a/pyre/pyre-interpreter/src/cpyext/gc.rs
+++ b/pyre/pyre-interpreter/src/cpyext/gc.rs
@@ -33,8 +33,36 @@ type TrackedSet =
 static TRACKED: super::ForkMutex<TrackedSet> =
     super::ForkMutex::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
 
+/// The blocks whose `tp_finalize` has already run.
+///
+/// A collected type's finalizer runs at most once over the object's life, and
+/// nothing in the block records that: `ob_pyre_link` is the interpreter
+/// object and the header carries no spare bit here, so the answer is kept
+/// beside the tracked set. An entry is cleared where the block is released
+/// rather than in `dealloc`, which runs before `tp_dealloc` -- that is the
+/// moment a second deallocation still has to read it -- and clearing at
+/// release is also what keeps a recycled address from inheriting a stale one.
+static FINALIZED: super::ForkMutex<TrackedSet> =
+    super::ForkMutex::new(TrackedSet::with_hasher(std::hash::BuildHasherDefault::new()));
+
 pub(super) unsafe fn after_fork_child() {
     unsafe { TRACKED.reinit_after_fork() };
+    unsafe { FINALIZED.reinit_after_fork() };
+}
+
+/// Whether `tp_finalize` has already run for the block at `raw`.
+pub(super) fn is_finalized(raw: usize) -> bool {
+    FINALIZED.lock().contains(&raw)
+}
+
+/// Record that `tp_finalize` has run for the block at `raw`.
+pub(super) fn mark_finalized(raw: usize) {
+    FINALIZED.lock().insert(raw);
+}
+
+/// Drop the finalized flag for a block that is being released.
+pub(super) fn forget_finalized(raw: usize) {
+    FINALIZED.lock().remove(&raw);
 }
 
 /// `true` when `tp` declares the cyclic-collection protocol.

--- a/pyre/pyre-interpreter/src/cpyext/import_.rs
+++ b/pyre/pyre-interpreter/src/cpyext/import_.rs
@@ -138,6 +138,15 @@ pub unsafe extern "C" fn PyImport_ImportModuleLevelObject(
     level: std::ffi::c_int,
 ) -> *mut CPyObject {
     super::object::realize_all([name, globals, locals, fromlist]);
+    // Answered before the conversion and before `level`, which is the order
+    // `import.c` asks in: a NULL name is the empty-name case rather than a
+    // bad internal call, and the message says so.
+    if name.is_null() {
+        super::pyerrors::set_pending_error(crate::PyError::value_error(
+            "Empty module name".to_owned(),
+        ));
+        return std::ptr::null_mut();
+    }
     let Some(name) = argument(name) else {
         return std::ptr::null_mut();
     };

--- a/pyre/pyre-interpreter/src/cpyext/methodobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/methodobject.rs
@@ -24,6 +24,7 @@ pub const METH_CLASS: c_int = 0x0010;
 pub const METH_STATIC: c_int = 0x0020;
 pub const METH_COEXIST: c_int = 0x0040;
 pub const METH_FASTCALL: c_int = 0x0080;
+pub const METH_METHOD: c_int = 0x0200;
 
 /// One row of a `PyMethodDef` table.
 #[repr(C)]
@@ -42,6 +43,30 @@ const NAME_KEY: &str = "__name__";
 const QUALNAME_KEY: &str = "__qualname__";
 const DOC_KEY: &str = "__doc__";
 const MODULE_KEY: &str = "__module__";
+/// The defining class a `METH_METHOD` row is handed beside its receiver.
+const CLASS_KEY: &str = "__pyre_mm_class__";
+
+/// The carrier keys a store from Python must not reach.
+///
+/// Everything the carrier knows lives in its instance namespace, which is a
+/// mapping like any other; a store into one of these would retarget the
+/// receiver a C callable casts to its own struct, or name a different
+/// `PyMethodDef` row for it to call.  `__module__` is left writable, which is
+/// the one the reference type allows as well.
+/// The `tp_methods` / `tp_getset` / `tp_members` descriptor carriers in
+/// `typeobject` share this fence and these keys; `__pyre_def__` there holds a
+/// definition's address outright, so a store into it is the same hole in a
+/// straighter line.
+const RESERVED_KEYS: &[&str] = &[
+    ML_KEY,
+    SELF_KEY,
+    NAME_KEY,
+    QUALNAME_KEY,
+    DOC_KEY,
+    CLASS_KEY,
+    "__pyre_def__",
+    "__objclass__",
+];
 
 /// Every `PyMethodDef` row a carrier may name.
 ///
@@ -90,6 +115,75 @@ fn method_def_at(index: i64) -> Option<*mut CPyMethodDef> {
 }
 
 static PYCFUNCTION_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
+static PYCMETHOD_TYPE_OBJ: OnceLock<usize> = OnceLock::new();
+
+/// `__setattr__` / `__delattr__` for a carrier type.
+///
+/// `value` is `None` for the delete spelling.
+fn store_attribute(
+    carrier: PyObjectRef,
+    name: PyObjectRef,
+    value: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { pyre_object::unicodeobject::is_str(name) } {
+        return Err(crate::PyError::type_error("attribute name must be string"));
+    }
+    let attribute = unsafe { pyre_object::w_str_get_wtf8(name) }.to_string();
+    if attribute != MODULE_KEY {
+        let type_name = unsafe { pyre_object::w_type_get_name((*carrier).w_class) };
+        let message = if RESERVED_KEYS.contains(&attribute.as_str()) {
+            format!("attribute '{attribute}' of '{type_name}' objects is not writable")
+        } else {
+            format!("'{type_name}' object has no attribute '{attribute}'")
+        };
+        return Err(crate::PyError::attribute_error(message));
+    }
+    let dict = crate::baseobjspace::getdict_native(carrier);
+    if !dict.is_null() {
+        match value {
+            Some(value) => unsafe {
+                pyre_object::dictmultiobject::w_dict_setitem_str(dict, MODULE_KEY, value)
+            },
+            None => {
+                unsafe { pyre_object::dictmultiobject::w_dict_delitem_str(dict, MODULE_KEY) };
+            }
+        }
+    }
+    Ok(pyre_object::w_none())
+}
+
+fn descr_setattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 3 {
+        return Err(crate::PyError::type_error(
+            "__setattr__ requires name and value",
+        ));
+    }
+    store_attribute(args[0], args[1], Some(args[2]))
+}
+
+fn descr_delattr(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if args.len() < 2 {
+        return Err(crate::PyError::type_error("__delattr__ requires a name"));
+    }
+    store_attribute(args[0], args[1], None)
+}
+
+/// Install the stores every carrier type refuses, so nothing but
+/// `__module__` can be written into its namespace from Python.
+pub(super) fn install_attribute_fence(ns: PyObjectRef) {
+    unsafe {
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__setattr__",
+            crate::make_builtin_function_with_arity("__setattr__", descr_setattr, 3),
+        );
+        pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+            ns,
+            "__delattr__",
+            crate::make_builtin_function_with_arity("__delattr__", descr_delattr, 2),
+        );
+    }
+}
 
 /// The carrier type, named as upstream names its typedef.
 ///
@@ -114,17 +208,48 @@ pub fn pycfunction_type() -> PyObjectRef {
                     crate::make_builtin_function_with_arity("__repr__", descr_repr, 1),
                 );
             };
+            install_attribute_fence(ns);
         });
         unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
         tp as usize
     }) as PyObjectRef
 }
 
+/// `methodobject.py:264 W_PyCMethodObject` — the carrier a `METH_METHOD` row
+/// gets, which is everything `pycfunction_type` carries plus the class the
+/// definition was declared in.
+///
+/// This is what `PyCMethod_Type` names, and it derives from
+/// `PyCFunction_Type`, so `PyCFunction_Check` answers yes for one.
+pub fn pycmethod_type() -> PyObjectRef {
+    *PYCMETHOD_TYPE_OBJ.get_or_init(|| {
+        let tp = crate::typedef::make_builtin_type_with_base(
+            "builtin_method",
+            |_ns| {},
+            pycfunction_type(),
+        );
+        unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
+        tp as usize
+    }) as PyObjectRef
+}
+
+/// Whether `carrier` is one of this module's own, rather than something that
+/// merely has the reserved keys in its namespace.
+fn is_carrier(carrier: PyObjectRef) -> bool {
+    !carrier.is_null()
+        && unsafe { crate::baseobjspace::issubtype_w((*carrier).w_class, pycfunction_type()) }
+}
+
 /// The `PyMethodDef` behind `object`, or NULL with a `SystemError` when
 /// nothing is.
+///
+/// The type is checked before the namespace is read: `space.interp_w(
+/// W_PyCFunctionObject, w_obj)` is what upstream's accessors open with, and
+/// without it any object carrying a plausible `__pyre_ml__` would hand a
+/// caller a C function pointer.
 fn checked_method_def(object: *mut CPyObject) -> Option<*mut CPyMethodDef> {
     let object = unsafe { pyobject::from_ref(object) };
-    let definition = (!object.is_null()).then(|| method_def(object)).flatten();
+    let definition = is_carrier(object).then(|| method_def(object)).flatten();
     if definition.is_none() {
         super::pyerrors::set_pending_error(crate::PyError::new(
             crate::PyErrorKind::SystemError,
@@ -191,15 +316,77 @@ pub unsafe extern "C" fn PyCFunction_NewEx(
         unsafe { super::pyerrors::PyErr_BadInternalCall() };
         return std::ptr::null_mut();
     }
-    super::object::realize_all([receiver, module]);
+    unsafe { PyCMethod_New(method, receiver, module, std::ptr::null_mut()) }
+}
+
+/// `methodobject.py:544 PyCMethod_New(ml, self, module, cls)` — the same,
+/// naming the class a `METH_METHOD` definition was declared in.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCMethod_New(
+    method: *mut CPyMethodDef,
+    receiver: *mut CPyObject,
+    module: *mut CPyObject,
+    class: *mut super::typeobject::CPyTypeObject,
+) -> *mut CPyObject {
+    if method.is_null() {
+        unsafe { super::pyerrors::PyErr_BadInternalCall() };
+        return std::ptr::null_mut();
+    }
+    let flags = unsafe { (*method).ml_flags };
+    let message = match (flags & METH_METHOD != 0, class.is_null()) {
+        (true, true) => Some("attempting to create PyCMethod with a METH_METHOD flag but no class"),
+        (false, false) => {
+            Some("attempting to create PyCFunction with class but no METH_METHOD flag")
+        }
+        _ => None,
+    };
+    if let Some(message) = message {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            message,
+        ));
+        return std::ptr::null_mut();
+    }
+    let class = class as *mut CPyObject;
+    super::object::realize_all([receiver, module, class]);
     let receiver = unsafe { pyobject::from_ref(receiver) };
     let module = unsafe { pyobject::from_ref(module) };
+    let class = unsafe { pyobject::from_ref(class) };
+    if !class.is_null() && !unsafe { pyre_object::is_type(class) } {
+        super::pyerrors::set_pending_error(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "bad argument to PyCMethod_New",
+        ));
+        return std::ptr::null_mut();
+    }
     let module = if module.is_null() {
         pyre_object::w_none()
     } else {
         module
     };
-    super::object::result(new_pycfunction(method, receiver, module))
+    let class = (!class.is_null()).then_some(class);
+    super::object::result(new_pycfunction_in_class(method, receiver, module, class))
+}
+
+/// `methodobject.py:155 PyCMethod_GetClass(op)` — the class a `METH_METHOD`
+/// definition was declared in, borrowed, and NULL for one that is not.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyCMethod_GetClass(
+    object: *mut CPyObject,
+) -> *mut super::typeobject::CPyTypeObject {
+    let Some(definition) = checked_method_def(object) else {
+        return std::ptr::null_mut();
+    };
+    if unsafe { (*definition).ml_flags } & METH_METHOD == 0 {
+        return std::ptr::null_mut();
+    }
+    let carrier = unsafe { pyobject::from_ref(object) };
+    match carrier_get(carrier, CLASS_KEY) {
+        Some(class) => {
+            pyobject::borrow_from(object, class) as *mut super::typeobject::CPyTypeObject
+        }
+        None => std::ptr::null_mut(),
+    }
 }
 
 fn carrier_get(carrier: PyObjectRef, key: &str) -> Option<PyObjectRef> {
@@ -242,12 +429,31 @@ pub fn new_pycfunction(
     w_self: PyObjectRef,
     w_module: PyObjectRef,
 ) -> Result<PyObjectRef, crate::PyError> {
+    new_pycfunction_in_class(method, w_self, w_module, None)
+}
+
+/// [`new_pycfunction`] naming the class a `METH_METHOD` definition was
+/// declared in, whose carrier is `pycmethod_type` rather than
+/// `pycfunction_type`.
+pub fn new_pycfunction_in_class(
+    method: *mut CPyMethodDef,
+    w_self: PyObjectRef,
+    w_module: PyObjectRef,
+    w_class: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let self_slot = pyre_object::gc_roots::shadow_stack_len();
     roots.pin_root(w_self);
     let module_slot = pyre_object::gc_roots::shadow_stack_len();
     roots.pin_root(w_module);
-    let carrier = pyre_object::w_instance_new(pycfunction_type());
+    let class_slot = pyre_object::gc_roots::shadow_stack_len();
+    roots.pin_root(w_class.unwrap_or_else(pyre_object::w_none));
+    let carrier_type = if w_class.is_some() {
+        pycmethod_type()
+    } else {
+        pycfunction_type()
+    };
+    let carrier = pyre_object::w_instance_new(carrier_type);
     let carrier_slot = pyre_object::gc_roots::shadow_stack_len();
     roots.pin_root(carrier);
 
@@ -289,6 +495,13 @@ pub fn new_pycfunction(
         ML_KEY,
         ml,
     );
+    if w_class.is_some() {
+        carrier_set(
+            pyre_object::gc_roots::shadow_stack_get(carrier_slot),
+            CLASS_KEY,
+            pyre_object::gc_roots::shadow_stack_get(class_slot),
+        );
+    }
     Ok(pyre_object::gc_roots::shadow_stack_get(carrier_slot))
 }
 
@@ -328,8 +541,19 @@ fn descr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "cpyext function carrier lost its method definition",
         ));
     };
-    let w_self = carrier_get(carrier, SELF_KEY).unwrap_or_else(pyre_object::w_none);
-    call_method_def(method, w_self, positional, kwargs)
+    let Some(w_self) = carrier_get(carrier, SELF_KEY) else {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            "cpyext function carrier lost its receiver",
+        ));
+    };
+    call_method_def_in_class(
+        method,
+        w_self,
+        carrier_get(carrier, CLASS_KEY),
+        positional,
+        kwargs,
+    )
 }
 
 /// Validate one call against its `ml_flags` and hand it to the bridge.
@@ -339,6 +563,18 @@ fn descr_call(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
 pub(super) fn call_method_def(
     method: *mut CPyMethodDef,
     w_self: PyObjectRef,
+    positional: &[PyObjectRef],
+    kwargs: Option<PyObjectRef>,
+) -> Result<PyObjectRef, crate::PyError> {
+    call_method_def_in_class(method, w_self, None, positional, kwargs)
+}
+
+/// [`call_method_def`] naming the class the definition was declared in, which
+/// a `METH_METHOD` row is handed beside its receiver.
+pub(super) fn call_method_def_in_class(
+    method: *mut CPyMethodDef,
+    w_self: PyObjectRef,
+    defining_class: Option<PyObjectRef>,
     positional: &[PyObjectRef],
     kwargs: Option<PyObjectRef>,
 ) -> Result<PyObjectRef, crate::PyError> {
@@ -379,10 +615,33 @@ pub(super) fn call_method_def(
             "{name}() uses an unknown calling convention"
         )));
     }
-    super::call_cfunction(
+    // `METH_METHOD` widens the fastcall-with-keywords signature by one
+    // argument rather than naming a signature of its own, so it is the only
+    // combination it may appear in; in any other it would select a transmute
+    // whose arity the callee does not have.
+    if flags & METH_METHOD != 0
+        && flags & (METH_FASTCALL | METH_KEYWORDS) != (METH_FASTCALL | METH_KEYWORDS)
+    {
+        return Err(crate::PyError::new(
+            crate::PyErrorKind::SystemError,
+            format!("{name}() method: bad call flags"),
+        ));
+    }
+    let defining_class = match (flags & METH_METHOD != 0, defining_class) {
+        (false, _) => None,
+        (true, Some(class)) => Some(class),
+        (true, None) => {
+            return Err(crate::PyError::new(
+                crate::PyErrorKind::SystemError,
+                format!("{name}() method: no defining class"),
+            ));
+        }
+    };
+    super::call_cfunction_in_class(
         unsafe { (*method).ml_meth },
         flags,
         w_self,
+        defining_class,
         positional,
         &keywords,
     )

--- a/pyre/pyre-interpreter/src/cpyext/mod.rs
+++ b/pyre/pyre-interpreter/src/cpyext/mod.rs
@@ -568,6 +568,20 @@ pub(super) fn call_cfunction(
     positional: &[PyObjectRef],
     keywords: &[(String, PyObjectRef)],
 ) -> Result<PyObjectRef, crate::PyError> {
+    call_cfunction_in_class(function, flags, w_self, None, positional, keywords)
+}
+
+/// [`call_cfunction`] naming the class a `METH_METHOD` definition was
+/// declared in, which its signature takes between the receiver and the
+/// arguments.
+pub(super) fn call_cfunction_in_class(
+    function: *const std::ffi::c_void,
+    flags: c_int,
+    w_self: PyObjectRef,
+    defining_class: Option<PyObjectRef>,
+    positional: &[PyObjectRef],
+    keywords: &[(String, PyObjectRef)],
+) -> Result<PyObjectRef, crate::PyError> {
     use methodobject::{METH_FASTCALL, METH_KEYWORDS, METH_NOARGS, METH_O};
 
     if function.is_null() {
@@ -630,8 +644,30 @@ pub(super) fn call_cfunction(
     }
 
     let receiver = pyobject::make_ref(pyre_object::gc_roots::shadow_stack_get(base));
+    let class = match defining_class {
+        Some(class) => pyobject::make_ref(class),
+        None => std::ptr::null_mut(),
+    };
     let result = unsafe {
-        if fastcall && flags & METH_KEYWORDS != 0 {
+        if !class.is_null() {
+            // `METH_METHOD | METH_FASTCALL | METH_KEYWORDS`, the only
+            // combination the flag rides in: the fastcall-with-keywords
+            // signature widened by the defining class.
+            let call: unsafe extern "C" fn(
+                *mut CPyObject,
+                *mut CPyObject,
+                *const *mut CPyObject,
+                isize,
+                *mut CPyObject,
+            ) -> *mut CPyObject = std::mem::transmute(function);
+            call(
+                receiver,
+                class,
+                fastcall_slots.as_ptr(),
+                positional.len() as isize,
+                keywords_arg,
+            )
+        } else if fastcall && flags & METH_KEYWORDS != 0 {
             let call: unsafe extern "C" fn(
                 *mut CPyObject,
                 *const *mut CPyObject,
@@ -666,6 +702,7 @@ pub(super) fn call_cfunction(
     };
     unsafe {
         pyobject::decref(receiver);
+        pyobject::decref(class);
         pyobject::decref(arguments);
         pyobject::decref(keywords_arg);
         for slot in fastcall_slots {

--- a/pyre/pyre-interpreter/src/cpyext/object.rs
+++ b/pyre/pyre-interpreter/src/cpyext/object.rs
@@ -1002,11 +1002,11 @@ pub unsafe extern "C" fn PyObject_GC_IsTracked(_object: *mut CPyObject) -> c_int
     1
 }
 
-/// `PyObject_GC_IsFinalized(object)` — nothing runs `tp_finalize`, so nothing
-/// has been finalized (`object.py:501-504`).
+/// `PyObject_GC_IsFinalized(object)` — whether `tp_finalize` has already run
+/// for this object (`object.py:501-504`).
 #[unsafe(no_mangle)]
-pub unsafe extern "C" fn PyObject_GC_IsFinalized(_object: *mut CPyObject) -> c_int {
-    0
+pub unsafe extern "C" fn PyObject_GC_IsFinalized(object: *mut CPyObject) -> c_int {
+    (!object.is_null() && super::gc::is_finalized(object as usize)) as c_int
 }
 
 /// `PyObject_CallFinalizerFromDealloc(object)` — run the type's
@@ -1029,14 +1029,52 @@ pub unsafe extern "C" fn PyObject_CallFinalizerFromDealloc(object: *mut CPyObjec
     if finalize.is_null() {
         return 0;
     }
-    let finalize: unsafe extern "C" fn(*mut CPyObject) = unsafe { std::mem::transmute(finalize) };
     unsafe { (*object).ob_refcnt = 1 };
-    unsafe { finalize(object) };
-    if unsafe { (*object).ob_refcnt } > 1 {
-        return -1;
+    unsafe { PyObject_CallFinalizer(object) };
+    debug_assert!(
+        unsafe { (*object).ob_refcnt } > 0,
+        "a finalizer dropped the reference the caller was holding for it"
+    );
+    // Undo the temporary reference by hand rather than through `decref`,
+    // which at zero would re-enter the deallocator this is called from.
+    // Whatever is left above zero is something the finalizer handed `self`
+    // to, and the caller is told to leave the block alone.
+    unsafe { (*object).ob_refcnt -= 1 };
+    if unsafe { (*object).ob_refcnt } != 0 {
+        -1
+    } else {
+        0
     }
-    unsafe { (*object).ob_refcnt = 0 };
-    0
+}
+
+/// `object.py:501 PyObject_CallFinalizer(object)` — run the type's
+/// `tp_finalize`, once.
+///
+/// A collected type's finalizer runs at most once over the object's life: a
+/// deallocator chain reaches this from every level that defines one, and a
+/// second call would release the same resources twice.
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn PyObject_CallFinalizer(object: *mut CPyObject) {
+    if object.is_null() {
+        return;
+    }
+    let tp = unsafe { (*object).ob_type };
+    if tp.is_null() {
+        return;
+    }
+    let finalize = unsafe { (*tp).tp_finalize };
+    if finalize.is_null() {
+        return;
+    }
+    let collected = super::gc::has_gc(tp);
+    if collected && super::gc::is_finalized(object as usize) {
+        return;
+    }
+    let finalize: unsafe extern "C" fn(*mut CPyObject) = unsafe { std::mem::transmute(finalize) };
+    unsafe { finalize(object) };
+    if collected {
+        super::gc::mark_finalized(object as usize);
+    }
 }
 
 /// `PyObject_VisitManagedDict(object, visit, arg)` — nothing to visit.
@@ -1097,6 +1135,18 @@ unsafe fn PyTuple_from_vector(args: *const *mut CPyObject, count: usize) -> *mut
     }
     for index in 0..count {
         let item = unsafe { *args.add(index) };
+        // A NULL here would be stored as an empty slot -- `PyTuple_New` fills
+        // the block with those already, so nothing downstream would notice --
+        // and the hole reaches the interpreter as a value.  The vectorcall
+        // path refuses it, and this is the same vector.
+        if item.is_null() {
+            unsafe { pyobject::decref(tuple) };
+            super::pyerrors::set_pending_error(crate::PyError::new(
+                crate::PyErrorKind::SystemError,
+                "vectorcall argument vector holds a NULL",
+            ));
+            return std::ptr::null_mut();
+        }
         unsafe { pyobject::incref(item) };
         if unsafe { super::tupleobject::PyTuple_SetItem(tuple, index as isize, item) } != 0 {
             unsafe { pyobject::decref(tuple) };

--- a/pyre/pyre-interpreter/src/cpyext/pyobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pyobject.rs
@@ -440,7 +440,11 @@ unsafe fn dealloc(raw: *mut CPyObject) {
     // reference this block owns in its type is released at the end.
     let ob_type = unsafe { (*raw).ob_type };
     // object.c:77, the same thing as `rawrefcount.mark_deallocating()`: the
-    // link is dead but `tp_dealloc` may still ask for it.
+    // link is dead but `tp_dealloc` may still ask for it.  The link itself is
+    // kept, because a `tp_finalize` run from the deallocator may hand `self`
+    // out and leave the object alive; the marker is only in force for the
+    // duration of the deallocator.
+    let link = unsafe { (*raw).ob_pyre_link };
     majit_gc::gc_rawrefcount_mark_deallocating(deallocating_marker(), address);
     // Everything this layer holds on the mirror's behalf goes before
     // `tp_dealloc` can free the block out from under it.  A borrow it owns may
@@ -466,6 +470,17 @@ unsafe fn dealloc(raw: *mut CPyObject) {
     } else {
         false
     };
+    // A count above zero here is a resurrection: `tp_finalize`, run from the
+    // deallocator through `PyObject_CallFinalizerFromDealloc`, handed `self`
+    // to something that kept it, and that deallocator answered by returning
+    // without freeing.  The block is live again, so it is neither freed nor
+    // left wearing the deallocating marker, and a collected type goes back
+    // into the tracked set the teardown above dropped it from.
+    if !returned && unsafe { (*raw).ob_refcnt } != 0 {
+        unsafe { (*raw).ob_pyre_link = link };
+        super::gc::track(raw);
+        return;
+    }
     if !returned {
         unsafe { free_block(raw) };
     }
@@ -551,6 +566,7 @@ pub(super) unsafe fn reallocate_raw(
 /// # Safety
 /// `raw` must be a block this module entered, and must not be used afterwards.
 pub(super) unsafe fn free_block(raw: *mut CPyObject) {
+    super::gc::forget_finalized(raw as usize);
     let Some(block) = BLOCK_SIZES.lock().remove(&(raw as usize)) else {
         return;
     };

--- a/pyre/pyre-interpreter/src/cpyext/pystate.rs
+++ b/pyre/pyre-interpreter/src/cpyext/pystate.rs
@@ -160,11 +160,21 @@ pub unsafe extern "C" fn PyGILState_GetThisThreadState() -> *mut CPyThreadState 
     }
 }
 
-/// `pystate.py:51 PyEval_InitThreads` — threads are always available, so
-/// upstream's `setup_threads` has nothing left to do here.
 /// `PyInterpreterState_Get()` — the interpreter the calling thread runs in.
+///
+/// There is no interpreter to answer with while this thread's state is not
+/// current, and no way to say so, so this ends the process where
+/// [`PyThreadState_Get`] does and for the same reason.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyInterpreterState_Get() -> *mut CPyInterpreterState {
+    if !STATE_IS_CURRENT.with(|current| current.get()) {
+        super::pyerrors::fatal_error(
+            Some("PyInterpreterState_Get"),
+            "the function must be called with the GIL held, after Python \
+             initialization and before Python finalization, but the GIL is \
+             released (the current Python thread state is NULL)",
+        );
+    }
     &INTERPRETER as *const CPyInterpreterState as *mut CPyInterpreterState
 }
 
@@ -179,6 +189,8 @@ pub unsafe extern "C" fn PyInterpreterState_GetID(interp: *mut CPyInterpreterSta
     0
 }
 
+/// `pystate.py:51 PyEval_InitThreads` — threads are always available, so
+/// upstream's `setup_threads` has nothing left to do here.
 #[unsafe(no_mangle)]
 pub unsafe extern "C" fn PyEval_InitThreads() {}
 
@@ -198,6 +210,8 @@ pub(super) fn ensure_linked() {
     std::hint::black_box(PyThreadState_Swap as *const ());
     std::hint::black_box(PyGILState_Check as *const ());
     std::hint::black_box(PyGILState_GetThisThreadState as *const ());
+    std::hint::black_box(PyInterpreterState_Get as *const ());
+    std::hint::black_box(PyInterpreterState_GetID as *const ());
     std::hint::black_box(PyEval_InitThreads as *const ());
     std::hint::black_box(PyEval_ThreadsInitialized as *const ());
 }

--- a/pyre/pyre-interpreter/src/cpyext/typeobject.rs
+++ b/pyre/pyre-interpreter/src/cpyext/typeobject.rs
@@ -376,6 +376,7 @@ type_mirrors! {
     // `PyCFunction_Check` answers no for it; `methodobject`'s
     // `pycfunction_type` says why that is the safe half of the gap.
     PyCFunction_Type => super::methodobject::pycfunction_type(),
+    PyCMethod_Type => super::methodobject::pycmethod_type(),
     PyClassMethodDescr_Type => builtin_type(&crate::function::CLASSMETHOD_DESCRIPTOR_TYPE),
     PyClassMethod_Type => builtin_type(&pyre_object::function::CLASSMETHOD_TYPE),
     PyFunction_Type => builtin_type(&crate::function::FUNCTION_TYPE),
@@ -626,7 +627,10 @@ fn descriptor_type(
     init: fn(PyObjectRef),
 ) -> PyObjectRef {
     *cell.get_or_init(|| {
-        let tp = crate::typedef::make_builtin_type(name, init);
+        let tp = crate::typedef::make_builtin_type(name, |ns| {
+            init(ns);
+            super::methodobject::install_attribute_fence(ns);
+        });
         unsafe { pyre_object::typeobject::w_type_set_hasdict(tp, true) };
         tp as usize
     }) as PyObjectRef

--- a/pyre/pyrex/tests/cpyext_callables.rs
+++ b/pyre/pyrex/tests/cpyext_callables.rs
@@ -103,20 +103,38 @@ sys.unraisablehook = reports.append
 try:
     m.report_unraisable(subject)
     m.report_unraisable_msg()
+    m.report_unraisable_null()
+    m.report_unraisable_bad_format()
 finally:
     sys.unraisablehook = previous
 
-eq('two reports', len(reports), 2)
+eq('four reports', len(reports), 4)
 eq('named object', reports[0].object is subject, True)
-eq('named exception', type(reports[0].exc_type), type)
+eq('named exception', reports[0].exc_type, ValueError)
 eq('named exception value', str(reports[0].exc_value), 'boom')
+# Naming an object states no message.
+eq('named report has no message', reports[0].err_msg, None)
 eq('stated message', reports[1].err_msg,
    'Exception ignored while doing the thing')
 eq('stated object', reports[1].object, None)
+eq('stated exception', reports[1].exc_type, ValueError)
+eq('stated exception value', str(reports[1].exc_value), 'boom')
+# A NULL format is the spelling for "no message"; the exception is still
+# reported, and building nothing cannot crash.
+eq('no message', reports[2].err_msg, None)
+eq('no message object', reports[2].object, None)
+eq('no message exception', str(reports[2].exc_value), 'boom')
+# A format the engine refuses must not become what gets reported.
+eq('refused format keeps the exception', reports[3].exc_type, ValueError)
+eq('refused format keeps the value', str(reports[3].exc_value), 'boom')
+eq('refused format states nothing', reports[3].err_msg, None)
 # Reporting clears the indicator, so nothing is pending afterwards.
 eq('nothing pending', m.probe('still working'), 'still working')
 
 # ── the runtime it is running against ──────────────────────────────────
+
+# A module-level function was declared with no class, so it carries none.
+eq('no defining class', m.defining_class(m.probe), None)
 
 version, interpreter = m.runtime_identity()
 eq('version', version, sys.hexversion)

--- a/pyre/pyrex/tests/fixtures/cpyext_callables.c
+++ b/pyre/pyrex/tests/fixtures/cpyext_callables.c
@@ -160,6 +160,43 @@ static PyObject *report_unraisable_msg(PyObject *self, PyObject *unused)
     Py_RETURN_NONE;
 }
 
+/* No message at all, which is what a NULL format states. */
+static PyObject *report_unraisable_null(PyObject *self, PyObject *unused)
+{
+    (void)self;
+    (void)unused;
+    PyErr_SetString(PyExc_ValueError, "boom");
+    PyErr_FormatUnraisable(NULL);
+    Py_RETURN_NONE;
+}
+
+/* A format the engine refuses.  What gets reported is the caller's exception,
+   not the one building the message raised. */
+static PyObject *report_unraisable_bad_format(PyObject *self, PyObject *unused)
+{
+    (void)self;
+    (void)unused;
+    PyErr_SetString(PyExc_ValueError, "boom");
+    PyErr_FormatUnraisable("undecodable \xff");
+    Py_RETURN_NONE;
+}
+
+/* The defining class a callable carries, which is none for a module-level
+   function: `PyCFunction_GET_CLASS` answers NULL without an error for one. */
+static PyObject *defining_class(PyObject *self, PyObject *arg)
+{
+    PyTypeObject *owner;
+    (void)self;
+    owner = PyCFunction_GET_CLASS(arg);
+    if (owner == NULL) {
+        if (PyErr_Occurred()) {
+            return NULL;
+        }
+        Py_RETURN_NONE;
+    }
+    return Py_NewRef((PyObject *)owner);
+}
+
 /* The version the extension is running against, and the interpreter it is in. */
 static PyObject *runtime_identity(PyObject *self, PyObject *unused)
 {
@@ -189,6 +226,9 @@ static PyMethodDef methods[] = {
     {"call_with_dict", call_with_dict, METH_VARARGS, NULL},
     {"report_unraisable", report_unraisable, METH_O, NULL},
     {"report_unraisable_msg", report_unraisable_msg, METH_NOARGS, NULL},
+    {"report_unraisable_null", report_unraisable_null, METH_NOARGS, NULL},
+    {"report_unraisable_bad_format", report_unraisable_bad_format, METH_NOARGS, NULL},
+    {"defining_class", defining_class, METH_O, NULL},
     {"runtime_identity", runtime_identity, METH_NOARGS, NULL},
     {"is_traceback", is_traceback, METH_O, NULL},
     {NULL, NULL, 0, NULL}};


### PR DESCRIPTION
The automated reviews on #1363 landed after it merged. This is what they found,
checked against the code and against CPython 3.14 / PyPy before acting on it:
eleven confirmed, five partly right, two refuted.

## Memory safety: the carrier's state was Python-writable

`PyCFunction_Type`'s carrier keeps its `PyMethodDef` index, its receiver and
its defining class in the instance namespace — a mapping Python reaches. So
`m = ext.Box().read; m.__self__ = None; m()` handed `None` to a callable that
casts `self` to its own struct, and `x.__pyre_ml__ = <index>` handed an
arbitrary object a live C function pointer. The `tp_methods` / `tp_getset` /
`tp_members` descriptors were worse in a straighter line: their `__pyre_def__`
holds a definition's **address**.

The carrier types now refuse every store but `__module__`, with the two
messages the reference type gives, and `checked_method_def` tests the type
before it reads the namespace at all — `space.interp_w(W_PyCFunctionObject,
w_obj)` is what upstream's accessors open with. A deleted `__self__` is a
`SystemError` rather than a silent `None` receiver.

## `METH_METHOD` was advertised with nothing behind it

`methodobject.h` defined `METH_METHOD` and shipped `PyCMethod_Check`,
`PyCMethod_CheckExact` and `PyCFunction_GET_CLASS`, whose referents nothing
declared — a compile error for any extension using the 3.9+ API — while a
`METH_METHOD | METH_FASTCALL | METH_KEYWORDS` row passed the one-bit
convention test and was dispatched through the **four**-argument transmute.

Implemented rather than removed: `PyCMethod_Type` is the `builtin_method`
carrier deriving from `PyCFunction_Type`; `PyCMethod_New` carries the three
arms `methodobject.py:544` does and `PyCFunction_NewEx` delegates to it;
`PyCMethod_GetClass` answers the class; `call_cfunction_in_class` dispatches
the five-argument signature. The flag rides only with
`METH_FASTCALL | METH_KEYWORDS`, because it widens that signature rather than
naming one of its own — any other combination is `bad call flags`.

## Resurrection freed the block

`PyObject_CallFinalizerFromDealloc` returned -1 with the temporary reference
still in `ob_refcnt`, and `dealloc` freed the block anyway, because the
deallocator that answered -1 had not. Cython's own deallocator preamble
(`if (PyObject_CallFinalizerFromDealloc(o)) return;`) is exactly the trigger.

The temporary reference is now dropped by hand — `decref` at zero would
re-enter the deallocator — and a block whose count is above zero afterwards is
neither freed nor left wearing the deallocating marker: its link is restored
and a collected type goes back into the tracked set.

`PyObject_CallFinalizer` is exported and runs a collected type's finalizer
once, recorded beside the tracked set and cleared where the block is released
(not in `dealloc`, which runs before `tp_dealloc` — the moment a second
deallocation still has to read it). `PyObject_GC_IsFinalized` answers that
instead of a constant `0`.

## The unraisable report

`PyErr_FormatUnraisable` passed its format straight to
`PyUnicode_FromFormatV`, so the documented NULL spelling ("only the traceback
is printed") dereferenced null. It also built the message while the exception
to be reported was still pending, so a `%S` that raised or a non-ASCII format
byte **replaced** it — `set_pending_raw` decrefs the previous one, so the
original was not even kept as `__context__`. The indicator is now held aside
across the format and a failure there is dropped, which is the order
`format_unraisable_v` asks in.

## The rest

- `PyTuple_from_vector` accepted a NULL vector entry and shipped a tuple with
  a hole into the interpreter; it now refuses one, as the vectorcall path
  beside it already did.
- `PyImport_ImportModuleLevelObject` answers a NULL name with
  `ValueError("Empty module name")`, ahead of the `level` check — the order
  `import.c` asks in.
- `PyInterpreterState_Get` ends the process where `PyThreadState_Get` does
  when no state is current, and both new symbols are in `ensure_linked`.
- `PyMethod_Check` is `Py_IS_TYPE`, so the predicate and the accessors' own
  guard are one test.
- `code.h` gains the `CO_FUTURE_*` flags, `CO_NO_MONITORING_EVENTS` and
  `PyCode_Check`; `Python.h` reaches `frameobject.h`, which both reference
  header sets make `PyFrame_Check` reachable from.

## Refuted, and why

- **`lock.h` critical sections** — the six macros are verbatim
  `critical_section.h`'s `#ifndef Py_GIL_DISABLED` arm, which drops its
  argument too. Defining `Py_GIL_DISABLED` would select `struct _object` field
  names `object.h` does not declare.
- **`module_dict` returning NULL without an exception** — `PyImport_GetModuleDict`
  already sets `RuntimeError("sys.modules is not set")` first; the proposed
  remedy would overwrite it with generic text.
- **`Py_BuildValue("L", int64_t)`** — `int64_t` *is* `long long` on this
  target, and on LP64 both are 64-bit INTEGER-class, so the va_arg round-trip
  is exact.

Also left for their own changes, since none is introduced here: the typed
`#[pyre_class]` carrier payload, PEP 442 ordering in `clear_garbage`, unifying
`BUILTIN_FUNCTION_TYPE` with `pycfunction_type()` so `inspect.isbuiltin`
classifies extension functions, and `PyType_Ready` never consulting
`acceptable_as_base_class`.

## Gates

- `cargo test --all --no-default-features --features dynasm` — 8005 passed / 0 failed.
- `cargo test -p pyrex --features cpyext,dynasm --test 'cpyext_*'` — 25 tests.
- `cpyext-abi.py check` — 491 exports / 24 header inlines / 124 data objects.
- `cpyext_callables` pins the unraisable reports it was only half checking and
  covers the NULL format and the refused one; the fixture was built against
  CPython 3.14's headers and run on CPython, and gives the same output there.
- markupsafe 3.0.3's own test modules: 39 passed / 1 failed, unchanged
  (`test_leak.test_markup_leaks`, which wants fewer than three distinct
  `gc.get_objects()` counts and gets three).
