### PR TITLE
staticmethod/classmethod w_function? quasi-immutable, plus four review follow-ups

### DIFF
--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -2591,11 +2591,21 @@ fn handle_jitexception(
     mut bh: BlackholeInterpreter,
     exc: JitException,
     portal_runner: Option<&dyn Fn(&JitException) -> Result<(BhReturnType, i64), JitException>>,
+    on_leave_level: Option<&dyn Fn(i64)>,
     terminal_out: Option<&mut Option<BlackholeTerminalImage>>,
 ) -> Result<(BlackholeInterpreter, i64), JitException> {
     // blackhole.py:1764: while blackholeinterp.jitcode.jitdriver_sd is None
     while bh.jitcode.jitdriver_sd().is_none() {
         let next = bh.nextblackholeinterp.take();
+        // `pyopcode.py:184 handle_operation_error` — the no-handler propagation
+        // out of a frame stores `frame_finished_execution = True` there too, and
+        // this walk is exactly that: each level it discards on the way to the
+        // portal has been left by an exception it did not catch.  The `Ok` arm's
+        // twin store sits in `run_forever_with_portal`, which never sees these
+        // levels.
+        if let Some(on_leave_level) = on_leave_level {
+            on_leave_level(bh.virtualizable_ptr);
+        }
         builder.release_interp(bh);
         match next.map(|b| *b) {
             Some(caller) => bh = caller,
@@ -2691,6 +2701,7 @@ pub fn run_forever_with_portal(
                     bh,
                     jit_exc,
                     portal_runner,
+                    on_leave_level,
                     terminal_out.as_deref_mut(),
                 ) {
                     Ok((new_bh, exc)) => {
@@ -4190,6 +4201,7 @@ mod tests {
                     bh,
                     crate::jitexc::JitException::DoneWithThisFrameInt(42),
                     None,
+                    None,
                     Some(&mut terminal),
                 );
                 assert!(
@@ -4205,6 +4217,56 @@ mod tests {
                     assert_eq!(terminal.registers_i[0], 42);
                 }
             }
+        }
+
+        /// `pyopcode.py:184 handle_operation_error` stores
+        /// `frame_finished_execution = True` on the no-handler propagation out
+        /// of a frame, and the walk to the recursive portal
+        /// (`blackhole.py:1764`) discards exactly such frames.  The `Ok` arm's
+        /// twin store lives in `run_forever_with_portal`, which never sees a
+        /// level this walk released, so a frame left by an exception would read
+        /// back as still executing and refuse `frame.clear()`.
+        #[test]
+        fn handle_jitexception_finishes_each_non_portal_level_it_unwinds() {
+            let build = |portal: bool| {
+                let mut b = JitCodeBuilder::default();
+                b.load_const_i_value(0, 1);
+                b.int_return(0);
+                let jitcode = b.finish();
+                jitcode.set_index(0);
+                if portal {
+                    jitcode.set_jitdriver_sd(0);
+                }
+                jitcode
+            };
+
+            let mut builder = super::build_inline_call_only_bh_builder();
+            let mut portal_bh = builder.acquire_interp();
+            portal_bh.setposition(std::sync::Arc::new(build(true)), 0);
+            portal_bh.virtualizable_ptr = 0x2000;
+            let mut leaf = builder.acquire_interp();
+            leaf.setposition(std::sync::Arc::new(build(false)), 0);
+            leaf.virtualizable_ptr = 0x1000;
+            leaf.nextblackholeinterp = Some(Box::new(portal_bh));
+
+            let left = std::cell::RefCell::new(Vec::new());
+            let on_leave_level = |ptr: i64| left.borrow_mut().push(ptr);
+            let outcome = super::handle_jitexception(
+                &mut builder,
+                leaf,
+                crate::jitexc::JitException::DoneWithThisFrameInt(1),
+                None,
+                Some(&on_leave_level),
+                None,
+            );
+
+            assert!(outcome.is_err(), "the portal frame here is bottommost");
+            assert_eq!(
+                left.into_inner(),
+                vec![0x1000],
+                "the unwound non-portal level is finished; the portal one leaves \
+                 through the propagating arm, whose caller owns the store",
+            );
         }
 
         #[test]

--- a/pyre/bench/synth/wrapper_function_invalidation.cranelift.jitstats
+++ b/pyre/bench/synth/wrapper_function_invalidation.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/bench/synth/wrapper_function_invalidation.dynasm.jitstats
+++ b/pyre/bench/synth/wrapper_function_invalidation.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/bench/synth/wrapper_function_invalidation.py
+++ b/pyre/bench/synth/wrapper_function_invalidation.py
@@ -1,0 +1,104 @@
+# `function.py:673` / `:720` `StaticMethod._immutable_fields_ =
+# ['w_function?']` and the `ClassMethod` twin.  The `?` is what lets a tracer
+# bake the wrapped callable and equally what registers the invalidation an
+# assignment to the slot owes, so re-initialising an installed wrapper revokes
+# every loop that folded it.
+#
+# Re-initialising a wrapper is the case no other pin reaches: it changes no
+# type's version tag and leaves the descriptor at the same address, so a fold
+# that pinned the DESCRIPTOR still holds while the callable inside it has
+# already been replaced.
+#
+# Each rebind happens INSIDE its loop: a read after the loop is interpreted and
+# would not consult what the trace baked.  The wrapped bodies are residual-free
+# so the folds stand rather than aborting.
+N = 400000
+SWITCH = N // 2
+
+
+def first_hook(name):
+    return 1
+
+
+def second_hook(name):
+    return 2
+
+
+def first_class_hook(cls, name):
+    return 1
+
+
+def second_class_hook(cls, name):
+    return 2
+
+
+def first_scaled(cls, i):
+    return 1
+
+
+def second_scaled(cls, i):
+    return 2
+
+
+class StaticHook:
+    __getattr__ = staticmethod(first_hook)
+
+
+class ClassHook:
+    __getattr__ = classmethod(first_class_hook)
+
+
+class Scaled:
+    scaled = classmethod(first_scaled)
+
+
+def rebind_staticmethod_hook():
+    # The `__getattr__`-hook fold's `staticmethod` arm: the descriptor binds
+    # nothing, so the name is the only argument.
+    obj = StaticHook()
+    descr = StaticHook.__dict__['__getattr__']
+    total = 0
+    i = 0
+    while i < N:
+        total += obj.missing
+        if i == SWITCH:
+            descr.__init__(second_hook)
+        i += 1
+    # SWITCH+1 reads of 1, then N-SWITCH-1 reads of 2.
+    print('staticmethod hook', total)
+
+
+def rebind_classmethod_hook():
+    # The same fold's `classmethod` arm — a distinct code path, since the
+    # descriptor leads the positionals with the class it binds.
+    obj = ClassHook()
+    descr = ClassHook.__dict__['__getattr__']
+    total = 0
+    i = 0
+    while i < N:
+        total += obj.missing
+        if i == SWITCH:
+            descr.__init__(second_class_hook)
+        i += 1
+    print('classmethod hook', total)
+
+
+def rebind_classmethod_on_type():
+    # The `LOAD_METHOD` classmethod fold for a type receiver, which bakes
+    # `__func__` under the class's version tag alone.  Re-initialising the
+    # descriptor bumps no version tag, so this is the case that reads a stale
+    # callable without the `w_function?` pin.
+    descr = Scaled.__dict__['scaled']
+    total = 0
+    i = 0
+    while i < N:
+        total += Scaled.scaled(i)
+        if i == SWITCH:
+            descr.__init__(second_scaled)
+        i += 1
+    print('classmethod on type', total)
+
+
+rebind_staticmethod_hook()
+rebind_classmethod_hook()
+rebind_classmethod_on_type()

--- a/pyre/bench/synth/wrapper_function_invalidation.wasm.jitstats
+++ b/pyre/bench/synth/wrapper_function_invalidation.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9908,7 +9908,7 @@ pub unsafe fn load_method_fast_path(
 pub unsafe fn classmethod_on_type_fast_path(
     w_obj: PyObjectRef,
     name: &str,
-) -> Option<(PyObjectRef, u64, PyObjectRef)> {
+) -> Option<(PyObjectRef, u64, PyObjectRef, PyObjectRef)> {
     if w_obj.is_null() || !pyre_object::typeobject::is_type(w_obj) {
         return None;
     }
@@ -9943,7 +9943,11 @@ pub unsafe fn classmethod_on_type_fast_path(
     if w_func.is_null() {
         return None;
     }
-    Some((w_type, version_tag, w_func))
+    // The wrapper itself, not only what it wraps: `function.py:720
+    // _immutable_fields_ = ['w_function?']`, and re-initialising an installed
+    // `classmethod` swaps that slot without touching any type's version tag, so
+    // a caller that bakes `w_func` needs the descriptor to pin it against.
+    Some((w_type, version_tag, w_descr, w_func))
 }
 
 /// `Cls.__name__` read fast path: when `w_obj` is a class whose metaclass is

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -36,22 +36,6 @@ fn new_simple_weak_set() -> Result<PyObjectRef, crate::PyError> {
     crate::call::call_function_impl_result(simple_weak_set_type(), &[])
 }
 
-/// Whether `cls` can be weak-referenced at all, which is what decides whether
-/// a `SimpleWeakSet` can hold it.
-///
-/// `app_abc.py:39-40 add` has no such test — upstream reaches it only with a
-/// real class, because `_abc_register` rejects everything else. Pyre admits a
-/// callable non-type there (see `register`), so the test lives on this side of
-/// the boundary rather than in the app-level source, which stays verbatim.
-/// `__contains__` needs none: `app_abc.py:33-38` already reads a referent-less
-/// item as absent.
-fn can_weakref(cls: PyObjectRef) -> bool {
-    use crate::module::_weakref::interp__weakref as wr;
-    let roots = pyre_object::gc_roots::push_roots();
-    let cls_slot = roots.publish(&[cls]);
-    wr::getlifeline(roots.get(cls_slot)).is_ok()
-}
-
 /// `app_abc.py:33-38 SimpleWeakSet.__contains__` through the membership
 /// protocol, which is where the weakref probe and the `TypeError` fallback
 /// live.
@@ -82,15 +66,14 @@ fn weak_cache_contains(
 /// behind for every class the check ever saw.
 ///
 /// Silently declines a class with no collection, for the same reason
-/// [`weak_cache_contains`] reads one as a miss, and one that cannot be
-/// weak-referenced, for the reason [`can_weakref`] records.
+/// [`weak_cache_contains`] reads one as a miss.  Every item reaching here is a
+/// class — `register` and `subclass_of` each reject a non-type argument — and a
+/// class is weak-referenceable, so `add` needs no test of its own, which is
+/// also why `app_abc.py add` has none.
 fn weak_cache_add(cls: PyObjectRef, name: &str, item: PyObjectRef) -> Result<(), crate::PyError> {
     let roots = pyre_object::gc_roots::push_roots();
     let cls_slot = roots.publish(&[cls]);
     let item_slot = roots.publish(&[item]);
-    if !can_weakref(roots.get(item_slot)) {
-        return Ok(());
-    }
     let cache = cache_attr(roots.get(cls_slot), name)?;
     if cache.is_null() {
         return Ok(());
@@ -133,17 +116,35 @@ fn cache_attr(cls: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyErro
     }
 }
 
-/// The registry generation `cls`'s negative cache was recorded against.  A
-/// class with no version attribute, or one holding something other than an
-/// `int`, reports generation 0, which is below every counter value a
-/// registration produces — so its negative cache is discarded rather than
-/// trusted.
-fn negative_cache_version(cls: PyObjectRef) -> Result<u64, crate::PyError> {
-    let version = cache_attr(cls, "_abc_negative_cache_version")?;
-    if version.is_null() || !unsafe { is_int(version) } {
-        return Ok(0);
+/// Compare `cls._abc_negative_cache_version` against the invalidation counter
+/// the way `_abc_subclasscheck` (`<`) and `_abc_instancecheck` (`==`) do.
+///
+/// The stored value is passed to the comparison as it stands rather than
+/// normalised to an integer first: a rebound non-int raises from the compare,
+/// and a value with its own `__lt__` / `__eq__` stays observable.
+fn negative_cache_version_compare(
+    cls: PyObjectRef,
+    op: crate::objspace::descroperation::CompareOp,
+) -> Result<bool, crate::PyError> {
+    let roots = pyre_object::gc_roots::push_roots();
+    let cls_slot = roots.publish(&[cls]);
+    let version = cache_attr(roots.get(cls_slot), "_abc_negative_cache_version")?;
+    if version.is_null() {
+        // A class that never ran `_abc_init` records no generation.  Upstream
+        // raises `AttributeError` reading it; the collections are tolerated the
+        // same way here, and the answer that goes with an absent one is "older
+        // than any counter" — rebuild on `<`, refuse to trust on `==`.
+        return Ok(matches!(op, crate::objspace::descroperation::CompareOp::Lt));
     }
-    Ok(unsafe { w_int_get_value(version) }.max(0) as u64)
+    let version_slot = roots.publish(&[version]);
+    let counter_slot = roots.publish(&[w_int_new(
+        INVALIDATION_COUNTER.load(Ordering::Relaxed) as i64
+    )]);
+    crate::baseobjspace::is_true(crate::objspace::descroperation::compare(
+        roots.get(version_slot),
+        roots.get(counter_slot),
+        op,
+    )?)
 }
 
 /// `app_abc.py _abc_init` — install the three collections and the
@@ -217,29 +218,24 @@ fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     }
     let cls = args[0];
     let subclass = args[1];
-    // `subclass` must be a class (`PyType_Check`).  Pyre's stdlib stubs
-    // register callable non-type shells to ABCs — `_contextvars.Context` is a
-    // builtin function here, yet `contextvars` runs `Mapping.register(Context)`
-    // at import.  `__subclasscheck__` already tolerates such members by
-    // skipping non-type registry entries (see `subclass_of`), so the
-    // `PyObject_IsSubclass` guards below (which reject non-type args) only run
-    // for real types; a callable stub falls straight through to the append,
-    // and only a genuine non-class value (`register(42)`) is rejected.
-    if unsafe { is_type(subclass) } {
-        // Already a subclass (`PyObject_IsSubclass(subclass, cls) > 0`) —
-        // nothing to register.  This also dedups: a previously registered
-        // `subclass` resolves through `__subclasscheck__`'s registry walk.
-        if crate::baseobjspace::issubclass(subclass, cls)? {
-            return Ok(subclass);
-        }
-        // Registering `subclass` would also make `cls` its subclass.
-        if crate::baseobjspace::issubclass(cls, subclass)? {
-            return Err(crate::PyError::runtime_error(
-                "Refusing to create an inheritance cycle",
-            ));
-        }
-    } else if !crate::baseobjspace::callable_w(subclass) {
+    // `_abc_register`: `if not isinstance(subclass, type): raise TypeError(
+    // "Can only register classes")`.  Everything downstream reads a registry
+    // entry as a class, so the rejection is what makes that sound.
+    if !unsafe { is_type(subclass) } {
         return Err(crate::PyError::type_error("Can only register classes"));
+    }
+    // Already a subclass (`issubclass(subclass, cls)`) — nothing to register.
+    // This also dedups: a previously registered `subclass` resolves through
+    // `__subclasscheck__`'s registry walk.
+    if crate::baseobjspace::issubclass(subclass, cls)? {
+        return Ok(subclass);
+    }
+    // Registering `subclass` would also make `cls` its subclass.  Tested after
+    // the arm above, so `X.register(X)` stays a no-op rather than a cycle.
+    if crate::baseobjspace::issubclass(cls, subclass)? {
+        return Err(crate::PyError::runtime_error(
+            "Refusing to create an inheritance cycle",
+        ));
     }
     // `app_abc.py:99 cls._abc_registry.add(subclass)`.  An ABC that never ran
     // `_abc_init` has no collection to add to; it gets one here rather than
@@ -260,9 +256,12 @@ fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     // `Mapping` / `Sequence` is what makes `case {...}` / `case [...]` accept
     // a class that inherits from neither, so the marker has to travel with
     // the registration, not only with `__abc_tpflags__` at class creation.
-    let flag = unsafe { typeobject::w_type_get_flag_map_or_seq(cls) };
-    if flag != b'?' && unsafe { is_type(subclass) } {
-        set_collection_flag_recursive(subclass, flag);
+    // `_abc_register` reads the flags under `if isinstance(cls, type):`.
+    if unsafe { is_type(cls) } {
+        let flag = unsafe { typeobject::w_type_get_flag_map_or_seq(cls) };
+        if flag != b'?' {
+            set_collection_flag_recursive(subclass, flag);
+        }
     }
     Ok(subclass)
 }
@@ -333,7 +332,10 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
     // recorded against, so a bumped counter discards the whole cache rather
     // than trusting any entry in it.
     let counter = INVALIDATION_COUNTER.load(Ordering::Relaxed);
-    if negative_cache_version(roots.get(cls_slot))? < counter {
+    if negative_cache_version_compare(
+        roots.get(cls_slot),
+        crate::objspace::descroperation::CompareOp::Lt,
+    )? {
         let fresh = new_simple_weak_set()?;
         crate::baseobjspace::setattr_str(roots.get(cls_slot), "_abc_negative_cache", fresh)?;
         let version = w_int_new(counter as i64);
@@ -398,15 +400,6 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
                     Err(err) if err.matches_stop_iteration() => break,
                     Err(err) => return Err(err),
                 };
-                // A registered entry that is not a class cannot be a base
-                // class, so it can never make `subclass` a subclass — skip
-                // it rather than letting `issubclass` raise.  `range` is
-                // registered to `Sequence` but is a builtin function in
-                // pyre, so without this guard a single bad entry aborts the
-                // whole recursive check.
-                if !unsafe { is_type(rcls) } {
-                    continue;
-                }
                 let item_roots = pyre_object::gc_roots::push_roots();
                 let rcls_slot = item_roots.base();
                 item_roots.pin_root(rcls);
@@ -503,14 +496,14 @@ fn instancecheck(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         // The version test is `==`, not `<`: a cache recorded against a
         // *later* counter than the one read here cannot describe this
         // registry either.
-        if negative_cache_version(roots.get(cls_slot))?
-            == INVALIDATION_COUNTER.load(Ordering::Relaxed)
-            && weak_cache_contains(
-                roots.get(cls_slot),
-                "_abc_negative_cache",
-                roots.get(subclass_slot),
-            )?
-        {
+        if negative_cache_version_compare(
+            roots.get(cls_slot),
+            crate::objspace::descroperation::CompareOp::Eq,
+        )? && weak_cache_contains(
+            roots.get(cls_slot),
+            "_abc_negative_cache",
+            roots.get(subclass_slot),
+        )? {
             return Ok(w_bool_from(false));
         }
         return Ok(w_bool_from(subclasscheck_of(
@@ -606,9 +599,17 @@ fn get_dump(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         };
         data_slots.push(roots.publish(&[data]));
     }
-    // The last read that can run Python; take it before the reloads below so
-    // they answer with final addresses.
-    let version = w_int_new(negative_cache_version(roots.get(cls_slot))? as i64);
+    // `_get_dump` reports the generation attribute itself, not a number derived
+    // from it.  The last read that can run Python; take it before the reloads
+    // below so they answer with final addresses.
+    let version = cache_attr(roots.get(cls_slot), "_abc_negative_cache_version")?;
+    // Same tolerance as the collections above: a class that never ran
+    // `_abc_init` reports generation 0 rather than raising at a debug helper.
+    let version = if version.is_null() {
+        w_int_new(0)
+    } else {
+        version
+    };
     let mut items: Vec<PyObjectRef> = data_slots.iter().map(|&slot| roots.get(slot)).collect();
     items.push(version);
     Ok(w_tuple_new(items))

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -83,6 +83,19 @@ const PROPERTY_DESCR_TAG: u32 = 0x5100_0000;
 const PROPERTY_FGET_INDEX: u32 = PROPERTY_DESCR_TAG;
 const PROPERTY_FSET_INDEX: u32 = PROPERTY_DESCR_TAG | 1;
 
+// `StaticMethod.w_function` and `ClassMethod.w_function` sit at the same
+// coordinate as each other and as every other `W_*` class's first reference
+// field, and the two wrappers have byte-identical layouts, so
+// `stable_field_index` cannot even tell THEM apart — it names a layout, not an
+// owner, and the index is what selects the pointer cast in
+// `install_quasiimmut_field` / `register_quasi_immutable_deps`.  Reserved for
+// the same reason as the property block above, in a tag of its own.  Disjoint
+// from FIELD (0x10xx_xxxx), ARRAY, SIZE, CELL, MAPDICT, PROPERTY,
+// `object.typeptr` (0x6000_0000), the native mapdict block, and the GC tid.
+const WRAPPER_DESCR_TAG: u32 = 0x5200_0000;
+const STATICMETHOD_W_FUNCTION_INDEX: u32 = WRAPPER_DESCR_TAG;
+const CLASSMETHOD_W_FUNCTION_INDEX: u32 = WRAPPER_DESCR_TAG | 1;
+
 // The generated native user layouts append mapdict fields at different base
 // sizes. HeapCache keys by descriptor index; give each translated STRUCT field
 // the distinct identity provided by descr.py's per-STRUCT cache.
@@ -1552,11 +1565,10 @@ static W_METHOD_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
 
 /// `pypy/interpreter/function.py:673` / `:720`
 /// `_immutable_fields_ = ['w_function?']` for `StaticMethod` and `ClassMethod`.
-/// The `?` is what makes the wrapped callable a constant, and it registers the
-/// invalidation an assignment owes; pyre's setters do not force that yet, so
-/// the field stays LIVE/MUTABLE here and the read is paired with a
-/// `GuardValue`, the same pre-invalidation stand-in
-/// [`FUNCTION_DESCR_GROUP`] documents for `code?`.
+/// The `?` lives on [`STATICMETHOD_W_FUNCTION_QUASI_DESCR`] and its twin rather
+/// than on this row: those two carry an owner-reserved index the layout cannot
+/// supply, and `w_*_set_func` forces the invalidation.  This row stays LIVE and
+/// describes the same word for an ordinary read of the slot.
 ///
 /// Both censuses are COMPLETE — `w_dict` is listed even though nothing reads
 /// it, because a field the struct declares but a group omits has no
@@ -2750,17 +2762,54 @@ pub fn method_w_function_descr() -> DescrRef {
     field_descr_from_group(&W_METHOD_DESCR_GROUP, 0)
 }
 
-/// Live `StaticMethod.w_function` — the callable a descriptor fold unwraps in
-/// place of invoking `__get__`.  Read live and pinned by a `GuardValue`; see
-/// [`W_STATICMETHOD_DESCR_GROUP`] for why it is not a constant.
-pub fn staticmethod_w_function_descr() -> DescrRef {
-    field_descr_from_group(&W_STATICMETHOD_DESCR_GROUP, 0)
+/// `function.py:673 StaticMethod._immutable_fields_ = ['w_function?']` — the
+/// callable a descriptor fold unwraps in place of invoking `__get__`.
+///
+/// Minted standalone rather than read out of [`W_STATICMETHOD_DESCR_GROUP`],
+/// the way the `w_fget?` / `w_fset?` twins are: the group's own row derives its
+/// index from the layout, and this owner needs an index of its own for the
+/// reason [`WRAPPER_DESCR_TAG`] records.  The group keeps its census row for
+/// the field's ordinary reads.
+static STATICMETHOD_W_FUNCTION_QUASI_DESCR: LazyLock<DescrRef> = LazyLock::new(|| {
+    Arc::new(
+        majit_ir::descr::SimpleFieldDescr::new_with_name(
+            STATICMETHOD_W_FUNCTION_INDEX,
+            pyre_object::function::STATICMETHOD_W_FUNCTION_OFFSET,
+            std::mem::size_of::<usize>(),
+            Type::Ref,
+            false,
+            majit_ir::descr::ArrayFlag::Unsigned,
+            "StaticMethod.w_function".to_string(),
+            "w_function".to_string(),
+        )
+        .with_quasi_immutable(true),
+    )
+});
+
+pub fn staticmethod_w_function_quasi_descr() -> DescrRef {
+    STATICMETHOD_W_FUNCTION_QUASI_DESCR.clone()
 }
 
-/// Live `ClassMethod.w_function` — the `classmethod` twin of
-/// [`staticmethod_w_function_descr`].
-pub fn classmethod_w_function_descr() -> DescrRef {
-    field_descr_from_group(&W_CLASSMETHOD_DESCR_GROUP, 0)
+/// The `function.py:720 ClassMethod` twin of
+/// [`STATICMETHOD_W_FUNCTION_QUASI_DESCR`].
+static CLASSMETHOD_W_FUNCTION_QUASI_DESCR: LazyLock<DescrRef> = LazyLock::new(|| {
+    Arc::new(
+        majit_ir::descr::SimpleFieldDescr::new_with_name(
+            CLASSMETHOD_W_FUNCTION_INDEX,
+            pyre_object::function::CLASSMETHOD_W_FUNCTION_OFFSET,
+            std::mem::size_of::<usize>(),
+            Type::Ref,
+            false,
+            majit_ir::descr::ArrayFlag::Unsigned,
+            "ClassMethod.w_function".to_string(),
+            "w_function".to_string(),
+        )
+        .with_quasi_immutable(true),
+    )
+});
+
+pub fn classmethod_w_function_quasi_descr() -> DescrRef {
+    CLASSMETHOD_W_FUNCTION_QUASI_DESCR.clone()
 }
 
 /// Resolve one [`FUNCTION_DESCR_GROUP`] field by byte offset, so the accessors

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -2635,12 +2635,13 @@ pub(crate) fn fbw_callee_body_replay_safety(
             // replay reads the same value again.  Its writing twin
             // `SetCurrentException` is not here — it is journalled, and so
             // reaches the `deferred_call` arm below instead.
-            // `load_deref` is that same shape once more, and it is the one every
-            // closure body carries: `bh_load_deref_value_fn` dereferences a cell
-            // and returns its contents, writing nothing, so a replay reads the
-            // same cell again.  Its raise on an unbound free variable is no
-            // barrier — `load_global` above raises `NameError` too, and a replay
-            // raises the same one.  Its writing twin `StoreDeref` is not here.
+            // `load_deref` reads the same shape once more — `bh_load_deref_value_fn`
+            // dereferences a cell and returns its contents, writing nothing —
+            // but it is absent from this list because it reaches it untagged:
+            // the `load_deref_value` emit in `codewriter.rs` passes no
+            // `PyreHelperKind`, so `ei.pyre_helper` is `None` and every closure
+            // body that reads a free variable declines here.  Admitting it is a
+            // tag away, not a proof away.
             let replay_safe_read = matches!(
                 ei.pyre_helper,
                 majit_ir::PyreHelperKind::LoadConst

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -6315,7 +6315,7 @@ pub(crate) fn try_walker_inline_property_get<Sym: WalkSym>(
     // own past this point, so keep a rewind point the way the type-call fold
     // does.
     let pre_fold_pos = ctx.trace_ctx.get_trace_position();
-    walker_pin_property_accessor(ctx, op.pc, w_descr, crate::descr::property_fget_descr())?;
+    walker_pin_descriptor_slot(ctx, op.pc, w_descr, crate::descr::property_fget_descr())?;
     let inlined = try_walker_inline_resolved_user_call(
         ctx,
         op,
@@ -6403,10 +6403,10 @@ enum WrapperField {
 }
 
 impl WrapperField {
-    fn descr(&self) -> majit_ir::DescrRef {
+    fn quasi_descr(&self) -> majit_ir::DescrRef {
         match self {
-            Self::ClassMethod => crate::descr::classmethod_w_function_descr(),
-            Self::StaticMethod => crate::descr::staticmethod_w_function_descr(),
+            Self::ClassMethod => crate::descr::classmethod_w_function_quasi_descr(),
+            Self::StaticMethod => crate::descr::staticmethod_w_function_quasi_descr(),
         }
     }
 }
@@ -6499,12 +6499,13 @@ pub(crate) fn try_walker_inline_getattr_hook<Sym: WalkSym>(
     // The pins above make the DESCRIPTOR a constant; they say nothing about the
     // callable inside it.  Re-initialising an installed wrapper swaps
     // `w_function` without touching the owner type's version tag, which is the
-    // only thing those pins hold, so read the slot live and pin the value this
-    // fold unwrapped — the stand-in [`walker_guard_function_field`] already
-    // makes for a quasi-immutable field pyre's setters do not invalidate.
+    // only thing those pins hold, so the unwrapped callable needs a pin of its
+    // own.  `function.py:673`/`:720` declares that slot `w_function?`, and
+    // `w_*_set_func` now forces the invalidation, so this is the declared
+    // marker rather than the `GuardValue` that stood in for it — the fold bakes
+    // `w_func` below and never reads the slot back.
     if let Some(field) = wrapper_field {
-        let wrapper = ctx.trace_ctx.const_ref(w_getattr as i64);
-        walker_guard_function_field(ctx, op.pc, wrapper, field.descr(), w_func as i64)?;
+        walker_pin_descriptor_slot(ctx, op.pc, w_getattr, field.quasi_descr())?;
     }
 
     let name_obj =
@@ -6644,7 +6645,7 @@ pub(crate) fn try_walker_inline_property_set<Sym: WalkSym>(
     let fset_const = ctx.trace_ctx.const_ref(fset as i64);
     // Rewind point for the same reason as the getter twin.
     let pre_fold_pos = ctx.trace_ctx.get_trace_position();
-    walker_pin_property_accessor(ctx, op.pc, w_descr, crate::descr::property_fset_descr())?;
+    walker_pin_descriptor_slot(ctx, op.pc, w_descr, crate::descr::property_fset_descr())?;
     let inlined = try_walker_inline_resolved_user_call(
         ctx,
         op,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8698,8 +8698,10 @@ fn walker_pin_type_version_tag<Sym: WalkSym>(
 }
 
 /// The `descriptor.py:175 _immutable_fields_ = ["w_fget?", "w_fset?",
-/// "w_fdel?"]` twin of [`walker_pin_type_version_tag`]: pin the accessor slot
-/// a property fold is about to bake.
+/// "w_fdel?"]` / `function.py:673 ['w_function?']` twin of
+/// [`walker_pin_type_version_tag`]: pin the slot a descriptor fold is about to
+/// bake, whether that is a property's accessor or a `staticmethod` /
+/// `classmethod`'s wrapped callable.
 ///
 /// The receiver pins the folds already hold — class, `w_class`, and the type's
 /// `_version_tag?` — make the DESCRIPTOR a compile-time answer, and stop
@@ -8714,7 +8716,7 @@ fn walker_pin_type_version_tag<Sym: WalkSym>(
 /// dereferences the owner only at record and compile time, and a property is
 /// allocated non-moving, so both reads see the object where the constant says
 /// it is.
-fn walker_pin_property_accessor<Sym: WalkSym>(
+fn walker_pin_descriptor_slot<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,
     w_descr: pyre_object::PyObjectRef,
@@ -8726,7 +8728,7 @@ fn walker_pin_property_accessor<Sym: WalkSym>(
 }
 
 /// The `function.py:47 _immutable_fields_ = ['code?', 'w_func_globals?',
-/// 'closure?[*]', 'defs_w?[*]']` twin of [`walker_pin_property_accessor`]: pin
+/// 'closure?[*]', 'defs_w?[*]']` twin of [`walker_pin_descriptor_slot`]: pin
 /// the callee's code slot when the inline lever cannot re-prove it per
 /// iteration.
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -3292,8 +3292,8 @@ pub(crate) fn try_walker_specialize_load_method_attr<Sym: WalkSym>(
 /// The safety oracle is [`pyre_interpreter::classmethod_on_type_fast_path`]: it
 /// declines a custom metaclass, a metatype-defined name, an uncacheable type,
 /// and any non-`classmethod` descriptor.  On success the walker pins the exact
-/// type and its version tag, then writes the classmethod's `__func__` as a
-/// green constant.  Because the method-load result is the plain `__func__` (not
+/// type, its version tag, and the descriptor's `w_function?` slot, then writes
+/// the classmethod's `__func__` as a green constant.  Because the method-load result is the plain `__func__` (not
 /// a bound `Method`), the paired [`try_walker_fold_load_method_self`] runs
 /// `compute_load_method_bound`, whose `is_type` + `is_classmethod` arm binds the
 /// type as `cls`, and the following `CALL` inlines `__func__(cls, ...)` — the
@@ -3329,7 +3329,7 @@ pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
     if name.contains("__") {
         return Ok(None);
     }
-    let Some((w_type, version_tag, w_func)) =
+    let Some((w_type, version_tag, w_descr, w_func)) =
         (unsafe { pyre_interpreter::classmethod_on_type_fast_path(concrete_obj, &name) })
     else {
         return Ok(None);
@@ -3347,10 +3347,22 @@ pub(crate) fn try_walker_specialize_load_classmethod_attr<Sym: WalkSym>(
         .heap_cache_mut()
         .replace_box(obj, w_type_const);
 
-    // typeobject.py `promote(self.version_tag())`: class mutation or classmethod
-    // reassignment in the class or any base bumps `_version_tag`, so the pinned
-    // `__func__` side-exits.
+    // typeobject.py `promote(self.version_tag())`: class mutation or rebinding
+    // the attribute to a different descriptor in the class or any base bumps
+    // `_version_tag`, so the pinned `__func__` side-exits.
     walker_pin_type_version_tag(ctx, op_pc, w_type_const)?;
+
+    // What the version tag does NOT reach: re-initialising the classmethod in
+    // place leaves the class dict, the descriptor's address, and every version
+    // tag alone while replacing the callable this fold is about to bake.
+    // `function.py:720` declares that slot `w_function?` for exactly this, and
+    // `w_classmethod_set_func` forces the invalidation.
+    walker_pin_descriptor_slot(
+        ctx,
+        op_pc,
+        w_descr,
+        crate::descr::classmethod_w_function_quasi_descr(),
+    )?;
 
     let func_const = ctx.trace_ctx.const_ref(w_func as i64);
     write_residual_call_result_to_dst(ctx, op_pc, dst, dst_bank, func_const)?;

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5115,7 +5115,7 @@ fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
     // one must fail loudly rather than reinterpret a headerless map-node
     // allocation as a `W_TypeObject`.  Dropping the old implicit `W_TypeObject`
     // fallback is safe: the arms below are every quasi-immutable descr this
-    // binary can mint — the nine hand-minted singletons, plus the nine
+    // binary can mint — the eleven hand-minted singletons, plus the nine
     // `Function` fields `function.py:34-42` declares, which
     // `function_quasi_immut_slot` resolves as a group.  No analyzer-derived
     // descr reaches here: a `#[jit_immutable_fields]` entry would need the
@@ -5156,6 +5156,14 @@ fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
             );
         } else if index == crate::descr::property_fset_descr().index() {
             pyre_object::descriptor::w_property_install_fset_watcher(
+                struct_ptr as pyre_object::PyObjectRef,
+            );
+        } else if index == crate::descr::staticmethod_w_function_quasi_descr().index() {
+            pyre_object::function::w_staticmethod_install_w_function_watcher(
+                struct_ptr as pyre_object::PyObjectRef,
+            );
+        } else if index == crate::descr::classmethod_w_function_quasi_descr().index() {
+            pyre_object::function::w_classmethod_install_w_function_watcher(
                 struct_ptr as pyre_object::PyObjectRef,
             );
         } else if let Some(slot) = crate::descr::function_quasi_immut_slot(index) {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7490,6 +7490,18 @@ fn loop_region_ranges(
             // Without a handler to name a start the jump is not an out-of-line
             // rejoin, and the span back to the body is kept whole rather than
             // guessed at.
+            //
+            // With several disjoint handlers laid out after the body this
+            // swallows the bytecode between the earliest one and the jump, and
+            // the two readers of these ranges want opposite things from that.
+            // `loop_region_for_iter_bodies_all_jit_safe` only loses inlining —
+            // an unsafe `FOR_ITER` in the swallowed span declines a loop that
+            // could not reach it — while narrowing to the handler nearest the
+            // jump would let it admit a frame whose unsafe `FOR_ITER` really
+            // does run.  The pessimistic side is the one that cannot be wrong,
+            // so it stands until the ranges are built from the exception
+            // table's `(start, end, target)` extents, which name the block a
+            // jump belongs to instead of inferring it from target order.
             let start = handler_starts
                 .iter()
                 .copied()
@@ -7554,6 +7566,13 @@ fn loop_region_contains_escaping_range_append(
     for (pc, unit) in code.instructions.iter().copied().enumerate() {
         let (instr, op_arg) = decode.get(unit);
         if !ranges.iter().any(|range| range.contains(&pc)) {
+            // The region is a body span plus the out-of-line handler spans that
+            // rejoin it, so the scan crosses gaps.  A partial match may not span
+            // one: a body's trailing `LOAD_ATTR append` would otherwise stay
+            // `AwaitRange` until a handler's own `LOAD_GLOBAL range` and two
+            // calls completed the pattern, reporting an `append(range(...))` no
+            // execution path performs.
+            state = State::Searching;
             continue;
         }
         match instr {

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -6390,10 +6390,14 @@ pub(crate) fn register_quasi_immutable_deps(_green_key: u64) {
     let audit_holder_hooks = pyre_jit_trace::descr::audit_holder_hooks_descr().index();
     let property_fget = pyre_jit_trace::descr::property_fget_descr().index();
     let property_fset = pyre_jit_trace::descr::property_fset_descr().index();
+    let staticmethod_w_function =
+        pyre_jit_trace::descr::staticmethod_w_function_quasi_descr().index();
+    let classmethod_w_function =
+        pyre_jit_trace::descr::classmethod_w_function_quasi_descr().index();
     // Hoisted because each accessor clones a `LazyLock` descr; the index also
     // decides which type `dep_ptr` is cast to, so the chain below ends in a
     // fail-loud default rather than reinterpreting a headerless map node as a
-    // `W_TypeObject`.  These nine plus the nine `Function` fields
+    // `W_TypeObject`.  These eleven plus the nine `Function` fields
     // `function_quasi_immut_slot` resolves are every quasi-immutable descr this
     // binary mints — see the same reasoning on `state.rs
     // install_quasiimmut_field`.
@@ -6441,6 +6445,16 @@ pub(crate) fn register_quasi_immutable_deps(_green_key: u64) {
                 );
             } else if field_index == property_fset {
                 pyre_object::descriptor::w_property_register_fset_watcher(
+                    dep_ptr as pyre_object::PyObjectRef,
+                    &flag,
+                );
+            } else if field_index == staticmethod_w_function {
+                pyre_object::function::w_staticmethod_register_w_function_watcher(
+                    dep_ptr as pyre_object::PyObjectRef,
+                    &flag,
+                );
+            } else if field_index == classmethod_w_function {
+                pyre_object::function::w_classmethod_register_w_function_watcher(
                     dep_ptr as pyre_object::PyObjectRef,
                     &flag,
                 );

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -187,8 +187,13 @@ pub struct W_Property {
     /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
     /// stated precondition: the lock cannot be remapped out from under a
     /// holder.  A property the collector reclaims without a prior invalidation
-    /// leaks its instance box, the same bounded leak `W_TypeObject` carries,
-    /// because a GC object's `Drop` never runs.
+    /// leaks its instance box, because a GC object's `Drop` never runs — one
+    /// allocation per watched owner, so a program that keeps minting and
+    /// discarding traced descriptors keeps accumulating them rather than
+    /// settling at a fixed cost.  `W_TypeObject` and `Function::mutate_slots`
+    /// carry the same pattern; closing it needs a reclamation hook for a
+    /// collected object's off-heap side allocation, which the collector has
+    /// no notion of today.
     ///
     /// `w_fdel?` is declared upstream on the same line and gets no watcher
     /// here: no fold bakes `fdel`, so nothing would ever register on it.  A

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -175,6 +175,20 @@ pub struct StaticMethod {
     /// `StaticMethod.getdict`, then populated by `descr_init` with the
     /// wrapped function's presentation attributes.
     pub w_dict: PyObjectRef,
+    /// The hidden `mutate_w_function` field for `function.py:673
+    /// _immutable_fields_ = ['w_function?']` — see [`crate::quasiimmut`].
+    ///
+    /// Holds no GC pointers, so the derived `W_STATICMETHOD_GC_PTR_OFFSETS` has
+    /// nothing to walk here, and it is deliberately absent from the descr
+    /// census: it is an `AtomicPtr` plus a lock rather than one pointer-shaped
+    /// word, so a `Type::Ref` row would misdescribe it, and no emit allocates
+    /// either wrapper, so `rewrite.py clear_gc_fields` never runs over this
+    /// layout.  The allocation is [`crate::gc_hook::try_gc_alloc_stable_raw`],
+    /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
+    /// stated precondition: the lock cannot be remapped out from under a
+    /// holder, and the compile-time watcher registration resolves this owner
+    /// by the address recording saw.
+    pub w_function_watchers: crate::quasiimmut::QuasiImmutField,
 }
 
 /// Field offsets of the inline `PyObjectRef` slots within `StaticMethod`,
@@ -207,6 +221,7 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
                     ob: header,
                     w_function: func,
                     w_dict: PY_NULL,
+                    w_function_watchers: crate::quasiimmut::QuasiImmutField::new(),
                 },
             );
         }
@@ -217,6 +232,7 @@ pub fn w_staticmethod_new(func: PyObjectRef) -> PyObjectRef {
         ob: header,
         w_function: func,
         w_dict: PY_NULL,
+        w_function_watchers: crate::quasiimmut::QuasiImmutField::new(),
     })
 }
 
@@ -234,9 +250,59 @@ pub unsafe fn w_staticmethod_get_func(obj: PyObjectRef) -> PyObjectRef {
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_staticmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
     unsafe {
+        // `rclass.py hook_setfield` emits `jit_force_quasi_immutable` ahead of
+        // every store to a `?` field, so the wrapped callable stops being a
+        // trace constant before it stops being the live value.  The hook
+        // precedes the store and does not consult it, so re-initialising the
+        // slot with the value it already holds invalidates as well.  Nothing
+        // else revokes a fold over this wrapper: re-initialising an installed
+        // descriptor changes no type's version tag, which is the only other pin
+        // the folds that unwrap `w_function` hold.  The `is_installed` test is
+        // `pyjitpl.py:1112`'s `mutatebox.nonnull()` — a wrapper no loop watches
+        // pays one load.
+        if (*(obj as *const StaticMethod))
+            .w_function_watchers
+            .is_installed()
+        {
+            crate::quasiimmut::sweep_quasi_immut_field(
+                &(*(obj as *const StaticMethod)).w_function_watchers,
+            );
+        }
         (*(obj as *mut StaticMethod)).w_function = func;
         crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
+}
+
+/// `quasiimmut.py get_current_qmut_instance` for `function.py`'s
+/// `w_function?` — install the instance at RECORD time so a write reached
+/// later in the same trace sees it.
+///
+/// # Safety
+/// `obj` must point to a live [`StaticMethod`].
+pub unsafe fn w_staticmethod_install_w_function_watcher(obj: PyObjectRef) {
+    if obj.is_null() {
+        return;
+    }
+    (*(obj as *const StaticMethod))
+        .w_function_watchers
+        .ensure_installed();
+}
+
+/// Attach a compiled loop's invalidation flag to this wrapper's `w_function?`
+/// watcher, the `quasiimmut.py QuasiImmut.register_loop_token` half.
+///
+/// # Safety
+/// `obj` must point to a live [`StaticMethod`].
+pub unsafe fn w_staticmethod_register_w_function_watcher(
+    obj: PyObjectRef,
+    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if obj.is_null() {
+        return;
+    }
+    (*(obj as *const StaticMethod))
+        .w_function_watchers
+        .register_loop_token(flag);
 }
 
 /// function.py:678-681 `StaticMethod.getdict` — allocate the instance
@@ -306,6 +372,20 @@ pub struct ClassMethod {
     /// function.py:724 `self.w_dict = None` — a real per-wrapper field,
     /// allocated lazily by `ClassMethod.getdict`.
     pub w_dict: PyObjectRef,
+    /// The hidden `mutate_w_function` field for `function.py:720
+    /// _immutable_fields_ = ['w_function?']` — see [`crate::quasiimmut`].
+    ///
+    /// Holds no GC pointers, so the derived `W_CLASSMETHOD_GC_PTR_OFFSETS` has
+    /// nothing to walk here, and it is deliberately absent from the descr
+    /// census: it is an `AtomicPtr` plus a lock rather than one pointer-shaped
+    /// word, so a `Type::Ref` row would misdescribe it, and no emit allocates
+    /// either wrapper, so `rewrite.py clear_gc_fields` never runs over this
+    /// layout.  The allocation is [`crate::gc_hook::try_gc_alloc_stable_raw`],
+    /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
+    /// stated precondition: the lock cannot be remapped out from under a
+    /// holder, and the compile-time watcher registration resolves this owner
+    /// by the address recording saw.
+    pub w_function_watchers: crate::quasiimmut::QuasiImmutField,
 }
 
 /// Field offsets of the inline `PyObjectRef` slots within `ClassMethod`, the
@@ -337,6 +417,7 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
                     ob: header,
                     w_function: func,
                     w_dict: PY_NULL,
+                    w_function_watchers: crate::quasiimmut::QuasiImmutField::new(),
                 },
             );
         }
@@ -347,6 +428,7 @@ pub fn w_classmethod_new(func: PyObjectRef) -> PyObjectRef {
         ob: header,
         w_function: func,
         w_dict: PY_NULL,
+        w_function_watchers: crate::quasiimmut::QuasiImmutField::new(),
     })
 }
 
@@ -364,9 +446,59 @@ pub unsafe fn w_classmethod_get_func(obj: PyObjectRef) -> PyObjectRef {
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_classmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
     unsafe {
+        // `rclass.py hook_setfield` emits `jit_force_quasi_immutable` ahead of
+        // every store to a `?` field, so the wrapped callable stops being a
+        // trace constant before it stops being the live value.  The hook
+        // precedes the store and does not consult it, so re-initialising the
+        // slot with the value it already holds invalidates as well.  Nothing
+        // else revokes a fold over this wrapper: re-initialising an installed
+        // descriptor changes no type's version tag, which is the only other pin
+        // the folds that unwrap `w_function` hold.  The `is_installed` test is
+        // `pyjitpl.py:1112`'s `mutatebox.nonnull()` — a wrapper no loop watches
+        // pays one load.
+        if (*(obj as *const ClassMethod))
+            .w_function_watchers
+            .is_installed()
+        {
+            crate::quasiimmut::sweep_quasi_immut_field(
+                &(*(obj as *const ClassMethod)).w_function_watchers,
+            );
+        }
         (*(obj as *mut ClassMethod)).w_function = func;
         crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
     }
+}
+
+/// `quasiimmut.py get_current_qmut_instance` for `function.py`'s
+/// `w_function?` — install the instance at RECORD time so a write reached
+/// later in the same trace sees it.
+///
+/// # Safety
+/// `obj` must point to a live [`ClassMethod`].
+pub unsafe fn w_classmethod_install_w_function_watcher(obj: PyObjectRef) {
+    if obj.is_null() {
+        return;
+    }
+    (*(obj as *const ClassMethod))
+        .w_function_watchers
+        .ensure_installed();
+}
+
+/// Attach a compiled loop's invalidation flag to this wrapper's `w_function?`
+/// watcher, the `quasiimmut.py QuasiImmut.register_loop_token` half.
+///
+/// # Safety
+/// `obj` must point to a live [`ClassMethod`].
+pub unsafe fn w_classmethod_register_w_function_watcher(
+    obj: PyObjectRef,
+    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
+    if obj.is_null() {
+        return;
+    }
+    (*(obj as *const ClassMethod))
+        .w_function_watchers
+        .register_loop_token(flag);
 }
 
 /// function.py:726-729 `ClassMethod.getdict`.


### PR DESCRIPTION
Six commits. The last one is the substantive change; the first five close review findings from #1295.

## `w_function?` (`511bc770ff2`)

`function.py:673` / `:720` declare `_immutable_fields_ = ['w_function?']` for `StaticMethod` and `ClassMethod`. Neither slot was modelled that way: both were read live and pinned with a `GuardValue`, and the classmethod-on-type fold pinned only the receiving type's version tag.

That last one is **wrong code, not just a missed constant**. `bench/synth/wrapper_function_invalidation.py`, arm 3:

```python
descr = Scaled.__dict__['scaled']
while i < N:
    total += Scaled.scaled(i)
    if i == SWITCH:
        descr.__init__(second_scaled)
    i += 1
```

Re-initialising an installed `classmethod` swaps `w_function` and bumps no type's version tag, so the fold's only pin still holds while the callable it baked has been replaced. Measured on this branch with just that one pin removed (everything else identical):

| arm | pin | result |
|---|---|---|
| `staticmethod` hook | quasi-immut | 599999 ✅ |
| `classmethod` hook | quasi-immut | 599999 ✅ |
| `classmethod` on type | **none — as on `main`** | **400001** ❌ |

Interpreter (`PYRE_NO_JIT=1`), CPython and pypy all say 599999. 400001 = `N + 1`: every one of the 200000 reads after the switch returned the stale callable.

The other two arms were correct on `main` — the `GuardValue` caught the rebind — and are upgraded to the invalidation protocol here, so the fold survives as a constant instead of a guard.

### Shape

- `StaticMethod` / `ClassMethod` each carry a `QuasiImmutField`, initialised at all four allocation sites; `w_*_set_func` sweeps an installed field before every store, matching `rclass.py hook_setfield`.
- The two `w_function?` descrs are minted as **standalone singletons** under a new reserved `WRAPPER` tag, the way `w_fget?` / `w_fset?` already are. `stable_field_index` names a layout, not an owner, and the two wrappers' layouts are byte-identical — it cannot tell them apart, and that index is what selects the pointer cast in `install_quasiimmut_field` / `register_quasi_immutable_deps`. The group census rows stay put for ordinary reads of the same word.
- `classmethod_on_type_fast_path` now also returns the descriptor, so the specializer has something to pin `w_function?` against.

## Review follow-ups

- `d192a4240d8` — `for_iter` gate: the range recognizer kept partial state across a region gap, so a body's trailing `LOAD_ATTR append` could pair with a handler's `LOAD_GLOBAL range` and report an `append(range(...))` no execution path performs.
- `ff0ebfdd7fd` — corrected the `load_deref` note above `replay_safe_read`: it reaches the scan untagged, so every closure body reading a free variable declines.
- `3268150b64f` — `handle_jitexception` now marks each non-portal level it unwinds as finished, with a test.
- `b21c33676f1` — `_abc.register` rejects a non-type up front like upstream, and the negative-cache generation is compared as a value. The two in-code comments claiming this was blocked were stale: verified 0 non-type registrations over 1005 classes / 25 modules.
- `b31d896ba35` — corrected a leak note to "one allocation per watched owner".

## Gates

`check.py --backend dynasm` 443/443 · `cargo test --all --no-default-features --features dynasm` rc=0 · parity `--dynasm-only` rc=0 · `cpython_tests --backend dynasm` no regressions. cranelift and wasm left to CI; the new fixture's three baselines are identical, matching `property_accessor_invalidation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale optimized behavior when `staticmethod` or `classmethod` implementations are replaced at runtime.
  * Improved invalidation of optimized method lookups, ensuring subsequent calls use updated implementations.
  * Corrected abstract base class registration, subclass checks, cache generation handling, and non-type validation.
  * Improved exception unwinding across recursive execution levels while preserving terminal results.

* **Performance**
  * Enhanced runtime optimization reliability for descriptor access and method dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->