### PR TITLE
jit, wasm: cut an over-limit trace at a merge point, publish an always-failing guard's fail args, and reset a replacement loop's retrace count

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -4726,13 +4726,34 @@ fn build_function(
                 );
                 guard_idx += 1;
             }
-            OpCode::GuardFutureCondition | OpCode::GuardAlwaysFails => {
-                // GuardAlwaysFails always exits. This arm writes neither the
-                // fail args nor `frame[0]`, so it keeps branching to the shared
-                // epilogue — giving it the ordinary guard spill would change
-                // what the exit reports, not just how it gets there. The
-                // epilogue takes a cell address when bridge dispatch is on;
-                // otherwise retain the unused index write unchanged.
+            OpCode::GuardAlwaysFails => {
+                // This guard always exits, and what it exits INTO is the
+                // interpreter: it is the cut a segmented trace ends with
+                // (`rewrite.py:419-426` lowers it to `GUARD_VALUE(SAME_AS_I(0),
+                // 1)` for the backends that run the GC rewrite, so those reach
+                // the ordinary GUARD_VALUE path). This backend does not run
+                // that rewrite, so the raw opcode arrives here and has to
+                // publish its own fail args — the resume rebuilds the frame
+                // from them, and an exit that writes none leaves the
+                // interpreter reading whatever the slots last held.
+                emit_guard_exit(
+                    &mut sink,
+                    constants,
+                    value_types,
+                    guard_idx,
+                    op,
+                    block_exit_depth,
+                    guard_dispatch,
+                );
+                guard_idx += 1;
+            }
+            OpCode::GuardFutureCondition => {
+                // This arm writes neither the fail args nor `frame[0]`, so it
+                // keeps branching to the shared epilogue — giving it the
+                // ordinary guard spill would change what the exit reports, not
+                // just how it gets there. The epilogue takes a cell address
+                // when bridge dispatch is on; otherwise retain the unused index
+                // write unchanged.
                 if !guard_dispatch.param_type_indices.is_empty() {
                     emit_guard_param_tail_call(
                         &mut sink,

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -3035,13 +3035,16 @@ impl<S: JitState> JitDriver<S> {
             // pyjitpl.py:1617-1620 places the `force_finish_trace` segmenting
             // check INSIDE the tracing loop, in `MIFrame.debug_merge_point`, so
             // a JC_FORCE_FINISH key segments before the 1.0x too-long check can
-            // abort it.  Pyre's counterpart lives at the same place — the
-            // walker's `BC_JIT_MERGE_POINT` handler
-            // (`pyjitpl/dispatch.rs::create_segmented_trace`) — and reaches this
-            // driver as `TraceAction::SegmentedLoop`.  A check here instead
-            // would be unreachable: the walk returns `Continue` only once its
-            // framestack drains, and an over-budget walk returns `Abort` from
-            // inside its own loop.
+            // abort it.  Pyre's counterpart lives at the same place, in the
+            // production tracer's `jit_merge_point` arm
+            // (`jitcode_dispatch/mod.rs`, whose `create_segmented_trace` the
+            // walk returns `DispatchOutcome::SegmentTrace` from); `trace.rs`
+            // maps it onto the `TraceAction::SegmentedLoop` /
+            // `SegmentedBridge` arm below.  `pyjitpl/dispatch.rs` carries a
+            // second copy on `MIFrame::run_one_step`, which production tracing
+            // does not go through.  A check here instead would be unreachable:
+            // the walk returns `Continue` only once its framestack drains, and
+            // an over-budget walk returns `Abort` from inside its own loop.
 
             // Phase 2: handle trace result with full access to self
             match action {

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -4279,6 +4279,42 @@ mod tests {
     }
 
     #[test]
+    fn descrless_const_heap_short_box_is_skipped_not_panicked() {
+        // The sibling above builds the heap op through `Op::with_descr`, so the
+        // field descr the const channel needs is always there. A heap short box
+        // can reach this point without one, and the channel has to drop it
+        // rather than unwrap: without a descr there is nothing to re-emit the
+        // load from, and a produced entry would name a field the import cannot
+        // resolve.
+        let mut ctx = crate::optimizeopt::OptContext::with_inputarg_types(16, &[Type::Ref]);
+        let struct_arg = OpRef::input_arg_ref(0);
+        let constant = OpRef::const_int(7);
+        let mut sb = ShortBoxes::with_label_args(&[struct_arg]);
+        sb.add_short_input_arg(&mut ctx, struct_arg, Type::Ref);
+
+        let heap = Op::new(
+            OpCode::GetfieldGcI,
+            &[ctx.materialize_operand_at(struct_arg)],
+        );
+        heap.pos.set(constant);
+        sb.add_heap_op(&mut ctx, heap);
+
+        let produced = sb.produced_ops(&mut ctx);
+        let produced_const = sb.produced_const_ops(&mut ctx);
+
+        assert!(
+            produced
+                .iter()
+                .all(|(_, produced)| produced.res.to_opref() != constant),
+            "produced_ops must not carry the const result"
+        );
+        assert!(
+            produced_const.is_empty(),
+            "a descr-less const heap short box is skipped, not produced"
+        );
+    }
+
+    #[test]
     fn test_compound_pure_loser_to_short_inputarg_clears_label_arg_idx() {
         // shortpreamble.py:326-333 — when a Pure alternative loses the compound
         // tie to the ShortInputArg, its result is rebound to a fresh SameAs box

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -6063,9 +6063,8 @@ impl<M: Clone> MetaInterp<M> {
         // next `begin_trace_session` sees a clean slate, and fire the
         // `pyjitpl.py:2897 finally: profiler.end_tracing()` pairing for
         // the `start_tracing` opened by `prepare_trace_start_runtime`.
-        // Cancelled paths that kept `self.tracing` alive (e.g.
-        // `prior_retraced_count == MAX` above) fall through harmlessly
-        // and keep tracing running.
+        // Cancelled paths that kept `self.tracing` alive fall through
+        // harmlessly and keep tracing running.
         if self.tracing.is_none() {
             self.clear_trace_session();
         }
@@ -6322,12 +6321,14 @@ impl<M: Clone> MetaInterp<M> {
         // `abort_tracing(green_key, permanent = true)`, i.e. `DONT_TRACE_HERE`
         // forever, where the ordinary abort path escalates only after
         // `MAX_TRACE_ABORT_COUNT` aborts.
-        let prior_retraced_count_early = self
-            .compiled_loops
-            .get(&green_key)
-            .and_then(|compiled| compiled.live_token())
-            .map(|token| token.get_retraced_count())
-            .unwrap_or(0);
+        //
+        // Carrying the count forward is wrong for the same reason. That token
+        // is the one the cell no longer offers; the loop this compile builds
+        // gets a fresh `JitCellToken` (`compile.py:220` and `:266` both call
+        // `make_jitcell_token`), whose count starts at zero. Only
+        // `compile_retrace` reuses a token, and it reuses the live one
+        // (`compile.py:355 get_procedure_token`), so that is where a retrace
+        // budget legitimately persists.
 
         // compile.py:269-270 `jitcell_token = cross_loop.jitcell_token`: mark
         // the key this loop is about to be stored under as cut-owned, before
@@ -6525,10 +6526,9 @@ impl<M: Clone> MetaInterp<M> {
         // (`optimizeopt/unroll.rs`) inserts that one element, so an empty list
         // here is `[start_descr]`, not an absent label.
         //
-        // The drain stays: the `prior_retraced_count == u32::MAX` early
-        // Cancelled path returns above, so reaching this point means a
-        // recompile is under way and the tokens a previous InvalidLoop attempt
-        // parked for this green key are spent either way.
+        // The drain stays: reaching this point means a recompile is under way,
+        // so the tokens a previous InvalidLoop attempt parked for this green
+        // key are spent either way.
         self.pending_preamble_tokens.swap_remove(&green_key);
         let prior_front_target_tokens: Vec<crate::history::TargetToken> = Vec::new();
         let mut unroll_opt = crate::optimizeopt::unroll::UnrollOptimizer::new();
@@ -6540,7 +6540,12 @@ impl<M: Clone> MetaInterp<M> {
             Some((&mut self.compile_short_preamble_producer as *mut Option<usize>) as usize);
         unroll_opt.all_descrs = self.staticdata.all_descrs().lock().unwrap().clone();
         unroll_opt.seed_prior_target_tokens(prior_front_target_tokens.clone());
-        unroll_opt.retraced_count = prior_retraced_count_early;
+        // Zero, not the previous entry's count — see the fresh-token note above.
+        // The field still has to be stored back after the unroll runs, because
+        // that is where it is written: `unroll.py:217` increments it and
+        // `unroll.py:272 disable_retracing_if_max_retrace_guards` sets
+        // `sys.maxint`, both on the token this compile is creating.
+        unroll_opt.retraced_count = 0;
         unroll_opt.retrace_limit = self.warm_state.retrace_limit();
         unroll_opt.max_retrace_guards = self.warm_state.max_retrace_guards();
         unroll_opt.callinfocollection = self.callinfocollection.clone();

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -24736,6 +24736,78 @@ mod tests {
 
     // ── JitIface hook/callback parity tests (rpython/jit/metainterp/test/test_jitiface.py) ──
 
+    /// `compile.py:266` mints the loop's token with `make_jitcell_token`, so a
+    /// loop compiled here starts its retrace budget at zero however far the
+    /// previous occupant of the green key had run its own down.
+    ///
+    /// The state under test is the one `compile_loop` actually reaches: past
+    /// the `has_compiled_targets` give-up, which needs `front_target_tokens`
+    /// empty, while the entry's own `Weak` still upgrades. The seeded token
+    /// carries the `unroll.py:272 disable_retracing_if_max_retrace_guards`
+    /// sentinel, which is the value whose transfer costs the replacement loop
+    /// every later retrace.
+    #[test]
+    fn a_replacement_loop_does_not_inherit_the_retrace_count() {
+        let mut meta = MetaInterp::<()>::new(1);
+        meta.finish_setup_descrs_for_jitdrivers();
+
+        let green_key = 42;
+        for _ in 0..2 {
+            meta.on_back_edge(green_key, &[0]);
+        }
+        assert!(meta.tracing.is_some());
+        if let Some(ctx) = meta.trace_ctx() {
+            let i0 = OpRef::input_arg_int(0);
+            let const_one = ctx.const_int(1);
+            let sum = ctx.record_op(OpCode::IntAdd, &[i0, const_one]);
+            let g = ctx.record_guard(OpCode::GuardTrue, &[i0], 0);
+            ctx.capture_snapshot_for_last_guard(&[sum], 0, 0);
+            ctx.set_fail_args(g, &[sum]);
+        }
+
+        // Held for the whole test so the entry's `Weak` upgrades; an entry
+        // whose token is already gone reads as absent and proves nothing.
+        let stale = std::sync::Arc::new(JitCellToken::new(3));
+        stale.set_retraced_count(u32::MAX);
+        meta.compiled_loops.insert(
+            green_key,
+            CompiledEntry {
+                token: std::sync::Arc::downgrade(&stale),
+                meta: std::sync::Arc::new(()),
+                front_target_tokens: Vec::new(),
+                front_entry_index: None,
+                front_target_source_positions: None,
+                root_trace_id: 101,
+                traces: indexmap::IndexMap::new(),
+                previous_tokens: Vec::new(),
+                loop_header_pc: None,
+                next_global_opref: 0,
+            },
+        );
+        assert!(
+            !meta.has_compiled_targets(green_key),
+            "no front target tokens, so this key is one compile_loop proceeds from"
+        );
+
+        meta.compile_loop(&[OpRef::input_arg_int(0)], ());
+
+        let fresh = meta
+            .compiled_loops
+            .get(&green_key)
+            .and_then(|c| c.live_token())
+            .expect("the compile installed a live token");
+        assert_eq!(
+            fresh.get_retraced_count(),
+            0,
+            "the replacement token starts at zero; carrying the sentinel forward \
+             leaves it unable to retrace"
+        );
+        assert!(
+            !std::sync::Arc::ptr_eq(&fresh, &stale),
+            "and it is a new token, not the invalidated one"
+        );
+    }
+
     #[test]
     fn test_on_compile_loop_fires_with_correct_metadata() {
         // Parity with test_on_compile: after_compile hook fires with green_key,

--- a/pyre/bench/synth/trace_segmenting_over_limit_retry.cranelift.jitstats
+++ b/pyre/bench/synth/trace_segmenting_over_limit_retry.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=4
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=6
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1008
+internal_compile_panics=0
+loops_aborted=9
+loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/trace_segmenting_over_limit_retry.dynasm.jitstats
+++ b/pyre/bench/synth/trace_segmenting_over_limit_retry.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=4
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=6
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1008
+internal_compile_panics=0
+loops_aborted=9
+loops_compiled=2
+retraces_compiled=0

--- a/pyre/bench/synth/trace_segmenting_over_limit_retry.py
+++ b/pyre/bench/synth/trace_segmenting_over_limit_retry.py
@@ -1,0 +1,50 @@
+# A loop body fat enough that one traced iteration runs past `trace_limit`, so
+# the trace overflows before it can close. `blackhole_if_trace_too_long`
+# (`pyjitpl.py:2812-2830`) finds no inlinable huge function here, so it calls
+# `prepare_trace_segmenting` (`pyjitpl.py:2831-2859`), which marks the green key
+# with the force-finish flag and asks for the next iteration to be traced again.
+#
+# On that retry the marked key is supposed to CUT: once the trace passes 0.8x
+# `trace_limit` at a `jit_merge_point`, `pyjitpl.py:1617-1620` appends
+# `GUARD_ALWAYS_FAILS`, compiles what it has, and blackholes with
+# `ABORT_SEGMENTED_TRACE`. The cut arm is what turns the key's forever-retracing
+# into compiled code.
+#
+# Without the cut, every retry runs into the same overflow and aborts again:
+# `loops_aborted` read 64 with `bridges_compiled` 0 and `guard_failures` 11918.
+# With it the key segments and the workload runs out of compiled arms instead.
+#
+# The 0.8x check only has something to fire at if a merge point is CROSSED while
+# the trace sits in the 0.8x..1.0x band, so the body size and `trace_limit` are
+# load-bearing together, not independently: at `trace_limit=200` the same body
+# jumps the band in one crossing and never segments.
+#
+# CPython (the oracle) has no `pypyjit`; PyPy and pyre do. Guarding the import
+# keeps the output identical across all three while the params only bind where a
+# JIT exists. `set_param` rather than an environment variable because the wasm
+# guest sees no environment.
+try:
+    import pypyjit
+
+    pypyjit.set_param("trace_limit=300")
+    pypyjit.set_param("threshold=20")
+except ImportError:
+    pass
+
+
+def body(a, b, c, d, e):
+    t = 0
+    for _ in range(4):
+        t += a * 3 + b - c
+        t += (a + b) * (c - d) + e
+        t ^= (t >> 3) + (a | b) + (c & d)
+        t += a * b + c * d + e * 7
+        t -= (a - b) * (c + d) - e
+        t += (t & 0xFF) * 3 + a + b + c + d + e
+    return t
+
+
+s = 0
+for i in range(4000):
+    s += body(i, i + 1, i + 2, i + 3, i + 4)
+print(s % 1000)

--- a/pyre/bench/synth/trace_segmenting_over_limit_retry.wasm.jitstats
+++ b/pyre/bench/synth/trace_segmenting_over_limit_retry.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=4
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=6
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=1008
+internal_compile_panics=0
+loops_aborted=9
+loops_compiled=2
+retraces_compiled=0

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -2953,7 +2953,8 @@ pub(crate) fn try_walker_inline_builtin_call<Sym: WalkSym>(
         ))),
         DispatchOutcome::CloseLoop { .. }
         | DispatchOutcome::CompileTracePending { .. }
-        | DispatchOutcome::SubLoopCalleeCallAssembler { .. } => {
+        | DispatchOutcome::SubLoopCalleeCallAssembler { .. }
+        | DispatchOutcome::SegmentTrace { .. } => {
             Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
         }
         DispatchOutcome::Continue => {
@@ -7953,6 +7954,12 @@ pub(crate) fn dispatch_inline_call_dr_kind<Sym: WalkSym>(
             // breaks.
             Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
         }
+        DispatchOutcome::SegmentTrace { .. } => {
+            // The segmenting cut is gated on `is_top_level` for the same
+            // reason as the compile_trace attempt above: its compile half
+            // lives in the driver, which a callee body has no route to.
+            Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
+        }
         DispatchOutcome::Continue => {
             unreachable!(
                 "walk() only exits on Terminate / SubReturn / SubRaise / SwitchToBlackhole"
@@ -8150,6 +8157,12 @@ pub(crate) fn dispatch_inline_call_dir_kind<Sym: WalkSym>(
             // breaks.
             Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
         }
+        DispatchOutcome::SegmentTrace { .. } => {
+            // The segmenting cut is gated on `is_top_level` for the same
+            // reason as the compile_trace attempt above: its compile half
+            // lives in the driver, which a callee body has no route to.
+            Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
+        }
         DispatchOutcome::Continue => {
             unreachable!(
                 "walk() only exits on Terminate / SubReturn / SubRaise / SwitchToBlackhole"
@@ -8326,6 +8339,12 @@ pub(crate) fn dispatch_inline_call_dirf_kind<Sym: WalkSym>(
             // `try_walker_inline_user_call`; it cannot reach the `inline_call_*`
             // jitcode-op path. Fail loud (safe decline) if that invariant ever
             // breaks.
+            Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
+        }
+        DispatchOutcome::SegmentTrace { .. } => {
+            // The segmenting cut is gated on `is_top_level` for the same
+            // reason as the compile_trace attempt above: its compile half
+            // lives in the driver, which a callee body has no route to.
             Err(DispatchError::SubWalkClosedLoop { pc: op.pc })
         }
         DispatchOutcome::Continue => {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -1965,6 +1965,83 @@ pub enum DispatchOutcome {
         token: std::sync::Arc<majit_backend::JitCellToken>,
         target_pc: usize,
     },
+    /// `jit_merge_point` was crossed by a trace that already carries
+    /// `force_finish_trace` and has passed 0.8x the trace limit
+    /// (`pyjitpl.py:1617-1620`, the tail of `MIFrame.debug_merge_point`).
+    /// The trace is close enough to the limit that aborting it would waste
+    /// the whole recording, so it is terminated here instead: the walker has
+    /// already recorded a `GUARD_ALWAYS_FAILS` at this merge point, which
+    /// takes every execution back to the interpreter.
+    ///
+    /// The compile half needs the `MetaInterp` the walker does not hold, so
+    /// it runs in the driver, in one of the two arms upstream branches to at
+    /// `pyjitpl.py:1639`: `is_loop` selects
+    /// [`majit_metainterp::TraceAction::SegmentedLoop`] (`compile_simple_loop`
+    /// plus `attach_procedure_to_interp`) over
+    /// [`majit_metainterp::TraceAction::SegmentedBridge`] (`compile_trace`
+    /// with the resumekey). `exception_box` is the operand of the unreachable
+    /// FINISH behind the guard; the loop arm's FINISH is already recorded, the
+    /// bridge arm's is built by `compile_finish_from_active_session`.
+    SegmentTrace { is_loop: bool, exception_box: OpRef },
+}
+
+/// `pyjitpl.py:1622-1673 _create_segmented_trace_and_blackhole`.
+///
+/// The trace is close enough to `trace_limit` that aborting it would waste the
+/// whole recording, so it is terminated here instead: an always-failing guard
+/// takes every execution back to the interpreter, and the FINISH behind it
+/// exists only to give the segment a terminator.
+///
+/// `mp_opcode_pc` is the merge-point op's jitcode pc (the guard's resume
+/// coordinate); `mp_green_pc` is the Python pc it names.
+fn create_segmented_trace<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    mp_opcode_pc: usize,
+    mp_green_pc: usize,
+) -> Result<DispatchOutcome, DispatchError> {
+    // pyjitpl.py:1626 `generate_guard(rop.GUARD_ALWAYS_FAILS)`. The resume
+    // position is the merge-point op, whose preceding `-live-` marker names the
+    // boxes the blackhole resumes with.
+    ctx.trace_ctx.record_guard(OpCode::GuardAlwaysFails, &[], 0);
+    walker_capture_snapshot_for_last_guard(ctx, mp_opcode_pc)?;
+    // pyjitpl.py:1633-1636 `exception_box = ConstInt(ptr2int(
+    // llexception.typeptr))` — the AssertionError type pointer the unreachable
+    // FINISH escapes with. The op sits behind a guard that always fails, so the
+    // placeholder `ConstInt(0)` stands in for a value nothing reads. Both arms
+    // below take this same box, as upstream does.
+    let exception_box = ctx.trace_ctx.const_int(0);
+    // pyjitpl.py:1639-1640 `if (metainterp.current_merge_points and
+    // isinstance(metainterp.resumekey, compile.ResumeFromInterpDescr)):` — a
+    // trace that owns a merge point and entered from the interpreter becomes a
+    // segmented loop; anything else (a guard-origin bridge) takes the else-arm.
+    let is_loop = ctx
+        .trace_ctx
+        .current_merge_points_first_greenkey()
+        .is_some()
+        && ctx.trace_ctx.resumekey_original_loop_token().is_none();
+    // pyjitpl.py:1637 `history.record1(rop.FINISH, exception_box, None,
+    // descr=token)`. The loop arm keeps it here; the bridge arm leaves it to
+    // `compile_finish_from_active_session`, the port of pyjitpl.py:1666
+    // `compile_trace(metainterp, resumekey, [exception_box])`, which records the
+    // same FINISH carrying `exit_frame_with_exception_descr_ref`. Recording it
+    // here as well would give that trace two terminators.
+    if is_loop {
+        ctx.trace_ctx.record_finish(exception_box, Type::Int);
+    }
+    // pyjitpl.py:1671-1673: "we now need to blackhole back to the interpreter
+    // instead of jumping to some existing code, because we are at a really
+    // arbitrary place here." Under single-pass tracing the walk already RAN
+    // everything it recorded, so the interpreter must resume at this merge
+    // point's own green pc rather than at the one it was left holding —
+    // the same handoff the abort path publishes. Without it the walked
+    // iterations are executed a second time.
+    ctx.trace_ctx.walk_final_pc = Some(mp_green_pc);
+    ctx.trace_ctx.walk_final_reds = Vec::new();
+    // pyjitpl.py:1673 `raise SwitchToBlackhole(ABORT_SEGMENTED_TRACE)`.
+    Ok(DispatchOutcome::SegmentTrace {
+        is_loop,
+        exception_box,
+    })
 }
 
 impl PartialEq for DispatchOutcome {
@@ -2015,6 +2092,16 @@ impl PartialEq for DispatchOutcome {
                     && a_back_edge_pc == b_back_edge_pc
                     && a_back_edge_marker == b_back_edge_marker
             }
+            (
+                Self::SegmentTrace {
+                    is_loop: a_is_loop,
+                    exception_box: a_exc,
+                },
+                Self::SegmentTrace {
+                    is_loop: b_is_loop,
+                    exception_box: b_exc,
+                },
+            ) => a_is_loop == b_is_loop && a_exc == b_exc,
             (
                 Self::CompileTracePending {
                     loop_header_pc: a_pc,
@@ -3256,6 +3343,17 @@ pub fn walk<Sym: WalkSym>(
         // helper — so re-measure it rather than inheriting the numbers.
         // `helper_descent_defers_the_limit_check_to_the_enclosing_frame` pins
         // both halves.
+        // pyjitpl.py:1617-1620 raises out of `debug_merge_point`, i.e. from
+        // INSIDE the step, so `blackhole_if_trace_too_long` (pyjitpl.py:2812)
+        // never sees a segmented trace. When a walk crosses a merge point
+        // already past 1.0x the limit both conditions hold, and upstream
+        // segments rather than aborts because its cut raises first. Return
+        // ahead of the too-long check for the same reason — turning the cut
+        // back into `TraceTooLong` here would re-abort exactly the key the
+        // segmenting signal was set to stop aborting.
+        if let DispatchOutcome::SegmentTrace { .. } = outcome {
+            return Ok((outcome, pc));
+        }
         if !ctx.fbw_mode.transparent_helper_subwalk && ctx.trace_ctx.is_too_long() {
             // `step` has advanced the register banks for `Continue`. The
             // other outcomes still need the match below to perform their
@@ -3292,7 +3390,10 @@ pub fn walk<Sym: WalkSym>(
             // A multi-frame inlined callee reached its own loop
             // header; propagate up to `try_walker_inline_user_call`, which
             // emits the recursive CALL_ASSEMBLER at the call boundary.
-            | DispatchOutcome::SubLoopCalleeCallAssembler { .. } => {
+            | DispatchOutcome::SubLoopCalleeCallAssembler { .. }
+            // Returned above, ahead of the too-long check; covered here so the
+            // match stays exhaustive.
+            | DispatchOutcome::SegmentTrace { .. } => {
                 return Ok((outcome, pc));
             }
             DispatchOutcome::SubRaise { exc, exc_concrete } => {
@@ -11805,6 +11906,41 @@ fn handle<Sym: WalkSym>(
                 Some(Value::Int(v)) => v as usize,
                 _ => return Err(DispatchError::JitMergePointGreenKeyUnresolved { pc: op.pc }),
             };
+
+            // pyjitpl.py:1617-1620, the tail of `MIFrame.debug_merge_point`,
+            // which `opimpl_jit_merge_point` calls at :1542 — ahead of every
+            // early return the loop-header protocol below makes, so this check
+            // sits at the same place:
+            //
+            //     if (metainterp.force_finish_trace and
+            //             (metainterp.history.length() >
+            //              warmrunnerstate.trace_limit * 0.8)):
+            //         self._create_segmented_trace_and_blackhole()
+            //
+            // A key that already overflowed once carries the segmenting signal
+            // — `JC_FORCE_FINISH` on the cell for a loop, `FORCE_BRIDGE_SEGMENTING`
+            // on the source token for a bridge — and both reach the walk as
+            // `TraceCtx::force_finish`. Cutting the trace here, strictly before
+            // the 1.0x `blackhole_if_trace_too_long` check the step loop runs
+            // (`pyjitpl.py:2812-2830`), is what stops that key from overflowing
+            // and aborting forever.
+            //
+            // The cut belongs at a merge point and nowhere else: the guard it
+            // records resumes through the `-live-` marker that precedes every
+            // `jit_merge_point` op, which an arbitrary mid-walk position has no
+            // counterpart for.
+            //
+            // Top-level only. Upstream reaches this from an inlined frame too,
+            // but a sub-walk's outcome is consumed by
+            // `try_walker_inline_user_call`, which has no route to the driver
+            // arm that owns the compile half — surfacing it from there would
+            // abort the enclosing trace instead of segmenting it.
+            if ctx.is_top_level
+                && ctx.trace_ctx.force_finish_trace()
+                && ctx.trace_ctx.num_ops() > ctx.trace_ctx.trace_limit() * 4 / 5
+            {
+                return create_segmented_trace(ctx, op.pc, next_instr).map(|o| (o, op.next_pc));
+            }
             // An inlined callee's own loop
             // header routes to a `CALL_ASSEMBLER` into its already-compiled loop
             // token EVEN WHEN its pycode green resolves.  nbody's `advance` has a

--- a/pyre/pyre-jit-trace/src/trace.rs
+++ b/pyre/pyre-jit-trace/src/trace.rs
@@ -5866,6 +5866,19 @@ fn full_body_walk_trace<Sym: WalkSym>(
                 // compiles nor aborts this session again.
                 TraceAction::CompileTrace
             }
+            crate::jitcode_dispatch::DispatchOutcome::SegmentTrace {
+                is_loop,
+                exception_box,
+            } => {
+                // pyjitpl.py:1639-1668: the walk cut itself at a merge point
+                // and recorded the always-failing guard; the compile half is
+                // the driver's, in the arm upstream branches to.
+                if is_loop {
+                    TraceAction::SegmentedLoop
+                } else {
+                    TraceAction::SegmentedBridge { exception_box }
+                }
+            }
             other => {
                 crate::jitcode_dispatch::census_record("Outcome::Other");
                 if crate::jitcode_dispatch::fbw_debug_abort_enabled() {


### PR DESCRIPTION
Three defects on the trace-segmenting / retrace path, plus the two regression tests #1353's review asked for.

## 1. Trace segmenting never fired in production

`prepare_trace_segmenting` (`pyjitpl.py:2831-2859`) already had a pyre port: an over-limit trace with no inlinable function marks its green key with the force-finish signal (`JC_FORCE_FINISH`) or, for a bridge, sets `FORCE_BRIDGE_SEGMENTING` on the loop token. Both signals reached `TraceCtx::force_finish`, and nothing read them — the consumer, `pyjitpl.py:1617-1620` in the tail of `debug_merge_point`, had no counterpart in the production walker. Every retry of a marked key ran into the same overflow and aborted again.

This adds the cut: at a `jit_merge_point`, when the key carries the signal and the trace has passed **0.8×** `trace_limit`, append `GUARD_ALWAYS_FAILS`, capture its snapshot, compile what is there, and hand `SwitchToBlackhole(ABORT_SEGMENTED_TRACE)` back to the driver. The loop arm gets the unreachable `FINISH` upstream builds; the bridge arm's is built by `compile_finish_from_active_session`, so it is loop-arm-only here — mirroring the reference copy in `pyjitpl/dispatch.rs::create_segmented_trace`.

The trigger is gated on `ctx.is_top_level`. Upstream also cuts at an inlined callee's merge point; doing that here needs a multi-frame interpreter resume, and pyre's `single_pass_outcome = (pc, Vec::new())` handoff is single-frame. All three segments the new fixture produces take the **bridge** arm; `TraceAction::SegmentedLoop` stays unexercised.

Discriminator — same script, same `trace_limit=300`, control `main` vs this branch:

| counter | before | after |
| --- | --- | --- |
| `abrt_segmented` | 0 | 3 |
| `loops_aborted` | 64 | 9 |
| `bridges_compiled` | 0 | 4 |
| `guard_failures` | 11918 | 1008 |

Output is `504` both ways.

The 0.8×–1.0× window only has something to fire at if a merge point is **crossed** while the trace sits inside it. The same body at `trace_limit=200` jumps the band in one crossing and never segments; at `300` it segments three times. `bench/synth/trace_segmenting_over_limit_retry.py` pins the working combination and records the trap in its header.

## 2. wasm published no fail args for an always-failing guard

`rewrite.py:419-426` lowers `GUARD_ALWAYS_FAILS` to `GUARD_VALUE(SAME_AS_I(0), 1)`, but only the dynasm and cranelift backends run `rewrite_for_gc_with_constants`. On wasm the raw opcode reaches codegen, where it shared an arm with `GUARD_FUTURE_CONDITION` and wrote neither the fail args nor `frame[0]` — so the guard exited with an unwritten frame. Unreachable until (1) made the opcode reachable; with it, the new fixture died with `TypeError: '' object is not an iterator`. The arm is now split and the always-failing guard goes through `emit_guard_exit`.

## 3. A replacement loop inherited an invalidated token's retrace count

`compile_loop` seeded `unroll_opt.retraced_count` from `compiled_loops[green_key]`'s live token. When that token had been invalidated (so `has_compiled_targets` returns false and this compile is a *replacement*), the count was still read off it — including the `u32::MAX` that `unroll.py:272 disable_retracing_if_max_retrace_guards` writes — and stored back onto the fresh token. The loop could then never retrace to specialize later bridge shapes.

Both `compile.py:220` and `:266` call `make_jitcell_token`, so the token this compile installs is new and its count starts at zero; only `compile_retrace` reuses a token, and it reuses the live one (`compile.py:355 get_procedure_token`). The seed is now zero. Reported by Codex on #1353 (`pyjitpl.rs:6347`).

## 4. Two tests #1353's review asked for

- `a_replacement_loop_does_not_inherit_the_retrace_count` — pins (3). Fails on the pre-fix code with `left: 2147483647, right: 0`. (CodeRabbit, `pyjitpl.rs:6357`.)
- `descrless_const_heap_short_box_is_skipped_not_panicked` — a descr-less `GetfieldGcI` produces no const short box and does not abort. (CodeRabbit, `unroll.rs:7545`.)

## Verification

- `check.py --no-build --timeout-scale 2`: dynasm 443/443, wasm 436/436, cranelift 442/443. The red is the `generator_tree_recursion` ratio gate; a direct `/usr/bin/time` A/B against another worktree's cranelift binary gave median 0.45s on both, so it is the documented boundary flake driven by the pypy denominator (0.04s), not a regression.
- `cargo test`: `majit-metainterp --lib` 1585 passed / 0 failed / 1 ignored; `pyre-object --lib` 275/275.
- `cargo check --all --all-targets --features dynasm` clean after the rebase onto `main`.
- The new fixture passes on all three backends with byte-identical `.jitstats` baselines.

## Left open from #1353's review

- `inline_call.rs:3258` (Codex, P2) — asks to thread a guard operand for the resolved function instead of declining the inline. That is a design change to the guard shape, not a defect in what landed.
- `virtualize.rs:1113` (Codex, P2) — the descriptor-vs-slot lookup should key off `field_descrs` rather than the read's numeric index. Valid, but no fixture yet constructs the mismatched-layout read it describes.

— *authored by Claude*
