### PR TITLE
classmethod-on-type fold: require an exact classmethod

### DIFF
--- a/pyre/bench/synth/wrapper_subclass_get_override.cranelift.jitstats
+++ b/pyre/bench/synth/wrapper_subclass_get_override.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/bench/synth/wrapper_subclass_get_override.dynasm.jitstats
+++ b/pyre/bench/synth/wrapper_subclass_get_override.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/bench/synth/wrapper_subclass_get_override.py
+++ b/pyre/bench/synth/wrapper_subclass_get_override.py
@@ -1,0 +1,115 @@
+# `typeobject.py descr_getattribute` resolves an attribute through
+# `type(descr).__get__`, so a `classmethod` / `staticmethod` SUBCLASS that
+# overrides `__get__` binds through that override.  A fold that unwraps
+# `w_function` in its place calls the wrapped callable directly and never
+# reaches the override, which is why every wrapper type test is exact.
+#
+# One loop per fold that unwraps a wrapper — class receiver, instance
+# receiver, and the `__getattr__` hook's two arms — each reading through a
+# direct call so the fold is the shape that records, not a lambda's
+# megamorphic call site.  Every loop must report the OVERRIDE.
+# Sized for the fold, not for throughput: the declining path runs the whole
+# descriptor protocol per iteration, so this costs far more per `N` than a
+# folded loop.  Every loop still compiles at N=2000, leaving a wide margin.
+N = 100000
+
+
+class GetOverridingClassMethod(classmethod):
+    def __get__(self, obj, cls=None):
+        return overridden
+
+
+class GetOverridingStaticMethod(staticmethod):
+    def __get__(self, obj, cls=None):
+        return overridden
+
+
+def overridden(*args):
+    return 'override'
+
+
+def wrapped_class(cls, x):
+    return 'wrapped'
+
+
+def wrapped_static(x):
+    return 'wrapped'
+
+
+class Attrs:
+    cm = GetOverridingClassMethod(wrapped_class)
+    sm = GetOverridingStaticMethod(wrapped_static)
+
+
+class ClassHook:
+    __getattr__ = GetOverridingClassMethod(wrapped_class)
+
+
+class StaticHook:
+    __getattr__ = GetOverridingStaticMethod(wrapped_static)
+
+
+def classmethod_on_type():
+    seen = None
+    i = 0
+    while i < N:
+        seen = Attrs.cm(i)
+        i += 1
+    print('classmethod on type', seen)
+
+
+def staticmethod_on_type():
+    seen = None
+    i = 0
+    while i < N:
+        seen = Attrs.sm(i)
+        i += 1
+    print('staticmethod on type', seen)
+
+
+def classmethod_on_instance():
+    obj = Attrs()
+    seen = None
+    i = 0
+    while i < N:
+        seen = obj.cm(i)
+        i += 1
+    print('classmethod on instance', seen)
+
+
+def staticmethod_on_instance():
+    obj = Attrs()
+    seen = None
+    i = 0
+    while i < N:
+        seen = obj.sm(i)
+        i += 1
+    print('staticmethod on instance', seen)
+
+
+def classmethod_getattr_hook():
+    obj = ClassHook()
+    seen = None
+    i = 0
+    while i < N:
+        seen = obj.missing
+        i += 1
+    print('classmethod getattr hook', seen)
+
+
+def staticmethod_getattr_hook():
+    obj = StaticHook()
+    seen = None
+    i = 0
+    while i < N:
+        seen = obj.missing
+        i += 1
+    print('staticmethod getattr hook', seen)
+
+
+classmethod_on_type()
+staticmethod_on_type()
+classmethod_on_instance()
+staticmethod_on_instance()
+classmethod_getattr_hook()
+staticmethod_getattr_hook()

--- a/pyre/bench/synth/wrapper_subclass_get_override.wasm.jitstats
+++ b/pyre/bench/synth/wrapper_subclass_get_override.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=0
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=6
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=6
+retraces_compiled=0

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -9890,7 +9890,7 @@ pub unsafe fn load_method_fast_path(
 /// follow `type.__getattribute__`).  A name the metatype defines as a DATA
 /// DESCRIPTOR is declined too, since that is the one entry `descr_getattribute`
 /// selects ahead of the class's own MRO.  An uncacheable type and any
-/// non-`classmethod` descriptor also decline.
+/// descriptor that is not an EXACT `classmethod` also decline.
 ///
 /// # Safety
 /// `w_obj` must be a valid object pointer (null tolerated).
@@ -9925,7 +9925,10 @@ pub unsafe fn classmethod_on_type_fast_path(
         return None;
     }
     let w_descr = lookup_in_type(w_type, name)?;
-    if !pyre_object::is_classmethod(w_descr) {
+    // EXACT, for the reason the `__getattr__`-hook arm records: a `classmethod`
+    // subclass overriding `__get__` binds through that override, so unwrapping
+    // `w_function` in its place calls the wrong callable.
+    if !unsafe { pyre_object::function::is_exact_classmethod(w_descr) } {
         return None;
     }
     let w_func = pyre_object::function::w_classmethod_get_func(w_descr);


### PR DESCRIPTION
JIT-only wrong code, owned by `main`. Follow-up to #1369, which fixed the *other* way the same fold was unsound.

## The defect

`classmethod_on_type_fast_path` tested its descriptor with `is_classmethod`, which admits subclasses. `descr_getattribute` resolves an attribute through `type(descr).__get__`, so a `classmethod` subclass that overrides `__get__` binds through the override — unwrapping `w_function` in its place calls the wrapped callable and never reaches it.

```python
class GetOverridingClassMethod(classmethod):
    def __get__(self, obj, cls=None):
        return overridden          # -> 'override'

class Attrs:
    cm = GetOverridingClassMethod(wrapped_class)   # -> 'wrapped'

while i < N:
    seen = Attrs.cm(i)             # JIT: 'wrapped'   everything else: 'override'
```

CPython, pypy, and this interpreter with `PYRE_NO_JIT=1` all say `override`.

The `__getattr__`-hook arm already tests exactly, and already carries the reason: *"Upstream is explicit that they have to be (`isinstance(typ, Function)` would not be correct here … because a builtin function binds differently than a normal function), and the same holds for the two wrappers."* This fold just never applied it.

## Measured both directions

Rebuilt with only the predicate reverted, everything else identical:

| row | `is_exact_classmethod` (this PR) | `is_classmethod` (`main`) |
|---|---|---|
| classmethod on type | `override` | **`wrapped`** |
| staticmethod on type | `override` | `override` |
| classmethod on instance | `override` | `override` |
| staticmethod on instance | `override` | `override` |
| classmethod `__getattr__` hook | `override` | `override` |
| staticmethod `__getattr__` hook | `override` | `override` |

Exactly one row moves, so the fix is minimal and does not over-decline.

## Why the fixture covers six rows for a one-row fix

The other five are the regression net. I probed every fold that unwraps a wrapper before picking the fix, and that is what turned "gates on the wrong predicate" into "exactly one of six is broken".

The audit also bounds itself: only `property`, `classmethod` and `staticmethod` are subclassable at all. `method`, `builtin_function_or_method`, `function`, `member_descriptor` and `getset_descriptor` all refuse to be based, so a loose `is_*` over them is already exact and is *not* a latent instance of this bug. `property`'s four unwrapping sites already use `is_exact_property`; its three loose `is_property` sites are correct by intent (two ask a question a subclass still answers yes to, one is a decline condition). With this change the class is closed.

## Gates

`check.py` dynasm 444/444 · cranelift 444/444 · wasm 437/437 (all three run locally, so no `.jitstats` value in this PR is a guess) · `cargo test --all --no-default-features --features dynasm` rc=0 · parity `--dynasm-only` all pass · `cpython_tests --backend dynasm` 210 PASS / 0 FAIL / no regressions.

One `cargo test --all` run segfaulted in `majit-backend-cranelift`'s lib tests. It is not from this branch: that crate has no `pyre` dependency and this PR touches only `pyre/`, so the code under test is byte-identical to `main`'s. It did not reproduce (1 of 2 `--all` runs, 0 of 3 isolated runs at 138/138). Filed separately rather than folded in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected class method descriptor handling so subclasses with customized attribute access retain their overridden behavior.
  * Prevented descriptor subclasses from being incorrectly unwrapped during attribute lookup.

* **Benchmarks**
  * Added a synthetic benchmark covering class method and static method descriptor overrides across classes and instances.
  * Added JIT performance statistics for the new benchmark across supported execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->