### PR TITLE
majit: describe an array field by its declared width, and resolve an array_fields base spelled as a state ref scalar

### DIFF
--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_stmt.rs
@@ -110,11 +110,22 @@ impl<'c> Lowerer<'c> {
                     true,
                     quote! { ::core::mem::size_of::<usize>() },
                     quote! { false },
-                    // The array base's witness, for the same reason it gives:
-                    // naming the pointee accepts `*const T` as well as `*mut T`.
+                    // The array base's witness, and it claims the same thing:
+                    // the element's WIDTH, not its name.  Reading through the
+                    // field rather than naming a pointer type accepts
+                    // `*const T` as well as `*mut T`, and `transmute` accepts a
+                    // `#[repr(transparent)]` wrapper over the declared type —
+                    // which has the declared type's size and, by the definition
+                    // of `repr(transparent)`, its representation.  A
+                    // declaration that drifted in width (`=> u16` over a
+                    // `*mut u8`) still fails to compile; one that keeps the
+                    // width and flips the sign does not, the same gap the base
+                    // witness documents.
                     quote! {
-                        const _: fn(&#path) -> #element_path =
-                            |__s| unsafe { *__s.#field };
+                        const _: fn(&#path) = |__s| {
+                            let _: #element_path =
+                                unsafe { ::core::mem::transmute(*__s.#field) };
+                        };
                     },
                 ),
                 None => {

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -209,10 +209,24 @@ fn pool_array_layout_tokens(
     )
 }
 
-/// A `<local ref binding>.<field>` access that `array_fields` declares, resolved
-/// but not yet emitted.  See [`JitCodeLowerer::match_array_field_base`].
+/// Where the object holding the array base pointer comes from.
+///
+/// A local `ref_params` binding is already in a register, but a `ref(T)` state
+/// scalar still has to be read out of the state frame, and that read emits.
+/// Keeping the two apart is what lets [`JitCodeLowerer::match_array_field_base`]
+/// stay non-emitting for both.
+enum ArrayFieldHolder {
+    /// An already-materialized ref binding.
+    Reg(u16),
+    /// `state.<ref_scalar>`, to be read at emit time.
+    StateRef(Expr),
+}
+
+/// A `<ref binding or state ref scalar>.<field>` access that `array_fields`
+/// declares, resolved but not yet emitted.  See
+/// [`JitCodeLowerer::match_array_field_base`].
 struct ArrayFieldBase {
-    base_reg: u16,
+    holder: ArrayFieldHolder,
     struct_path: syn::Path,
     member: syn::Member,
     element_type: syn::Path,
@@ -1357,15 +1371,32 @@ impl<'c> Lowerer<'c> {
     /// interpreter.
     fn match_array_field_base(&self, field: &syn::ExprField) -> Option<ArrayFieldBase> {
         let config = self.config?;
-        let Expr::Path(path) = &*field.base else {
-            return None;
+        // Either a local ref binding (`jit_inline`'s `ref_params`) or a
+        // `ref(T)` state scalar (`jit_interp`'s `state_fields`). Both name an
+        // object whose field holds the buffer base; only where the object
+        // pointer comes from differs.
+        let (holder, struct_path) = match &*field.base {
+            Expr::Path(path) => {
+                let ident = path.path.get_ident()?;
+                let binding = self.bindings.get(&ident.to_string())?.clone();
+                if !matches!(binding.kind, BindingKind::Ref) {
+                    return None;
+                }
+                (
+                    ArrayFieldHolder::Reg(binding.reg),
+                    binding.struct_type.as_ref()?.clone(),
+                )
+            }
+            Expr::Field(base_field) if expr_matches_local_name(&base_field.base, "state") => {
+                let base_name = named_member(&base_field.member)?;
+                let (_, struct_path) = config.state_ref_scalars.get(&base_name).cloned()?;
+                (
+                    ArrayFieldHolder::StateRef((*field.base).clone()),
+                    struct_path,
+                )
+            }
+            _ => return None,
         };
-        let ident = path.path.get_ident()?;
-        let binding = self.bindings.get(&ident.to_string())?.clone();
-        if !matches!(binding.kind, BindingKind::Ref) {
-            return None;
-        }
-        let struct_path = binding.struct_type.as_ref()?.clone();
         let member = field.member.clone();
         let member_name = named_member(&field.member)?;
         // Resolve the access against the struct that DECLARES this field.
@@ -1387,7 +1418,7 @@ impl<'c> Lowerer<'c> {
         let key = format!("{}::{}", struct_last, member_name);
         let element_type = config.array_fields.get(&key)?.2.clone();
         Some(ArrayFieldBase {
-            base_reg: binding.reg,
+            holder,
             struct_path,
             member,
             element_type,
@@ -1401,19 +1432,27 @@ impl<'c> Lowerer<'c> {
     /// buffer pointer through the SAME interned field descr — a store to the
     /// base (a realloc on growth) then invalidates the load the heapcache
     /// served, instead of leaving a stale buffer pointer live in the trace.
-    fn emit_array_field_base(&mut self, shape: &ArrayFieldBase) -> u16 {
+    fn emit_array_field_base(&mut self, shape: &ArrayFieldBase) -> Option<u16> {
         let ArrayFieldBase {
-            base_reg,
+            holder,
             struct_path,
             member,
             element_type,
         } = shape;
-        let (base_reg, struct_path, member, element_type) = (
-            *base_reg,
-            struct_path.clone(),
-            member.clone(),
-            element_type.clone(),
-        );
+        let (struct_path, member, element_type) =
+            (struct_path.clone(), member.clone(), element_type.clone());
+        // A state scalar is read here rather than in the matcher, so nothing is
+        // emitted until the caller has committed to this shape.
+        let base_reg = match holder {
+            ArrayFieldHolder::Reg(reg) => *reg,
+            ArrayFieldHolder::StateRef(base_expr) => {
+                let base = self.lower_state_field_read(&base_expr.clone())?;
+                if !matches!(base.kind, BindingKind::Ref) {
+                    return None;
+                }
+                base.reg
+            }
+        };
         // No config means nothing was declared gc-managed or headerless,
         // which is the same answer the raw default gave before.
         let gc_managed = self
@@ -1490,7 +1529,7 @@ impl<'c> Lowerer<'c> {
                 );
             },
         );
-        buffer_reg
+        Some(buffer_reg)
     }
 
     /// Recognizes an array element READ on a local ref binding:
@@ -1517,7 +1556,7 @@ impl<'c> Lowerer<'c> {
         // before its index, which is the order emitted here.
         let shape = self.match_array_field_base(field)?;
         let element_type = shape.element_type.clone();
-        let buffer_reg = self.emit_array_field_base(&shape);
+        let buffer_reg = self.emit_array_field_base(&shape)?;
         let index = self.lower_value_expr(&index_expr.index)?;
         if !matches!(index.kind, BindingKind::Int) {
             return None;
@@ -1584,7 +1623,7 @@ impl<'c> Lowerer<'c> {
         if !matches!(value.kind, BindingKind::Int) {
             return None;
         }
-        let buffer_reg = self.emit_array_field_base(&shape);
+        let buffer_reg = self.emit_array_field_base(&shape)?;
         let index = self.lower_value_expr(&index_expr.index)?;
         if !matches!(index.kind, BindingKind::Int) {
             return None;

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_vable.rs
@@ -1443,12 +1443,30 @@ impl<'c> Lowerer<'c> {
                 // real pointer while the emitted descr takes its stride and
                 // signedness from the declaration, so a declaration that
                 // drifted from the struct (`Stack::data => u16` over a
-                // `*mut u8`) would compile and read past the buffer.  Naming
-                // the pointee rather than the pointer accepts `*const T` as
-                // well as `*mut T`; the closure body is type-checked but never
-                // evaluated.
-                const _: fn(&#struct_path) -> #element_type =
-                    |__s| unsafe { *__s.#member };
+                // `*mut u8`) would compile and read past the buffer.
+                //
+                // The claim is the element's WIDTH, not its name.  A
+                // `#[repr(transparent)]` wrapper over the declared type has
+                // the declared type's size and, by the definition of
+                // `repr(transparent)`, its representation — a legitimate
+                // element that nominal equality rejects.  `transmute` states
+                // the width, so the drifted `u16`-over-`*mut u8` declaration
+                // above still fails to compile.
+                //
+                // What this no longer catches: a declaration that keeps the
+                // width and flips the sign (`=> i8` over a `*mut u8`).  The
+                // stride is what bounds the access, so that mistake stays
+                // in-buffer and misreads a value rather than the heap, but it
+                // IS unchecked here — the sign now comes from the declaration
+                // alone.
+                //
+                // Reading through the field rather than naming a pointer type
+                // accepts `*const T` as well as `*mut T`; the closure body is
+                // type-checked but never evaluated.
+                const _: fn(&#struct_path) = |__s| {
+                    let _: #element_type =
+                        unsafe { ::core::mem::transmute(*__s.#member) };
+                };
                 #prefix_witness
                 __builder.register_struct_layout(
                     ::core::mem::size_of::<#struct_path>(),

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1974,26 +1974,38 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
             if let Expr::Assign(assign) = expr
                 && let Expr::Index(index_expr) = &*assign.left
                 && let Expr::Field(field) = &*index_expr.expr
-                && let Some(struct_path) = self
+                && let Some(base_path) = self
                     .ref_struct_of_base(&field.base)
                     .or_else(|| self.local_ref_struct_of_base(&field.base))
                 && let syn::Member::Named(member_id) = &field.member
+                // Resolve against the struct that DECLARES the field, the way
+                // `match_array_field_base` does on the JIT side. Looking the
+                // element type up under the base's own spelling misses a field
+                // an embedded base declares, and the plain-field arm below then
+                // rewrites `<base>.<field>` to the buffer pointer and leaves the
+                // `[]` on it, which does not compile.
+                && let struct_path = self.declaring_struct(&base_path, &member_id.to_string())
                 && self
                     .array_field_elem(&struct_path, &member_id.to_string())
                     .is_some()
             {
                 let base = (*field.base).clone();
                 let member = field.member.clone();
-                let struct_path = self.declaring_struct(&struct_path, &member_id.to_string());
                 let mut idx = (*index_expr.index).clone();
                 let mut rhs = (*assign.right).clone();
                 self.visit_expr_mut(&mut idx);
                 self.visit_expr_mut(&mut rhs);
+                // The assigned value is evaluated before the assignee place, so
+                // an index or RHS with side effects must not be reordered:
+                // `base.data[next_index()] = compute_value()` runs
+                // `compute_value()` first. The JIT side lowers the right-hand
+                // side first for the same reason, and the two paths have to
+                // agree or a warm run observes a different order from a cold one.
                 *expr = syn::parse_quote! {
                     {
+                        let __majit_arr_val = #rhs;
                         let __majit_arr_obj = #base;
                         let __majit_arr_idx = #idx;
-                        let __majit_arr_val = #rhs;
                         unsafe {
                             *((*(__majit_arr_obj as *mut #struct_path))
                                 .#member
@@ -2007,17 +2019,17 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
             // Array element READ: `<base>.<array_field>[<idx>]`.
             if let Expr::Index(index_expr) = expr
                 && let Expr::Field(field) = &*index_expr.expr
-                && let Some(struct_path) = self
+                && let Some(base_path) = self
                     .ref_struct_of_base(&field.base)
                     .or_else(|| self.local_ref_struct_of_base(&field.base))
                 && let syn::Member::Named(member_id) = &field.member
+                && let struct_path = self.declaring_struct(&base_path, &member_id.to_string())
                 && self
                     .array_field_elem(&struct_path, &member_id.to_string())
                     .is_some()
             {
                 let base = (*field.base).clone();
                 let member = field.member.clone();
-                let struct_path = self.declaring_struct(&struct_path, &member_id.to_string());
                 let mut idx = (*index_expr.index).clone();
                 self.visit_expr_mut(&mut idx);
                 *expr = syn::parse_quote! {

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -1884,6 +1884,10 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
         // The JIT lowerer consults the maps themselves; this walk only needs
         // to know whether a struct declares a field, not what it declared.
         declared_field_keys: std::collections::HashSet<String>,
+        // `array_fields` entries: `"StructLast::field"` -> element type. The
+        // field holds the buffer BASE POINTER, so an indexed access derefs
+        // through it instead of reading the field itself.
+        array_field_elems: std::collections::HashMap<String, syn::Path>,
     }
     impl RefFieldRewriter {
         // For `e == state.<ref_scalar>`, return the `ref(T)` struct path.
@@ -1933,6 +1937,14 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
             )
         }
 
+        // Whether `struct_path::field_name` is an array base, and if so the
+        // element type.
+        fn array_field_elem(&self, struct_path: &syn::Path, field_name: &str) -> Option<syn::Path> {
+            let struct_last = struct_path.segments.last()?.ident.to_string();
+            let key = format!("{}::{}", struct_last, field_name);
+            self.array_field_elems.get(&key).cloned()
+        }
+
         // Record a local binding as pointing to a struct type.
         fn record_local_ref(&mut self, name: &str, struct_type: syn::Path) {
             self.local_ref_types.insert(name.to_string(), struct_type);
@@ -1952,6 +1964,76 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
     }
     impl VisitMut for RefFieldRewriter {
         fn visit_expr_mut(&mut self, expr: &mut Expr) {
+            // Array element WRITE: `<base>.<array_field>[<idx>] = <rhs>`.
+            //
+            // Must precede the plain-field arms below: the field holds the
+            // buffer BASE POINTER, so letting them rewrite `<base>.<field>` on
+            // its own leaves a raw pointer being indexed with `[]`, which does
+            // not compile. `jit_inline` intercepts the same shape in the same
+            // order.
+            if let Expr::Assign(assign) = expr
+                && let Expr::Index(index_expr) = &*assign.left
+                && let Expr::Field(field) = &*index_expr.expr
+                && let Some(struct_path) = self
+                    .ref_struct_of_base(&field.base)
+                    .or_else(|| self.local_ref_struct_of_base(&field.base))
+                && let syn::Member::Named(member_id) = &field.member
+                && self
+                    .array_field_elem(&struct_path, &member_id.to_string())
+                    .is_some()
+            {
+                let base = (*field.base).clone();
+                let member = field.member.clone();
+                let struct_path = self.declaring_struct(&struct_path, &member_id.to_string());
+                let mut idx = (*index_expr.index).clone();
+                let mut rhs = (*assign.right).clone();
+                self.visit_expr_mut(&mut idx);
+                self.visit_expr_mut(&mut rhs);
+                *expr = syn::parse_quote! {
+                    {
+                        let __majit_arr_obj = #base;
+                        let __majit_arr_idx = #idx;
+                        let __majit_arr_val = #rhs;
+                        unsafe {
+                            *((*(__majit_arr_obj as *mut #struct_path))
+                                .#member
+                                .add(__majit_arr_idx as usize)) = __majit_arr_val;
+                        }
+                    }
+                };
+                return;
+            }
+
+            // Array element READ: `<base>.<array_field>[<idx>]`.
+            if let Expr::Index(index_expr) = expr
+                && let Expr::Field(field) = &*index_expr.expr
+                && let Some(struct_path) = self
+                    .ref_struct_of_base(&field.base)
+                    .or_else(|| self.local_ref_struct_of_base(&field.base))
+                && let syn::Member::Named(member_id) = &field.member
+                && self
+                    .array_field_elem(&struct_path, &member_id.to_string())
+                    .is_some()
+            {
+                let base = (*field.base).clone();
+                let member = field.member.clone();
+                let struct_path = self.declaring_struct(&struct_path, &member_id.to_string());
+                let mut idx = (*index_expr.index).clone();
+                self.visit_expr_mut(&mut idx);
+                *expr = syn::parse_quote! {
+                    {
+                        let __majit_arr_obj = #base;
+                        let __majit_arr_idx = #idx;
+                        unsafe {
+                            *((*(__majit_arr_obj as *const #struct_path))
+                                .#member
+                                .add(__majit_arr_idx as usize))
+                        }
+                    }
+                };
+                return;
+            }
+
             // Write-through: `state.<ref>.<member> = <rhs>` ->
             // `unsafe { (*(state.<ref> as *mut T)).<member> = <rhs> }`.
             if let Expr::Assign(assign) = expr
@@ -2217,6 +2299,14 @@ fn transform_function(config: &JitInterpConfig, func: &ItemFn) -> TokenStream {
                     &config.int_fields,
                     &config.array_fields,
                 ),
+                array_field_elems: config
+                    .array_fields
+                    .iter()
+                    .filter_map(|e| {
+                        let last = e.struct_type.segments.last()?.ident.to_string();
+                        Some((format!("{}::{}", last, e.field), e.element_type.clone()))
+                    })
+                    .collect(),
                 field_pointees,
                 local_ref_types: std::collections::HashMap::new(),
                 call_returns: call_returns_map,

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -283,8 +283,15 @@ fn rewrite_jit_inline_ref_param_fields(
             if let syn::Expr::Assign(assign) = expr
                 && let syn::Expr::Index(index_expr) = &*assign.left
                 && let syn::Expr::Field(field) = &*index_expr.expr
-                && let Some(struct_path) = self.local_ref_struct_of_base(&field.base)
+                && let Some(binding_path) = self.local_ref_struct_of_base(&field.base)
                 && let syn::Member::Named(member_id) = &field.member
+                // Resolve against the struct that DECLARES the field, the way
+                // `match_array_field_base` does on the JIT side. Looking the
+                // element type up under the binding's own spelling misses a
+                // field an embedded base declares, and the plain-field arm
+                // below then rewrites `<base>.<field>` to the buffer pointer
+                // and leaves the `[]` on it, which does not compile.
+                && let struct_path = self.declaring_struct(&binding_path, &member_id.to_string())
                 && self
                     .array_field_elem(&struct_path, &member_id.to_string())
                     .is_some()
@@ -317,8 +324,9 @@ fn rewrite_jit_inline_ref_param_fields(
             // Array element READ: `<base>.<array_field>[<idx>]`.
             if let syn::Expr::Index(index_expr) = expr
                 && let syn::Expr::Field(field) = &*index_expr.expr
-                && let Some(struct_path) = self.local_ref_struct_of_base(&field.base)
+                && let Some(binding_path) = self.local_ref_struct_of_base(&field.base)
                 && let syn::Member::Named(member_id) = &field.member
+                && let struct_path = self.declaring_struct(&binding_path, &member_id.to_string())
                 && self
                     .array_field_elem(&struct_path, &member_id.to_string())
                     .is_some()

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -6607,7 +6607,29 @@ impl OptContext {
         // and a 0-length vable section reached the backend unremarked. It then
         // surfaced only if the guard was actually deopted, as
         // `assert!(vable_size > 0)` in `resume.rs::consume_vable_info`.
+        // optimizer.py:761-766 answers a failed numbering by abandoning the
+        // whole compilation:
+        //
+        //     try:
+        //         newboxes = modifier.finish(pendingfields)
+        //         ...
+        //     except resume.TagOverflow:
+        //         raise compile.giveup()
+        //
+        // Returning without that signal leaves this guard with no resume data
+        // and lets the trace compile regardless. Nothing reports it: the guard
+        // is only consulted if it later fails, and the deopt then rebuilds
+        // interpreter state out of an empty numbering, so the interpreter
+        // resumes holding values that are not the ones it had. The witness is
+        // the interpreted program's own answer, not any JIT statistic.
+        //
+        // `signal_invalid_loop` rather than a literal `giveup()`: pyre has no
+        // `SwitchToBlackhole`, and this is the established way for a leaf that
+        // cannot raise to abandon the trace (`protect_speculative_operation`
+        // uses the same one). Both discard the compilation and leave the
+        // interpreter to carry on from state the JIT never took over.
         let Ok(numb_state) = memo.number(&snapshot, &env, self.minimum_virtualizable_size) else {
+            self.signal_invalid_loop("resume numbering: TagOverflow");
             return;
         };
 

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -727,8 +727,7 @@ pub struct OptContext {
     /// `Rc::ptr_eq` key would silent-miss the pop. Re-keying to box identity
     /// is gated on the same short-preamble / InputArg identity unification
     /// that defers `resolve_box_box`'s InputArg arm (#9).
-    pub(crate) potential_extra_ops:
-        indexmap::IndexMap<OpRef, crate::optimizeopt::info::PreambleOp>,
+    pub(crate) potential_extra_ops: indexmap::IndexMap<OpRef, crate::optimizeopt::info::PreambleOp>,
     /// RPython unroll.py: live ExtendedShortPreambleBuilder while replaying an
     /// existing target token's short preamble.
     active_short_preamble_producer:

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -707,10 +707,15 @@ pub struct OptContext {
     imported_short_preamble_used: Vec<OpRef>,
     /// `unroll.py:37` `self.optunroll.potential_extra_ops[op] = preamble_op` /
     /// `optimizer.py:354` `preamble_op = self.optunroll.potential_extra_ops.pop(op)`.
-    /// PyPy uses a dict keyed by the box; pyre uses a Vec of `(OpRef,
-    /// PreambleOp)` with linear-scan insert/pop/contains. The pool stays
-    /// small per trace (one entry per imported pure short-preamble op),
-    /// so O(n) operations are acceptable.
+    /// A keyed map, like the dict upstream keeps: insert, pop and `in` are
+    /// each one lookup, where the `Vec<(OpRef, PreambleOp)>` this replaced
+    /// scanned the whole pool for all three.
+    ///
+    /// `swap_remove` is the removal the `Vec` already performed, and nothing
+    /// iterates this map — every use is a keyed insert, pop or membership
+    /// test — so the order it leaves behind is unobservable. `IndexMap`
+    /// rather than `HashMap` because iteration order stays deterministic
+    /// even if a later reader does walk it.
     ///
     /// The key stays the box's `OpRef` position rather than PyPy's box
     /// identity (`unroll.py:37` keys by the box object). This is a
@@ -722,7 +727,8 @@ pub struct OptContext {
     /// `Rc::ptr_eq` key would silent-miss the pop. Re-keying to box identity
     /// is gated on the same short-preamble / InputArg identity unification
     /// that defers `resolve_box_box`'s InputArg arm (#9).
-    pub(crate) potential_extra_ops: Vec<(OpRef, crate::optimizeopt::info::PreambleOp)>,
+    pub(crate) potential_extra_ops:
+        indexmap::IndexMap<OpRef, crate::optimizeopt::info::PreambleOp>,
     /// RPython unroll.py: live ExtendedShortPreambleBuilder while replaying an
     /// existing target token's short preamble.
     active_short_preamble_producer:
@@ -1758,7 +1764,7 @@ impl OptContext {
             const_infos: indexmap::IndexMap::new(),
             imported_short_preamble_used: Vec::new(),
 
-            potential_extra_ops: Vec::new(),
+            potential_extra_ops: indexmap::IndexMap::new(),
             active_short_preamble_producer: None,
             preview_short_state: None,
             exported_const_short_boxes: Vec::new(),
@@ -2382,7 +2388,7 @@ impl OptContext {
             const_infos: indexmap::IndexMap::new(),
             imported_short_preamble_used: Vec::new(),
 
-            potential_extra_ops: Vec::new(),
+            potential_extra_ops: indexmap::IndexMap::new(),
             active_short_preamble_producer: None,
             preview_short_state: None,
             exported_const_short_boxes: Vec::new(),
@@ -3707,11 +3713,7 @@ impl OptContext {
                 }
                 // `unroll.py:37` dict-assign semantics — overwrite if the
                 // key already exists, otherwise append.
-                if let Some(entry) = self.potential_extra_ops.iter_mut().find(|(k, _)| *k == key) {
-                    entry.1 = preamble_op.clone();
-                } else {
-                    self.potential_extra_ops.push((key, preamble_op.clone()));
-                }
+                self.potential_extra_ops.insert(key, preamble_op.clone());
             }
         }
         // unroll.py:38 `return preamble_op.op`. RPython's `preamble_op.op`
@@ -4362,11 +4364,7 @@ impl OptContext {
         &mut self,
         result: OpRef,
     ) -> Option<crate::optimizeopt::info::PreambleOp> {
-        let idx = self
-            .potential_extra_ops
-            .iter()
-            .position(|(k, _)| *k == result)?;
-        Some(self.potential_extra_ops.swap_remove(idx).1)
+        self.potential_extra_ops.swap_remove(&result)
     }
 
     /// `unroll.py:37` `self.optunroll.potential_extra_ops[op] = preamble_op` —
@@ -4376,16 +4374,12 @@ impl OptContext {
         key: OpRef,
         preamble_op: crate::optimizeopt::info::PreambleOp,
     ) {
-        if let Some(entry) = self.potential_extra_ops.iter_mut().find(|(k, _)| *k == key) {
-            entry.1 = preamble_op;
-        } else {
-            self.potential_extra_ops.push((key, preamble_op));
-        }
+        self.potential_extra_ops.insert(key, preamble_op);
     }
 
     /// Dict-`in` parity for `potential_extra_ops`.
     pub fn has_potential_extra_op(&self, key: OpRef) -> bool {
-        self.potential_extra_ops.iter().any(|(k, _)| *k == key)
+        self.potential_extra_ops.contains_key(&key)
     }
 
     pub fn activate_short_preamble_producer(

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1548,7 +1548,9 @@ impl UnrollOptimizer {
                         if resolved_source == source {
                             continue;
                         }
-                        produced_by_resolved.entry(resolved_source).or_insert(produced);
+                        produced_by_resolved
+                            .entry(resolved_source)
+                            .or_insert(produced);
                     }
                     for op in p2_ops.iter() {
                         if op.opcode == OpCode::Jump {

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1521,6 +1521,35 @@ impl UnrollOptimizer {
                 }
                 {
                     let mut visited_force: indexmap::IndexSet<OpRef> = indexmap::IndexSet::new();
+                    // `shortpreamble.py:250` keeps the produced short boxes in a
+                    // DICT and looks them up by box (`:284`, `:312`, `:338`,
+                    // `:347`). pyre held a list and rescanned it per argument,
+                    // and every probe called `get_replacement_opref`, which
+                    // walks the producer maps and then the forwarding chain --
+                    // so the scan is quadratic in the entry count with an
+                    // expensive comparison.
+                    //
+                    // A virtualizable array contributes one entry per DECLARED
+                    // element whether or not the loop reads it, so the
+                    // quadratic term is paid in the square of the declared
+                    // length: the one-time compile cost of the same machine
+                    // goes 0.20 ms at 8 slots to 364 ms at 1792.
+                    //
+                    // The scan asked for `resolved(source) == arg && source !=
+                    // arg`. Keying by `resolved(source)` makes `arg` the key,
+                    // and since the key IS `resolved(source)`, `source != arg`
+                    // is just `source != resolved(source)` -- decidable once,
+                    // here. `or_insert` keeps the FIRST entry per key, which is
+                    // what `find` returned.
+                    let mut produced_by_resolved = std::collections::HashMap::new();
+                    for (_, produced) in exported_short_boxes_produced.iter() {
+                        let source = produced.res.to_opref();
+                        let resolved_source = final_ctx.get_replacement_opref(source);
+                        if resolved_source == source {
+                            continue;
+                        }
+                        produced_by_resolved.entry(resolved_source).or_insert(produced);
+                    }
                     for op in p2_ops.iter() {
                         if op.opcode == OpCode::Jump {
                             continue;
@@ -1541,12 +1570,7 @@ impl UnrollOptimizer {
                             let needs_force = final_ctx.potential_extra_ops.contains_key(&arg)
                                 || final_ctx.potential_extra_ops.contains_key(&resolved);
                             if !needs_force
-                                && let Some((_, produced)) =
-                                    exported_short_boxes_produced.iter().find(|(_, produced)| {
-                                        let source = produced.res.to_opref();
-                                        source != arg
-                                            && final_ctx.get_replacement_opref(source) == arg
-                                    })
+                                && let Some(produced) = produced_by_resolved.get(&arg).copied()
                             {
                                 let preamble_op = crate::optimizeopt::info::PreambleOp {
                                     op: produced.res.clone(),

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -1538,10 +1538,8 @@ impl UnrollOptimizer {
                             }
                             visited_force.insert(arg);
                             let resolved = final_ctx.get_replacement_opref(arg);
-                            let needs_force = final_ctx
-                                .potential_extra_ops
-                                .iter()
-                                .any(|(k, _)| *k == arg || *k == resolved);
+                            let needs_force = final_ctx.potential_extra_ops.contains_key(&arg)
+                                || final_ctx.potential_extra_ops.contains_key(&resolved);
                             if !needs_force
                                 && let Some((_, produced)) =
                                     exported_short_boxes_produced.iter().find(|(_, produced)| {

--- a/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
+++ b/majit/majit-metainterp/src/optimizeopt/virtualstate.rs
@@ -857,19 +857,44 @@ impl VirtualState {
         if concrete_refs.len() != self.state.len() {
             return None;
         }
+        // Resolve each candidate ONCE and look the answer up, rather than
+        // rescanning `concrete_refs` per inputarg.
+        //
+        // virtualstate.py:427-431 `_enum` assigns `position_in_notvirtuals` in
+        // constant time on the same walk that will later place the box, and
+        // virtualstate.py:412-425 `enum_forced_boxes` writes straight to
+        // `boxes[self.position_in_notvirtuals]`. Upstream never searches for
+        // the slot, so its cost is one pass. Recovering the mapping by a
+        // nested scan makes it quadratic in the entry count, and
+        // `get_replacement_opref` is not a cheap comparison: it walks the
+        // producer maps and then the forwarding chain, so the same candidate
+        // was being re-resolved once per inputarg.
+        //
+        // Both lists are one entry per loop-carried value, so a virtualizable
+        // array contributes one entry per declared element whether or not the
+        // loop reads it (pyjitpl.py:3329 `original_boxes +=
+        // self.virtualizable_boxes`). The quadratic term is therefore paid in
+        // the square of the declared array length.
+        //
+        // Reverse iteration with an overwriting insert leaves the LOWEST
+        // matching index in the map, which is what the first-match-wins scan
+        // this replaces returned.
+        let mut index_by_resolved: std::collections::HashMap<OpRef, usize> =
+            std::collections::HashMap::with_capacity(concrete_refs.len());
+        for (index, &candidate) in concrete_refs.iter().enumerate().rev() {
+            if self.state[index].is_virtual() || candidate.is_constant() {
+                continue;
+            }
+            let resolved_candidate = ctx.get_replacement_opref(candidate);
+            index_by_resolved.insert(resolved_candidate, index);
+        }
         inputargs
             .iter()
             .map(|&inputarg| {
                 let resolved_inputarg = ctx.get_replacement_opref(inputarg);
-                concrete_refs
-                    .iter()
-                    .enumerate()
-                    .find_map(|(index, &candidate)| {
-                        if self.state[index].is_virtual() || candidate.is_constant() {
-                            return None;
-                        }
-                        (ctx.get_replacement_opref(candidate) == resolved_inputarg).then_some(index)
-                    })
+                index_by_resolved
+                    .get(&resolved_inputarg)
+                    .copied()
                     .or_else(|| inputarg.is_input_arg().then_some(inputarg.raw() as usize))
             })
             .collect()

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -7034,7 +7034,22 @@ impl<M: Clone> MetaInterp<M> {
                     crate::debug::debug_print(line);
                 }
             } else {
-                crate::debug::debug_print("[trace too large for full dump]");
+                // The pre-optimizer dump above answers the same truncation with an
+                // op-count table. Answering it here with a bare notice instead
+                // leaves a census over this log reading zero of every opcode it
+                // looks for, which is indistinguishable from a trace that really
+                // contains none.
+                crate::debug::debug_print("[trace too large for full dump, showing op counts]");
+                let mut counts: indexmap::IndexMap<majit_ir::OpCode, usize> =
+                    indexmap::IndexMap::new();
+                for op in &compiled_ops {
+                    *counts.entry(op.opcode).or_insert(0) += 1;
+                }
+                let mut sorted: Vec<_> = counts.into_iter().collect();
+                sorted.sort_by(|a, b| b.1.cmp(&a.1));
+                for (opcode, count) in sorted.iter().take(15) {
+                    crate::debug::debug_print(&format!("  {opcode:?}: {count}"));
+                }
             }
             for op in &compiled_ops {
                 if op.opcode == majit_ir::OpCode::GuardNotInvalidated

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -3772,12 +3772,17 @@ where
                     let frame = self.frames.current_mut();
                     frame.read_setfield_gc()
                 };
-                let (offset, fielddescr) = {
+                let (offset, field_size, fielddescr) = {
                     let frame = self.frames.current_mut();
                     let bh = frame.runtime_bh_descr(descr_idx).unwrap_or_else(|| {
                         panic!("BC_SETFIELD_GC: descrs[{descr_idx}] is not a BhDescr entry")
                     });
-                    field_descr_ref_from_bh(bh)
+                    let field_size = match bh {
+                        crate::blackhole::BhDescr::Field { field_size, .. } => *field_size,
+                        _ => 8,
+                    };
+                    let (offset, fielddescr) = field_descr_ref_from_bh(bh);
+                    (offset, field_size, fielddescr)
                 };
                 let (struct_opref, struct_ptr) = self.read_ref_reg(struct_reg);
                 let (value_opref, concrete) = match bytecode {
@@ -3795,7 +3800,25 @@ where
                     fielddescr,
                 );
                 if struct_ptr != 0 {
-                    unsafe { *((struct_ptr as *mut u8).add(offset) as *mut i64) = concrete };
+                    // blackhole.py:1471-1483 stores through the fielddescr,
+                    // which carries the field's byte width, and the getfield
+                    // twin above already reads at that width. A sub-word field
+                    // written as a full word writes over whatever follows it —
+                    // for a `u32` with a live `u32` sibling behind it, the
+                    // store of one silently zeroes the other — and a field the
+                    // walk widened would then disagree with the same store as
+                    // the backend emits it.
+                    let addr = (struct_ptr as usize).wrapping_add(offset);
+                    unsafe {
+                        match field_size {
+                            1 => core::ptr::write_unaligned(addr as *mut u8, concrete as u8),
+                            2 => core::ptr::write_unaligned(addr as *mut u16, concrete as u16),
+                            4 => core::ptr::write_unaligned(addr as *mut u32, concrete as u32),
+                            // A non-{1,2,4,8}-byte field has no fixed-width
+                            // primitive store; fall back to the word-sized one.
+                            _ => core::ptr::write_unaligned(addr as *mut i64, concrete),
+                        }
+                    }
                     // A ref store adds a heap edge struct→value; notify the GC
                     // on the container so a young value survives a minor
                     // collection triggered later in the walk (mirrors

--- a/majit/majit-metainterp/tests/jit_interp_array_field_state_ref_base.rs
+++ b/majit/majit-metainterp/tests/jit_interp_array_field_state_ref_base.rs
@@ -1,0 +1,262 @@
+//! An `array_fields` base spelled as a `ref(T)` state scalar.
+//!
+//! `array_fields = { S::f => E }` says the field `f` holds a buffer BASE
+//! POINTER, so `<obj>.f[i]` is a `getfield_gc_r` of the base followed by a
+//! `get/setarrayitem_gc` on the element. The vocabulary is accepted by both
+//! `#[jit_inline]` and `#[jit_interp]`, but `<obj>` can be spelled two ways and
+//! only one of them was ever resolved:
+//!
+//! * a local `ref_params` binding — already materialized in a register, and
+//! * `state.<ref_scalar>` — a `ref(T)` state field, which has to be READ out of
+//!   the state frame first, and that read emits.
+//!
+//! Both halves of the lowering handled only the first. On the JIT path
+//! `match_array_field_base` required an `Expr::Path`, so the shape matched
+//! nothing and the whole arm degraded to an abort stub; a dispatch whose arms
+//! all degrade leaves its switch pointing at blocks that were never emitted.
+//! On the concrete path `RefFieldRewriter` had no `Expr::Index` arm at all, so
+//! the plain-field arms rewrote `<base>.<field>` on their own and left a raw
+//! pointer being indexed with `[]` — which does not compile.
+//!
+//! That second failure mode is why this fixture is worth its length: the
+//! concrete half regresses as a BUILD failure, so a test that merely ran the
+//! machine would never get the chance to report it. What needs asserting is the
+//! JIT half, and the census below is what separates "the trace lowered the
+//! element access" from "the arm degraded and the concrete fallback ran and
+//! happened to agree". A degraded arm still returns the right number.
+//!
+//! The read and the write reach the base through two different call sites, so
+//! both are exercised. Getting a read to survive at all takes care: at a fixed
+//! index it is loop-invariant and gets hoisted, and immediately after a write
+//! to the same index it is answered from the store. The machine below walks its
+//! index instead, which is also the only arrangement under which the base read
+//! has to be redone rather than folded.
+
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_ir::OpCode;
+use majit_metainterp::JitDriver;
+
+/// The optimized opcode list of the last loop compiled.
+static COMPILED: Mutex<Vec<OpCode>> = Mutex::new(Vec::new());
+static COMPILES: AtomicUsize = AtomicUsize::new(0);
+
+/// `data` is deliberately NOT the first member: a base read that ignores the
+/// field's own offset lands on `guard` and indexes a sentinel, which the
+/// element assertions below would catch. With `data` at offset 0 the wrong
+/// answer and the right one coincide.
+#[repr(C)]
+struct ElemStack {
+    guard: i64,
+    data: *mut i64,
+}
+
+struct WalkState {
+    /// `ref(ElemStack)` — the address of the holder, not of the buffer.
+    stack: usize,
+    /// The element index. It advances every iteration, so the read below is
+    /// neither loop-invariant nor answerable from the write that follows it.
+    sp: i64,
+    acc: i64,
+    ticks: i64,
+}
+
+pub type Bytecode = [u8];
+
+/// `acc += stack.data[sp]` — reads what the buffer was seeded with
+const OP_LOAD: u8 = 1;
+/// `stack.data[sp] = ticks` — overwrites the slot just read
+const OP_STORE: u8 = 2;
+/// `sp += 1`
+const OP_STEP: u8 = 3;
+/// `ticks -= 1`; back edge to 0 while non-zero
+const OP_TICK: u8 = 4;
+const OP_HALT: u8 = 5;
+
+#[majit_macros::jit_interp(
+    state = WalkState,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        stack: ref(ElemStack),
+        sp: int,
+        acc: int,
+        ticks: int,
+    },
+    array_fields = { ElemStack::data => i64 },
+)]
+#[allow(unused_assignments, unused_variables)]
+fn dispatch_walk(program: &Bytecode, threshold: u32, stack: usize, ticks: i64) -> i64 {
+    let mut driver: JitDriver<WalkState> = JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_gk, _before, _after, opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+        *COMPILED.lock().unwrap() = opcodes.to_vec();
+    });
+    let mut pc: usize = 0;
+    let mut state = WalkState {
+        stack,
+        sp: 0i64,
+        acc: 0i64,
+        ticks,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+        let opcode = program[pc];
+        pc += 1;
+        match opcode {
+            OP_LOAD => {
+                state.acc = state.acc + state.stack.data[state.sp];
+            }
+            OP_STORE => {
+                state.stack.data[state.sp] = state.ticks;
+            }
+            OP_STEP => {
+                state.sp = state.sp + 1i64;
+            }
+            OP_TICK => {
+                state.ticks = state.ticks - 1i64;
+                if state.ticks != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_HALT => break,
+            _ => break,
+        }
+    }
+    state.acc
+}
+
+const PROGRAM: [u8; 5] = [OP_LOAD, OP_STORE, OP_STEP, OP_TICK, OP_HALT];
+
+/// How many iterations the machine runs, and how far `sp` therefore walks.
+const TICKS: i64 = 200;
+/// Enough slots that `sp` never leaves the buffer, so the machine needs no wrap
+/// branch and the trace stays a single un-bridged loop.
+const SLOTS: usize = 256;
+
+struct Fixture {
+    buf: Vec<i64>,
+    holder: Box<ElemStack>,
+}
+
+impl Fixture {
+    /// Slot `i` is seeded with `i + 1`, so a read from the wrong slot returns a
+    /// wrong sum rather than the same one.
+    fn new() -> Self {
+        let mut buf: Vec<i64> = (0..SLOTS as i64).map(|i| i + 1).collect();
+        let base = buf.as_mut_ptr();
+        Self {
+            buf,
+            holder: Box::new(ElemStack {
+                guard: i64::MIN,
+                data: base,
+            }),
+        }
+    }
+
+    fn holder_addr(&mut self) -> usize {
+        &mut *self.holder as *mut ElemStack as usize
+    }
+}
+
+/// Iteration `i` reads the seed at slot `i` and writes `TICKS - i` over it.
+fn expected_acc() -> i64 {
+    (1..=TICKS).sum()
+}
+
+/// The machine answers the same warm and cold, and its writes land in the
+/// buffer the field points at.
+///
+/// The cold arm is not decoration: it is the only statement of what the right
+/// answer IS. Comparing the warm run against a constant would grade the JIT
+/// against this file's arithmetic instead of against the interpreter.
+#[test]
+fn an_array_field_under_a_state_ref_base_agrees_warm_and_cold() {
+    let mut cold = Fixture::new();
+    let addr = cold.holder_addr();
+    let cold_acc = dispatch_walk(&PROGRAM, u32::MAX, addr, TICKS);
+
+    let mut warm = Fixture::new();
+    let addr = warm.holder_addr();
+    let warm_acc = dispatch_walk(&PROGRAM, 8, addr, TICKS);
+
+    assert_eq!(cold_acc, expected_acc(), "the cold arm must interpret it");
+    assert_eq!(
+        warm_acc, cold_acc,
+        "a compiled element access answered differently from the interpreter",
+    );
+
+    let touched: Vec<i64> = (0..TICKS).map(|i| TICKS - i).collect();
+    assert_eq!(
+        &warm.buf[..TICKS as usize],
+        touched.as_slice(),
+        "each visited slot must hold the tick written to it",
+    );
+    let untouched: Vec<i64> = (TICKS..SLOTS as i64).map(|i| i + 1).collect();
+    assert_eq!(
+        &warm.buf[TICKS as usize..],
+        untouched.as_slice(),
+        "the machine never walks past slot {TICKS}; a stride off by a word \
+         would have disturbed a slot beyond it",
+    );
+    assert_eq!(
+        warm.holder.guard,
+        i64::MIN,
+        "the element write must go through the buffer, not into the holder",
+    );
+}
+
+/// The compiled trace must carry BOTH element accesses as array ops.
+///
+/// This is the assertion that fails on the regressed JIT half. When
+/// `match_array_field_base` cannot resolve a `state.<ref_scalar>` base the arm
+/// degrades to an abort stub, and the machine still returns the right number
+/// through the concrete path — so the check above passes and grades nothing.
+///
+/// The read and the write are asserted separately because they reach the base
+/// through separate call sites: `lower_ref_binding_array_read` and
+/// `lower_ref_binding_array_write`. Either one alone would pass this test on a
+/// build where the other still could not resolve the base.
+#[test]
+fn the_compiled_trace_lowers_both_element_accesses_to_array_ops() {
+    let mut fixture = Fixture::new();
+    let addr = fixture.holder_addr();
+    let before = COMPILES.load(Ordering::Relaxed);
+    let acc = dispatch_walk(&PROGRAM, 8, addr, TICKS);
+    assert_eq!(acc, expected_acc());
+    assert!(
+        COMPILES.load(Ordering::Relaxed) > before,
+        "no trace compiled, so the census below would read zero vacuously",
+    );
+
+    let loop_ops = COMPILED.lock().unwrap().clone();
+    let count = |wanted: OpCode| loop_ops.iter().filter(|op| **op == wanted).count();
+    let sets = count(OpCode::SetarrayitemGc);
+    let gets = count(OpCode::GetarrayitemGcI);
+    let bases = count(OpCode::GetfieldGcR);
+    assert!(
+        bases > 0,
+        "the buffer base must be read out of the holder as a pointer field; \
+         loop was {loop_ops:?}",
+    );
+    assert!(
+        sets > 0,
+        "the element write must survive as a setarrayitem; an arm that degraded \
+         to an abort stub leaves none. Loop was {loop_ops:?}",
+    );
+    assert!(
+        gets > 0,
+        "the element read must survive as a getarrayitem; an arm that degraded \
+         to an abort stub leaves none. Loop was {loop_ops:?}",
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_array_field_state_ref_base.rs
+++ b/majit/majit-metainterp/tests/jit_interp_array_field_state_ref_base.rs
@@ -260,3 +260,133 @@ fn the_compiled_trace_lowers_both_element_accesses_to_array_ops() {
          to an abort stub leaves none. Loop was {loop_ops:?}",
     );
 }
+
+/// The same access, but the array field is declared on an EMBEDDED base.
+///
+/// `array_fields` names the struct that declares the field. A `ref(T)` state
+/// scalar names the OUTER struct, so looking the element type up under the
+/// scalar's own spelling misses a field an `inlined_prefix` base declares. The
+/// JIT matcher resolves the declaring struct before its lookup; the concrete
+/// rewriter has to do the same, or its guard does not fire, the plain-field arm
+/// rewrites `<base>.<field>` to the buffer pointer on its own, and the `[]` is
+/// left applied to a raw pointer — which does not compile.
+///
+/// So this fixture's assertion is that the crate builds at all. It runs the
+/// machine anyway, because a shape that compiles but reads the wrong slot would
+/// otherwise go unnoticed.
+mod embedded_base {
+    use super::{OP_HALT, OP_LOAD, OP_STEP, OP_STORE, OP_TICK, SLOTS, TICKS};
+    use majit_metainterp::JitDriver;
+
+    /// Declares the array field. Must sit at offset 0 of the outer struct: an
+    /// inlined base is required to start there, which is what makes the base
+    /// register the same for both spellings.
+    #[repr(C)]
+    struct PrefixBase {
+        data: *mut i64,
+    }
+
+    #[repr(C)]
+    struct PrefixStack {
+        base: PrefixBase,
+        /// Behind the base, so the struct is genuinely an outer type rather
+        /// than a rename of the one that declares the field.
+        touched: i64,
+    }
+
+    struct PrefixState {
+        stack: usize,
+        sp: i64,
+        acc: i64,
+        ticks: i64,
+    }
+
+    pub type Bytecode = [u8];
+
+    #[majit_macros::jit_interp(
+        state = PrefixState,
+        env = Bytecode,
+        greens = [pc, program],
+        state_fields = {
+            stack: ref(PrefixStack),
+            sp: int,
+            acc: int,
+            ticks: int,
+        },
+        int_fields = { PrefixStack::touched => i64 },
+        inlined_prefix = { PrefixStack::base => PrefixBase },
+        array_fields = { PrefixBase::data => i64 },
+    )]
+    #[allow(unused_assignments, unused_variables)]
+    fn dispatch_prefix(program: &Bytecode, threshold: u32, stack: usize, ticks: i64) -> i64 {
+        let mut driver: JitDriver<PrefixState> = JitDriver::new(threshold);
+        let mut pc: usize = 0;
+        let mut state = PrefixState {
+            stack,
+            sp: 0i64,
+            acc: 0i64,
+            ticks,
+        };
+        {
+            use majit_metainterp::JitState as _;
+            state
+                .build_meta(0, program)
+                .install_canonical_liveness(&mut driver);
+        }
+
+        while pc < program.len() {
+            jit_merge_point!(driver, program, pc; state);
+            let opcode = program[pc];
+            pc += 1;
+            match opcode {
+                OP_LOAD => {
+                    state.acc = state.acc + state.stack.data[state.sp];
+                }
+                OP_STORE => {
+                    state.stack.data[state.sp] = state.ticks;
+                }
+                OP_STEP => {
+                    state.sp = state.sp + 1i64;
+                }
+                OP_TICK => {
+                    state.ticks = state.ticks - 1i64;
+                    if state.ticks != 0 {
+                        can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                        pc = 0;
+                        continue;
+                    }
+                }
+                OP_HALT => break,
+                _ => break,
+            }
+        }
+        state.acc
+    }
+
+    const PROGRAM: [u8; 5] = [OP_LOAD, OP_STORE, OP_STEP, OP_TICK, OP_HALT];
+
+    #[test]
+    fn an_array_field_declared_on_an_inlined_base_resolves_from_the_outer_scalar() {
+        let mut buf: Vec<i64> = (0..SLOTS as i64).map(|i| i + 1).collect();
+        let mut holder = Box::new(PrefixStack {
+            base: PrefixBase {
+                data: buf.as_mut_ptr(),
+            },
+            touched: 0,
+        });
+        let addr = &mut *holder as *mut PrefixStack as usize;
+        let acc = dispatch_prefix(&PROGRAM, 8, addr, TICKS);
+
+        assert_eq!(
+            acc,
+            (1..=TICKS).sum::<i64>(),
+            "the element read must reach the buffer the embedded base points at",
+        );
+        let touched: Vec<i64> = (0..TICKS).map(|i| TICKS - i).collect();
+        assert_eq!(
+            &buf[..TICKS as usize],
+            touched.as_slice(),
+            "each visited slot must hold the tick written to it",
+        );
+    }
+}

--- a/majit/majit-metainterp/tests/jit_interp_vable_tag_overflow_gives_up.rs
+++ b/majit/majit-metainterp/tests/jit_interp_vable_tag_overflow_gives_up.rs
@@ -116,9 +116,7 @@ pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32) -> i64 {
 /// losing iterations is not.
 #[test]
 fn a_virtualizable_too_large_to_number_still_interprets_correctly() {
-    let program = vec![
-        OP_PUSH1, OP_PUSH2, OP_ADD, OP_DRAIN, OP_BACK, OP_RET,
-    ];
+    let program = vec![OP_PUSH1, OP_PUSH2, OP_ADD, OP_DRAIN, OP_BACK, OP_RET];
     // Kept small on purpose: every compile attempt at this declared length pays
     // the numbering cost, and the trace is re-attempted after each giveup, so the
     // iteration count is what sets the test's runtime. The unfixed tree loses all
@@ -132,7 +130,8 @@ fn a_virtualizable_too_large_to_number_still_interprets_correctly() {
 
     let warm = mainloop(&program, ITERATIONS, 3);
     assert_eq!(
-        warm, cold,
+        warm,
+        cold,
         "a virtualizable that cannot be numbered must abandon the compile and \
          keep interpreting; instead {} of {ITERATIONS} iterations survived",
         warm / 3

--- a/majit/majit-metainterp/tests/jit_interp_vable_tag_overflow_gives_up.rs
+++ b/majit/majit-metainterp/tests/jit_interp_vable_tag_overflow_gives_up.rs
@@ -1,0 +1,140 @@
+//! A virtualizable too large to number must abandon the compile, not compile a
+//! guard that has no resume data.
+//!
+//! `resume.py:96-103` raises `TagOverflow` once a livebox index no longer fits
+//! the tag's 13 value bits, and `optimizer.py:761-766
+//! store_final_boxes_in_guard` answers it with `raise compile.giveup()` — the
+//! whole compilation is abandoned and the interpreter keeps running from state
+//! it never handed over. Every element of a virtualizable array is a distinct
+//! livebox (`resume.py:243-247 _number_boxes`), so a long enough declared
+//! length reaches that limit on its own.
+//!
+//! What makes this a correctness test rather than a capacity one: the failure
+//! is silent. A guard emitted without resume data still compiles, and the
+//! damage appears only when it later fails and the deopt rebuilds interpreter
+//! state out of an empty numbering. The interpreter then resumes with values
+//! that are not the ones it had, so the machine's own arithmetic — not any JIT
+//! statistic — is what witnesses it.
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+/// Past the 13 value bits `resume.py:100-103` tags a box index with.
+const SLOTS: usize = 8192;
+
+const OP_PUSH1: u8 = 1;
+const OP_PUSH2: u8 = 2;
+const OP_ADD: u8 = 3;
+const OP_DRAIN: u8 = 4;
+const OP_BACK: u8 = 5;
+const OP_RET: u8 = 6;
+
+pub static COMPILES: AtomicUsize = AtomicUsize::new(0);
+
+struct StackMachine {
+    stack: VirtArray<i64>,
+    sp: usize,
+    counter: i64,
+    acc: i64,
+}
+
+#[majit_macros::jit_interp(
+    state = StackMachine,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        stack: [int; virt],
+        sp: int(usize),
+        counter: int,
+        acc: int,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<StackMachine> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = StackMachine {
+        stack: VirtArray::filled(0i64, SLOTS),
+        sp: 0usize,
+        counter: iterations,
+        acc: 0i64,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH1 => {
+                state.stack[state.sp] = 1;
+                state.sp = state.sp + 1;
+            }
+            OP_PUSH2 => {
+                state.stack[state.sp] = 2;
+                state.sp = state.sp + 1;
+            }
+            OP_ADD => {
+                let top = state.stack[state.sp - 1];
+                state.sp = state.sp - 1;
+                state.stack[state.sp - 1] = state.stack[state.sp - 1] + top;
+            }
+            OP_DRAIN => {
+                state.sp = state.sp - 1;
+                state.acc = state.acc + state.stack[state.sp];
+            }
+            OP_BACK => {
+                state.counter = state.counter - 1;
+                if state.counter != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_RET => break,
+            _ => unreachable!(),
+        }
+    }
+    state.acc
+}
+
+/// Each iteration pushes 1 and 2, adds them, and drains the sum, so the answer
+/// counts the iterations that actually ran. Losing the compile is allowed;
+/// losing iterations is not.
+#[test]
+fn a_virtualizable_too_large_to_number_still_interprets_correctly() {
+    let program = vec![
+        OP_PUSH1, OP_PUSH2, OP_ADD, OP_DRAIN, OP_BACK, OP_RET,
+    ];
+    // Kept small on purpose: every compile attempt at this declared length pays
+    // the numbering cost, and the trace is re-attempted after each giveup, so the
+    // iteration count is what sets the test's runtime. The unfixed tree loses all
+    // but 5 iterations, so a few hundred is already a wide margin.
+    const ITERATIONS: i64 = 300;
+
+    // The cold run never reaches the threshold, so it fixes the answer without
+    // the JIT having any say in it.
+    let cold = mainloop(&program, ITERATIONS, u32::MAX);
+    assert_eq!(cold, ITERATIONS * 3, "cold interpretation");
+
+    let warm = mainloop(&program, ITERATIONS, 3);
+    assert_eq!(
+        warm, cold,
+        "a virtualizable that cannot be numbered must abandon the compile and \
+         keep interpreting; instead {} of {ITERATIONS} iterations survived",
+        warm / 3
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_stack_has_no_memory_ops.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_stack_has_no_memory_ops.rs
@@ -1,0 +1,236 @@
+//! A virtualizable array used as an operand stack, indexed by a runtime depth.
+//!
+//! `pyjitpl.py:1201-1216 _get_arrayitem_vable_index` promotes the index of a
+//! virtualizable array access with `implement_guard_value` and then answers
+//! from `virtualizable_boxes`. So a stack whose index is the machine's own
+//! depth — never a constant in the source — still lowers to boxes rather than
+//! to memory: the element accesses leave no `getarrayitem`/`setarrayitem`
+//! behind at all.
+//!
+//! That is the property a heap array cannot have. `optimizeopt/heap.rs`'s
+//! array-item cache answers for constant indices only, so the same machine
+//! written over a heap array keeps every store and every load.
+//!
+//! The second fixture holds the program fixed and varies only the DECLARED
+//! length of the array, which is what a virtualizable's box count scales with
+//! (`virtualizable.py:115-121 get_total_size`). The compiled loop must not
+//! grow with it.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use majit_ir::OpCode;
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+/// `stack[sp] = 1; sp += 1`
+const OP_PUSH1: u8 = 1;
+/// `stack[sp] = 2; sp += 1`
+const OP_PUSH2: u8 = 2;
+/// `sp -= 1; stack[sp - 1] += stack[sp]`
+const OP_ADD: u8 = 3;
+/// `sp -= 1; acc += stack[sp]`
+const OP_DRAIN: u8 = 4;
+/// `counter -= 1`; back edge to 0 while non-zero
+const OP_BACK: u8 = 5;
+/// yield `acc`
+const OP_RET: u8 = 6;
+
+/// One iteration pushes two values, adds them, and drains the sum into `acc`,
+/// so the stack is balanced across the back edge and `acc` grows by 3.
+fn balanced_program() -> Vec<u8> {
+    vec![OP_PUSH1, OP_PUSH2, OP_ADD, OP_DRAIN, OP_BACK, OP_RET]
+}
+
+/// Opcodes that read or write memory the trace could have kept in a box.
+fn memory_ops(opcodes: &[OpCode]) -> usize {
+    opcodes
+        .iter()
+        .filter(|op| {
+            matches!(
+                op,
+                OpCode::SetarrayitemGc
+                    | OpCode::GetarrayitemGcI
+                    | OpCode::GetarrayitemGcR
+                    | OpCode::GetarrayitemGcF
+            )
+        })
+        .count()
+}
+
+macro_rules! stack_machine {
+    ($name:ident, $decl:tt, $container:ty, $init:expr) => {
+        pub mod $name {
+            use super::{
+                AtomicUsize, Bytecode, Mutex, OP_ADD, OP_BACK, OP_DRAIN, OP_PUSH1, OP_PUSH2,
+                OP_RET, Ordering, VirtArray,
+            };
+
+            /// The optimized opcode list of the last loop this machine compiled.
+            pub static COMPILED: Mutex<Vec<majit_ir::OpCode>> = Mutex::new(Vec::new());
+            pub static COMPILES: AtomicUsize = AtomicUsize::new(0);
+            /// Ops recorded before the optimizer ran, for the last loop.
+            pub static RECORDED: AtomicUsize = AtomicUsize::new(0);
+
+            struct StackMachine {
+                stack: $container,
+                sp: usize,
+                counter: i64,
+                acc: i64,
+            }
+
+            #[majit_macros::jit_interp(
+                state = StackMachine,
+                env = Bytecode,
+                greens = [pc, program],
+                state_fields = {
+                    stack: $decl,
+                    sp: int(usize),
+                    counter: int,
+                    acc: int,
+                },
+            )]
+            #[allow(unused_assignments, unused_variables)]
+            pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32) -> i64 {
+                let mut driver: majit_metainterp::JitDriver<StackMachine> =
+                    majit_metainterp::JitDriver::new(threshold);
+                driver.set_on_compile_loop(|_green_key, before, _after, opcodes| {
+                    COMPILES.fetch_add(1, Ordering::Relaxed);
+                    RECORDED.store(before, Ordering::Relaxed);
+                    *COMPILED.lock().unwrap() = opcodes.to_vec();
+                });
+                let mut pc: usize = 0;
+                let mut state = StackMachine {
+                    stack: $init,
+                    sp: 0usize,
+                    counter: iterations,
+                    acc: 0i64,
+                };
+                {
+                    use majit_metainterp::JitState as _;
+                    state
+                        .build_meta(0, program)
+                        .install_canonical_liveness(&mut driver);
+                }
+
+                while pc < program.len() {
+                    jit_merge_point!(driver, program, pc; state);
+
+                    let opcode = program[pc];
+                    pc += 1;
+
+                    match opcode {
+                        OP_PUSH1 => {
+                            state.stack[state.sp] = 1;
+                            state.sp = state.sp + 1;
+                        }
+                        OP_PUSH2 => {
+                            state.stack[state.sp] = 2;
+                            state.sp = state.sp + 1;
+                        }
+                        OP_ADD => {
+                            let top = state.stack[state.sp - 1];
+                            state.sp = state.sp - 1;
+                            state.stack[state.sp - 1] = state.stack[state.sp - 1] + top;
+                        }
+                        OP_DRAIN => {
+                            state.sp = state.sp - 1;
+                            state.acc = state.acc + state.stack[state.sp];
+                        }
+                        OP_BACK => {
+                            state.counter = state.counter - 1;
+                            if state.counter != 0 {
+                                can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                                pc = 0;
+                                continue;
+                            }
+                        }
+                        OP_RET => break,
+                        _ => unreachable!(),
+                    }
+                }
+                state.acc
+            }
+        }
+    };
+}
+
+stack_machine!(
+    eight_slots,
+    [int; virt],
+    VirtArray<i64>,
+    VirtArray::filled(0i64, 8)
+);
+stack_machine!(
+    five_hundred_slots,
+    [int; virt],
+    VirtArray<i64>,
+    VirtArray::filled(0i64, 512)
+);
+// A plain `[int]` array is not a control here: `jit_interp` refuses one that is
+// loop-carried, because a loop-carried plain element does not read its heap
+// value back. The control for "a heap array keeps its accesses" is the aheui
+// array backend, whose logo loop holds 2055 `setarrayitem` and 1306
+// `getarrayitem` against this shape's none.
+
+/// The machine computes the same answer warm and cold.
+#[test]
+fn a_vable_stack_machine_interprets_its_program() {
+    let program = balanced_program();
+    assert_eq!(eight_slots::mainloop(&program, 5, u32::MAX), 15, "cold");
+    assert_eq!(eight_slots::mainloop(&program, 200, 3), 600, "warm");
+}
+
+/// The payoff: a stack indexed by a runtime depth leaves no element access in
+/// the compiled loop.
+///
+/// A zero that cannot fail proves nothing, so the same program over a plain
+/// heap array is the control: it must report a nonzero count, and the loop
+/// must be non-trivial in both arms.
+#[test]
+fn a_vable_stack_indexed_by_a_runtime_depth_lowers_to_no_memory_ops() {
+    let program = balanced_program();
+    assert_eq!(eight_slots::mainloop(&program, 400, 3), 1200);
+    assert!(
+        eight_slots::COMPILES.load(Ordering::Relaxed) > 0,
+        "the fixture must compile a loop for the census to mean anything"
+    );
+
+    let vable = eight_slots::COMPILED.lock().unwrap().clone();
+    eprintln!(
+        "vable stack loop: {} recorded -> {} ops, {} of them memory",
+        eight_slots::RECORDED.load(Ordering::Relaxed),
+        vable.len(),
+        memory_ops(&vable),
+    );
+    // An empty loop would report zero memory ops vacuously, and so would one
+    // the optimizer never touched.
+    assert!(
+        vable.iter().any(|op| matches!(op, OpCode::IntAdd)),
+        "the loop must still carry the machine's arithmetic; loop was {vable:?}"
+    );
+    assert!(
+        eight_slots::RECORDED.load(Ordering::Relaxed) > vable.len(),
+        "the optimizer must have removed something for the census to be about it"
+    );
+    assert_eq!(
+        memory_ops(&vable),
+        0,
+        "vable stack element accesses must not survive as memory ops; loop was {vable:?}"
+    );
+}
+
+/// The declared length drives the virtualizable's box count, not the loop.
+#[test]
+fn the_compiled_loop_does_not_grow_with_the_declared_array_length() {
+    let program = balanced_program();
+    assert_eq!(eight_slots::mainloop(&program, 400, 3), 1200);
+    assert_eq!(five_hundred_slots::mainloop(&program, 400, 3), 1200);
+    let small = eight_slots::COMPILED.lock().unwrap().len();
+    let large = five_hundred_slots::COMPILED.lock().unwrap().len();
+    assert_eq!(
+        small, large,
+        "a 512-slot declaration compiled {large} ops against the 8-slot {small}"
+    );
+}


### PR DESCRIPTION
Eleven commits from the aheui-driven work on `array_fields`, plus three optimizer changes found alongside them.

## Array-field descrs say what the field is

Four commits close a family where the two producers that describe the same member disagreed, and `get_field_descr` being cache-OR-mint meant the winner was decided by emission order rather than by correctness.

- `Resolve an inline array-field access against the struct that declares it`
- `Claim an array element's width rather than its type name`
- `Claim a residual array-element write's width rather than its type name`
- `Store a field at its declared width in the jitcode walk`

## `array_fields` accepts a `ref(T)` state scalar as its base

`array_fields` is documented as accepted by both `#[jit_inline]` and `#[jit_interp]`, but both halves of its lowering resolved the base only as a local `ref_params` binding, so `state.<ref_scalar>.<field>[i]` reached neither.

- On the JIT path `match_array_field_base` required an `Expr::Path`; it now also accepts `state.<ref_scalar>` through `state_ref_scalars`. Which of the two the base is becomes `ArrayFieldHolder`, resolved in `emit_array_field_base` rather than in the matcher, so the matcher stays non-emitting and the element write can still lower its right-hand side first.
- On the concrete path `RefFieldRewriter` had no `Expr::Index` arm at all, so the plain-field arms rewrote `<base>.<field>` on their own and left a raw pointer being indexed with `[]`.

Without both, an arm naming such an access degrades to an abort stub, and a dispatch whose arms all degrade leaves its switch pointing at blocks that were never emitted.

The fixture that pins it gates the two halves separately. Reverting the concrete rewriter alone stops the crate compiling; reverting the JIT lowering alone leaves the fixture compiling and its warm/cold check **passing** — a degraded arm returns the same number through the concrete path — and fails only at the compile-count guard.

## Optimizer

- `Resolve each label source position once instead of rescanning per inputarg` — `label_source_positions_for_inputargs` was O(N²) in the inputarg count, where upstream assigns `position_in_notvirtuals` in O(1) (`virtualstate.py:427-431`). This is the whole cost of a long virtualizable array: measured flat 1.3–1.7 ns/iteration from 8 to 1024 declared slots, with the entire penalty in one compile.
- `Abandon the trace when a guard's resume data cannot be numbered`
- `Key potential_extra_ops by the box instead of scanning a Vec` — `unroll.py:118` builds it as a dict, `unroll.py:37` assigns by box and `optimizer.py:354` pops by box; pyre open-coded all three as linear scans over a `Vec`. The `OpRef`-position key is unchanged and still a deviation, for the reason the field's comment already records.

## Diagnostics and fixtures

- `Print op counts when the post-optimizer trace dump is truncated` — the dumper truncates above 10000 ops, which silently makes every census counter read zero. That reads as a spectacular win.
- `Pin that a vable stack indexed by a runtime depth keeps no memory ops`

## Verification

`python3 pyre/check.py` green — dynasm 442/442, cranelift 442/442, wasm 435/435 — run on base `712fc16c29b`. The branch has since been rebased onto `e4fb0a308c6`; CI covers that base.

— *commented by Claude*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added indexed access to configured array fields, including fields stored through references and embedded structures.
  * Improved virtualized array handling so runtime-indexed stack operations can avoid unnecessary memory access.

* **Bug Fixes**
  * Corrected narrow-field writes to preserve their declared size.
  * Compilation now stops safely when loop-state numbering or virtualization metadata exceeds supported limits.

* **Diagnostics**
  * Large trace output now reports the most frequently compiled operations for easier troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->