### PR TITLE
jit: stop recover_ref_value answering the NO_CONCRETE sentinel, and record why filtering it downstream is not the follow-up

### DIFF
--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -9702,6 +9702,18 @@ impl<M: Clone> MetaInterp<M> {
                 self.stats.loops_compiled += 1;
                 // `cpu.tracker.total_compiled_loops` is bumped inside
                 // `CompiledLoopToken::new` (model.py:297 parity).
+                //
+                // Counted as a LOOP even though nothing here closes one: this
+                // arm is root-only (`compile_finish_from_active_session` routes
+                // `bridge.is_some()` to `compile_trace_finish`), and a root
+                // trace that ends in FINISH with no LABEL attaches upstream
+                // through `ResumeFromInterpDescr.compile_and_attach`
+                // (compile.py:1006-1017), which mints its own JitCellToken and
+                // calls `send_loop_to_backend(.., "entry bridge", ..)`.  So a
+                // portal function that always raises legitimately reads
+                // `loops_compiled=2` with only one `compiled loop at key=`
+                // line -- that line is logged by `compile_loop_body` alone, and
+                // its absence here is not a double count.
                 if crate::debug::have_debug_prints() {
                     crate::debug::log_one(
                         "jit-summary",

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -1898,6 +1898,38 @@ impl TraceCtx {
     /// silently substituting `Value::Void` would conflate "unstamped"
     /// with "stamped Void", which the `set_value` type-check
     /// already forbids.
+    ///
+    /// A stamped `Value::Ref(GcRef::NO_CONCRETE)` comes back as a value, not
+    /// as `None`: `heapcache_ops`' materialized-array walk writes that
+    /// sentinel over a load it could not replay, and this table hands back
+    /// what it holds.  [`Self::recover_ref_value`] rejects the sentinel; this
+    /// method deliberately does not, because "never stamped" and "stamped
+    /// unresolved" are different states and only the caller knows which one
+    /// it can act on.
+    ///
+    /// Three sites pair the two in the order `lookup_opref_concrete(..)
+    /// .or_else(|| recover_ref_value(..))` — `vable_value_concrete` and
+    /// `current_inline_vable_target` in `jitcode_dispatch/vable_ops.rs`, and
+    /// `fill_trace_too_long_register_banks` in
+    /// `jitcode_dispatch/residual_call.rs`.  `Some(_).or_else(f)` never calls
+    /// `f`, so a stamped sentinel short-circuits ahead of the guard in
+    /// `recover_ref_value` and reaches the consumer.  Two more accept it
+    /// through a bare `value.0 != 0` arm, which excludes NULL but not
+    /// `usize::MAX - 1`: the snapshot live-root reads in the same file.
+    ///
+    /// Filtering the sentinel at those sites is NOT the one-line fix it looks
+    /// like, and the reading that says so is worth keeping.  Each of them
+    /// ends in a fallback tail — `.or(from_register)`, `.or(from_shadow)`,
+    /// `_ => sym.live_vable_frame_addr()` — so rejecting the sentinel does
+    /// not decline the image, it PROMOTES the next fallback, and that is a
+    /// different concrete address landing in a blackhole frame's ref bank or,
+    /// through `store_live_frame_array_slot`, in a live frame's locals array
+    /// behind a write barrier.  `vable_ops.rs` records of the shadow it would
+    /// promote that re-reading that color "can return a stale concrete value
+    /// from a prior loop iteration".  That is wrong data, not a refusal.  A
+    /// fix has to decide what each site should answer for an unresolved box,
+    /// which is a per-site question; dropping the sentinel here or there is
+    /// not it.
     pub fn lookup_opref_concrete(&self, opref: OpRef) -> Option<Value> {
         if opref.is_constant() {
             return opref.inline_const_to_value();

--- a/majit/majit-metainterp/src/trace_ctx.rs
+++ b/majit/majit-metainterp/src/trace_ctx.rs
@@ -3198,8 +3198,21 @@ impl TraceCtx {
     /// sub-walk records the load before its outer-frame input acquires a concrete
     /// resume value. `depth` bounds recursive field chains; unsupported
     /// producers, null objects, and exhausted depth return `None`.
+    ///
+    /// `GcRef::NO_CONCRETE` is the stamp for "no runtime value is known for
+    /// this box", not a value: `heapcache_ops` writes it over a load the walk
+    /// could not replay. Returning it hands the sentinel address on as if it
+    /// were an object — the caller-image ref fill in
+    /// `jitcode_dispatch/resume_snapshot.rs` and the innermost-frame fill in
+    /// `jitcode_dispatch/residual_call.rs` both write whatever `Value::Ref`
+    /// arrives here into a blackhole frame's ref bank, and resuming through
+    /// that frame dereferences it. Answer unresolved instead, so those sites
+    /// decline the image the way they already do for a color with no box.
     pub fn recover_ref_value(&self, opref: OpRef, depth: u32) -> Option<Value> {
         if let Some(v) = self.concrete_of_opref(opref) {
+            if matches!(v, Value::Ref(r) if r == majit_ir::GcRef::NO_CONCRETE) {
+                return None;
+            }
             return Some(v);
         }
         if depth == 0 {
@@ -3214,10 +3227,10 @@ impl TraceCtx {
         let Value::Ref(obj_ref) = self.recover_ref_value(obj, depth - 1)? else {
             return None;
         };
-        let obj_ptr = obj_ref.0 as i64;
-        if obj_ptr == 0 || obj_ptr == usize::MAX as i64 {
-            return None;
-        }
+        // The receiver is about to be loaded through, so it is judged by
+        // [`live_gc_ptr`] — the one place that names all three addresses no
+        // object model owns — rather than by a local copy of two of them.
+        let obj_ptr = live_gc_ptr(obj_ref)?;
         self.field_sanity_load(obj_ptr, &descr, Type::Ref)
     }
 
@@ -5532,6 +5545,32 @@ mod tests {
             }
             other => panic!("expected ConstFloat, got {:?}", other),
         }
+    }
+
+    /// `recover_ref_value` answers unresolved for a box stamped with the
+    /// `NO_CONCRETE` sentinel, and still answers a real address.
+    ///
+    /// The sentinel is what `heapcache_ops` writes over a load it could not
+    /// replay, so handing it back as a `Value::Ref` puts `usize::MAX - 1`
+    /// into every consumer that only matches on the variant — including the
+    /// two blackhole-frame ref fills, which then seed a frame that resumption
+    /// dereferences.
+    #[test]
+    fn recover_ref_value_rejects_the_no_concrete_sentinel() {
+        let mut ctx = TraceCtx::for_test(0);
+        let unknown = ctx.record_op(OpCode::NewWithVtable, &[]);
+        assert!(ctx.try_set_opref_concrete(unknown, Value::Ref(majit_ir::GcRef::NO_CONCRETE)));
+        assert_eq!(ctx.recover_ref_value(unknown, 8), None);
+
+        // Positive control: an ordinary stamped address still comes back, so
+        // the assertion above is about the sentinel and not about the stamp
+        // failing to land.
+        let known = ctx.record_op(OpCode::NewWithVtable, &[]);
+        assert!(ctx.try_set_opref_concrete(known, Value::Ref(majit_ir::GcRef(0x1000))));
+        assert_eq!(
+            ctx.recover_ref_value(known, 8),
+            Some(Value::Ref(majit_ir::GcRef(0x1000)))
+        );
     }
 
     /// With no cpu wired, `field_sanity_load` returns `None` —


### PR DESCRIPTION
Three commits on top of `origin/main`. One behaviour change — the Codex review finding on #1364, which merged before the fix was written — and two comments recording measured refutations.

## The fix

**`recover_ref_value` no longer answers the `NO_CONCRETE` sentinel as if it were an address.** It returned whatever `concrete_of_opref` held, including the `Value::Ref(GcRef::NO_CONCRETE)` stamp `heapcache_ops`' materialized-array walk writes over a load it could not replay. The two blackhole-frame ref fills that reach this function *directly* match on the `Value::Ref` variant alone, so `usize::MAX - 1` was written into a resumed frame's ref bank as an object address: `capture_inline_parent_blackhole` (the site Codex flagged) and `build_single_frame_miframe`. It now answers unresolved, which is what those sites already do for a color whose register holds no box — the image is declined and the outer flush falls back to the legacy replay. The receiver guard inside the same function checked NULL and the all-ones tombstone by hand and missed the sentinel; it now calls `live_gc_ptr`, the one predicate that names all three. Pinned by a test shown to fail on the unfixed function, with a positive control.

The deliberately conservative variant was chosen: return `None` rather than falling through to the producer-chain replay. Falling through could produce a *different* concrete value; answering unresolved can only turn a poisoned answer into a decline.

## Two comments, and why they are worth their diff

Both record work whose result was "do not change the code" — the kind of finding that gets rediscovered and re-attempted if it is not written where the next reader hits it.

**`lookup_opref_concrete`: filtering the sentinel is not the follow-up fix it looks like.** Three more sites pair the stamp table with `recover_ref_value` in the order `lookup_opref_concrete(..).or_else(|| recover_ref_value(..))`, and `Some(_).or_else(f)` never calls `f`, so the stamp short-circuits ahead of the new guard. Two others accept the sentinel through a `value.0 != 0` arm that excludes NULL but not `usize::MAX - 1`. The obvious patch — filter it at those sites — was written and then refuted: **every one of them ends in a fallback tail** (`.or(from_register)`, `.or(from_shadow)`, `_ => sym.live_vable_frame_addr()`), so rejecting the sentinel does not decline the image, it *promotes the next fallback* — a different concrete address into a blackhole ref bank or, through `store_live_frame_array_slot`, into a live frame's locals array behind a write barrier. `vable_ops.rs` already records that re-reading the shadow it would promote "can return a stale concrete value from a prior loop iteration". Wrong data, not a refusal. The real question is per-site: what should each answer for an unresolved box? Filed as a follow-up; reachability there is inferred, never observed, and the first step is a measurement, not a patch.

Related, and *not* changed here: the literal worry that started this — that the sentinel could reach `vable_setfield` — is inert. That function does `let _ = concrete;` on one leg and `concrete.unwrap_or(Value::Ref(GcRef::NO_CONCRETE))` on the other, so `None` and `Some(sentinel)` are indistinguishable inputs there.

**`finish_and_compile`: the second `loops_compiled` is not a double count.** `exception_bridge_traceback_head` reads `loops_compiled=2` with a single `[jit] compiled loop at key=` line, which invites exactly that conclusion. Five sites bump the counter, one per `Backend::compile_loop` caller, and only `compile_loop_body` logs that line. The second increment is this site, reached only from the `bridge.is_none()` arm, and upstream counts a root FINISH trace with no LABEL as a loop too — `ResumeFromInterpDescr.compile_and_attach` (compile.py:1006-1017) mints its own JitCellToken and calls `send_loop_to_backend(.., "entry bridge", ..)`. The backend-side `total_compiled_loops`, bumped at the `model.py:297` point, independently reads 2 on that fixture: two CompiledLoopTokens, two green keys, two code buffers.

## Verification

`cargo fmt --all` clean; `cargo check --all --all-targets --features dynasm` rc=0 (the target set a rebase can break without `check.py` ever seeing it); full LLBC re-extract; then `pyre/check.py` — **dynasm 443/443, cranelift 443/443, wasm 436/436, 3/3 backend runs**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TBNBmnBveAQFbqRtrvQVyQ
