### PR TITLE
jit, _abc: carry the recorded QuasiImmut instance on the marker descr, and let a missing _abc collection raise

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3486,6 +3486,12 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
     fn as_loop_target_descr(&self) -> Option<&dyn LoopTargetDescr> {
         None
     }
+    /// `heap.py:814` `assert isinstance(qmutdescr, QuasiImmutDescr)` — the
+    /// descr a recorded `QUASIIMMUT_FIELD` carries.  Default `None`; only
+    /// [`QuasiImmutDescr`] overrides.
+    fn as_quasi_immut_descr(&self) -> Option<&QuasiImmutDescr> {
+        None
+    }
 
     /// Whether the field/array described is always pure (immutable).
     fn is_always_pure(&self) -> bool {
@@ -3616,6 +3622,117 @@ pub trait Descr: Send + Sync + std::fmt::Debug {
         } else {
             (0, false)
         }
+    }
+}
+
+/// `quasiimmut.py:54-110 QuasiImmut` seen from the JIT side — one object
+/// gathering the loops that folded a single quasi-immutable field.
+///
+/// The instance itself belongs to the interpreter, which owns the hidden
+/// `mutate_<name>` field it hangs off; majit only ever asks it the two
+/// questions upstream asks: whether it is still the field's current instance
+/// (`quasiimmut.py:152`), and to record a finished loop (`:72-75`).
+pub trait QuasiImmutHandle: Send + Sync + std::fmt::Debug {
+    /// `quasiimmut.py:151-153` — the `qmut is not self.qmut` test, answered by
+    /// the recorded instance rather than by re-reading the field.
+    fn is_current(&self) -> bool;
+
+    /// `quasiimmut.py:72-75 register_loop_token`, reached from
+    /// `compile.py:204-207`.
+    fn register_loop_token(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>);
+}
+
+/// `quasiimmut.py:113-158 QuasiImmutDescr` — the descr a recorded
+/// `QUASIIMMUT_FIELD` carries, minted fresh per read so it can hold what that
+/// read resolved: the struct, the field, and the `QuasiImmut` instance
+/// `get_current_qmut_instance` handed back.
+///
+/// Everything else about it is the wrapped field descr, so the whole `Descr`
+/// surface delegates and the op stays indistinguishable from one carrying the
+/// field descr directly — including `index()`, which the heap cache and the
+/// tracer key on.
+///
+/// `constantfieldbox` (`quasiimmut.py:125`) is the one member that stays off
+/// this descr: it is a Box, and pyre records it as the op's second operand
+/// instead.
+#[derive(Debug)]
+pub struct QuasiImmutDescr {
+    fielddescr: DescrRef,
+    /// `quasiimmut.py:121 self.struct = struct` — compared, never dereferenced.
+    struct_ptr: u64,
+    qmut: std::sync::Arc<dyn QuasiImmutHandle>,
+}
+
+impl QuasiImmutDescr {
+    /// `quasiimmut.py:119-125 QuasiImmutDescr.__init__`, minus the field read
+    /// the caller keeps as an operand.
+    pub fn new(
+        fielddescr: DescrRef,
+        struct_ptr: u64,
+        qmut: std::sync::Arc<dyn QuasiImmutHandle>,
+    ) -> Self {
+        Self {
+            fielddescr,
+            struct_ptr,
+            qmut,
+        }
+    }
+
+    /// `quasiimmut.py:122 self.fielddescr = fielddescr`.
+    pub fn fielddescr(&self) -> &DescrRef {
+        &self.fielddescr
+    }
+
+    /// `quasiimmut.py:121 self.struct = struct`.
+    pub fn struct_ptr(&self) -> u64 {
+        self.struct_ptr
+    }
+
+    /// `quasiimmut.py:124 self.qmut = get_current_qmut_instance(...)`.
+    pub fn qmut(&self) -> &std::sync::Arc<dyn QuasiImmutHandle> {
+        &self.qmut
+    }
+}
+
+impl Descr for QuasiImmutDescr {
+    fn as_quasi_immut_descr(&self) -> Option<&QuasiImmutDescr> {
+        Some(self)
+    }
+    fn as_any(&self) -> Option<&dyn std::any::Any> {
+        Some(self)
+    }
+    fn index(&self) -> u32 {
+        self.fielddescr.index()
+    }
+    fn set_index(&self, index: u32) {
+        self.fielddescr.set_index(index);
+    }
+    fn get_descr_index(&self) -> i32 {
+        self.fielddescr.get_descr_index()
+    }
+    fn set_descr_index(&self, index: i32) {
+        self.fielddescr.set_descr_index(index);
+    }
+    fn get_ei_index(&self) -> u32 {
+        self.fielddescr.get_ei_index()
+    }
+    fn set_ei_index(&self, ei_index: u32) {
+        self.fielddescr.set_ei_index(ei_index);
+    }
+    fn is_always_pure(&self) -> bool {
+        self.fielddescr.is_always_pure()
+    }
+    fn is_quasi_immutable(&self) -> bool {
+        self.fielddescr.is_quasi_immutable()
+    }
+    fn is_virtualizable(&self) -> bool {
+        self.fielddescr.is_virtualizable()
+    }
+    fn as_field_descr(&self) -> Option<&dyn FieldDescr> {
+        self.fielddescr.as_field_descr()
+    }
+    fn repr(&self) -> String {
+        self.fielddescr.repr()
     }
 }
 

--- a/majit/majit-ir/src/lib.rs
+++ b/majit/majit-ir/src/lib.rs
@@ -30,12 +30,13 @@ pub mod value;
 pub use descr::{
     AccumInfo, ArrayDescr, ArrayFlag, CallDescr, DebugMergePointDescr, DebugMergePointInfo, Descr,
     DescrRef, FailDescr, FailDescrCell, FieldDescr, GcCache, InteriorFieldDescr, JitCodeDescr,
-    LLType, LoopTargetDescr, LoopTokenDescr, SimpleCallDescr, SimpleFailDescr, SimpleFieldDescr,
-    SizeDescr, SwitchDescr, TargetArgLoc, UnpackAtExitInfo, descr_identity, make_array_descr,
-    make_array_descr_signed, make_call_descr, make_field_descr, make_field_descr_full,
-    make_loop_target_descr, make_malloc_array_calldescr, make_malloc_array_nonstandard_calldescr,
-    make_malloc_big_fixedsize_calldescr, make_malloc_str_calldescr, make_malloc_unicode_calldescr,
-    make_memcpy_calldescr, make_size_descr_full, make_size_descr_with_vtable, make_tid_field_descr,
+    LLType, LoopTargetDescr, LoopTokenDescr, QuasiImmutDescr, QuasiImmutHandle, SimpleCallDescr,
+    SimpleFailDescr, SimpleFieldDescr, SizeDescr, SwitchDescr, TargetArgLoc, UnpackAtExitInfo,
+    descr_identity, make_array_descr, make_array_descr_signed, make_call_descr, make_field_descr,
+    make_field_descr_full, make_loop_target_descr, make_malloc_array_calldescr,
+    make_malloc_array_nonstandard_calldescr, make_malloc_big_fixedsize_calldescr,
+    make_malloc_str_calldescr, make_malloc_unicode_calldescr, make_memcpy_calldescr,
+    make_size_descr_full, make_size_descr_with_vtable, make_tid_field_descr,
     make_vtable_field_descr, memcpy_fn_addr, recover_fail_descr_cell, unpack_fielddescr,
 };
 pub use effectinfo::{

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -921,8 +921,8 @@ impl OptHeap {
         descr_identity(descr)
     }
 
-    /// `quasiimmut.py:147-159 QuasiImmutDescr.is_still_valid_for`, the check
-    /// `heap.py:802-804` turns into `InvalidLoop('quasi immutable field changed
+    /// `quasiimmut.py:146-158 QuasiImmutDescr.is_still_valid_for`, the check
+    /// `heap.py:818-819` turns into `InvalidLoop('quasi immutable field changed
     /// during tracing')`.
     ///
     /// ```text
@@ -940,41 +940,42 @@ impl OptHeap {
     ///          return True
     /// ```
     ///
-    /// Upstream detects the change through the `qmut` object's identity —
-    /// invalidation nulls the hidden `mutate_*` field, so
-    /// `get_current_qmut_instance` hands back a fresh instance and the `is not`
-    /// test fires; the field-value comparison is the assert that backs it up.
-    /// Pyre has no per-read `QuasiImmutDescr` to hang that identity on, so the
-    /// value comparison is the test itself: the tracer captured the field on
-    /// `arg(1)` (`state::current_quasiimmut_field_value`) and a live re-read
-    /// through `get_runtime_field` is `get_current_constant_fieldvalue`.
+    /// `struct_ptr` is `structconst.getref_base()`, already resolved by the
+    /// caller's `heap.py:809 is_constant()` gate.
     ///
-    /// Returns `true` — keep the loop — whenever the comparison cannot be made:
-    /// a struct that did not fold to a constant is the case heap.py:794-796
-    /// ignores outright, and an op without the captured value is the namespace
-    /// twin, which carries a slot index there instead.
+    /// The identity test asks the recorded instance whether it is still the
+    /// field's own, instead of re-reading the field to compare: the two answers
+    /// coincide, because a fresh instance is only ever minted into a field the
+    /// sweep has nulled, and the recorded one needs no second walk from the
+    /// struct to the hidden `mutate_*` slot.
+    ///
+    /// The value comparison is upstream's closing assert: the recording
+    /// captured the field on `arg(1)` (`state::current_quasiimmut_field_value`)
+    /// and a live re-read through `get_runtime_field` is
+    /// `get_current_constant_fieldvalue`. It is answered as a verdict rather
+    /// than an assert, and skipped for an op that carries no captured value —
+    /// the namespace twin, which records a slot index there instead.
     fn quasiimmut_field_still_valid(
         op: &Op,
         obj: OpRef,
-        descr: &DescrRef,
+        struct_ptr: u64,
+        qmutdescr: &majit_ir::QuasiImmutDescr,
         ctx: &mut OptContext,
     ) -> bool {
+        if struct_ptr != qmutdescr.struct_ptr() {
+            return false;
+        }
+        if !qmutdescr.qmut().is_current() {
+            return false;
+        }
         if op.num_args() < 2 {
             return true;
         }
         let Some(constantfieldbox) = op.arg(1).const_value() else {
             return true;
         };
-        // heap.py:794-796 `if not structvalue.is_constant(): return`.
-        if ctx
-            .get_box_replacement_operand_opt(obj)
-            .and_then(|b| ctx.get_constant_ptr_box(&b))
-            .is_none()
-        {
-            return true;
-        }
         let Some(currentbox) = ctx
-            .get_runtime_field(obj, descr)
+            .get_runtime_field(obj, qmutdescr.fielddescr())
             .and_then(|r| r.inline_const_to_value())
         else {
             return true;
@@ -3302,7 +3303,7 @@ impl OptHeap {
                 }
             }
 
-            // heap.py:810-825 optimize_GUARD_NOT_INVALIDATED
+            // heap.py:825-840 optimize_GUARD_NOT_INVALIDATED
             OpCode::GuardNotInvalidated => {
                 if self.seen_guard_not_invalidated {
                     OptimizationResult::Remove
@@ -3317,52 +3318,58 @@ impl OptHeap {
             // The optimizer replaces the field read with the cached value and
             // emits GUARD_NOT_INVALIDATED to ensure validity.
             OpCode::QuasiimmutField => {
-                // RPython optimize_QUASIIMMUT_FIELD (heap.py:781):
+                // RPython optimize_QUASIIMMUT_FIELD (heap.py:798):
                 // Does NOT create a new GUARD_NOT_INVALIDATED — the tracer
                 // already emitted one via generate_guard (pyjitpl.py:1087).
                 // Records quasi_immutable_deps for invalidation tracking.
                 let obj = op.arg(0).to_opref();
-                // heap.py:798-804 — the field can have changed between the
-                // tracer reading it and this pass running.  Abandon the loop
-                // when it has; the traced value is baked in as a constant and
-                // nothing downstream will re-prove it.
-                if let Some(descr) = op.getdescr()
-                    && !Self::quasiimmut_field_still_valid(op, obj, &descr, ctx)
+                let descr = op.getdescr();
+                // heap.py:808-810 `structvalue = self.ensure_ptr_info_arg0(op)`
+                // / `if not structvalue.is_constant(): return`.  The dependency
+                // object is baked as a `ConstPtr`, so its pointer lives in
+                // `Value::Ref`, not `Value::Int`.
+                let struct_ptr = ctx
+                    .get_box_replacement_operand_opt(obj)
+                    .and_then(|b| ctx.get_constant_ptr_box(&b));
+                if let Some(struct_ptr) = struct_ptr
+                    && struct_ptr != 0
                 {
-                    return OptimizationResult::InvalidLoop(
-                        "quasi immutable field changed during tracing",
-                    );
-                }
-                // heap.py:807-809 `self.optimizer.quasi_immutable_deps[
-                // qmutdescr.qmut] = None`.  Upstream keys the set on the
-                // `QuasiImmut` instance the descr already resolved; pyre records
-                // the pair that identifies it — the owning object and which of
-                // its quasi-immutable fields — and `register_quasi_immutable_deps`
-                // resolves the instance after compilation.
-                let (dep_field_idx, cache_field_key) = match op.getdescr() {
-                    Some(descr) => (
-                        Some(descr.index()),
-                        Some(Self::field_cache_identity(&descr)),
-                    ),
-                    None => (None, None),
-                };
-                if let Some(idx) = dep_field_idx {
-                    // The quasi-immutable dependency object (namespace dict /
-                    // struct) is baked as a `ConstPtr`, so its pointer lives in
-                    // `Value::Ref`, not `Value::Int`.  Reading it as an int
-                    // yielded `None` and silently dropped the dependency, so a
-                    // later `mutated()` never flipped the loop's invalidation
-                    // flag.
-                    if let Some(dep_ptr) = ctx
-                        .get_box_replacement_operand_opt(obj)
-                        .and_then(|b| ctx.get_constant_ptr_box(&b))
-                    {
-                        ctx.add_quasi_immutable_dep((dep_ptr, idx));
+                    // heap.py:812-814 `assert isinstance(qmutdescr,
+                    // QuasiImmutDescr)`, answered as a verdict.  A marker whose
+                    // recording resolved no instance has nobody to register the
+                    // finished loop with, and a loop that folded the field with
+                    // no watcher behind it would never be revoked.
+                    let Some(qmutdescr) = descr.as_ref().and_then(|d| d.as_quasi_immut_descr())
+                    else {
+                        return OptimizationResult::InvalidLoop(
+                            "quasi immutable field marker carries no QuasiImmut instance",
+                        );
+                    };
+                    // heap.py:818-819 — the field can have changed between the
+                    // tracer reading it and this pass running.  Abandon the loop
+                    // when it has; the traced value is baked in as a constant
+                    // and nothing downstream will re-prove it.
+                    if !Self::quasiimmut_field_still_valid(op, obj, struct_ptr, qmutdescr, ctx) {
+                        return OptimizationResult::InvalidLoop(
+                            "quasi immutable field changed during tracing",
+                        );
                     }
+                    // heap.py:821-823 `self.optimizer.quasi_immutable_deps[
+                    // qmutdescr.qmut] = None`.
+                    ctx.add_quasi_immutable_dep(qmutdescr.qmut().clone());
                 }
-                if let Some(key) = cache_field_key
+                if let Some(descr) = descr.as_ref()
                     && let Some(obj_box) = ctx.get_box_replacement_operand_opt(obj)
                 {
+                    // The cache is keyed on the field, so it reads through the
+                    // per-read `QuasiImmutDescr` to the registry singleton it
+                    // wraps — a fresh wrapper per read would key each entry to
+                    // itself and never hit.
+                    let key = Self::field_cache_identity(
+                        descr
+                            .as_quasi_immut_descr()
+                            .map_or(descr, |q| q.fielddescr()),
+                    );
                     self.quasi_immut_cache.insert((obj_box, key), OpRef::NONE);
                 }
                 OptimizationResult::Remove

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -687,13 +687,14 @@ pub struct OptContext {
     pub imported_short_preamble_builder:
         Option<crate::optimizeopt::shortpreamble::ShortPreambleBuilder>,
     /// `optimizer.py:243` `self.quasi_immutable_deps = None` (initialized
-    /// lazily as a dict in `heap.py:806-808`). Each entry pairs an
-    /// `(object_ptr, field_index)` quasi-immutable slot the trace
-    /// depends on; PyPy uses `dict[k] = None` for set semantics, but the
-    /// HashMap house rule forbids that — pyre uses a Vec with
-    /// linear-scan dedup. Typical size is small (< a few dozen entries
-    /// per trace), so O(n) inserts are acceptable.
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    /// lazily as a dict in `heap.py:821-823`). Each entry is one `QuasiImmut`
+    /// instance the trace folded a field of, exactly as upstream keys the dict
+    /// (`heap.py:821-823 quasi_immutable_deps[qmutdescr.qmut] = None`); PyPy
+    /// uses `dict[k] = None` for set semantics, but the HashMap house rule
+    /// forbids that — pyre uses a Vec with linear-scan dedup on instance
+    /// identity. Typical size is small (< a few dozen entries per trace), so
+    /// O(n) inserts are acceptable.
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// `info.py:722` `optheap.const_infos.get(ref, None)` /
     /// `info.py:725` `optheap.const_infos[ref] = info`. Stores
     /// `StructPtrInfo` / `ArrayPtrInfo` for constant GC objects keyed
@@ -1699,11 +1700,16 @@ impl crate::walkvirtual::VirtualVisitor for RdVirtualInfoBuilder {
 
 impl OptContext {
     /// `optimizer.py:243` quasi-immutable dep registration with
-    /// dict-as-set semantics (`heap.py:807-808`
+    /// dict-as-set semantics (`heap.py:821-823`
     /// `self.optimizer.quasi_immutable_deps[qmutdescr.qmut] = None`).
-    /// Vec-backed set with linear-scan dedup.
-    pub fn add_quasi_immutable_dep(&mut self, dep: (u64, u32)) {
-        if !self.quasi_immutable_deps.contains(&dep) {
+    /// Vec-backed set keyed on instance identity, the way a Python dict keys
+    /// on the object.
+    pub fn add_quasi_immutable_dep(&mut self, dep: std::sync::Arc<dyn majit_ir::QuasiImmutHandle>) {
+        if !self
+            .quasi_immutable_deps
+            .iter()
+            .any(|seen| std::sync::Arc::ptr_eq(seen, &dep))
+        {
             self.quasi_immutable_deps.push(dep);
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -271,7 +271,7 @@ pub trait LoopInfo {
 #[derive(Clone, Debug)]
 pub struct BasicLoopInfo {
     pub inputargs: Vec<OpRef>,
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     pub jump_op: Option<Op>,
     pub extra_same_as: Vec<Op>,
     pub extra_before_label: Vec<Op>,
@@ -281,7 +281,7 @@ pub struct BasicLoopInfo {
 impl BasicLoopInfo {
     pub fn new(
         inputargs: Vec<OpRef>,
-        quasi_immutable_deps: Vec<(u64, u32)>,
+        quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
         jump_op: Option<Op>,
     ) -> Self {
         Self {
@@ -367,12 +367,11 @@ pub struct Optimizer {
     pendingfields: Vec<Op>,
     /// optimizer.py: `can_replace_guards` — flag to enable/disable guard sharing.
     can_replace_guards: bool,
-    /// optimizer.py: `quasi_immutable_deps` — quasi-immutable field dependencies.
-    /// RPython: dict[QuasiImmut → None]. We store (object_ptr, field_index)
-    /// pairs identifying the specific quasi-immutable slot that compiled
-    /// code depends on. After compilation, each dependency gets the loop's
-    /// invalidation flag registered as a per-slot watcher.
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    /// optimizer.py: `quasi_immutable_deps` — quasi-immutable field
+    /// dependencies, `dict[QuasiImmut -> None]` upstream. Each entry is the
+    /// instance the recording resolved; after compilation each one gets the
+    /// loop's invalidation flag registered on it.
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// RPython unroll.py: import_state — virtual structures to inject at Phase 2 start.
     /// Maps the original loop-carried input slot to a recursive abstract
     /// description of the virtual's field values.
@@ -1736,11 +1735,15 @@ impl Optimizer {
         ctx.can_replace_guards = guard.oldval;
     }
 
-    /// `optimizer.py:243` + `heap.py:807-808`
+    /// `optimizer.py:243` + `heap.py:821-823`
     /// `self.quasi_immutable_deps[qmutdescr.qmut] = None`. Vec-backed
     /// set with linear-scan dedup.
-    pub fn add_quasi_immutable_dep(&mut self, dep: (u64, u32)) {
-        if !self.quasi_immutable_deps.contains(&dep) {
+    pub fn add_quasi_immutable_dep(&mut self, dep: std::sync::Arc<dyn majit_ir::QuasiImmutHandle>) {
+        if !self
+            .quasi_immutable_deps
+            .iter()
+            .any(|seen| std::sync::Arc::ptr_eq(seen, &dep))
+        {
             self.quasi_immutable_deps.push(dep);
         }
     }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -326,9 +326,9 @@ pub struct UnrollOptimizer {
     /// pyjitpl.py:2289 all_descrs: dense list indexed by descr_index.
     /// Threaded through inner Optimizer instances for inline registration.
     pub all_descrs: std::sync::Arc<Vec<majit_ir::descr::DescrRef>>,
-    /// compile.py:204-207 / heap.py:807-808 quasi-immutable deps collected
+    /// compile.py:204-207 / heap.py:821-823 quasi-immutable deps collected
     /// by the phase optimizers for post-compile watcher registration.
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// RPython Box type parity: trace inputarg types from recorder.
     /// Each RPython Box carries its type; in majit OpRef is untyped u32.
     /// Propagated to Phase 1 and Phase 2 Optimizer.trace_inputargs
@@ -2189,10 +2189,13 @@ impl Default for UnrollOptimizer {
     }
 }
 
-pub(crate) fn merge_quasi_immutable_deps(dst: &mut Vec<(u64, u32)>, src: &[(u64, u32)]) {
+pub(crate) fn merge_quasi_immutable_deps(
+    dst: &mut Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
+    src: &[std::sync::Arc<dyn majit_ir::QuasiImmutHandle>],
+) {
     for dep in src {
-        if !dst.contains(dep) {
-            dst.push(*dep);
+        if !dst.iter().any(|seen| std::sync::Arc::ptr_eq(seen, dep)) {
+            dst.push(dep.clone());
         }
     }
 }
@@ -2275,7 +2278,7 @@ pub struct ExportedState {
     /// unroll.py:234 `exported_state.quasi_immutable_deps` — deps collected
     /// while optimizing the preamble, merged into retrace deps at
     /// compile.py:384-390.
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// `OptContext::next_pos` at end of Phase 1 — strict upper bound of
     /// every OpRef Phase 1 allocated, including intermediates folded /
     /// forwarded away. `reserve_pos_typed` skips `materialize_operand_at` on the
@@ -2943,9 +2946,9 @@ pub struct UnrollInfo {
     /// Extra same_as ops added during finalization.
     pub extra_same_as: Vec<Op>,
     /// Quasi-immutable dependencies discovered during optimization
-    /// (`optimizer.py:243` + `heap.py:807-808`). Vec-backed set with
-    /// linear-scan dedup.
-    pub quasi_immutable_deps: Vec<(u64, u32)>,
+    /// (`optimizer.py:243` + `heap.py:821-823`). Vec-backed set with
+    /// linear-scan dedup on instance identity.
+    pub quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// Extra ops to insert before the label (from bridge inlining).
     pub extra_before_label: Vec<Op>,
 }

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -1552,11 +1552,11 @@ pub struct MetaInterp<M: Clone> {
     /// becomes the retracing_from position.
     pub(crate) potential_retrace_position: Option<crate::recorder::TracePosition>,
     /// RPython compile.py:204-207 (record_loop_or_bridge) parity:
-    /// quasi-immutable dependencies from the last compilation.
-    /// Raw pointers to namespace/quasi-immutable objects that the compiled
-    /// loop depends on. After compilation, the caller registers the loop's
-    /// invalidation flag on each dep. Cleared on each compile attempt.
-    pub last_quasi_immutable_deps: Vec<(u64, u32)>,
+    /// quasi-immutable dependencies from the last compilation — the
+    /// `QuasiImmut` instances the recording resolved. After compilation, the
+    /// caller registers the loop's invalidation flag on each. Cleared on each
+    /// compile attempt.
+    pub last_quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     /// Addresses of live `SnapshotBox.opref` slots holding an inline
     /// `ConstPtr` reference during compilation. RPython traces the
     /// `ConstPtr.value` field in place; pyre's root walker follows these
@@ -8841,7 +8841,7 @@ impl<M: Clone> MetaInterp<M> {
         constants: majit_ir::ConstMap<majit_ir::Value>,
         unroll_opt: &mut crate::optimizeopt::unroll::UnrollOptimizer,
         num_combined_ops: usize,
-        quasi_immutable_deps: Vec<(u64, u32)>,
+        quasi_immutable_deps: Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     ) -> bool {
         let Some(fail_descr) = bridge.source_descr.as_fail_descr() else {
             crate::debug::log_one(
@@ -11646,21 +11646,17 @@ impl<M: Clone> MetaInterp<M> {
 
         // `compile.py:204-207` quasi-immutable_deps register_loop_token.
         //
-        // TODO: crate-boundary: the registration walker
-        // is ported in `pyre/pyre-jit/src/eval.rs::register_quasi_immutable_deps`
-        // and called at the post-compile sites that follow `compile_loop`
-        // / `compile_bridge` in `eval.rs`.  It cannot
-        // live inside this method because the dependency target is a
-        // `pyre_interpreter::DictStorage` slot watcher; majit-metainterp
-        // sits below the pyre/* crates and may not import them
-        // (`/parity` crate boundary invariant).  Convergence requires a
-        // backend-resident watcher trait plumbed through `MetaInterp` so
-        // that the registration walker can execute here without the
-        // pyre-interpreter import.  `last_quasi_immutable_deps` (the
-        // pyre-side analog of `loop.quasi_immutable_deps`) is populated
-        // in this file from `optimizer.quasi_immutable_deps` and drained
-        // by the eval.rs walker at the same call-graph depth as
-        // `compile.py:204-207`.
+        // The walk itself is `pyre/pyre-jit/src/eval.rs::
+        // register_quasi_immutable_deps`, called at the post-compile sites that
+        // follow `compile_loop` / `compile_bridge` — the same call-graph depth
+        // as `compile.py:204-207`.  What keeps it out of this method is no
+        // longer the dependency type (each entry is a
+        // `majit_ir::QuasiImmutHandle`, which this crate can name) but
+        // upstream's `wref`: pyre's stand-in for the loop token is the
+        // artifact's invalidation flag, and the compiling driver owns it, not
+        // the metainterp.  `last_quasi_immutable_deps` is the pyre-side analog
+        // of `loop.quasi_immutable_deps`, populated in this file from
+        // `optimizer.quasi_immutable_deps` and drained by that walk.
 
         // `compile.py:210` `loop.original_jitcell_token = None`.
         //

--- a/pyre/pyre-interpreter/src/function.rs
+++ b/pyre/pyre-interpreter/src/function.rs
@@ -261,9 +261,9 @@ impl QuasiImmutSlot {
 /// is not (`quasiimmut.py:85-110`).
 ///
 /// Answers `None` while [`Function::mutate_slots`] is still null, which is the
-/// null `mutate_<name>` of `quasiimmut.py:130`: nothing has folded the field, so
-/// there is nothing to revoke. Only [`function_install_quasi_immut`] creates the
-/// block.
+/// null `mutate_<name>` of `quasiimmut.py:41`: nothing has folded the field, so
+/// there is nothing to revoke. Only [`function_current_qmut_instance`] creates
+/// the block.
 ///
 /// # Safety
 /// `obj` must be null or point at a live `PyObject`.
@@ -282,9 +282,10 @@ pub unsafe fn function_quasi_immut_field<'a>(
     Some(unsafe { &(*slots).0[slot.index()] })
 }
 
-/// `quasiimmut.py:116-126 get_current_qmut_instance` — install the instance
+/// `quasiimmut.py:17-27 get_current_qmut_instance` — resolve the instance
 /// while the read is still being recorded, so a write reached later in the same
-/// trace sees a non-null mutate field and aborts the attempt.
+/// trace sees a non-null mutate field and aborts the attempt, and the recording
+/// can carry the instance to `compile.py:204-207`.
 ///
 /// Creates the slot block on first use. The losing racer frees its own
 /// allocation rather than the published one, so the winner's block is the only
@@ -292,9 +293,12 @@ pub unsafe fn function_quasi_immut_field<'a>(
 ///
 /// # Safety
 /// `obj` must be null or point at a live `PyObject`.
-pub unsafe fn function_install_quasi_immut(obj: PyObjectRef, slot: QuasiImmutSlot) {
+pub unsafe fn function_current_qmut_instance(
+    obj: PyObjectRef,
+    slot: QuasiImmutSlot,
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if obj.is_null() || !unsafe { is_function_carrier(obj) } {
-        return;
+        return None;
     }
     let f = obj as *const Function;
     let cell = unsafe { &(*f).mutate_slots };
@@ -316,25 +320,10 @@ pub unsafe fn function_install_quasi_immut(obj: PyObjectRef, slot: QuasiImmutSlo
             }
         }
     }
-    unsafe { &(*slots).0[slot.index()] }.ensure_installed();
+    Some(unsafe { &(*slots).0[slot.index()] }.get_current_qmut_instance())
 }
 
-/// `quasiimmut.py:72-75 register_loop_token` — record a compiled loop's
-/// invalidation flag against one `?` field.
-///
-/// # Safety
-/// `obj` must be null or point at a live `PyObject`.
-pub unsafe fn function_register_quasi_immut_watcher(
-    obj: PyObjectRef,
-    slot: QuasiImmutSlot,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
-    if let Some(field) = unsafe { function_quasi_immut_field(obj, slot) } {
-        field.register_loop_token(flag);
-    }
-}
-
-/// `quasiimmut.py:129-134 make_invalidation_function._invalidate_now` — revoke
+/// `quasiimmut.py:33-38 make_invalidation_function._invalidate_now` — revoke
 /// every loop that folded this field. Runs BEFORE the store, the way
 /// `typeobject.rs w_type_set_version_tag` calls its notify first.
 ///
@@ -799,7 +788,7 @@ pub(crate) fn function_new_impl(
         w_text_signature: PY_NULL,
         w_new_self: PY_NULL,
         w_moduleobj: PY_NULL,
-        // `quasiimmut.py:116-126` — null until the first loop registers.
+        // `quasiimmut.py:17-27` — null until the first read is recorded.
         mutate_slots: AtomicPtr::new(std::ptr::null_mut()),
     };
 

--- a/pyre/pyre-interpreter/src/jit_fnaddr.rs
+++ b/pyre/pyre-interpreter/src/jit_fnaddr.rs
@@ -2178,7 +2178,7 @@ pub fn jit_trace_fnaddrs() -> Vec<(&'static str, i64)> {
         "pyre_object::next_version_tag_serial",
         next_version_tag_serial as *const (),
     );
-    // `quasiimmut.py:129-134 _invalidate_now`, shared by both `?` fields.
+    // `quasiimmut.py:33-38 _invalidate_now`, shared by both `?` fields.
     push_alias_pair(
         &mut entries,
         "pyre_object::quasiimmut::sweep_quasi_immut_field",

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -40,10 +40,6 @@ fn new_simple_weak_set() -> Result<PyObjectRef, crate::PyError> {
 /// protocol, which is where the weakref probe and the `TypeError` fallback
 /// live.
 ///
-/// A missing collection reads as "not cached" rather than raising:
-/// `_abc_init` installs all three, but an ABC built before this module (a
-/// pickled class, a hand-rolled `ABCMeta` subclass that skips `_abc_init`)
-/// has none, and such a class must still answer subclass checks.
 fn weak_cache_contains(
     cls: PyObjectRef,
     name: &str,
@@ -53,9 +49,6 @@ fn weak_cache_contains(
     let cls_slot = roots.publish(&[cls]);
     let item_slot = roots.publish(&[item]);
     let cache = cache_attr(roots.get(cls_slot), name)?;
-    if cache.is_null() {
-        return Ok(false);
-    }
     let cache_slot = roots.publish(&[cache]);
     crate::baseobjspace::contains(roots.get(cache_slot), roots.get(item_slot))
 }
@@ -65,8 +58,7 @@ fn weak_cache_contains(
 /// discards it once the referent dies; a bare `ref` would leave a spent one
 /// behind for every class the check ever saw.
 ///
-/// Silently declines a class with no collection, for the same reason
-/// [`weak_cache_contains`] reads one as a miss.  Every item reaching here is a
+/// Every item reaching here is a
 /// class — `register` and `subclass_of` each reject a non-type argument — and a
 /// class is weak-referenceable, so `add` needs no test of its own, which is
 /// also why `app_abc.py add` has none.
@@ -75,9 +67,6 @@ fn weak_cache_add(cls: PyObjectRef, name: &str, item: PyObjectRef) -> Result<(),
     let cls_slot = roots.publish(&[cls]);
     let item_slot = roots.publish(&[item]);
     let cache = cache_attr(roots.get(cls_slot), name)?;
-    if cache.is_null() {
-        return Ok(());
-    }
     let cache_slot = roots.publish(&[cache]);
     let add = crate::baseobjspace::getattr_str(roots.get(cache_slot), "add")?;
     let add_slot = roots.publish(&[add]);
@@ -91,9 +80,6 @@ fn weak_cache_clear(cls: PyObjectRef, name: &str) -> Result<(), crate::PyError> 
     let roots = pyre_object::gc_roots::push_roots();
     let cls_slot = roots.publish(&[cls]);
     let cache = cache_attr(roots.get(cls_slot), name)?;
-    if cache.is_null() {
-        return Ok(());
-    }
     let cache_slot = roots.publish(&[cache]);
     let clear = crate::baseobjspace::getattr_str(roots.get(cache_slot), "clear")?;
     let clear_slot = roots.publish(&[clear]);
@@ -105,15 +91,12 @@ fn weak_cache_clear(cls: PyObjectRef, name: &str) -> Result<(), crate::PyError> 
 /// fresh at every use: the walks between two reads run arbitrary Python, which
 /// can rebind the attribute and can move the object.
 ///
-/// `app_abc.py:110` reads the slot as a plain attribute, so only its absence
-/// is a miss.  A metaclass hook that raises something else raises out of the
-/// check rather than being read as a class with no cache.
+/// `app_abc.py:110` reads the slot as a plain attribute, so a class that never
+/// ran `_abc_init` raises `AttributeError` out of the check rather than being
+/// answered as a class with an empty cache.  A metaclass hook that raises
+/// something else propagates unchanged.
 fn cache_attr(cls: PyObjectRef, name: &str) -> Result<PyObjectRef, crate::PyError> {
-    match crate::baseobjspace::getattr_str(cls, name) {
-        Ok(cache) => Ok(cache),
-        Err(err) if err.kind == crate::PyErrorKind::AttributeError => Ok(std::ptr::null_mut()),
-        Err(err) => Err(err),
-    }
+    crate::baseobjspace::getattr_str(cls, name)
 }
 
 /// Compare `cls._abc_negative_cache_version` against the invalidation counter
@@ -129,13 +112,6 @@ fn negative_cache_version_compare(
     let roots = pyre_object::gc_roots::push_roots();
     let cls_slot = roots.publish(&[cls]);
     let version = cache_attr(roots.get(cls_slot), "_abc_negative_cache_version")?;
-    if version.is_null() {
-        // A class that never ran `_abc_init` records no generation.  Upstream
-        // raises `AttributeError` reading it; the collections are tolerated the
-        // same way here, and the answer that goes with an absent one is "older
-        // than any counter" — rebuild on `<`, refuse to trust on `==`.
-        return Ok(matches!(op, crate::objspace::descroperation::CompareOp::Lt));
-    }
     let version_slot = roots.publish(&[version]);
     let counter_slot = roots.publish(&[w_int_new(
         INVALIDATION_COUNTER.load(Ordering::Relaxed) as i64
@@ -237,13 +213,7 @@ fn register(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             "Refusing to create an inheritance cycle",
         ));
     }
-    // `app_abc.py:99 cls._abc_registry.add(subclass)`.  An ABC that never ran
-    // `_abc_init` has no collection to add to; it gets one here rather than
-    // dropping the registration.
-    if cache_attr(cls, "_abc_registry")?.is_null() {
-        let fresh = new_simple_weak_set()?;
-        crate::baseobjspace::setattr_str(cls, "_abc_registry", fresh)?;
-    }
+    // `app_abc.py:99 cls._abc_registry.add(subclass)`.
     weak_cache_add(cls, "_abc_registry", subclass)?;
     // `app_abc.py:100-101` — invalidate every negative cache.  A class this
     // registration now makes a subclass may already be recorded as a non-match
@@ -387,7 +357,7 @@ fn subclass_of(cls: PyObjectRef, subclass: PyObjectRef) -> Result<bool, crate::P
         // walk survives a collection that fires the discard callback partway
         // through it.
         let registry = cache_attr(roots.get(cls_slot), "_abc_registry")?;
-        if !registry.is_null() {
+        {
             let registry_roots = pyre_object::gc_roots::push_roots();
             let registry_slot = registry_roots.base();
             registry_roots.pin_root(registry);
@@ -589,27 +559,14 @@ fn get_dump(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let mut data_slots = Vec::with_capacity(3);
     for name in ["_abc_registry", "_abc_cache", "_abc_negative_cache"] {
         let cache = cache_attr(roots.get(cls_slot), name)?;
-        // A class that never ran `_abc_init` has nothing to describe; an empty
-        // set keeps the tuple's shape rather than raising at a debug helper.
-        let data = if cache.is_null() {
-            w_set_new()
-        } else {
-            let cache_slot = roots.publish(&[cache]);
-            crate::baseobjspace::getattr_str(roots.get(cache_slot), "data")?
-        };
+        let cache_slot = roots.publish(&[cache]);
+        let data = crate::baseobjspace::getattr_str(roots.get(cache_slot), "data")?;
         data_slots.push(roots.publish(&[data]));
     }
     // `_get_dump` reports the generation attribute itself, not a number derived
     // from it.  The last read that can run Python; take it before the reloads
     // below so they answer with final addresses.
     let version = cache_attr(roots.get(cls_slot), "_abc_negative_cache_version")?;
-    // Same tolerance as the collections above: a class that never ran
-    // `_abc_init` reports generation 0 rather than raising at a debug helper.
-    let version = if version.is_null() {
-        w_int_new(0)
-    } else {
-        version
-    };
     let mut items: Vec<PyObjectRef> = data_slots.iter().map(|&slot| roots.get(slot)).collect();
     items.push(version);
     Ok(w_tuple_new(items))

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2856,29 +2856,18 @@ pub fn audit_holder_ptr() -> *const AuditHolder {
     AUDIT_HOOKS.load(std::sync::atomic::Ordering::Acquire)
 }
 
-/// Register a loop against the holder's `hooks_w?` field.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for the holder's
+/// `hooks_w?` field.
 ///
 /// # Safety
 /// `holder` must be null or a live [`AuditHolder`].
-pub unsafe fn audit_holder_register_hooks_watcher(
+pub unsafe fn audit_holder_current_hooks_qmut(
     holder: *const AuditHolder,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if holder.is_null() {
-        return;
+        return None;
     }
-    unsafe { (*holder).hooks_watchers.register_loop_token(flag) };
-}
-
-/// Install the holder's `hooks_w?` watcher without registering a loop.
-///
-/// # Safety
-/// `holder` must be null or a live [`AuditHolder`].
-pub unsafe fn audit_holder_install_hooks_watcher(holder: *const AuditHolder) {
-    if holder.is_null() {
-        return;
-    }
-    unsafe { (*holder).hooks_watchers.ensure_installed() };
+    Some(unsafe { (*holder).hooks_watchers.get_current_qmut_instance() })
 }
 
 /// Forward the installed hooks.  Upstream reaches them through the space's

--- a/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/mapdict.rs
@@ -225,12 +225,10 @@ impl Terminator {
         self.allow_unboxing.set(v);
     }
 
-    pub fn register_allow_unboxing_watcher(&self, flag: &Arc<AtomicBool>) {
-        self.allow_unboxing_watchers.register_loop_token(flag);
-    }
-
-    pub fn install_allow_unboxing_watcher(&self) {
-        self.allow_unboxing_watchers.ensure_installed();
+    pub fn current_allow_unboxing_qmut(
+        &self,
+    ) -> std::sync::Arc<pyre_object::quasiimmut::QuasiImmut> {
+        self.allow_unboxing_watchers.get_current_qmut_instance()
     }
 
     pub fn allow_unboxing_qmut_installed(&self) -> bool {
@@ -242,29 +240,17 @@ impl Terminator {
     }
 }
 
-/// Register a loop against a Terminator's `allow_unboxing?` field.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for a Terminator's `allow_unboxing?` field.
 ///
 /// # Safety
 /// `terminator` must be null or point at a live owner.
-pub unsafe fn terminator_register_allow_unboxing_watcher(
+pub unsafe fn terminator_current_allow_unboxing_qmut(
     terminator: *const Terminator,
-    flag: &Arc<AtomicBool>,
-) {
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if terminator.is_null() {
-        return;
+        return None;
     }
-    unsafe { (*terminator).register_allow_unboxing_watcher(flag) };
-}
-
-/// Install a Terminator's `allow_unboxing?` watcher without registering a loop.
-///
-/// # Safety
-/// `terminator` must be null or point at a live owner.
-pub unsafe fn terminator_install_allow_unboxing_watcher(terminator: *const Terminator) {
-    if terminator.is_null() {
-        return;
-    }
-    unsafe { (*terminator).install_allow_unboxing_watcher() };
+    Some(unsafe { (*terminator).current_allow_unboxing_qmut() })
 }
 
 /// Whether a Terminator's `allow_unboxing?` watcher is installed.
@@ -368,12 +354,8 @@ impl PlainAttribute {
         self.ever_mutated.set(v);
     }
 
-    pub fn register_ever_mutated_watcher(&self, flag: &Arc<AtomicBool>) {
-        self.ever_mutated_watchers.register_loop_token(flag);
-    }
-
-    pub fn install_ever_mutated_watcher(&self) {
-        self.ever_mutated_watchers.ensure_installed();
+    pub fn current_ever_mutated_qmut(&self) -> std::sync::Arc<pyre_object::quasiimmut::QuasiImmut> {
+        self.ever_mutated_watchers.get_current_qmut_instance()
     }
 
     pub fn ever_mutated_qmut_installed(&self) -> bool {
@@ -385,29 +367,17 @@ impl PlainAttribute {
     }
 }
 
-/// Register a loop against a PlainAttribute's `ever_mutated?` field.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for a PlainAttribute's `ever_mutated?` field.
 ///
 /// # Safety
 /// `attribute` must be null or point at a live owner.
-pub unsafe fn plain_attribute_register_ever_mutated_watcher(
+pub unsafe fn plain_attribute_current_ever_mutated_qmut(
     attribute: *const PlainAttribute,
-    flag: &Arc<AtomicBool>,
-) {
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if attribute.is_null() {
-        return;
+        return None;
     }
-    unsafe { (*attribute).register_ever_mutated_watcher(flag) };
-}
-
-/// Install a PlainAttribute's `ever_mutated?` watcher without registering a loop.
-///
-/// # Safety
-/// `attribute` must be null or point at a live owner.
-pub unsafe fn plain_attribute_install_ever_mutated_watcher(attribute: *const PlainAttribute) {
-    if attribute.is_null() {
-        return;
-    }
-    unsafe { (*attribute).install_ever_mutated_watcher() };
+    Some(unsafe { (*attribute).current_ever_mutated_qmut() })
 }
 
 /// Whether a PlainAttribute's `ever_mutated?` watcher is installed.
@@ -4000,12 +3970,8 @@ impl CachedAttributeHolder {
         self.typ.set(t);
     }
 
-    pub fn register_attr_watcher(&self, flag: &Arc<AtomicBool>) {
-        self.attr_watchers.register_loop_token(flag);
-    }
-
-    pub fn install_attr_watcher(&self) {
-        self.attr_watchers.ensure_installed();
+    pub fn current_attr_qmut(&self) -> std::sync::Arc<pyre_object::quasiimmut::QuasiImmut> {
+        self.attr_watchers.get_current_qmut_instance()
     }
 
     pub fn attr_qmut_installed(&self) -> bool {
@@ -4016,12 +3982,8 @@ impl CachedAttributeHolder {
         self.attr_watchers.invalidate();
     }
 
-    pub fn register_typ_watcher(&self, flag: &Arc<AtomicBool>) {
-        self.typ_watchers.register_loop_token(flag);
-    }
-
-    pub fn install_typ_watcher(&self) {
-        self.typ_watchers.ensure_installed();
+    pub fn current_typ_qmut(&self) -> std::sync::Arc<pyre_object::quasiimmut::QuasiImmut> {
+        self.typ_watchers.get_current_qmut_instance()
     }
 
     pub fn typ_qmut_installed(&self) -> bool {
@@ -4033,29 +3995,17 @@ impl CachedAttributeHolder {
     }
 }
 
-/// Register a loop against a CachedAttributeHolder's `attr?` field.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for a CachedAttributeHolder's `attr?` field.
 ///
 /// # Safety
 /// `holder` must be null or point at a live owner.
-pub unsafe fn holder_register_attr_watcher(
+pub unsafe fn holder_current_attr_qmut(
     holder: *const CachedAttributeHolder,
-    flag: &Arc<AtomicBool>,
-) {
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if holder.is_null() {
-        return;
+        return None;
     }
-    unsafe { (*holder).register_attr_watcher(flag) };
-}
-
-/// Install a CachedAttributeHolder's `attr?` watcher without registering a loop.
-///
-/// # Safety
-/// `holder` must be null or point at a live owner.
-pub unsafe fn holder_install_attr_watcher(holder: *const CachedAttributeHolder) {
-    if holder.is_null() {
-        return;
-    }
-    unsafe { (*holder).install_attr_watcher() };
+    Some(unsafe { (*holder).current_attr_qmut() })
 }
 
 /// Whether a CachedAttributeHolder's `attr?` watcher is installed.
@@ -4079,29 +4029,17 @@ pub unsafe fn holder_force_attr_qmut(holder: *const CachedAttributeHolder) {
     unsafe { (*holder).force_attr_qmut() };
 }
 
-/// Register a loop against a CachedAttributeHolder's `typ?` field.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for a CachedAttributeHolder's `typ?` field.
 ///
 /// # Safety
 /// `holder` must be null or point at a live owner.
-pub unsafe fn holder_register_typ_watcher(
+pub unsafe fn holder_current_typ_qmut(
     holder: *const CachedAttributeHolder,
-    flag: &Arc<AtomicBool>,
-) {
+) -> Option<std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>> {
     if holder.is_null() {
-        return;
+        return None;
     }
-    unsafe { (*holder).register_typ_watcher(flag) };
-}
-
-/// Install a CachedAttributeHolder's `typ?` watcher without registering a loop.
-///
-/// # Safety
-/// `holder` must be null or point at a live owner.
-pub unsafe fn holder_install_typ_watcher(holder: *const CachedAttributeHolder) {
-    if holder.is_null() {
-        return;
-    }
-    unsafe { (*holder).install_typ_watcher() };
+    Some(unsafe { (*holder).current_typ_qmut() })
 }
 
 /// Whether a CachedAttributeHolder's `typ?` watcher is installed.
@@ -4384,7 +4322,7 @@ pub unsafe fn setattr_would_force_quasi_immut(
 /// re-add chain (mapdict.py:461-470) is deliberately not modelled: simulating
 /// that rebuild side-effect-free is not tractable against the current
 /// `node_copy` / `add_attr` shape. The optimizer's
-/// `quasiimmut_field_still_valid` revalidation (heap.py:798-804, ported in
+/// `quasiimmut_field_still_valid` revalidation (heap.py:818-819, ported in
 /// majit-metainterp's `optimizeopt/heap.rs`) discards a loop whose recorded `?`
 /// value moved during tracing, so a missed force costs a wasted trace, never
 /// correctness. Watcher installation belongs to the tracer; this predicate

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -58,7 +58,7 @@ const INT_MUTABLE_CELL_VALUE_INDEX: u32 = CELL_DESCR_TAG;
 // `Terminator.allow_unboxing` and `PlainAttribute.ever_mutated` are both
 // `Cell<bool>`, so `stable_field_index(offset, field_size, field_type, signed)`
 // could collide whenever their `repr(Rust)` offsets coincide. Because the
-// index selects the pointer cast in `install_quasiimmut_field`, that collision
+// index selects the pointer cast in `quasi_immut_descr`, that collision
 // would be type confusion rather than merely a shared `HeapCache` key.
 const MAPDICT_DESCR_TAG: u32 = 0x5000_0000;
 const TERMINATOR_ALLOW_UNBOXING_INDEX: u32 = MAPDICT_DESCR_TAG;
@@ -78,7 +78,7 @@ const AUDIT_HOLDER_HOOKS_INDEX: u32 = MAPDICT_DESCR_TAG | 4;
 // every `W_*` class's first reference field lands there.  A
 // `stable_field_index(offset, size, type, signed)` would therefore name a
 // layout, not an owner, and the index is what selects the pointer cast in
-// `install_quasiimmut_field` / `register_quasi_immutable_deps`.  Reserved for
+// `quasi_immut_descr`.  Reserved for
 // the same reason as the map-node block above, in a tag of its own because the
 // owner here IS a `PyObject` and the reasoning that groups those four does not
 // apply.  Disjoint from FIELD (0x10xx_xxxx), ARRAY, SIZE, CELL, MAPDICT,
@@ -92,7 +92,7 @@ const PROPERTY_FSET_INDEX: u32 = PROPERTY_DESCR_TAG | 1;
 // field, and the two wrappers have byte-identical layouts, so
 // `stable_field_index` cannot even tell THEM apart — it names a layout, not an
 // owner, and the index is what selects the pointer cast in
-// `install_quasiimmut_field` / `register_quasi_immutable_deps`.  Reserved for
+// `quasi_immut_descr`.  Reserved for
 // the same reason as the property block above, in a tag of its own.  Disjoint
 // from FIELD (0x10xx_xxxx), ARRAY, SIZE, CELL, MAPDICT, PROPERTY,
 // `object.typeptr` (0x6000_0000), the native mapdict block, and the GC tid.
@@ -2890,7 +2890,7 @@ pub fn function_w_text_signature_descr() -> DescrRef {
 /// Resolve a field-descr index to the `Function` watcher slot it names, or
 /// `None` when the index is not one of the nine `function.py:34-42` fields.
 ///
-/// `quasiimmut.py:116-126 get_current_qmut_instance` reaches the hidden
+/// `quasiimmut.py:17-27 get_current_qmut_instance` reaches the hidden
 /// `mutate_<name>` field through a `mutatefielddescr` the rtyper minted next to
 /// the field's own descr.  Pyre carries the same pairing as this table: both
 /// the record-time install (`state.rs`) and the compile-time watcher

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -8906,7 +8906,7 @@ fn walker_pin_namespace_version<Sym: WalkSym>(
 }
 
 /// Pin mapdict's quasi-immutable fields with `const_ref`, never `const_int`:
-/// `install_quasiimmut_field`, `current_quasiimmut_field_value`, and optimizer
+/// `quasi_immut_descr`, `current_quasiimmut_field_value`, and optimizer
 /// dependency collection require `Value::Ref`. The raw non-GC pointer cannot
 /// reach the gcref table because `OptHeap` consumes `QUASIIMMUT_FIELD` before
 /// the GC rewriter runs, exactly as `walker_pin_namespace_version` relies on.

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -4880,7 +4880,7 @@ fn try_walker_force_quasi_immut_mapdict_write<Sym: WalkSym>(
     // (`end=ForceQuasiImmutable committed=false effects=4`).
     //
     // Declining is sound, not a hole: without the abort the trace keeps
-    // recording and the optimizer's revalidation (heap.py:798-804
+    // recording and the optimizer's revalidation (heap.py:818-819
     // `is_still_valid_for`) discards any loop whose recorded `?` value moved,
     // so the only cost is a wasted trace attempt.
     if !ctx.vstack_valid || ctx.fbw_mode.inline_subwalk || ctx.trace_ctx.is_bridge_trace {

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -4091,9 +4091,13 @@ pub(crate) fn opimpl_getfield_gc_i(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                 majit_metainterp::counters::HEAPCACHED_OPS,
             );
         } else {
-            install_quasiimmut_field(ctx, obj, &descr);
+            let qmutdescr = quasi_immut_descr(ctx, obj, &descr);
             ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
-            ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr.clone());
+            ctx.record_op_with_descr(
+                OpCode::QuasiimmutField,
+                &[obj],
+                qmutdescr.unwrap_or_else(|| descr.clone()),
+            );
             if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
                 ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
             }
@@ -4187,9 +4191,13 @@ pub(crate) fn opimpl_getfield_gc_r(ctx: &mut TraceCtx, obj: OpRef, descr: DescrR
                 majit_metainterp::counters::HEAPCACHED_OPS,
             );
         } else {
-            install_quasiimmut_field(ctx, obj, &descr);
+            let qmutdescr = quasi_immut_descr(ctx, obj, &descr);
             ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
-            ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr.clone());
+            ctx.record_op_with_descr(
+                OpCode::QuasiimmutField,
+                &[obj],
+                qmutdescr.unwrap_or_else(|| descr.clone()),
+            );
             if ctx.heap_cache_mut().check_and_clear_guard_not_invalidated() {
                 ctx.set_pending_guard_not_invalidated(Some(ctx.last_traced_pc));
             }
@@ -5067,20 +5075,18 @@ pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: Des
     // installed, so nothing invalidates and nothing bumps the force counter,
     // and the trace keeps a value that is already stale.  Without a GIL that
     // window is a real interleaving, not a theoretical one.
-    install_quasiimmut_field(ctx, obj, &descr);
+    let qmutdescr = quasi_immut_descr(ctx, obj, &descr);
     // quasiimmut.py:125 `self.constantfieldbox =
     // self.get_current_constant_fieldvalue()` — the field's value at the moment
-    // the trace baked it.  `heap.py:803 is_still_valid_for` compares it against
+    // the trace baked it.  `heap.py:818 is_still_valid_for` compares it against
     // the live value and abandons the loop when they disagree, so it has to be
     // captured here; by the time the optimizer runs, the change it is looking
     // for has already happened.
     let constantfieldbox = current_quasiimmut_field_value(ctx, obj, &descr);
     ctx.heap_cache_mut().quasi_immut_now_known(field_index, obj);
-    // Upstream carries the captured value on the per-op `QuasiImmutDescr`
-    // (quasiimmut.py:113-159), a descr minted fresh for every recorded
-    // QUASIIMMUT_FIELD.  Pyre's descrs are registry-indexed singletons, so a
-    // fresh one per op would mint a fresh registry entry per read; the value
-    // rides on the op instead.
+    // The captured value is the one `QuasiImmutDescr` member that stays off the
+    // descr: it is a Box, so it rides as the op's second operand.
+    let descr = qmutdescr.unwrap_or(descr);
     match constantfieldbox {
         Some(value) => ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj, value], descr),
         None => ctx.record_op_with_descr(OpCode::QuasiimmutField, &[obj], descr),
@@ -5090,28 +5096,52 @@ pub(crate) fn record_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: Des
     }
 }
 
-/// `quasiimmut.py:116-126 get_current_qmut_instance`, reached from
-/// `pyjitpl.py:1081 QuasiImmutDescr(...)` — install the qmut instance at RECORD
-/// time.
+/// `quasiimmut.py:54-110 QuasiImmut` published to the optimizer and the
+/// compiler as a [`majit_ir::QuasiImmutHandle`].
 ///
-/// Upstream builds a `QuasiImmutDescr` for every recorded `QUASIIMMUT_FIELD`,
-/// and its `__init__` installs the instance. It therefore exists for the rest of
-/// the recording, which is what arms `opimpl_jit_force_quasi_immutable`'s
-/// `mutatebox.nonnull()` (`pyjitpl.py:1112`) for a write reached later in that
-/// same trace.
+/// The interpreter's own type cannot carry the impl: `pyre-object` does not
+/// depend on `majit-ir`, and which JIT questions an instance answers is not a
+/// property of the object model.
+struct RecordedQuasiImmut(std::sync::Arc<pyre_object::quasiimmut::QuasiImmut>);
+
+impl std::fmt::Debug for RecordedQuasiImmut {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "QuasiImmut({:p})", std::sync::Arc::as_ptr(&self.0))
+    }
+}
+
+impl majit_ir::QuasiImmutHandle for RecordedQuasiImmut {
+    fn is_current(&self) -> bool {
+        self.0.is_current()
+    }
+
+    fn register_loop_token(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        self.0.register_loop_token(flag);
+    }
+}
+
+/// `pyjitpl.py:1081 QuasiImmutDescr(cpu, structbox.getref_base(), fielddescr,
+/// mutatefielddescr)` — the descr a recorded `QUASIIMMUT_FIELD` carries.
 ///
-/// Pyre installed only from `register_quasi_immutable_deps`
-/// (`pyre-jit/src/eval.rs`), which runs at COMPILE time, and every invalidation
-/// uninstalls — so through a whole recording the field stayed null and no
-/// write-side test could ever fire. This is the read dual of that function and
-/// resolves `(object, field_index)` → owner the same way it does.
-fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
+/// Building it is what resolves the instance (`quasiimmut.py:124
+/// get_current_qmut_instance`), so it exists for the rest of the recording,
+/// which is what arms `opimpl_jit_force_quasi_immutable`'s `mutatebox.nonnull()`
+/// (`pyjitpl.py:1112`) for a write reached later in that same trace. The
+/// instance rides on the descr from here to `heap.py:818 is_still_valid_for`
+/// and `compile.py:204-207 register_loop_token`, so neither has to walk from
+/// the struct back to the hidden `mutate_*` slot a second time.
+///
+/// `None` where upstream cannot fail: an operand that is not a concrete
+/// pointer, or a descr index no arm claims. The caller records the plain field
+/// descr, and the optimizer then refuses the loop rather than standing a fold
+/// with no watcher behind it — `heap.py:814`'s assert, read as a verdict.
+fn quasi_immut_descr(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) -> Option<DescrRef> {
     let Some(majit_ir::Value::Ref(struct_ref)) = ctx.box_value(obj) else {
-        return;
+        return None;
     };
     let struct_ptr = struct_ref.0 as i64;
     if struct_ptr == 0 || struct_ptr == usize::MAX as i64 {
-        return;
+        return None;
     }
     let index = descr.index();
     // The index decides which type `struct_ptr` is cast to, so an unrecognised
@@ -5124,63 +5154,69 @@ fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
     // descr reaches here: a `#[jit_immutable_fields]` entry would need the
     // `_immutable_fields_` `?` suffix and no declaration in the tree carries
     // one, and `record_quasiimmut_field` is absent from the emitted-opname set.
-    unsafe {
+    let qmut = unsafe {
         if index == crate::descr::module_dict_version_descr().index() {
-            pyre_object::dictmultiobject::module_dict_strategy_install_version_watcher(
+            pyre_object::dictmultiobject::module_dict_strategy_current_version_qmut(
                 struct_ptr as *mut pyre_object::celldict::ModuleDictStrategy,
-            );
+            )
         } else if index == crate::descr::type_version_tag_descr().index() {
-            pyre_object::typeobject::w_type_install_quasi_immut(
+            pyre_object::typeobject::w_type_current_qmut_instance(
                 struct_ptr as pyre_object::PyObjectRef,
-            );
+            )
         } else if index == crate::descr::terminator_allow_unboxing_descr().index() {
-            pyre_interpreter::objspace::std::mapdict::terminator_install_allow_unboxing_watcher(
+            pyre_interpreter::objspace::std::mapdict::terminator_current_allow_unboxing_qmut(
                 struct_ptr as *const _,
-            );
+            )
         } else if index == crate::descr::plain_attribute_ever_mutated_descr().index() {
-            pyre_interpreter::objspace::std::mapdict::plain_attribute_install_ever_mutated_watcher(
+            pyre_interpreter::objspace::std::mapdict::plain_attribute_current_ever_mutated_qmut(
                 struct_ptr as *const _,
-            );
+            )
         } else if index == crate::descr::holder_attr_descr().index() {
-            pyre_interpreter::objspace::std::mapdict::holder_install_attr_watcher(
+            pyre_interpreter::objspace::std::mapdict::holder_current_attr_qmut(
                 struct_ptr as *const _,
-            );
+            )
         } else if index == crate::descr::holder_typ_descr().index() {
-            pyre_interpreter::objspace::std::mapdict::holder_install_typ_watcher(
+            pyre_interpreter::objspace::std::mapdict::holder_current_typ_qmut(
                 struct_ptr as *const _,
-            );
+            )
         } else if index == crate::descr::audit_holder_hooks_descr().index() {
-            pyre_interpreter::module::sys::vm::audit_holder_install_hooks_watcher(
+            pyre_interpreter::module::sys::vm::audit_holder_current_hooks_qmut(
                 struct_ptr as *const _,
-            );
+            )
         } else if index == crate::descr::property_fget_descr().index() {
-            pyre_object::descriptor::w_property_install_fget_watcher(
+            pyre_object::descriptor::w_property_current_fget_qmut(
                 struct_ptr as pyre_object::PyObjectRef,
-            );
+            )
         } else if index == crate::descr::property_fset_descr().index() {
-            pyre_object::descriptor::w_property_install_fset_watcher(
+            pyre_object::descriptor::w_property_current_fset_qmut(
                 struct_ptr as pyre_object::PyObjectRef,
-            );
+            )
         } else if index == crate::descr::staticmethod_w_function_quasi_descr().index() {
-            pyre_object::function::w_staticmethod_install_w_function_watcher(
+            pyre_object::function::w_staticmethod_current_w_function_qmut(
                 struct_ptr as pyre_object::PyObjectRef,
-            );
+            )
         } else if index == crate::descr::classmethod_w_function_quasi_descr().index() {
-            pyre_object::function::w_classmethod_install_w_function_watcher(
+            pyre_object::function::w_classmethod_current_w_function_qmut(
                 struct_ptr as pyre_object::PyObjectRef,
-            );
+            )
         } else if let Some(slot) = crate::descr::function_quasi_immut_slot(index) {
-            pyre_interpreter::function::function_install_quasi_immut(
+            pyre_interpreter::function::function_current_qmut_instance(
                 struct_ptr as pyre_object::PyObjectRef,
                 slot,
-            );
+            )
         } else {
             debug_assert!(
                 false,
                 "unrecognised quasi-immutable field descr index {index:#x}"
             );
+            None
         }
-    }
+    }?;
+    Some(std::sync::Arc::new(majit_ir::QuasiImmutDescr::new(
+        descr.clone(),
+        struct_ptr as u64,
+        std::sync::Arc::new(RecordedQuasiImmut(qmut)),
+    )))
 }
 
 /// quasiimmut.py:135-143 `QuasiImmutDescr.get_current_constant_fieldvalue`.
@@ -5200,7 +5236,7 @@ fn install_quasiimmut_field(ctx: &mut TraceCtx, obj: OpRef, descr: &DescrRef) {
 /// `field_sanity_load` is the `cpu.bh_getfield_gc_*` triple behind one
 /// `field_type()` dispatch.  `None` when the receiver is not a concrete
 /// pointer or the descr is not a field descr — the optimizer then skips the
-/// revalidation, matching heap.py:794-796, which ignores a QUASIIMMUT_FIELD
+/// revalidation, matching heap.py:808-810, which ignores a QUASIIMMUT_FIELD
 /// whose struct did not fold to a constant.
 fn current_quasiimmut_field_value(
     ctx: &mut TraceCtx,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -466,7 +466,7 @@ unsafe fn type_object_destructor(obj_addr: usize) {
     if !weak_subclasses.is_null() {
         drop(unsafe { Box::from_raw(weak_subclasses) });
     }
-    // The `mutate__version_tag` instance (`quasiimmut.py:116-126
+    // The `mutate__version_tag` instance (`quasiimmut.py:17-27
     // get_current_qmut_instance`) is Rust-owned and off-GC too. A type that was
     // compiled against and never mutated afterwards still holds one, so without
     // this the box outlives the only pointer to it.
@@ -6379,139 +6379,27 @@ pub fn make_green_key(code_ptr: *const (), pc: usize) -> u64 {
 ///          qmut.register_loop_token(wref)
 /// ```
 ///
-/// Upstream's set holds the `QuasiImmut` instances the optimizer already
-/// resolved through each `QuasiImmutDescr`. Pyre records the pair that
-/// identifies one — the owning object and the registry index of the
-/// quasi-immutable field — and resolves the instance here, which is why the
-/// field index has to select the registrar: a `ModuleDictStrategy` box carries
-/// no `PyObject` header, so offering it to the type-keyed registrar would read
-/// one that is not there.
+/// The set holds the `QuasiImmut` instances the recording resolved and the
+/// optimizer collected (`heap.py:821-823`), so this is the whole of upstream's
+/// loop. Registering on the recorded instance rather than on whatever the field
+/// publishes now is what makes the window between the optimizer's
+/// `is_still_valid_for` and this call safe without a GIL: an instance swept in
+/// that window reports the loop invalid instead of accepting a registration
+/// nothing will ever sweep again.
 ///
-/// The declared `?` fields:
-///
-/// `celldict.py:34 _immutable_fields_ = ["version?"]` — the global cell fast
-/// path bakes a slot's stored cell as a `ConstPtr` under a
-/// `QUASIIMMUT_FIELD(strategy, version)`. `mutated()` (new key, `del`,
-/// `switch_to_object_strategy`, and every write that replaces the stored
-/// pointer) flips the flag; a same-key reassign mutates the cell in place
-/// without bumping the version and is observed by the live `cell.w_value` read
-/// instead.
-///
-/// `typeobject.py:177 _immutable_fields_ = ['_version_tag?']` — the
-/// LOAD_METHOD / LOAD_ATTR method-cache fold bakes a type's `version_tag` as a
-/// constant under a `QUASIIMMUT_FIELD(w_type, _version_tag)`. `mutated()`
-/// (typeobject.py:285-291) bumps the tag and walks subclasses, and the setter
-/// revokes each level's loops.
-///
-/// `function.py:34-42 _immutable_fields_ = ['code?', 'w_func_globals?',
-/// 'closure?[*]', 'defs_w?[*]', 'name?', 'qualname?', 'w_objclass?',
-/// 'w_text_signature?', 'w_kw_defs?']` — the inline-call path reads these off
-/// the live callee, and `f.__defaults__ = ...` / `f.__code__ = ...` retires
-/// every loop that folded one.  All nine share `function_register_quasi_immut_watcher`,
-/// which the slot the index resolves to picks apart.
+/// Lives here rather than in `record_loop_or_bridge` only because the
+/// invalidation flag is the compiling driver's, not the metainterp's.
 pub(crate) fn register_quasi_immutable_deps(_green_key: u64) {
     let (driver, _) = driver_pair();
-    let deps: Vec<(u64, u32)> =
-        std::mem::take(&mut driver.meta_interp_mut().last_quasi_immutable_deps);
+    let deps = std::mem::take(&mut driver.meta_interp_mut().last_quasi_immutable_deps);
     if deps.is_empty() {
         return;
     }
     let Some(flag) = driver.last_compiled_artifact_invalidation_flag() else {
         return;
     };
-    let module_dict_version = pyre_jit_trace::descr::module_dict_version_descr().index();
-    let type_version_tag = pyre_jit_trace::descr::type_version_tag_descr().index();
-    let terminator_allow_unboxing =
-        pyre_jit_trace::descr::terminator_allow_unboxing_descr().index();
-    let plain_attribute_ever_mutated =
-        pyre_jit_trace::descr::plain_attribute_ever_mutated_descr().index();
-    let holder_attr = pyre_jit_trace::descr::holder_attr_descr().index();
-    let holder_typ = pyre_jit_trace::descr::holder_typ_descr().index();
-    let audit_holder_hooks = pyre_jit_trace::descr::audit_holder_hooks_descr().index();
-    let property_fget = pyre_jit_trace::descr::property_fget_descr().index();
-    let property_fset = pyre_jit_trace::descr::property_fset_descr().index();
-    let staticmethod_w_function =
-        pyre_jit_trace::descr::staticmethod_w_function_quasi_descr().index();
-    let classmethod_w_function =
-        pyre_jit_trace::descr::classmethod_w_function_quasi_descr().index();
-    // Hoisted because each accessor clones a `LazyLock` descr; the index also
-    // decides which type `dep_ptr` is cast to, so the chain below ends in a
-    // fail-loud default rather than reinterpreting a headerless map node as a
-    // `W_TypeObject`.  These eleven plus the nine `Function` fields
-    // `function_quasi_immut_slot` resolves are every quasi-immutable descr this
-    // binary mints — see the same reasoning on `state.rs
-    // install_quasiimmut_field`.
-    for (dep_ptr, field_index) in deps {
-        unsafe {
-            if field_index == module_dict_version {
-                pyre_object::dictmultiobject::module_dict_strategy_register_version_watcher(
-                    dep_ptr as *mut pyre_object::celldict::ModuleDictStrategy,
-                    &flag,
-                );
-            } else if field_index == type_version_tag {
-                pyre_object::typeobject::w_type_register_quasi_immut_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    &flag,
-                );
-            } else if field_index == terminator_allow_unboxing {
-                pyre_interpreter::objspace::std::mapdict::terminator_register_allow_unboxing_watcher(
-                    dep_ptr as *const _,
-                    &flag,
-                );
-            } else if field_index == plain_attribute_ever_mutated {
-                pyre_interpreter::objspace::std::mapdict::plain_attribute_register_ever_mutated_watcher(
-                    dep_ptr as *const _,
-                    &flag,
-                );
-            } else if field_index == holder_attr {
-                pyre_interpreter::objspace::std::mapdict::holder_register_attr_watcher(
-                    dep_ptr as *const _,
-                    &flag,
-                );
-            } else if field_index == holder_typ {
-                pyre_interpreter::objspace::std::mapdict::holder_register_typ_watcher(
-                    dep_ptr as *const _,
-                    &flag,
-                );
-            } else if field_index == audit_holder_hooks {
-                pyre_interpreter::module::sys::vm::audit_holder_register_hooks_watcher(
-                    dep_ptr as *const _,
-                    &flag,
-                );
-            } else if field_index == property_fget {
-                pyre_object::descriptor::w_property_register_fget_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    &flag,
-                );
-            } else if field_index == property_fset {
-                pyre_object::descriptor::w_property_register_fset_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    &flag,
-                );
-            } else if field_index == staticmethod_w_function {
-                pyre_object::function::w_staticmethod_register_w_function_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    &flag,
-                );
-            } else if field_index == classmethod_w_function {
-                pyre_object::function::w_classmethod_register_w_function_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    &flag,
-                );
-            } else if let Some(slot) = pyre_jit_trace::descr::function_quasi_immut_slot(field_index)
-            {
-                pyre_interpreter::function::function_register_quasi_immut_watcher(
-                    dep_ptr as pyre_object::PyObjectRef,
-                    slot,
-                    &flag,
-                );
-            } else {
-                debug_assert!(
-                    false,
-                    "unrecognised quasi-immutable field descr index {field_index:#x}"
-                );
-            }
-        }
+    for qmut in deps {
+        qmut.register_loop_token(&flag);
     }
 }
 
@@ -9494,7 +9382,7 @@ fn handle_fail(
     // the key through `get_procedure_token`, which skips invalidated tokens —
     // so an unscoped revoke kills the *replacement* loop instead, on every
     // guard failure that still reports through the old trace.  `QuasiImmut.
-    // invalidate` (quasiimmut.py:84-109) marks only the looptokens registered
+    // invalidate` (quasiimmut.py:84-110) marks only the looptokens registered
     // on that instance and then drops the list, so a retired token never
     // revokes a later compile upstream.
     if let Some(owner) = descr_arc

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -740,21 +740,12 @@ impl ModuleDictStrategy {
         }
     }
 
-    /// Register a JIT loop's invalidation flag against the `version?`
-    /// quasi-immutable field (`quasiimmut.py:116-126
-    /// get_current_qmut_instance` + `:72-75 register_loop_token`).  The
-    /// compile-time glue (`register_quasi_immutable_deps`) calls this once per
-    /// version-keyed module-global dependency, passing the
-    /// `JitCellToken.invalidation_flag()`.
-    pub fn register_version_watcher(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
-        self.version_watchers.register_loop_token(flag);
-    }
-
-    /// `quasiimmut.py:116-126 get_current_qmut_instance` alone — install the
-    /// instance while the trace is still recording, so a `mutated()` reached
-    /// later in the same trace finds the field non-null.
-    pub fn install_version_watcher(&self) {
-        self.version_watchers.ensure_installed();
+    /// `quasiimmut.py:17-27 get_current_qmut_instance` for the `version?`
+    /// field — resolve the instance while the trace is still recording, so a
+    /// `mutated()` reached later in the same trace finds the field non-null and
+    /// the recording can carry the instance to `compile.py:204-207`.
+    pub fn current_version_qmut(&self) -> std::sync::Arc<crate::quasiimmut::QuasiImmut> {
+        self.version_watchers.get_current_qmut_instance()
     }
 
     /// `pyjitpl.py:1112 mutatebox.nonnull()` — whether some trace or loop is
@@ -772,7 +763,7 @@ impl ModuleDictStrategy {
     }
 
     /// Invalidate every loop watching `version`
-    /// (`quasiimmut.py:129-134 _invalidate_now`).  Sets each live flag to
+    /// (`quasiimmut.py:33-38 _invalidate_now`).  Sets each live flag to
     /// `true`, the polarity `GuardNotInvalidated` tests.
     ///
     /// The installed check stays traced and the sweep is residual, for the
@@ -1348,7 +1339,7 @@ mod tests {
         use std::sync::atomic::{AtomicBool, Ordering};
         let mut strategy = ModuleDictStrategy::new();
         let flag = Arc::new(AtomicBool::new(false));
-        strategy.register_version_watcher(&flag);
+        strategy.current_version_qmut().register_loop_token(&flag);
         // Before a structural change the watching loop is still valid.
         assert!(!flag.load(Ordering::Acquire));
         // `mutated()` reassigns `version` and must invalidate the loop.
@@ -1362,7 +1353,7 @@ mod tests {
         use std::sync::atomic::AtomicBool;
         let mut strategy = ModuleDictStrategy::new();
         let flag = Arc::new(AtomicBool::new(false));
-        strategy.register_version_watcher(&flag);
+        strategy.current_version_qmut().register_loop_token(&flag);
         // Drop the only strong ref: the weak watcher can no longer upgrade.
         drop(flag);
         // notify (via mutated) must not panic, and `_invalidate_now` unlinks

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -323,67 +323,44 @@ pub unsafe fn w_property_reinit(
     crate::gc_hook::try_gc_write_barrier(obj as *mut u8);
 }
 
-/// `quasiimmut.py:116-126 get_current_qmut_instance` for
-/// `descriptor.py:175`'s `w_fget?` — install the instance at RECORD time so a
-/// write reached later in the same trace sees it.  The
-/// [`w_type_install_quasi_immut`](crate::typeobject::w_type_install_quasi_immut)
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for
+/// `descriptor.py:175`'s `w_fget?` — resolved at RECORD time so a write
+/// reached later in the same trace sees it, and handed back so the loop
+/// compiled from that trace registers on it and `property.__init__` revokes
+/// it.  The
+/// [`w_type_current_qmut_instance`](crate::typeobject::w_type_current_qmut_instance)
 /// shape.
 ///
 /// # Safety
 /// `obj` must point to a live [`W_Property`].
-pub unsafe fn w_property_install_fget_watcher(obj: PyObjectRef) {
-    if obj.is_null() {
-        return;
-    }
-    (*(obj as *const W_Property))
-        .fget_watchers
-        .ensure_installed();
-}
-
-/// The `w_fset?` twin of [`w_property_install_fget_watcher`].
-///
-/// # Safety
-/// `obj` must point to a live [`W_Property`].
-pub unsafe fn w_property_install_fset_watcher(obj: PyObjectRef) {
-    if obj.is_null() {
-        return;
-    }
-    (*(obj as *const W_Property))
-        .fset_watchers
-        .ensure_installed();
-}
-
-/// `quasiimmut.py:72-75 register_loop_token` for `w_fget?` — record a compiled
-/// loop's invalidation flag so `property.__init__` revokes it.
-///
-/// # Safety
-/// `obj` must point to a live [`W_Property`].
-pub unsafe fn w_property_register_fget_watcher(
+pub unsafe fn w_property_current_fget_qmut(
     obj: PyObjectRef,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if obj.is_null() {
-        return;
+        return None;
     }
-    (*(obj as *const W_Property))
-        .fget_watchers
-        .register_loop_token(flag);
+    Some(
+        (*(obj as *const W_Property))
+            .fget_watchers
+            .get_current_qmut_instance(),
+    )
 }
 
-/// The `w_fset?` twin of [`w_property_register_fget_watcher`].
+/// The `w_fset?` twin of [`w_property_current_fget_qmut`].
 ///
 /// # Safety
 /// `obj` must point to a live [`W_Property`].
-pub unsafe fn w_property_register_fset_watcher(
+pub unsafe fn w_property_current_fset_qmut(
     obj: PyObjectRef,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if obj.is_null() {
-        return;
+        return None;
     }
-    (*(obj as *const W_Property))
-        .fset_watchers
-        .register_loop_token(flag);
+    Some(
+        (*(obj as *const W_Property))
+            .fset_watchers
+            .get_current_qmut_instance(),
+    )
 }
 
 /// `descriptor.py:249-250 W_Property.get_doc` — returns the raw slot

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1173,43 +1173,26 @@ pub unsafe fn module_dict_storage_len(obj: PyObjectRef) -> Option<usize> {
     Some((*md.dstorage).len())
 }
 
-/// Register a compiled loop's invalidation `flag` against a module dict
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for a module dict
 /// strategy's `version?` quasi-immutable field (`celldict.py:34
-/// _immutable_fields_ = ["version?"]`).  The compile-time glue calls this once
-/// per version-keyed module-global dependency so a later `mutated()` (new key,
-/// `del`, `switch_to_object_strategy`, or a write that replaces a stored cell)
-/// flips the flag and fails the loop's `GUARD_NOT_INVALIDATED`.
+/// _immutable_fields_ = ["version?"]`).  The recording binds the returned
+/// instance, and the loop compiled from it registers there, so a later
+/// `mutated()` (new key, `del`, `switch_to_object_strategy`, or a write that
+/// replaces a stored cell) flips the flag and fails the loop's
+/// `GUARD_NOT_INVALIDATED`.
 ///
 /// Takes the strategy rather than the dict because that is what the trace pins:
 /// `version` lives on the strategy, so the `QUASIIMMUT_FIELD` names it directly.
 ///
 /// # Safety
 /// `strategy` must be null or point at a valid `ModuleDictStrategy`.
-pub unsafe fn module_dict_strategy_register_version_watcher(
+pub unsafe fn module_dict_strategy_current_version_qmut(
     strategy: *mut crate::celldict::ModuleDictStrategy,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if strategy.is_null() {
-        return;
+        return None;
     }
-    (*strategy).register_version_watcher(flag);
-}
-
-/// Install this strategy's `version?` qmut instance without registering a loop
-/// (`quasiimmut.py:116-126 get_current_qmut_instance`).
-///
-/// The recording-time half, for the reason spelled out on
-/// [`crate::typeobject::w_type_install_quasi_immut`].
-///
-/// # Safety
-/// `strategy` must be null or point at a valid `ModuleDictStrategy`.
-pub unsafe fn module_dict_strategy_install_version_watcher(
-    strategy: *mut crate::celldict::ModuleDictStrategy,
-) {
-    if strategy.is_null() {
-        return;
-    }
-    (*strategy).install_version_watcher();
+    Some((*strategy).current_version_qmut())
 }
 
 /// `pyjitpl.py:1112 mutatebox.nonnull()` for this strategy's `version?`.

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -273,36 +273,24 @@ pub unsafe fn w_staticmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
     }
 }
 
-/// `quasiimmut.py get_current_qmut_instance` for `function.py`'s
-/// `w_function?` — install the instance at RECORD time so a write reached
-/// later in the same trace sees it.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for `function.py`'s
+/// `w_function?` — resolved at RECORD time so a write reached later in the same
+/// trace sees it, and handed back so the loop compiled from that trace
+/// registers on it.
 ///
 /// # Safety
 /// `obj` must point to a live [`StaticMethod`].
-pub unsafe fn w_staticmethod_install_w_function_watcher(obj: PyObjectRef) {
-    if obj.is_null() {
-        return;
-    }
-    (*(obj as *const StaticMethod))
-        .w_function_watchers
-        .ensure_installed();
-}
-
-/// Attach a compiled loop's invalidation flag to this wrapper's `w_function?`
-/// watcher, the `quasiimmut.py QuasiImmut.register_loop_token` half.
-///
-/// # Safety
-/// `obj` must point to a live [`StaticMethod`].
-pub unsafe fn w_staticmethod_register_w_function_watcher(
+pub unsafe fn w_staticmethod_current_w_function_qmut(
     obj: PyObjectRef,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if obj.is_null() {
-        return;
+        return None;
     }
-    (*(obj as *const StaticMethod))
-        .w_function_watchers
-        .register_loop_token(flag);
+    Some(
+        (*(obj as *const StaticMethod))
+            .w_function_watchers
+            .get_current_qmut_instance(),
+    )
 }
 
 /// function.py:678-681 `StaticMethod.getdict` — allocate the instance
@@ -469,36 +457,24 @@ pub unsafe fn w_classmethod_set_func(obj: PyObjectRef, func: PyObjectRef) {
     }
 }
 
-/// `quasiimmut.py get_current_qmut_instance` for `function.py`'s
-/// `w_function?` — install the instance at RECORD time so a write reached
-/// later in the same trace sees it.
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for `function.py`'s
+/// `w_function?` — resolved at RECORD time so a write reached later in the same
+/// trace sees it, and handed back so the loop compiled from that trace
+/// registers on it.
 ///
 /// # Safety
 /// `obj` must point to a live [`ClassMethod`].
-pub unsafe fn w_classmethod_install_w_function_watcher(obj: PyObjectRef) {
-    if obj.is_null() {
-        return;
-    }
-    (*(obj as *const ClassMethod))
-        .w_function_watchers
-        .ensure_installed();
-}
-
-/// Attach a compiled loop's invalidation flag to this wrapper's `w_function?`
-/// watcher, the `quasiimmut.py QuasiImmut.register_loop_token` half.
-///
-/// # Safety
-/// `obj` must point to a live [`ClassMethod`].
-pub unsafe fn w_classmethod_register_w_function_watcher(
+pub unsafe fn w_classmethod_current_w_function_qmut(
     obj: PyObjectRef,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if obj.is_null() {
-        return;
+        return None;
     }
-    (*(obj as *const ClassMethod))
-        .w_function_watchers
-        .register_loop_token(flag);
+    Some(
+        (*(obj as *const ClassMethod))
+            .w_function_watchers
+            .get_current_qmut_instance(),
+    )
 }
 
 /// function.py:726-729 `ClassMethod.getdict`.

--- a/pyre/pyre-object/src/quasiimmut.rs
+++ b/pyre/pyre-object/src/quasiimmut.rs
@@ -6,26 +6,59 @@
 //! (`get_mutate_field_name`), `get_current_qmut_instance` fills it in on the
 //! first registration, and the invalidation function the rtyper installs on the
 //! real field's write path nulls it and sweeps it. Pyre has no rtyper, so
-//! [`QuasiImmutField`] is that hidden field written out, and the two `?` fields
-//! this tree declares — `W_TypeObject._version_tag`
-//! (typeobject.py:177) and `ModuleDictStrategy.version` (celldict.py:34) —
-//! share it.
+//! [`QuasiImmutField`] is that hidden field written out — one per `?`
+//! declaration, embedded in the owner the declaration belongs to, and reached
+//! by the record-time resolver in `pyre-jit-trace::state quasi_immut_descr`.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 
-/// `quasiimmut.py:55-109 QuasiImmut` — the loops that baked one quasi-immutable
+/// `quasiimmut.py:54-110 QuasiImmut` — the loops that baked one quasi-immutable
 /// field's value as a constant, and must be revoked when it changes.
 ///
 /// The flag stands in for upstream's `looptoken` + `cpu.invalidate_loop`: the
 /// backend already routes `GUARD_NOT_INVALIDATED` through a per-artifact
 /// `AtomicBool`, so setting it is what `looptoken.invalidated = True` buys.
+///
+/// Upstream reaches an instance twice — `QuasiImmutDescr.__init__` binds it
+/// while recording (`pyjitpl.py:1081`) and `compile.py:204-207` registers the
+/// finished loop on that same object — so the instance outlives the field slot
+/// that published it. It is shared through an [`Arc`] here for that reason, so
+/// the methods take `&self` and reach the list through a lock.
 pub struct QuasiImmut {
-    /// `quasiimmut.py:62-63` — weak so a retired loop drops out instead of
+    tokens: parking_lot::Mutex<LoopTokens>,
+    /// Whether [`QuasiImmutField::invalidate`] has already unlinked and swept
+    /// this instance. Upstream asks the same question by identity —
+    /// `quasiimmut.py:153 if qmut is not self.qmut` compares the recorded
+    /// instance against the field's current one, and the two differ exactly
+    /// when the recorded one was unlinked, since a fresh instance is only ever
+    /// minted into a nulled field.
+    unlinked: AtomicBool,
+}
+
+/// The list `quasiimmut.py:59-63 __init__` sets up, behind the lock that keeps
+/// a registration and a sweep from interleaving.
+struct LoopTokens {
+    /// `quasiimmut.py:61-63` — weak so a retired loop drops out instead of
     /// being kept alive by the object whose field it read.
     looptokens_wrefs: Vec<std::sync::Weak<AtomicBool>>,
-    /// `quasiimmut.py:57 compress_limit = 30`.
+    /// `quasiimmut.py:56 compress_limit = 30`.
     compress_limit: usize,
+}
+
+impl LoopTokens {
+    /// `quasiimmut.py:77-82 compress_looptokens_list` — drop the entries whose
+    /// loop is gone and re-derive the limit from what is left, so an object that
+    /// is recompiled against many times and never mutated cannot grow an
+    /// unbounded list.
+    ///
+    /// Upstream's note that already-invalidated tokens must be kept applies
+    /// here too: the flag stays live while its artifact does, and re-flipping
+    /// an already-set flag is what keeps a multiply-invalidated loop revoked.
+    fn compress(&mut self) {
+        self.looptokens_wrefs.retain(|w| w.strong_count() > 0);
+        self.compress_limit = (self.looptokens_wrefs.len() + 15) * 2;
+    }
 }
 
 impl Default for QuasiImmut {
@@ -35,41 +68,50 @@ impl Default for QuasiImmut {
 }
 
 impl QuasiImmut {
-    /// `quasiimmut.py:59-64 __init__`. The initial limit is the growth formula
-    /// in [`Self::compress_looptokens_list`] evaluated at length zero.
+    /// `quasiimmut.py:59-63 __init__`. The initial limit is the growth formula
+    /// in [`LoopTokens::compress`] evaluated at length zero.
     pub fn new() -> Self {
         Self {
-            looptokens_wrefs: Vec::new(),
-            compress_limit: 30,
+            tokens: parking_lot::Mutex::new(LoopTokens {
+                looptokens_wrefs: Vec::new(),
+                compress_limit: 30,
+            }),
+            unlinked: AtomicBool::new(false),
         }
+    }
+
+    /// `quasiimmut.py:151-153` — whether this instance is still the one the
+    /// field publishes, which is what `is_still_valid_for` tests before a loop
+    /// that folded the field is allowed to stand.
+    pub fn is_current(&self) -> bool {
+        !self.unlinked.load(Ordering::Acquire)
     }
 
     /// `quasiimmut.py:72-75 register_loop_token`.
-    pub fn register_loop_token(&mut self, flag: &Arc<AtomicBool>) {
-        if self.looptokens_wrefs.len() > self.compress_limit {
-            self.compress_looptokens_list();
-        }
-        self.looptokens_wrefs.push(Arc::downgrade(flag));
-    }
-
-    /// `quasiimmut.py:77-82 compress_looptokens_list` — drop the entries whose
-    /// loop is gone and re-derive the limit from what is left, so an object that
-    /// is recompiled against many times and never mutated cannot grow an
-    /// unbounded list.
     ///
-    /// Upstream's note that already-invalidated tokens must be kept applies
-    /// here too: the flag stays live while its artifact does, and re-flipping
-    /// an already-set flag is what keeps a multiply-invalidated loop revoked.
-    fn compress_looptokens_list(&mut self) {
-        self.looptokens_wrefs.retain(|w| w.strong_count() > 0);
-        self.compress_limit = (self.looptokens_wrefs.len() + 15) * 2;
+    /// A caller holding a recorded instance can reach here after the sweep:
+    /// upstream cannot, because the GIL spans its optimize-and-compile, but
+    /// pyre's runs with other threads live. The loop is then born invalid —
+    /// its `GUARD_NOT_INVALIDATED` has to fail on the first entry, since the
+    /// value it baked is the pre-mutation one and no later sweep will reach a
+    /// list this instance has already emptied.
+    pub fn register_loop_token(&self, flag: &Arc<AtomicBool>) {
+        let mut tokens = self.tokens.lock();
+        if self.unlinked.load(Ordering::Acquire) {
+            flag.store(true, Ordering::Release);
+            return;
+        }
+        if tokens.looptokens_wrefs.len() > tokens.compress_limit {
+            tokens.compress();
+        }
+        tokens.looptokens_wrefs.push(Arc::downgrade(flag));
     }
 
-    /// `quasiimmut.py:84-109 invalidate` — every loop recorded here becomes
+    /// `quasiimmut.py:84-110 invalidate` — every loop recorded here becomes
     /// invalid, so each `GUARD_NOT_INVALIDATED` in it (and in its bridges) must
     /// now fail. The list is emptied like upstream's `self.looptokens_wrefs =
-    /// []`; the caller then drops the instance itself, so a loop that recompiles
-    /// registers against a fresh one.
+    /// []`, and the instance is marked unlinked under the same lock so a
+    /// registration that arrives afterwards cannot be dropped on the floor.
     ///
     /// Taking the list is what bounds the walk. Keeping the live entries would
     /// be doubly wrong: the flag is already `true`, so re-storing it does
@@ -79,8 +121,13 @@ impl QuasiImmut {
     /// each iteration walk every loop ever compiled against the object:
     /// O(compiled loops) per store, and the JIT compiling more loops would make
     /// the interpreter slower.
-    pub fn invalidate(&mut self) {
-        for wref in std::mem::take(&mut self.looptokens_wrefs) {
+    pub fn invalidate(&self) {
+        let wrefs = {
+            let mut tokens = self.tokens.lock();
+            self.unlinked.store(true, Ordering::Release);
+            std::mem::take(&mut tokens.looptokens_wrefs)
+        };
+        for wref in wrefs {
             if let Some(flag) = wref.upgrade() {
                 flag.store(true, Ordering::Release);
             }
@@ -90,13 +137,13 @@ impl QuasiImmut {
     /// Number of entries still recorded, for tests.
     #[cfg(test)]
     pub(crate) fn len(&self) -> usize {
-        self.looptokens_wrefs.len()
+        self.tokens.lock().looptokens_wrefs.len()
     }
 
     /// The current growth limit, for tests.
     #[cfg(test)]
     pub(crate) fn compress_limit(&self) -> usize {
-        self.compress_limit
+        self.tokens.lock().compress_limit
     }
 }
 
@@ -104,19 +151,22 @@ impl QuasiImmut {
 /// declaration (`quasiimmut.py get_mutate_field_name`), written out because
 /// pyre has no rtyper to synthesise it.
 ///
-/// Null until the first loop registers (`get_current_qmut_instance`,
-/// quasiimmut.py:116-126); nulled and dropped by the invalidation function
-/// (`make_invalidation_function._invalidate_now`, quasiimmut.py:129-134), so
-/// the next registration starts from a fresh instance and the identity a
-/// revalidation compares really did change.
+/// Null until the first read is recorded (`get_current_qmut_instance`,
+/// quasiimmut.py:17-27); nulled by the invalidation function
+/// (`make_invalidation_function._invalidate_now`, quasiimmut.py:33-38), so
+/// the next recording starts from a fresh instance and the identity a
+/// revalidation compares really did change. The stored pointer is one strong
+/// [`Arc`] reference, so an instance a trace is still holding survives being
+/// unlinked here — which is what lets a compile register on the instance its
+/// recording resolved.
 ///
 /// The pointer is the single source of truth, exactly as upstream's field is.
 /// The lock is the nogil adaptation: upstream gets the null-then-sweep pair for
 /// free from the GIL, while pyre runs Python threads on real OS threads, so
-/// without it two mutators free one instance twice and a mutator can free the
-/// instance a compiling thread is pushing into. Only the dereferencing paths
-/// take it — [`Self::is_installed`] deliberately does not, because that bare
-/// test is the whole cost a mutation on an object no loop watches has to pay.
+/// without it two mutators unlink one instance twice. Only the paths that
+/// publish or unpublish take it — [`Self::is_installed`] deliberately does not,
+/// because that bare test is the whole cost a mutation on an object no loop
+/// watches has to pay.
 ///
 /// Both owners are allocated non-moving (`try_gc_alloc_stable_raw` /
 /// `malloc_typed`), so the lock cannot be remapped out from under a holder and
@@ -142,76 +192,63 @@ impl QuasiImmutField {
         }
     }
 
-    /// Whether any loop has registered since the last invalidation — the
+    /// Whether any read has been recorded since the last invalidation — the
     /// `if not qmut_ptr` test that guards `_invalidate_now`'s body
-    /// (quasiimmut.py:130). Lock-free so it can stay inside a trace.
+    /// (quasiimmut.py:41). Lock-free so it can stay inside a trace.
     #[inline]
     pub fn is_installed(&self) -> bool {
         !self.ptr.load(Ordering::Acquire).is_null()
     }
 
-    /// `quasiimmut.py:116-126 get_current_qmut_instance` on its own — create the
-    /// instance when the field is still null and register nothing.
+    /// `quasiimmut.py:17-27 get_current_qmut_instance` — the field's instance,
+    /// created when it is still null, handed back so the caller can hold it.
     ///
-    /// Upstream installs while RECORDING the read: `pyjitpl.py:1081` builds a
-    /// `QuasiImmutDescr`, whose `__init__` calls `get_current_qmut_instance`,
-    /// which `bh_setfield_gc_r`s a fresh instance into the hidden field
-    /// (`quasiimmut.py:26`). No loop token exists yet at that point; the token
-    /// joins later through [`Self::register_loop_token`].
-    ///
-    /// Pyre only ever had the fused create-and-register, driven from compile
-    /// time (`pyre-jit/src/eval.rs register_quasi_immutable_deps`). Since every
-    /// invalidation uninstalls, the field was null for the whole of tracing, so
-    /// the write path's [`Self::is_installed`] — pyre's `mutatebox.nonnull()` —
-    /// could never fire during a recording.
-    pub fn ensure_installed(&self) {
-        // The null test is the fast path a hot read must not pay a lock for.
-        if self.is_installed() {
-            return;
-        }
+    /// Upstream calls this while RECORDING the read: `pyjitpl.py:1081` builds a
+    /// `QuasiImmutDescr`, whose `__init__` `bh_setfield_gc_r`s a fresh instance
+    /// into the hidden field (`quasiimmut.py:26`) and keeps it as
+    /// `self.qmut`. That binding is what `heap.py:818 is_still_valid_for` and
+    /// `compile.py:204-207 register_loop_token` both read later; pyre returns it
+    /// for the same two consumers.
+    pub fn get_current_qmut_instance(&self) -> Arc<QuasiImmut> {
         let _guard = self.lock.lock();
-        let _ = self.locked_get_current_qmut_instance();
-    }
-
-    /// `quasiimmut.py:116-126 get_current_qmut_instance`.  Caller holds
-    /// [`Self::lock`].
-    fn locked_get_current_qmut_instance(&self) -> *mut QuasiImmut {
         let qmut_ptr = self.ptr.load(Ordering::Acquire);
-        if !qmut_ptr.is_null() {
-            return qmut_ptr;
+        if qmut_ptr.is_null() {
+            let fresh = Arc::new(QuasiImmut::new());
+            let raw = Arc::into_raw(fresh).cast_mut();
+            // One reference stays in the field, one goes to the caller.
+            unsafe { Arc::increment_strong_count(raw) };
+            self.ptr.store(raw, Ordering::Release);
+            return unsafe { Arc::from_raw(raw) };
         }
-        let fresh = Box::into_raw(Box::new(QuasiImmut::new()));
-        self.ptr.store(fresh, Ordering::Release);
-        fresh
+        // Safe: the field holds a strong reference for as long as the pointer
+        // is published, and it is only unpublished under the same lock.
+        unsafe {
+            Arc::increment_strong_count(qmut_ptr);
+            Arc::from_raw(qmut_ptr)
+        }
     }
 
-    /// `quasiimmut.py:116-126 get_current_qmut_instance` followed by
-    /// `:72-75 register_loop_token`: create the instance if the field is still
-    /// null, then record this loop's invalidation flag on it.
-    pub fn register_loop_token(&self, flag: &Arc<AtomicBool>) {
-        let _guard = self.lock.lock();
-        let qmut_ptr = self.locked_get_current_qmut_instance();
-        // Safe: the pointer is only ever cleared under the same lock, and the
-        // instance is freed by whoever wins that clear.
-        unsafe { (*qmut_ptr).register_loop_token(flag) };
-    }
-
-    /// `quasiimmut.py:129-134 make_invalidation_function._invalidate_now` —
+    /// `quasiimmut.py:33-38 make_invalidation_function._invalidate_now` —
     /// unlink the instance, then flip every loop flag it recorded.
     ///
     /// Re-reads the pointer under the lock rather than trusting an earlier
     /// [`Self::is_installed`]: two threads mutating the same object both see it
-    /// installed, and only the one that wins the swap owns the [`Box`].
+    /// installed, and only the one that wins the swap gets the reference.
     pub fn invalidate(&self) {
-        let Some(mut qmut) = self.take() else {
+        let Some(qmut) = self.take() else {
             return;
         };
         qmut.invalidate();
     }
 
-    /// Unlink the instance and hand it to the caller. The owner's destructor
-    /// uses this to reclaim a box that was never invalidated.
-    pub fn take(&self) -> Option<Box<QuasiImmut>> {
+    /// Unlink the instance and hand the field's reference to the caller, who
+    /// drops it. [`Self::invalidate`] sweeps first; a swept owner's destructor
+    /// calls it on its own to release an instance that was never invalidated.
+    ///
+    /// The reference, not the allocation: a recording still holding this
+    /// instance keeps it alive, so an owner reclaimed mid-compile cannot leave
+    /// the compiler registering into freed memory.
+    pub fn take(&self) -> Option<Arc<QuasiImmut>> {
         let qmut_ptr = {
             let _guard = self.lock.lock();
             self.ptr.swap(std::ptr::null_mut(), Ordering::AcqRel)
@@ -219,8 +256,9 @@ impl QuasiImmutField {
         if qmut_ptr.is_null() {
             return None;
         }
-        // Safe: the swap is what transfers ownership, and it happens once.
-        Some(unsafe { Box::from_raw(qmut_ptr) })
+        // Safe: the swap is what transfers the field's reference, and it
+        // happens once.
+        Some(unsafe { Arc::from_raw(qmut_ptr) })
     }
 }
 
@@ -228,7 +266,7 @@ impl Drop for QuasiImmutField {
     fn drop(&mut self) {
         let qmut_ptr = *self.ptr.get_mut();
         if !qmut_ptr.is_null() {
-            drop(unsafe { Box::from_raw(qmut_ptr) });
+            drop(unsafe { Arc::from_raw(qmut_ptr) });
         }
     }
 }
@@ -255,11 +293,11 @@ pub unsafe fn sweep_quasi_immut_field(field: *const QuasiImmutField) {
 mod tests {
     use super::*;
 
-    /// `quasiimmut.py:84-109 invalidate` flips every registered flag and empties
+    /// `quasiimmut.py:84-110 invalidate` flips every registered flag and empties
     /// the list, and a flag whose loop is gone is simply skipped.
     #[test]
     fn invalidate_flips_live_flags_and_clears() {
-        let mut qi = QuasiImmut::new();
+        let qi = QuasiImmut::new();
         let live = Arc::new(AtomicBool::new(false));
         let dead = Arc::new(AtomicBool::new(false));
         qi.register_loop_token(&live);
@@ -284,8 +322,8 @@ mod tests {
     /// mutated must not grow an unbounded watcher list.
     #[test]
     fn register_compresses_dead_loop_tokens() {
-        let mut qi = QuasiImmut::new();
-        assert_eq!(qi.compress_limit(), 30, "quasiimmut.py:57 compress_limit");
+        let qi = QuasiImmut::new();
+        assert_eq!(qi.compress_limit(), 30, "quasiimmut.py:56 compress_limit");
         for _ in 0..500 {
             // Each "recompile" drops its artifact immediately, so every
             // registered weak ref is already dead by the next round.
@@ -304,14 +342,14 @@ mod tests {
     }
 
     /// `_invalidate_now` nulls the field before sweeping, so a later
-    /// registration starts from a fresh instance.
+    /// recording starts from a fresh instance.
     #[test]
     fn invalidate_unlinks_before_sweeping() {
         let field = QuasiImmutField::new();
         assert!(!field.is_installed());
 
         let flag = Arc::new(AtomicBool::new(false));
-        field.register_loop_token(&flag);
+        field.get_current_qmut_instance().register_loop_token(&flag);
         assert!(field.is_installed());
 
         field.invalidate();
@@ -324,21 +362,46 @@ mod tests {
         // A second invalidation with nothing installed must not double-free.
         field.invalidate();
 
-        // A recompile registers against a fresh instance rather than reviving
-        // the swept one.  Only the address would witness that directly, and the
-        // allocator is free to hand the freed box straight back, so the
-        // observable is that the new flag rides its own list.
         let flag2 = Arc::new(AtomicBool::new(false));
-        field.register_loop_token(&flag2);
+        field
+            .get_current_qmut_instance()
+            .register_loop_token(&flag2);
         assert!(field.is_installed());
         field.invalidate();
         assert!(flag2.load(Ordering::Acquire));
     }
 
-    /// Registration runs on the compiling thread while any other Python thread
-    /// can be mutating the same object. Upstream is safe here only because of
-    /// the GIL; pyre has none, so the get-or-create, the push and the free have
-    /// to be serialised or this races the instance to a double free.
+    /// `quasiimmut.py:151-153 if qmut is not self.qmut` — a recording holds the
+    /// instance it resolved, so an invalidation that lands before the compile
+    /// is visible on that handle rather than being hidden by the field having
+    /// already minted a replacement.
+    #[test]
+    fn a_recorded_instance_reports_a_sweep_and_is_not_reused() {
+        let field = QuasiImmutField::new();
+        let recorded = field.get_current_qmut_instance();
+        assert!(recorded.is_current());
+
+        field.invalidate();
+        assert!(!recorded.is_current(), "the recorded instance was swept");
+
+        // The field mints a fresh instance rather than republishing the one the
+        // recording still holds.
+        let fresh = field.get_current_qmut_instance();
+        assert!(fresh.is_current());
+        assert!(!Arc::ptr_eq(&recorded, &fresh));
+
+        // Registering on the swept instance cannot be silently lost: the loop
+        // folded a pre-mutation value, so it is born invalid.
+        let flag = Arc::new(AtomicBool::new(false));
+        recorded.register_loop_token(&flag);
+        assert!(flag.load(Ordering::Acquire));
+        assert_eq!(recorded.len(), 0, "a swept list must not grow again");
+    }
+
+    /// Recording runs on one thread while any other Python thread can be
+    /// mutating the same object. Upstream is safe here only because of the GIL;
+    /// pyre has none, so the get-or-create, the push and the unlink have to be
+    /// serialised or this races the instance to a double free.
     ///
     /// Reverting [`QuasiImmutField::take`] to an unlocked load/store aborts this
     /// with heap corruption inside `Vec`.
@@ -350,15 +413,15 @@ mod tests {
         let stop = AtomicBool::new(false);
 
         std::thread::scope(|scope| {
-            // Two compiling threads keep re-installing the instance, so the
-            // mutators below keep finding one to free.
+            // Two recording threads keep re-installing the instance, so the
+            // mutators below keep finding one to sweep.
             for _ in 0..2 {
                 let field = &field;
                 let stop = &stop;
                 scope.spawn(move || {
                     let flag = Arc::new(AtomicBool::new(false));
                     while !stop.load(Ordering::Relaxed) {
-                        field.register_loop_token(&flag);
+                        field.get_current_qmut_instance().register_loop_token(&flag);
                     }
                 });
             }

--- a/pyre/pyre-object/src/typeobject.rs
+++ b/pyre/pyre-object/src/typeobject.rs
@@ -230,8 +230,8 @@ pub struct W_TypeObject {
     /// _immutable_fields_ = ['_version_tag?']` — see [`QuasiImmut`].
     ///
     /// Allocated on the first registration (`get_current_qmut_instance`,
-    /// quasiimmut.py:116-126), null until then, and unlinked + freed on
-    /// invalidation (`_invalidate_now`, quasiimmut.py:129-134), so a type nobody
+    /// quasiimmut.py:17-27), null until then, and unlinked + freed on
+    /// invalidation (`_invalidate_now`, quasiimmut.py:33-38), so a type nobody
     /// has mutated since its last compile is the only one holding a box. Holds
     /// no GC pointers, so the `W_TYPE_GC_TYPE_ID` custom trace has nothing to
     /// walk here.
@@ -853,52 +853,34 @@ pub unsafe fn w_type_set_version_tag(obj: PyObjectRef, v: u64) {
         .store(v, std::sync::atomic::Ordering::Release);
 }
 
-/// Register a compiled loop's invalidation flag against this type's
-/// `_version_tag?` (`quasiimmut.py:72-74 QuasiImmut.register_loop_token`),
-/// creating the instance on demand exactly like `get_current_qmut_instance`
-/// (quasiimmut.py:116-126).
+/// `quasiimmut.py:17-27 get_current_qmut_instance` for this type's
+/// `_version_tag?`.
 ///
-/// The compile-time glue (`register_quasi_immutable_deps`) calls this once per
-/// type-keyed dependency the optimizer collected from a `QUASIIMMUT_FIELD`, so
-/// [`w_type_notify_quasi_immut_watchers`] can revoke the loop when the tag is
-/// bumped.
+/// Called while the trace is still being recorded, exactly where
+/// `QuasiImmutDescr.__init__` (`pyjitpl.py:1081`) calls it: a write reached
+/// later in that same trace then sees a non-null `mutate_*` field and aborts
+/// the attempt. The instance is handed back so the recording can carry it to
+/// `heap.py:818 is_still_valid_for` and `compile.py:204-207
+/// register_loop_token`, after which [`w_type_notify_quasi_immut_watchers`]
+/// revokes the loop when the tag is bumped.
 ///
 /// # Safety
 /// `obj` must be null or point at a valid `W_TypeObject`.
-pub unsafe fn w_type_register_quasi_immut_watcher(
+pub unsafe fn w_type_current_qmut_instance(
     obj: PyObjectRef,
-    flag: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-) {
+) -> Option<std::sync::Arc<crate::quasiimmut::QuasiImmut>> {
     if obj.is_null() || !is_type(obj) {
-        return;
+        return None;
     }
-    (*(obj as *const W_TypeObject))
-        .quasi_immut_watchers
-        .register_loop_token(flag);
-}
-
-/// Install this type's `_version_tag?` qmut instance without registering a
-/// loop (`quasiimmut.py:116-126 get_current_qmut_instance`).
-///
-/// The recording half of the protocol: upstream's `QuasiImmutDescr.__init__`
-/// (`pyjitpl.py:1081`) installs while the trace is still being recorded, so a
-/// write reached later in that same trace sees a non-null `mutate_*` field and
-/// aborts the attempt. [`w_type_register_quasi_immut_watcher`] is the compile-
-/// time half and runs far too late to arm that test.
-///
-/// # Safety
-/// `obj` must be null or point at a valid `W_TypeObject`.
-pub unsafe fn w_type_install_quasi_immut(obj: PyObjectRef) {
-    if obj.is_null() || !is_type(obj) {
-        return;
-    }
-    (*(obj as *const W_TypeObject))
-        .quasi_immut_watchers
-        .ensure_installed();
+    Some(
+        (*(obj as *const W_TypeObject))
+            .quasi_immut_watchers
+            .get_current_qmut_instance(),
+    )
 }
 
 /// Revoke every loop that baked this type's `version_tag` as a constant
-/// (`quasiimmut.py:129-134 make_invalidation_function._invalidate_now`).
+/// (`quasiimmut.py:33-38 make_invalidation_function._invalidate_now`).
 ///
 /// ```text
 ///  def _invalidate_now(p):
@@ -1753,7 +1735,7 @@ mod tests {
     }
 
     /// The `_version_tag?` wiring: publishing a new tag runs the invalidation
-    /// function (`quasiimmut.py:129-134 _invalidate_now`), so the loops that
+    /// function (`quasiimmut.py:33-38 _invalidate_now`), so the loops that
     /// baked the old tag are revoked and the field is left uninstalled.
     /// `quasiimmut::tests` covers the field itself.
     #[test]
@@ -1769,7 +1751,9 @@ mod tests {
         );
 
         let flag = Arc::new(AtomicBool::new(false));
-        unsafe { w_type_register_quasi_immut_watcher(obj, &flag) };
+        unsafe { w_type_current_qmut_instance(obj) }
+            .expect("a type resolves an instance")
+            .register_loop_token(&flag);
         assert!(w_type.quasi_immut_watchers.is_installed());
 
         unsafe { w_type_set_version_tag(obj, new_version_tag()) };
@@ -1786,12 +1770,8 @@ mod tests {
     /// A non-type pointer must not be walked as one.
     #[test]
     fn quasi_immut_watcher_helpers_ignore_non_types() {
-        use std::sync::Arc;
-        use std::sync::atomic::AtomicBool;
-
-        let flag = Arc::new(AtomicBool::new(false));
         unsafe {
-            w_type_register_quasi_immut_watcher(PY_NULL, &flag);
+            assert!(w_type_current_qmut_instance(PY_NULL).is_none());
             w_type_notify_quasi_immut_watchers(PY_NULL);
         }
     }


### PR DESCRIPTION
Two independent changes on one branch.

## `quasiimmut`: record the resolved `QuasiImmut` instance on the marker descr

`record_quasiimmut_field` now builds a per-read `majit_ir::QuasiImmutDescr` binding
the `QuasiImmut` instance resolved at record time together with the owner pointer,
the way `QuasiImmutDescr.__init__` does upstream. The heap optimizer's
`QuasiimmutField` arm runs the full `is_still_valid_for` test against that descr —
owner pointer, instance identity, current field value — and answers `InvalidLoop`
when the marker carries no instance or the test fails. The dependency it records is
the instance itself rather than an `(owner pointer, descr index)` pair the compile
side re-resolves.

What made the pair necessary was an objection recorded in the tree — that pyre's
descrs are registry-indexed singletons, so a record-time value cannot ride on one.
That does not hold: `record_op_with_descr` only stores the `Arc<dyn Descr>` and pyre
traces are never serialized, so a per-read wrapper descr costs one `Arc`.

Dropping the pair does lose something, and this is where the `InvalidLoop` comes
from: re-resolution also covered the case where the record side cannot resolve the
instance but the optimizer *can* fold the owner to a constant, and it registered the
watcher late. Carrying the instance instead would leave that fold with no watcher
behind it, so the optimizer now refuses the loop rather than standing one — which is
how `heap.py:814`'s assert reads as a verdict.

`QuasiImmut` becomes `Arc`-shared and carries an `unlinked` flag, so an instance
already swept answers `is_current() == false` and its `register_loop_token` sets the
flag immediately instead of storing a weak ref nothing will visit. That is what makes
the window safe here: upstream's GIL spans optimize→compile and pyre's does not.

`QuasiImmutField::get_current_qmut_instance` resolves-or-creates under the field lock
and returns that `Arc`, which collapses the twelve `*_install_*` /
`*_register_*_watcher` accessor pairs into one `*_current_*_qmut` each and reduces
`pyre-jit`'s `register_quasi_immutable_deps` from an 11-arm re-resolution chain to
registering the artifact's invalidation flag on the recorded instances.

`pyre-object` gains no majit dependency: the handle is a `majit-ir` trait
(`QuasiImmutHandle`) with a newtype adapter in `pyre-jit-trace`, which already sees
both crates.

`quasi_immutable_deps` is `Vec<Arc<dyn QuasiImmutHandle>>` through optimizer, unroll
and pyjitpl; dedup is by `Arc::ptr_eq`.

Also repairs 51 citations in the touched regions that named `quasiimmut.py` and
`heap.py` lines the current sources no longer hold — `quasiimmut.py:116-126` names a
different function; `get_current_qmut_instance` is at 17-27.

## `_abc`: let a missing collection raise instead of reading as an empty one

A missing `_abc_impl` collection was read as empty. It now raises, as upstream does.

## Gates

Run on the pre-rebase base `e4fb0a308c6`:

| gate | result |
|---|---|
| `cargo check --all --no-default-features --features dynasm` | rc=0, no warnings |
| `pyre/check.py --backend dynasm` | 445/445, no jitstats counter movement |
| parity (`--dynasm-only`) | all pass |
| `cpython_tests` | 207 PASS / 3 FAIL |
| `cargo test --all --no-default-features --features dynasm` | rc=0, 158 test binaries ok |

The three `cpython_tests` failures — `test_robotparser`, `test_smtpnet`, `test_urllib2` —
all died on the same DNS error (`gaierror (8, 'nodename nor servname provided, or not
known')`) and each passes on an isolated `--filter` re-run. Reporting the batch result
as it stood.

check.py at 445/445 with no counter movement is the evidence that neither the added
identity check nor the new `InvalidLoop` arm costs a loop. It also retires the one
open concern: `QuasiImmutDescr.struct_ptr` is a raw `u64` the GC does not update, so
an owner that moved between record and optimize would mismatch and lose the loop —
safe, but a cliff. Nothing moved.

The branch was then rebased onto `01b740aedaf`, picking up #1362, #1370 and #1380.
The rebase was clean and `cargo check --all` is rc=0 on the new base, but the gate
table above predates it — CI on this PR is the verdict for the current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q