### PR TITLE
gc: close the rooting holes a joined-artefact collection census finds, and settle gc.collect()'s answer

### DIFF
--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -3689,15 +3689,51 @@ impl MiniMarkGC {
     #[inline]
     fn validate_type_id(&self, type_id: u32, obj_addr: usize, site: &str) {
         if type_id as usize >= self.types.len() {
+            self.report_invalid_type_id(type_id, obj_addr, site);
+        }
+    }
+
+    /// Out-of-line half of [`validate_type_id`](Self::validate_type_id).
+    ///
+    /// A type id past the end of the type table has two very different
+    /// causes, and the bare number does not separate them.  When the header
+    /// word is `FORWARDED_MARKER` the object is not mistyped at all: it is a
+    /// nursery corpse whose live copy sits at the forwarding address, and the
+    /// caller reached it through a field nothing updated.  Say so, and give
+    /// the copy plus the nursery geometry and collection cadence, so the
+    /// surviving question is only which holder kept the stale pointer.
+    #[cold]
+    #[inline(never)]
+    fn report_invalid_type_id(&self, type_id: u32, obj_addr: usize, site: &str) -> ! {
+        let header_addr = obj_addr - GcHeader::SIZE;
+        let nursery_start = self.nursery.start_ptr() as usize;
+        let nursery_end = nursery_start + self.nursery.size();
+        let in_nursery = (nursery_start..nursery_end).contains(&obj_addr);
+        let header = unsafe { *(header_addr as *const GcHeader) };
+        if header.is_forwarded() {
+            let moved_to = unsafe { GcHeader::forwarding_address(header_addr as *const GcHeader) };
+            let moved_to_type_id = self
+                .is_managed_heap_object(moved_to)
+                .then(|| unsafe { (*header_of(moved_to)).type_id() });
             panic!(
-                "GC BUG: invalid type_id={} at obj_addr={:#x} (header_addr={:#x}, nursery_start={:#x}, site={})",
-                type_id,
-                obj_addr,
-                obj_addr - GcHeader::SIZE,
-                self.nursery.start_ptr() as usize,
-                site,
+                "GC BUG: {site} was handed {obj_addr:#x}, a STALE address whose object a                  minor collection already moved to {moved_to:#x}                  (live copy type_id={moved_to_type_id:?}).                  nursery=[{nursery_start:#x}, {nursery_end:#x}) obj_in_nursery={in_nursery}                  offset_from_nursery_start={:#x} minor_collections={} major_collections={}.                  FORWARDED_MARKER sets every flag bit, so an inline TRACK_YOUNG_PTRS test                  cannot tell this corpse from a live old object — the defect is the holder                  that kept the pre-collection pointer, not this barrier.",
+                obj_addr.wrapping_sub(nursery_start),
+                self.minor_collections,
+                self.major_collections,
             );
         }
+        panic!(
+            "GC BUG: invalid type_id={} at obj_addr={:#x} (header_addr={:#x}, nursery_start={:#x}, site={})              header_word={:#x} obj_in_nursery={} minor_collections={} major_collections={}",
+            type_id,
+            obj_addr,
+            header_addr,
+            nursery_start,
+            site,
+            header.tid_and_flags,
+            in_nursery,
+            self.minor_collections,
+            self.major_collections,
+        );
     }
 
     /// `base.py:134-144 _get_size_for_typeid` — the payload size of `obj_addr`,
@@ -10424,6 +10460,39 @@ mod tests {
             gc.minor_collections, 0,
             "stress_collect defaults off: no collection without opt-in"
         );
+    }
+
+    /// A forwarded header is a moved object, not an unknown type.  The
+    /// barrier's type-id validation must say so and name the live copy: the
+    /// bare out-of-range number reads the same whether the header is a corpse
+    /// marker or genuine corruption, and only the first has a holder to go
+    /// find.
+    #[test]
+    #[should_panic(expected = "already moved to")]
+    fn write_barrier_on_a_forwarded_object_names_the_live_copy() {
+        let ptr_size = std::mem::size_of::<GcRef>();
+        let mut gc = test_gc(1 << 20);
+        let tid = gc.register_type(TypeInfo::with_gc_ptrs(ptr_size, vec![0]));
+
+        let obj = gc.alloc_with_type(tid, ptr_size);
+        unsafe {
+            *(obj.0 as *mut GcRef) = GcRef::NULL;
+        }
+        let stale = obj.0;
+        let mut root = obj;
+        unsafe {
+            gc.roots.add(&mut root as *mut GcRef);
+        }
+        gc.do_collect_nursery();
+        gc.roots.clear();
+        assert_ne!(root.0, stale, "the collection must move the object");
+        assert!(
+            unsafe { (*header_of(stale)).is_forwarded() },
+            "the moved-from header must carry the forwarding marker"
+        );
+
+        // What a holder that kept the pre-collection pointer does next.
+        gc.remember_young_pointer(GcRef(stale));
     }
 
     #[test]

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -185,13 +185,17 @@ fn main() {
              {} call(s) withheld as dominated by a push_roots",
             stats.bodies_scanned, stats.unparsed_terminator_bodies, stats.withheld_under_a_bracket
         );
+        println!(
+            "       and {} body/bodies with a statement this reader could not parse",
+            stats.unparsed_statement_bodies
+        );
         // The resolved graph is an *under*-approximation of what collects: a
         // call whose dispatch edge is unresolved is excluded, so a clean
         // resolved census is not a clean census.  Re-run with the opaque set
         // folded in and report both, rather than let the difference go unsaid.
         let mut conservative = reach.clone();
         conservative.extend(opaque.iter().copied());
-        let (found_conservative, _) =
+        let (found_conservative, stats_conservative) =
             liveness::scan(&llbc, &cg, &conservative, &push_root_ids, &gc_tys);
         let conservative_fns: std::collections::BTreeSet<&str> = found_conservative
             .iter()
@@ -216,6 +220,18 @@ fn main() {
             "       counting unresolved dispatch as collecting too: {} in {} fn(s)",
             found_conservative.len(),
             conservative_fns.len()
+        );
+        // The conservative scan covers a superset of bodies, so its own
+        // withheld and unparsed figures are the ones its finding count has to
+        // be read against; quoting the resolved scan's line next to it would
+        // pair a count with another scan's accounting.
+        println!(
+            "           over {} bodies; {} with an unparsable terminator, {} with an \
+             unparsable statement; {} call(s) withheld under a push_roots",
+            stats_conservative.bodies_scanned,
+            stats_conservative.unparsed_terminator_bodies,
+            stats_conservative.unparsed_statement_bodies,
+            stats_conservative.withheld_under_a_bracket
         );
         println!(
             "       of which hold a NON-ARGUMENT live pointer: {} fn(s)",

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -94,9 +94,11 @@ fn main() {
         }
         if !donor_graphs.is_empty() {
             println!(
-                "   joined graph          : {} distinct names; {} name(s) carried by more than one artefact",
+                "   joined graph          : {} nodes; {} spelling(s) merged across artefacts, \
+                 {} held apart as ambiguous",
                 joined.graph.names.len(),
-                joined.shared_names
+                joined.joined_names,
+                joined.ambiguous_names
             );
         }
         // A seed that matches nothing empties half the closure silently, and
@@ -149,7 +151,7 @@ fn main() {
         let (jcol, _) = joined.graph.seeds_for(framework::COLLECTING_SEEDS);
         let mut joined_seeds = jpy;
         joined_seeds.extend(jcol);
-        let reach = joined.project(&cg, &joined.graph.reaching(&joined_seeds));
+        let reach = joined.project(0, &joined.graph.reaching(&joined_seeds));
         // The seeds as *this* artefact spells them.  The tiering below compares
         // a finding's `callee_id`, which is an id in this artefact, so it needs
         // the local set; the closure above needs the joined one.
@@ -208,7 +210,7 @@ fn main() {
         // dispatches through a `global_hook!` function pointer makes every one
         // of its callers undecidable too, not just itself.  Without this the
         // "cannot reach a collection" bucket silently absorbs them.
-        let opaque = joined.project(&cg, &joined.graph.reaching(&joined.graph.indirect));
+        let opaque = joined.project(0, &joined.graph.reaching(&joined.graph.indirect));
         let (mut justified, mut undecidable, mut unjustified) = (0usize, 0usize, Vec::new());
         for id in &bracketed {
             if reach.contains(id) {

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -13,6 +13,37 @@ fn main() {
         eprintln!("usage: gc-root-reachability <file.ullbc>...");
         std::process::exit(2);
     }
+    // Artefacts whose call graph is joined in but whose bodies are not scanned.
+    // One artefact is not one program: `pyre-jit.ullbc` carries the portal and
+    // the blackhole but hardly any of the interpreter they hand control to, so
+    // asked alone it answers that nothing reaches a collection.  Naming
+    // `pyre-interpreter.ullbc` here is what makes that answer mean anything.
+    // Donors are loaded once and their `Llbc` dropped: only the graph is kept,
+    // because holding two multi-hundred-megabyte artefacts open at once is what
+    // the memory goes to.
+    let donors: Vec<String> = std::env::var("GC_JOIN_WITH")
+        .ok()
+        .map(|v| {
+            v.split(',')
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect()
+        })
+        .unwrap_or_default();
+    let donor_graphs: Vec<(String, framework::CallGraph)> = donors
+        .iter()
+        .map(|path| {
+            let llbc = match majit_charon_reader::Llbc::load(path) {
+                Ok(l) => l,
+                Err(e) => {
+                    eprintln!("{path}: {e:?}");
+                    std::process::exit(1);
+                }
+            };
+            (path.clone(), framework::build(&llbc))
+        })
+        .collect();
+
     for path in &args {
         let llbc = match majit_charon_reader::Llbc::load(path) {
             Ok(l) => l,
@@ -47,12 +78,37 @@ fn main() {
             shown.join(" "),
             if per_crate.len() > 6 { " …" } else { "" }
         );
+        // Every question below — the seeds, the closure, the opaque taint — is
+        // asked of the joined graph and the answer projected back onto this
+        // artefact's ids, because the liveness scan walks *these* bodies.  With
+        // no donors the join is a renumbering of `cg` and nothing changes.
+        let mut parts: Vec<&framework::CallGraph> = vec![&cg];
+        parts.extend(donor_graphs.iter().map(|(_, g)| g));
+        let joined = framework::Joined::build(&parts);
+        for (donor, g) in &donor_graphs {
+            println!(
+                "   joined with          : {} ({} fun_decls)",
+                donor,
+                g.names.len()
+            );
+        }
+        if !donor_graphs.is_empty() {
+            println!(
+                "   joined graph          : {} distinct names; {} name(s) carried by more than one artefact",
+                joined.graph.names.len(),
+                joined.shared_names
+            );
+        }
         // A seed that matches nothing empties half the closure silently, and
         // the name table is the only place to see why.  Substring, not the
         // anchored form the seeds use, so a near-miss spelling still shows up.
         if let Ok(pat) = std::env::var("GC_NAME_GREP") {
-            let mut hits: Vec<&String> =
-                cg.names.values().filter(|n| n.contains(&pat)).collect();
+            let mut hits: Vec<&String> = joined
+                .graph
+                .names
+                .values()
+                .filter(|n| n.contains(&pat))
+                .collect();
             hits.sort();
             println!("   names containing {pat:?}: {}", hits.len());
             for n in hits.iter().take(60) {
@@ -63,18 +119,19 @@ fn main() {
         // adjudication of an opaque finding turns on, and a reachability bit
         // is worthless without the chain behind it.
         if let Ok(pat) = std::env::var("GC_PATH_FROM") {
-            let (py0, _) = cg.seeds_for(PYTHON_DISPATCH_SEEDS_REF);
-            let (col0, _) = cg.seeds_for(framework::COLLECTING_SEEDS);
+            let (py0, _) = joined.graph.seeds_for(PYTHON_DISPATCH_SEEDS_REF);
+            let (col0, _) = joined.graph.seeds_for(framework::COLLECTING_SEEDS);
             let mut sd = py0;
             sd.extend(col0);
-            let mut hits: Vec<(&u64, &String)> = cg
+            let mut hits: Vec<(&u64, &String)> = joined
+                .graph
                 .names
                 .iter()
                 .filter(|(_, n)| n.contains(&pat))
                 .collect();
             hits.sort_by_key(|(_, n)| n.as_str());
             for (id, n) in hits.iter().take(20) {
-                match cg.path_to(**id, &sd) {
+                match joined.graph.path_to(**id, &sd) {
                     Some(chain) => println!("   {n}\n       REACHES: {}", chain.join(" -> ")),
                     None => println!("   {n}\n       reaches no seed"),
                 }
@@ -82,17 +139,24 @@ fn main() {
         }
         println!(
             "   python-dispatch seeds : {}",
-            cg.seed_report(framework::PYTHON_DISPATCH_SEEDS)
+            joined.graph.seed_report(framework::PYTHON_DISPATCH_SEEDS)
         );
         println!(
             "   collecting-alloc seeds: {}",
-            cg.seed_report(framework::COLLECTING_SEEDS)
+            joined.graph.seed_report(framework::COLLECTING_SEEDS)
         );
+        let (jpy, _) = joined.graph.seeds_for(framework::PYTHON_DISPATCH_SEEDS);
+        let (jcol, _) = joined.graph.seeds_for(framework::COLLECTING_SEEDS);
+        let mut joined_seeds = jpy;
+        joined_seeds.extend(jcol);
+        let reach = joined.project(&cg, &joined.graph.reaching(&joined_seeds));
+        // The seeds as *this* artefact spells them.  The tiering below compares
+        // a finding's `callee_id`, which is an id in this artefact, so it needs
+        // the local set; the closure above needs the joined one.
         let (py, _) = cg.seeds_for(framework::PYTHON_DISPATCH_SEEDS);
         let (col, _) = cg.seeds_for(framework::COLLECTING_SEEDS);
         let mut seeds = py;
         seeds.extend(col);
-        let reach = cg.reaching(&seeds);
         println!(
             "   can reach a collection: {} / {} ({}%)",
             reach.len(),
@@ -103,6 +167,15 @@ fn main() {
                 reach.len() * 100 / total
             }
         );
+        // What the join bought, so a run without donors is never mistaken for
+        // the whole-program answer this one is.
+        if !donor_graphs.is_empty() {
+            let alone = cg.reaching(&seeds).len();
+            println!(
+                "       without the join  : {alone} / {total} — the join admits {} more",
+                reach.len().saturating_sub(alone)
+            );
+        }
         println!(
             "   unresolved-callee fns : {} (call through fn-ptr / dyn / unresolved trait)",
             cg.indirect.len()
@@ -135,7 +208,7 @@ fn main() {
         // dispatches through a `global_hook!` function pointer makes every one
         // of its callers undecidable too, not just itself.  Without this the
         // "cannot reach a collection" bucket silently absorbs them.
-        let opaque = cg.reaching(&cg.indirect);
+        let opaque = joined.project(&cg, &joined.graph.reaching(&joined.graph.indirect));
         let (mut justified, mut undecidable, mut unjustified) = (0usize, 0usize, Vec::new());
         for id in &bracketed {
             if reach.contains(id) {
@@ -237,8 +310,7 @@ fn main() {
         // folded in and report both, rather than let the difference go unsaid.
         let mut conservative = reach.clone();
         conservative.extend(opaque.iter().copied());
-        let (found_conservative, stats_conservative) =
-            liveness::scan(
+        let (found_conservative, stats_conservative) = liveness::scan(
             &llbc,
             &cg,
             &conservative,
@@ -352,15 +424,19 @@ fn main() {
             .and_then(|v| v.parse().ok())
             .unwrap_or(0);
         for name in non_arg_fns.iter().take(show) {
-            let v = &by_fn[**name];
-            let f = v.iter().find(|f| !f.live_non_arg.is_empty()).unwrap();
-            println!(
-                "           {}:{}  across {}  live: {:?}",
-                name,
-                f.line,
-                f.callee_name.rsplit("::").next().unwrap_or(""),
-                f.live_non_arg
-            );
+            // Every such call in the body, not the first one found.  A single
+            // row per function hides a second unrooted use further down the
+            // same body — and that is precisely the one a repair pass, working
+            // from this list, then leaves behind.
+            for f in by_fn[**name].iter().filter(|f| !f.live_non_arg.is_empty()) {
+                println!(
+                    "           {}:{}  across {}  live: {:?}",
+                    name,
+                    f.line,
+                    f.callee_name.rsplit("::").next().unwrap_or(""),
+                    f.live_non_arg
+                );
+            }
         }
 
         // The same question asked of the running frame.  A `PyObjectRef` has a
@@ -421,8 +497,10 @@ fn main() {
             // scan finds — a body whose dispatch this reader cannot follow —
             // are adjudicated as the weaker claim they are rather than read
             // beside the others.
-            let resolved: std::collections::HashSet<(u64, u64, u64)> =
-                frames.iter().map(|f| (f.func, f.line, f.callee_id)).collect();
+            let resolved: std::collections::HashSet<(u64, u64, u64)> = frames
+                .iter()
+                .map(|f| (f.func, f.line, f.callee_id))
+                .collect();
             for f in &frames_conservative {
                 if !filter.is_empty() && !f.func_name.contains(&filter) {
                     continue;

--- a/majit/majit-translate/examples/gc-root-reachability.rs
+++ b/majit/majit-translate/examples/gc-root-reachability.rs
@@ -5,6 +5,8 @@
 
 use majit_translate::memory::gctransform::{framework, liveness};
 
+const PYTHON_DISPATCH_SEEDS_REF: &[&str] = framework::PYTHON_DISPATCH_SEEDS;
+
 fn main() {
     let args: Vec<String> = std::env::args().skip(1).collect();
     if args.is_empty() {
@@ -45,6 +47,39 @@ fn main() {
             shown.join(" "),
             if per_crate.len() > 6 { " …" } else { "" }
         );
+        // A seed that matches nothing empties half the closure silently, and
+        // the name table is the only place to see why.  Substring, not the
+        // anchored form the seeds use, so a near-miss spelling still shows up.
+        if let Ok(pat) = std::env::var("GC_NAME_GREP") {
+            let mut hits: Vec<&String> =
+                cg.names.values().filter(|n| n.contains(&pat)).collect();
+            hits.sort();
+            println!("   names containing {pat:?}: {}", hits.len());
+            for n in hits.iter().take(60) {
+                println!("       {n}");
+            }
+        }
+        // "Can this particular helper collect?" is the question every
+        // adjudication of an opaque finding turns on, and a reachability bit
+        // is worthless without the chain behind it.
+        if let Ok(pat) = std::env::var("GC_PATH_FROM") {
+            let (py0, _) = cg.seeds_for(PYTHON_DISPATCH_SEEDS_REF);
+            let (col0, _) = cg.seeds_for(framework::COLLECTING_SEEDS);
+            let mut sd = py0;
+            sd.extend(col0);
+            let mut hits: Vec<(&u64, &String)> = cg
+                .names
+                .iter()
+                .filter(|(_, n)| n.contains(&pat))
+                .collect();
+            hits.sort_by_key(|(_, n)| n.as_str());
+            for (id, n) in hits.iter().take(20) {
+                match cg.path_to(**id, &sd) {
+                    Some(chain) => println!("   {n}\n       REACHES: {}", chain.join(" -> ")),
+                    None => println!("   {n}\n       reaches no seed"),
+                }
+            }
+        }
         println!(
             "   python-dispatch seeds : {}",
             cg.seed_report(framework::PYTHON_DISPATCH_SEEDS)
@@ -179,7 +214,14 @@ fn main() {
             continue;
         }
         let push_root_ids: std::collections::HashSet<u64> = pin_ids.iter().copied().collect();
-        let (found, stats) = liveness::scan(&llbc, &cg, &reach, &push_root_ids, &gc_tys);
+        let (found, stats) = liveness::scan(
+            &llbc,
+            &cg,
+            &reach,
+            &push_root_ids,
+            &gc_tys,
+            liveness::MOVABLE_GC_MARKERS,
+        );
         println!(
             "   liveness scan: {} bodies; {} with a terminator this reader could not parse; \
              {} call(s) withheld as dominated by a push_roots",
@@ -196,7 +238,14 @@ fn main() {
         let mut conservative = reach.clone();
         conservative.extend(opaque.iter().copied());
         let (found_conservative, stats_conservative) =
-            liveness::scan(&llbc, &cg, &conservative, &push_root_ids, &gc_tys);
+            liveness::scan(
+            &llbc,
+            &cg,
+            &conservative,
+            &push_root_ids,
+            &gc_tys,
+            liveness::MOVABLE_GC_MARKERS,
+        );
         let conservative_fns: std::collections::BTreeSet<&str> = found_conservative
             .iter()
             .map(|f| f.func_name.as_str())
@@ -312,6 +361,86 @@ fn main() {
                 f.callee_name.rsplit("::").next().unwrap_or(""),
                 f.live_non_arg
             );
+        }
+
+        // The same question asked of the running frame.  A `PyObjectRef` has a
+        // root stack to be pinned on; the frame is carried as a bare
+        // `&mut PyFrame` no walker reaches, so the only repair is to re-read it
+        // out of a `FrameAnchor` after the call.  That reload kills the stale
+        // local at the call, so no bracket set is passed — a body that reloads
+        // correctly simply has nothing live across the call to report.
+        let frame_tys = liveness::frame_ptr_type_ids(&llbc);
+        if frame_tys.is_empty() {
+            println!("   (no PyFrame pointer type id found — frame scan skipped)");
+            continue;
+        }
+        let no_bracket: std::collections::HashSet<u64> = Default::default();
+        let (frames, frame_stats) =
+            liveness::scan(&llbc, &cg, &reach, &no_bracket, &frame_tys, &[]);
+        let (frames_conservative, _) =
+            liveness::scan(&llbc, &cg, &conservative, &no_bracket, &frame_tys, &[]);
+        let frame_fns: std::collections::BTreeSet<&str> =
+            frames.iter().map(|f| f.func_name.as_str()).collect();
+        println!(
+            "   frame carried across a call that can collect: {} in {} fn(s)",
+            frames.len(),
+            frame_fns.len()
+        );
+        println!(
+            "       counting unresolved dispatch as collecting too: {} call(s)",
+            frames_conservative.len()
+        );
+        println!(
+            "           over {} bodies; {} with an unparsable terminator, {} with an \
+             unparsable statement",
+            frame_stats.bodies_scanned,
+            frame_stats.unparsed_terminator_bodies,
+            frame_stats.unparsed_statement_bodies
+        );
+        // The frame reaches the callee as an argument in most of these, and an
+        // argument goes just as stale as any other local here (the module
+        // header records why upstream can drop them and pyre cannot).  Both
+        // columns are therefore hazards; they are split only because a frame
+        // the call does not even see is the more obviously wrong shape.
+        let mut frame_tier1: Vec<&liveness::Finding> = frames
+            .iter()
+            .filter(|f| seeds.contains(&f.callee_id))
+            .collect();
+        frame_tier1.sort_by(|a, b| a.func_name.cmp(&b.func_name).then(a.line.cmp(&b.line)));
+        let ft1_fns: std::collections::BTreeSet<&str> =
+            frame_tier1.iter().map(|f| f.func_name.as_str()).collect();
+        println!(
+            "       tier 1 (callee IS a dispatch seed): {} call(s) in {} fn(s)",
+            frame_tier1.len(),
+            ft1_fns.len()
+        );
+        if let Ok(filter) = std::env::var("GC_FRAME_SCAN") {
+            // A whole-crate list is not a work item; the filter is how a
+            // surface (`OpcodeStepExecutor`, say) is cut out of it and read.
+            // The resolved rows are marked, so the ones only the conservative
+            // scan finds — a body whose dispatch this reader cannot follow —
+            // are adjudicated as the weaker claim they are rather than read
+            // beside the others.
+            let resolved: std::collections::HashSet<(u64, u64, u64)> =
+                frames.iter().map(|f| (f.func, f.line, f.callee_id)).collect();
+            for f in &frames_conservative {
+                if !filter.is_empty() && !f.func_name.contains(&filter) {
+                    continue;
+                }
+                let mark = if resolved.contains(&(f.func, f.line, f.callee_id)) {
+                    "resolved"
+                } else {
+                    "opaque  "
+                };
+                println!(
+                    "           [{mark}] {}:{}  across {}  live: {:?} arg: {:?}",
+                    f.func_name,
+                    f.line,
+                    f.callee_name.rsplit("::").next().unwrap_or(""),
+                    f.live_non_arg,
+                    f.live_arg
+                );
+            }
         }
     }
 }

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -322,62 +322,96 @@ impl CallGraph {
 /// program, and `collect_analyzer` closes over the whole call graph at once.
 /// So the artefacts are joined back into one graph here.
 ///
-/// The join key is `item_meta.name_path()`.  Two artefacts that both carry a
-/// body for the same name contribute the union of its edges; two genuinely
-/// different functions sharing a spelling would be merged into one node.  Both
-/// can only *widen* `reaching`, which is the safe direction for this question —
-/// `framework.py` errs towards bracketing an operation that cannot collect,
-/// never towards leaving one bare.
+/// # The join key does not always identify a function
+///
+/// `ItemMeta::name_path` renders an inherent `impl` block as the opaque segment
+/// `<Impl>`, so `PyFrame::new` and `FrameDebugData::new` are both spelled
+/// `pyframe::<Impl>::new`.  Joining on that spelling merges them into one node
+/// and invents an edge from every caller of one to every callee of the other —
+/// which is how a `getorcreatedebug` that only allocates came out reaching
+/// `call_user_function_with_args`.  Widening is not automatically safe here:
+/// `framework.py` over-brackets rather than under-brackets, but a fabricated
+/// path is not conservatism, it is a wrong answer with a citation.
+///
+/// So a name **one artefact carries more than once** is not a join key at all:
+/// each occurrence keeps its own node, exactly as it had before the join.  What
+/// is joined is the unambiguous majority — the free functions the JIT reaches
+/// the interpreter through (`finditem_str`, `call_function_impl_result`) — and
+/// [`Self::ambiguous_names`] reports what that rule held back.
 pub struct Joined {
-    /// The joined graph, over canonical ids: one per distinct name.
-    ///
-    /// `opaque` is left empty.  An opaque *count* is per-artefact accounting,
-    /// and summing two of them double-counts every body both artefacts carry;
-    /// `indirect` is joined, because that one is a per-function fact.
+    /// The joined graph.  Its `opaque` census is left empty: an opaque *count*
+    /// is per-artefact accounting, and summing two of them double-counts every
+    /// body both artefacts carry.  `indirect` is joined, being a per-function
+    /// fact.
     pub graph: CallGraph,
-    canonical: HashMap<String, u64>,
-    /// Names carried by more than one of the joined artefacts, or by one of
-    /// them more than once.  Reported rather than assumed away: this is the
-    /// count that says how much the join merged.
-    pub shared_names: usize,
+    /// `part index -> (that artefact's def id -> node id)`.
+    canonical: Vec<HashMap<u64, u64>>,
+    /// Unambiguous names carried by more than one artefact — what the join
+    /// actually merged.
+    pub joined_names: usize,
+    /// Names some artefact carries more than once, kept apart.
+    pub ambiguous_names: usize,
 }
 
 impl Joined {
     pub fn build(parts: &[&CallGraph]) -> Self {
-        let mut canonical: HashMap<String, u64> = HashMap::new();
-        let mut names: HashMap<u64, String> = HashMap::new();
-        let mut shared_names = 0usize;
+        let mut ambiguous: HashSet<&str> = HashSet::new();
         for part in parts {
-            // Sorted, so the canonical numbering does not depend on hash order
-            // and two runs over the same inputs print the same ids.
-            let mut sorted: Vec<&String> = part.names.values().collect();
-            sorted.sort_unstable();
-            for n in sorted {
-                if canonical.contains_key(n) {
-                    shared_names += 1;
-                    continue;
+            let mut seen: HashSet<&str> = HashSet::new();
+            for name in part.names.values() {
+                if !seen.insert(name.as_str()) {
+                    ambiguous.insert(name.as_str());
                 }
-                let id = canonical.len() as u64;
-                canonical.insert(n.clone(), id);
-                names.insert(id, n.clone());
             }
+        }
+        let mut shared: HashMap<&str, u64> = HashMap::new();
+        let mut names: HashMap<u64, String> = HashMap::new();
+        let mut canonical: Vec<HashMap<u64, u64>> = Vec::with_capacity(parts.len());
+        let mut next = 0u64;
+        let mut joined_names = 0usize;
+        for part in parts {
+            // Sorted, so the numbering does not depend on hash order and two
+            // runs over the same inputs print the same ids.
+            let mut sorted: Vec<(&u64, &String)> = part.names.iter().collect();
+            sorted.sort_unstable_by(|a, b| a.1.cmp(b.1).then(a.0.cmp(b.0)));
+            let mut mine: HashMap<u64, u64> = HashMap::new();
+            for (&def_id, name) in sorted {
+                let id = if ambiguous.contains(name.as_str()) {
+                    let id = next;
+                    next += 1;
+                    names.insert(id, name.clone());
+                    id
+                } else if let Some(&id) = shared.get(name.as_str()) {
+                    joined_names += 1;
+                    id
+                } else {
+                    let id = next;
+                    next += 1;
+                    names.insert(id, name.clone());
+                    shared.insert(name.as_str(), id);
+                    id
+                };
+                mine.insert(def_id, id);
+            }
+            canonical.push(mine);
         }
         let mut callees: HashMap<u64, HashSet<u64>> = HashMap::new();
         let mut callers: HashMap<u64, HashSet<u64>> = HashMap::new();
         let mut indirect: HashSet<u64> = HashSet::new();
-        for part in parts {
-            let canon = |id: &u64| part.names.get(id).and_then(|n| canonical.get(n)).copied();
+        for (part, map) in parts.iter().zip(&canonical) {
             for (caller, cs) in &part.callees {
-                let Some(from) = canon(caller) else { continue };
+                let Some(&from) = map.get(caller) else {
+                    continue;
+                };
                 let entry = callees.entry(from).or_default();
                 for callee in cs {
-                    if let Some(to) = canon(callee) {
+                    if let Some(&to) = map.get(callee) {
                         entry.insert(to);
                     }
                 }
             }
             for id in &part.indirect {
-                if let Some(c) = canon(id) {
+                if let Some(&c) = map.get(id) {
                     indirect.insert(c);
                 }
             }
@@ -396,18 +430,19 @@ impl Joined {
                 opaque: OpaqueCensus::default(),
             },
             canonical,
-            shared_names,
+            joined_names,
+            ambiguous_names: ambiguous.len(),
         }
     }
 
-    /// Project a set of joined ids back onto one artefact's local ids, so the
+    /// Project a set of joined nodes back onto one artefact's def ids, so the
     /// liveness scan — which walks that artefact's bodies — can be asked the
-    /// whole-program question.
-    pub fn project(&self, cg: &CallGraph, joined: &HashSet<u64>) -> HashSet<u64> {
-        cg.names
+    /// whole-program question.  `part` indexes the slice `build` was given.
+    pub fn project(&self, part: usize, joined: &HashSet<u64>) -> HashSet<u64> {
+        self.canonical[part]
             .iter()
-            .filter(|(_, n)| self.canonical.get(*n).is_some_and(|c| joined.contains(c)))
-            .map(|(&id, _)| id)
+            .filter(|(_, cid)| joined.contains(cid))
+            .map(|(&def_id, _)| def_id)
             .collect()
     }
 }

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -312,6 +312,106 @@ impl CallGraph {
     }
 }
 
+/// Several artefacts' call graphs, joined on fully qualified name.
+///
+/// A charon artefact carries only what rustc monomorphised into that crate, so
+/// `pyre-jit.ullbc` holds the portal and the blackhole and almost none of the
+/// interpreter they call into: its own closure comes out at 1%, and a scan over
+/// it reports nothing because nothing in it reaches a seed — not because the
+/// crate is clean.  Upstream never meets this: RPython analyses one translated
+/// program, and `collect_analyzer` closes over the whole call graph at once.
+/// So the artefacts are joined back into one graph here.
+///
+/// The join key is `item_meta.name_path()`.  Two artefacts that both carry a
+/// body for the same name contribute the union of its edges; two genuinely
+/// different functions sharing a spelling would be merged into one node.  Both
+/// can only *widen* `reaching`, which is the safe direction for this question —
+/// `framework.py` errs towards bracketing an operation that cannot collect,
+/// never towards leaving one bare.
+pub struct Joined {
+    /// The joined graph, over canonical ids: one per distinct name.
+    ///
+    /// `opaque` is left empty.  An opaque *count* is per-artefact accounting,
+    /// and summing two of them double-counts every body both artefacts carry;
+    /// `indirect` is joined, because that one is a per-function fact.
+    pub graph: CallGraph,
+    canonical: HashMap<String, u64>,
+    /// Names carried by more than one of the joined artefacts, or by one of
+    /// them more than once.  Reported rather than assumed away: this is the
+    /// count that says how much the join merged.
+    pub shared_names: usize,
+}
+
+impl Joined {
+    pub fn build(parts: &[&CallGraph]) -> Self {
+        let mut canonical: HashMap<String, u64> = HashMap::new();
+        let mut names: HashMap<u64, String> = HashMap::new();
+        let mut shared_names = 0usize;
+        for part in parts {
+            // Sorted, so the canonical numbering does not depend on hash order
+            // and two runs over the same inputs print the same ids.
+            let mut sorted: Vec<&String> = part.names.values().collect();
+            sorted.sort_unstable();
+            for n in sorted {
+                if canonical.contains_key(n) {
+                    shared_names += 1;
+                    continue;
+                }
+                let id = canonical.len() as u64;
+                canonical.insert(n.clone(), id);
+                names.insert(id, n.clone());
+            }
+        }
+        let mut callees: HashMap<u64, HashSet<u64>> = HashMap::new();
+        let mut callers: HashMap<u64, HashSet<u64>> = HashMap::new();
+        let mut indirect: HashSet<u64> = HashSet::new();
+        for part in parts {
+            let canon = |id: &u64| part.names.get(id).and_then(|n| canonical.get(n)).copied();
+            for (caller, cs) in &part.callees {
+                let Some(from) = canon(caller) else { continue };
+                let entry = callees.entry(from).or_default();
+                for callee in cs {
+                    if let Some(to) = canon(callee) {
+                        entry.insert(to);
+                    }
+                }
+            }
+            for id in &part.indirect {
+                if let Some(c) = canon(id) {
+                    indirect.insert(c);
+                }
+            }
+        }
+        for (&caller, cs) in &callees {
+            for &c in cs {
+                callers.entry(c).or_default().insert(caller);
+            }
+        }
+        Self {
+            graph: CallGraph {
+                names,
+                callees,
+                callers,
+                indirect,
+                opaque: OpaqueCensus::default(),
+            },
+            canonical,
+            shared_names,
+        }
+    }
+
+    /// Project a set of joined ids back onto one artefact's local ids, so the
+    /// liveness scan — which walks that artefact's bodies — can be asked the
+    /// whole-program question.
+    pub fn project(&self, cg: &CallGraph, joined: &HashSet<u64>) -> HashSet<u64> {
+        cg.names
+            .iter()
+            .filter(|(_, n)| self.canonical.get(*n).is_some_and(|c| joined.contains(c)))
+            .map(|(&id, _)| id)
+            .collect()
+    }
+}
+
 /// Where each function-pointer call gets its callee from, counted by source.
 ///
 /// A count of unresolved calls says how much is opaque; this says *what* is

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -163,9 +163,26 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     "descroperation::try_call_special",
 ];
 
-/// Explicit collection entry points and the one collecting host allocator.
+/// Explicit collection entry points and the collecting host allocator.
+///
+/// These are the same external symbols `majit-translate`'s call control marks
+/// `canmallocgc` (`lib.rs`, the `mark_canmallocgc` loop): the `*_collecting_*`
+/// allocators run a minor collection when the nursery cannot satisfy the
+/// request, and the `collect_*` entries are requested collections outright.
+/// They carry no lowered body, so nothing reaches them transitively — they have
+/// to be named, or every direct caller (`pyre_object_gc_alloc_collecting_trampoline`
+/// in `pyre-jit/src/eval.rs`, say) is classified non-collecting and so is
+/// everything above it.
 pub const COLLECTING_SEEDS: &[&str] = &[
-    "gc_hook::try_gc_alloc_collecting",
+    "majit_gc::alloc_nursery_collecting_typed",
+    "majit_gc::alloc_nursery_collecting_typed_rooted",
+    "majit_gc::alloc_fast_nursery_collecting_typed_rooted",
+    "majit_gc::standalone_alloc_nursery_collecting_typed_rooted",
+    "majit_gc::standalone_alloc_fast_nursery_collecting_typed_rooted",
+    "majit_gc::collect_full",
+    "majit_gc::collect_step",
+    "majit_gc::collect_oldgen_nonmoving",
+    // The host hook the interpreter reaches them through.
     "gc_hook::try_gc_alloc_collecting_rooted",
 ];
 

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -159,6 +159,19 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     "eval::eval_loop",
     "pyframe::<Impl>::execute_frame",
     "pyframe::<Impl>::resume_execute_frame",
+    // The JIT layer's routes back into interpretation.  An artefact extracted
+    // for `pyre-jit` carries only part of `pyre-interpreter`, so most of the
+    // entries above are absent from it and the closure comes out at 0% -- a
+    // scan over that is vacuous rather than clean.  These are the portal and
+    // blackhole entries that artefact does carry.
+    "call_jit::ll_portal_runner_shim",
+    "call_jit::run_frame_through_portal",
+    "call_jit::bh_portal_runner",
+    "call_jit::bh_call_self_recursive_portal",
+    "eval::portal_runner",
+    "eval::portal_runner_dispatch",
+    "eval::portal_runner_result",
+    "eval::eval_loop_jit",
     // The space-level helpers most builtins reach Python through.
     "baseobjspace::call_function",
     "baseobjspace::call_method",

--- a/majit/majit-translate/src/memory/gctransform/framework.rs
+++ b/majit/majit-translate/src/memory/gctransform/framework.rs
@@ -150,12 +150,15 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
     "call::call_builtin_code_positional",
     // The gateway's indirect call into a builtin's Rust body.
     "gateway::builtin_code_call",
-    // The frame executors.
+    // The frame executors.  `execute_frame` and its resumed twin are inherent
+    // methods, so the `impl` block sits in the path as an opaque segment and
+    // the bare `pyframe::execute_frame` spelling can never match.
     "eval::eval_frame_plain",
     "eval::eval_frame_plain_with_operr",
     "eval::eval_frame_plain_with_resume",
     "eval::eval_loop",
-    "pyframe::execute_frame",
+    "pyframe::<Impl>::execute_frame",
+    "pyframe::<Impl>::resume_execute_frame",
     // The space-level helpers most builtins reach Python through.
     "baseobjspace::call_function",
     "baseobjspace::call_method",
@@ -173,6 +176,17 @@ pub const PYTHON_DISPATCH_SEEDS: &[&str] = &[
 /// to be named, or every direct caller (`pyre_object_gc_alloc_collecting_trampoline`
 /// in `pyre-jit/src/eval.rs`, say) is classified non-collecting and so is
 /// everything above it.
+///
+/// ⛔ The plain host allocator is deliberately **not** here.  `try_gc_alloc`
+/// routes to `alloc_nursery_typed` and on through the backend's
+/// `dynasm_alloc_nursery_typed`, which falls back to old-gen rather than
+/// collect precisely because its caller holds an unregistered raw pointer; so
+/// no host-side `w_*_new` is a collection point, and seeding one would report
+/// every allocating body in the interpreter.  A minor runs from compiled code
+/// allocating inline in the nursery, from the elidable bigint payload helpers,
+/// and from a requested collection — which is why an artefact carrying only
+/// interpreter bodies legitimately matches none of the allocator entries and
+/// takes its whole closure from [`PYTHON_DISPATCH_SEEDS`].
 pub const COLLECTING_SEEDS: &[&str] = &[
     "majit_gc::alloc_nursery_collecting_typed",
     "majit_gc::alloc_nursery_collecting_typed_rooted",
@@ -184,6 +198,11 @@ pub const COLLECTING_SEEDS: &[&str] = &[
     "majit_gc::collect_oldgen_nonmoving",
     // The host hook the interpreter reaches them through.
     "gc_hook::try_gc_alloc_collecting_rooted",
+    // A requested collection, which is the one collection point an interpreter
+    // body reaches without running Python at all (`gc.collect()`).
+    "gc_hook::try_gc_collect",
+    "gc_hook::try_gc_collect_step",
+    "gc_hook::try_gc_collect_oldgen",
 ];
 
 impl CallGraph {

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -69,20 +69,25 @@ pub struct ScanStats {
     pub withheld_under_a_bracket: usize,
 }
 
-/// Callee names that address a `list` or a `dict` through the pointer.
-fn addresses_movable(name: &str) -> bool {
-    const MARKERS: &[&str] = &[
-        "w_list_",
-        "w_dict_",
-        "list_concat",
-        "list_repeat",
-        "sequence_repeat",
-        "require_list",
-        "require_dict",
-        "dict_method_",
-        "list_method_",
-    ];
-    MARKERS.iter().any(|m| name.contains(m))
+/// Callee names that say the pointer is addressed as a movable object.
+///
+/// `list` and `dict` are the only two kinds whose header a minor collection
+/// relocates, so a stale `PyObjectRef` handed to one of these is dereferenced
+/// as a corpse rather than merely stored or returned.
+pub const MOVABLE_GC_MARKERS: &[&str] = &[
+    "w_list_",
+    "w_dict_",
+    "list_concat",
+    "list_repeat",
+    "sequence_repeat",
+    "require_list",
+    "require_dict",
+    "dict_method_",
+    "list_method_",
+];
+
+fn addresses_movable(markers: &[&str], name: &str) -> bool {
+    markers.iter().any(|m| name.contains(m))
 }
 
 fn ty_id(t: &TyRef) -> Option<u64> {
@@ -109,6 +114,44 @@ pub fn gc_ptr_type_ids(llbc: &majit_charon_reader::Llbc) -> HashSet<u64> {
             }
         } else if name.ends_with("gc_roots::shadow_stack_get") {
             if let Some(t) = ty_id(&fd.signature.output) {
+                out.insert(t);
+            }
+        }
+    }
+    out
+}
+
+/// The type ids a `PyFrame` pointer is spelled with in *this* artefact.
+///
+/// The frame is the second thing a minor collection can leave a body holding a
+/// corpse of, and it is the harder one: a `PyObjectRef` at least has a root
+/// stack it can be pinned on, whereas the running frame is carried as a bare
+/// `&mut PyFrame` that no walker reaches.  `eval::FrameAnchor` is the reload
+/// point, and a body that takes one and re-reads `live()` kills its stale local
+/// at the call, so [`scan`] needs no bracket set for this kind — the liveness
+/// answer already distinguishes a reloaded frame from a carried one.
+///
+/// The interpreter spells the pointer three ways and all three go stale, so
+/// each is read off a signature pyre already declares in those terms rather
+/// than hard-coded: a dedup id is artefact-local.  An empty result means the
+/// scan would silently find nothing, so callers must report it.
+pub fn frame_ptr_type_ids(llbc: &majit_charon_reader::Llbc) -> HashSet<u64> {
+    // Free functions, so the name is the whole match: an inherent method
+    // carries its `impl` block as an opaque segment and cannot be named here.
+    const FIRST_INPUT: &[&str] = &[
+        "eval::install_current_frame",   // &mut PyFrame
+        "eval::handle_exception",        // &mut PyFrame
+        "executioncontext::force_frame", // *mut PyFrame
+        "call::enter_recursive_frame",   // *const PyFrame
+    ];
+    let mut out = HashSet::new();
+    for fd in llbc.iter_local_fns() {
+        let name = fd.item_meta.name_path();
+        if FIRST_INPUT
+            .iter()
+            .any(|p| name == *p || name.ends_with(&format!("::{p}")))
+        {
+            if let Some(t) = fd.signature.inputs.first().and_then(ty_id) {
                 out.insert(t);
             }
         }
@@ -205,12 +248,18 @@ fn successors(t: &TermKind) -> Vec<u64> {
 /// unreachable from entry once the bracket blocks are removed".  A function
 /// that brackets one branch and leaves another bare is therefore still
 /// reported on the bare branch.
+///
+/// `gc_tys` selects which pointer kind is being judged — [`gc_ptr_type_ids`]
+/// for a managed reference, [`frame_ptr_type_ids`] for the running frame — and
+/// `movable_markers` ranks the findings for that kind ([`MOVABLE_GC_MARKERS`],
+/// or empty where the kind has no such call).
 pub fn scan(
     llbc: &majit_charon_reader::Llbc,
     cg: &super::framework::CallGraph,
     reach: &HashSet<u64>,
     push_roots: &HashSet<u64>,
     gc_tys: &HashSet<u64>,
+    movable_markers: &[&str],
 ) -> (Vec<Finding>, ScanStats) {
     let mut findings = Vec::new();
     let mut stats = ScanStats::default();
@@ -336,7 +385,11 @@ pub fn scan(
             let CallKind::Fun(FunId::Regular { id: cid }) = &r2.kind else {
                 continue;
             };
-            if !cg.names.get(cid).is_some_and(|n| addresses_movable(n)) {
+            if !cg
+                .names
+                .get(cid)
+                .is_some_and(|n| addresses_movable(movable_markers, n))
+            {
                 continue;
             }
             for a in &c2.args {

--- a/majit/majit-translate/src/memory/gctransform/liveness.rs
+++ b/majit/majit-translate/src/memory/gctransform/liveness.rs
@@ -57,6 +57,11 @@ pub struct ScanStats {
     /// Bodies holding a terminator this reader could not classify.  Their
     /// liveness is incomplete, so they are reported rather than counted clean.
     pub unparsed_terminator_bodies: usize,
+    /// Bodies holding a statement this reader could not classify.  A statement
+    /// that does not parse, and one that parses as `StmtKind::Unknown`, both
+    /// contribute no uses, so the live set computed over such a body is a lower
+    /// bound and a clean result over it is one too.
+    pub unparsed_statement_bodies: usize,
     /// Collecting calls withheld because a `push_roots` dominates them.
     /// Whether that scope is still alive at the call is a drop-placement
     /// question this pass cannot answer, so they are neither reported nor
@@ -245,6 +250,15 @@ pub fn scan(
             // from it is a lower bound.  Count the body; do not pretend it is
             // clean.
             stats.unparsed_terminator_bodies += 1;
+        }
+        if body.body.iter().any(|blk| {
+            blk.statements
+                .iter()
+                .any(|st| matches!(st.stmt_kind(), Err(_) | Ok(StmtKind::Unknown)))
+        }) {
+            // `transfer_stmt` reads no uses out of either shape, so the live
+            // sets below can only be smaller than the truth.
+            stats.unparsed_statement_bodies += 1;
         }
 
         // Blocks whose terminator opens a root scope, and the blocks that are

--- a/pyre/extra_tests/parity_tests/descr_get_and_call_gc_roots.py
+++ b/pyre/extra_tests/parity_tests/descr_get_and_call_gc_roots.py
@@ -1,0 +1,65 @@
+# CPython-suite gap: no test binds a binary special to a descriptor whose
+# __get__ collects.
+# parity-tests reason: this is a pyre/PyPy moving-GC root-liveness regression.
+
+"""A special method bound through a descriptor must survive its own ``__get__``.
+
+``get_and_call_function`` receives the raw class attribute and the operand
+list.  When that attribute is a descriptor rather than a plain function, the
+``__get__`` dispatch is application-level Python and can run a collection; the
+receiver and the argument slice — the latter living on the Rust stack, where no
+root reaches it — must therefore be read back afterwards rather than reused.
+"""
+
+import gc
+
+
+def _churn():
+    # Enough allocation to fill a nursery and force a moving collection while
+    # the caller's operand addresses are the only copies in existence.
+    garbage = [[index] for index in range(20000)]
+    assert len(garbage) == 20000
+    gc.collect()
+
+
+class BoundThroughDescriptor:
+    """A non-function class attribute, so the descriptor arm of `get` runs."""
+
+    def __init__(self, impl):
+        self.impl = impl
+
+    def __get__(self, obj, objtype=None):
+        _churn()
+        impl = self.impl
+        return lambda *args: impl(obj, *args)
+
+
+def _take_rhs(self, other):
+    return other
+
+
+def _take_rhs_inplace(self, other):
+    return other
+
+
+class Operand:
+    __add__ = BoundThroughDescriptor(_take_rhs)
+    __iadd__ = BoundThroughDescriptor(_take_rhs_inplace)
+
+
+for round_index in range(20):
+    # A `list` right-hand side is a kind whose header a minor collection
+    # relocates, so a stale operand address is observable rather than benign.
+    rhs = [[value] for value in range(round_index + 1)]
+    expected = [[value] for value in range(round_index + 1)]
+
+    got = Operand() + rhs
+    assert got is rhs, (round_index, "binary special lost its operand")
+    assert got == expected, (round_index, got)
+
+    accumulator = Operand()
+    accumulator += rhs
+    assert accumulator is rhs, (round_index, "in-place special lost its operand")
+    assert accumulator == expected, (round_index, accumulator)
+
+print("OK")

--- a/pyre/extra_tests/snippets/stdlib_gc.py
+++ b/pyre/extra_tests/snippets/stdlib_gc.py
@@ -1,13 +1,7 @@
+# pyre-check: gate=1
 import gc
 
 from testutils import assert_raises
-
-
-assert isinstance(gc.collect(), int)
-assert isinstance(gc.collect(0), int)
-assert isinstance(gc.collect(1), int)
-assert isinstance(gc.collect(2), int)
-assert isinstance(gc.collect(generation=2), int)
 
 
 class Index:
@@ -15,41 +9,32 @@ class Index:
         return 0
 
 
-assert isinstance(gc.collect(Index()), int)
+# The generation argument is bound and integer-unwrapped, and every value is
+# accepted -- `interp_gc.py:7-26 collect` ignores it.  What that argument then
+# means, and what `collect` answers, is where pyre follows pypy rather than the
+# reference; `bench/synth/gc_pypy_frontend.py` pins both against the pypy
+# oracle.  This file asserts only what every implementation agrees on.
+gc.collect()
+gc.collect(0)
+gc.collect(2)
+gc.collect(generation=2)
+gc.collect(True)
+gc.collect(Index())
 
-for generation in (-1, 3):
-    with assert_raises(ValueError):
+for generation in (None, 1.25, "0"):
+    with assert_raises(TypeError):
         gc.collect(generation)
-
-with assert_raises(TypeError):
-    gc.collect("0")
 
 with assert_raises(TypeError):
     gc.collect(0, 1)
 
+
 assert isinstance(gc.get_objects(), list)
 assert isinstance(gc.get_objects(None), list)
 assert isinstance(gc.get_objects(generation=None), list)
-assert isinstance(gc.get_objects(-1), list)
-assert isinstance(gc.get_objects(0), list)
-assert isinstance(gc.get_objects(1), list)
-assert isinstance(gc.get_objects(2), list)
-assert isinstance(gc.get_objects(Index()), list)
 
 marker = []
 assert any(obj is marker for obj in gc.get_objects())
-assert any(
-    obj is marker
-    for obj in gc.get_objects(0) + gc.get_objects(2)
-)
-
-for generation in (-2, 3):
-    with assert_raises(ValueError):
-        gc.get_objects(generation)
-
-for generation in ("0", 1.25):
-    with assert_raises(TypeError):
-        gc.get_objects(generation)
 
 with assert_raises(TypeError):
     gc.get_objects(None, None)

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1331,8 +1331,51 @@ pub(crate) unsafe fn get_and_call_function(
         full.extend_from_slice(args_w);
         return crate::call::call_function_impl_result(w_descr, full.as_slice());
     }
-    let w_impl = unsafe { get(w_descr, w_obj, w_type) }?.unwrap_or(w_descr);
-    crate::call::call_function_impl_result(w_impl, args_w)
+    // `get` dispatches `__get__`: a `property` getter and a user descriptor are
+    // application-level Python, so a collection can land between the descriptor
+    // lookup and the call below.  `w_obj` and `args_w` are raw addresses — the
+    // latter a slice into the caller's Rust stack, which no root reaches — so
+    // both would name pre-collection copies afterwards.  Pin the three
+    // descriptor operands and every argument across the lookup, then rebuild the
+    // argument list from the shadow stack.  Both slices are published before the
+    // first `normalize_roots` so nothing is still invisible to a foreign
+    // collector once this mutator starts entering safepoints.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::publish_roots(&[w_descr, w_obj, w_type]);
+    let args_base = pyre_object::gc_roots::publish_roots(args_w);
+    pyre_object::gc_roots::normalize_roots(base, 3);
+    pyre_object::gc_roots::normalize_roots(args_base, args_w.len());
+    use pyre_object::gc_roots::shadow_stack_get;
+    let w_impl = unsafe {
+        get(
+            shadow_stack_get(base),
+            shadow_stack_get(base + 1),
+            shadow_stack_get(base + 2),
+        )
+    }?
+    .unwrap_or_else(|| shadow_stack_get(base));
+    // The same stack-array-or-`Vec` split as the fast path above, and for the
+    // same reason: a `Vec::with_capacity` on the common arity is an opaque
+    // residual the walker cannot descend through.
+    const INLINE_ARGS: usize = 8;
+    let mut inline_args = [pyre_object::PY_NULL; INLINE_ARGS];
+    let mut wide_args;
+    let reloaded: &[PyObjectRef] = if args_w.len() <= INLINE_ARGS {
+        // The index loop lowers to `setarrayitem`; iterator adapters are
+        // residual calls.
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..args_w.len() {
+            inline_args[i] = shadow_stack_get(args_base + i);
+        }
+        &inline_args[..args_w.len()]
+    } else {
+        wide_args = Vec::with_capacity(args_w.len());
+        for i in 0..args_w.len() {
+            wide_args.push(shadow_stack_get(args_base + i));
+        }
+        &wide_args
+    };
+    crate::call::call_function_impl_result(w_impl, reloaded)
 }
 
 /// `isinstance(w_obj, Coroutine) or gen_is_coroutine(w_obj)` from PyPy

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -12972,6 +12972,12 @@ fn exec_or_eval(
     }
 
     let caller_frame = crate::eval::CURRENT_FRAME.with(|current| current.get());
+    // The caller's frame is read once here and consulted again after
+    // `ensure_*_builtins` (a dict subclass's `setdefault` / `__setitem__`),
+    // after the frame object and function are built, and after the builtin
+    // module is picked -- every one of which can collect.  A frame a compiled
+    // trace built moves there, so it is re-read out of the anchor at each.
+    let caller_anchor = unsafe { crate::eval::FrameAnchor::from_raw(caller_frame) };
     let exec_ctx = if caller_frame.is_null() {
         std::ptr::null::<crate::PyExecutionContext>()
     } else {
@@ -13022,6 +13028,7 @@ fn exec_or_eval(
     // globals_arg is supplied but locals_arg is None, PyPy collapses
     // locals=globals and pyre's existing same-dict path handles it.
     let mut implicit_caller_locals: pyre_object::PyObjectRef = std::ptr::null_mut();
+    let caller_frame = caller_anchor.live();
     if is_none_or_null(globals_arg) && is_none_or_null(locals_arg) && !caller_frame.is_null() {
         // The caller's locals as `locals()` reports them: its real namespace
         // for a module or class frame, an independent snapshot for an
@@ -13123,7 +13130,7 @@ fn exec_or_eval(
         // resolved object is the caller's globals (module-level exec
         // collapses to locals=globals — same-dict shape kept by the
         // module-frame's initialize_frame_scopes binding).
-        let caller_globals_obj = unsafe { (*caller_frame).get_w_globals() };
+        let caller_globals_obj = unsafe { (*caller_anchor.live()).get_w_globals() };
         let same_as_globals = !caller_globals_obj.is_null()
             && std::ptr::eq(implicit_caller_locals, caller_globals_obj);
         if !same_as_globals {
@@ -13196,8 +13203,11 @@ fn topframe_for_locals() -> *mut crate::PyFrame {
         return std::ptr::null_mut();
     }
     let frame = unsafe { (*ec).gettopframe_nohidden() };
+    // The force materializes the fastlocals through a backend hook whose callee
+    // this crate cannot follow, so it is judged as able to collect.
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
     crate::executioncontext::force_frame_before_locals_read(frame);
-    frame
+    anchor.live()
 }
 
 fn builtin_locals(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2711,6 +2711,11 @@ fn call_with_kwargs_in_ctx_impl(
                 // below rather than invoking the builtin directly.
                 let frame_ptr = c_profile_frame(execution_context);
                 if !frame_ptr.is_null() {
+                    // The argument marshalling below allocates before the frame
+                    // is handed to the profiling call, so the profiled frame is
+                    // read back out of the anchor rather than from this local.
+                    let frame_anchor =
+                        unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
                     let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
                         .iter()
                         .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
@@ -2723,7 +2728,7 @@ fn call_with_kwargs_in_ctx_impl(
                         &keywords_w,
                     );
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
-                        unsafe { &mut *frame_ptr },
+                        unsafe { &mut *frame_anchor.live() },
                         callable,
                         &mut arguments,
                         &bound,
@@ -2813,6 +2818,11 @@ fn call_with_kwargs_in_ctx_impl(
                 // when positional count is zero, not the kwargs dict).
                 let frame_ptr = c_profile_frame(execution_context);
                 if !frame_ptr.is_null() {
+                    // The argument marshalling below allocates before the frame
+                    // is handed to the profiling call, so the profiled frame is
+                    // read back out of the anchor rather than from this local.
+                    let frame_anchor =
+                        unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
                     let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
                         .iter()
                         .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
@@ -2836,7 +2846,7 @@ fn call_with_kwargs_in_ctx_impl(
                         .chain(std::iter::once(kw_roots.get(kw_slot)))
                         .collect();
                     let w_res = crate::baseobjspace::call_args_and_c_profile_args(
-                        unsafe { &mut *frame_ptr },
+                        unsafe { &mut *frame_anchor.live() },
                         callable,
                         &mut arguments,
                         &full_args,

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -2714,8 +2714,7 @@ fn call_with_kwargs_in_ctx_impl(
                     // The argument marshalling below allocates before the frame
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
-                    let frame_anchor =
-                        unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
+                    let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
                     let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
                         .iter()
                         .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))
@@ -2821,8 +2820,7 @@ fn call_with_kwargs_in_ctx_impl(
                     // The argument marshalling below allocates before the frame
                     // is handed to the profiling call, so the profiled frame is
                     // read back out of the anchor rather than from this local.
-                    let frame_anchor =
-                        unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
+                    let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_ptr) };
                     let keyword_names_w: Vec<pyre_object::PyObjectRef> = kwargs
                         .iter()
                         .map(|(k, _)| pyre_object::w_str_from_wtf8(k.clone()))

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -215,7 +215,21 @@ pub struct FrameAnchor {
 
 impl FrameAnchor {
     pub fn new(frame: &mut PyFrame) -> Self {
-        let depth = majit_gc::shadow_stack::push(majit_ir::GcRef(frame as *mut PyFrame as usize));
+        unsafe { Self::from_raw(frame as *mut PyFrame) }
+    }
+
+    /// Anchor a frame the caller holds as a raw pointer.
+    ///
+    /// `executioncontext`, the frame typedef and the introspection builtins
+    /// carry `*mut PyFrame` rather than a reference, because the same frame
+    /// stays reachable through the `f_backref` chain it was read off.  Minting
+    /// a `&mut` for the length of the anchor would claim an exclusivity none of
+    /// them has.
+    ///
+    /// # Safety
+    /// `frame` must name a live `PyFrame`.
+    pub unsafe fn from_raw(frame: *mut PyFrame) -> Self {
+        let depth = majit_gc::shadow_stack::push(majit_ir::GcRef(frame as usize));
         Self {
             depth,
             _not_send: std::marker::PhantomData,

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -227,7 +227,11 @@ impl FrameAnchor {
     /// them has.
     ///
     /// # Safety
-    /// `frame` must name a live `PyFrame`.
+    /// `frame` must be null or name a live `PyFrame`.  A null is an
+    /// anticipated input for the residual helpers, which take the caller frame
+    /// as a raw operand the emit site may not have; the root walker skips a
+    /// null slot, so anchoring one costs a push and answers null from
+    /// [`Self::live`].
     pub unsafe fn from_raw(frame: *mut PyFrame) -> Self {
         let depth = majit_gc::shadow_stack::push(majit_ir::GcRef(frame as usize));
         Self {

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1520,15 +1520,6 @@ pub fn set_current_exception(exc: PyObjectRef) {
     }
 }
 
-pub fn normalize_raise_value(value: PyObjectRef) -> PyObjectRef {
-    unsafe {
-        if crate::baseobjspace::exception_is_valid_obj_as_class_w(value) {
-            return crate::call_function(value, &[]);
-        }
-    }
-    value
-}
-
 /// `pyopcode.py:764-766` — `raise Class` instantiates the class, and
 /// `normalize_exception` then validates the result.  `space.call_function`
 /// propagates the constructor's own error in RPython; pyre's returns
@@ -1550,23 +1541,27 @@ unsafe fn instantiate_raised_class(w_type: PyObjectRef) -> Result<PyObjectRef, P
     Ok(result)
 }
 
-/// Normalize the `from` cause of a `raise X from Y` statement: instantiate
-/// the cause if it is an exception class, validate that the result is
-/// `None` / a `BaseException` instance, and return a `PyError::type_error`
-/// otherwise.
+/// Instantiate the `from` cause of a `raise X from Y` when it is an exception
+/// class, and answer it unchanged otherwise.
+///
+/// Whether the result derives from `BaseException` is deliberately not asked
+/// here.  `pyopcode.py:757-760` instantiates and does nothing else; the check
+/// is `error.py:376-385 set_cause`, which runs after the raised value has been
+/// popped and normalized.  Asking it early lets `raise Cls from 42` answer the
+/// cause's TypeError without ever running `Cls()`, and lets it pre-empt the
+/// raised value's own "exceptions must derive from BaseException".
+/// [`attach_raise_cause`] is where it is asked.
 ///
 /// # TODO: inline back into RAISE_VARARGS
 ///
-/// **Deviation.** RPython performs this validation inline inside
-/// `RAISE_VARARGS` (`pypy/interpreter/pyopcode.py:704-707`,
-/// `space.call_function(w_cause)` when `w_cause` is an exception class)
-/// without a named helper, deferring the BaseException check to
-/// `OperationError.set_cause` (`pypy/interpreter/error.py`). Pyre
-/// extracts this pre-step into a standalone helper so the JIT raise/r
-/// BH path (`pyre-jit/src/call_jit.rs::bh_normalize_raise_varargs_fn`)
-/// and the interpreter raise path can share the same validation.
+/// **Deviation.** RPython performs this inline inside `RAISE_VARARGS`
+/// (`pypy/interpreter/pyopcode.py:757-760`, `space.call_function(w_cause)`
+/// when `w_cause` is an exception class) without a named helper. Pyre
+/// extracts the step into a standalone helper so the JIT raise BH path
+/// (`pyre-jit/src/call_jit.rs`), the tracer (`pyre-jit-trace`) and the
+/// interpreter raise path share one instantiation.
 ///
-/// **When to fix.** When `bh_normalize_raise_varargs_fn` is removed or
+/// **When to fix.** When `bh_normalize_raise_varargs_with_frame` is removed or
 /// rewritten — e.g. when the JIT BH path can dispatch the same inlined
 /// `RAISE_VARARGS` sequence directly without a shared helper.
 ///
@@ -1576,18 +1571,20 @@ unsafe fn instantiate_raised_class(w_type: PyObjectRef) -> Result<PyObjectRef, P
 /// the BH path through the inlined sequence or rewrite it to match
 /// RPython's inline shape.
 pub fn normalize_raise_cause(cause: PyObjectRef) -> Result<PyObjectRef, PyError> {
-    let cause = normalize_raise_value(cause);
-    unsafe {
-        if cause.is_null() || pyre_object::is_none(cause) || pyre_object::is_exception(cause) {
-            return Ok(cause);
-        }
+    if !unsafe { crate::baseobjspace::exception_is_valid_obj_as_class_w(cause) } {
+        return Ok(cause);
     }
-    // `error.py:376-385 set_cause` validates through
-    // `_exception_getclass(space, w_cause, "exception causes")`, whose wording
-    // is not the one `descr_setcause` uses for `e.__cause__ = x`.
-    Err(PyError::type_error(
-        "exception causes must derive from BaseException",
-    ))
+    // `space.call_function(w_cause)` propagates the constructor's own error;
+    // pyre's answers `PY_NULL` with the error parked in the pending-call slot,
+    // so an unchecked null would lose it and report the raise as having no
+    // cause at all.
+    let result = unsafe { crate::call_function(cause, &[]) };
+    if result.is_null() {
+        return Err(crate::call::take_call_error().unwrap_or_else(|| {
+            PyError::type_error("exception causes must derive from BaseException")
+        }));
+    }
+    Ok(result)
 }
 
 pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Result<(), PyError> {
@@ -1610,14 +1607,28 @@ pub fn attach_raise_cause(exc: PyObjectRef, cause: Option<PyObjectRef>) -> Resul
     crate::error::chain_context(exc, get_sys_exception());
     if let Some(cause_obj) = cause
         && !cause_obj.is_null()
-        && unsafe { pyre_object::is_exception(exc) }
     {
-        // `interp_exceptions.py:166-174 descr_setcause` — writes
-        // `w_cause` and flips `suppress_context` to True.
-        unsafe {
-            pyre_object::interp_exceptions::w_exception_set_cause(exc, cause_obj);
-            pyre_object::interp_exceptions::w_exception_set_suppress_context(exc, true);
-        };
+        // `error.py:376-385 set_cause` checks the cause here, after the raised
+        // value has been normalized: `raise Cls from 42` therefore runs `Cls()`
+        // first, and a raised value that is not an exception answers its own
+        // TypeError rather than this one.  The wording is
+        // `_exception_getclass(space, w_cause, "exception causes")`, not the one
+        // `descr_setcause` uses for `e.__cause__ = x`.
+        let valid =
+            unsafe { pyre_object::is_none(cause_obj) || pyre_object::is_exception(cause_obj) };
+        if !valid {
+            return Err(PyError::type_error(
+                "exception causes must derive from BaseException",
+            ));
+        }
+        if unsafe { pyre_object::is_exception(exc) } {
+            // `interp_exceptions.py:166-174 descr_setcause` — writes
+            // `w_cause` and flips `suppress_context` to True.
+            unsafe {
+                pyre_object::interp_exceptions::w_exception_set_cause(exc, cause_obj);
+                pyre_object::interp_exceptions::w_exception_set_suppress_context(exc, true);
+            };
+        }
     }
     Ok(())
 }

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -1775,6 +1775,14 @@ pub fn handle_exception_with_context(
     // tracing hooks are skipped per `:91-94`.  Pyre carries the same
     // intent via `PyError.attach_tb` set by `eval.rs::reraise`.
     let ec = frame.execution_context as *mut crate::PyExecutionContext;
+    // Everything below allocates before it touches the frame again:
+    // `to_exc_object` materialises the exception, `chain_context` builds the
+    // `__context__` link, the trace hooks run arbitrary Python and
+    // `record_application_traceback` allocates a `PyTraceback`.  A frame the
+    // JIT built is a nursery object (`emit_new_pyframe_inline_with_params`),
+    // so `frame` names the abandoned copy after any of them collect.  Anchor it
+    // once and re-read at each point the frame is next used.
+    let frame_anchor = FrameAnchor::new(frame);
     let exc_obj = err.to_exc_object();
     if err.exc_object.is_null() {
         err.exc_object = exc_obj;
@@ -1797,6 +1805,7 @@ pub fn handle_exception_with_context(
         crate::error::chain_context(err.exc_object, active);
         err.context_recorded = true;
     }
+    let frame = unsafe { &mut *frame_anchor.live() };
     if err.attach_tb {
         if !ec.is_null() && unsafe { !(*ec).gettrace().is_null() } {
             // The materialized exception is old-gen managed but lives only in the
@@ -1811,6 +1820,9 @@ pub fn handle_exception_with_context(
             }
             let after_exc_result =
                 unsafe { (*ec).bytecode_trace_after_exception(frame as *mut PyFrame) };
+            // The hook ran application code; restore the slot on the frame that
+            // survived it.
+            let frame = unsafe { &mut *frame_anchor.live() };
             if !saved_trace.is_null() {
                 frame.getorcreatedebug(-1).w_f_trace = saved_trace;
             }
@@ -1832,6 +1844,9 @@ pub fn handle_exception_with_context(
         // `pyopcode.py:147-148 pytraceback.record_application_traceback`
         // — prepends a `PyTraceback` wrapping the current frame onto
         // the exception's `w_traceback` chain.
+        // `w_pytraceback_new` copies this pointer into the node it allocates,
+        // so it has to be the address the frame has now.
+        let frame = unsafe { &mut *frame_anchor.live() };
         unsafe {
             crate::pytraceback::record_application_traceback(
                 operr_obj,
@@ -1853,6 +1868,7 @@ pub fn handle_exception_with_context(
         // `operr.get_w_traceback(space)` — the slot read with its mark.
         let w_tb = unsafe { pyre_object::interp_exceptions::w_exception_get_traceback(operr_obj) };
         unsafe { crate::pytraceback::mark_traceback_escaped(w_tb) };
+        let frame = unsafe { &mut *frame_anchor.live() };
         if let Err(trace_err) = unsafe {
             (*ec).exception_trace(frame as *mut PyFrame, operr_obj, pyre_object::PY_NULL, w_tb)
         } {
@@ -1872,6 +1888,10 @@ pub fn handle_exception_with_context(
     // records its own traceback entry — mirroring the special-exception being
     // unwrapped to a plain OperationError after one frame.
     err.attach_tb = true;
+    // `record_application_traceback` and `exception_trace` above both allocate;
+    // `pycode` is read off the frame, so a stale frame yields a stale code
+    // object as well as a stale value stack.
+    let frame = unsafe { &mut *frame_anchor.live() };
     let code = unsafe { &*crate::pyframe_get_pycode(frame) };
     // pyre's `last_instr` is a rustpython code-unit index; the PyPy-shaped
     // `lookup_exceptiontable` lookup takes byte offsets, so multiply by 2.
@@ -1928,6 +1948,9 @@ pub fn handle_exception_with_context(
         // here so a re-thrown PyError does not double-consume.
         err.reraise_lasti = -1;
         let exc_obj = err.to_exc_object();
+        // Same shape as `opcode_build_list`: materialise, then push. The push
+        // has to land on the frame the materialisation left live.
+        let frame = unsafe { &mut *frame_anchor.live() };
         frame.push(exc_obj);
         // The decoded `target` is a byte offset; pyre's `next_instr` is a
         // code-unit index, so divide by 2.
@@ -3508,13 +3531,13 @@ impl OpcodeStepExecutor for PyFrame {
         let val = locals_w!(self)[i_val];
         let exit_self = locals_w!(self)[i_self];
         let exit_func = locals_w!(self)[i_func];
+        let anchor = FrameAnchor::new(self);
         let res = with_except_start_values(exit_func, exit_self, val);
         if res.is_null() {
             return Err(crate::call::take_call_error()
                 .unwrap_or_else(|| crate::PyError::type_error("__exit__ failed")));
         }
-        self.push(res);
-        Ok(())
+        Self::push_anchored(&anchor, res)
     }
 
     // ── LoadCommonConstant ──
@@ -3777,11 +3800,11 @@ impl OpcodeStepExecutor for PyFrame {
         // Stack: [strings, interpolations] (two tuples the compiler split).
         let interpolations = self.pop();
         let strings = self.pop();
+        let anchor = FrameAnchor::new(self);
         let module = self.import_module("_template")?;
         let func = getattr_str(module, "_build_template")?;
         let result = call_callable(self, func, &[strings, interpolations])?;
-        self.push(result);
-        Ok(())
+        Self::push_anchored(&anchor, result)
     }
 
     fn build_interpolation_op(
@@ -3799,6 +3822,7 @@ impl OpcodeStepExecutor for PyFrame {
         let expression = self.pop();
         let value = self.pop();
         let conversion_obj = pyre_object::w_int_new(conversion as i64);
+        let anchor = FrameAnchor::new(self);
         let module = self.import_module("_template")?;
         let func = getattr_str(module, "_build_interpolation")?;
         let result = call_callable(
@@ -3806,25 +3830,25 @@ impl OpcodeStepExecutor for PyFrame {
             func,
             &[value, expression, conversion_obj, format_spec],
         )?;
-        self.push(result);
-        Ok(())
+        Self::push_anchored(&anchor, result)
     }
 
     fn import_name(&mut self, name: &str) -> Result<(), PyError> {
         let w_fromlist = self.pop();
         let w_flag = self.pop();
+        let anchor = FrameAnchor::new(self);
         let w_obj = crate::importing::import_name(self, name, w_fromlist, w_flag)?;
-        self.push(w_obj);
-        Ok(())
+        Self::push_anchored(&anchor, w_obj)
     }
 
     // PyPy: pyopcode.py IMPORT_FROM
     // Stack: [module] → peek module, push getattr(module, name)
     fn import_from(&mut self, name: &str) -> Result<(), PyError> {
         let module = self.peek();
-        let attr = crate::importing::import_from(module, name, self.execution_context)?;
-        self.push(attr);
-        Ok(())
+        let ec = self.execution_context;
+        let anchor = FrameAnchor::new(self);
+        let attr = crate::importing::import_from(module, name, ec)?;
+        Self::push_anchored(&anchor, attr)
     }
 
     // ── ContainsOp (in / not in) ──
@@ -3834,13 +3858,13 @@ impl OpcodeStepExecutor for PyFrame {
         // CPython 3.13: TOS = container, TOS1 = item
         let haystack = self.pop();
         let needle = self.pop();
+        let anchor = FrameAnchor::new(self);
         let result = crate::baseobjspace::contains(haystack, needle)?;
         let inverted = match invert {
             crate::bytecode::Invert::No => result,
             crate::bytecode::Invert::Yes => !result,
         };
-        self.push(pyre_object::w_bool_from(inverted));
-        Ok(())
+        Self::push_anchored(&anchor, pyre_object::w_bool_from(inverted))
     }
 
     // ── IsOp (is / is not) ──
@@ -3866,9 +3890,9 @@ impl OpcodeStepExecutor for PyFrame {
 
     fn to_bool(&mut self) -> Result<(), PyError> {
         let val = self.pop();
+        let anchor = FrameAnchor::new(self);
         let truth = crate::baseobjspace::is_true(val)?;
-        self.push(pyre_object::w_bool_from(truth));
-        Ok(())
+        Self::push_anchored(&anchor, pyre_object::w_bool_from(truth))
     }
 
     // ── DeleteSubscr ──
@@ -3903,9 +3927,9 @@ impl OpcodeStepExecutor for PyFrame {
         let val = self.pop();
         // `f'{x}'` → `PyObject_Format(x, NULL)`; a user `__format__` is
         // invoked with an empty spec, otherwise this is `str(value)`.
+        let anchor = FrameAnchor::new(self);
         let s = crate::runtime_ops::format_value(val, pyre_object::PY_NULL)?;
-        self.push(s);
-        Ok(())
+        Self::push_anchored(&anchor, s)
     }
 
     // ── FormatWithSpec (format(TOS1, TOS)) ──
@@ -3917,9 +3941,9 @@ impl OpcodeStepExecutor for PyFrame {
         // (empty spec → `str(value)`).  `runtime_ops::format_value` keeps
         // f-string `{n:08.3f}` and `"{:08.3f}".format(n)` identical, and
         // reads a non-`str`/non-UTF-8 spec as empty rather than panicking.
+        let anchor = FrameAnchor::new(self);
         let s = crate::runtime_ops::format_value(val, spec)?;
-        self.push(s);
-        Ok(())
+        Self::push_anchored(&anchor, s)
     }
 
     // ── ConvertValue (repr/str/ascii conversion) ──
@@ -3931,8 +3955,9 @@ impl OpcodeStepExecutor for PyFrame {
         // the path the `'%s' % x` → CONVERT_VALUE/FORMAT_SIMPLE compile
         // rewrite takes.
         let code = crate::runtime_ops::convert_value_code(conv);
-        self.push(crate::runtime_ops::convert_value(val, code)?);
-        Ok(())
+        let anchor = FrameAnchor::new(self);
+        let converted = crate::runtime_ops::convert_value(val, code)?;
+        Self::push_anchored(&anchor, converted)
     }
 
     // ── CopyFreeVars ──
@@ -4071,13 +4096,14 @@ impl OpcodeStepExecutor for PyFrame {
         let exc_type = self.pop();
         validate_check_eg_match_class(exc_type)?;
         let exc_value = self.pop();
+        let anchor = FrameAnchor::new(self);
         let (matching, rest) = if unsafe { pyre_object::is_none(exc_value) } {
             (pyre_object::w_none(), pyre_object::w_none())
         } else {
             crate::builtins::exception_group_match(exc_value, exc_type)?
         };
-        self.push(rest);
-        self.push(matching);
+        Self::push_anchored(&anchor, rest)?;
+        Self::push_anchored(&anchor, matching)?;
         if !unsafe { pyre_object::is_none(matching) } {
             set_current_exception(matching);
         }
@@ -4157,18 +4183,17 @@ impl OpcodeStepExecutor for PyFrame {
     fn load_from_dict_or_globals(&mut self, name: &str, nameindex: usize) -> Result<(), PyError> {
         let mapping = self.pop();
         let key = pyre_object::w_str_new(name);
+        let anchor = FrameAnchor::new(self);
         match crate::baseobjspace::getitem(mapping, key) {
             Ok(value) => {
-                self.push(value);
-                return Ok(());
+                return Self::push_anchored(&anchor, value);
             }
             Err(err) if matches!(err.kind, PyErrorKind::KeyError) => {}
             Err(err) => return Err(err),
         }
 
-        let value = self.load_global_value(name, nameindex)?;
-        self.push(value);
-        Ok(())
+        let value = unsafe { &mut *anchor.live() }.load_global_value(name, nameindex)?;
+        Self::push_anchored(&anchor, value)
     }
 
     // ── LoadFromDictOrDeref ──
@@ -4178,44 +4203,45 @@ impl OpcodeStepExecutor for PyFrame {
     fn load_from_dict_or_deref(&mut self, idx: usize, name: &str) -> Result<(), PyError> {
         let mapping = self.pop();
         let key = pyre_object::w_str_new(name);
+        let anchor = FrameAnchor::new(self);
         match crate::baseobjspace::getitem(mapping, key) {
             Ok(value) => {
-                self.push(value);
-                return Ok(());
+                return Self::push_anchored(&anchor, value);
             }
             Err(err) if matches!(err.kind, PyErrorKind::KeyError) => {}
             Err(err) => return Err(err),
         }
+        // `getitem` may have run a `__getitem__`; everything below reads the
+        // frame's own code object, globals and cells.
+        let self_ = unsafe { &mut *anchor.live() };
         // CPython 3.14 addresses the outer `__class__` freevar in the
         // class-cell collision. The pinned compiler encodes the implicit
         // method cell instead; if no outer cell exists, it emits this opcode
         // where CPython uses LOAD_NAME, so preserve globals/builtins fallback.
-        let deref_idx = if crate::pyframe::class_scope_class_deref_is_name(self.code(), idx) {
-            match crate::pyframe::class_scope_outer_class_freevar(self.code()) {
+        let deref_idx = if crate::pyframe::class_scope_class_deref_is_name(self_.code(), idx) {
+            match crate::pyframe::class_scope_outer_class_freevar(self_.code()) {
                 Some(free_idx) => free_idx,
                 None => {
                     // This deref name has no `co_names` index, so do the
                     // uncached LOAD_NAME fallback directly rather than
                     // corrupting an unrelated per-code LOAD_GLOBAL cache slot.
-                    let w_globals = self.get_w_globals();
+                    let w_globals = self_.get_w_globals();
                     if !w_globals.is_null()
                         && let Some(value) = unsafe {
                             pyre_object::dictmultiobject::w_dict_getitem_str(w_globals, name)
                         }
                     {
-                        self.push(value);
-                        return Ok(());
+                        return Self::push_anchored(&anchor, value);
                     }
                     // `self.get_builtin()`, not the `builtin` field — see
                     // `load_global_value`.
-                    let w_builtin = self.get_builtin();
+                    let w_builtin = self_.get_builtin();
                     if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
                         let w_dict = unsafe { pyre_object::w_module_get_w_dict(w_builtin) };
                         if !w_dict.is_null()
                             && let Some(value) = crate::baseobjspace::finditem_str(w_dict, name)?
                         {
-                            self.push(value);
-                            return Ok(());
+                            return Self::push_anchored(&anchor, value);
                         }
                     }
                     return Err(PyError::name_error_with_name(
@@ -4227,17 +4253,17 @@ impl OpcodeStepExecutor for PyFrame {
         } else {
             idx
         };
-        let slot = locals_w!(self)[deref_idx];
+        let self_ = unsafe { &mut *anchor.live() };
+        let slot = locals_w!(self_)[deref_idx];
         let value = if !slot.is_null() && unsafe { pyre_object::is_cell(slot) } {
             unsafe { pyre_object::w_cell_get(slot) }
         } else {
             slot
         };
         if value == PY_NULL {
-            return Err(crate::pyframe::deref_unbound_error(self.code(), deref_idx));
+            return Err(crate::pyframe::deref_unbound_error(self_.code(), deref_idx));
         }
-        self.push(value);
-        Ok(())
+        Self::push_anchored(&anchor, value)
     }
 
     // ── GetLen ──
@@ -4265,9 +4291,9 @@ impl OpcodeStepExecutor for PyFrame {
     fn match_keys(&mut self) -> Result<(), PyError> {
         let keys = PyFrame::peek_at(self, 0);
         let subject = PyFrame::peek_at(self, 1);
+        let anchor = FrameAnchor::new(self);
         let result = crate::opcode_ops::match_keys_value(subject, keys)?;
-        self.push(result);
-        Ok(())
+        Self::push_anchored(&anchor, result)
     }
 
     // MATCH_CLASS count: STACK[-1] = keyword attr-name tuple, STACK[-2] = class,
@@ -4277,9 +4303,9 @@ impl OpcodeStepExecutor for PyFrame {
         let kwd_attrs = self.pop();
         let cls = self.pop();
         let subject = self.pop();
+        let anchor = FrameAnchor::new(self);
         let result = crate::opcode_ops::match_class_value(subject, cls, kwd_attrs, count)?;
-        self.push(result);
-        Ok(())
+        Self::push_anchored(&anchor, result)
     }
 
     // ── LoadFastAndClear (comprehension scope) ──
@@ -4298,9 +4324,9 @@ impl OpcodeStepExecutor for PyFrame {
             items.push(self.pop());
         }
         items.reverse();
+        let anchor = FrameAnchor::new(self);
         let set_obj = crate::builtins::builtin_set_from_items(&items)?;
-        self.push(set_obj);
-        Ok(())
+        Self::push_anchored(&anchor, set_obj)
     }
 
     // ── DictUpdate ──
@@ -4457,9 +4483,9 @@ impl OpcodeStepExecutor for PyFrame {
     // `self.get_builtin().getdictvalue('__build_class__')`.  Python 3.14
     // reports a NameError when the selected builtin mapping has no entry.
     fn load_build_class(&mut self) -> Result<(), PyError> {
+        let anchor = FrameAnchor::new(self);
         let bc = self.load_build_class_value()?;
-        self.push(bc);
-        Ok(())
+        Self::push_anchored(&anchor, bc)
     }
 
     fn load_build_class_value(&mut self) -> Result<PyObjectRef, PyError> {
@@ -4486,6 +4512,7 @@ impl OpcodeStepExecutor for PyFrame {
     // ── yield from / send ──
     fn get_yield_from_iter(&mut self) -> Result<(), PyError> {
         let iterable = self.pop();
+        let anchor = FrameAnchor::new(self);
         // CPython 3.14 `GET_YIELD_FROM_ITER` / PyPy's coroutine-aware
         // `YIELD_FROM`: exact generators already are their iterator.  A
         // native coroutine is also sent to directly, but only when the
@@ -4510,13 +4537,13 @@ impl OpcodeStepExecutor for PyFrame {
                 crate::baseobjspace::iter(iterable)?
             }
         };
-        self.push(iter);
-        Ok(())
+        Self::push_anchored(&anchor, iter)
     }
 
     fn send_value(&mut self, target: usize) -> Result<(), PyError> {
         let value = self.pop();
         let iter = self.peek();
+        let anchor = FrameAnchor::new(self);
         let result = if unsafe { pyre_object::is_none(value) } {
             // generator.py / pyopcode.py `next_yield_from`: coroutine
             // objects are not public iterators, but the interpreter's SEND
@@ -4533,16 +4560,17 @@ impl OpcodeStepExecutor for PyFrame {
         };
         match result {
             Ok(result) => {
-                self.w_yielding_from = iter;
-                if pyre_object::gc_hook::try_gc_owns_object(self as *mut PyFrame as *mut u8) {
-                    pyre_object::gc_hook::try_gc_write_barrier(self as *mut PyFrame as *mut u8);
+                let frame = unsafe { &mut *anchor.live() };
+                frame.w_yielding_from = iter;
+                if pyre_object::gc_hook::try_gc_owns_object(frame as *mut PyFrame as *mut u8) {
+                    pyre_object::gc_hook::try_gc_write_barrier(frame as *mut PyFrame as *mut u8);
                 }
-                self.push(result);
-                Ok(())
+                Self::push_anchored(&anchor, result)
             }
             Err(e) if e.matches_stop_iteration() => {
-                if std::ptr::eq(self.w_yielding_from, iter) {
-                    self.w_yielding_from = pyre_object::PY_NULL;
+                let frame = unsafe { &mut *anchor.live() };
+                if std::ptr::eq(frame.w_yielding_from, iter) {
+                    frame.w_yielding_from = pyre_object::PY_NULL;
                 }
                 // `pypy/interpreter/pyopcode.py:1158-1166 next_yield_from`:
                 //     try:
@@ -4566,8 +4594,8 @@ impl OpcodeStepExecutor for PyFrame {
                 } else {
                     pyre_object::w_none()
                 };
-                self.push(value);
-                self.set_last_instr_from_next_instr(target);
+                Self::push_anchored(&anchor, value)?;
+                unsafe { &mut *anchor.live() }.set_last_instr_from_next_instr(target);
                 Ok(())
             }
             Err(e) => Err(e),
@@ -4584,18 +4612,19 @@ impl OpcodeStepExecutor for PyFrame {
     fn get_awaitable(&mut self, context: u32) -> Result<(), PyError> {
         // pyopcode.py:1599 GET_AWAITABLE.
         let w_iterable = self.pop();
+        let anchor = FrameAnchor::new(self);
         let w_iter = crate::baseobjspace::get_awaitable_iter(w_iterable, context)?;
         // pyopcode.py:1604 guards a coroutine that is already being awaited
         // (`w_iter.get_delegate() is not None`) with RuntimeError.  pyre's
         // generator object has no delegate / `w_yielded_from` field, so the
         // reentrant-await case is instead caught at SEND by the generator
         // `running` flag.
-        self.push(w_iter);
-        Ok(())
+        Self::push_anchored(&anchor, w_iter)
     }
 
     fn get_aiter(&mut self) -> Result<(), PyError> {
         let obj = self.pop();
+        let anchor = FrameAnchor::new(self);
         let method =
             unsafe { crate::baseobjspace::lookup_special(obj, "__aiter__")? }.ok_or_else(|| {
                 crate::PyError::type_error(format!(
@@ -4610,12 +4639,12 @@ impl OpcodeStepExecutor for PyFrame {
                 crate::type_methods::arg_type_name(iter)
             )));
         }
-        self.push(iter);
-        Ok(())
+        Self::push_anchored(&anchor, iter)
     }
 
     fn get_anext(&mut self) -> Result<(), PyError> {
         let iter = self.peek();
+        let anchor = FrameAnchor::new(self);
         let method = unsafe { crate::baseobjspace::lookup_special(iter, "__anext__")? }
             .ok_or_else(|| {
                 crate::PyError::type_error(format!(
@@ -4649,8 +4678,7 @@ impl OpcodeStepExecutor for PyFrame {
                 crate::PyError::from_exc_object(error_obj)
             }
         })?;
-        self.push(awaitable);
-        Ok(())
+        Self::push_anchored(&anchor, awaitable)
     }
 
     fn end_async_for(&mut self) -> Result<(), PyError> {
@@ -4695,6 +4723,7 @@ impl OpcodeStepExecutor for PyFrame {
         let self_obj = self.pop();
         let cls = self.pop();
         let global_super = self.pop();
+        let anchor = FrameAnchor::new(self);
 
         // CPython 3.14 `LOAD_SUPER_ATTR`: the callable loaded from globals is
         // authoritative (it may shadow builtins.super).  Bit 1 distinguishes
@@ -4717,16 +4746,16 @@ impl OpcodeStepExecutor for PyFrame {
             if unsafe { pyre_object::is_method(result) } {
                 let func = unsafe { pyre_object::w_method_get_func(result) };
                 let recv = unsafe { pyre_object::w_method_get_self(result) };
-                self.push(func);
-                self.push(recv);
+                Self::push_anchored(&anchor, func)?;
+                Self::push_anchored(&anchor, recv)?;
             } else {
                 // staticmethod or classmethod — no self binding
-                self.push(result);
-                self.push(PY_NULL);
+                Self::push_anchored(&anchor, result)?;
+                Self::push_anchored(&anchor, PY_NULL)?;
             }
         } else {
             // is_method=false: getattr already returned a bound method.
-            self.push(result);
+            Self::push_anchored(&anchor, result)?;
         }
         Ok(())
     }
@@ -4802,22 +4831,18 @@ impl OpcodeStepExecutor for PyFrame {
         let roots = pyre_object::gc_roots::push_roots();
         let obj_slot = roots.base();
         roots.pin_root(obj);
+        let pycode = self.pycode as PyObjectRef;
+        let anchor = FrameAnchor::new(self);
         let w_value = unsafe {
-            crate::objspace::std::mapdict::load_attr_caching(
-                self.pycode as PyObjectRef,
-                obj,
-                nameindex,
-                name,
-            )
+            crate::objspace::std::mapdict::load_attr_caching(pycode, obj, nameindex, name)
         }
         .map_err(|error| {
             if finalize_failed_attr_receiver_now(roots.get(obj_slot)) {
-                self.defer_failed_attr_until_pop_except();
+                unsafe { &mut *anchor.live() }.defer_failed_attr_until_pop_except();
             }
             error
         })?;
-        self.push(w_value);
-        Ok(())
+        Self::push_anchored(&anchor, w_value)
     }
 
     /// pyopcode.py:917-926 `STORE_ATTR` — consults the mapdict attribute cache
@@ -5010,9 +5035,9 @@ impl OpcodeStepExecutor for PyFrame {
         // treating a dict subclass as a non-dict can also accidentally copy
         // globals into the class namespace and make LOAD_FROM_DICT_OR_DEREF
         // select a global over its closure cell.
+        let anchor = FrameAnchor::new(self);
         let w_locals = self.get_or_create_w_locals();
-        self.push(w_locals);
-        Ok(())
+        Self::push_anchored(&anchor, w_locals)
     }
 
     // ── unpack_ex ──
@@ -5025,9 +5050,10 @@ impl OpcodeStepExecutor for PyFrame {
         // `unpack_ex_slots` returns the `before + 1 + after` slots in TOS
         // order (head items, starred list, tail items); push bottom-first so
         // the first head item ends on top.
+        let anchor = FrameAnchor::new(self);
         let slots = crate::runtime_ops::unpack_ex_slots(before, after, value)?;
         for item in slots.into_iter().rev() {
-            self.push(item);
+            Self::push_anchored(&anchor, item)?;
         }
         Ok(())
     }
@@ -5068,9 +5094,9 @@ impl OpcodeStepExecutor for PyFrame {
         let stop = self.pop();
         let start = self.pop();
         let obj = self.pop();
+        let anchor = FrameAnchor::new(self);
         let result = crate::runtime_ops::binary_slice_values(obj, start, stop)?;
-        self.push(result);
-        Ok(())
+        Self::push_anchored(&anchor, result)
     }
 
     // ── StoreSlice (a[b:c] = d) ──

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -643,6 +643,10 @@ impl ExecutionContext {
         };
         let frame = anchor.live();
         let frame_vref = self.topframeref;
+        // At interp level a vref in the chain *is* the frame pointer, so the
+        // slot `force_vref` is about to be handed goes stale across the force
+        // `get_f_back` performs just above it.
+        let vref_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame_vref) };
         unsafe {
             // `self.topframeref = frame.f_backref` (no parens — move the raw
             // caller vref back, do not force it).
@@ -656,7 +660,7 @@ impl ExecutionContext {
                 // `frame_vref()` — force the leaving frame's own vref so it
                 // stays reachable after the JIT frame is gone (identity at
                 // interp level).
-                force_vref(frame_vref);
+                force_vref(vref_anchor.live());
             }
         }
         // `jit.virtual_ref_finish(frame_vref, frame)` — keepalives only at
@@ -812,14 +816,7 @@ impl ExecutionContext {
         // callback exception), the ticker decrement + slow-path
         // action_dispatcher do NOT run.  Use `?` so a tracer error
         // short-circuits before touching actionflag.
-        // `bytecode_only_trace` returns without touching anything when no
-        // tracer is installed, so that is the test the anchor rides.
-        let trace_anchor =
-            (!self.w_tracefunc.is_null()).then(|| unsafe { crate::eval::FrameAnchor::from_raw(frame) });
-        self.bytecode_only_trace(frame)?;
-        if let Some(anchor) = &trace_anchor {
-            frame = anchor.live();
-        }
+        frame = self.bytecode_only_trace(frame)?;
         if self.actionflag.decrement_ticker(decr_by as isize) < 0 {
             // executioncontext.py:165 — `actionflag.action_dispatcher`.
             // Routed through a residual (dont_look_inside) boundary so the
@@ -869,19 +866,29 @@ impl ExecutionContext {
     /// observes the unmodified instr_prev_plus_one and can fire its
     /// first `line` event correctly).
     #[inline(always)]
-    pub fn bytecode_only_trace(&mut self, frame: *mut PyFrame) -> Result<(), crate::PyError> {
+    /// Answers the frame, because the tracer arm below runs Python and a frame
+    /// a compiled trace built moves there.  Returning it puts the reload on the
+    /// arm that can collect instead of on every caller: this is the per-opcode
+    /// path, and an anchor taken before the early-outs would be a shadow-stack
+    /// push and pop for every bytecode with no tracer installed.
+    pub fn bytecode_only_trace(
+        &mut self,
+        frame: *mut PyFrame,
+    ) -> Result<*mut PyFrame, crate::PyError> {
         // PyPy has no object-space-null guard here: `space` is the interpreter
         // owner, not an optional tracing flag. Pyre represents that owner with
         // PY_NULL in this runtime, so testing it suppressed every line event
         // while still allowing call/return events through `_trace`.
         if frame.is_null() {
-            return Ok(());
+            return Ok(frame);
         }
         let f_trace_is_none = unsafe { (*frame).get_w_f_trace().is_null() };
         if f_trace_is_none || self.is_tracing != 0 || self.w_tracefunc.is_null() {
-            return Ok(());
+            return Ok(frame);
         }
-        self.run_trace_func(frame)
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
+        self.run_trace_func(frame)?;
+        Ok(anchor.live())
     }
 
     pub fn _run_finalizers_now(&mut self) {
@@ -1012,10 +1019,7 @@ impl ExecutionContext {
         &mut self,
         frame: *mut PyFrame,
     ) -> Result<(), crate::PyError> {
-        // The tracer runs Python and the dispatcher below is handed the frame.
-        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
-        self.bytecode_only_trace(frame)?;
-        let frame = anchor.live();
+        let frame = self.bytecode_only_trace(frame)?;
         if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
             self.actionflag.sync_async_ticker();
         }
@@ -1370,13 +1374,14 @@ impl ExecutionContext {
                 Ok::<(), crate::PyError>(())
             })();
 
-            let frame = frame_anchor.live();
             if call_result.is_err() {
                 self.settrace(pyre_object::w_none());
                 unsafe {
-                    (*frame).getorcreatedebug(init_lineno).w_f_trace = pyre_object::PY_NULL;
+                    (*frame_anchor.live()).getorcreatedebug(init_lineno).w_f_trace =
+                        pyre_object::PY_NULL;
                 }
             }
+            let frame = frame_anchor.live();
 
             unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -531,8 +531,12 @@ impl ExecutionContext {
         // `executioncontext.py:_gettopframe` → `self.topframeref()` (vref
         // force), then the virtualizable force materializes the fastlocals.
         let frame = force_vref(self.topframeref);
+        // The force reaches the JIT's virtualizable writeback through a backend
+        // hook whose callee this crate cannot follow, so it is judged as able to
+        // collect and the frame is handed back out of the anchor.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         force_frame(frame);
-        frame
+        anchor.live()
     }
 
     /// `self.topframeref()` without the virtualizable force that
@@ -629,11 +633,15 @@ impl ExecutionContext {
         // the topframeref restore and the vref dance always run.  We
         // capture the trace result and propagate it after the cleanup
         // block below.
+        // `_trace` runs the profile callback, which is application-level
+        // Python; the chain surgery below reads the frame's own fields.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         let trace_result = if self.profilefunc.is_some() {
             self._trace(frame, "leaveframe", w_exitvalue, None)
         } else {
             Ok(())
         };
+        let frame = anchor.live();
         let frame_vref = self.topframeref;
         unsafe {
             // `self.topframeref = frame.f_backref` (no parens — move the raw
@@ -741,7 +749,11 @@ impl ExecutionContext {
 
     pub fn call_trace(&mut self, frame: *mut PyFrame) -> Result<(), crate::PyError> {
         if !self.gettrace().is_null() || self.profilefunc.is_some() {
+            // The callback is Python, and the profiling flag below is a write
+            // into the frame's own debug block.
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
             self._trace(frame, "call", pyre_object::w_none(), None)?;
+            let frame = anchor.live();
             if self.profilefunc.is_some() && !frame.is_null() {
                 unsafe {
                     (*frame).getorcreatedebug(-1).is_being_profiled = true;
@@ -766,11 +778,16 @@ impl ExecutionContext {
     #[inline(always)]
     pub fn bytecode_trace(
         &mut self,
-        frame: *mut PyFrame,
+        mut frame: *mut PyFrame,
         decr_by: usize,
     ) -> Result<(), crate::PyError> {
+        // This runs on the per-tick path, so neither anchor is taken
+        // unconditionally: each rides the same test that decides whether the
+        // call below it can run Python at all.
         if !crate::module::thread::all_thread_hooks_current(self) {
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
             crate::module::thread::apply_all_thread_hooks(self)?;
+            frame = anchor.live();
         }
         if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
             let w_async_exception_type =
@@ -795,7 +812,14 @@ impl ExecutionContext {
         // callback exception), the ticker decrement + slow-path
         // action_dispatcher do NOT run.  Use `?` so a tracer error
         // short-circuits before touching actionflag.
+        // `bytecode_only_trace` returns without touching anything when no
+        // tracer is installed, so that is the test the anchor rides.
+        let trace_anchor =
+            (!self.w_tracefunc.is_null()).then(|| unsafe { crate::eval::FrameAnchor::from_raw(frame) });
         self.bytecode_only_trace(frame)?;
+        if let Some(anchor) = &trace_anchor {
+            frame = anchor.live();
+        }
         if self.actionflag.decrement_ticker(decr_by as isize) < 0 {
             // executioncontext.py:165 — `actionflag.action_dispatcher`.
             // Routed through a residual (dont_look_inside) boundary so the
@@ -948,12 +972,17 @@ impl ExecutionContext {
             (lastline, want_line, want_opcode)
         };
         let _ = lastline;
+        // Reached only with a tracer installed, so the anchor is already on the
+        // slow path; both events run Python and the sentinel write below is a
+        // store into the frame's debug block.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         if want_line {
             self._trace(frame, "line", pyre_object::w_none(), None)?;
         }
         if want_opcode {
-            self._trace(frame, "opcode", pyre_object::w_none(), None)?;
+            self._trace(anchor.live(), "opcode", pyre_object::w_none(), None)?;
         }
+        let frame = anchor.live();
         // executioncontext.py:200 — record the next-PC sentinel so
         // backward jumps re-fire the line event even when staying on
         // the same source line.
@@ -983,7 +1012,10 @@ impl ExecutionContext {
         &mut self,
         frame: *mut PyFrame,
     ) -> Result<(), crate::PyError> {
+        // The tracer runs Python and the dispatcher below is handed the frame.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         self.bytecode_only_trace(frame)?;
+        let frame = anchor.live();
         if majit_ir::eval_breaker_word::load() & majit_ir::eval_breaker_word::EB_ASYNC != 0 {
             self.actionflag.sync_async_ticker();
         }
@@ -1186,7 +1218,9 @@ impl ExecutionContext {
     pub fn force_all_frames(&mut self, is_being_profiled: bool) {
         let mut frame = self.gettopframe_nohidden();
         while !frame.is_null() {
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
             force_frame(frame);
+            frame = anchor.live();
             if is_being_profiled {
                 unsafe {
                     (*frame).getorcreatedebug(-1).is_being_profiled = true;
@@ -1241,6 +1275,15 @@ impl ExecutionContext {
             return Ok(());
         }
 
+        // Everything below this point can collect: `normalize_exception`
+        // materialises the exception, `fast2locals` builds the locals mapping,
+        // `wrap_trace_frame` allocates the frame object handed out, and the
+        // callback is application-level Python.  A frame a compiled trace built
+        // is a nursery allocation, so `frame` names the abandoned copy after any
+        // of them and the `getorcreatedebug` / `locals2fast` writes below would
+        // land there.  Anchor once and re-read where the frame is next used.
+        let frame_anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
+
         let space = self.space;
 
         // executioncontext.py:353-356 Tracing cases
@@ -1277,6 +1320,7 @@ impl ExecutionContext {
                 w_arg
             };
 
+            let frame = frame_anchor.live();
             let lineno = unsafe { (*frame).get_last_lineno() };
             let init_lineno = if unsafe { (*frame).last_instr } >= 1 {
                 lineno
@@ -1290,6 +1334,7 @@ impl ExecutionContext {
             if had_locals {
                 unsafe { (*frame).fast2locals()? };
             }
+            let frame = frame_anchor.live();
             let (prev_line_tracing, old_lineno) = unsafe {
                 let d = (*frame).getorcreatedebug(init_lineno);
                 (d.is_in_line_tracing, d.f_lineno)
@@ -1316,6 +1361,7 @@ impl ExecutionContext {
                 // `frame.f_trace = local` / `frame.f_lineno = N` setattrs
                 // already landed on the frame's getsets — no writeback pass.
                 let w_result = call_result?;
+                let frame = frame_anchor.live();
                 if w_result != pyre_object::w_none() {
                     unsafe {
                         (*frame).getorcreatedebug(init_lineno).w_f_trace = w_result;
@@ -1324,6 +1370,7 @@ impl ExecutionContext {
                 Ok::<(), crate::PyError>(())
             })();
 
+            let frame = frame_anchor.live();
             if call_result.is_err() {
                 self.settrace(pyre_object::w_none());
                 unsafe {
@@ -1388,7 +1435,13 @@ impl ExecutionContext {
             self.is_tracing += 1;
             // executioncontext.py:420-425 self.profilefunc(...), clearing
             // profile slots on exceptions.
-            let profile_result = profilefunc(space, self.w_profilefuncarg, frame, event, w_arg);
+            let profile_result = profilefunc(
+                space,
+                self.w_profilefuncarg,
+                frame_anchor.live(),
+                event,
+                w_arg,
+            );
             if let Err(err) = profile_result {
                 // executioncontext.py:421-425 — clear profile slots and
                 // re-raise so the caller observes the failure (matches
@@ -1836,6 +1889,9 @@ pub trait ActionFlagOps {
         ec: *mut ExecutionContext,
         frame: *mut PyFrame,
     ) -> Result<(), crate::PyError> {
+        // Each `perform` may deliver a signal, which runs the handler at
+        // app level; the next action in the loop is handed the same frame.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         // executioncontext.py:538 — `self.reset_ticker(self.checkinterval_scaled)`.
         let interval = self.abstract_flag().checkinterval_scaled as isize;
         self.reset_ticker(interval);
@@ -1848,7 +1904,7 @@ pub trait ActionFlagOps {
                 continue;
             }
             unsafe {
-                perform_async_action(action_ptr, ec, frame)?;
+                perform_async_action(action_ptr, ec, anchor.live())?;
             }
         }
         // executioncontext.py:543-556 — nonperiodic bit-mask scan.
@@ -1863,7 +1919,7 @@ pub trait ActionFlagOps {
                     self.abstract_flag_mut()._fired_bitmask &= !mask;
                     if !action_ptr.is_null() && !ec.is_null() {
                         unsafe {
-                            perform_async_action(action_ptr, ec, frame)?;
+                            perform_async_action(action_ptr, ec, anchor.live())?;
                         }
                     }
                 }

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -1377,8 +1377,9 @@ impl ExecutionContext {
             if call_result.is_err() {
                 self.settrace(pyre_object::w_none());
                 unsafe {
-                    (*frame_anchor.live()).getorcreatedebug(init_lineno).w_f_trace =
-                        pyre_object::PY_NULL;
+                    (*frame_anchor.live())
+                        .getorcreatedebug(init_lineno)
+                        .w_f_trace = pyre_object::PY_NULL;
                 }
             }
             let frame = frame_anchor.live();

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -812,7 +812,12 @@ pub fn getframe(depth: i64) -> crate::PyResult {
         current = crate::executioncontext::ExecutionContext::getnextframe_nohidden(current);
     }
     unsafe { (*current).mark_as_escaped() };
+    // The force reaches the JIT's virtualizable writeback through a backend
+    // hook whose callee this crate cannot follow, and the audit hook below is
+    // handed this frame.
+    let anchor = unsafe { crate::eval::FrameAnchor::from_raw(current) };
     crate::executioncontext::force_frame(current);
+    current = anchor.live();
     // `vm.py:51 audit(space, "sys._getframe", [f])`.  Ordered after the force
     // because a hook is app code that reads the frame it is handed, and the
     // force is what makes those reads see the JIT's live virtualizable fields —
@@ -1483,8 +1488,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             // not at the walk that reached the frame — see [`force_frame`]:
             // forcing a walk escapes the traced virtualizable and
             // `vable_after_residual_call` aborts the trace with ABORT_ESCAPE.
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(current) };
             crate::executioncontext::force_frame(current);
-            let w_globals = unsafe { (*current).w_globals };
+            let w_globals = unsafe { (*anchor.live()).w_globals };
             if w_globals.is_null() {
                 return Ok(pyre_object::w_none());
             }

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -486,9 +486,13 @@ pub(crate) fn current_frames() -> PyObjectRef {
             if !frame.is_null() {
                 unsafe { (*frame).mark_as_escaped() };
                 // The frame becomes a user-visible value; materialize the
-                // virtualizable fields the JIT may still be holding.
+                // virtualizable fields the JIT may still be holding.  The force
+                // runs through a backend hook whose callee this crate cannot
+                // follow, so what gets pinned is read back out of the anchor
+                // rather than taken from the pre-force local.
+                let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
                 crate::executioncontext::force_frame(frame);
-                pyre_object::gc_roots::pin_root(frame as PyObjectRef);
+                pyre_object::gc_roots::pin_root(anchor.live() as PyObjectRef);
                 entries.push(ident);
             }
         }

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -966,11 +966,22 @@ impl FrameBox {
     /// Rust has no such pass, and a running opcode holds a `&mut PyFrame`
     /// across its own allocations, so this allocation standing still is what
     /// takes the place of that rewrite.  It is not a rule about every frame —
-    /// a compiled trace's inlined-callee frame is a nursery allocation, and
-    /// making that uniform times `fib_recursive` out of its gate — so the
-    /// crossing into raw-pointer territory is guarded at the seams instead
-    /// (`gate-triage.md`, which also records why the ratio that experiment is
-    /// often quoted with is not reproducible).
+    /// a compiled trace's inlined-callee frame is a nursery allocation
+    /// (`emit_new_pyframe_inline_with_params` -> `NewWithVtable`), so the
+    /// crossing into raw-pointer territory is guarded at the seams instead,
+    /// by `crate::eval::FrameAnchor` and the JIT layer's `FrameRoot`.
+    ///
+    /// Making it uniform is one line —
+    /// `PYFRAME_DESCR_GROUP.size_descr.set_non_moving(true)` sends
+    /// `NewWithVtable` down `gen_malloc_fixedsize` to the old generation —
+    /// and it costs 3.6x on `bench/fib_recursive.py`: 0.39s against 1.43s,
+    /// user CPU, five samples per arm, arm64 darwin, 2026-08-20.  An old-gen
+    /// frame holding young argument boxes joins the remembered set and is
+    /// re-traced every minor collection, and each returned frame is old-gen
+    /// garbage only a major reclaims.  Pinning is not an alternative:
+    /// `GcAllocator::pin` ports `gctypelayout.py:88-92 q_cannot_pin` and
+    /// refuses any type carrying GC pointers or a custom trace, which a
+    /// `PyFrame` does both.
     ///
     /// Before the hook is wired (bootstrap, tests) `try_gc_alloc_stable`
     /// returns `None`; fall back to the `std::alloc` `GcFramePrefix` box,

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -5271,9 +5271,12 @@ pub fn report_stale_locals_array_holder(stale_addr: usize) -> bool {
         let frame_addr = frame as usize;
         let owned = pyre_object::gc_hook::try_gc_owns_object(frame_addr as *mut u8);
         if depth > 0 && !owned {
-            eprintln!(
-                "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} is not GC-owned; \
-stopping rather than dereferencing an unvalidated f_backref"
+            crate::host_seam::emit_stderr(
+                format!(
+                    "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} is not \
+GC-owned; stopping rather than dereferencing an unvalidated f_backref\n"
+                )
+                .as_bytes(),
             );
             break;
         }
@@ -5291,10 +5294,13 @@ stopping rather than dereferencing an unvalidated f_backref"
         };
         let holds = array == stale_addr;
         found |= holds;
-        eprintln!(
-            "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} \
+        crate::host_seam::emit_stderr(
+            format!(
+                "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} \
 locals={array:#x} holds_stale={holds} gc_owned={owned} nursery={nursery} \
-type_id={type_id} frame_forwarded={forwarded} track_young_ptrs={tracks_young}"
+type_id={type_id} frame_forwarded={forwarded} track_young_ptrs={tracks_young}\n"
+            )
+            .as_bytes(),
         );
         frame = unsafe { (*frame).f_backref };
         depth += 1;

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -1304,12 +1304,17 @@ fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
             break;
         }
         // `fget_f_lineno` below reads `last_instr`, a virtualizable field.
+        // The force and the filename object both sit between the reads of this
+        // frame, so it is read back out of the anchor at each of them.
+        let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
         crate::executioncontext::force_frame(frame);
-        let w_code = unsafe { (*frame).fget_f_code() };
+        let w_code = unsafe { (*anchor.live()).fget_f_code() };
         let filename_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_filename_obj(w_code) });
         let lineno_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(w_int_new(unsafe { (*frame).fget_f_lineno() } as i64));
+        pyre_object::gc_roots::pin_root(w_int_new(
+            unsafe { (*anchor.live()).fget_f_lineno() } as i64
+        ));
         let funcname_slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(unsafe { crate::pycode::w_code_name_obj(w_code) });
         let summary = w_tuple_new(vec![
@@ -1319,7 +1324,7 @@ fn capture_coroutine_origin(ec: *const PyExecutionContext) -> PyObjectRef {
         ]);
         pyre_object::gc_roots::pin_root(summary);
         summary_slots.push(pyre_object::gc_roots::shadow_stack_len() - 1);
-        frame = crate::executioncontext::ExecutionContext::getnextframe_nohidden(frame);
+        frame = crate::executioncontext::ExecutionContext::getnextframe_nohidden(anchor.live());
     }
     w_tuple_new(
         summary_slots

--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -5233,6 +5233,59 @@ pub extern "C" fn jit_locals_dict_snapshot(w_locals: i64) -> i64 {
     }
 }
 
+/// Name whichever frame on the current call chain still points at a
+/// `locals_cells_stack_w` array a collection has already moved.
+///
+/// Installed as `pyre_object::gc_hook`'s stale-array holder reporter: the
+/// object-space store site sees only the array, while the holder's generation
+/// is the datum that separates the two causes.  An old-generation holder means
+/// the minor collection never scanned it — a remembered-set miss.  A holder
+/// that is itself forwarded means the frame was never traced, so every field
+/// read out of it names pre-collection memory.  Walks `f_backref` because a
+/// JIT-built inline callee frame sits on that chain and nowhere else.
+///
+/// This runs on an already-fatal path, so it stops rather than chase an
+/// unvalidated `f_backref`: losing the walk costs one line, while faulting
+/// inside it would cost the whole report.
+pub fn report_stale_locals_array_holder(stale_addr: usize) -> bool {
+    let mut frame = crate::eval::current_frame();
+    let mut depth = 0usize;
+    let mut found = false;
+    while !frame.is_null() && depth < 64 {
+        let frame_addr = frame as usize;
+        let owned = pyre_object::gc_hook::try_gc_owns_object(frame_addr as *mut u8);
+        if depth > 0 && !owned {
+            eprintln!(
+                "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} is not GC-owned; \
+stopping rather than dereferencing an unvalidated f_backref"
+            );
+            break;
+        }
+        let array = unsafe { (*frame).locals_cells_stack_w } as usize;
+        let nursery = majit_gc::gc_is_nursery_object(frame_addr);
+        let (type_id, forwarded, tracks_young) = if owned {
+            let header = unsafe { *majit_gc::header::header_of(frame_addr) };
+            (
+                header.type_id(),
+                header.is_forwarded(),
+                header.has_flag(majit_gc::flags::TRACK_YOUNG_PTRS),
+            )
+        } else {
+            (u32::MAX, false, false)
+        };
+        let holds = array == stale_addr;
+        found |= holds;
+        eprintln!(
+            "STALE ARRAY holder scan: depth={depth} frame={frame_addr:#x} \
+locals={array:#x} holds_stale={holds} gc_owned={owned} nursery={nursery} \
+type_id={type_id} frame_forwarded={forwarded} track_young_ptrs={tracks_young}"
+        );
+        frame = unsafe { (*frame).f_backref };
+        depth += 1;
+    }
+    found
+}
+
 #[cfg(test)]
 mod tests {
     use super::load_const_from_code;

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7848,8 +7848,11 @@ fn init_frame_type(ns: PyObjectRef) {
             // side effect of the walk: `gettopframe_nohidden` forces only the
             // VREF of the frame it starts from, which is not enough.  A frame
             // reached through a traceback's `tb_frame` gets neither.
+            // The force materializes the fastlocals through a backend hook
+            // whose callee this crate cannot follow, so the frame is read back.
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
             crate::executioncontext::force_frame_before_locals_read(f);
-            let frame = unsafe { &mut *f };
+            let frame = unsafe { &mut *anchor.live() };
             if frame.code().flags.contains(crate::CodeFlags::OPTIMIZED)
                 || frame.has_active_hidden_locals()
             {
@@ -8021,9 +8024,11 @@ fn init_frame_type(ns: PyObjectRef) {
             if f.is_null() {
                 return Ok(pyre_object::w_none());
             }
+            // `int_w` reaches `__index__`, which is application-level Python.
+            let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
             let new_lineno = crate::baseobjspace::int_w(args[2])
                 .map_err(|_| crate::PyError::value_error("lineno must be an integer"))?;
-            unsafe { &mut *f }.fset_f_lineno(new_lineno as isize)?;
+            unsafe { &mut *anchor.live() }.fset_f_lineno(new_lineno as isize)?;
             Ok(pyre_object::w_none())
         },
         3,
@@ -8107,8 +8112,10 @@ fn init_frame_type(ns: PyObjectRef) {
         |args| {
             let f = frame_ptr(args[1]);
             if !f.is_null() {
+                // `is_true` reaches `__bool__` / `__len__`.
+                let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
                 let v = crate::baseobjspace::is_true(args[2])?;
-                unsafe { &mut *f }.fset_f_trace_lines(v);
+                unsafe { &mut *anchor.live() }.fset_f_trace_lines(v);
             }
             Ok(pyre_object::w_none())
         },
@@ -8146,8 +8153,10 @@ fn init_frame_type(ns: PyObjectRef) {
         |args| {
             let f = frame_ptr(args[1]);
             if !f.is_null() {
+                // `is_true` reaches `__bool__` / `__len__`.
+                let anchor = unsafe { crate::eval::FrameAnchor::from_raw(f) };
                 let v = crate::baseobjspace::is_true(args[2])?;
-                unsafe { &mut *f }.fset_f_trace_opcodes(v);
+                unsafe { &mut *anchor.live() }.fset_f_trace_opcodes(v);
             }
             Ok(pyre_object::w_none())
         },

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -251,6 +251,12 @@ pub fn r#type(obj: PyObjectRef) -> Option<NonNull<PyObject>> {
 ///
 /// Must be called before any getattr on builtin objects.
 pub fn init_typeobjects() {
+    // The object-space store site can see that a `locals_cells_stack_w` array
+    // has already moved, but not who still points at it; this crate owns the
+    // frame chain, so it supplies the holder scan.
+    pyre_object::gc_hook::register_stale_array_holder_hook(
+        crate::pyframe::report_stale_locals_array_holder,
+    );
     // Interpreter-only test path: libtest runs each `#[test]` on a fresh
     // thread and `dict_eq_hook`'s hash hook is thread-local, so install it
     // here — the single type-system entry every dict-building test funnels

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -4522,12 +4522,16 @@ fn create_self_recursive_callee_frame_impl_1_boxed(
     let w_globals = caller.w_globals;
     let execution_context = caller.execution_context;
 
+    // Read before the call: `alloc_callee_frame` resolves `__builtins__`, which
+    // can run a user `__getitem__` and so collect.  What this line reports is
+    // the operand the trace passed; `locals` below is the frame's own.
+    let passed_arg = boxed_arg as usize;
     let frame_ptr = alloc_callee_frame(func_code, &[boxed_arg], w_globals, execution_context);
     if majit_metainterp::majit_log_enabled() {
         let f = unsafe { &*frame_ptr };
         eprintln!(
-            "[jit][ca-frame] ptr={frame_ptr:p} locals=0x{:x} vsd={} boxed_arg=0x{:x}",
-            f.locals_cells_stack_w as usize, f.valuestackdepth, boxed_arg as usize,
+            "[jit][ca-frame] ptr={frame_ptr:p} locals=0x{:x} vsd={} boxed_arg=0x{passed_arg:x}",
+            f.locals_cells_stack_w as usize, f.valuestackdepth,
         );
     }
     frame_ptr as i64
@@ -5159,8 +5163,14 @@ fn bh_call_fn_impl(callable: PyObjectRef, null_or_self: PyObjectRef, args: &[PyO
         // The Python coordinate comes off the caller frame, which the dispatch
         // itself never resolves — force it here, inside the diagnostic, so an
         // unarmed run leaves the frame virtual.
-        let parent_frame_ptr = unsafe { (*ec).gettopframe_raw() as *const PyFrame };
+        // `descr_repr` fsdecodes the code filename, and a filename that fails
+        // to decode reaches a registered decode error handler — Python, and so
+        // a collection.  The next iteration reads the frame again, so hold it
+        // on the shadow stack and re-read rather than carry the pointer.
+        let frame_anchor =
+            unsafe { pyre_interpreter::eval::FrameAnchor::from_raw((*ec).gettopframe_raw()) };
         for i in 0..args.len() {
+            let parent_frame_ptr = frame_anchor.live();
             if !parent_frame_ptr.is_null()
                 && pyre_object::gc_roots::shadow_stack_get(root_base + 2 + i).is_null()
             {
@@ -5413,7 +5423,13 @@ pub extern "C" fn bh_load_global_fn(
 
     let varname = code.names[idx].as_ref();
     let _ = namespace_ptr;
-    let parent_frame_ptr = frame_ptr as *const PyFrame;
+    // The builtins leg reads the frame again after the globals lookup, and
+    // `finditem_str` reaches a user `__getitem__` on a non-dict mapping.  A
+    // frame the JIT built lives in the nursery, so hold it on the shadow stack
+    // and re-read at each use instead of carrying the operand across.
+    let frame_anchor =
+        unsafe { pyre_interpreter::eval::FrameAnchor::from_raw(frame_ptr as *mut PyFrame) };
+    let parent_frame_ptr = frame_anchor.live();
     // pypy/interpreter/pyopcode.py:958-969 `_load_global`:
     //   w_value = self.space.finditem_str(self.get_w_globals_storage(), varname)
     //   if w_value is None:
@@ -5458,6 +5474,7 @@ pub extern "C" fn bh_load_global_fn(
     // Residual helper adaptation: `self` is the live portal frame passed as
     // an explicit Ref argument, so `self.get_builtin()` maps to
     // PyFrame::get_builtin() without relying on blackhole-only TLS.
+    let parent_frame_ptr = frame_anchor.live();
     if !parent_frame_ptr.is_null() {
         let w_builtin = unsafe { (*parent_frame_ptr).get_builtin() };
         if !w_builtin.is_null() && unsafe { pyre_object::is_module(w_builtin) } {
@@ -5529,14 +5546,23 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
 
     // Fall back to the live frame's globals (GC-safe when the frame owns
     // this w_code; else the promoted w_code's own globals).
-    let parent_frame_ptr = frame_ptr as *const PyFrame;
-    let w_globals = if !parent_frame_ptr.is_null()
-        && unsafe { (*parent_frame_ptr).pycode } as usize == w_code_ptr as usize
-    {
-        unsafe { (*parent_frame_ptr).get_w_globals() }
-    } else {
-        unsafe { pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef) }
+    //
+    // The globals lookup below reaches a user `__getitem__` on a non-dict
+    // mapping, and the builtins leg after it reads both the frame and the
+    // globals again.  The frame is held on the shadow stack and the globals
+    // re-derived from it — a dict is one of the two kinds a minor collection
+    // relocates, and the promoted `w_code` it otherwise comes off does not
+    // move — so neither is carried across the lookup.
+    let frame_anchor =
+        unsafe { pyre_interpreter::eval::FrameAnchor::from_raw(frame_ptr as *mut PyFrame) };
+    let live_globals = |frame: *mut PyFrame| unsafe {
+        if !frame.is_null() && (*frame).pycode as usize == w_code_ptr as usize {
+            (*frame).get_w_globals()
+        } else {
+            pyre_interpreter::w_code_get_w_globals(w_code_ptr as pyre_object::PyObjectRef)
+        }
     };
+    let w_globals = live_globals(frame_anchor.live());
     if !w_globals.is_null() {
         match pyre_interpreter::baseobjspace::finditem_str(w_globals, varname) {
             Ok(Some(val)) => return val as i64,
@@ -5564,11 +5590,12 @@ pub extern "C" fn bh_load_from_dict_or_globals_fn(
     // name seen by a function created under an exec'd namespace.
     // `try_walker_load_global_cell_fold` declines the fold in that case and
     // leaves the name to this residual, so the handling has to live here.
+    let parent_frame_ptr = frame_anchor.live();
     let w_builtin = if !parent_frame_ptr.is_null() {
         unsafe { (*parent_frame_ptr).get_builtin() }
     } else {
         match pyre_interpreter::baseobjspace::pick_builtin_obj_checked(
-            w_globals,
+            live_globals(parent_frame_ptr),
             pyre_interpreter::call::take_last_exec_ctx(),
         ) {
             Ok(w_builtin) => w_builtin,
@@ -6412,7 +6439,7 @@ pub extern "C" fn bh_normalize_raise_varargs_with_frame(
          PyFrame; every RAISE_VARARGS emit site must thread portal_frame_reg \
          as the leading ref operand"
     );
-    let exc = exc as PyObjectRef;
+    let mut exc = exc as PyObjectRef;
     let raw_cause = cause as PyObjectRef;
 
     // pyopcode.py:704-722 — cause and exc normalization share
@@ -6425,17 +6452,26 @@ pub extern "C" fn bh_normalize_raise_varargs_with_frame(
         pyre_interpreter::call::set_last_exec_ctx(frame_ctx);
     }
 
-    let cause = if raw_cause.is_null() {
+    let mut cause = if raw_cause.is_null() {
         None
     } else {
         // pyopcode.py:706-707 — cause class-call must mirror the exc
         // class-call (pyopcode.py:711-713) on blackhole re-entry.
         // Force both onto the plain interpreter path so the constructor
         // cannot re-enter the tracer.
+        //
+        // That class call runs Python.  `exc` arrives as a bare operand out of
+        // compiled code and holds no root of its own, so bracket the call the
+        // way `framework.py:1501 get_livevars_for_roots` does — around the
+        // operation, not the function — and read the forwarded value back.
+        let roots = pyre_object::gc_roots::push_roots();
+        let exc_slot = roots.publish(&[exc]);
+        roots.normalize(exc_slot, 1);
         let result = {
             let _plain_guard = pyre_interpreter::call::force_plain_eval();
             pyre_interpreter::eval::normalize_raise_cause(raw_cause)
         };
+        exc = roots.get(exc_slot);
         match result {
             Ok(cause) => Some(cause),
             Err(mut err) => {
@@ -6452,10 +6488,19 @@ pub extern "C" fn bh_normalize_raise_varargs_with_frame(
             // pyopcode.py:711-713 — `space.call_function(w_type)` does
             // not depend on `frame.execution_context`; if the field is
             // null on a valid frame the class-call still proceeds.
+            //
+            // It runs the exception's `__init__`.  `exc` is still unrooted and
+            // the cause normalized above is a fresh nursery object, so both
+            // ride the bracket across the call.
+            let roots = pyre_object::gc_roots::push_roots();
+            let base = roots.publish(&[exc, cause.unwrap_or(std::ptr::null_mut())]);
+            roots.normalize(base, 2);
             let result = {
                 let _plain_guard = pyre_interpreter::call::force_plain_eval();
                 pyre_interpreter::call::call_function_impl_result(exc, &[])
             };
+            exc = roots.get(base);
+            cause = cause.map(|_| roots.get(base + 1));
             match result {
                 Ok(obj) if pyre_object::is_exception(obj) => obj,
                 Ok(obj) => pyre_interpreter::error::exception_from_call_type_error(exc, obj)

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -3736,7 +3736,6 @@ pub fn trace_and_compile_from_bridge(
     // point rather than mid-body or past a dropped loop iteration (a
     // value-stack underflow / off-by-one-iteration result otherwise).
     let resume_state = frame.snapshot_for_tracing();
-    let live_frame_addr = frame as *const PyFrame as usize;
     let mut adopted_walk_end_state = false;
     // Arm the bridge `Terminate` no-replay shortcut for this walk.  The walk
     // epilogue (`run_perfn_walk` in trace.rs) reads this flag: only when armed
@@ -3784,6 +3783,14 @@ pub fn trace_and_compile_from_bridge(
                 // here rather than once outside — `FrameBox` owns a shadow
                 // stack root guard and cannot be cloned.
                 let trace_frame = bridge_frame_root.frame().snapshot_for_tracing();
+                // `sym.set_live_vable_frame_addr` records this word as the
+                // virtualizable the walk writes back through, so it has to be
+                // the frame's address as of this entry: the driver re-enters
+                // the closure per merge point and `snapshot_for_tracing`
+                // allocates, either of which can have moved the frame since the
+                // root was taken.  Read it back out of the root, the same way
+                // `trace_frame` above is.
+                let live_frame_addr = bridge_frame_root.frame() as *const PyFrame as usize;
                 let (action, executed) = trace_bytecode(
                     meta,
                     sym,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -335,6 +335,9 @@ unsafe fn pyre_object_eq_w_trampoline(
         Ok(v) => v,
         Err(e) => {
             pyre_interpreter::baseobjspace::set_pending_hash_error(e);
+            // `a` outlived a user `__eq__` and so may name the pre-collection
+            // copy.  It is stored as a presence token — `take_eq_error` only
+            // tests the slot for null — and never followed.
             pyre_object::dict_eq_hook::signal_eq_error(a);
             false
         }
@@ -355,6 +358,8 @@ unsafe fn pyre_object_hash_w_trampoline(obj: pyre_object::PyObjectRef) -> i64 {
         Ok(h) => h,
         Err(e) => {
             pyre_interpreter::baseobjspace::set_pending_dict_hash_error(e);
+            // A presence token, as in `pyre_object_eq_w_trampoline`: stale
+            // after a user `__hash__`, and only ever tested for null.
             pyre_object::dict_eq_hook::signal_hash_error(obj);
             0
         }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8527,14 +8527,24 @@ fn deliver_exit_frame_exception(
     frame: &mut PyFrame,
     mut err: pyre_interpreter::PyError,
 ) -> PyResult {
-    let mut handler_instr = frame.next_instr();
-    if exit_frame_handler_needs_unwritten_stack(frame) {
+    // `handle_exception` normalizes the exception, records a traceback and can
+    // run a trace function, all of which allocate.  The frame reaching this
+    // entry is the movable kind — `ll_portal_runner_shim` carries the nursery
+    // `PyFrame` a trace built — so the argument names the abandoned copy once a
+    // minor collection has run.  Read it back out of the root for the handler
+    // pc write and for the resumed interpretation, which would otherwise pin
+    // the dead address into `handle_jitexception`'s own root.
+    let mut frame_root = FrameRoot::new(frame);
+    let mut handler_instr = frame_root.frame().next_instr();
+    if exit_frame_handler_needs_unwritten_stack(frame_root.frame()) {
         return Err(err);
     }
-    screen_frame_already_recorded(frame as *const PyFrame, &mut err);
-    if pyre_interpreter::eval::handle_exception(frame, &mut err, &mut handler_instr) {
-        frame.set_last_instr_from_next_instr(handler_instr);
-        handle_jitexception(frame)
+    screen_frame_already_recorded(frame_root.frame() as *const PyFrame, &mut err);
+    if pyre_interpreter::eval::handle_exception(frame_root.frame(), &mut err, &mut handler_instr) {
+        frame_root
+            .frame()
+            .set_last_instr_from_next_instr(handler_instr);
+        handle_jitexception(frame_root.frame())
     } else {
         Err(err)
     }

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -8581,14 +8581,26 @@ pub(crate) fn portal_runner_result(frame: &mut PyFrame) -> PyResult {
     let mut frame_root = FrameRoot::new(frame);
     frame_root.frame().fix_array_ptrs();
     let _frame_guard = pyre_interpreter::eval::install_current_frame(frame_root.frame());
-    portal_runner_dispatch(frame_root.frame())
+    portal_runner_dispatch(&mut frame_root)
 }
 
-fn portal_runner_dispatch(frame: &mut PyFrame) -> PyResult {
-    if let Some(result) = try_function_entry_jit(frame) {
+/// The dispatch half of `portal_runner_result`, taking the caller's
+/// [`FrameRoot`] rather than a raw frame.
+///
+/// `try_function_entry_jit` runs compiled code, and it roots the frame only for
+/// its own body: the root is gone by the time it hands back `None`.  The frame
+/// reaching this entry is the one kind that moves — `ll_portal_runner_shim`
+/// receives the nursery `PyFrame` `emit_new_pyframe_inline_with_params` built,
+/// not an interpreter frame allocated old-gen and stationary — so a collection
+/// inside that compiled run leaves the address passed in naming a corpse whose
+/// `locals_cells_stack_w` is a pre-collection array.  Read the frame back out
+/// of the root, the way `eval_with_jit_inner` already does at its own
+/// `try_function_entry_jit` / `handle_jitexception` pair.
+fn portal_runner_dispatch(frame_root: &mut FrameRoot) -> PyResult {
+    if let Some(result) = try_function_entry_jit(frame_root.frame()) {
         result
     } else {
-        handle_jitexception(frame)
+        handle_jitexception(frame_root.frame())
     }
 }
 

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3208,6 +3208,11 @@ fn frontend_global_object(w_code: *const (), name: &str) -> Option<pyre_object::
     {
         return Some(w_value);
     }
+    // That lookup reaches a user `__getitem__` on a non-dict mapping, and a
+    // dict is one of the two kinds a minor collection relocates.  Re-read the
+    // globals off the code object, whose field the collector forwards, rather
+    // than reuse the pointer from before the call.
+    let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
     let w_builtin = pyre_interpreter::baseobjspace::finditem_str(w_globals, "__builtins__")
         .ok()
         .flatten()?;

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -3210,8 +3210,9 @@ fn frontend_global_object(w_code: *const (), name: &str) -> Option<pyre_object::
     }
     // That lookup reaches a user `__getitem__` on a non-dict mapping, and a
     // dict is one of the two kinds a minor collection relocates.  Re-read the
-    // globals off the code object, whose field the collector forwards, rather
-    // than reuse the pointer from before the call.
+    // globals off the code object rather than reuse the pointer from before the
+    // call: `PyCode` is minted through `malloc_typed_stable` (`pycode.rs:664`)
+    // and so keeps its address, and the collector forwards its `w_globals`.
     let w_globals = unsafe { pyre_interpreter::w_code_get_w_globals(w_code) };
     let w_builtin = pyre_interpreter::baseobjspace::finditem_str(w_globals, "__builtins__")
         .ok()

--- a/pyre/pyre-object/src/gc_hook.rs
+++ b/pyre/pyre-object/src/gc_hook.rs
@@ -543,6 +543,31 @@ pub fn try_gc_remove_root(slot: *mut *mut u8) -> bool {
     }
 }
 
+/// Signature of the host-side reporter that names whoever still points at a
+/// GC array a collection has already moved. `pyre-object` sees only the array;
+/// the interpreter owns the frame chain the array hangs off, so it installs
+/// this and reports the holder's identity and generation. Returns whether a
+/// holder was found.
+pub type StaleArrayHolderHookFn = fn(stale_addr: usize) -> bool;
+
+majit_gc::global_hook!(static STALE_ARRAY_HOLDER_HOOK: StaleArrayHolderHookFn);
+
+/// Install the stale-array holder reporter. Overwrites any previously-
+/// installed hook.
+pub fn register_stale_array_holder_hook(hook: StaleArrayHolderHookFn) {
+    STALE_ARRAY_HOLDER_HOOK.set(Some(hook));
+}
+
+/// Ask the installed reporter to describe whoever still points at
+/// `stale_addr`. Returns `false` when no hook is installed, which is the
+/// answer a bare object-space build (unit tests, the L1 stepping stone) gives.
+pub fn report_stale_array_holder(stale_addr: usize) -> bool {
+    match STALE_ARRAY_HOLDER_HOOK.get() {
+        Some(f) => f(stale_addr),
+        None => false,
+    }
+}
+
 /// Signature of the host-side "is GC-managed" predicate. Callers
 /// (host-side allocators with mixed `try_gc_alloc_stable` /
 /// `std::alloc` allocation paths during the L1/L2 stepping-stone

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -941,6 +941,14 @@ impl FixedObjectArray {
             unsafe { self.items_mut_ptr().add(index).write(value) };
             return;
         }
+        // `FORWARDED_MARKER` sets every flag bit, so the test above cannot
+        // tell an array a minor collection already moved from a live old one.
+        // Report it here, where the array and the store that reached it are
+        // both still named, instead of one frame deeper where the barrier sees
+        // only a type id past the end of the type table.
+        if unsafe { (*header).is_forwarded() } {
+            stale_array_abort(self as *mut Self as usize, index);
+        }
         let _roots = crate::gc_roots::push_roots();
         let root_base = _roots.base();
         _roots.pin_root(self as *mut Self as PyObjectRef);
@@ -969,6 +977,29 @@ impl FixedObjectArray {
     pub fn swap(&mut self, a: usize, b: usize) {
         self.as_mut_slice().swap(a, b);
     }
+}
+
+/// Out-of-line half of [`FixedObjectArray::set_ref`]'s forwarded-header check.
+///
+/// A forwarded header means the array is a nursery corpse: the collection that
+/// moved it left this holder's field naming the old copy.  Print the live copy
+/// and hand the address to whoever can name the holder before aborting, so the
+/// surviving question is only which field kept the pre-collection pointer.
+#[cold]
+#[inline(never)]
+fn stale_array_abort(array_addr: usize, index: usize) -> ! {
+    let header = unsafe { majit_gc::header::header_of(array_addr) };
+    let moved_to = unsafe { majit_gc::header::GcHeader::forwarding_address(header) };
+    eprintln!(
+        "STALE ARRAY: FixedObjectArray::set_ref(index={index}) reached {array_addr:#x}, \
+         already moved to {moved_to:#x}"
+    );
+    let named = crate::gc_hook::report_stale_array_holder(array_addr);
+    panic!(
+        "FixedObjectArray::set_ref on {array_addr:#x}: a minor collection moved this \
+         array to {moved_to:#x} and its holder kept the pre-collection pointer \
+         (holder named: {named})"
+    );
 }
 
 impl Index<usize> for FixedObjectArray {

--- a/pyre/pyre-object/src/object_array.rs
+++ b/pyre/pyre-object/src/object_array.rs
@@ -994,6 +994,15 @@ fn stale_array_abort(array_addr: usize, index: usize) -> ! {
         "STALE ARRAY: FixedObjectArray::set_ref(index={index}) reached {array_addr:#x}, \
          already moved to {moved_to:#x}"
     );
+    // The holder is not on the live frame chain in any observed occurrence, so
+    // the walk below cannot name it.  Capture the Rust stack here instead: this
+    // arm is `#[cold]` and ends the process, so the cost is irrelevant and the
+    // return addresses are the only thing that names the caller that kept the
+    // pre-collection pointer.
+    eprintln!(
+        "STALE ARRAY backtrace:\n{}",
+        std::backtrace::Backtrace::force_capture()
+    );
     let named = crate::gc_hook::report_stale_array_holder(array_addr);
     panic!(
         "FixedObjectArray::set_ref on {array_addr:#x}: a minor collection moved this \


### PR DESCRIPTION
Sixteen commits: fifteen close the GC rooting holes a whole-program collection census reports, and one settles what `gc.collect()` is supposed to answer.

## The census, and what it found

`gc-root-reachability` answered per charon artefact, and one artefact is not one program. `pyre-jit.ullbc` carries the portal and the blackhole but only 575 of `pyre-interpreter`'s bodies, so its closure was **77 / 7615** and the liveness scan over it reported nothing — because nothing in it reached a seed, not because the crate was clean.

`framework::Joined` merges `CallGraph`s across artefacts and `project()` maps a joined node set back onto one artefact's def ids, so `liveness::scan` gets the whole-program reachability. `GC_JOIN_WITH=build/llbc/pyre-interpreter.ullbc` lifts pyre-jit to **240 / 7615**.

| | alone | joined |
|---|---|---|
| pyre-jit closure | 77 / 7615 | **240 / 7615** |
| pyre-jit **frame** findings | 0 (vacuous) | **3 real → fixed → 0** |
| pyre-interpreter closure | 5316 / 41565 | 5316 — **the join admits 0** |

So the reverse direction is closed too: pyre-interpreter's census was never vacuous, and only pyre-jit needed the join.

### The trap in the join

`ItemMeta::name_path` renders an inherent `impl` block as the opaque segment `<Impl>`, so **`PyFrame::new` and `FrameDebugData::new` are both `pyframe::<Impl>::new`**. Joining on that spelling merged them and invented an edge from every caller of one to every callee of the other — `getorcreate_debug_data`, which only allocates, came out reaching `call_user_function_with_args`, and pyre-interpreter grew 7 frame findings that do not exist.

"Widening is safe for a may-collect analysis" is false when the widening comes from a fabricated identity. Over-bracketing is conservatism; a fabricated path is a wrong answer with a citation. The rule the last commit implements: **a name one artefact carries more than once is not a join key** — each occurrence keeps its own node. The join line now reports both counts (1341 spellings merged across artefacts, 2430 held apart).

### The repairs

Each one re-reads its operand after the call that can collect, per `rpython/memory/gctransform/framework.py:1501-1508 get_livevars_for_roots`, and each bracket is narrow — per collecting operation, not per function — so the tail of the body stays scanned.

- `bh_load_global_fn` / `bh_load_from_dict_or_globals_fn` read the frame **and** the globals again in the builtins leg after `finditem_str`
- `bh_call_fn_impl` re-derefs the frame each iteration across `descr_repr`, which fsdecodes the filename into `call_registered_decode_error_handler`
- `bh_normalize_raise_varargs_with_frame` carries `exc` across both class calls and the normalized cause across the second
- `frontend_global_object` re-reads the globals for `__builtins__`
- the interpreter side anchors the running frame across the opcode steps that run Python, hands the frame back from `bytecode_only_trace`, and roots the descriptor operands `get_and_call_function` re-reads after `__get__`

Two sites were adjudicated rather than fixed: `dict_eq_hook::signal_eq_error` and `signal_hash_error` store the pointer as a presence token — `take_*_error` only tests it for null — so a stale one is never followed. That is recorded at the call.

## `gc.collect()` — measured, not inferred

A forwarded report said `gc.collect()` returning None violates the 3.14 contract and that `extra_tests/snippets/stdlib_gc.py` proves it. Both halves needed checking.

**What pypy actually answers.** `interp_gc.py` reads as though `collect` has no return value: the `return space.newint(0)` that closed it from `01b045acd645` (2016) is still in the file, but `b5632df5b6e0` (2018) split `_run_finalizers` out of `collect` and the statement went with the extracted half, where neither caller reads it. Rather than infer intent from that, I ran the interpreter:

```
$ pypy3 -c 'import gc; print(repr(gc.collect()), repr(gc.collect(-1)))'
None None                       # PyPy 7.3.22 / 3.11.15
```

A full differential probe of the module against pyre agrees on every other `collect` and `get_objects` case, including `__index__` conversion and every TypeError. The two remaining differences are error-message wording, which is reference-styled across the whole interpreter by design.

**Why the snippet is not evidence.** `.github/workflows/pyre-ci.yml` runs `extra_tests/run.py --gated-only`; `stdlib_gc.py` carries no `# pyre-check: gate=1`, so **CI has never run it**, and `git log` shows it landed in #822 — the same commit as the implementation it contradicts. It has failed at line 6 since the day it was added.

**What this PR changes.** Nothing in `module/gc/mod.rs`: pyre already answers exactly what pypy answers. The snippet asserted a contract the tree deliberately does not implement, in a file CI cannot enforce, while the pypy behaviour was already pinned — correctly, and graded against the pypy oracle — in `bench/synth/gc_pypy_frontend.py`. It now asserts the argument binding, the `__index__` conversion, the TypeError cases and `get_objects()`, all of which cpython 3.14.6, pypy 7.3.22 and both backends answer alike, and it carries `gate=1` so CI runs it.

> **One line is still open for the reviewer.** If the intent is that `gc.collect()` should answer an int, the change is `Ok(w_none())` → `Ok(w_int_new(0))` in `module/gc/mod.rs`. It diverges from the running pypy, and it requires deleting `assert gc.collect(generation) is None` from `gc_pypy_frontend.py`, whose only oracle is pypy. I did not take it, because every authority I could check — the vendored source, the shipped interpreter, and the gated fixture — says None.

## Gate

Rebased onto `origin/main` (`01b740aedaf`, #1370); one conflict, in `pytraceback.rs:159`, resolved to origin/main, which applies the read-back rule our side only documented.

| | |
|---|---|
| llbc, 4 crates | `--check` RC=0, fingerprints match the tree |
| `cargo test --all --no-default-features --features dynasm` | RC=0 |
| `check.py --backend dynasm,cranelift` | **446/446 · 446/446 ALL PASSED** |
| `extra_tests/run.py --gated-only` | **68/68** on cpython, dynasm and cranelift |
| jitstats drift | none |
| raise-from + frame stress, 2 backends × 2 nursery sizes | 40/40 |
| census, re-run after the repairs | 240/7615, frame findings **0** |
| `get_objects()` marker assertion, 2 backends × 3 nursery sizes × 10 | 60/60 |

— *authored by Claude*
