### PR TITLE
quasiimmut watcher fixes; the for_iter gate's loop region as the backedge's natural loop

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -3640,6 +3640,14 @@ pub trait QuasiImmutHandle: Send + Sync + std::fmt::Debug {
     /// `quasiimmut.py:72-75 register_loop_token`, reached from
     /// `compile.py:204-207`.
     fn register_loop_token(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+    /// Identity of the instance behind the handle.
+    ///
+    /// `heap.py:821-823` keys `quasi_immutable_deps` by the `QuasiImmut`
+    /// itself, so one instance is one entry however many reads found it. A
+    /// handle is minted per read, so comparing handles would let repeated
+    /// markers for one instance each register the loop again.
+    fn instance_identity(&self) -> usize;
 }
 
 /// `quasiimmut.py:113-158 QuasiImmutDescr` — the descr a recorded

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -1726,7 +1726,7 @@ impl OptContext {
         if !self
             .quasi_immutable_deps
             .iter()
-            .any(|seen| std::sync::Arc::ptr_eq(seen, &dep))
+            .any(|seen| seen.instance_identity() == dep.instance_identity())
         {
             self.quasi_immutable_deps.push(dep);
         }

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -1742,7 +1742,7 @@ impl Optimizer {
         if !self
             .quasi_immutable_deps
             .iter()
-            .any(|seen| std::sync::Arc::ptr_eq(seen, &dep))
+            .any(|seen| seen.instance_identity() == dep.instance_identity())
         {
             self.quasi_immutable_deps.push(dep);
         }

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -2213,12 +2213,59 @@ impl Default for UnrollOptimizer {
     }
 }
 
+#[cfg(test)]
+mod quasi_immutable_dep_tests {
+    #[derive(Debug)]
+    struct FakeHandle(std::sync::Arc<()>);
+
+    impl majit_ir::QuasiImmutHandle for FakeHandle {
+        fn is_current(&self) -> bool {
+            true
+        }
+
+        fn register_loop_token(&self, _flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {}
+
+        fn instance_identity(&self) -> usize {
+            std::sync::Arc::as_ptr(&self.0) as usize
+        }
+    }
+
+    fn handle(instance: &std::sync::Arc<()>) -> std::sync::Arc<dyn majit_ir::QuasiImmutHandle> {
+        std::sync::Arc::new(FakeHandle(instance.clone()))
+    }
+
+    /// `heap.py:821-823` keys `quasi_immutable_deps` by the `QuasiImmut`, so an
+    /// instance is one entry however many reads found it. A handle is minted per
+    /// read, so deduping on the handle instead lets two markers for one instance
+    /// each register the loop again.
+    #[test]
+    fn two_handles_for_one_instance_merge_to_one_dep() {
+        let instance = std::sync::Arc::new(());
+        let first = handle(&instance);
+        let second = handle(&instance);
+        assert!(
+            !std::sync::Arc::ptr_eq(&first, &second),
+            "the two reads must mint distinct handles or this proves nothing",
+        );
+
+        let mut deps = vec![first];
+        super::merge_quasi_immutable_deps(&mut deps, &[second]);
+        assert_eq!(deps.len(), 1);
+
+        super::merge_quasi_immutable_deps(&mut deps, &[handle(&std::sync::Arc::new(()))]);
+        assert_eq!(deps.len(), 2, "a different instance is a different dep");
+    }
+}
+
 pub(crate) fn merge_quasi_immutable_deps(
     dst: &mut Vec<std::sync::Arc<dyn majit_ir::QuasiImmutHandle>>,
     src: &[std::sync::Arc<dyn majit_ir::QuasiImmutHandle>],
 ) {
     for dep in src {
-        if !dst.iter().any(|seen| std::sync::Arc::ptr_eq(seen, dep)) {
+        if !dst
+            .iter()
+            .any(|seen| seen.instance_identity() == dep.instance_identity())
+        {
             dst.push(dep.clone());
         }
     }

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5144,6 +5144,10 @@ impl majit_ir::QuasiImmutHandle for RecordedQuasiImmut {
     fn register_loop_token(&self, flag: &std::sync::Arc<std::sync::atomic::AtomicBool>) {
         self.0.register_loop_token(flag);
     }
+
+    fn instance_identity(&self) -> usize {
+        std::sync::Arc::as_ptr(&self.0) as usize
+    }
 }
 
 /// `pyjitpl.py:1081 QuasiImmutDescr(cpu, structbox.getref_base(), fielddescr,

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7398,25 +7398,48 @@ fn function_entry_trace_is_jit_safe(code: &pyre_interpreter::CodeObject) -> bool
 }
 
 /// Return the pc ranges that make up the natural loop region whose header is
-/// `loop_header_pc`: the loop body, plus every out-of-line exception handler
-/// that rejoins the body through a backward jump. An empty result means
-/// `loop_header_pc` has no backedge and so names no region.
+/// `loop_header_pc`: the header, plus every instruction that can reach one of
+/// its backedges without passing through the header again. An empty result
+/// means `loop_header_pc` has no backedge and so names no region.
 ///
-/// The region is a set of ranges rather than one span because a handler is laid
+/// This is the natural loop of the backedge, computed over
+/// [`crate::jit::codewriter::code_successors`], which already carries the
+/// exception edges — so an out-of-line handler that rejoins the body is in the
+/// region exactly when control really can return through it, with no appeal to
+/// where the handler was laid out. A `return` leg is reachable from the header
+/// but reaches no backedge, so it stays outside.
+///
+/// It is deliberately not the header's strongly connected component. An inner
+/// loop's SCC is its *outer* loop: leaving the inner loop, finishing the outer
+/// body and taking the outer backedge does return to the inner header, so the
+/// intersection of "reaches" and "is reached by" swallows the enclosing loop
+/// and gates the inner backedge on `FOR_ITER`s outside it. Stopping the walk at
+/// the header is what keeps a nested loop scoped to itself.
+///
+/// The result is a set of ranges rather than one span because a handler is laid
 /// out after the code that follows its `try`, not next to the body it protects.
-/// Whatever sits between the two — a later comprehension, a disjoint loop —
-/// belongs to neither and cannot run in this backedge's trace, so covering the
-/// gap would gate the backedge on `FOR_ITER`s it never reaches. The exception
-/// table names where the out-of-line code begins, which is what lets a
-/// rejoining jump widen the region back to its own handler instead of across
-/// the gap.
+/// Whatever sits between the two belongs to neither and cannot run in this
+/// backedge's trace.
+///
+/// Reading the ranges off the exception table's own `(start, end, target)`
+/// extents does not work, and is not what carries the handlers here. A
+/// rejoining jump is emitted after the block's `PopBlock` / `PopExcept`, so
+/// `assemble_exception_table` stamps it with the popped handler and no entry
+/// covers it — the extents name where a handler protects, never where control
+/// re-enters from. The successor edges do carry it, because the handler's own
+/// instructions reach the backedge.
 fn loop_region_ranges(
     code: &pyre_interpreter::CodeObject,
     loop_header_pc: usize,
 ) -> Vec<std::ops::RangeInclusive<usize>> {
     use pyre_interpreter::Instruction as I;
 
-    let mut backward_jumps: Vec<(usize, usize)> = Vec::new();
+    let num_instrs = code.instructions.len();
+    if loop_header_pc >= num_instrs {
+        return Vec::new();
+    }
+
+    let mut backedge_sources: Vec<usize> = Vec::new();
     let mut arg_state = pyre_interpreter::OpArgState::default();
     for (pc, unit) in code.instructions.iter().copied().enumerate() {
         let (instr, op_arg) = arg_state.get(unit);
@@ -7429,73 +7452,59 @@ fn loop_region_ranges(
             }
             _ => None,
         };
-        if let Some(target) = target {
-            backward_jumps.push((pc, target));
+        if target == Some(loop_header_pc) {
+            backedge_sources.push(pc);
         }
     }
-
-    let Some(body_end) = backward_jumps
-        .iter()
-        .filter(|(_, target)| *target == loop_header_pc)
-        .map(|(pc, _)| *pc)
-        .max()
-    else {
+    if backedge_sources.is_empty() {
         return Vec::new();
-    };
+    }
 
-    // The exception table is keyed by byte offset; pyre's `pc` is the
-    // instruction-unit index (two bytes per unit). Only the handlers laid out
-    // past the body can start an out-of-line block; one inside the body is
-    // already covered.
-    let mut handler_starts: Vec<usize> =
-        pyre_interpreter::pycode::decode_exceptiontable(&code.exceptiontable)
-            .map(|entry| entry.target as usize / 2)
-            .filter(|start| *start > body_end)
-            .collect();
-    handler_starts.sort_unstable();
-
-    let mut ranges = vec![loop_header_pc..=body_end];
-    loop {
-        let rejoins: Vec<usize> = backward_jumps
-            .iter()
-            .filter(|(pc, target)| {
-                !ranges.iter().any(|range| range.contains(pc))
-                    && ranges.iter().any(|range| range.contains(target))
-            })
-            .map(|(pc, _)| *pc)
-            .collect();
-        if rejoins.is_empty() {
-            return ranges;
-        }
-        for pc in rejoins {
-            // Take the earliest handler that still starts at or before the
-            // jump: a handler runs on through the ones nested inside it, so
-            // the block this jump closes begins at the outermost of them.
-            // Without a handler to name a start the jump is not an out-of-line
-            // rejoin, and the span back to the body is kept whole rather than
-            // guessed at.
-            //
-            // With several disjoint handlers laid out after the body this
-            // swallows the bytecode between the earliest one and the jump.
-            // `loop_region_for_iter_bodies_all_jit_safe`, the one reader, only
-            // loses inlining —
-            // an unsafe `FOR_ITER` in the swallowed span declines a loop that
-            // could not reach it — while narrowing to the handler nearest the
-            // jump would let it admit a frame whose unsafe `FOR_ITER` really
-            // does run.  The pessimistic side is the one that cannot be wrong,
-            // so it stands until the ranges are built from the exception
-            // table's `(start, end, target)` extents, which name the block a
-            // jump belongs to instead of inferring it from target order.
-            let start = handler_starts
-                .iter()
-                .copied()
-                .find(|start| *start <= pc)
-                .unwrap_or(body_end + 1);
-            ranges.push(start..=pc);
+    let succ = crate::jit::codewriter::code_successors(code);
+    let mut pred: Vec<Vec<usize>> = vec![Vec::new(); num_instrs];
+    for (pc, nexts) in succ.iter().enumerate() {
+        for &next in nexts {
+            pred[next].push(pc);
         }
     }
-}
 
+    // Seeding the header first is what bounds the walk: it is already in the
+    // region, so no predecessor edge is ever followed out through it.
+    let mut in_region = vec![false; num_instrs];
+    in_region[loop_header_pc] = true;
+    let mut stack: Vec<usize> = Vec::new();
+    for source in backedge_sources {
+        if source < num_instrs && !in_region[source] {
+            in_region[source] = true;
+            stack.push(source);
+        }
+    }
+    while let Some(pc) = stack.pop() {
+        for &prev in &pred[pc] {
+            if !in_region[prev] {
+                in_region[prev] = true;
+                stack.push(prev);
+            }
+        }
+    }
+
+    let mut ranges: Vec<std::ops::RangeInclusive<usize>> = Vec::new();
+    let mut run_start: Option<usize> = None;
+    for pc in 0..num_instrs {
+        match (in_region[pc], run_start) {
+            (true, None) => run_start = Some(pc),
+            (false, Some(start)) => {
+                ranges.push(start..=pc - 1);
+                run_start = None;
+            }
+            _ => {}
+        }
+    }
+    if let Some(start) = run_start {
+        ranges.push(start..=num_instrs - 1);
+    }
+    ranges
+}
 /// Apply the FOR_ITER safety gate only to loops inside the natural loop region
 /// whose backedge is being considered. `interp_jit.py:118-120` invokes
 /// `can_enter_jit` for that backedge. Later disjoint loops remain outside the
@@ -13698,6 +13707,137 @@ mod tests {
             &code,
             outer_header
         ));
+    }
+
+    /// A `return` leg is reachable from the header and never returns to it, so
+    /// it is not in the region and its `FOR_ITER`s cannot run in this
+    /// backedge's trace.
+    ///
+    /// The span from the header to the last backedge contains that leg, so
+    /// reading the region off the layout declines the loop for an unsafe
+    /// `FOR_ITER` the loop can only reach on its way out.
+    #[test]
+    fn an_inner_loops_region_excludes_the_loop_that_encloses_it() {
+        use pyre_interpreter::{Instruction as I, compile_exec};
+        // Two backedges: the outer `for`, and the inlined comprehension nested
+        // in its body. Control does leave the inner loop, finish the outer body
+        // and come back round to the inner header — so the inner header's
+        // strongly connected component is the whole outer loop. Its natural
+        // loop is not.
+        let module = compile_exec(
+            "def run(rows, k):\n    total = 0\n    for row in rows:\n        total += sum([y * k for y in row])\n    return total\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "run");
+
+        let mut headers: Vec<usize> = Vec::new();
+        let mut arg_state = pyre_interpreter::OpArgState::default();
+        for (pc, unit) in code.instructions.iter().copied().enumerate() {
+            let (instr, op_arg) = arg_state.get(unit);
+            let target = match instr {
+                I::JumpBackward { delta } => {
+                    Some(skip_caches(&code, pc + 1).saturating_sub(delta.get(op_arg).as_usize()))
+                }
+                I::JumpBackwardNoInterrupt { delta } => {
+                    Some((pc + 1).saturating_sub(delta.get(op_arg).as_usize()))
+                }
+                _ => None,
+            };
+            if let Some(target) = target {
+                headers.push(target);
+            }
+        }
+        headers.sort_unstable();
+        headers.dedup();
+        assert_eq!(
+            headers.len(),
+            2,
+            "fixture must nest one loop inside another"
+        );
+        let (outer_header, inner_header) = (headers[0], headers[1]);
+
+        let inner = loop_region_ranges(&code, inner_header);
+        let outer = loop_region_ranges(&code, outer_header);
+        assert!(
+            !inner.is_empty() && !outer.is_empty(),
+            "both have backedges"
+        );
+
+        assert!(
+            !inner.iter().any(|range| range.contains(&outer_header)),
+            "the enclosing loop's header is not in the inner loop's region",
+        );
+        assert!(
+            outer.iter().any(|range| range.contains(&inner_header)),
+            "the inner header is in the enclosing loop's region",
+        );
+        let count = |ranges: &[std::ops::RangeInclusive<usize>]| -> usize {
+            ranges
+                .iter()
+                .map(|range| range.end() + 1 - range.start())
+                .sum()
+        };
+        assert!(
+            count(&inner) < count(&outer),
+            "the inner region is the smaller of the two, not the same set",
+        );
+    }
+
+    #[test]
+    fn loop_region_excludes_a_return_leg_inside_the_body_span() {
+        use pyre_interpreter::{Instruction as I, compile_exec};
+        let module = compile_exec(
+            "def run(items, k):\n    out = []\n    for x in items:\n        if x < 0:\n            return [str(y) for y in range(k)]\n        out.append(x)\n    return out\n",
+        )
+        .expect("test code should compile");
+        let code = function_code_from_module(&module, "run");
+
+        let mut header = usize::MAX;
+        let mut last_backedge = 0usize;
+        let mut arg_state = pyre_interpreter::OpArgState::default();
+        for (pc, unit) in code.instructions.iter().copied().enumerate() {
+            let (instr, op_arg) = arg_state.get(unit);
+            let target = match instr {
+                I::JumpBackward { delta } => {
+                    Some(skip_caches(&code, pc + 1).saturating_sub(delta.get(op_arg).as_usize()))
+                }
+                I::JumpBackwardNoInterrupt { delta } => {
+                    Some((pc + 1).saturating_sub(delta.get(op_arg).as_usize()))
+                }
+                _ => None,
+            };
+            if let Some(target) = target {
+                header = header.min(target);
+                last_backedge = last_backedge.max(pc);
+            }
+        }
+        assert!(header != usize::MAX, "fixture must contain a backedge");
+
+        // The comprehension's FOR_ITER is the one on the return leg: it sits
+        // inside the header..=last_backedge span but is not the loop's own.
+        let mut return_leg_for_iter = None;
+        let mut arg_state = pyre_interpreter::OpArgState::default();
+        for (pc, unit) in code.instructions.iter().copied().enumerate() {
+            let (instr, _) = arg_state.get(unit);
+            if matches!(instr, I::ForIter { .. }) && pc > header && pc < last_backedge {
+                return_leg_for_iter = Some(pc);
+            }
+        }
+        let return_leg_for_iter =
+            return_leg_for_iter.expect("fixture must inline the comprehension in the body span");
+
+        let ranges = loop_region_ranges(&code, header);
+        assert!(!ranges.is_empty(), "the header has a backedge");
+        assert!(
+            ranges.iter().any(|range| range.contains(&header)),
+            "the header is in its own region",
+        );
+        assert!(
+            !ranges
+                .iter()
+                .any(|range| range.contains(&return_leg_for_iter)),
+            "a return leg does not reach the header, so it is outside the region",
+        );
     }
 
     #[test]

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -7582,7 +7582,7 @@ fn for_iter_body_is_jit_safe_at(code: &pyre_interpreter::CodeObject, pc: usize) 
     // take now does.
     //
     // The shape no longer reaches it here: #1174 made that walk raise
-    // `callee_inline_blackhole_required` where it raised
+    // `callee_inline_abort` with `blackhole_required` set where it raised
     // `callee_inline_unsupported`, so it stops aborting — 0 in-flight
     // takes and 0 divergences across the whole probe family — which also
     // means this base cannot re-witness the fix end to end; the selection

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -478,6 +478,47 @@ unsafe fn type_object_destructor(obj_addr: usize) {
     drop(unsafe { (*t).quasi_immut_watchers.take() });
 }
 
+/// Reclaim `W_Property`'s `w_fget?` / `w_fset?` instances on sweep.
+///
+/// The instances hang off an `AtomicPtr` that no descr row and no
+/// `gc_ptr_offsets` entry covers, so nothing traces them and a swept property
+/// strands one allocation per watched owner. Upstream needs no such hook: its
+/// `mutate_<name>` is itself a GC pointer.
+///
+/// [`pyre_object::quasiimmut::QuasiImmutField::take`] drops exactly one strong
+/// count, so an in-flight compile holding its own clone keeps the instance
+/// alive and reclaiming here cannot pull the ground out from under it.
+///
+/// # Safety
+///
+/// `obj_addr` must be a live `W_Property` payload the collector is sweeping,
+/// and the collector must call this exactly once.
+unsafe fn property_destructor(obj_addr: usize) {
+    let p = obj_addr as *const pyre_object::descriptor::W_Property;
+    drop(unsafe { (*p).fget_watchers.take() });
+    drop(unsafe { (*p).fset_watchers.take() });
+}
+
+/// The `w_function?` counterpart of [`property_destructor`] for `staticmethod`.
+///
+/// # Safety
+///
+/// As [`property_destructor`], for a `StaticMethod` payload.
+unsafe fn staticmethod_destructor(obj_addr: usize) {
+    let m = obj_addr as *const pyre_object::function::StaticMethod;
+    drop(unsafe { (*m).w_function_watchers.take() });
+}
+
+/// The `classmethod` twin of [`staticmethod_destructor`].
+///
+/// # Safety
+///
+/// As [`property_destructor`], for a `ClassMethod` payload.
+unsafe fn classmethod_destructor(obj_addr: usize) {
+    let m = obj_addr as *const pyre_object::function::ClassMethod;
+    drop(unsafe { (*m).w_function_watchers.take() });
+}
+
 /// Custom trace for `GeneratorIterator` (generator.py GeneratorIterator).
 ///
 /// The suspended frame is held behind an opaque `frame_ptr`
@@ -2020,21 +2061,27 @@ fn build_gc() -> Box<MiniMarkGC> {
     // field each: w_function) — typed payload via `#[pyre_class]`.
     // Pre-registered ahead of the foreign-pytype loop so the GC
     // walker reaches the inline descriptor refs.
-    register_pyre_class(
+    let property_tid = register_pyre_class(
         &mut gc,
         &mut pytype_to_tid,
         <pyre_object::descriptor::W_Property as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
-    register_pyre_class(
+    let staticmethod_tid = register_pyre_class(
         &mut gc,
         &mut pytype_to_tid,
         <pyre_object::function::StaticMethod as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
-    register_pyre_class(
+    let classmethod_tid = register_pyre_class(
         &mut gc,
         &mut pytype_to_tid,
         <pyre_object::function::ClassMethod as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
     );
+    // All three own `QuasiImmutField`s, which the type census does not reach.
+    gc.types.set_destructor(property_tid, property_destructor);
+    gc.types
+        .set_destructor(staticmethod_tid, staticmethod_destructor);
+    gc.types
+        .set_destructor(classmethod_tid, classmethod_destructor);
     // UnionType (PEP 604 `X | Y`) — typed payload via `#[pyre_class]`.
     // Pre-registered ahead of the foreign-pytype loop because that
     // loop's `size_of::<PyObject>()` approximation drops gc_ptr_offsets,

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -15859,7 +15859,7 @@ fn backward_jump_target(
 /// one sequential decode pass so an `EXTENDED_ARG` prefix folds into the
 /// following opcode's argument, matching the edge model of
 /// `find_branch_target_pcs`.
-fn code_successors(code: &CodeObject) -> Vec<Vec<usize>> {
+pub(crate) fn code_successors(code: &CodeObject) -> Vec<Vec<usize>> {
     let num_instrs = code.instructions.len();
     let mut succ: Vec<Vec<usize>> = vec![Vec::new(); num_instrs];
     let mut scan_state = OpArgState::default();

--- a/pyre/pyre-object/src/descriptor.rs
+++ b/pyre/pyre-object/src/descriptor.rs
@@ -186,14 +186,10 @@ pub struct W_Property {
     /// here.  The allocation is [`crate::gc_hook::try_gc_alloc_stable_raw`],
     /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
     /// stated precondition: the lock cannot be remapped out from under a
-    /// holder.  A property the collector reclaims without a prior invalidation
-    /// leaks its instance box, because a GC object's `Drop` never runs — one
-    /// allocation per watched owner, so a program that keeps minting and
-    /// discarding traced descriptors keeps accumulating them rather than
-    /// settling at a fixed cost.  `W_TypeObject` and `Function::mutate_slots`
-    /// carry the same pattern; closing it needs a reclamation hook for a
-    /// collected object's off-heap side allocation, which the collector has
-    /// no notion of today.
+    /// holder.  A GC object's `Drop` never runs, so the field cannot reclaim
+    /// its own instance; `property_destructor` in `pyre-jit/src/eval.rs` takes
+    /// it back on sweep instead.  `W_TypeObject` and `Function::mutate_slots`
+    /// carry the same pattern.
     ///
     /// `w_fdel?` is declared upstream on the same line and gets no watcher
     /// here: no fold bakes `fdel`, so nothing would ever register on it.  A

--- a/pyre/pyre-object/src/function.rs
+++ b/pyre/pyre-object/src/function.rs
@@ -186,8 +186,10 @@ pub struct StaticMethod {
     /// layout.  The allocation is [`crate::gc_hook::try_gc_alloc_stable_raw`],
     /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
     /// stated precondition: the lock cannot be remapped out from under a
-    /// holder, and the compile-time watcher registration resolves this owner
-    /// by the address recording saw.
+    /// holder.  Recording binds the instance onto the marker descr as an
+    /// `Arc`, so the compiler never re-resolves this owner and a sweep
+    /// mid-compile is safe; the sweep hook is `{static,class}method_destructor`
+    /// in `pyre-jit/src/eval.rs`.
     pub w_function_watchers: crate::quasiimmut::QuasiImmutField,
 }
 
@@ -371,8 +373,10 @@ pub struct ClassMethod {
     /// layout.  The allocation is [`crate::gc_hook::try_gc_alloc_stable_raw`],
     /// i.e. non-moving, which is [`crate::quasiimmut::QuasiImmutField`]'s
     /// stated precondition: the lock cannot be remapped out from under a
-    /// holder, and the compile-time watcher registration resolves this owner
-    /// by the address recording saw.
+    /// holder.  Recording binds the instance onto the marker descr as an
+    /// `Arc`, so the compiler never re-resolves this owner and a sweep
+    /// mid-compile is safe; the sweep hook is `{static,class}method_destructor`
+    /// in `pyre-jit/src/eval.rs`.
     pub w_function_watchers: crate::quasiimmut::QuasiImmutField,
 }
 

--- a/pyre/pyre-object/src/quasiimmut.rs
+++ b/pyre/pyre-object/src/quasiimmut.rs
@@ -398,6 +398,40 @@ mod tests {
         assert_eq!(recorded.len(), 0, "a swept list must not grow again");
     }
 
+    /// The premise the sweep hooks rest on. `property_destructor` and its two
+    /// twins in `pyre-jit/src/eval.rs` run when the collector reclaims an owner,
+    /// which can happen while a compile that recorded a read of its field is
+    /// still in flight. Taking the field's reference back must not disturb that
+    /// compile's own.
+    ///
+    /// This is what carrying the instance rather than re-resolving `(owner,
+    /// field index)` bought: the older shape handed the compiler an address to
+    /// resolve later, so reclaiming here would have been a use-after-free.
+    #[test]
+    fn a_swept_owner_hands_back_only_its_own_reference() {
+        let field = QuasiImmutField::new();
+        // What recording bound onto the marker descr.
+        let recorded = field.get_current_qmut_instance();
+        assert_eq!(Arc::strong_count(&recorded), 2, "the field's and ours");
+
+        // The collector sweeps the owner and the destructor runs.
+        drop(field.take());
+        assert_eq!(
+            Arc::strong_count(&recorded),
+            1,
+            "only the compile's is left"
+        );
+
+        // The compile can still finish against it. Reclamation is not
+        // revocation: nothing invalidated the field, so the instance is current
+        // and the registration is recorded rather than born-invalid.
+        assert!(recorded.is_current());
+        let flag = Arc::new(AtomicBool::new(false));
+        recorded.register_loop_token(&flag);
+        assert!(!flag.load(Ordering::Acquire));
+        assert_eq!(recorded.len(), 1);
+    }
+
     /// Recording runs on one thread while any other Python thread can be
     /// mutating the same object. Upstream is safe here only because of the GIL;
     /// pyre has none, so the get-or-create, the push and the unlink have to be


### PR DESCRIPTION
Two follow-ups to #1383, which is now merged.

## 1. Dedup `quasi_immutable_deps` on the instance, not the per-read handle

A parity regression #1383 introduced, found by the Codex review on that PR and
**live in `main` today**.

`quasi_immut_descr` mints a `RecordedQuasiImmut` per read, so the three sites
deduping with `Arc::ptr_eq` compared two distinct handles and never matched:
repeated markers for one instance each pushed an entry and registered the same
loop again. `heap.py` keys `quasi_immutable_deps` by the `QuasiImmut` itself, and
the `(owner pointer, descr index)` key #1383 replaced deduplicated it too.

`QuasiImmutHandle` gains `instance_identity`, answered by the address of the
`Arc<QuasiImmut>` the adapter holds; `optimizeopt/optimizer.rs`,
`optimizeopt/mod.rs` and `optimizeopt/unroll.rs` compare that.

Two notes on scope. The review named only `optimizer.rs`; the same comparison was
in three places, so this fixes the class rather than the instance. And
`optimizeopt/mod.rs` already documented the field as *"Vec-backed set keyed on
instance identity, the way a Python dict keys on the object"* — the comment
described the intended behaviour while the code did something else.

`merge_quasi_immutable_deps` gets a unit test that asserts its two handles are
genuinely distinct before merging, so it reports 2 against an expected 1 under
the previous comparison rather than passing vacuously.

## 2. Reclaim a swept property or method wrapper's watcher instance

`W_Property`'s `w_fget?` / `w_fset?` and `ClassMethod` / `StaticMethod`'s
`w_function?` hold their instance behind an `AtomicPtr` that no descr row and no
`gc_ptr_offsets` entry covers. A GC object runs no `Drop`, so the field could not
reclaim its own instance and each swept owner stranded one allocation — per
owner, so a program that keeps minting and discarding traced descriptors keeps
accumulating them.

`property_destructor`, `staticmethod_destructor` and `classmethod_destructor`
take it back on sweep, attached with `GcTypes::set_destructor` on the three tids,
following `type_object_destructor` and `function_destructor`. Upstream needs no
such hook because its `mutate_<name>` is itself a GC pointer.

This had been recorded as blocked on "the collector has no reclamation hook for
an object's off-heap side allocation". That is not so: `with_destructor_fn` /
`set_destructor` is that hook, run on sweep as the `incminimark.py
call_destructor` analog, and `W_TypeObject` and `Function::mutate_slots` were
already using it. `celldict`'s `ModuleDictStrategy` is covered too, by drop glue
through `storage_box_destructor`. `sys/vm.rs`'s `hooks_watchers` is deliberately
left alone — its owner is itself one permanent process-wide leak, a fixed cost
rather than a per-owner one.

What had actually made it look blocked was a use-after-free that only existed
under the previous design: with `(owner pointer, descr index)` re-resolution, an
owner swept mid-compile left the compiler resolving a dangling pointer. #1383
removed that by carrying the instance as an `Arc`, so an in-flight compile now
holds its own strong count. A test pins exactly that premise — after the field's
reference is taken, the recorded instance is left with one holder and still
accepts a registration.

Also drops two notes that no longer hold: the "collector has no notion of it"
claim above, and the claim that the compile side resolves the owner by the
address recording saw.

### Deliberately not decided here

These hooks call `take()`, which reclaims without unlinking, so loops registered
on a dead owner are never revoked — matching `type_object_destructor`. Whether a
sweep should instead `invalidate()` is a behaviour change that would have to be
uniform across every owner and needs a fixture of its own, so it is filed rather
than folded in. This is not a regression: before this change the instance leaked,
so a dead owner's loops were equally never revoked. Only memory reclamation
changes.

## Gates

All green, measured on the pre-rebase base (`c0183ff96f0`, i.e. #1383's tip):

| gate | result |
|---|---|
| `cargo check --all --no-default-features --features dynasm` | rc=0, no errors |
| `cargo test --all --no-default-features --features dynasm` | rc=0, 161 test binaries ok |
| parity (`--dynasm-only`) | all parity tests pass |
| `cpython_tests --baseline` | 222 PASS / 0 FAIL, no regressions |
| `pyre/check.py --backend dynasm` | 446/446, no jitstats counter movement |

check.py was run at load 6.58 on an otherwise quiet machine. The working tree was
empty afterwards, so nothing re-recorded itself.

The destructors were additionally smoke-tested against a script that mints and
discards 4000 watched owners of each of the three kinds, in four configurations —
dynasm, `PYRE_JIT=0`, `MAJIT_GC_NURSERY_POISON=1`, and `PYPY_GC_NURSERY=4096`.
All four agree, including the two that force many sweeps, and the run confirms a
reassigned `property` still revokes its fold.

The branch has since been rebased onto `6cc6de4a536`, picking up #1385 and #1387.
`cargo check --all` is rc=0 on that base, but the table above predates it, and
#1385 touches GC rooting — so CI on this PR is the verdict for the current base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dependency tracking so equivalent quasi-immutable instances are deduplicated reliably.
  - Preserved active recordings when quasi-immutable field references are released.
  - Added garbage-collection cleanup for property, static method, and class method watchers.
  - Improved loop-region detection for nested loops, returns, and exception-handler paths.

- **Documentation**
  - Clarified watcher ownership, cleanup behavior, and garbage-collection lifecycle.

- **Tests**
  - Added coverage for dependency merging, instance identity handling, loop scoping, and reference lifetime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## 3. Build the `FOR_ITER` gate's loop region as the backedge's natural loop

Independent of 1 and 2 — same work branch, separate commit.

`loop_region_ranges`'s doc already called its result the "natural loop region",
but the computation was a heuristic: the contiguous span from the header to the
last backedge source, then one widening pass per backward jump that rejoined the
span from outside, taking that block's start from the earliest exception-table
*target* at or before the jump and falling back to `body_end + 1` when none
qualified. Its own comment conceded that several disjoint handlers laid out after
the body make it "swallow the bytecode between the earliest one and the jump".

It now computes the actual natural loop of the backedge over
`jit::codewriter::code_successors`: the header, plus every pc that reaches a
backedge source without passing through the header. `code_successors` becomes
`pub(crate)`.

That edge set already carries the exception edges, so a handler that rejoins the
body is in the region exactly when control can return through it — with no appeal
to where the handler was laid out — and a `return` leg sitting inside the old
span reaches no backedge and drops out.

**Not the header's SCC.** This was the first re-scope attempted, and check.py
caught it: three fixtures fell to `loops_compiled 0`
(`synth/gc_id_stable_across_move`, `synth/list_append_virtual_payload`,
`synth/minmax_key_rooting`), all nested-loop shapes. An inner loop's SCC *is* its
outer loop — control can leave the inner loop, finish the outer body and take the
outer backedge back to the inner header — so the SCC gates an inner backedge on
`FOR_ITER`s outside it. Seeding the header into the region before walking
predecessors is what bounds the walk. `an_inner_loops_region_excludes_the_loop_
that_encloses_it` pins this and was confirmed to fail on the SCC formulation
before being kept.

**The route the old doc proposed is refuted, and the code now says so.** It named
the exception table's own `(start, end, target)` extents as its eventual
replacement. That does not work: a rejoining jump is emitted after the block's
`PopBlock`/`PopExcept`, so `assemble_exception_table` stamps it with the popped
handler and no entry covers it — leaving the same `body_end + 1` fallback and a
strictly wider region than the heuristic it would replace.

Gates, all against the existing jitstats baseline with nothing re-recorded:
`check.py --backend dynasm` **447/447 ALL PASSED**; `cargo test --all` 40 suites
0 failed; parity all pass; CPython suite 222 PASS / 0 FAIL / no regressions.

## 4. Name the real constructor in the in-flight `FOR_ITER` note

A comment in `eval.rs` said #1174 made that walk raise
`callee_inline_blackhole_required`. No such function exists anywhere in the tree.
The constructor is `DispatchError::callee_inline_abort`, which takes
`blackhole_required`; `callee_inline_unsupported` is the sibling passing `false`.

Not cosmetic: a later investigation cited "exactly ONE constructor
(`callee_inline_blackhole_required`)" as a load-bearing fact about why an abort
image was allegedly unconsumed, and that citation came from this comment. A
fictional symbol name in a comment reads as a citation and gets propagated as one.
