### PR TITLE
Windows module surface and constant values; capture the merge-point GuardFutureCondition at the jit_merge_point op's JitCode pc

### DIFF
--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -103,6 +103,7 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 # HANDLE types match at the boundary.
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
+    "Win32_Globalization",
     "Win32_Media_Audio",
     "Win32_Networking_WinSock",
     "Win32_Storage_FileSystem",

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -104,6 +104,7 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 # Kept on the same 0.61 line rustpython-host_env's nt module resolves to, so
 # HANDLE types match at the boundary.
 windows-sys = { version = "0.61", features = [
+    "Win32_Devices_Bluetooth",
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_Media_Audio",

--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -98,7 +98,9 @@ lz4_flex = { version = "0.13", default-features = false, features = [
 # (PlaySoundW in Media_Audio, Beep and MessageBeep in
 # System_Diagnostics_Debug), and `_winapi.NeedCurrentDirectoryForExePath`
 # (System_Environment), and the OVERLAPPED record `_winapi.Overlapped` owns
-# with the CancelIoEx/GetOverlappedResult pair that drives it (System_IO).
+# with the CancelIoEx/GetOverlappedResult pair that drives it (System_IO), and
+# the UuidFromStringW/UuidToStringW pair an AF_HYPERV address is spelled with
+# (System_Rpc).
 # Kept on the same 0.61 line rustpython-host_env's nt module resolves to, so
 # HANDLE types match at the boundary.
 windows-sys = { version = "0.61", features = [
@@ -115,6 +117,7 @@ windows-sys = { version = "0.61", features = [
     "Win32_System_IO",
     "Win32_System_LibraryLoader",
     "Win32_System_Pipes",
+    "Win32_System_Rpc",
     "Win32_System_Threading",
     "Win32_UI_Shell",
     "Win32_UI_WindowsAndMessaging",

--- a/pyre/pyre-interpreter/src/_structseq.rs
+++ b/pyre/pyre-interpreter/src/_structseq.rs
@@ -344,6 +344,11 @@ pub(crate) fn structseq_descr_new(args: &[PyObjectRef]) -> Result<PyObjectRef, P
         return Err(PyError::type_error("structseq() requires class + sequence"));
     }
     let cls = args[0];
+    // A type built by [`disallow_instantiation`] has no `tp_new` upstream, so
+    // its `__new__` is `object.__new__`, which refuses it.  The descriptor is
+    // reached directly as `type(sys.flags).__new__(...)`, past the check
+    // `type.__call__` makes.
+    crate::call::check_type_instantiable(cls)?;
     let n_seq = read_class_int(cls, "n_sequence_fields").unwrap_or(0) as usize;
     let n_fields = read_class_int(cls, "n_fields").unwrap_or(n_seq as i64) as usize;
     let (name, extra_names) = {
@@ -579,6 +584,17 @@ pub fn make_struct_seq_with_extra(
     extra_field_names: &[&'static str],
 ) -> PyObjectRef {
     make_struct_seq_impl(name, field_names, extra_field_names)
+}
+
+/// Mark a structseq type `Py_TPFLAGS_DISALLOW_INSTANTIATION`, which is how
+/// `sys.flags`, `sys.version_info` and `sys.getwindowsversion` are built —
+/// their single instance is the module's own answer and there is nothing a
+/// second one could describe.  Interpreter-side construction goes through
+/// [`new_instance`], which allocates directly, so only `Type(...)` from Python
+/// is refused.
+pub fn disallow_instantiation(cls: PyObjectRef) -> PyObjectRef {
+    unsafe { pyre_object::w_type_set_disallow_instantiation(cls) };
+    cls
 }
 
 fn make_struct_seq_impl(

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6889,13 +6889,13 @@ pub(crate) fn set_crt_errno(value: i32) {
 
 /// The errno the last C runtime call reported.
 pub(crate) fn crt_errno() -> i32 {
-    #[cfg(all(windows, feature = "host_env"))]
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
     {
         rustpython_host_env::os::get_errno()
     }
     // Off Windows the two are the same table, and a Windows build without the
     // host_env seam has no `_get_errno` to read.
-    #[cfg(not(all(windows, feature = "host_env")))]
+    #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
     {
         std::io::Error::last_os_error().raw_os_error().unwrap_or(0)
     }
@@ -17082,8 +17082,9 @@ fn fileio_set_non_inheritable(fd: i32, w_name: PyObjectRef) -> Result<(), crate:
 /// `open()` — PyPy `pypy/module/_io/interp_io.py:open`.
 ///
 /// Keep the upstream construction order literal: validate the mode, create a
-/// `FileIO`, choose exactly one buffered class, and only then add the text
-/// wrapper.  In particular, binary unbuffered I/O returns the raw `FileIO`.
+/// raw stream (`FileIO`, or PEP 528 `_WindowsConsoleIO` for a Windows console),
+/// choose exactly one buffered class, and only then add the text wrapper.  In
+/// particular, binary unbuffered I/O returns that raw stream.
 pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     let (positional, kwargs) = split_builtin_kwargs(args);
     // Every declared slot binds before the unrecognized keywords are
@@ -17304,8 +17305,21 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
         'x'
     };
     let raw_mode = format!("{primary}{}", if updating { "+" } else { "" });
+    // The console stream is a host-console type, so a sandbox build — which
+    // compiles it out — keeps the plain `FileIO` construction.
+    #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+    let raw_type = {
+        let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
+        if crate::module::_io::winconsoleio::pyio_get_console_type(file) != '\0' {
+            crate::module::_io::windows_console_io_type()
+        } else {
+            crate::module::_io::fileio_type()
+        }
+    };
+    #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
+    let raw_type = crate::module::_io::fileio_type();
     let raw = crate::call::call_function_impl_result(
-        crate::module::_io::fileio_type(),
+        raw_type,
         &[
             pyre_object::gc_roots::shadow_stack_get(file_slot),
             w_str_new(&raw_mode),

--- a/pyre/pyre-interpreter/src/call.rs
+++ b/pyre/pyre-interpreter/src/call.rs
@@ -3623,7 +3623,9 @@ pub(crate) fn calculate_metaclass(
 /// `Type()` with `cannot create 'X' instances`.
 pub(crate) fn check_type_instantiable(w_type: PyObjectRef) -> Result<(), PyError> {
     if unsafe { pyre_object::w_type_disallows_instantiation(w_type) } {
-        let name = unsafe { pyre_object::w_type_get_name(w_type) };
+        // The name here is `tp_name`, which a heap type such as `sys.flags`
+        // spells with its module in front of it.
+        let name = unsafe { crate::baseobjspace::type_repr_qualified_name(w_type) };
         return Err(PyError::type_error(format!(
             "cannot create '{name}' instances"
         )));

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -161,6 +161,8 @@ pub mod stack_check;
 pub mod syntax_warnings;
 pub mod type_methods;
 pub mod typedef;
+#[cfg(windows)]
+pub mod unicodehelper_win32;
 pub mod warn;
 
 // ── Execution and import modules ──

--- a/pyre/pyre-interpreter/src/lib.rs
+++ b/pyre/pyre-interpreter/src/lib.rs
@@ -1212,6 +1212,11 @@ pub fn all_subclass_range_aliases() -> Vec<pyre_object::pyobject::SubclassRangeA
             189,
             typed::<crate::module::_winapi::overlapped::W_Overlapped>(),
         ),
+        // PEP 528's raw console stream follows the two overlapped owners at
+        // the append-only Windows tail.  It is subclassable and therefore
+        // participates in the same rclass hierarchy as every typed IO base.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        subclass_range_alias(190, typed::<crate::module::_io::W_WindowsConsoleIO>()),
     ]
 }
 
@@ -1230,10 +1235,10 @@ pub fn active_subclass_range_hierarchy() -> &'static [(u32, Option<u32>)] {
         const MMAP_HIERARCHY_SLOTS: usize = 1;
         #[cfg(not(any(unix, windows)))]
         const MMAP_HIERARCHY_SLOTS: usize = 0;
-        // `_overlapped.Overlapped` and `_winapi.Overlapped`, both of which a
-        // sandbox build leaves out.
+        // `_overlapped.Overlapped`, `_winapi.Overlapped`, and the host-backed
+        // `_WindowsConsoleIO`, all of which a sandbox build leaves out.
         #[cfg(windows)]
-        const OVERLAPPED_HIERARCHY_SLOTS: usize = 2;
+        const OVERLAPPED_HIERARCHY_SLOTS: usize = 3;
         #[cfg(not(windows))]
         const OVERLAPPED_HIERARCHY_SLOTS: usize = 0;
         &hierarchy[..hierarchy.len()

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -1895,9 +1895,179 @@ fn charmap_build(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Ok(w_charmap)
 }
 
+/// `_PyArg_BadArgument`, which names the argument by its position rather
+/// than by the name the signature gives it.
+fn bad_argument(name: &str, position: usize, expected: &str, w_obj: PyObjectRef) -> crate::PyError {
+    crate::PyError::type_error(format!(
+        "{name}() argument {position} must be {expected}, not {}",
+        crate::type_methods::arg_type_name(w_obj)
+    ))
+}
+
+/// The `errors` argument the code page entry points share: `None` is
+/// `strict`, a `str` is itself, and nothing else is accepted.
+#[cfg(windows)]
+fn code_page_errors(
+    name: &str,
+    position: usize,
+    w_errors: PyObjectRef,
+) -> Result<&'static str, crate::PyError> {
+    if unsafe { pyre_object::is_none(w_errors) } {
+        return Ok("strict");
+    }
+    if !unsafe { is_str(w_errors) } {
+        return Err(bad_argument(name, position, "str or None", w_errors));
+    }
+    crate::baseobjspace::str_utf8_w(w_errors)
+}
+
+/// The code page number argument.  A negative number names no code page and
+/// is rejected before any conversion is attempted.
+#[cfg(windows)]
+fn code_page_number(w_code_page: PyObjectRef) -> Result<u32, crate::PyError> {
+    let code_page = crate::baseobjspace::c_int_w(w_code_page)?;
+    if code_page < 0 {
+        return Err(crate::PyError::value_error("invalid code page number"));
+    }
+    Ok(code_page as u32)
+}
+
+/// `_codecs.code_page_encode` - `(bytes, characters consumed)`, where the
+/// count is the whole string whatever the error handler did inside it.
+#[cfg(windows)]
+fn code_page_encode_impl(
+    name: &str,
+    position: usize,
+    code_page: u32,
+    w_str: PyObjectRef,
+    w_errors: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    if !unsafe { is_str(w_str) } {
+        return Err(bad_argument(name, position, "str", w_str));
+    }
+    let errors = code_page_errors(name, position + 1, w_errors)?;
+    let bytes = crate::unicodehelper_win32::encode_code_page(code_page, w_str, errors)?;
+    Ok(w_tuple_new(vec![
+        pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
+        w_int_new(unsafe { w_str_len(w_str) } as i64),
+    ]))
+}
+
+/// `_codecs.code_page_decode` - `(str, bytes consumed)`.
+#[cfg(windows)]
+fn code_page_decode_impl(
+    name: &str,
+    position: usize,
+    code_page: u32,
+    w_data: PyObjectRef,
+    w_errors: PyObjectRef,
+    w_final: PyObjectRef,
+) -> Result<PyObjectRef, crate::PyError> {
+    let data = decode_input_bytes(w_data)?;
+    let errors = code_page_errors(name, position + 1, w_errors)?;
+    let is_final = crate::baseobjspace::is_true(w_final)?;
+    let (text, consumed) =
+        crate::unicodehelper_win32::decode_code_page(code_page, &data, errors, is_final)?;
+    // `final` is the caller promising that no continuation is coming, so the
+    // whole buffer reads as consumed: nothing is being held back for one.
+    let consumed = if is_final { data.len() } else { consumed };
+    Ok(w_tuple_new(vec![
+        w_str_from_wtf8_managed(text),
+        w_int_new(consumed as i64),
+    ]))
+}
+
+/// Strip the keyword marker these positional-only entry points cannot take.
+/// A variadic builtin is handed the raw slice, with a keyword call's marker
+/// dict as its last element; left in place it reads as one more positional
+/// argument.
+#[cfg(windows)]
+fn code_page_positional<'a>(
+    name: &str,
+    args: &'a [PyObjectRef],
+) -> Result<&'a [PyObjectRef], crate::PyError> {
+    let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+    if crate::builtins::has_real_kwargs(kwargs) {
+        return Err(crate::PyError::type_error(format!(
+            "_codecs.{name}() takes no keyword arguments"
+        )));
+    }
+    Ok(positional)
+}
+
+/// Split `(str[, errors])` for the two encoders that name their own code page.
+#[cfg(windows)]
+fn fixed_code_page_encode(
+    name: &str,
+    code_page: u32,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let args = code_page_positional(name, args)?;
+    match args {
+        [w_str] => code_page_encode_impl(name, 1, code_page, *w_str, w_none()),
+        [w_str, w_errors] => code_page_encode_impl(name, 1, code_page, *w_str, *w_errors),
+        _ => Err(code_page_arity_error(name, 1, 2, args.len())),
+    }
+}
+
+/// Split `(data[, errors[, final]])` for the two decoders that name their own
+/// code page.
+#[cfg(windows)]
+fn fixed_code_page_decode(
+    name: &str,
+    code_page: u32,
+    args: &[PyObjectRef],
+) -> Result<PyObjectRef, crate::PyError> {
+    let args = code_page_positional(name, args)?;
+    match args {
+        [w_data] => {
+            code_page_decode_impl(name, 1, code_page, *w_data, w_none(), w_bool_from(false))
+        }
+        [w_data, w_errors] => {
+            code_page_decode_impl(name, 1, code_page, *w_data, *w_errors, w_bool_from(false))
+        }
+        [w_data, w_errors, w_final] => {
+            code_page_decode_impl(name, 1, code_page, *w_data, *w_errors, *w_final)
+        }
+        _ => Err(code_page_arity_error(name, 1, 3, args.len())),
+    }
+}
+
+/// `_PyArg_CheckPositional` wording for a positional-only entry point whose
+/// trailing arguments carry defaults.
+#[cfg(windows)]
+fn code_page_arity_error(name: &str, least: usize, most: usize, given: usize) -> crate::PyError {
+    let bound = if given < least {
+        let plural = if least == 1 { "" } else { "s" };
+        format!("at least {least} argument{plural}")
+    } else {
+        format!("at most {most} arguments")
+    };
+    crate::PyError::type_error(format!("{name} expected {bound}, got {given}"))
+}
+
 crate::py_module! {
     "_codecs",
     inline_functions: {
+        fn readbuffer_encode(
+            data: PyObjectRef,
+            #[default(w_none())] errors: PyObjectRef,
+        ) -> Result<PyObjectRef, crate::PyError> {
+            if !unsafe { pyre_object::is_none(errors) || is_str(errors) } {
+                return Err(bad_argument("readbuffer_encode", 2, "str or None", errors));
+            }
+            // `Py_buffer(accept={str, buffer})`: a str contributes its own
+            // UTF-8 bytes, anything else the buffer it exposes.
+            let bytes = if unsafe { is_str(data) } {
+                crate::baseobjspace::str_utf8_w(data)?.as_bytes().to_vec()
+            } else {
+                decode_input_bytes(data)?
+            };
+            Ok(w_tuple_new(vec![
+                pyre_object::bytesobject::w_bytes_from_bytes(&bytes),
+                w_int_new(bytes.len() as i64),
+            ]))
+        }
         fn ascii_encode(
             obj: PyObjectRef,
             #[default(w_str_new("strict"))] errors: PyObjectRef,
@@ -2134,5 +2304,97 @@ crate::py_module! {
         "lookup"         / 1 = lookup_codec,
         "_forget_codec"  / 1 = forget_codec,
         "charmap_build"  / 1 = charmap_build,
+    },
+    extra_init: |ns| {
+        // The code page codecs exist only where the code pages do; their
+        // absence elsewhere is what makes `encodings/mbcs.py` an ImportError
+        // rather than a codec that answers with the wrong bytes.
+        #[cfg(windows)]
+        {
+            use windows_sys::Win32::Globalization::{CP_ACP, CP_OEMCP};
+
+            fn mbcs_encode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                fixed_code_page_encode("mbcs_encode", CP_ACP, args)
+            }
+            fn mbcs_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                fixed_code_page_decode("mbcs_decode", CP_ACP, args)
+            }
+            fn oem_encode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                fixed_code_page_encode("oem_encode", CP_OEMCP, args)
+            }
+            fn oem_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                fixed_code_page_decode("oem_decode", CP_OEMCP, args)
+            }
+            fn code_page_encode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                let args = code_page_positional("code_page_encode", args)?;
+                match args {
+                    [w_cp, w_str] => code_page_encode_impl(
+                        "code_page_encode",
+                        2,
+                        code_page_number(*w_cp)?,
+                        *w_str,
+                        w_none(),
+                    ),
+                    [w_cp, w_str, w_errors] => code_page_encode_impl(
+                        "code_page_encode",
+                        2,
+                        code_page_number(*w_cp)?,
+                        *w_str,
+                        *w_errors,
+                    ),
+                    _ => Err(code_page_arity_error("code_page_encode", 2, 3, args.len())),
+                }
+            }
+            fn code_page_decode(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+                let args = code_page_positional("code_page_decode", args)?;
+                match args {
+                    [w_cp, w_data] => code_page_decode_impl(
+                        "code_page_decode",
+                        2,
+                        code_page_number(*w_cp)?,
+                        *w_data,
+                        w_none(),
+                        w_bool_from(false),
+                    ),
+                    [w_cp, w_data, w_errors] => code_page_decode_impl(
+                        "code_page_decode",
+                        2,
+                        code_page_number(*w_cp)?,
+                        *w_data,
+                        *w_errors,
+                        w_bool_from(false),
+                    ),
+                    [w_cp, w_data, w_errors, w_final] => code_page_decode_impl(
+                        "code_page_decode",
+                        2,
+                        code_page_number(*w_cp)?,
+                        *w_data,
+                        *w_errors,
+                        *w_final,
+                    ),
+                    _ => Err(code_page_arity_error("code_page_decode", 2, 4, args.len())),
+                }
+            }
+
+            for (name, entry) in [
+                ("mbcs_encode", mbcs_encode as crate::BuiltinCodeFn),
+                ("mbcs_decode", mbcs_decode),
+                ("oem_encode", oem_encode),
+                ("oem_decode", oem_decode),
+                ("code_page_encode", code_page_encode),
+                ("code_page_decode", code_page_decode),
+            ] {
+                crate::module_ns_store(
+                    ns,
+                    name,
+                    crate::gateway::with_module(
+                        "_codecs",
+                        crate::make_module_builtin_function(name, entry),
+                    ),
+                );
+            }
+        }
+        #[cfg(not(windows))]
+        let _ = ns;
     },
 }

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -21,6 +21,10 @@ mod stringio;
 pub use stringio::W_StringIO;
 mod textio;
 pub use textio::W_TextIOWrapper;
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+pub(crate) mod winconsoleio;
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+pub use winconsoleio::W_WindowsConsoleIO;
 
 pub fn text_io_wrapper_type() -> PyObjectRef {
     textio::type_object()
@@ -97,7 +101,10 @@ fn iobase_internal_closed(obj: PyObjectRef) -> bool {
         })
 }
 
-fn iobase_set_internal_closed(obj: PyObjectRef, closed: bool) -> Result<(), crate::PyError> {
+pub(crate) fn iobase_set_internal_closed(
+    obj: PyObjectRef,
+    closed: bool,
+) -> Result<(), crate::PyError> {
     if crate::baseobjspace::setdictvalue(obj, "__iobase_closed__", w_bool_from(closed))? {
         Ok(())
     } else {
@@ -1221,7 +1228,7 @@ fn io_base_type() -> PyObjectRef {
     }) as PyObjectRef
 }
 
-fn raw_iobase_type() -> PyObjectRef {
+pub(super) fn raw_iobase_type() -> PyObjectRef {
     static TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
     *TYPE.get_or_init(|| {
         let tp = crate::typedef::make_builtin_type_with_base(
@@ -1265,6 +1272,11 @@ pub(crate) fn fileio_type() -> PyObjectRef {
         }
         tp as usize
     }) as PyObjectRef
+}
+
+#[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+pub(crate) fn windows_console_io_type() -> PyObjectRef {
+    winconsoleio::type_object()
 }
 
 pub(crate) fn buffered_reader_type() -> PyObjectRef {
@@ -1440,6 +1452,20 @@ crate::py_module! {
                 pyre_object::typeobject::w_type_set_hasdict(t, true);
             }
             crate::module_ns_store(ns, name, t);
+        }
+
+        // `PyInit__io` exposes the PEP 528 raw console stream only on
+        // Windows.  PyPy's `W_WinConsoleIO` likewise derives directly from
+        // `W_RawIOBase`; the descriptor, ownership flag and UTF-8 carry buffer
+        // live on that one stream object.
+        #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
+        {
+            let console_io = winconsoleio::type_object();
+            unsafe {
+                pyre_object::w_type_set_acceptable_as_base_class(console_io, true);
+                pyre_object::typeobject::w_type_set_hasdict(console_io, true);
+            }
+            crate::module_ns_store(ns, "_WindowsConsoleIO", console_io);
         }
 
         // `TextIOWrapper` is a real (subclassable) type: stdlib modules such

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -1,0 +1,503 @@
+//! Windows console raw stream — `_io._WindowsConsoleIO` (PEP 528),
+//! ported from PyPy `W_WinConsoleIO`.
+
+use pyre_object::*;
+use rustpython_host_env::{io as host_io, nt as host_nt};
+
+const SMALLBUF: usize = 4;
+const BUFMAX: usize = 32 * 1024 * 1024;
+
+#[crate::pyre_class("_io._WindowsConsoleIO")]
+pub struct W_WindowsConsoleIO {
+    // PyPy `W_WinConsoleIO.__init__`: all state belongs to the raw stream.
+    // In particular the incomplete UTF-8 character is not a process-global or
+    // thread-local side table; it resumes with this exact console frame.
+    fd: i32,
+    readable: bool,
+    writable: bool,
+    closefd: bool,
+    // The flag a buffered layer sets before dropping its raw stream during
+    // interpreter finalization, so the `ResourceWarning` it would otherwise
+    // emit is suppressed.  Written by Python, never read from here.
+    finalizing: bool,
+    blksize: i64,
+    smallbuf: [u8; SMALLBUF],
+}
+
+impl Default for W_WindowsConsoleIO {
+    fn default() -> Self {
+        Self {
+            ob: PyObject::default(),
+            fd: -1,
+            readable: false,
+            writable: false,
+            closefd: false,
+            finalizing: false,
+            blksize: super::DEFAULT_BUFFER_SIZE,
+            smallbuf: [0; SMALLBUF],
+        }
+    }
+}
+
+fn io_error(error: std::io::Error, filename: PyObjectRef) -> crate::PyError {
+    match error.raw_os_error() {
+        Some(code) => crate::PyError::os_error_win32_syscall2(code, filename, PY_NULL),
+        None => crate::PyError::os_error(error.to_string()),
+    }
+}
+
+fn read_console_error(error: host_nt::ReadConsoleError) -> crate::PyError {
+    match error {
+        host_nt::ReadConsoleError::Io(error) => io_error(error, PY_NULL),
+        host_nt::ReadConsoleError::BufferTooSmall {
+            available,
+            required,
+        } => crate::PyError::system_error(format!(
+            "Buffer had room for {available} bytes but {required} bytes required"
+        )),
+    }
+}
+
+/// `_PyIO_get_console_type` / RustPython `pyio_get_console_type`.
+/// This is deliberately only a probe: an invalid fd or ordinary path stays a
+/// normal FileIO candidate and its constructor reports the authoritative error.
+pub(crate) fn pyio_get_console_type(path_or_fd: PyObjectRef) -> char {
+    if unsafe { pyre_object::is_int(path_or_fd) } {
+        return crate::baseobjspace::c_int_w(path_or_fd)
+            .ok()
+            .map_or('\0', host_nt::console_type_from_fd);
+    }
+    let Ok(path) = crate::gateway::fsencode_path_w(path_or_fd) else {
+        return '\0';
+    };
+    let os_name = crate::gateway::os_string_from_fs_bytes(&path.as_bytes);
+    host_nt::console_type_from_name(&os_name.to_string_lossy())
+}
+
+impl W_WindowsConsoleIO {
+    fn self_obj(&self) -> PyObjectRef {
+        self as *const Self as PyObjectRef
+    }
+
+    fn pin_self(&self) -> usize {
+        pyre_object::gc_roots::pin_root(self.self_obj());
+        pyre_object::gc_roots::shadow_stack_len() - 1
+    }
+
+    fn from_slot(slot: usize) -> &'static mut Self {
+        unsafe { &mut *(pyre_object::gc_roots::shadow_stack_get(slot) as *mut Self) }
+    }
+
+    fn check_closed(&self) -> Result<(), crate::PyError> {
+        if self.fd < 0 {
+            Err(crate::PyError::value_error("I/O operation on closed file"))
+        } else {
+            Ok(())
+        }
+    }
+
+    fn close_descriptor(&mut self) -> Result<(), crate::PyError> {
+        let fd = std::mem::replace(&mut self.fd, -1);
+        if fd >= 0 && self.closefd {
+            host_io::close_owned_fd(unsafe { rustpython_host_env::crt_fd::Owned::from_raw(fd) })
+                .map_err(|error| io_error(error, PY_NULL))?;
+        }
+        Ok(())
+    }
+
+    fn mode_string(&self) -> &'static str {
+        if self.readable { "rb" } else { "wb" }
+    }
+
+    fn console_handle(&self) -> Result<host_nt::Handle, crate::PyError> {
+        self.check_closed()?;
+        let handle = host_nt::handle_from_fd(self.fd);
+        if host_nt::is_invalid_handle(handle) {
+            return Err(io_error(std::io::Error::last_os_error(), PY_NULL));
+        }
+        Ok(handle)
+    }
+
+    fn read_native(
+        handle: host_nt::Handle,
+        length: usize,
+        smallbuf: &mut [u8; SMALLBUF],
+    ) -> Result<Vec<u8>, crate::PyError> {
+        let mut data = vec![0; length];
+        let read = {
+            // `ReadConsoleW` may block.  The destination and UTF-8 carry are
+            // native stack/Vec storage, never pointers into movable GC objects.
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::read_console_into(handle, &mut data, smallbuf)
+        }
+        .map_err(read_console_error)?;
+        data.truncate(read);
+        Ok(data)
+    }
+}
+
+#[crate::pyre_methods(base = super::raw_iobase_type(), weakrefable)]
+impl W_WindowsConsoleIO {
+    #[staticmethod]
+    fn __new__(cls: PyObjectRef, _args: &[PyObjectRef]) -> PyObjectRef {
+        let obj = W_WindowsConsoleIO::allocate_stable(W_WindowsConsoleIO::default());
+        super::tag_io_instance(obj, cls)
+    }
+
+    fn __init__(
+        &mut self,
+        w_name: PyObjectRef,
+        #[default(pyre_object::w_str_new("r"))] w_mode: PyObjectRef,
+        #[default(pyre_object::w_bool_from(true))] w_closefd: PyObjectRef,
+        #[default(pyre_object::w_none())] _w_opener: PyObjectRef,
+    ) -> Result<(), crate::PyError> {
+        self.close_descriptor()?;
+        self.readable = false;
+        self.writable = false;
+        self.closefd = false;
+        self.smallbuf = [0; SMALLBUF];
+
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(w_name);
+        let name_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        pyre_object::gc_roots::pin_root(w_mode);
+        let mode_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        pyre_object::gc_roots::pin_root(w_closefd);
+        let closefd_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
+        let self_slot = self.pin_self();
+
+        if unsafe { pyre_object::is_bool(w_name) } {
+            crate::warn::warn_category("bool is used as a file descriptor", "RuntimeWarning", 1)?;
+        }
+
+        let mode_obj = pyre_object::gc_roots::shadow_stack_get(mode_slot);
+        if unsafe { !pyre_object::is_str(mode_obj) } {
+            return Err(crate::PyError::type_error(format!(
+                "_WindowsConsoleIO() argument 'mode' must be str, not {}",
+                crate::type_methods::arg_type_name(mode_obj)
+            )));
+        }
+        let mode = crate::baseobjspace::str_utf8_w(mode_obj)?.to_string();
+        let mut rwa = false;
+        let mut readable = false;
+        let mut writable = false;
+        for flag in mode.chars() {
+            match flag {
+                '+' | 'a' | 'b' | 'x' => {}
+                'r' => {
+                    if rwa {
+                        return Err(crate::PyError::value_error(format!("invalid mode: {mode}")));
+                    }
+                    rwa = true;
+                    readable = true;
+                }
+                'w' => {
+                    if rwa {
+                        return Err(crate::PyError::value_error(format!("invalid mode: {mode}")));
+                    }
+                    rwa = true;
+                    writable = true;
+                }
+                _ => {
+                    return Err(crate::PyError::value_error(format!("invalid mode: {mode}")));
+                }
+            }
+        }
+        if !rwa {
+            return Err(crate::PyError::value_error(
+                "Must have exactly one of read or write mode",
+            ));
+        }
+
+        let name_obj = pyre_object::gc_roots::shadow_stack_get(name_slot);
+        let (fd, closefd, mut console_type) = if unsafe { pyre_object::is_int(name_obj) } {
+            let fd = crate::baseobjspace::c_int_w(name_obj)?;
+            if fd < 0 {
+                return Err(crate::PyError::value_error("negative file descriptor"));
+            }
+            (fd, false, host_nt::console_type_from_fd(fd))
+        } else {
+            let closefd = crate::baseobjspace::is_true(pyre_object::gc_roots::shadow_stack_get(
+                closefd_slot,
+            ))?;
+            if !closefd {
+                return Err(crate::PyError::value_error(
+                    "Cannot use closefd=False with file name",
+                ));
+            }
+            let path = crate::gateway::fsencode_path_w(name_obj)?;
+            let path_obj = path.w_path();
+            let os_name = crate::gateway::os_string_from_fs_bytes(&path.as_bytes);
+            let mut kind = host_nt::console_type_from_name(&os_name.to_string_lossy());
+            if kind == 'x' {
+                kind = if writable { 'w' } else { 'r' };
+            }
+            let wide = widestring::WideCString::from_os_str(&os_name)
+                .map_err(|_| crate::PyError::value_error("embedded null in path"))?;
+            let opened = {
+                let _blocked = crate::module::thread::before_external_block();
+                host_nt::open_console_path_fd(&wide, writable)
+            }
+            .map_err(|error| io_error(error, path_obj))?;
+            (opened, true, kind)
+        };
+
+        if console_type == '\0' {
+            console_type = host_nt::console_type(host_nt::handle_from_fd(fd));
+        }
+        if (writable && console_type != 'w')
+            || (readable && console_type != 'r')
+            || console_type == '\0'
+        {
+            if closefd {
+                let _ = host_io::close_owned_fd(unsafe {
+                    rustpython_host_env::crt_fd::Owned::from_raw(fd)
+                });
+            }
+            // Mode parsing has already settled exactly one of the two, so a
+            // target that is no console at all is reported through whichever
+            // direction was asked for rather than by its own name.
+            return Err(crate::PyError::value_error(if writable {
+                "Cannot open console input buffer for writing"
+            } else if readable {
+                "Cannot open console output buffer for reading"
+            } else {
+                "Cannot open non-console file"
+            }));
+        }
+
+        let this = Self::from_slot(self_slot);
+        this.fd = fd;
+        this.readable = readable;
+        this.writable = writable;
+        this.closefd = closefd;
+        this.blksize = super::DEFAULT_BUFFER_SIZE;
+        this.smallbuf = [0; SMALLBUF];
+        crate::baseobjspace::setattr_str(
+            this.self_obj(),
+            "name",
+            pyre_object::gc_roots::shadow_stack_get(name_slot),
+        )?;
+        // `W_IOBase.__init__` installs the per-instance closed flag.  A
+        // successful second `__init__` reopens the same object, so its base
+        // flush/close methods must observe the new live state as well as this
+        // payload's fd-backed `closed` property.
+        super::iobase_set_internal_closed(this.self_obj(), false)?;
+        Ok(())
+    }
+
+    #[getter]
+    fn closed(&self) -> bool {
+        self.fd < 0
+    }
+
+    #[getter]
+    fn closefd(&self) -> bool {
+        self.closefd
+    }
+
+    #[getter]
+    fn _blksize(&self) -> i64 {
+        self.blksize
+    }
+
+    #[getter]
+    fn mode(&self) -> PyObjectRef {
+        w_str_new(self.mode_string())
+    }
+
+    fn fileno(&self) -> Result<i64, crate::PyError> {
+        self.check_closed()?;
+        Ok(self.fd as i64)
+    }
+
+    fn readable(&self) -> Result<bool, crate::PyError> {
+        self.check_closed()?;
+        Ok(self.readable)
+    }
+
+    fn writable(&self) -> Result<bool, crate::PyError> {
+        self.check_closed()?;
+        Ok(self.writable)
+    }
+
+    fn isatty(&self) -> Result<bool, crate::PyError> {
+        self.check_closed()?;
+        Ok(true)
+    }
+
+    /// The variant `open()` asks for right after construction.  A console
+    /// handle is a terminal by definition, so this is `isatty` with no other
+    /// state left to consult.
+    fn _isatty_open_only(&self) -> Result<bool, crate::PyError> {
+        self.check_closed()?;
+        Ok(true)
+    }
+
+    #[getter]
+    fn _finalizing(&self) -> bool {
+        self.finalizing
+    }
+
+    #[setter]
+    fn set__finalizing(&mut self, value: PyObjectRef) -> Result<(), crate::PyError> {
+        if unsafe { !pyre_object::is_bool(value) } {
+            return Err(crate::PyError::type_error(
+                "attribute value type must be bool",
+            ));
+        }
+        self.finalizing = crate::baseobjspace::is_true(value)?;
+        Ok(())
+    }
+
+    fn close(&mut self) -> Result<(), crate::PyError> {
+        if self.fd < 0 {
+            return Ok(());
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = self.pin_self();
+        let flush_error = super::iobase_close(&[self.self_obj()]).err();
+        let close_error = Self::from_slot(self_slot).close_descriptor().err();
+        match (flush_error, close_error) {
+            (Some(mut flush), Some(mut close)) => {
+                let flush_obj = flush.to_exc_object();
+                pyre_object::gc_roots::pin_root(flush_obj);
+                let close_obj = close.to_exc_object();
+                unsafe {
+                    pyre_object::interp_exceptions::w_exception_set_context(close_obj, flush_obj)
+                };
+                close.exc_object = close_obj;
+                Err(close)
+            }
+            (Some(error), None) | (None, Some(error)) => Err(error),
+            (None, None) => Ok(()),
+        }
+    }
+
+    fn readinto(&mut self, w_buffer: PyObjectRef) -> Result<i64, crate::PyError> {
+        self.check_closed()?;
+        if !self.readable {
+            return Err(super::unsupported(
+                "Console buffer does not support reading",
+            ));
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = self.pin_self();
+        let mut output = unsafe { crate::builtins::WritableBuffer::acquire(w_buffer)? };
+        let length = unsafe { output.as_mut_slice().len() };
+        if length > BUFMAX {
+            return Err(crate::PyError::value_error(format!(
+                "cannot read more than {BUFMAX} bytes"
+            )));
+        }
+        if length == 0 {
+            return Ok(0);
+        }
+        let this = Self::from_slot(self_slot);
+        let handle = this.console_handle()?;
+        let mut smallbuf = this.smallbuf;
+        let data = Self::read_native(handle, length, &mut smallbuf)?;
+        let this = Self::from_slot(self_slot);
+        this.smallbuf = smallbuf;
+        let target = unsafe { output.as_mut_slice() };
+        target[..data.len()].copy_from_slice(&data);
+        Ok(data.len() as i64)
+    }
+
+    fn read(
+        &mut self,
+        #[default(pyre_object::w_none())] w_size: PyObjectRef,
+    ) -> Result<PyObjectRef, crate::PyError> {
+        self.check_closed()?;
+        if !self.readable {
+            return Err(super::unsupported(
+                "Console buffer does not support reading",
+            ));
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = self.pin_self();
+        let size = super::iobase_convert_size(w_size)?;
+        if size < 0 {
+            return Self::from_slot(self_slot).readall();
+        }
+        let length = usize::try_from(size)
+            .map_err(|_| crate::PyError::overflow_error("Python int too large"))?;
+        if length > BUFMAX {
+            return Err(crate::PyError::value_error(format!(
+                "cannot read more than {BUFMAX} bytes"
+            )));
+        }
+        let this = Self::from_slot(self_slot);
+        let handle = this.console_handle()?;
+        let mut smallbuf = this.smallbuf;
+        let data = Self::read_native(handle, length, &mut smallbuf)?;
+        Self::from_slot(self_slot).smallbuf = smallbuf;
+        Ok(pyre_object::bytesobject::w_bytes_from_bytes(&data))
+    }
+
+    fn readall(&mut self) -> Result<PyObjectRef, crate::PyError> {
+        self.check_closed()?;
+        // No readable check here: a write handle reaches `ReadConsole` and
+        // fails with the invalid-handle error the console API reports, which
+        // is a different answer from the one `read` gives for the same stream.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = self.pin_self();
+        let handle = self.console_handle()?;
+        let mut smallbuf = self.smallbuf;
+        let data = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::read_console_all(handle, &mut smallbuf)
+        }
+        .map_err(|error| io_error(error, PY_NULL))?;
+        Self::from_slot(self_slot).smallbuf = smallbuf;
+        Ok(pyre_object::bytesobject::w_bytes_from_bytes(&data))
+    }
+
+    fn write(&mut self, w_data: PyObjectRef) -> Result<i64, crate::PyError> {
+        self.check_closed()?;
+        if !self.writable {
+            return Err(super::unsupported(
+                "Console buffer does not support writing",
+            ));
+        }
+        let _roots = pyre_object::gc_roots::push_roots();
+        let self_slot = self.pin_self();
+        let Some(input) = crate::baseobjspace::simple_buffer_bytes(w_data)? else {
+            return Err(crate::PyError::type_error(format!(
+                "a bytes-like object is required, not '{}'",
+                crate::type_methods::arg_type_name(w_data)
+            )));
+        };
+        let data = input.as_bytes().to_vec();
+        input.release();
+        if data.is_empty() {
+            return Ok(0);
+        }
+        let handle = Self::from_slot(self_slot).console_handle()?;
+        let written = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::write_console_utf8(handle, &data, BUFMAX)
+        }
+        .map_err(|error| io_error(error, PY_NULL))?;
+        Ok(written as i64)
+    }
+
+    fn __reduce__(&self) -> Result<PyObjectRef, crate::PyError> {
+        Err(crate::PyError::type_error(
+            "cannot pickle '_WindowsConsoleIO' object",
+        ))
+    }
+
+    fn __repr__(&self) -> rustpython_wtf8::Wtf8Buf {
+        let typename = crate::type_methods::arg_type_name(self.self_obj());
+        if self.fd < 0 {
+            rustpython_wtf8::Wtf8Buf::from_string(format!("<{typename} [closed]>"))
+        } else {
+            rustpython_wtf8::Wtf8Buf::from_string(format!(
+                "<{typename} mode='{}' closefd={}>",
+                self.mode_string(),
+                if self.closefd { "True" } else { "False" }
+            ))
+        }
+    }
+}

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -222,6 +222,9 @@ impl W_WindowsConsoleIO {
             if fd < 0 {
                 return Err(crate::PyError::value_error("negative file descriptor"));
             }
+            // `winconsoleio.c:417-419` sets `self->closefd = 0` for every
+            // `fd >= 0` whatever the argument said, so a descriptor is never
+            // owned here and `close()` leaves it open.
             (fd, false, host_nt::console_type_from_fd(fd))
         } else {
             let closefd = crate::baseobjspace::is_true(pyre_object::gc_roots::shadow_stack_get(

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -113,7 +113,14 @@ impl W_WindowsConsoleIO {
         self.check_closed()?;
         let handle = host_nt::handle_from_fd(self.fd);
         if host_nt::is_invalid_handle(handle) {
-            return Err(io_error(std::io::Error::last_os_error(), PY_NULL));
+            // `_get_osfhandle` rejects a bad descriptor through `errno`, not
+            // `GetLastError`, so this is an `EBADF` `OSError` with no
+            // `winerror` slot - `_Py_get_osfhandle` raises it with
+            // `PyErr_SetFromErrno`.
+            return Err(crate::PyError::os_error_syscall(
+                crate::builtins::crt_errno(),
+                PY_NULL,
+            ));
         }
         Ok(handle)
     }
@@ -362,11 +369,18 @@ impl W_WindowsConsoleIO {
         let close_error = Self::from_slot(self_slot).close_descriptor().err();
         match (flush_error, close_error) {
             (Some(mut flush), Some(mut close)) => {
+                let flush_slot = pyre_object::gc_roots::shadow_stack_len();
                 let flush_obj = flush.to_exc_object();
                 pyre_object::gc_roots::pin_root(flush_obj);
+                // The second `to_exc_object` allocates, so a moving collection
+                // can run between the pin and the read: it forwards the slot,
+                // never the local copy above.
                 let close_obj = close.to_exc_object();
                 unsafe {
-                    pyre_object::interp_exceptions::w_exception_set_context(close_obj, flush_obj)
+                    pyre_object::interp_exceptions::w_exception_set_context(
+                        close_obj,
+                        pyre_object::gc_roots::shadow_stack_get(flush_slot),
+                    )
                 };
                 close.exc_object = close_obj;
                 Err(close)

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -226,7 +226,6 @@ impl W_WindowsConsoleIO {
                 ));
             }
             let path = crate::gateway::fsencode_path_w(name_obj)?;
-            let path_obj = path.w_path();
             let os_name = crate::gateway::os_string_from_fs_bytes(&path.as_bytes);
             let mut kind = host_nt::console_type_from_name(&os_name.to_string_lossy());
             if kind == 'x' {
@@ -238,7 +237,10 @@ impl W_WindowsConsoleIO {
                 let _blocked = crate::module::thread::before_external_block();
                 host_nt::open_console_path_fd(&wide, writable)
             }
-            .map_err(|error| io_error(error, path_obj))?;
+            // Read the rooted slot after the block, not before: releasing the
+            // GIL lets a moving collection run, and a `PyObjectRef` snapshotted
+            // ahead of it names the old address.
+            .map_err(|error| io_error(error, path.w_path()))?;
             (opened, true, kind)
         };
 

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -278,7 +278,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // is Windows-only.  The locale name is built from the user's ISO
     // language and territory and reports the active ANSI code page separately.
     // PyPy publishes the same two-item shape from `getdefaultlocale`.
-    #[cfg(windows)]
+    #[cfg(all(windows, not(feature = "sandbox")))]
     crate::module_ns_store(
         ns,
         "_getdefaultlocale",
@@ -625,5 +625,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 crate::make_builtin_function(name, locale_unavailable),
             );
         }
+        // `_getdefaultlocale` reads the user's locale and the active ANSI code
+        // page, so it is host state on the same terms.
+        #[cfg(windows)]
+        crate::module_ns_store(
+            ns,
+            "_getdefaultlocale",
+            crate::make_builtin_function_with_arity(
+                "_getdefaultlocale",
+                locale_unavailable,
+                0,
+            ),
+        );
     }
 }

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -296,12 +296,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     _ => pyre_object::w_none(),
                 };
+                // The active ANSI code page, spelled `cp<n>` whatever it is:
+                // code page 65001 answers `cp65001`, not `utf-8`.  Mapping it
+                // to a codec name is `locale.getdefaultlocale`'s job, not this
+                // hook's.
                 let codepage = unsafe { windows_sys::Win32::Globalization::GetACP() };
-                let encoding = if codepage == 65001 {
-                    pyre_object::w_str_new("utf-8")
-                } else {
-                    pyre_object::w_str_new(&format!("cp{codepage}"))
-                };
+                let encoding = pyre_object::w_str_new(&format!("cp{codepage}"));
                 Ok(pyre_object::w_tuple_new(vec![locale, encoding]))
             },
             0,

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -72,6 +72,26 @@ fn locale_error(message: &str) -> crate::PyError {
     err
 }
 
+#[cfg(windows)]
+fn windows_default_locale_component(lctype: u32) -> Option<String> {
+    use windows_sys::Win32::Globalization::{GetLocaleInfoW, GetUserDefaultLCID};
+
+    let mut buffer = [0u16; 16];
+    let len = unsafe {
+        GetLocaleInfoW(
+            GetUserDefaultLCID(),
+            lctype,
+            buffer.as_mut_ptr(),
+            buffer.len() as i32,
+        )
+    };
+    if len <= 1 {
+        None
+    } else {
+        Some(String::from_utf16_lossy(&buffer[..len as usize - 1]))
+    }
+}
+
 /// Numeric/monetary locale parameters decoded into owned buffers, the
 /// `lconv` fields `localeconv` exposes (`interp_locale.py`).
 struct LocaleConvData {
@@ -253,6 +273,40 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         exception_base,
     );
     crate::module_ns_store(ns, "Error", w_error);
+
+    // `_localemodule.c:_locale._getdefaultlocale` — this compatibility hook
+    // is Windows-only.  The locale name is built from the user's ISO
+    // language and territory and reports the active ANSI code page separately.
+    // PyPy publishes the same two-item shape from `getdefaultlocale`.
+    #[cfg(windows)]
+    crate::module_ns_store(
+        ns,
+        "_getdefaultlocale",
+        crate::make_builtin_function_with_arity(
+            "_getdefaultlocale",
+            |_| {
+                use windows_sys::Win32::Globalization::{
+                    LOCALE_SISO3166CTRYNAME, LOCALE_SISO639LANGNAME,
+                };
+                let language = windows_default_locale_component(LOCALE_SISO639LANGNAME);
+                let territory = windows_default_locale_component(LOCALE_SISO3166CTRYNAME);
+                let locale = match (language, territory) {
+                    (Some(language), Some(territory)) => {
+                        pyre_object::w_str_new(&format!("{language}_{territory}"))
+                    }
+                    _ => pyre_object::w_none(),
+                };
+                let codepage = unsafe { windows_sys::Win32::Globalization::GetACP() };
+                let encoding = if codepage == 65001 {
+                    pyre_object::w_str_new("utf-8")
+                } else {
+                    pyre_object::w_str_new(&format!("cp{codepage}"))
+                };
+                Ok(pyre_object::w_tuple_new(vec![locale, encoding]))
+            },
+            0,
+        ),
+    );
 
     // localeconv() — numeric/monetary parameters of the current locale.
     // Reads the host locale DB; under sandbox the stub override below replaces

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1906,7 +1906,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
     }
 
-    // `socket.py:286 socket.dup` and `:554 fromfd` both go through
+    // `socket.py`'s `socket.dup` and `fromfd` both go through
     // `_socket.dup`, which on Windows cannot duplicate a descriptor in place:
     // a socket is not a C runtime file descriptor there.  `socket_dup` hands
     // the socket to the process it is already in with `WSADuplicateSocketW`

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -119,6 +119,27 @@ fn socket_converted_error(
     err
 }
 
+#[cfg(all(windows, feature = "host_env"))]
+fn interface_io_error(error: std::io::Error) -> crate::PyError {
+    use rustpython_host_env::os::ErrorExt;
+
+    // The two scalar conversions fail through the C runtime `errno` the IP
+    // Helper API sets, which `raw_os_error` leaves empty on purpose so that no
+    // `winerror` is attached to it; `posix_errno` is what recovers it.  The
+    // enumeration path instead fails through a Win32 status, and that one is
+    // reported as the Win32 flavour it is.
+    let Some(winerror) = error.raw_os_error() else {
+        let errno = error.posix_errno();
+        let message = match errno {
+            libc::ENODEV => "No such device".to_string(),
+            libc::ENXIO => "No such device or address".to_string(),
+            _ => error.to_string(),
+        };
+        return crate::PyError::os_error_with_errno(errno, message);
+    };
+    crate::PyError::os_error_win32_syscall2(winerror, pyre_object::PY_NULL, pyre_object::PY_NULL)
+}
+
 /// One `space.acquire_writebuf` export held for the whole of a `recv_into`
 /// family call, the way `with rwbuffer:` keeps it across `c_recv`.
 ///
@@ -531,6 +552,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("AF_DECnet", ws::AF_DECnet);
         cst!("AF_IPX", ws::AF_IPX);
         cst!("AF_LINK", ws::AF_LINK);
+        // `socketmodule.c:PyInit__socket` publishes the address families the
+        // 3.14 Windows SDK exposes in addition to PyPy's older MSVC census.
+        cst!("AF_SNA", 11);
+        cst!("AF_IRDA", 26);
+        cst!("AF_BLUETOOTH", 32);
+        cst!("AF_HYPERV", 34);
         // ── Socket types ──
         cst!("SOCK_STREAM", ws::SOCK_STREAM);
         cst!("SOCK_DGRAM", ws::SOCK_DGRAM);
@@ -543,12 +570,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IPPROTO_ICMP", ws::IPPROTO_ICMP);
         cst!("IPPROTO_IGMP", ws::IPPROTO_IGMP);
         cst!("IPPROTO_GGP", ws::IPPROTO_GGP);
+        cst!("IPPROTO_ST", 5);
+        cst!("IPPROTO_CBT", 7);
+        cst!("IPPROTO_IGP", 9);
         cst!("IPPROTO_IPV4", ws::IPPROTO_IPV4);
         cst!("IPPROTO_TCP", ws::IPPROTO_TCP);
         cst!("IPPROTO_EGP", ws::IPPROTO_EGP);
         cst!("IPPROTO_PUP", ws::IPPROTO_PUP);
         cst!("IPPROTO_UDP", ws::IPPROTO_UDP);
         cst!("IPPROTO_IDP", ws::IPPROTO_IDP);
+        cst!("IPPROTO_ICLFXBM", 78);
         cst!("IPPROTO_IPV6", ws::IPPROTO_IPV6);
         cst!("IPPROTO_ROUTING", ws::IPPROTO_ROUTING);
         cst!("IPPROTO_FRAGMENT", ws::IPPROTO_FRAGMENT);
@@ -561,6 +592,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IPPROTO_PIM", ws::IPPROTO_PIM);
         cst!("IPPROTO_PGM", ws::IPPROTO_PGM);
         cst!("IPPROTO_RDP", ws::IPPROTO_RDP);
+        cst!("IPPROTO_L2TP", 115);
         cst!("IPPROTO_SCTP", ws::IPPROTO_SCTP);
         cst!("IPPROTO_RAW", ws::IPPROTO_RAW);
         cst!("IPPROTO_MAX", ws::IPPROTO_MAX);
@@ -599,14 +631,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("SO_SNDBUF", ws::SO_SNDBUF);
         cst!("SO_RCVTIMEO", ws::SO_RCVTIMEO);
         cst!("SO_SNDTIMEO", ws::SO_SNDTIMEO);
+        cst!("SO_SNDLOWAT", 0x1003);
+        cst!("SO_RCVLOWAT", 0x1004);
         cst!("SO_ERROR", ws::SO_ERROR);
         cst!("SO_TYPE", ws::SO_TYPE);
         cst!("SO_ACCEPTCONN", ws::SO_ACCEPTCONN);
         cst!("SO_USELOOPBACK", ws::SO_USELOOPBACK);
+        cst!("SO_ORIGINAL_DST", 12303);
+        // Bluetooth/RFCOMM constants.  The option names are unsigned SDK
+        // words but `PyModule_AddIntConstant` exposes their signed C-long
+        // readings on Windows.
+        cst!("BTPROTO_RFCOMM", 3);
+        cst!("SOL_RFCOMM", 3);
+        cst!("SO_BTH_ENCRYPT", 2);
+        cst!("SO_BTH_MTU", 0x80000007u32 as i32);
+        cst!("SO_BTH_MTU_MAX", 0x80000008u32 as i32);
+        cst!("SO_BTH_MTU_MIN", 0x8000000au32 as i32);
         // ── TCP-level ──
         cst!("TCP_NODELAY", ws::TCP_NODELAY);
         cst!("TCP_MAXSEG", ws::TCP_MAXSEG);
         cst!("TCP_KEEPALIVE", ws::TCP_KEEPALIVE);
+        cst!("TCP_KEEPIDLE", 3);
+        cst!("TCP_FASTOPEN", 15);
+        cst!("TCP_KEEPCNT", 16);
+        cst!("TCP_KEEPINTVL", 17);
+        cst!("TCP_QUICKACK", 0x98000017u32 as i32);
         // ── IP-level ──
         cst!("IP_TTL", ws::IP_TTL);
         cst!("IP_TOS", ws::IP_TOS);
@@ -618,6 +667,14 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IP_DROP_MEMBERSHIP", ws::IP_DROP_MEMBERSHIP);
         cst!("IP_HDRINCL", ws::IP_HDRINCL);
         cst!("IP_RECVDSTADDR", ws::IP_RECVDSTADDR);
+        cst!("IP_ADD_SOURCE_MEMBERSHIP", 15);
+        cst!("IP_DROP_SOURCE_MEMBERSHIP", 16);
+        cst!("IP_BLOCK_SOURCE", 17);
+        cst!("IP_UNBLOCK_SOURCE", 18);
+        cst!("IP_PKTINFO", 19);
+        cst!("IP_RECVTTL", 21);
+        cst!("IP_RECVTOS", 40);
+        cst!("IP_RECVERR", 75);
         cst!("IP_DEFAULT_MULTICAST_LOOP", 1);
         cst!("IP_DEFAULT_MULTICAST_TTL", 1);
         cst!("IP_MAX_MEMBERSHIPS", 20);
@@ -635,6 +692,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IPV6_PKTINFO", ws::IPV6_PKTINFO);
         cst!("IPV6_RECVRTHDR", ws::IPV6_RECVRTHDR);
         cst!("IPV6_RECVTCLASS", ws::IPV6_RECVTCLASS);
+        cst!("IPV6_RECVERR", 75);
         cst!("IPV6_RTHDR", ws::IPV6_RTHDR);
         cst!("IPV6_TCLASS", ws::IPV6_TCLASS);
         cst!("IPV6_UNICAST_HOPS", ws::IPV6_UNICAST_HOPS);
@@ -651,6 +709,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("MSG_TRUNC", ws::MSG_TRUNC);
         cst!("MSG_BCAST", ws::MSG_BCAST);
         cst!("MSG_MCAST", ws::MSG_MCAST);
+        cst!("MSG_ERRQUEUE", 0x1000);
         // ── Address-info flags ──
         cst!("AI_PASSIVE", ws::AI_PASSIVE);
         cst!("AI_CANONNAME", ws::AI_CANONNAME);
@@ -687,6 +746,26 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("RCVALL_ON", ws::RCVALL_ON);
         cst!("RCVALL_SOCKETLEVELONLY", ws::RCVALL_SOCKETLEVELONLY);
         cst!("RCVALL_IPLEVEL", ws::RCVALL_IPLEVEL);
+        cst!("RCVALL_MAX", 3);
+        // Hyper-V socket ABI constants (`hvsocket.h`).  GUIDs and Bluetooth
+        // addresses are public strings rather than integer enum members.
+        cst!("HV_PROTOCOL_RAW", 1);
+        cst!("HVSOCKET_CONNECT_TIMEOUT", 1);
+        cst!("HVSOCKET_CONNECTED_SUSPEND", 4);
+        cst!("HVSOCKET_CONNECT_TIMEOUT_MAX", 300_000);
+        cst!("HVSOCKET_ADDRESS_FLAG_PASSTHRU", 1);
+        for (name, value) in [
+            ("BDADDR_ANY", "00:00:00:00:00:00"),
+            ("BDADDR_LOCAL", "00:00:00:FF:FF:FF"),
+            ("HV_GUID_ZERO", "00000000-0000-0000-0000-000000000000"),
+            ("HV_GUID_WILDCARD", "00000000-0000-0000-0000-000000000000"),
+            ("HV_GUID_BROADCAST", "FFFFFFFF-FFFF-FFFF-FFFF-FFFFFFFFFFFF"),
+            ("HV_GUID_CHILDREN", "90DB8B89-0D35-4F79-8CE9-49EA0AC8B7CD"),
+            ("HV_GUID_LOOPBACK", "E0E16197-DD56-4A10-9195-5EE7A155A838"),
+            ("HV_GUID_PARENT", "A42E7CDA-D03F-480C-9CC2-A4DE20ABB878"),
+        ] {
+            crate::module_ns_store(ns, name, pyre_object::w_str_new(value));
+        }
         // ── socket-level cap ──
         // `<winsock2.h>` defines SOMAXCONN as 0x7fffffff; the WinSock 1.1
         // value of 5 the metadata carries is the one `listen` outgrew.
@@ -1527,6 +1606,94 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
     }
 
+    // Windows has the same public trio but no POSIX `if_nameindex` array.
+    // `rustpython_host_env::socket` follows the same IP Helper API route:
+    // `GetIfTable2Ex` for enumeration and the WinSock conversion calls for
+    // the two scalar directions.
+    #[cfg(all(windows, feature = "host_env"))]
+    {
+        crate::module_ns_store(
+            ns,
+            "if_nameindex",
+            crate::make_builtin_function_with_arity(
+                "if_nameindex",
+                |_| {
+                    let entries = rustpython_host_env::socket::if_nameindex()
+                        .map_err(interface_io_error)?;
+                    Ok(pyre_object::w_list_new(
+                        entries
+                            .into_iter()
+                            .map(|(index, name)| {
+                                pyre_object::w_tuple_new(vec![
+                                    pyre_object::w_int_new(index as i64),
+                                    pyre_object::w_str_new(&name),
+                                ])
+                            })
+                            .collect(),
+                    ))
+                },
+                0,
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "if_nametoindex",
+            crate::make_builtin_function_with_arity(
+                "if_nametoindex",
+                |args| {
+                    let name = crate::gateway::fsencode_bytes_w(args[0])?;
+                    let name = std::ffi::CString::new(name)
+                        .map_err(|_| crate::PyError::value_error("embedded null in name"))?;
+                    let index = rustpython_host_env::socket::if_nametoindex_checked(&name)
+                        .map_err(interface_io_error)?;
+                    Ok(pyre_object::w_int_new(index as i64))
+                },
+                1,
+            ),
+        );
+        crate::module_ns_store(
+            ns,
+            "if_indextoname",
+            crate::make_builtin_function_with_arity(
+                "if_indextoname",
+                |args| {
+                    // `socket_if_indextoname`'s NET_IFINDEX converter reads
+                    // `__index__` first, rejects a negative value, and only
+                    // then the ones no interface index can hold.  An argument
+                    // wider than a machine word has to reach those same two
+                    // answers rather than a conversion error of its own, so
+                    // take its sign from the object when the word conversion
+                    // is the thing that fails.
+                    let w_index = crate::baseobjspace::space_index(args[0])?;
+                    let word = crate::builtins::space_index_w(w_index).ok();
+                    let negative = match word {
+                        Some(index) => index < 0,
+                        // Only a long fails to fit a machine word.
+                        None => unsafe {
+                            pyre_object::longobject::jit_bigint_sign_i64(
+                                pyre_object::longobject::w_long_get_value(w_index),
+                            ) < 0
+                        },
+                    };
+                    if negative {
+                        return Err(crate::PyError::value_error("Cannot convert negative int"));
+                    }
+                    let index = word
+                        .and_then(|index| u32::try_from(index).ok())
+                        .ok_or_else(|| {
+                            crate::PyError::overflow_error(
+                                "Python int too large for C NET_IFINDEX",
+                            )
+                        })?;
+                    let name = rustpython_host_env::socket::if_indextoname_checked(index)
+                        .map_err(interface_io_error)?;
+                    Ok(pyre_object::w_str_new(&name))
+                },
+                1,
+            ),
+        );
+    }
+
     // ── CMSG_SPACE / CMSG_LEN ──
     // `interp_func.py:341-376` — POSIX macros, exposed only when the
     // host libc has them.  rust's `libc` crate provides both on every
@@ -1608,10 +1775,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         crate::module_ns_store(ns, "SocketType", socket_tp);
     }
 
-    // `socket.py` reaches for `_socket.socketpair` and falls back to its
-    // own AF_INET pair when the module does not carry one; `dup`/`fromfd`
-    // likewise have no WinSock spelling that duplicates a descriptor in
-    // place.  All three stay with the POSIX calls they are built on.
+    // `socket.py` defines `socketpair` only when `_socket` carries one and
+    // falls back to `_fallback_socketpair`'s own AF_INET pair otherwise, and
+    // `fromfd` is built out of `dup` at app level everywhere else.  Both stay
+    // with the POSIX calls they are made of; `dup` itself is registered for
+    // Windows too, further down, out of the WinSock calls that stand in for
+    // it.
     #[cfg(unix)]
     {
         // socketpair(family=AF_UNIX, type=SOCK_STREAM, proto=0)
@@ -1734,6 +1903,33 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             }),
         );
     }
+
+    // `socket.py:286 socket.dup` and `:554 fromfd` both go through
+    // `_socket.dup`, which on Windows cannot duplicate a descriptor in place:
+    // a socket is not a C runtime file descriptor there.  `socket_dup` hands
+    // the socket to the process it is already in with `WSADuplicateSocketW`
+    // and re-opens it from the protocol info that writes, which is the pair of
+    // calls `share_socket` / `socket_from_share_data` make.  The new socket is
+    // non-inheritable, as PEP 446 asks and as `socket_from_share_data` leaves
+    // it.
+    #[cfg(all(windows, feature = "host_env"))]
+    crate::module_ns_store(
+        ns,
+        "dup",
+        crate::make_builtin_function_with_arity(
+            "dup",
+            |args| {
+                let fd = crate::builtins::space_index_w(args[0])?;
+                let share =
+                    rustpython_host_env::socket::share_socket(fd as _, std::process::id())
+                        .map_err(socket_io_err)?;
+                let shared = rustpython_host_env::socket::socket_from_share_data(&share)
+                    .map_err(socket_io_err)?;
+                Ok(pyre_object::w_int_new(shared.raw as i64))
+            },
+            1,
+        ),
+    );
 }
 
 // ── hostent → (name, aliases, addrs) ──
@@ -4573,4 +4769,3 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
         ),
     ) };
 }
-

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -655,6 +655,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("TCP_FASTOPEN", 15);
         cst!("TCP_KEEPCNT", 16);
         cst!("TCP_KEEPINTVL", 17);
+        // `SIO_TCP_SET_ACK_FREQUENCY` - the name `socketmodule.c` gives this
+        // option on Windows, which `windows-sys` does not spell.
         cst!("TCP_QUICKACK", 0x98000017u32 as i32);
         // ── IP-level ──
         cst!("IP_TTL", ws::IP_TTL);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -650,14 +650,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // ── TCP-level ──
         cst!("TCP_NODELAY", ws::TCP_NODELAY);
         cst!("TCP_MAXSEG", ws::TCP_MAXSEG);
-        cst!("TCP_KEEPALIVE", ws::TCP_KEEPALIVE);
         cst!("TCP_KEEPIDLE", 3);
         cst!("TCP_FASTOPEN", 15);
         cst!("TCP_KEEPCNT", 16);
+        cst!("TCP_KEEPALIVE", ws::TCP_KEEPALIVE);
         cst!("TCP_KEEPINTVL", 17);
         // `SIO_TCP_SET_ACK_FREQUENCY` - the name `socketmodule.c` gives this
-        // option on Windows, which `windows-sys` does not spell.
-        cst!("TCP_QUICKACK", 0x98000017u32 as i32);
+        // option on Windows.  It is an ioctl code, not an option number, which
+        // is why `setsockopt` and `getsockopt` both special-case it.
+        cst!("TCP_QUICKACK", ws::SIO_TCP_SET_ACK_FREQUENCY as i32);
         // ── IP-level ──
         cst!("IP_TTL", ws::IP_TTL);
         cst!("IP_TOS", ws::IP_TOS);
@@ -2609,6 +2610,11 @@ fn socket_init_state(
     socket_set_attr(obj, "_type", pyre_object::w_int_new(ty as i64));
     socket_set_attr(obj, "_proto", pyre_object::w_int_new(proto as i64));
     socket_set_attr(obj, "_timeout", pyre_object::w_none());
+    // `sock_new` starts this at 0 on every socket object, and only
+    // `setsockopt` moves it: `SIO_TCP_SET_ACK_FREQUENCY` has no counterpart to
+    // read the live setting back with, so what was written is the answer.
+    #[cfg(windows)]
+    socket_set_attr(obj, "_quickack", pyre_object::w_int_new(0));
     // `interp_socket.py:977 usecount = 1` — start the refcount at 1 so
     // `_drop` followed by no `_reuse` closes the underlying fd exactly
     // once.
@@ -4608,6 +4614,21 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let level = (unsafe { pyre_object::w_int_get_value(args[1]) }) as libc::c_int;
             let name = (unsafe { pyre_object::w_int_get_value(args[2]) }) as libc::c_int;
             let val = args[3];
+            // `sock_setsockopt` sends an int for this option through
+            // `WSAIoctl` and keeps the value, because the option number is an
+            // ioctl code that `setsockopt` itself rejects.  A bytes value is
+            // not covered there either and still goes the ordinary way.
+            #[cfg(windows)]
+            if name == windows_sys::Win32::Networking::WinSock::SIO_TCP_SET_ACK_FREQUENCY as libc::c_int
+                && unsafe { pyre_object::is_int(val) }
+            {
+                let flag = (unsafe { pyre_object::w_int_get_value(val) }) as libc::c_int;
+                if unsafe { rffi::set_ack_frequency(fd, flag) } != 0 {
+                    return Err(socket_last_error());
+                }
+                socket_set_attr(args[0], "_quickack", pyre_object::w_int_new(flag as i64));
+                return Ok(pyre_object::w_none());
+            }
             let r = unsafe {
                 if pyre_object::is_int(val) {
                     let v = pyre_object::w_int_get_value(val) as libc::c_int;
@@ -4661,6 +4682,16 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 0
             };
             if buflen == 0 {
+                // `sock_getsockopt` answers the value `setsockopt` last wrote
+                // rather than asking WinSock, which has no call that reads an
+                // ioctl's current setting.
+                #[cfg(windows)]
+                if name == windows_sys::Win32::Networking::WinSock::SIO_TCP_SET_ACK_FREQUENCY as libc::c_int {
+                    return Ok(pyre_object::w_int_new(socket_get_attr_i64(
+                        args[0],
+                        "_quickack",
+                    )));
+                }
                 let mut v: libc::c_int = 0;
                 let mut sz = core::mem::size_of::<libc::c_int>() as rffi::SockLen;
                 let r = unsafe {

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -544,6 +544,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 crate::module_ns_store(ns, $name, pyre_object::w_int_new($val as i64));
             };
         }
+        use windows_sys::Win32::Devices::Bluetooth as bt;
         // ── Address families ──
         cst!("AF_UNSPEC", ws::AF_UNSPEC);
         cst!("AF_INET", ws::AF_INET);
@@ -556,7 +557,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // 3.14 Windows SDK exposes in addition to PyPy's older MSVC census.
         cst!("AF_SNA", 11);
         cst!("AF_IRDA", 26);
-        cst!("AF_BLUETOOTH", 32);
+        cst!("AF_BLUETOOTH", bt::AF_BTH);
         cst!("AF_HYPERV", ws::AF_HYPERV);
         // ── Socket types ──
         cst!("SOCK_STREAM", ws::SOCK_STREAM);
@@ -641,7 +642,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         // Bluetooth/RFCOMM constants.  The option names are unsigned SDK
         // words but `PyModule_AddIntConstant` exposes their signed C-long
         // readings on Windows.
-        cst!("BTPROTO_RFCOMM", 3);
+        cst!("BTPROTO_RFCOMM", bt::BTHPROTO_RFCOMM);
         cst!("SOL_RFCOMM", 3);
         cst!("SO_BTH_ENCRYPT", 2);
         cst!("SO_BTH_MTU", 0x80000007u32 as i32);
@@ -2680,6 +2681,132 @@ fn socket_get_so_protocol(_fd: rffi::Socket) -> Result<libc::c_int, crate::PyErr
 #[cfg(unix)]
 const SUN_PATH_OFFSET: usize = core::mem::offset_of!(libc::sockaddr_un, sun_path);
 
+/// One `%X` conversion of the scan `setbdaddr` runs: blanks, an optional sign,
+/// an optional `0x` prefix, then hex digits accumulated into the `unsigned
+/// int` the C code declares.  Answers the value and what is left to read.
+#[cfg(windows)]
+fn scan_hex_field(text: &str) -> Option<(u32, &str)> {
+    let text = text.trim_start_matches([' ', '\t', '\n', '\r', '\u{b}', '\u{c}']);
+    let (negative, text) = match text.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, text.strip_prefix('+').unwrap_or(text)),
+    };
+    // A `0x` counts as a prefix only when a hex digit follows: otherwise the
+    // conversion stops after the `0` and leaves the `x` to be read.
+    let digits = match text.strip_prefix("0x").or_else(|| text.strip_prefix("0X")) {
+        Some(rest) if rest.starts_with(|c: char| c.is_ascii_hexdigit()) => rest,
+        _ => text,
+    };
+    let mut value: u32 = 0;
+    let mut end = 0;
+    for digit in digits.bytes().take_while(u8::is_ascii_hexdigit) {
+        let digit = char::from(digit).to_digit(16).expect("hex digit");
+        value = value.wrapping_mul(16).wrapping_add(digit);
+        end += 1;
+    }
+    if end == 0 {
+        return None;
+    }
+    Some((if negative { value.wrapping_neg() } else { value }, &digits[end..]))
+}
+
+/// `setbdaddr` — six `%X` fields with a colon between each pair, every one of
+/// them below 256, and a trailing `%c` that makes anything after the sixth a
+/// seventh conversion and so a failure.  The leading field is the most
+/// significant octet, and `BTH_ADDR` carries the six as one number.
+#[cfg(windows)]
+fn parse_bdaddr(name: &str) -> Option<u64> {
+    let mut rest = name;
+    let mut octets = [0u32; 6];
+    for (i, octet) in octets.iter_mut().enumerate() {
+        if i > 0 {
+            rest = rest.strip_prefix(':')?;
+        }
+        (*octet, rest) = scan_hex_field(rest)?;
+    }
+    if !rest.is_empty() || octets.iter().fold(0, |acc, octet| acc | octet) >= 256 {
+        return None;
+    }
+    Some(octets.iter().fold(0u64, |acc, &octet| (acc << 8) | u64::from(octet)))
+}
+
+/// `makebdaddr` — `XX:XX:XX:XX:XX:XX`, most significant octet first.
+#[cfg(windows)]
+fn bdaddr_string(bdaddr: u64) -> String {
+    let octet = |i: u32| (bdaddr >> (8 * i)) & 0xFF;
+    format!(
+        "{:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X}",
+        octet(5),
+        octet(4),
+        octet(3),
+        octet(2),
+        octet(1),
+        octet(0)
+    )
+}
+
+/// The `AF_BLUETOOTH` case of `getsockaddrarg` (`socketmodule.c:2104-2205`).
+/// Only RFCOMM reaches here: it is the one Bluetooth protocol Windows carries,
+/// and `SOCKADDR_BTH` is the one address form that goes with it.
+#[cfg(windows)]
+fn pack_bluetooth_addr(
+    caller: &str,
+    proto: libc::c_int,
+    addr: pyre_object::PyObjectRef,
+    storage: &mut rffi::sockaddr_storage,
+) -> Result<rffi::SockLen, crate::PyError> {
+    use windows_sys::Win32::Devices::Bluetooth as bt;
+
+    if proto != bt::BTHPROTO_RFCOMM as libc::c_int {
+        return Err(crate::PyError::os_error(format!(
+            "{caller}(): unknown Bluetooth protocol"
+        )));
+    }
+    // `PyArg_ParseTuple(args, "sk")` fails and is answered with this one
+    // message, so every shape that is not a `str` beside an integer channel —
+    // a wrong length, `bytes`, an embedded NUL, a lone surrogate — reads alike.
+    let wrong_format = || crate::PyError::os_error(format!("{caller}(): wrong format"));
+    if !unsafe { pyre_object::is_tuple(addr) } || unsafe { pyre_object::w_tuple_len(addr) } != 2 {
+        return Err(wrong_format());
+    }
+    let w_name = unsafe { pyre_object::w_tuple_getitem(addr, 0) }.expect("length checked above");
+    let w_channel = unsafe { pyre_object::w_tuple_getitem(addr, 1) }.expect("length checked above");
+    if !unsafe { pyre_object::is_str(w_name) } || !unsafe { pyre_object::is_int(w_channel) } {
+        return Err(wrong_format());
+    }
+    let name = crate::baseobjspace::str_utf8_w(w_name).map_err(|_| wrong_format())?;
+    if name.contains('\0') {
+        return Err(wrong_format());
+    }
+    let bd_addr = parse_bdaddr(name).ok_or_else(|| crate::PyError::os_error("bad bluetooth address"))?;
+    let bth = bt::SOCKADDR_BTH {
+        addressFamily: bt::AF_BTH,
+        btAddr: bd_addr,
+        serviceClassId: Default::default(),
+        // `k` keeps the low `ULONG` of whatever it is handed rather than
+        // reporting an overflow.
+        port: (unsafe { pyre_object::w_int_get_value(w_channel) }) as u32,
+    };
+    // `SOCKADDR_BTH` is packed, so its `BTH_ADDR` sits two bytes into the
+    // storage and no aligned write reaches it.
+    unsafe { core::ptr::write_unaligned(storage as *mut _ as *mut bt::SOCKADDR_BTH, bth) };
+    Ok(core::mem::size_of::<bt::SOCKADDR_BTH>() as rffi::SockLen)
+}
+
+/// The RFCOMM case of `makesockaddr` (`socketmodule.c:1546-1560`) — the address
+/// as a string beside the channel, the shape `bind` and `connect` take back.
+#[cfg(windows)]
+fn unpack_bluetooth_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObjectRef {
+    use windows_sys::Win32::Devices::Bluetooth as bt;
+
+    let bth: bt::SOCKADDR_BTH =
+        unsafe { core::ptr::read_unaligned(storage as *const _ as *const bt::SOCKADDR_BTH) };
+    pyre_object::w_tuple_new(vec![
+        pyre_object::w_str_new(&bdaddr_string(bth.btAddr)),
+        pyre_object::w_int_new(i64::from(bth.port)),
+    ])
+}
+
 /// `HV_PROTOCOL_RAW` — the only protocol an `AF_HYPERV` socket is opened with.
 /// `hvsocket.h` defines it; `windows-sys` does not carry that header.
 #[cfg(windows)]
@@ -2868,6 +2995,12 @@ fn pack_inet_addr(
     #[cfg(windows)]
     if family == windows_sys::Win32::Networking::WinSock::AF_HYPERV as libc::c_int {
         let addrlen = pack_hyperv_addr(caller, proto, addr, &mut storage)?;
+        return Ok((storage, addrlen));
+    }
+
+    #[cfg(windows)]
+    if family == windows_sys::Win32::Devices::Bluetooth::AF_BTH as libc::c_int {
+        let addrlen = pack_bluetooth_addr(caller, proto, addr, &mut storage)?;
         return Ok((storage, addrlen));
     }
 
@@ -3072,6 +3205,10 @@ fn unpack_inet_addr(
         #[cfg(windows)]
         if family == windows_sys::Win32::Networking::WinSock::AF_HYPERV as libc::c_int {
             return unpack_hyperv_addr(storage);
+        }
+        #[cfg(windows)]
+        if family == windows_sys::Win32::Devices::Bluetooth::AF_BTH as libc::c_int {
+            return unpack_bluetooth_addr(storage);
         }
         pyre_object::w_tuple_new(vec![])
     }

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -564,19 +564,25 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IPPROTO_SCTP", ws::IPPROTO_SCTP);
         cst!("IPPROTO_RAW", ws::IPPROTO_RAW);
         cst!("IPPROTO_MAX", ws::IPPROTO_MAX);
-        // `_rsocket_rffi.py constants_w_defaults` — SOL_IP/TCP/UDP
-        // kept for PyPy compatibility.
-        cst!("SOL_IP", 0);
+        // `_rsocket_rffi.py constants_w_defaults` — SOL_TCP/UDP kept for
+        // PyPy compatibility.  `SOL_IP` is the platform's own here:
+        // `ws2def.h` defines it, so the zero placeholder the other arm uses
+        // would name `IPPROTO_IP` instead of the level.
+        cst!("SOL_IP", ws::SOL_IP);
         cst!("SOL_TCP", 6);
         cst!("SOL_UDP", 17);
         // ── INADDR_* (host byte order) ──
-        cst!("INADDR_ANY", ws::INADDR_ANY);
-        cst!("INADDR_LOOPBACK", ws::INADDR_LOOPBACK);
-        cst!("INADDR_BROADCAST", ws::INADDR_BROADCAST);
-        cst!("INADDR_NONE", ws::INADDR_NONE);
-        cst!("INADDR_ALLHOSTS_GROUP", 0xe0000001u32);
-        cst!("INADDR_UNSPEC_GROUP", 0xe0000000u32);
-        cst!("INADDR_MAX_LOCAL_GROUP", 0xe00000ffu32);
+        //
+        // `PyModule_AddIntConstant` takes a C `long`, which is 32 bits here, so
+        // every one of these with the top bit set is published as the negative
+        // number that word spells rather than as its unsigned reading.
+        cst!("INADDR_ANY", ws::INADDR_ANY as i32);
+        cst!("INADDR_LOOPBACK", ws::INADDR_LOOPBACK as i32);
+        cst!("INADDR_BROADCAST", ws::INADDR_BROADCAST as i32);
+        cst!("INADDR_NONE", ws::INADDR_NONE as i32);
+        cst!("INADDR_ALLHOSTS_GROUP", 0xe0000001u32 as i32);
+        cst!("INADDR_UNSPEC_GROUP", 0xe0000000u32 as i32);
+        cst!("INADDR_MAX_LOCAL_GROUP", 0xe00000ffu32 as i32);
         cst!("IPPORT_RESERVED", ws::IPPORT_RESERVED);
         cst!("IPPORT_USERRESERVED", 5000);
         // ── SOL_* / SO_* (socket level) ──
@@ -667,7 +673,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("EAI_FAIL", ws::WSANO_RECOVERY);
         cst!("EAI_FAMILY", ws::WSAEAFNOSUPPORT);
         cst!("EAI_MEMORY", ws::WSA_NOT_ENOUGH_MEMORY);
-        cst!("EAI_NODATA", ws::WSANO_DATA);
+        // `ws2tcpip.h` spells `EAI_NODATA` as `EAI_NONAME`, the RFC 3493
+        // deprecation, so both name `WSAHOST_NOT_FOUND` and not `WSANO_DATA`.
+        cst!("EAI_NODATA", ws::WSAHOST_NOT_FOUND);
         cst!("EAI_NONAME", ws::WSAHOST_NOT_FOUND);
         cst!("EAI_SERVICE", ws::WSATYPE_NOT_FOUND);
         cst!("EAI_SOCKTYPE", ws::WSAESOCKTNOSUPPORT);

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -653,7 +653,6 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("TCP_KEEPIDLE", 3);
         cst!("TCP_FASTOPEN", 15);
         cst!("TCP_KEEPCNT", 16);
-        cst!("TCP_KEEPALIVE", ws::TCP_KEEPALIVE);
         cst!("TCP_KEEPINTVL", 17);
         // `SIO_TCP_SET_ACK_FREQUENCY` - the name `socketmodule.c` gives this
         // option on Windows.  It is an ioctl code, not an option number, which

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -557,7 +557,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("AF_SNA", 11);
         cst!("AF_IRDA", 26);
         cst!("AF_BLUETOOTH", 32);
-        cst!("AF_HYPERV", 34);
+        cst!("AF_HYPERV", ws::AF_HYPERV);
         // ── Socket types ──
         cst!("SOCK_STREAM", ws::SOCK_STREAM);
         cst!("SOCK_DGRAM", ws::SOCK_DGRAM);
@@ -2675,11 +2675,144 @@ fn socket_get_so_protocol(_fd: rffi::Socket) -> Result<libc::c_int, crate::PyErr
 #[cfg(unix)]
 const SUN_PATH_OFFSET: usize = core::mem::offset_of!(libc::sockaddr_un, sun_path);
 
+/// `HV_PROTOCOL_RAW` — the only protocol an `AF_HYPERV` socket is opened with.
+/// `hvsocket.h` defines it; `windows-sys` does not carry that header.
+#[cfg(windows)]
+const HV_PROTOCOL_RAW: libc::c_int = 1;
+
+/// `SOCKADDR_HV` (`hvsocket.h`): the family, a reserved word, and the two
+/// GUIDs a Hyper-V endpoint is named by.  36 bytes, so it fits a
+/// `sockaddr_storage` like every other form here.
+#[cfg(windows)]
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct SockaddrHv {
+    family: u16,
+    reserved: u16,
+    vm_id: windows_sys::core::GUID,
+    service_id: windows_sys::core::GUID,
+}
+
+/// The single message `PyArg_ParseTuple(args, "UU;...")` produces for every
+/// shape that is a tuple but not two `str`s — a wrong length included.
+#[cfg(windows)]
+fn hyperv_address_shape_error() -> crate::PyError {
+    crate::PyError::type_error("AF_HYPERV address must be a str tuple (vm_id, service_id)")
+}
+
+/// `UuidFromStringW`, which takes the bare 8-4-4-4-12 spelling and nothing
+/// else: a braced or truncated GUID is rejected here rather than reinterpreted.
+#[cfg(windows)]
+fn parse_hyperv_guid(
+    caller: &str,
+    field: &str,
+    w_text: pyre_object::PyObjectRef,
+) -> Result<windows_sys::core::GUID, crate::PyError> {
+    let mut wide: Vec<u16> = unsafe { pyre_object::w_str_get_wtf8(w_text) }
+        .encode_wide()
+        .collect();
+    wide.push(0);
+    let mut guid = windows_sys::core::GUID {
+        data1: 0,
+        data2: 0,
+        data3: 0,
+        data4: [0; 8],
+    };
+    let status =
+        unsafe { windows_sys::Win32::System::Rpc::UuidFromStringW(wide.as_ptr(), &mut guid) };
+    if status != windows_sys::Win32::System::Rpc::RPC_S_OK {
+        return Err(crate::PyError::value_error(format!(
+            "{caller}(): AF_HYPERV address {field} is not a valid UUID string"
+        )));
+    }
+    Ok(guid)
+}
+
+/// The spelling `UuidToStringW` gives a GUID: lower case, unbraced.
+#[cfg(windows)]
+fn hyperv_guid_string(guid: &windows_sys::core::GUID) -> String {
+    use windows_sys::Win32::System::Rpc::{RPC_S_OK, RpcStringFreeW, UuidToStringW};
+
+    let mut text: *mut u16 = std::ptr::null_mut();
+    if unsafe { UuidToStringW(guid, &mut text) } != RPC_S_OK {
+        return String::new();
+    }
+    let mut end = 0usize;
+    while unsafe { *text.add(end) } != 0 {
+        end += 1;
+    }
+    let out = String::from_utf16_lossy(unsafe { std::slice::from_raw_parts(text, end) });
+    unsafe { RpcStringFreeW(&mut text) };
+    out
+}
+
+/// The `AF_HYPERV` case of `getsockaddrarg` (`socketmodule.c:2643-2712`).
+#[cfg(windows)]
+fn pack_hyperv_addr(
+    caller: &str,
+    proto: libc::c_int,
+    addr: pyre_object::PyObjectRef,
+    storage: &mut rffi::sockaddr_storage,
+) -> Result<rffi::SockLen, crate::PyError> {
+    if proto != HV_PROTOCOL_RAW {
+        return Err(crate::PyError::os_error(format!(
+            "{caller}(): unsupported AF_HYPERV protocol: {proto}"
+        )));
+    }
+    if !unsafe { pyre_object::is_tuple(addr) } {
+        return Err(crate::PyError::type_error(format!(
+            "{caller}(): AF_HYPERV address must be tuple, not {}",
+            crate::type_methods::arg_type_name(addr)
+        )));
+    }
+    if unsafe { pyre_object::w_tuple_len(addr) } != 2 {
+        return Err(hyperv_address_shape_error());
+    }
+    let w_vm_id = unsafe { pyre_object::w_tuple_getitem(addr, 0) }.expect("length checked above");
+    let w_service_id =
+        unsafe { pyre_object::w_tuple_getitem(addr, 1) }.expect("length checked above");
+    if !unsafe { pyre_object::is_str(w_vm_id) } || !unsafe { pyre_object::is_str(w_service_id) } {
+        return Err(hyperv_address_shape_error());
+    }
+    // Both GUIDs are parsed before either is stored: no step here runs Python,
+    // so the two lookups above stay valid across the second parse.
+    let vm_id = parse_hyperv_guid(caller, "vm_id", w_vm_id)?;
+    let service_id = parse_hyperv_guid(caller, "service_id", w_service_id)?;
+    let hv = unsafe { &mut *(storage as *mut _ as *mut SockaddrHv) };
+    *hv = SockaddrHv {
+        family: windows_sys::Win32::Networking::WinSock::AF_HYPERV,
+        reserved: 0,
+        vm_id,
+        service_id,
+    };
+    Ok(core::mem::size_of::<SockaddrHv>() as rffi::SockLen)
+}
+
+/// The `AF_HYPERV` case of `makesockaddr` (`socketmodule.c:1740-1767`) — the
+/// two GUIDs as strings, the same shape `bind` and `connect` accept.
+#[cfg(windows)]
+fn unpack_hyperv_addr(storage: &rffi::sockaddr_storage) -> pyre_object::PyObjectRef {
+    let hv = unsafe { &*(storage as *const _ as *const SockaddrHv) };
+    let vm_id = hyperv_guid_string(&hv.vm_id);
+    let service_id = hyperv_guid_string(&hv.service_id);
+    pyre_object::w_tuple_new(vec![
+        pyre_object::w_str_new(&vm_id),
+        pyre_object::w_str_new(&service_id),
+    ])
+}
+
 #[cfg(any(unix, windows))]
 fn pack_inet_addr(
+    caller: &str,
     family: libc::c_int,
+    proto: libc::c_int,
     addr: pyre_object::PyObjectRef,
 ) -> Result<(rffi::sockaddr_storage, rffi::SockLen), crate::PyError> {
+    // Only the AF_HYPERV form reads these two: `getsockaddrarg` names the
+    // calling method in its messages and rejects any protocol but
+    // `HV_PROTOCOL_RAW`.
+    #[cfg(not(windows))]
+    let _ = (caller, proto);
     let mut storage: rffi::sockaddr_storage = unsafe { std::mem::zeroed() };
     // AF_UNIX is special: rsocket.py:RSocket.bind/connect accept a bare
     // bytes/str path (or a 1-tuple wrapping the path).  Pull the path
@@ -2725,6 +2858,12 @@ fn pack_inet_addr(
         // terminator is counted only for a regular name that has one.
         let addrlen = SUN_PATH_OFFSET + path_bytes_vec.len() + usize::from(!abstract_name);
         return Ok((storage, addrlen as rffi::SockLen));
+    }
+
+    #[cfg(windows)]
+    if family == windows_sys::Win32::Networking::WinSock::AF_HYPERV as libc::c_int {
+        let addrlen = pack_hyperv_addr(caller, proto, addr, &mut storage)?;
+        return Ok((storage, addrlen));
     }
 
     if !unsafe { pyre_object::is_tuple(addr) } {
@@ -2924,6 +3063,10 @@ fn unpack_inet_addr(
         #[cfg(unix)]
         if family == libc::AF_UNIX {
             return unpack_unix_addr(storage, addrlen);
+        }
+        #[cfg(windows)]
+        if family == windows_sys::Win32::Networking::WinSock::AF_HYPERV as libc::c_int {
+            return unpack_hyperv_addr(storage);
         }
         pyre_object::w_tuple_new(vec![])
     }
@@ -3278,7 +3421,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let obj = args[0];
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-                let (storage, slen) = pack_inet_addr(family, args[1])?;
+                let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                let (storage, slen) = pack_inet_addr("bind", family, proto, args[1])?;
                 let r =
                     unsafe { rffi::bind(fd, &storage as *const _ as *const rffi::sockaddr, slen) };
                 if r != 0 {
@@ -3408,7 +3552,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let obj = args[0];
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-                let (storage, slen) = pack_inet_addr(family, args[1])?;
+                let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                let (storage, slen) = pack_inet_addr("connect", family, proto, args[1])?;
                 #[cfg(windows)]
                 if let Some(timeout) = socket_positive_timeout(obj) {
                     return match socket_connect_timed(fd, &storage, slen, timeout) {
@@ -3454,7 +3599,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 let obj = args[0];
                 let fd = socket_fd(obj)?;
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-                let (storage, slen) = pack_inet_addr(family, args[1])?;
+                let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                let (storage, slen) = pack_inet_addr("connect_ex", family, proto, args[1])?;
                 #[cfg(windows)]
                 if let Some(timeout) = socket_positive_timeout(obj) {
                     let err = socket_connect_timed(fd, &storage, slen, timeout).err();
@@ -3662,7 +3808,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let result = (|| -> Result<isize, crate::PyError> {
                 let buf = buffer.as_bytes();
                 let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-                let (storage, slen) = pack_inet_addr(family, addr_obj)?;
+                let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                let (storage, slen) = pack_inet_addr("sendto", family, proto, addr_obj)?;
                 loop {
                     let (r, errno) = socket_call(|| unsafe {
                         rffi::sendto(
@@ -4321,7 +4468,8 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
             let (addr_storage, addr_len) =
                 if args.len() >= 5 && !unsafe { pyre_object::is_none(args[4]) } {
                     let family = socket_get_attr_i64(obj, "_family") as libc::c_int;
-                    let (s, l) = pack_inet_addr(family, args[4])?;
+                    let proto = socket_get_attr_i64(obj, "_proto") as libc::c_int;
+                    let (s, l) = pack_inet_addr("sendmsg", family, proto, args[4])?;
                     (Some(s), l)
                 } else {
                     (None, 0)

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -760,6 +760,28 @@ pub unsafe fn getsockopt(
     unsafe { ws::getsockopt(s, level, option, value.cast(), len) }
 }
 
+/// `SIO_TCP_SET_ACK_FREQUENCY`, which is what `TCP_QUICKACK` names here.
+/// It is an ioctl rather than a socket option, so `setsockopt` answers
+/// `WSAENOPROTOOPT` for it and the flag has to travel through `WSAIoctl`.
+/// Nothing reads it back: WinSock exposes no query for the current setting.
+#[cfg(windows)]
+pub unsafe fn set_ack_frequency(s: Socket, flag: libc::c_int) -> libc::c_int {
+    let mut returned: u32 = 0;
+    unsafe {
+        ws::WSAIoctl(
+            s,
+            ws::SIO_TCP_SET_ACK_FREQUENCY,
+            (&raw const flag).cast(),
+            core::mem::size_of::<libc::c_int>() as u32,
+            core::ptr::null_mut(),
+            0,
+            &mut returned,
+            core::ptr::null_mut(),
+            None,
+        )
+    }
+}
+
 #[cfg(unix)]
 pub unsafe fn setsockopt(
     s: Socket,

--- a/pyre/pyre-interpreter/src/module/gc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/gc/mod.rs
@@ -17,6 +17,13 @@ pub mod hook;
 /// call so callers that toggle and re-read the state stay consistent.
 static GC_ENABLED: AtomicBool = AtomicBool::new(true);
 
+/// The collector debug word.  PyPy does not expose this frontend knob, but
+/// the 3.14 observable contract requires the value to be interpreter-owned and
+/// shared by all threads.  The moving collector has no
+/// refcount-cycle diagnostic stream to toggle; the word is nevertheless kept
+/// exactly so callers can bracket a collection and restore the prior flags.
+static GC_DEBUG: AtomicI64 = AtomicI64::new(0);
+
 /// The collection thresholds `gc.get_threshold()` reports.  pyre's collector
 /// has no generational allocation counters to drive, so the values are only
 /// remembered: `set_threshold` stores what it was given and `get_threshold`
@@ -1451,6 +1458,17 @@ crate::py_module! {
         "get_count"     / 0 = |_| Ok(w_tuple_new(vec![
             w_int_new(0), w_int_new(0), w_int_new(0),
         ])),
+        "get_debug"     / 0 = |_| Ok(w_int_new(GC_DEBUG.load(Ordering::Relaxed))),
+        "set_debug"     / 1 = |args| {
+            // `gc_set_debug_impl` parses a C int through the index protocol.
+            // Convert before storing so a failed conversion leaves the old
+            // process-wide word untouched.
+            let flags = crate::baseobjspace::c_int_w(
+                crate::baseobjspace::space_index(args[0])?,
+            )?;
+            GC_DEBUG.store(flags as i64, Ordering::Relaxed);
+            Ok(w_none())
+        },
         "is_tracked"    / 1 = |args| {
             // CPython 3.14 `gc.is_tracked(obj)`: whether the collector
             // traverses references out of the object. Asked of the registered

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -10520,15 +10520,24 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     // The path names itself; the argv entries do not, because
                     // each of those is converted on the sequence's behalf
                     // rather than as an argument of its own.
-                    let command =
-                        crate::gateway::fsencode_path_named_w(args[0], "execv", "path")?.as_bytes;
-                    let command_w = wide_path(&command)?;
+                    let path = crate::gateway::fsencode_path_named_w(args[0], "execv", "path")?;
+                    let command_w = wide_path(&path.as_bytes)?;
                     let argv = exec_argv_wide(args[1], "execv")?;
                     let argv_ptrs = exec_pointer_array_wide(&argv);
-                    unsafe { libc::wexecv(command_w.as_ptr(), argv_ptrs.as_ptr()) };
-                    // `wrap_oserror` names no file, so the path stays out of
-                    // the error.
-                    Err(io_err(std::io::Error::last_os_error(), ""))
+                    // The runtime's invalid parameter handler is silenced
+                    // around the call: an empty path reaches it, and its
+                    // default action ends the process where the call is
+                    // supposed to return -1 with `EINVAL` in `errno`.
+                    crate::builtins::crt_call!(libc::wexecv(
+                        command_w.as_ptr(),
+                        argv_ptrs.as_ptr()
+                    ));
+                    // `os_execv_impl` reports through `path_error`, so the
+                    // path this failed on is the error's filename.
+                    Err(errno_err_with_filename(
+                        crate::builtins::crt_errno(),
+                        path.w_path(),
+                    ))
                 },
                 2,
             ),
@@ -10540,9 +10549,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             crate::make_builtin_function_with_arity(
                 "execve",
                 |args| {
-                    let command =
-                        crate::gateway::fsencode_path_named_w(args[0], "execve", "path")?.as_bytes;
-                    let command_w = wide_path(&command)?;
+                    let path = crate::gateway::fsencode_path_named_w(args[0], "execve", "path")?;
+                    let command_w = wide_path(&path.as_bytes)?;
                     let argv = exec_argv_wide(args[1], "execve")?;
                     let argv_ptrs = exec_pointer_array_wide(&argv);
 
@@ -10558,12 +10566,40 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         })
                         .collect::<Result<Vec<_>, _>>()?;
                     let env_ptrs = exec_pointer_array_wide(&env);
-                    unsafe {
-                        libc::wexecve(command_w.as_ptr(), argv_ptrs.as_ptr(), env_ptrs.as_ptr())
-                    };
-                    Err(io_err(std::io::Error::last_os_error(), ""))
+                    crate::builtins::crt_call!(libc::wexecve(
+                        command_w.as_ptr(),
+                        argv_ptrs.as_ptr(),
+                        env_ptrs.as_ptr()
+                    ));
+                    Err(errno_err_with_filename(
+                        crate::builtins::crt_errno(),
+                        path.w_path(),
+                    ))
                 },
                 3,
+            ),
+        );
+
+        // os.kill(pid, sig)
+        //
+        // `os_kill_impl` under `MS_WINDOWS`: the two console control events
+        // are delivered to the process group with `GenerateConsoleCtrlEvent`,
+        // and any other number is the exit code `TerminateProcess` stamps on
+        // the process it ends — there are no signals to send one.
+        crate::module_ns_store(
+            ns,
+            "kill",
+            crate::make_builtin_function_with_arity(
+                "kill",
+                |args| {
+                    let pid = crate::baseobjspace::c_int_w(args[0])?;
+                    let sig = crate::baseobjspace::c_int_w(args[1])?;
+                    let _blocked = crate::module::thread::before_external_block();
+                    host_nt::kill(pid as u32, sig as u32)
+                        .map_err(|error| fs_err_with_filename(error, pyre_object::PY_NULL))?;
+                    Ok(pyre_object::w_none())
+                },
+                2,
             ),
         );
 
@@ -10638,6 +10674,30 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 result.map_err(|e| fs_err_with_filename(e, path.w_path()))?;
                 Ok(pyre_object::w_none())
             }),
+        );
+
+        // `os.lchmod` is the named `follow_symlinks=False` operation.  Windows
+        // implements that distinction with the reparse point's own file
+        // attributes (`rustpython_host_env::nt::win32_lchmod`), so publishing
+        // the function is truthful here rather than the unsupported POSIX
+        // `lchmod(2)` stub some Unix hosts carry.
+        crate::module_ns_store(
+            ns,
+            "lchmod",
+            crate::make_builtin_function_with_arity(
+                "lchmod",
+                |args| {
+                    let path = crate::gateway::fsencode_path_or_fd_w(
+                        args[0], "lchmod", false,
+                    )?;
+                    let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
+                    let name = os_str_from_bytes(&path.as_bytes);
+                    host_nt::win32_lchmod(&name, mode, S_IWRITE)
+                        .map_err(|error| fs_err_with_filename(error, path.w_path()))?;
+                    Ok(pyre_object::w_none())
+                },
+                2,
+            ),
         );
 
         // os.fchmod(fd, mode) -> None

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -10691,8 +10691,8 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         args[0], "lchmod", false,
                     )?;
                     let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
-                    let name = os_str_from_bytes(&path.as_bytes);
-                    host_nt::win32_lchmod(&name, mode, S_IWRITE)
+                    let wide = wide_path(&path.as_bytes)?;
+                    host_nt::win32_lchmod(&wide, mode, S_IWRITE)
                         .map_err(|error| fs_err_with_filename(error, path.w_path()))?;
                     Ok(pyre_object::w_none())
                 },

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -10,6 +10,10 @@ use crate::{
 use pyre_object::*;
 use std::sync::OnceLock;
 
+#[cfg(windows)]
+static LEGACY_WINDOWS_FS_ENCODING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 const GETSIZEOF_DOC: &str = "getsizeof(object [, default]) -> int\n\n\
 Return the size of object in bytes.";
 
@@ -1360,10 +1364,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // sys.version_info — structseq(major, minor, micro, releaselevel,
     // serial); a tuple subclass so `>= (3, 14)` / `[0]` and `.major` both work.
     {
-        let version_info_type = crate::_structseq::make_struct_seq(
-            "sys.version_info",
-            &["major", "minor", "micro", "releaselevel", "serial"],
-        );
+        let version_info_type =
+            crate::_structseq::disallow_instantiation(crate::_structseq::make_struct_seq(
+                "sys.version_info",
+                &["major", "minor", "micro", "releaselevel", "serial"],
+            ));
         let vi = crate::_structseq::new_instance(
             version_info_type,
             vec![
@@ -1521,29 +1526,31 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     // `context_aware_warnings` sit past the sequence as named-only extras,
     // which is what makes `n_fields` (21) exceed `len()` (18).
     {
-        let flags_type = crate::_structseq::make_struct_seq_with_extra(
-            "sys.flags",
-            &[
-                "debug",
-                "inspect",
-                "interactive",
-                "optimize",
-                "dont_write_bytecode",
-                "no_user_site",
-                "no_site",
-                "ignore_environment",
-                "verbose",
-                "bytes_warning",
-                "quiet",
-                "hash_randomization",
-                "isolated",
-                "dev_mode",
-                "utf8_mode",
-                "warn_default_encoding",
-                "safe_path",
-                "int_max_str_digits",
-            ],
-            &["gil", "thread_inherit_context", "context_aware_warnings"],
+        let flags_type = crate::_structseq::disallow_instantiation(
+            crate::_structseq::make_struct_seq_with_extra(
+                "sys.flags",
+                &[
+                    "debug",
+                    "inspect",
+                    "interactive",
+                    "optimize",
+                    "dont_write_bytecode",
+                    "no_user_site",
+                    "no_site",
+                    "ignore_environment",
+                    "verbose",
+                    "bytes_warning",
+                    "quiet",
+                    "hash_randomization",
+                    "isolated",
+                    "dev_mode",
+                    "utf8_mode",
+                    "warn_default_encoding",
+                    "safe_path",
+                    "int_max_str_digits",
+                ],
+                &["gil", "thread_inherit_context", "context_aware_warnings"],
+            ),
         );
         let flags = crate::_structseq::new_instance_with_extra(
             flags_type,
@@ -1621,16 +1628,18 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `type(sys.getwindowsversion())` a different class each time.
                 static SEQ_TYPE: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
                 let cls = *SEQ_TYPE.get_or_init(|| {
-                    crate::_structseq::make_struct_seq_with_extra(
-                        "sys.getwindowsversion",
-                        &["major", "minor", "build", "platform", "service_pack"],
-                        &[
-                            "service_pack_major",
-                            "service_pack_minor",
-                            "suite_mask",
-                            "product_type",
-                            "platform_version",
-                        ],
+                    crate::_structseq::disallow_instantiation(
+                        crate::_structseq::make_struct_seq_with_extra(
+                            "sys.getwindowsversion",
+                            &["major", "minor", "build", "platform", "service_pack"],
+                            &[
+                                "service_pack_major",
+                                "service_pack_minor",
+                                "suite_mask",
+                                "product_type",
+                                "platform_version",
+                            ],
+                        ),
                     ) as usize
                 }) as PyObjectRef;
                 Ok(crate::_structseq::new_instance_with_extra(
@@ -1798,6 +1807,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             0,
         ),
     );
+    module_ns_store(
+        ns,
+        "_current_exceptions",
+        make_builtin_function_with_arity(
+            "_current_exceptions",
+            |_| Ok(crate::module::thread::current_exceptions()),
+            0,
+        ),
+    );
     // PyPy: pypy/module/sys/state.py:get_int_max_str_digits and
     // set_int_max_str_digits. The limit is object-space state, shared by
     // every caller rather than thread-local state.
@@ -1875,6 +1893,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    module_ns_store(ns, "api_version", w_int_new(1013));
+    module_ns_store(
+        ns,
+        "_git",
+        w_tuple_new(vec![w_str_new("pyre"), w_str_new(""), w_str_new("")]),
+    );
+    module_ns_store(ns, "_home", w_none());
     // sys.implementation — PyPy app.py's implementation_dict, with the Pyre
     // implementation version rather than Python's language version.
     {
@@ -1907,57 +1932,93 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         );
         module_ns_store(ns, "implementation", impl_obj);
     }
-    // sys.hash_info — structseq with width/modulus/... fields.
-    // PyPy: pypy/module/sys/system.py hash_info.
+    // `system.py:get_hash_info|get_float_info|get_thread_info|get_int_info`:
+    // these values are instances of their named structseq classes, not
+    // namespace-shaped records. Tuple storage is observable through indexing,
+    // unpacking, repr, pickling and the n_* class attributes.
     {
-        let hash_info = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue_native(hash_info, "width", w_int_new(64));
-        crate::baseobjspace::setdictvalue_native(hash_info, "modulus", w_int_new((1i64 << 61) - 1));
-        crate::baseobjspace::setdictvalue_native(hash_info, "inf", w_int_new(314159));
-        crate::baseobjspace::setdictvalue_native(hash_info, "nan", w_int_new(0));
-        crate::baseobjspace::setdictvalue_native(hash_info, "imag", w_int_new(1000003));
-        crate::baseobjspace::setdictvalue_native(hash_info, "algorithm", w_str_new("siphash13"));
-        crate::baseobjspace::setdictvalue_native(hash_info, "hash_bits", w_int_new(64));
-        crate::baseobjspace::setdictvalue_native(hash_info, "seed_bits", w_int_new(128));
-        crate::baseobjspace::setdictvalue_native(hash_info, "cutoff", w_int_new(0));
-        module_ns_store(ns, "hash_info", hash_info);
+        let ty = crate::_structseq::make_struct_seq(
+            "sys.hash_info",
+            &[
+                "width", "modulus", "inf", "nan", "imag", "algorithm", "hash_bits",
+                "seed_bits", "cutoff",
+            ],
+        );
+        let value = crate::_structseq::new_instance(
+            ty,
+            vec![
+                w_int_new(64),
+                w_int_new((1i64 << 61) - 1),
+                w_int_new(314159),
+                w_int_new(0),
+                w_int_new(1000003),
+                w_str_new("siphash13"),
+                w_int_new(64),
+                w_int_new(128),
+                w_int_new(0),
+            ],
+        );
+        module_ns_store(ns, "hash_info", value);
     }
-    // sys.float_info — structseq with IEEE 754 double metadata.
-    // PyPy: pypy/module/sys/system.py float_info.
     {
-        let fi = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue_native(fi, "max", w_float_new(f64::MAX));
-        crate::baseobjspace::setdictvalue_native(fi, "max_exp", w_int_new(1024));
-        crate::baseobjspace::setdictvalue_native(fi, "max_10_exp", w_int_new(308));
-        crate::baseobjspace::setdictvalue_native(fi, "min", w_float_new(f64::MIN_POSITIVE));
-        crate::baseobjspace::setdictvalue_native(fi, "min_exp", w_int_new(-1021));
-        crate::baseobjspace::setdictvalue_native(fi, "min_10_exp", w_int_new(-307));
-        crate::baseobjspace::setdictvalue_native(fi, "dig", w_int_new(15));
-        crate::baseobjspace::setdictvalue_native(fi, "mant_dig", w_int_new(53));
-        crate::baseobjspace::setdictvalue_native(fi, "epsilon", w_float_new(f64::EPSILON));
-        crate::baseobjspace::setdictvalue_native(fi, "radix", w_int_new(2));
-        crate::baseobjspace::setdictvalue_native(fi, "rounds", w_int_new(1));
-        module_ns_store(ns, "float_info", fi);
+        let ty = crate::_structseq::make_struct_seq(
+            "sys.float_info",
+            &[
+                "max", "max_exp", "max_10_exp", "min", "min_exp", "min_10_exp", "dig",
+                "mant_dig", "epsilon", "radix", "rounds",
+            ],
+        );
+        let value = crate::_structseq::new_instance(
+            ty,
+            vec![
+                w_float_new(f64::MAX),
+                w_int_new(1024),
+                w_int_new(308),
+                w_float_new(f64::MIN_POSITIVE),
+                w_int_new(-1021),
+                w_int_new(-307),
+                w_int_new(15),
+                w_int_new(53),
+                w_float_new(f64::EPSILON),
+                w_int_new(2),
+                w_int_new(1),
+            ],
+        );
+        module_ns_store(ns, "float_info", value);
     }
     // sysmodule.c — `sys.float_repr_style` is "short" wherever float repr
     // uses David Gay's shortest-round-trip algorithm (always, here).
     module_ns_store(ns, "float_repr_style", w_str_new("short"));
-    // sys.thread_info — structseq(name, lock, version).
     {
-        let ti = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue_native(ti, "name", w_str_new("pthread"));
-        crate::baseobjspace::setdictvalue_native(ti, "lock", w_str_new("semaphore"));
-        crate::baseobjspace::setdictvalue_native(ti, "version", w_none());
-        module_ns_store(ns, "thread_info", ti);
+        let ty = crate::_structseq::make_struct_seq(
+            "sys.thread_info",
+            &["name", "lock", "version"],
+        );
+        let value = crate::_structseq::new_instance(
+            ty,
+            vec![
+                w_str_new(if cfg!(windows) { "nt" } else { "pthread" }),
+                if cfg!(windows) { w_none() } else { w_str_new("semaphore") },
+                w_none(),
+            ],
+        );
+        module_ns_store(ns, "thread_info", value);
     }
-    // sys.int_info — structseq with int implementation details.
     {
-        let ii = make_sys_namespace_instance();
-        crate::baseobjspace::setdictvalue_native(ii, "bits_per_digit", w_int_new(30));
-        crate::baseobjspace::setdictvalue_native(ii, "sizeof_digit", w_int_new(4));
-        crate::baseobjspace::setdictvalue_native(ii, "default_max_str_digits", w_int_new(4300));
-        crate::baseobjspace::setdictvalue_native(ii, "str_digits_check_threshold", w_int_new(640));
-        module_ns_store(ns, "int_info", ii);
+        let ty = crate::_structseq::make_struct_seq(
+            "sys.int_info",
+            &[
+                "bits_per_digit",
+                "sizeof_digit",
+                "default_max_str_digits",
+                "str_digits_check_threshold",
+            ],
+        );
+        let value = crate::_structseq::new_instance(
+            ty,
+            vec![w_int_new(30), w_int_new(4), w_int_new(4300), w_int_new(640)],
+        );
+        module_ns_store(ns, "int_info", value);
     }
     module_ns_store(ns, "hexversion", w_int_new(0x030e06f0));
     #[cfg(feature = "host_env")]
@@ -2193,11 +2254,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             Err(unsafe { crate::PyError::from_exc_object(exc) })
         }),
     );
-    // sys.abiflags — `t` for a build without a global interpreter lock.  The
-    // attribute is absent on Windows, where the flag is spelled in
-    // `sys.winver` and neither the `nt` scheme nor `site._get_path` reads it;
-    // every reader guards with `hasattr`, so an empty string answers the same.
-    module_ns_store(ns, "abiflags", w_str_new(if cfg!(windows) { "" } else { "t" }));
+    // `init_sys_streams`: Windows has no `sys.abiflags`; its ABI tag
+    // belongs to `sys.winver`.  Absence is observable through `hasattr` and is
+    // relied on by the 3.14 Windows sys tests, so do not publish an empty
+    // stand-in.
+    #[cfg(not(windows))]
+    module_ns_store(ns, "abiflags", w_str_new("t"));
     // sys.argv — pick up pending argv from set_sys_argv if available.
     let pending = crate::importing::take_pending_sys_argv();
     let argv = if pending.is_null() {
@@ -2567,6 +2629,202 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "exc_clear",
         make_builtin_function_with_arity("exc_clear", |_| Ok(w_none()), 0),
     );
+    module_ns_store(
+        ns,
+        "call_tracing",
+        make_builtin_function_with_arity(
+            "call_tracing",
+            |args| {
+                if !unsafe { pyre_object::is_tuple(args[1]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "call_tracing() argument 2 must be tuple, not {}",
+                        crate::type_methods::arg_type_name(args[1])
+                    )));
+                }
+                let ec = current_execution_context();
+                if ec.is_null() {
+                    return Err(crate::PyError::runtime_error(
+                        "no current execution context",
+                    ));
+                }
+                let result = unsafe { (*ec).call_tracing(args[0], args[1]) };
+                if result.is_null() {
+                    Err(crate::call::take_call_error().unwrap_or_else(|| {
+                        crate::PyError::runtime_error("call_tracing failed")
+                    }))
+                } else {
+                    Ok(result)
+                }
+            },
+            2,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_clear_internal_caches",
+        make_builtin_function_with_arity(
+            "_clear_internal_caches",
+            |_| {
+                crate::baseobjspace::clear_method_cache();
+                crate::objspace::std::mapdict::clear_map_attr_cache();
+                Ok(w_none())
+            },
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_clear_type_cache",
+        make_builtin_function_with_arity(
+            "_clear_type_cache",
+            |_| {
+                crate::warn::warn_category(
+                    "sys._clear_type_cache() is deprecated and scheduled for removal in a future version. Use sys._clear_internal_caches() instead.",
+                    "DeprecationWarning",
+                    1,
+                )?;
+                crate::baseobjspace::clear_method_cache();
+                crate::objspace::std::mapdict::clear_map_attr_cache();
+                Ok(w_none())
+            },
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_debugmallocstats",
+        make_builtin_function_with_arity("_debugmallocstats", |_| Ok(w_none()), 0),
+    );
+    module_ns_store(
+        ns,
+        "getallocatedblocks",
+        make_builtin_function_with_arity(
+            "getallocatedblocks",
+            // MiniMark accounts bytes rather than allocator blocks.  Zero is
+            // the documented answer for a build without pymalloc accounting.
+            |_| Ok(w_int_new(0)),
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "getunicodeinternedsize",
+        crate::make_builtin_function("getunicodeinternedsize", |args| {
+            let (positional, kwargs) = crate::builtins::split_builtin_kwargs(args);
+            crate::builtins::kwarg_reject_unknown(
+                kwargs,
+                &["_only_immortal"],
+                "getunicodeinternedsize",
+            )?;
+            if !positional.is_empty() {
+                return Err(crate::PyError::type_error(
+                    "getunicodeinternedsize() takes no positional arguments",
+                ));
+            }
+            if let Some(value) = crate::builtins::kwarg_get(kwargs, "_only_immortal") {
+                let _ = crate::baseobjspace::is_true(value)?;
+            }
+            Ok(w_int_new(
+                pyre_object::unicodeobject::interned_size() as i64,
+            ))
+        }),
+    );
+    module_ns_store(
+        ns,
+        "_is_interned",
+        make_builtin_function_with_arity(
+            "_is_interned",
+            |args| {
+                if !unsafe { pyre_object::is_str(args[0]) } {
+                    return Err(crate::PyError::type_error(format!(
+                        "_is_interned() argument must be str, not {}",
+                        crate::type_methods::arg_type_name(args[0]),
+                    )));
+                }
+                let exact = unsafe {
+                    pyre_object::is_exact_type(args[0], &pyre_object::STR_TYPE)
+                };
+                Ok(w_bool_from(
+                    exact && unsafe {
+                        pyre_object::unicodeobject::is_interned_exact_str(args[0])
+                    },
+                ))
+            },
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_is_immortal",
+        make_builtin_function_with_arity(
+            "_is_immortal",
+            |args| Ok(w_bool_from(!pyre_object::gc_hook::try_gc_owns_object(args[0].cast()))),
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_is_gil_enabled",
+        // This is the 3.14t observable: pyre's execution contexts run
+        // concurrently and synchronize the moving collector with STW safepoints,
+        // not a process-wide interpreter lock.
+        make_builtin_function_with_arity("_is_gil_enabled", |_| Ok(w_bool_from(false)), 0),
+    );
+    module_ns_store(
+        ns,
+        "activate_stack_trampoline",
+        make_builtin_function_with_arity(
+            "activate_stack_trampoline",
+            |_| Err(crate::PyError::value_error("perf trampoline not available")),
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "deactivate_stack_trampoline",
+        make_builtin_function_with_arity("deactivate_stack_trampoline", |_| Ok(w_none()), 0),
+    );
+    module_ns_store(
+        ns,
+        "is_stack_trampoline_active",
+        make_builtin_function_with_arity(
+            "is_stack_trampoline_active",
+            |_| Ok(w_bool_from(false)),
+            0,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_dump_tracelets",
+        make_builtin_function_with_arity(
+            "_dump_tracelets",
+            |args| {
+                let _ = crate::gateway::fsencode_bytes_w(args[0])?;
+                Err(crate::PyError::not_implemented("No JIT available"))
+            },
+            1,
+        ),
+    );
+    module_ns_store(
+        ns,
+        "_baserepl",
+        make_builtin_function_with_arity("_baserepl", |_| Ok(w_none()), 0),
+    );
+    module_ns_store(
+        ns,
+        "remote_exec",
+        make_builtin_function_with_arity(
+            "remote_exec",
+            |args| {
+                let _pid = crate::builtins::space_index_w(args[0])?;
+                let _script = crate::gateway::fsencode_bytes_w(args[1])?;
+                Err(crate::PyError::runtime_error(
+                    "remote debugging is not supported by this interpreter",
+                ))
+            },
+            2,
+        ),
+    );
     // sys.is_remote_debug_enabled() — no remote-debug interface is wired,
     // so always False.
     module_ns_store(
@@ -2702,7 +2960,17 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "getfilesystemencoding",
-        make_builtin_function_with_arity("getfilesystemencoding", |_| Ok(w_str_new("utf-8")), 0),
+        make_builtin_function_with_arity(
+            "getfilesystemencoding",
+            |_| {
+                #[cfg(windows)]
+                if LEGACY_WINDOWS_FS_ENCODING.load(std::sync::atomic::Ordering::Relaxed) {
+                    return Ok(w_str_new("mbcs"));
+                }
+                Ok(w_str_new("utf-8"))
+            },
+            0,
+        ),
     );
     // `interp_encoding.py:8-12 base_error` — PEP 529 puts Windows on
     // `surrogatepass`, every other platform on `surrogateescape`. `os.fsencode`
@@ -2713,7 +2981,32 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "getfilesystemencodeerrors",
         make_builtin_function_with_arity(
             "getfilesystemencodeerrors",
-            |_| Ok(w_str_new(crate::typedef::FS_ERRORS)),
+            |_| {
+                #[cfg(windows)]
+                if LEGACY_WINDOWS_FS_ENCODING.load(std::sync::atomic::Ordering::Relaxed) {
+                    return Ok(w_str_new("replace"));
+                }
+                Ok(w_str_new(crate::typedef::FS_ERRORS))
+            },
+            0,
+        ),
+    );
+    #[cfg(windows)]
+    module_ns_store(
+        ns,
+        "_enablelegacywindowsfsencoding",
+        make_builtin_function_with_arity(
+            "_enablelegacywindowsfsencoding",
+            |_| {
+                crate::warn::warn_category(
+                    "sys._enablelegacywindowsfsencoding() is deprecated and will be removed in Python 3.16. Use PYTHONLEGACYWINDOWSFSENCODING instead.",
+                    "DeprecationWarning",
+                    1,
+                )?;
+                LEGACY_WINDOWS_FS_ENCODING
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                Ok(w_none())
+            },
             0,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -1156,6 +1156,55 @@ fn sys_breakpointhook(args: &[PyObjectRef]) -> crate::PyResult {
     crate::builtins::call_forwarding_args(hook, args)
 }
 
+/// `sys._baserepl` — `PyRun_AnyFileExFlags(stdin, "<stdin>", 0, &cf)`: read
+/// stdin and execute what it holds in `__main__`'s namespace.
+/// `_pyrepl.main.interactive_console` calls this whenever the enhanced REPL
+/// cannot run, so a body that returns without reading anything ends the
+/// session instead of starting it.
+///
+/// `code.interact` is that loop at applevel, over the same namespace.  pyre's
+/// own prompt cannot answer here: `pyrex::repl::run_repl` builds a fresh
+/// `PyExecutionContext` and a fresh `__main__`, which is a top-level driver
+/// rather than something a running program can call into.
+///
+/// `_Py_FdIsInteractive` sends a terminal — and `-i` — down that prompt
+/// loop, and everything else to `_PyRun_SimpleFileObject`, which compiles the
+/// whole of stdin at once and reports a failure through `PyErr_Print`.  Only
+/// the prompt loop is reproduced: `PyErr_Print` belongs to the driver that
+/// owns process exit, which this crate sits below, so redirected stdin runs
+/// here statement by statement with a prompt written between each.
+fn sys_baserepl(_args: &[PyObjectRef]) -> crate::PyResult {
+    crate::importing::dunder_import(
+        "code",
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        pyre_object::PY_NULL,
+        0,
+        std::ptr::null(),
+    )?;
+    let code_module = crate::importing::get_sys_module("code")
+        .ok_or_else(|| crate::PyError::runtime_error("no module named 'code'"))?;
+    // Every argument is pinned as it is produced and read back at the call:
+    // the attribute lookups and string allocations between them can each run a
+    // collection that forwards the slot without touching a local copy.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(code_module, "interact")?);
+    // `interact(banner, readfunc, local, exitmsg)`.  Both messages are empty:
+    // the console this stands in for prints neither a banner nor a farewell.
+    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
+    let main_module = crate::importing::get_sys_module("__main__")
+        .ok_or_else(|| crate::PyError::runtime_error("no module named '__main__'"))?;
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(main_module, "__dict__")?);
+    pyre_object::gc_roots::pin_root(pyre_object::w_str_new(""));
+    let slot = pyre_object::gc_roots::shadow_stack_get;
+    crate::call::call_function_impl_result(
+        slot(base),
+        &[slot(base + 1), w_none(), slot(base + 2), slot(base + 3)],
+    )?;
+    Ok(w_none())
+}
+
 fn sys_unraisablehook(args: &[PyObjectRef]) -> crate::PyResult {
     let Some(&w_hookargs) = args.first() else {
         return Err(crate::PyError::type_error(
@@ -2815,7 +2864,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "_baserepl",
-        make_builtin_function_with_arity("_baserepl", |_| Ok(w_none()), 0),
+        make_builtin_function_with_arity("_baserepl", sys_baserepl, 0),
     );
     module_ns_store(
         ns,
@@ -3013,10 +3062,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // `_PyUnicode_EnableLegacyWindowsFSEncoding` also re-runs
                 // `init_fs_codec`, so every path converter switches to
                 // mbcs/replace with it.  Here the flag reaches only the two
-                // getters: `gateway::fsencode` and `typedef::FS_ERRORS` stay on
-                // UTF-8/surrogatepass because there is no `_codecs.mbcs_encode`
-                // to switch them to.  That codec is the dependency to land
-                // before this flag can drive the converters.
+                // getters.  Switching `gateway::fsencode` and
+                // `typedef::FS_ERRORS` as well is not enough on its own: pyre
+                // carries host names as WTF-8 through `fsencode_os_str` and
+                // `os_string_from_fs_bytes`, so the app-level converters and
+                // the host bridge have to change together or a name stops
+                // round-tripping between them.
                 LEGACY_WINDOWS_FS_ENCODING
                     .store(true, std::sync::atomic::Ordering::Relaxed);
                 Ok(w_none())

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -2721,12 +2721,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "getunicodeinternedsize() takes no positional arguments",
                 ));
             }
-            if let Some(value) = crate::builtins::kwarg_get(kwargs, "_only_immortal") {
-                let _ = crate::baseobjspace::is_true(value)?;
-            }
-            Ok(w_int_new(
-                pyre_object::unicodeobject::interned_size() as i64,
-            ))
+            let only_immortal = match crate::builtins::kwarg_get(kwargs, "_only_immortal") {
+                Some(value) => crate::baseobjspace::is_true(value)?,
+                None => false,
+            };
+            let size = if only_immortal {
+                pyre_object::unicodeobject::interned_size_immortal()
+            } else {
+                pyre_object::unicodeobject::interned_size()
+            };
+            Ok(w_int_new(size as i64))
         }),
     );
     module_ns_store(
@@ -2765,10 +2769,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     module_ns_store(
         ns,
         "_is_gil_enabled",
-        // This is the 3.14t observable: pyre's execution contexts run
-        // concurrently and synchronize the moving collector with STW safepoints,
-        // not a process-wide interpreter lock.
-        make_builtin_function_with_arity("_is_gil_enabled", |_| Ok(w_bool_from(false)), 0),
+        // Whether the interpreter is *currently* running with the lock on,
+        // which is a separate question from the `t` ABI `sysconfig` publishes.
+        // pyre runs bytecode under `rgil` (majit-gc/src/rgil.rs:21-31): one
+        // process-wide lock, taken when a thread starts and dropped only around
+        // external calls, so a thread holds it across arbitrarily many
+        // bytecodes.  That is a GIL, and it is never off.
+        make_builtin_function_with_arity("_is_gil_enabled", |_| Ok(w_bool_from(true)), 0),
     );
     module_ns_store(
         ns,
@@ -3003,6 +3010,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "DeprecationWarning",
                     1,
                 )?;
+                // `_PyUnicode_EnableLegacyWindowsFSEncoding` also re-runs
+                // `init_fs_codec`, so every path converter switches to
+                // mbcs/replace with it.  Here the flag reaches only the two
+                // getters: `gateway::fsencode` and `typedef::FS_ERRORS` stay on
+                // UTF-8/surrogatepass because there is no `_codecs.mbcs_encode`
+                // to switch them to.  That codec is the dependency to land
+                // before this flag can drive the converters.
                 LEGACY_WINDOWS_FS_ENCODING
                     .store(true, std::sync::atomic::Ordering::Relaxed);
                 Ok(w_none())

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1828,19 +1828,35 @@ fn spawn_thread(
             // driver owner is made interpreter-global.
             let _plain_worker = crate::call::force_plain_eval();
             if let Err(mut error) = call_thread_target(callable, &args, kwargs, ec_ptr) {
-                let callable_repr = unsafe {
-                    crate::display::py_repr_wtf8(callable).unwrap_or_else(|_| {
-                        rustpython_wtf8::Wtf8Buf::from_string("<unknown>".to_string())
-                    })
-                };
-                error.write_unraisable(
-                    w_none(),
-                    &crate::display::wtf8_format!(
-                        "Exception ignored in thread started by ",
-                        callable_repr
-                    ),
-                    w_none(),
+                // `os_thread.py:136-142` reports every error but `SystemExit`,
+                // which is how `_thread.exit()` ends a worker: printing an
+                // ignored-exception traceback for it would report a normal
+                // exit as a fault.
+                let ends_the_thread = crate::builtins::lookup_exc_class("SystemExit").is_some_and(
+                    |system_exit| unsafe {
+                        crate::baseobjspace::isinstance_w(error.to_exc_object(), system_exit)
+                    },
                 );
+                if !ends_the_thread {
+                    // Read the target out of its pinned slot rather than the
+                    // local: running it is arbitrary Python, and a moving
+                    // collection inside forwards the slot, not the copy taken
+                    // before the call.
+                    let callable = pyre_object::gc_roots::shadow_stack_get(worker_base);
+                    let callable_repr = unsafe {
+                        crate::display::py_repr_wtf8(callable).unwrap_or_else(|_| {
+                            rustpython_wtf8::Wtf8Buf::from_string("<unknown>".to_string())
+                        })
+                    };
+                    error.write_unraisable(
+                        w_none(),
+                        &crate::display::wtf8_format!(
+                            "Exception ignored in thread started by ",
+                            callable_repr
+                        ),
+                        w_none(),
+                    );
+                }
             }
             thread_is_stopping(&mut ec);
             crate::call::set_last_exec_ctx(std::ptr::null());

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -1828,7 +1828,7 @@ fn spawn_thread(
             // driver owner is made interpreter-global.
             let _plain_worker = crate::call::force_plain_eval();
             if let Err(mut error) = call_thread_target(callable, &args, kwargs, ec_ptr) {
-                // `os_thread.py:136-142` reports every error but `SystemExit`,
+                // `bootstrapper.run` reports every error but `SystemExit`,
                 // which is how `_thread.exit()` ends a worker: printing an
                 // ignored-exception traceback for it would report a normal
                 // exit as a fault.

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -506,6 +506,42 @@ pub(crate) fn current_frames() -> PyObjectRef {
     result
 }
 
+/// `threadmappings.py:_current_exceptions` — snapshot every registered
+/// ExecutionContext's currently handled exception under the same stop-the-
+/// world boundary `_current_frames` uses.  Values are rooted before the
+/// registry lock is released, so building the result dict cannot retain a
+/// pre-move address.
+pub(crate) fn current_exceptions() -> PyObjectRef {
+    let roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    let mut entries = Vec::new();
+    majit_gc::gc_sync::request_stw(|_| {
+        let contexts = EXECUTION_CONTEXTS.lock();
+        for (&ident, &ec) in contexts.iter() {
+            let exception =
+                unsafe { (*(ec as *const crate::PyExecutionContext)).current_exception() };
+            pyre_object::gc_roots::pin_root(if exception.is_null() {
+                w_none()
+            } else {
+                exception
+            });
+            entries.push(ident);
+        }
+    });
+    let result = w_dict_new();
+    for (index, ident) in entries.into_iter().enumerate() {
+        unsafe {
+            w_dict_setitem(
+                result,
+                ident,
+                pyre_object::gc_roots::shadow_stack_get(base + index),
+            )
+        };
+    }
+    drop(roots);
+    result
+}
+
 /// `pypy/module/thread/os_thread.py:reinit_threads`.
 pub(crate) fn after_fork_child() {
     let ident = current_ident();
@@ -2241,6 +2277,167 @@ fn thread_excepthook(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
     Ok(w_none())
 }
 
+/// `os_thread.py:exit` — ending a thread is expressed as `SystemExit`, so the
+/// bootstrapper's normal exception path performs the same handle/count/TLS
+/// cleanup as a function which returned normally.
+fn exit_thread(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    let cls = crate::builtins::lookup_exc_class("SystemExit")
+        .expect("SystemExit must be installed before _thread init");
+    let exc = crate::builtins::exc_exception_new(&[cls])?;
+    Err(unsafe { crate::PyError::from_exc_object(exc) })
+}
+
+#[cfg(windows)]
+fn current_thread_name() -> Result<PyObjectRef, crate::PyError> {
+    use windows_sys::Win32::{
+        Foundation::LocalFree,
+        System::Threading::{GetCurrentThread, GetThreadDescription},
+    };
+
+    let mut raw = std::ptr::null_mut();
+    let status = unsafe { GetThreadDescription(GetCurrentThread(), &mut raw) };
+    if status < 0 {
+        // An unnamed thread is reported as absent by older Windows builds;
+        // That state is reported as the empty string.
+        return Ok(w_str_new(""));
+    }
+    if raw.is_null() {
+        return Ok(w_str_new(""));
+    }
+    let mut len = 0usize;
+    unsafe {
+        while *raw.add(len) != 0 {
+            len += 1;
+        }
+    }
+    let name = pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(unsafe {
+        std::slice::from_raw_parts(raw, len)
+    }));
+    unsafe { LocalFree(raw.cast()) };
+    Ok(name)
+}
+
+#[cfg(windows)]
+fn set_current_thread_name(w_name: PyObjectRef) -> Result<(), crate::PyError> {
+    use windows_sys::Win32::System::Threading::{GetCurrentThread, SetThreadDescription};
+
+    // `PyThread_set_name`: Windows counts UTF-16 code units, stops at
+    // the first NUL, and truncates without splitting a surrogate pair.
+    let all: Vec<u16> = unsafe { pyre_object::w_str_get_wtf8(w_name) }
+        .encode_wide()
+        .collect();
+    let nul = all.iter().position(|&unit| unit == 0).unwrap_or(all.len());
+    let mut end = nul.min(32_766);
+    if end < all.len()
+        && end > 0
+        && (0xD800..=0xDBFF).contains(&all[end - 1])
+        && (0xDC00..=0xDFFF).contains(&all[end])
+    {
+        end -= 1;
+    }
+    let wide: Vec<u16> = all[..end].iter().copied().chain([0]).collect();
+    let status = unsafe { SetThreadDescription(GetCurrentThread(), wide.as_ptr()) };
+    if status < 0 {
+        return Err(crate::PyError::os_error(format!(
+            "SetThreadDescription failed with HRESULT 0x{:08x}",
+            status as u32
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn current_thread_name() -> Result<String, crate::PyError> {
+    let mut buffer = [0u8; 16];
+    let status = unsafe {
+        libc::pthread_getname_np(
+            libc::pthread_self(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+        )
+    };
+    if status != 0 {
+        return Err(crate::PyError::os_error_syscall(status, PY_NULL));
+    }
+    let len = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
+    Ok(String::from_utf8_lossy(&buffer[..len]).into_owned())
+}
+
+#[cfg(target_os = "macos")]
+fn current_thread_name() -> Result<String, crate::PyError> {
+    let mut buffer = [0u8; 64];
+    let status = unsafe {
+        libc::pthread_getname_np(
+            libc::pthread_self(),
+            buffer.as_mut_ptr().cast(),
+            buffer.len(),
+        )
+    };
+    if status != 0 {
+        return Err(crate::PyError::os_error_syscall(status, PY_NULL));
+    }
+    let len = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
+    Ok(String::from_utf8_lossy(&buffer[..len]).into_owned())
+}
+
+#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+fn current_thread_name() -> Result<String, crate::PyError> {
+    Ok(std::thread::current().name().unwrap_or("").to_string())
+}
+
+#[cfg(not(windows))]
+fn set_current_thread_name(name: &str) -> Result<(), crate::PyError> {
+    let limit = if cfg!(target_os = "linux") {
+        15
+    } else if cfg!(target_os = "macos") {
+        63
+    } else {
+        usize::MAX
+    };
+    let nul = name.find('\0').unwrap_or(name.len());
+    let mut end = nul.min(limit);
+    while !name.is_char_boundary(end) {
+        end -= 1;
+    }
+    #[cfg(all(feature = "host_env", any(unix, windows)))]
+    rustpython_host_env::thread::set_current_thread_name(&name[..end]);
+    #[cfg(not(all(feature = "host_env", any(unix, windows))))]
+    let _ = end;
+    Ok(())
+}
+
+#[cfg(windows)]
+fn get_thread_name(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    current_thread_name()
+}
+
+#[cfg(not(windows))]
+fn get_thread_name(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    Ok(w_str_new(&current_thread_name()?))
+}
+
+fn set_thread_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
+    if unsafe { !pyre_object::is_str(args[0]) } {
+        // `_PyArg_BadArgument` renders the None singleton as `None`, rather
+        // than its class name `NoneType`.
+        let type_name = if unsafe { pyre_object::is_none(args[0]) } {
+            "None"
+        } else {
+            unsafe { pyre_object::type_name_of(args[0]) }
+        };
+        return Err(crate::PyError::type_error(format!(
+            "set_name() argument 'name' must be str, not {type_name}"
+        )));
+    }
+    // The wide host takes the string object itself, since the name it sets is
+    // counted in UTF-16 code units.
+    #[cfg(windows)]
+    set_current_thread_name(args[0])?;
+    #[cfg(not(windows))]
+    set_current_thread_name(crate::baseobjspace::str_utf8_w(args[0])?)?;
+    Ok(w_none())
+}
+
 crate::py_module! {
     "_thread",
     interpleveldefs: {
@@ -2259,6 +2456,15 @@ crate::py_module! {
         "_local"        => local_type(),
         "_ExceptHookArgs" => except_hook_args_type(),
         "TIMEOUT_MAX"   => w_float_new(TIMEOUT_MAX),
+        "_NAME_MAXLEN"  => w_int_new(if cfg!(windows) {
+            32_766
+        } else if cfg!(target_os = "linux") {
+            15
+        } else if cfg!(target_os = "macos") {
+            63
+        } else {
+            0
+        }),
         "error"         => crate::builtins::lookup_exc_class("RuntimeError")
                                .unwrap_or_else(crate::typedef::w_object),
     },
@@ -2275,7 +2481,10 @@ crate::py_module! {
         "_shutdown"              / 0 = shutdown_threads,
         "stack_size"             / * = stack_size,
         "interrupt_main"         / * = interrupt_main,
-        "set_name"               / 1 = |_| Ok(w_none()),
+        "exit"                   / 0 = exit_thread,
+        "exit_thread"            / 0 = exit_thread,
+        "_get_name"              / 0 = get_thread_name,
+        "set_name"               / 1 = set_thread_name,
         "_excepthook"            / 1 = thread_excepthook,
         "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),
         "start_joinable_thread"  / * = start_joinable_thread,

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -2287,6 +2287,20 @@ fn exit_thread(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     Err(unsafe { crate::PyError::from_exc_object(exc) })
 }
 
+/// `_thread._NAME_MAXLEN` — the platform's own ceiling on a thread name and
+/// the unit it counts in: UTF-16 code units for `SetThreadDescription`,
+/// encoded bytes for `pthread_setname_np`.  Defined only where a ceiling
+/// exists: a platform without one publishes no such attribute at all, and
+/// `test_threading.test_set_name` reads that absence as "do not truncate".
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+const NAME_MAXLEN: usize = if cfg!(windows) {
+    32_766
+} else if cfg!(target_os = "linux") {
+    15
+} else {
+    63
+};
+
 #[cfg(windows)]
 fn current_thread_name() -> Result<PyObjectRef, crate::PyError> {
     use windows_sys::Win32::{
@@ -2327,7 +2341,7 @@ fn set_current_thread_name(w_name: PyObjectRef) -> Result<(), crate::PyError> {
         .encode_wide()
         .collect();
     let nul = all.iter().position(|&unit| unit == 0).unwrap_or(all.len());
-    let mut end = nul.min(32_766);
+    let mut end = nul.min(NAME_MAXLEN);
     if end < all.len()
         && end > 0
         && (0xD800..=0xDBFF).contains(&all[end - 1])
@@ -2347,8 +2361,8 @@ fn set_current_thread_name(w_name: PyObjectRef) -> Result<(), crate::PyError> {
 }
 
 #[cfg(target_os = "linux")]
-fn current_thread_name() -> Result<String, crate::PyError> {
-    let mut buffer = [0u8; 16];
+fn current_thread_name() -> Result<Vec<u8>, crate::PyError> {
+    let mut buffer = [0u8; NAME_MAXLEN + 1];
     let status = unsafe {
         libc::pthread_getname_np(
             libc::pthread_self(),
@@ -2360,12 +2374,12 @@ fn current_thread_name() -> Result<String, crate::PyError> {
         return Err(crate::PyError::os_error_syscall(status, PY_NULL));
     }
     let len = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
-    Ok(String::from_utf8_lossy(&buffer[..len]).into_owned())
+    Ok(buffer[..len].to_vec())
 }
 
 #[cfg(target_os = "macos")]
-fn current_thread_name() -> Result<String, crate::PyError> {
-    let mut buffer = [0u8; 64];
+fn current_thread_name() -> Result<Vec<u8>, crate::PyError> {
+    let mut buffer = [0u8; NAME_MAXLEN + 1];
     let status = unsafe {
         libc::pthread_getname_np(
             libc::pthread_self(),
@@ -2377,32 +2391,54 @@ fn current_thread_name() -> Result<String, crate::PyError> {
         return Err(crate::PyError::os_error_syscall(status, PY_NULL));
     }
     let len = buffer.iter().position(|&b| b == 0).unwrap_or(buffer.len());
-    Ok(String::from_utf8_lossy(&buffer[..len]).into_owned())
+    Ok(buffer[..len].to_vec())
 }
 
-#[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
-fn current_thread_name() -> Result<String, crate::PyError> {
-    Ok(std::thread::current().name().unwrap_or("").to_string())
-}
-
-#[cfg(not(windows))]
-fn set_current_thread_name(name: &str) -> Result<(), crate::PyError> {
-    let limit = if cfg!(target_os = "linux") {
-        15
-    } else if cfg!(target_os = "macos") {
-        63
-    } else {
-        usize::MAX
-    };
-    let nul = name.find('\0').unwrap_or(name.len());
-    let mut end = nul.min(limit);
-    while !name.is_char_boundary(end) {
-        end -= 1;
+/// The filesystem encoding of a name under the `replace` error handler, which
+/// is what `_thread.set_name` encodes with: no str can fail to encode, and a
+/// lone surrogate - which has no UTF-8 spelling - becomes `?` rather than an
+/// exception.  `threading.Thread._bootstrap_inner` guards `_set_os_name` for
+/// `OSError` alone, so a name that raised anything else would leave the thread
+/// unregistered and its `_started` event unset, hanging `Thread.start()`.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn fsencode_name_replace(w_name: PyObjectRef) -> Vec<u8> {
+    let wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_name) };
+    let mut encoded = Vec::with_capacity(wtf8.len());
+    let mut buffer = [0u8; 4];
+    for code_point in wtf8.code_points() {
+        match code_point.to_char() {
+            Some(ch) => encoded.extend_from_slice(ch.encode_utf8(&mut buffer).as_bytes()),
+            None => encoded.push(b'?'),
+        }
     }
-    #[cfg(all(feature = "host_env", any(unix, windows)))]
-    rustpython_host_env::thread::set_current_thread_name(&name[..end]);
-    #[cfg(not(all(feature = "host_env", any(unix, windows))))]
-    let _ = end;
+    encoded
+}
+
+/// `pthread_setname_np` takes the encoded name, so the ceiling counts BYTES
+/// and the cut lands wherever `NAME_MAXLEN` falls - mid-sequence included.
+/// `_get_name` decodes what the platform kept with `surrogateescape`, so a
+/// severed trailing sequence comes back as the lone surrogates spelling those
+/// bytes; backing the cut off to a character boundary would answer a different
+/// name than the one the platform holds.
+///
+/// Called through `libc` rather than `rustpython_host_env::thread`, whose
+/// setter takes a `&str` and so can express neither the lossy encoding nor a
+/// byte-exact cut; `current_thread_name` reads its counterpart the same way.
+#[cfg(any(target_os = "linux", target_os = "macos"))]
+fn set_current_thread_name(w_name: PyObjectRef) -> Result<(), crate::PyError> {
+    let mut encoded = fsencode_name_replace(w_name);
+    if let Some(nul) = encoded.iter().position(|&byte| byte == 0) {
+        encoded.truncate(nul);
+    }
+    encoded.truncate(NAME_MAXLEN);
+    let name = std::ffi::CString::new(encoded).expect("truncated at the first NUL above");
+    #[cfg(target_os = "linux")]
+    let status = unsafe { libc::pthread_setname_np(libc::pthread_self(), name.as_ptr()) };
+    #[cfg(target_os = "macos")]
+    let status = unsafe { libc::pthread_setname_np(name.as_ptr()) };
+    if status != 0 {
+        return Err(crate::PyError::os_error_syscall(status, PY_NULL));
+    }
     Ok(())
 }
 
@@ -2411,11 +2447,17 @@ fn get_thread_name(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     current_thread_name()
 }
 
-#[cfg(not(windows))]
+#[cfg(any(target_os = "linux", target_os = "macos"))]
 fn get_thread_name(_args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-    Ok(w_str_new(&current_thread_name()?))
+    // `PyUnicode_DecodeFSDefault` - `surrogateescape`, so a name the platform
+    // truncated mid-sequence reads back as the lone surrogates spelling the
+    // bytes that survived.
+    Ok(crate::gateway::fsdecode_filename_bytes(
+        &current_thread_name()?,
+    ))
 }
 
+#[cfg(any(windows, target_os = "linux", target_os = "macos"))]
 fn set_thread_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     if unsafe { !pyre_object::is_str(args[0]) } {
         // `_PyArg_BadArgument` renders the None singleton as `None`, rather
@@ -2429,12 +2471,9 @@ fn set_thread_name(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             "set_name() argument 'name' must be str, not {type_name}"
         )));
     }
-    // The wide host takes the string object itself, since the name it sets is
-    // counted in UTF-16 code units.
-    #[cfg(windows)]
+    // Both hosts take the string object itself: each counts the ceiling in its
+    // own unit and encodes for its own call.
     set_current_thread_name(args[0])?;
-    #[cfg(not(windows))]
-    set_current_thread_name(crate::baseobjspace::str_utf8_w(args[0])?)?;
     Ok(w_none())
 }
 
@@ -2456,15 +2495,6 @@ crate::py_module! {
         "_local"        => local_type(),
         "_ExceptHookArgs" => except_hook_args_type(),
         "TIMEOUT_MAX"   => w_float_new(TIMEOUT_MAX),
-        "_NAME_MAXLEN"  => w_int_new(if cfg!(windows) {
-            32_766
-        } else if cfg!(target_os = "linux") {
-            15
-        } else if cfg!(target_os = "macos") {
-            63
-        } else {
-            0
-        }),
         "error"         => crate::builtins::lookup_exc_class("RuntimeError")
                                .unwrap_or_else(crate::typedef::w_object),
     },
@@ -2483,12 +2513,40 @@ crate::py_module! {
         "interrupt_main"         / * = interrupt_main,
         "exit"                   / 0 = exit_thread,
         "exit_thread"            / 0 = exit_thread,
-        "_get_name"              / 0 = get_thread_name,
-        "set_name"               / 1 = set_thread_name,
         "_excepthook"            / 1 = thread_excepthook,
         "_get_main_thread_ident" / 0 = |_| Ok(w_int_new(current_ident())),
         "start_joinable_thread"  / * = start_joinable_thread,
         "start_new_thread"       / * = start_new_thread,
         "start_new"              / * = start_new_thread,
+    },
+    extra_init: |ns| {
+        // `set_name`, `_get_name` and `_NAME_MAXLEN` are published only where
+        // the platform has the calls behind them - `HAVE_PTHREAD_GETNAME_NP`
+        // or `MS_WINDOWS` - and a ceiling to name.  Their absence is what
+        // makes `threading._set_os_name` a no-op and
+        // `test_threading.test_set_name` skip, instead of comparing against a
+        // name the platform never stored.
+        #[cfg(any(windows, target_os = "linux", target_os = "macos"))]
+        {
+            crate::module_ns_store(ns, "_NAME_MAXLEN", w_int_new(NAME_MAXLEN as i64));
+            crate::module_ns_store(
+                ns,
+                "_get_name",
+                crate::gateway::with_module(
+                    "_thread",
+                    crate::py_module_fn!("_get_name", 0, get_thread_name),
+                ),
+            );
+            crate::module_ns_store(
+                ns,
+                "set_name",
+                crate::gateway::with_module(
+                    "_thread",
+                    crate::py_module_fn!("set_name", 1, set_thread_name),
+                ),
+            );
+        }
+        #[cfg(not(any(windows, target_os = "linux", target_os = "macos")))]
+        let _ = ns;
     },
 }

--- a/pyre/pyre-interpreter/src/module/winreg/mod.rs
+++ b/pyre/pyre-interpreter/src/module/winreg/mod.rs
@@ -68,8 +68,11 @@ crate::py_module! {
         "REG_NOTIFY_CHANGE_ATTRIBUTES" => 2,
         "REG_NOTIFY_CHANGE_LAST_SET" => 4,
         "REG_NOTIFY_CHANGE_SECURITY" => 8,
-        "REG_LEGAL_CHANGE_FILTER" => 0x000F,
-        "REG_LEGAL_OPTION" => 0x000F,
+        // Both masks carry a bit whose own name `winreg` does not publish:
+        // `REG_NOTIFY_THREAD_AGNOSTIC` in the filter, `REG_OPTION_DONT_VIRTUALIZE`
+        // in the option word.
+        "REG_LEGAL_CHANGE_FILTER" => 0x1000_000F,
+        "REG_LEGAL_OPTION" => 0x001F,
     },
     extra_init: |ns| {
         #[cfg(feature = "host_env")]

--- a/pyre/pyre-interpreter/src/unicodehelper_win32.rs
+++ b/pyre/pyre-interpreter/src/unicodehelper_win32.rs
@@ -1,0 +1,423 @@
+//! `unicodehelper_win32.py` — the Windows code page codecs.
+//!
+//! `MultiByteToWideChar` / `WideCharToMultiByte` are reached directly rather
+//! than through a mapping table: the table is the operating system's, and
+//! which one applies is chosen per call by code page number.  `mbcs`, `oem`
+//! and every `cpNNN` that `encodings/__init__.py`'s
+//! `win32_code_page_search_function` builds land here.
+
+use pyre_object::{PY_NULL, PyObjectRef};
+use rustpython_wtf8::Wtf8Buf;
+use windows_sys::Win32::Foundation::{
+    ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_FLAGS, ERROR_NO_UNICODE_TRANSLATION,
+};
+use windows_sys::Win32::Globalization::{
+    CP_ACP, CP_UTF7, CP_UTF8, MB_ERR_INVALID_CHARS, MultiByteToWideChar, WC_ERR_INVALID_CHARS,
+    WC_NO_BEST_FIT_CHARS, WideCharToMultiByte,
+};
+
+/// The Windows 2000 English message the decoder reports, which
+/// `decode_code_page_errors` hardcodes rather than asking `FormatMessage` for.
+const DECODE_REASON: &str = "No mapping for the Unicode character exists in the target code page.";
+
+/// The encoder's counterpart, likewise fixed rather than looked up.
+const ENCODE_REASON: &str = "invalid character";
+
+/// A code page's codec name: the active ANSI code page is `mbcs`, everything
+/// else is its own number.  `CP_OEMCP` is 1 rather than the resolved OEM code
+/// page, so `oem` reports `cp1` — the number that was asked for, not the one
+/// the system chose for it.
+pub fn code_page_name(code_page: u32) -> String {
+    if code_page == CP_ACP {
+        "mbcs".to_owned()
+    } else {
+        format!("cp{code_page}")
+    }
+}
+
+/// The CP_UTF7 decoder accepts no flags at all; every other code page takes
+/// `MB_ERR_INVALID_CHARS`, so an unmappable byte fails rather than becoming
+/// U+FFFD behind the error handler's back.
+fn decode_code_page_flags(code_page: u32) -> u32 {
+    if code_page == CP_UTF7 {
+        0
+    } else {
+        MB_ERR_INVALID_CHARS
+    }
+}
+
+/// `WC_NO_BEST_FIT_CHARS` is what makes an unencodable character report itself
+/// through `lpUsedDefaultChar` instead of silently becoming a lookalike.
+/// `replace` drops it: that caller has already asked for a substitution.
+fn encode_code_page_flags(code_page: u32, errors: Option<&str>) -> u32 {
+    if code_page == CP_UTF8 {
+        WC_ERR_INVALID_CHARS
+    } else if code_page == CP_UTF7 {
+        0
+    } else if errors == Some("replace") {
+        0
+    } else {
+        WC_NO_BEST_FIT_CHARS
+    }
+}
+
+fn last_win32_error() -> u32 {
+    std::io::Error::last_os_error().raw_os_error().unwrap_or(0) as u32
+}
+
+fn win32_error() -> crate::PyError {
+    crate::PyError::os_error_win32_syscall2(last_win32_error() as i32, PY_NULL, PY_NULL)
+}
+
+/// The outcome of a conversion the caller retries through an error handler.
+enum CodePageFail {
+    /// `ERROR_NO_UNICODE_TRANSLATION` — the input has no spelling in the
+    /// target, which is the error handler's business rather than the system's.
+    NoTranslation,
+    /// Anything else the system reported, which is reported as it stands.
+    Os(crate::PyError),
+}
+
+/// `decode_code_page_strict` — the whole buffer in one call, which is the
+/// answer whenever every byte maps.
+fn decode_strict(code_page: u32, data: &[u8]) -> Result<Vec<u16>, CodePageFail> {
+    debug_assert!(!data.is_empty());
+    let mut flags = decode_code_page_flags(code_page);
+    let insize = data.len() as i32;
+    let outsize = loop {
+        let size = unsafe {
+            MultiByteToWideChar(
+                code_page,
+                flags,
+                data.as_ptr(),
+                insize,
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if size > 0 {
+            break size;
+        }
+        // Some code pages — UTF-7 among them — reject any flag word at all.
+        if flags != 0 && last_win32_error() == ERROR_INVALID_FLAGS {
+            flags = 0;
+            continue;
+        }
+        return Err(decode_fail());
+    };
+    let mut out = vec![0u16; outsize as usize];
+    let written = unsafe {
+        MultiByteToWideChar(
+            code_page,
+            flags,
+            data.as_ptr(),
+            insize,
+            out.as_mut_ptr(),
+            outsize,
+        )
+    };
+    if written <= 0 {
+        return Err(decode_fail());
+    }
+    out.truncate(written as usize);
+    Ok(out)
+}
+
+/// Classify the failure a conversion call just reported.
+fn decode_fail() -> CodePageFail {
+    if last_win32_error() == ERROR_NO_UNICODE_TRANSLATION {
+        CodePageFail::NoTranslation
+    } else {
+        CodePageFail::Os(win32_error())
+    }
+}
+
+/// `decode_code_page_errors` — one character at a time, so the error handler
+/// sees the byte that failed rather than the whole buffer.
+fn decode_errors(
+    code_page: u32,
+    data: &[u8],
+    errors: &str,
+    is_final: bool,
+) -> Result<(Wtf8Buf, usize), crate::PyError> {
+    let encoding = code_page_name(code_page);
+    // A strict decode of a complete buffer has nothing left to try, so the
+    // whole input is what gets reported — not the byte a walk would reach.
+    if errors == "strict" && is_final {
+        return Err(crate::typedef::unicode_decode_error(
+            &encoding,
+            data,
+            0,
+            0,
+            DECODE_REASON,
+        ));
+    }
+    let mut flags = decode_code_page_flags(code_page);
+    let mut out = Wtf8Buf::new();
+    let mut pos = 0usize;
+    while pos < data.len() {
+        // A character is at most 4 bytes and decodes to at most a surrogate
+        // pair, so the input span grows until one width converts.
+        let mut insize = 1usize;
+        let mut wide = [0u16; 2];
+        let converted = loop {
+            let size = unsafe {
+                MultiByteToWideChar(
+                    code_page,
+                    flags,
+                    data[pos..].as_ptr(),
+                    insize as i32,
+                    wide.as_mut_ptr(),
+                    wide.len() as i32,
+                )
+            };
+            if size > 0 {
+                break size as usize;
+            }
+            let err = last_win32_error();
+            if err == ERROR_INVALID_FLAGS && flags != 0 {
+                flags = 0;
+                continue;
+            }
+            if err != ERROR_NO_UNICODE_TRANSLATION && err != ERROR_INSUFFICIENT_BUFFER {
+                return Err(win32_error());
+            }
+            insize += 1;
+            if insize > 4 || pos + insize > data.len() {
+                break 0;
+            }
+        };
+        if converted > 0 {
+            out.push_wtf8(&Wtf8Buf::from_wide(&wide[..converted]));
+            pos += insize;
+            continue;
+        }
+        // The span that failed runs to the end of the buffer, so more bytes
+        // could still complete it: stop and leave them to the caller.
+        if pos + insize >= data.len() && !is_final {
+            break;
+        }
+        let (newpos, _) = crate::type_methods::call_registered_decode_error_handler(
+            errors,
+            &encoding,
+            data,
+            pos,
+            pos + 1,
+            DECODE_REASON,
+            &mut out,
+        )?;
+        pos = newpos;
+    }
+    Ok((out, pos))
+}
+
+/// `PyUnicode_DecodeCodePageStateful` — the decoded text and how many bytes of
+/// `data` it consumed.  `is_final` says no more bytes are coming, which is what
+/// turns a truncated trailing sequence from "wait" into an error.
+pub fn decode_code_page(
+    code_page: u32,
+    data: &[u8],
+    errors: &str,
+    is_final: bool,
+) -> Result<(Wtf8Buf, usize), crate::PyError> {
+    if data.is_empty() {
+        return Ok((Wtf8Buf::new(), 0));
+    }
+    match decode_strict(code_page, data) {
+        Ok(wide) => Ok((Wtf8Buf::from_wide(&wide), data.len())),
+        Err(CodePageFail::NoTranslation) => decode_errors(code_page, data, errors, is_final),
+        Err(CodePageFail::Os(error)) => Err(error),
+    }
+}
+
+/// Whether this code page reports an unencodable character through
+/// `lpUsedDefaultChar`.  The two Unicode transformations take no such
+/// argument, since every character has a spelling in them.
+fn uses_default_char(code_page: u32) -> bool {
+    code_page != CP_UTF8 && code_page != CP_UTF7
+}
+
+/// `encode_code_page_strict` — the whole string in one call, which is the
+/// answer whenever every character maps.
+fn encode_strict(code_page: u32, wide: &[u16]) -> Result<Vec<u8>, CodePageFail> {
+    debug_assert!(!wide.is_empty());
+    let flags = encode_code_page_flags(code_page, None);
+    let mut used_default = 0i32;
+    let used_default_ptr = if uses_default_char(code_page) {
+        &raw mut used_default
+    } else {
+        std::ptr::null_mut()
+    };
+    let insize = wide.len() as i32;
+    let outsize = unsafe {
+        WideCharToMultiByte(
+            code_page,
+            flags,
+            wide.as_ptr(),
+            insize,
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null(),
+            used_default_ptr,
+        )
+    };
+    if outsize <= 0 {
+        return Err(encode_fail());
+    }
+    // A default character stands in for one this code page cannot spell, so
+    // its use is the failure the per-character walk is there to report.
+    if used_default != 0 {
+        return Err(CodePageFail::NoTranslation);
+    }
+    let mut out = vec![0u8; outsize as usize];
+    let written = unsafe {
+        WideCharToMultiByte(
+            code_page,
+            flags,
+            wide.as_ptr(),
+            insize,
+            out.as_mut_ptr(),
+            outsize,
+            std::ptr::null(),
+            used_default_ptr,
+        )
+    };
+    if written <= 0 {
+        return Err(encode_fail());
+    }
+    if used_default != 0 {
+        return Err(CodePageFail::NoTranslation);
+    }
+    out.truncate(written as usize);
+    Ok(out)
+}
+
+/// [`decode_fail`]'s counterpart for the encoding direction.
+fn encode_fail() -> CodePageFail {
+    if last_win32_error() == ERROR_NO_UNICODE_TRANSLATION {
+        CodePageFail::NoTranslation
+    } else {
+        CodePageFail::Os(win32_error())
+    }
+}
+
+/// `encode_code_page_errors` — one character at a time, so the error handler
+/// sees the character that failed.
+fn encode_errors(
+    code_page: u32,
+    w_unicode: PyObjectRef,
+    code_points: &[u32],
+    errors: &str,
+) -> Result<Vec<u8>, crate::PyError> {
+    let encoding = code_page_name(code_page);
+    // `strict` reports the string rather than the character: the walk that
+    // would find it only runs for a handler that can answer with something.
+    if errors == "strict" {
+        return Err(crate::typedef::unicode_encode_error(
+            &encoding,
+            w_unicode,
+            0,
+            0,
+            ENCODE_REASON,
+        ));
+    }
+    let flags = encode_code_page_flags(code_page, Some(errors));
+    let takes_default = uses_default_char(code_page);
+    let mut out: Vec<u8> = Vec::with_capacity(code_points.len());
+    let mut pos = 0usize;
+    while pos < code_points.len() {
+        let ch = code_points[pos];
+        let mut chars = [0u16; 2];
+        let charsize = if ch < 0x10000 {
+            chars[0] = ch as u16;
+            1
+        } else {
+            chars[0] = (0xD800 - (0x10000 >> 10) + (ch >> 10)) as u16;
+            chars[1] = (0xDC00 + (ch & 0x3FF)) as u16;
+            2
+        };
+        let mut used_default = 0i32;
+        let used_default_ptr = if takes_default {
+            &raw mut used_default
+        } else {
+            std::ptr::null_mut()
+        };
+        // 4 is the longest sequence any code page spells one character in.
+        let mut buffer = [0u8; 4];
+        let outsize = unsafe {
+            WideCharToMultiByte(
+                code_page,
+                flags,
+                chars.as_ptr(),
+                charsize,
+                buffer.as_mut_ptr(),
+                buffer.len() as i32,
+                std::ptr::null(),
+                used_default_ptr,
+            )
+        };
+        if outsize > 0 {
+            if used_default == 0 {
+                out.extend_from_slice(&buffer[..outsize as usize]);
+                pos += 1;
+                continue;
+            }
+        } else if last_win32_error() != ERROR_NO_UNICODE_TRANSLATION {
+            return Err(win32_error());
+        }
+        let (replacement, newpos) = crate::type_methods::call_registered_encode_error_handler(
+            errors,
+            &encoding,
+            w_unicode,
+            code_points.len(),
+            pos,
+            pos + 1,
+            ENCODE_REASON,
+        )?;
+        match replacement {
+            crate::type_methods::EncodeReplacement::Bytes(bytes) => {
+                out.extend_from_slice(&bytes);
+            }
+            // A str replacement is copied as ASCII rather than re-encoded: a
+            // handler that answers with anything else has not produced
+            // something this code page can be asked to spell.
+            crate::type_methods::EncodeReplacement::Str(replacement_points) => {
+                for point in replacement_points {
+                    if point > 127 {
+                        return Err(crate::typedef::unicode_encode_error(
+                            &encoding,
+                            w_unicode,
+                            pos,
+                            pos + 1,
+                            "unable to encode error handler result to ASCII",
+                        ));
+                    }
+                    out.push(point as u8);
+                }
+            }
+        }
+        pos = newpos;
+    }
+    Ok(out)
+}
+
+/// `PyUnicode_EncodeCodePage`.
+pub fn encode_code_page(
+    code_page: u32,
+    w_unicode: PyObjectRef,
+    errors: &str,
+) -> Result<Vec<u8>, crate::PyError> {
+    let wtf8 = unsafe { pyre_object::w_str_get_wtf8(w_unicode) };
+    if wtf8.is_empty() {
+        return Ok(Vec::new());
+    }
+    let wide: Vec<u16> = wtf8.encode_wide().collect();
+    match encode_strict(code_page, &wide) {
+        Ok(bytes) => Ok(bytes),
+        Err(CodePageFail::NoTranslation) => {
+            let code_points: Vec<u32> = wtf8.code_points().map(|c| c.to_u32()).collect();
+            encode_errors(code_page, w_unicode, &code_points, errors)
+        }
+        Err(CodePageFail::Os(error)) => Err(error),
+    }
+}

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -12347,13 +12347,18 @@ fn handle<Sym: WalkSym>(
                         // replayed short-preamble guard (unroll.py:409).
                         //
                         // Emitted on this leg only, so the own-loop leg is not
-                        // double-guarded. `next_instr` is the merge point being
-                        // crossed — the loop header the synthesized JUMP goes
-                        // to, matching `close_loop_args_at`'s `orgpc =
-                        // target_pc` rather than the back edge that got here.
+                        // double-guarded. The capture coordinate is the
+                        // `jit_merge_point` op's OWN JitCode pc — the walk is
+                        // standing on the loop header, so "where we are" and
+                        // "where the synthesized JUMP goes" are the same
+                        // program point. `next_instr` is the green Python pc
+                        // (`make_green_key` above); feeding it to a parameter
+                        // read as a JitCode offset resolves an unrelated
+                        // `-live-` marker, and the snapshot then describes a
+                        // program point the walk registers hold nothing for.
                         ctx.trace_ctx
                             .record_guard(OpCode::GuardFutureCondition, &[], 0);
-                        walker_capture_snapshot_for_last_guard(ctx, next_instr)?;
+                        walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
                         // `JitDriver::merge_point` states the rule the latch runs
                         // under: only latch what an attempt actually rejected.
                         // The give-up below returns without calling into

--- a/pyre/pyre-jit/src/eval.rs
+++ b/pyre/pyre-jit/src/eval.rs
@@ -4118,6 +4118,22 @@ fn build_gc() -> Box<MiniMarkGC> {
         let tid = register_pyre_class(&mut gc, &mut pytype_to_tid, descr);
         gc.types.set_destructor(tid, winapi_overlapped_destructor);
     }
+    // `_io._WindowsConsoleIO` is a PEP 528 raw stream: its own fields are the
+    // descriptor, the three mode flags and the carry buffer, but the type
+    // accepts subclasses and carries a dict, so the header prefix its marker
+    // forwards is the whole of its managed children. Append it after every
+    // existing object type so their automatic ids do not move.
+    //
+    // The interpreter gates the type on `host_env` too, but that is a default
+    // feature of `pyre-interpreter`, which `pyre-jit` takes with defaults on;
+    // only the two halves a build can actually turn off are spelled here.
+    #[cfg(all(windows, not(feature = "sandbox")))]
+    register_pyre_class(
+        &mut gc,
+        &mut pytype_to_tid,
+        <pyre_interpreter::module::_io::W_WindowsConsoleIO
+            as pyre_object::lltype::PyreClassPyTypeOf>::DESCRIPTOR,
+    );
     // `rrandom.Random` — the Mersenne Twister `interp_random.py` allocates
     // beside its holder. Like W_DequeBlock it is GC-managed without being an
     // rclass.OBJECT subclass and has no Python-visible vtable, so it takes a

--- a/pyre/pyre-object/src/pyobject.rs
+++ b/pyre/pyre-object/src/pyobject.rs
@@ -718,6 +718,10 @@ pub const SUBCLASS_RANGE_HIERARCHY: &[(u32, Option<u32>)] = &[
     // waited on through an event of its own rather than a completion port.
     #[cfg(windows)]
     (189, Some(0)),
+    // PEP 528 `_io._WindowsConsoleIO` is a subclassable `_RawIOBase` payload.
+    // Its append-only vtable id follows both Windows overlapped owners.
+    #[cfg(windows)]
+    (190, Some(0)),
 ];
 
 /// Compute subclass IDs from [`SUBCLASS_RANGE_HIERARCHY`] and write every

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -625,6 +625,16 @@ pub unsafe fn is_interned_exact_str(obj: PyObjectRef) -> bool {
         .is_some_and(|slot| **slot as PyObjectRef == obj)
 }
 
+/// Number of canonical strings owned by the process-wide intern table.
+/// `sys.getunicodeinternedsize` exposes this census.
+#[majit_macros::dont_look_inside]
+pub fn interned_size() -> usize {
+    STRING_INTERN_TABLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .len()
+}
+
 /// Box a string constant into a heap Python str object.
 ///
 /// Reads the process-global intern table the tracer cannot model; the JIT

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -635,6 +635,22 @@ pub fn interned_size() -> usize {
         .len()
 }
 
+/// The immortal half of that census - `getunicodeinternedsize(
+/// _only_immortal=True)`.  A build-time constant is immortal; a value first
+/// presented to `sys.intern()` is a managed object the collector owns, and is
+/// not counted.  `libregrtest.refleak` subtracts this number from
+/// `getallocatedblocks`, so a string a test interns dynamically must not move
+/// it.
+#[majit_macros::dont_look_inside]
+pub fn interned_size_immortal() -> usize {
+    STRING_INTERN_TABLE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .values()
+        .filter(|slot| !crate::gc_hook::try_gc_owns_object(***slot as *mut u8))
+        .count()
+}
+
 /// Box a string constant into a heap Python str object.
 ///
 /// Reads the process-global intern table the tracer cannot model; the JIT

--- a/scripts/check-new-line-citations.py
+++ b/scripts/check-new-line-citations.py
@@ -31,7 +31,11 @@ def added_lines(base):
     """(path, hunk line number, text) for every line the diff adds."""
     cmd = ["git", "diff", "-U0"]
     cmd += [base, "--"] if base else ["--cached", "--"]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
+    # Decode as UTF-8 rather than letting `text=True` pick the locale codec:
+    # the diff carries this tree's own bytes, and a Windows box whose ANSI code
+    # page is not UTF-8 fails on the first em dash.
+    proc = subprocess.run(cmd, capture_output=True,
+                          encoding="utf-8", errors="replace")
     if proc.returncode != 0:
         sys.exit(f"error: {' '.join(cmd)} failed: {proc.stderr.strip()}")
     path, lineno = None, 0

--- a/scripts/check-new-line-citations.py
+++ b/scripts/check-new-line-citations.py
@@ -23,6 +23,20 @@ import re
 import subprocess
 import sys
 
+def keep_output_printable():
+    """Report through the console's codec without dying on it.
+
+    The comments these scripts quote carry em dashes, and a Windows box whose
+    code page is not UTF-8 cannot spell one: piping the report into anything
+    raises `UnicodeEncodeError` before a single finding reaches the reader.
+    `backslashreplace` spells those characters out instead, so the report
+    survives a console that cannot render it.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(errors="backslashreplace")
+
+
 CITE = re.compile(r"(?:[A-Za-z0-9_.-]+/)*[a-z_][a-z0-9_]*\.py:\d+")
 ESCAPE = "allow-line-citation"
 
@@ -56,6 +70,7 @@ def main():
     ap.add_argument("--base", help="diff against this ref instead of the index")
     ap.add_argument("files", nargs="*", help="ignored; pre-commit passes them")
     args = ap.parse_args()
+    keep_output_printable()
 
     bad = []
     for path, lineno, text in added_lines(args.base):

--- a/scripts/drop-line-citations.py
+++ b/scripts/drop-line-citations.py
@@ -170,6 +170,20 @@ def rewrite_line(line, index, by_path, stats, refused):
     return "".join(out)
 
 
+def keep_output_printable():
+    """Report through the console's codec without dying on it.
+
+    The comments these scripts quote carry em dashes, and a Windows box whose
+    code page is not UTF-8 cannot spell one: piping the report into anything
+    raises `UnicodeEncodeError` before a single finding reaches the reader.
+    `backslashreplace` spells those characters out instead, so the report
+    survives a console that cannot render it.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure"):
+            stream.reconfigure(errors="backslashreplace")
+
+
 def main():
     ap = argparse.ArgumentParser(description=__doc__,
                                  formatter_class=argparse.RawDescriptionHelpFormatter)
@@ -179,6 +193,7 @@ def main():
     ap.add_argument("--report", action="store_true", help="print refusal samples")
     ap.add_argument("--limit", type=int, default=0, help="stop after N files (bisecting aid)")
     args = ap.parse_args()
+    keep_output_printable()
 
     root = args.root.resolve()
     search_roots = args.search_roots or list(SEARCH_ROOTS)

--- a/scripts/drop-line-citations.py
+++ b/scripts/drop-line-citations.py
@@ -66,7 +66,7 @@ def build_index(root: Path):
             continue
         for p in base_dir.rglob("*.py"):
             try:
-                text = p.read_text(errors="replace")
+                text = p.read_text(encoding="utf-8", errors="replace")
             except OSError:
                 continue
             names = set()
@@ -99,7 +99,7 @@ def candidates(pyfile, index, by_path):
 def scan(root: Path, search_roots):
     proc = subprocess.run(
         ["rg", "-l", "--type", "rust", RG_PREFILTER, *search_roots],
-        cwd=root, capture_output=True, text=True,
+        cwd=root, capture_output=True, encoding="utf-8", errors="replace",
     )
     if proc.returncode not in (0, 1):
         sys.exit(f"error: rg failed ({proc.returncode}): {proc.stderr.strip()}")
@@ -110,6 +110,12 @@ def scan(root: Path, search_roots):
             "That is a misconfigured search, not a clean tree."
         )
     return files
+
+
+def read_source(path):
+    """A source file's exact text: UTF-8, and its own line endings kept."""
+    with open(path, encoding="utf-8", newline="") as fh:
+        return fh.read()
 
 
 def rewrite_line(line, index, by_path, stats, refused):
@@ -185,7 +191,7 @@ def main():
     touched = []
     for rel in files:
         p = root / rel
-        original = p.read_text()
+        original = read_source(p)
         lines = original.splitlines(keepends=True)
         new = [rewrite_line(l, index, by_path, stats, refused) for l in lines]
         text = "".join(new)
@@ -196,7 +202,11 @@ def main():
     # citation set nobody can reason about if a later file raises.
     if args.apply:
         for p, text in touched:
-            p.write_text(text)
+            # newline="" on both halves, so a file goes back the way it
+            # came: text mode would read CRLF as LF and then write every LF
+            # as os.linesep, turning an LF tree into a CRLF one on Windows.
+            with open(p, "w", encoding="utf-8", newline="") as fh:
+                fh.write(text)
 
     print(f"citations seen        {stats['total']:6d}")
     print(f"numbers dropped       {stats['dropped']:6d}")


### PR DESCRIPTION
Five independent changes.

## The merge-point `GuardFutureCondition` is captured at the `jit_merge_point` op's JitCode pc

`walker_capture_snapshot_for_last_guard` reads its pc argument as a JitCode
offset (`resume_marker_for_jitcode_pc`, `depth_trivia_for_jitcode_pc`,
`after_residual_marker_for_jitcode_pc`).  The cross-loop close leg passed
`next_instr` - the green Python pc it builds the green key from - where every
other capture site passes `op.pc` / `op_pc`, and where upstream captures:
`pyjitpl.py:1567` sets `frame.pc = orgpc`, the `jit_merge_point` op's own
JitCode pc, for the duration of `reached_loop_header`, and `generate_guard`'s
default `resumepc=-1` leaves `capture_resumedata`:2610 reading it.

This is the `ntpath.normpath` `TypeError: call on null callable`: a resume
coordinate in the wrong space named another function's bytes.

`op.pc` was tried and reverted once on this branch, on a reading of 15 failed /
432 passed.  Those 15 were the LLBC artefact join merging 1341 distinct
function spellings, which main fixed in #1389; only the JIT reads LLBC, which
is why the interpreter was right and the JIT wrong about the same coordinate.
On that base `check.py --backend dynasm` reads 450/450 with `op.pc`, and the
revert is dropped.

## `winreg` and `_socket` constant values

`REG_LEGAL_CHANGE_FILTER` and `REG_LEGAL_OPTION` each carry a bit whose own
name `winreg` does not publish - `REG_NOTIFY_THREAD_AGNOSTIC` (0x10000000) in
the filter and `REG_OPTION_DONT_VIRTUALIZE` (0x10) in the option word - so the
masks are 0x1000000F and 0x1F, not 0xF.

`SOL_IP` is defined by `ws2def.h` here, so the 0 placeholder the other arm uses
named `IPPROTO_IP` instead of the level.

`PyModule_AddIntConstant` takes a C `long`, 32 bits here, so every `INADDR_*`
with the top bit set is published as the negative number that word spells:
`INADDR_BROADCAST` and `INADDR_NONE` are -1, `INADDR_ALLHOSTS_GROUP`
-536870911, `INADDR_UNSPEC_GROUP` -536870912, `INADDR_MAX_LOCAL_GROUP`
-536870657.

`ws2tcpip.h` spells `EAI_NODATA` as `EAI_NONAME`, the RFC 3493 deprecation, so
both name `WSAHOST_NOT_FOUND` and not `WSANO_DATA`.

All twelve values read back equal to CPython 3.14.2 on this host.

## The `sys`, `_thread`, `_io`, `_socket`, `nt`, `_locale` and `gc` surface

Each module's `dir()` was diffed against CPython 3.14.2 on this host; these are
the names that were missing or answered differently.

**`_io`** gains `_WindowsConsoleIO` (PEP 528), ported from PyPy
`W_WinConsoleIO`.  `open()` picks it over `FileIO` when
`_PyIO_get_console_type` recognizes the path or fd as a console.  The type is
subclassable and carries a dict, so it takes a subclass-range id (190) after
both Windows overlapped owners and is registered with the collector in
`pyre-jit`'s `build_gc`; without that root the interpreter panicked at startup.
A sandbox build compiles the type out and keeps the plain `FileIO`
construction.

**`sys`**: `abiflags` is absent on Windows rather than an empty string, since
the ABI tag belongs to `sys.winver` and `hasattr` is what reads it.  Added
`api_version`, `_home`, `_git`, `_baserepl`, `_is_immortal`, `_is_interned`,
`_is_gil_enabled`, `getunicodeinternedsize` (over a new
`unicodeobject::interned_size`, with `_only_immortal=True` counting only the
entries the collector does not own), `getallocatedblocks`, `_clear_type_cache`,
`_clear_internal_caches`, `_current_exceptions`, `_debugmallocstats`,
`call_tracing`, the three stack-trampoline calls,
`_enablelegacywindowsfsencoding`, `int_max_str_digits`, and the missing
`float_info` / `int_info` / `hash_info` / `thread_info` and `sys.flags` members
(`gil`, `thread_inherit_context`, `context_aware_warnings`).

`_is_gil_enabled()` answers `True`: `rgil` is one process-wide lock a thread
holds across arbitrarily many bytecodes, whatever ABI tag `sysconfig` publishes.

`sys.flags`, `sys.version_info` and `sys.getwindowsversion()` carry
`Py_TPFLAGS_DISALLOW_INSTANTIATION`, so both `type(sys.flags)(...)` and
`type(sys.flags).__new__(...)` raise - the second because
`structseq_descr_new` is reachable past the check `type.__call__` makes.  The
message spells `tp_name`, naming `sys.flags` rather than `flags`.

**`_thread`**: `set_name` was a no-op stub; it and the new `_get_name` now
reach the platform on all three hosts.  Windows goes through
`SetThreadDescription` / `GetThreadDescription`, counting UTF-16 code units,
stopping at the first NUL and truncating without splitting a surrogate pair.
POSIX encodes through the filesystem codec with the `replace` error handler and
cuts at the first NUL and at `_NAME_MAXLEN` bytes (15 on Linux, 63 on macOS),
then calls `pthread_setname_np`; `_get_name` decodes what the platform kept
with `surrogateescape`.

`set_name`, `_get_name` and `_NAME_MAXLEN` are published only where those calls
exist, mirroring `#if (HAVE_PTHREAD_GETNAME_NP || MS_WINDOWS)` and
`#ifdef _PYTHREAD_NAME_MAXLEN`.  A no-op setter that reports success is worse
than absence: `test_threading.test_set_name` is gated on
`hasattr(_thread, '_get_name')`, so exposing the pair on a host that cannot
store the name makes the test compare against a name that was never set.

Also added `exit_thread`.

**`_socket`**: `if_nameindex`, `if_nametoindex` and `if_indextoname` through
`rustpython_host_env::socket`.  The two scalar conversions fail through the C
runtime `errno`, which `raw_os_error` leaves empty on that path, so
`posix_errno` recovers it; enumeration fails through a Win32 status and is
reported as that flavour.  A negative index raises `ValueError`, one past a
machine word `OverflowError`.  Windows `dup` shares the socket into this
process and returns the new descriptor.

**`nt`**: `kill` was a no-op stub that `test_os` hung on; it now delivers the
two console control events with `GenerateConsoleCtrlEvent` and otherwise passes
the number to `TerminateProcess` as the exit code.  Added `lchmod`, which is
the reparse point's own file attributes here.  `execv` / `execve` silence the
invalid parameter handler around `_wexecv`: an empty path reached it and ended
the process where the call is supposed to return -1 with `EINVAL`.

**`_locale`**: `_getdefaultlocale`, built from the user ISO language and
territory with the active ANSI code page reported separately, spelled `cp<n>`
for every code page including 65001.

**`gc`**: `get_debug` / `set_debug` over an interpreter-owned debug word.

`test_os` goes from crashing at `test_execve_with_empty_path` to running 375
tests, and `test_sys` from 11 failures to 8.

## The citation tools do not run on a non-UTF-8 Windows host

Both scripts #1399 added read this tree's own bytes through the locale codec.
On a box whose ANSI code page is cp949 that fails on the first em dash:
`check-new-line-citations.py` dies in `subprocess`'s reader thread and then on
`proc.stdout` being None, and `drop-line-citations.py` dies in
`Path.read_text`.  Both now name utf-8.

`drop-line-citations.py --apply` also wrote each file back through
`Path.write_text`, whose text mode turns every `
` into `os.linesep` -
measured here, `write_text("a
b
")` lands `b"a
b
"`.  Running it on
Windows would have converted the tree it edited to CRLF, which is what the LLBC
fingerprint reads.  The read and the write now both pass `newline=""`.

Both scripts also quote the comments they read, and those carry em dashes, so
piping either one still raised `UnicodeEncodeError` from the first `print` and
no finding reached the reader.  Their stdout and stderr now carry
`backslashreplace`: a character the console cannot spell is written out rather
than raised over.

## Review round

Sixteen comments.  Each was checked against CPython 3.14 source or a measured
run on this host before it was changed or left alone.

**Changed**

- `_WindowsConsoleIO` reads its rooted path after the blocking open rather than
  from a snapshot taken before it: `FsEncodedPath::w_path` re-reads the
  shadow-stack slot, and releasing the GIL lets a moving collection run.
- An invalid descriptor is reported the way `_Py_get_osfhandle` reports one:
  `_get_osfhandle` rejects it through `errno`, so this is an `EBADF` `OSError`
  with no `winerror` slot rather than whatever `GetLastError` last held.
- `_WindowsConsoleIO.close()` pins the flush exception and reads the slot back
  before attaching it as the close exception's context.  The second
  `to_exc_object` allocates, so a moving collection can run between the pin and
  the read and forwards the slot, never the local copy.
- `sys._is_gil_enabled()` answers `True`.  Bytecode runs under `rgil`
  (`majit-gc/src/rgil.rs:21-31`): one process-wide lock, taken when a thread
  starts and dropped only around external calls, so a thread holds it across
  arbitrarily many bytecodes.
- `sys.getunicodeinternedsize(_only_immortal=True)` counts the immortal entries
  instead of converting the keyword and then discarding it.
- `_locale._getdefaultlocale` spells code page 65001 `cp65001` like every other
  page, and is published only outside the sandbox build, beside `setlocale`,
  `localeconv` and `nl_langinfo`.
- `_codecs` gains `mbcs_encode`, `mbcs_decode`, `oem_encode`, `oem_decode`,
  `code_page_encode`, `code_page_decode` and `readbuffer_encode`, ported from
  `unicodehelper_win32.py`.  76 differential cases - handlers, truncated
  trailing sequences, the `final` flag, the registry round trip and the
  incremental decoder - read identical to CPython 3.14.2 on this host.
- `AF_HYPERV` addresses pack and unpack as `SOCKADDR_HV`, so `bind`, `connect`,
  `connect_ex`, `sendto`, `sendmsg` and `getsockname` take and answer the
  `(vm_id, service_id)` GUID pair.  Its value now comes from `windows-sys`
  rather than the literal 34.
- `AF_BLUETOOTH` addresses pack and unpack as `SOCKADDR_BTH`, the one form
  RFCOMM takes - and RFCOMM is the one Bluetooth protocol Windows carries.
  Publishing the family without it left `bind` answering `unsupported address
  family: 32`, so `test_socket.BluetoothTest` was 2 errors; it is now OK with
  11 skips, the verdict CPython 3.14.2 reaches on this host, which has a radio.
  The address scan reproduces one `%X` conversion of the `sscanf` in
  `setbdaddr`, so all 20 spellings probed - a leading blank and a `0x` prefix
  accepted, a trailing character and an out-of-range octet not - answer
  identical to CPython, error flavours and `getsockname` round trip included.
  `AF_BLUETOOTH` and `BTPROTO_RFCOMM` come from `windows-sys` now rather than
  from literals.
- `_thread` no longer reports a `SystemExit` out of a worker as an ignored
  exception - that is how `_thread.exit()` ends one - and reads the target back
  out of its pinned slot before `repr()`.
- `sys._baserepl()` runs `code.interact` over `__main__`'s namespace instead of
  returning at once, so the fallback in `_pyrepl.main.interactive_console`
  starts a session rather than ending one.
- The socket constants were re-checked by dumping all 127 `AF_*`, `IPPROTO_*`,
  `SO_*`, `TCP_*`, `IP_*`, `IPV6_*`, `MSG_*`, `RCVALL_*` and `HV_*` names from
  CPython 3.14.2 on this host and diffing: no mismatches and none missing.
  `TCP_QUICKACK` is `SIO_TCP_SET_ACK_FREQUENCY`, which `windows-sys` does
  carry, so the literal it was first published as is gone.
- `TCP_QUICKACK` reaches `WSAIoctl`.  That option number is an ioctl code, not
  an option, so `setsockopt` answers WSAENOPROTOOPT for it; `sock_setsockopt`
  sends an int value through `WSAIoctl` and remembers it, and
  `sock_getsockopt` answers the remembered value because WinSock has no call
  that reads an ioctl's current setting.  Publishing the constant is what armed
  `test_socket.TestQuickackFlag`, gated on `hasattr(socket, 'TCP_QUICKACK')`
  and skipped on Windows before this branch; it passes now, and reads
  0 / 1 / 0 across the same set calls CPython 3.14.2 does here.
- `TCP_KEEPALIVE` is no longer published on Windows.  `socketmodule.c` guards
  it with `#if defined(__APPLE__)`, and the unix arm here was already
  `target_os = "macos"`; it was the one name that failed
  `test_socket.TestMSWindowsTCPFlags.test_new_tcp_flags`, which compares every
  `socket.TCP*` against a fixed set.

**Measured, and left alone**

- `_WindowsConsoleIO(fd, closefd=True)` reporting `closefd == False` is what
  CPython reports: `winconsoleio.c:417-419` sets `self->closefd = 0` for every
  `fd >= 0`, whatever the argument said.
- `_thread.set_name` / `_get_name` cannot silently succeed on wasm: they and
  `_NAME_MAXLEN` are published only where `HAVE_PTHREAD_GETNAME_NP` or
  `MS_WINDOWS` has the call behind them, which is what makes
  `test_threading.test_set_name` skip instead of comparing against a name the
  platform never stored.
- The `W_WindowsConsoleIO` registration in `pyre-jit` needs no `host_env` term:
  `pyre-jit` takes `pyre-interpreter` with defaults on, so the feature is
  enabled through that edge whatever the top-level `--no-default-features`
  says.  `cargo test --all --no-default-features --features dynasm,cpyext` -
  the Windows CI command - builds it.
- The new Windows `posix` handlers raise no audit event because
  `interp_posix.py` raises only `open` and `os.add_dll_directory`, and pyre's
  `posix` carries no audit site at all; two here would be the module's only
  ones.

## Not addressed

`sys._enablelegacywindowsfsencoding` reaches only `getfilesystemencoding` and
`getfilesystemencodeerrors`.  With the code page codecs landed, the remaining
blocker is a different one: `gateway::fsencode` and `typedef::FS_ERRORS` are
not the only converters, because pyre carries host names as WTF-8 through
`fsencode_os_str` and `os_string_from_fs_bytes`.  The app-level converters and
that host bridge have to change together or a name stops round-tripping
between them.

`sys._baserepl()` reproduces only the prompt loop.  `_Py_FdIsInteractive` sends
everything that is not a terminal to `_PyRun_SimpleFileObject`, which compiles
the whole of stdin at once and reports failure through `PyErr_Print`; that
belongs to the driver owning process exit, which `pyre-interpreter` sits below.
Redirected stdin therefore runs statement by statement with a prompt between
each.

Three message wordings differ, none of them new and none Windows-specific.
`c_int_w` says `expected integer, got str object` and `expected a 32-bit
integer` where CPython says `'str' object cannot be interpreted as an integer`
and `Python int too large to convert to C int`; a `py_module!` arity failure
says `takes N positional arguments but M were given` where a positional-only
clinic function says `expected at most N arguments, got M`.  Both belong to
shared machinery that every module reaches.

`write_unraisable_default` omits the `:` CPython writes after `err_msg` when
there is no object, so the thread report reads `Exception ignored in thread
started by <function f ...>` without it.  The `err_msg` field itself matches -
`test_thread.test_unraisable_exception` reads it, not the printed line.

`_socket` publishes four names Windows CPython does not -
`IP_DEFAULT_MULTICAST_LOOP`, `IP_DEFAULT_MULTICAST_TTL`, `IP_MAX_MEMBERSHIPS`
and `RCVALL_IPLEVEL` - and is missing `CAPI`.  `nt` is missing
the `_path_*` predicates, `_getvolumepathname`, `_inputhook`,
`_is_inputhook_installed` and `uname_result`; `_io` is missing
`_BytesIOBuffer` and `msvcrt` `CRT_ASSEMBLY_VERSION`.  All of these predate
this branch: no name among them appears in its diff.

`os.spawnv`, `os.spawnve` and `os.waitpid` remain no-op stubs on Windows, and
`socket.socket.share` / `socket.fromshare` are absent - which is what
`test_socket.TestSocketSharing` errors on.  `socket.socket.ioctl` is absent
too, which `test_sock_ioctl` and `test_sio_loopback_fast_path` error on; the
`SIO_*` and `RCVALL_*` constants it reads were published by #1228 and are on
main already, so neither gap starts here.

CI runs the vendored CPython suite on Linux alone, so the modules this branch
touches were run here by hand as well.  `test_thread` (35) and `test_threading`
(228) are OK.  `test_codecs` runs 12 of `CodePageTest`'s 13 cases (2 skipped
for memory); its one error, `test_cp1252`, goes through `encodings/cp1252.py`
rather than a code page call, and is `charmap_encode` raising
`UnicodeEncodeError` with one argument where CPython passes the five-tuple -
`5be0a87807`, already on main.  `test_socket.BluetoothTest` is OK with 11
skips and `test_socket.TestQuickackFlag` passes, both the verdict CPython
3.14.2 reaches here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows console stream support through `_io._WindowsConsoleIO`.
  * Added Windows code-page codecs, locale detection, and expanded socket capabilities.
  * Added `gc.get_debug()` and `gc.set_debug()`.
  * Added thread exception inspection, naming, and exit APIs.
  * Expanded `sys` compatibility, platform information, and runtime utility APIs.
* **Bug Fixes**
  * Prevented direct construction of protected system information types.
  * Improved Windows error reporting, filesystem operations, and encoding behavior.
  * Corrected Windows platform constants, interface handling, and socket operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

