### PR TITLE
pip performance, plus nested code identity across marshal, RootScope's foreign-mutator guard, and root-set shape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,6 +2070,7 @@ dependencies = [
  "md-5",
  "proc-macro2",
  "quote",
+ "rustc-hash",
  "rustpython-compiler",
  "rustpython-compiler-core",
  "rustpython-wtf8",
@@ -2766,6 +2767,7 @@ dependencies = [
  "pyre-interpreter",
  "pyre-jit-trace",
  "pyre-object",
+ "rustc-hash",
  "rustpython-wtf8",
  "vecset",
 ]

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -755,12 +755,10 @@ impl RootSet {
             self.roots.pop();
             return;
         }
-        // shadowstack.py:80-106 advances one `root_stack_top` on push and
-        // decrements that same top before pop: duplicate roots are therefore
-        // retired newest-first.  The same slot can be registered by nested
-        // host brackets, so the out-of-order fallback must preserve that
-        // order too. Searching from the front leaves the newest duplicate in
-        // place and turns the following, otherwise-LIFO removals into scans.
+        // `shadowstack.py` has no by-value removal: `push_stack`/`pop_stack`
+        // move one `root_stack_top`, so the newest registration is the one
+        // retired.  Either copy leaves the same roots here, but taking the
+        // front one breaks that shape and rescans on every following removal.
         if let Some(pos) = self.roots.iter().rposition(|r| *r == root) {
             self.roots.swap_remove(pos);
         }

--- a/majit/majit-gc/src/collector.rs
+++ b/majit/majit-gc/src/collector.rs
@@ -755,7 +755,13 @@ impl RootSet {
             self.roots.pop();
             return;
         }
-        if let Some(pos) = self.roots.iter().position(|r| *r == root) {
+        // shadowstack.py:80-106 advances one `root_stack_top` on push and
+        // decrements that same top before pop: duplicate roots are therefore
+        // retired newest-first.  The same slot can be registered by nested
+        // host brackets, so the out-of-order fallback must preserve that
+        // order too. Searching from the front leaves the newest duplicate in
+        // place and turns the following, otherwise-LIFO removals into scans.
+        if let Some(pos) = self.roots.iter().rposition(|r| *r == root) {
             self.roots.swap_remove(pos);
         }
     }
@@ -7681,6 +7687,28 @@ mod tests {
         roots.remove(a);
         assert_eq!(roots.roots, vec![b]);
         roots.remove(b);
+        assert!(roots.is_empty());
+    }
+
+    #[test]
+    fn root_set_out_of_order_remove_prefers_the_newest_duplicate() {
+        let mut roots = RootSet::new();
+        let mut a = GcRef(1);
+        let mut b = GcRef(2);
+        let (a, b) = (&mut a as *mut GcRef, &mut b as *mut GcRef);
+        unsafe {
+            roots.add(a);
+            roots.add(b);
+            roots.add(a);
+            roots.add(b);
+        }
+
+        roots.remove(a);
+        assert_eq!(roots.roots, vec![a, b, b]);
+        roots.remove(b);
+        assert_eq!(roots.roots, vec![a, b]);
+        roots.remove(b);
+        roots.remove(a);
         assert!(roots.is_empty());
     }
 

--- a/majit/majit-translate/Cargo.toml
+++ b/majit/majit-translate/Cargo.toml
@@ -23,6 +23,7 @@ serde_json = { workspace = true }
 # iteration is insertion-ordered.  IndexMap preserves that semantic while
 # `HashMap` does not.
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 majit-ir = { workspace = true }
 libc = { workspace = true }
 # PRE-EXISTING-ADAPTATION, parity rule #1.

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -5912,21 +5912,21 @@ mod tests {
         regallocs.insert(
             RegKind::Int,
             regalloc::RegAllocator {
-                coloring: HashMap::new(),
+                coloring: regalloc::Coloring::default(),
                 num_regs: 0,
             },
         );
         regallocs.insert(
             RegKind::Ref,
             regalloc::RegAllocator {
-                coloring: HashMap::new(),
+                coloring: regalloc::Coloring::default(),
                 num_regs: 0,
             },
         );
         regallocs.insert(
             RegKind::Float,
             regalloc::RegAllocator {
-                coloring: HashMap::new(),
+                coloring: regalloc::Coloring::default(),
                 num_regs: 0,
             },
         );

--- a/majit/majit-translate/src/codewriter/flatten.rs
+++ b/majit/majit-translate/src/codewriter/flatten.rs
@@ -1601,8 +1601,7 @@ mod tests {
         graph: &FunctionGraph,
         max_id: usize,
     ) -> std::collections::HashMap<RegKind, crate::regalloc::RegAllocator> {
-        let mut coloring: std::collections::HashMap<crate::flowspace::model::Variable, usize> =
-            std::collections::HashMap::new();
+        let mut coloring = crate::regalloc::Coloring::default();
         for var in graph.iter_variables() {
             let color = coloring.len();
             coloring.entry(var).or_insert(color);
@@ -2596,7 +2595,7 @@ mod tests {
             .collect();
         let mut regallocs = HashMap::new();
         for (kind, pairs) in kind_colors {
-            let mut coloring: HashMap<crate::flowspace::model::Variable, usize> = HashMap::new();
+            let mut coloring = crate::regalloc::Coloring::default();
             let mut max_color = 0usize;
             for (vid, color) in *pairs {
                 coloring.insert(vars[*vid].clone(), *color);

--- a/majit/majit-translate/src/codewriter/regalloc.rs
+++ b/majit/majit-translate/src/codewriter/regalloc.rs
@@ -12,7 +12,7 @@
 use crate::flatten::RegKind;
 use crate::model::FunctionGraph;
 
-pub use crate::tool::algo::regalloc::RegAllocator;
+pub use crate::tool::algo::regalloc::{Coloring, RegAllocator};
 
 /// `regalloc.py::perform_register_allocation(graph, kind)` wrapper.
 pub fn perform_register_allocation(graph: &FunctionGraph, kind: RegKind) -> RegAllocator {

--- a/majit/majit-translate/src/tool/algo/color.rs
+++ b/majit/majit-translate/src/tool/algo/color.rs
@@ -1,6 +1,16 @@
 //! Chordal graph coloring helper from `rpython/tool/algo/color.py`.
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// Nodes are compiler-internal identities — a flow-graph `Variable`, a jitcode
+/// variable id — and upstream hashes them by object identity, so a probe there
+/// is a pointer read.  `std`'s default `RandomState` runs SipHash-1-3 over the
+/// key instead, and the chordal walk probes the adjacency of every node once
+/// per node.  Iteration order is not observable: `getnodes` orders from the
+/// `_all_nodes` insertion list, and the adjacency sets are only ever tested
+/// for membership or folded into an order-independent accumulator.
+type HashMap<K, V> = FxHashMap<K, V>;
+type HashSet<T> = FxHashSet<T>;
 
 /// Interference graph for register allocation.
 ///
@@ -35,14 +45,14 @@ impl<N: Eq + std::hash::Hash + Clone> DependencyGraph<N> {
     pub fn new() -> Self {
         Self {
             _all_nodes: Vec::new(),
-            neighbours: HashMap::new(),
+            neighbours: HashMap::default(),
         }
     }
 
     pub fn add_node(&mut self, v: N) {
         if !self.neighbours.contains_key(&v) {
             self._all_nodes.push(v.clone());
-            self.neighbours.insert(v, HashSet::new());
+            self.neighbours.insert(v, HashSet::default());
         }
     }
 
@@ -136,7 +146,7 @@ impl<N: Eq + std::hash::Hash + Clone> DependencyGraph<N> {
     /// Assumes the graph is chordal, as upstream does.
     pub fn size_of_largest_clique(&self) -> usize {
         let mut result = 0;
-        let mut seen = HashSet::new();
+        let mut seen = HashSet::default();
         for v in self.lexicographic_order() {
             let mut num = 1;
             if let Some(neighbours) = self.neighbours.get(&v) {
@@ -155,9 +165,9 @@ impl<N: Eq + std::hash::Hash + Clone> DependencyGraph<N> {
     /// RPython: `DependencyGraph.find_node_coloring()`.
     /// Uses `HashSet<usize>` — no color limit (fixes u64 overflow).
     pub fn find_node_coloring(&self) -> HashMap<N, usize> {
-        let mut result = HashMap::new();
+        let mut result = HashMap::default();
         for v in self.lexicographic_order() {
-            let mut forbidden: HashSet<usize> = HashSet::new();
+            let mut forbidden: HashSet<usize> = HashSet::default();
             if let Some(neighbours) = self.neighbours.get(&v) {
                 for n in neighbours {
                     if let Some(&color) = result.get(n) {

--- a/majit/majit-translate/src/tool/algo/regalloc.rs
+++ b/majit/majit-translate/src/tool/algo/regalloc.rs
@@ -9,7 +9,23 @@
 //! 2. Coalesce variables connected by Goto link args
 //! 3. Greedy graph coloring via lexicographic BFS
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
+use std::collections::HashMap;
+
+/// The per-variable tables — coloring, interference, liveness — key on
+/// flow-graph `Variable`s, which upstream's dictionaries hash by object
+/// identity, so a probe there is a pointer read.  `std`'s default
+/// `RandomState` runs SipHash-1-3 per probe instead, and the assembler reads
+/// the coloring once per variable occurrence in the flattened graph.  Ordering
+/// is not observable: every read is a point lookup, a `len`, or a value-only
+/// rewrite.  The per-kind map keeps `RandomState`; it holds one entry per
+/// `RegKind` and is not probed in a loop.
+pub type VarMap<V> = FxHashMap<crate::flowspace::model::Variable, V>;
+
+/// The coloring an [`AllocationResult`] carries, nameable by callers that
+/// build one directly.
+pub type Coloring = VarMap<usize>;
+type VarSet = FxHashSet<crate::flowspace::model::Variable>;
 
 use crate::flatten::RegKind;
 use crate::model::{Block, ConcreteType, FunctionGraph, OpKind};
@@ -19,15 +35,15 @@ pub use crate::tool::algo::color::DependencyGraph;
 
 #[derive(Debug, Clone)]
 struct UnionFind<N: Eq + std::hash::Hash + Clone> {
-    parent: HashMap<N, N>,
-    weight: HashMap<N, usize>,
+    parent: FxHashMap<N, N>,
+    weight: FxHashMap<N, usize>,
 }
 
 impl<N: Eq + std::hash::Hash + Clone> UnionFind<N> {
     fn new() -> Self {
         Self {
-            parent: HashMap::new(),
-            weight: HashMap::new(),
+            parent: FxHashMap::default(),
+            weight: FxHashMap::default(),
         }
     }
 
@@ -76,7 +92,7 @@ impl<N: Eq + std::hash::Hash + Clone> UnionFind<N> {
 struct RegAllocatorState {
     depgraph: DependencyGraph<crate::flowspace::model::Variable>,
     unionfind: UnionFind<crate::flowspace::model::Variable>,
-    coloring: HashMap<crate::flowspace::model::Variable, usize>,
+    coloring: VarMap<usize>,
 }
 
 impl RegAllocatorState {
@@ -84,7 +100,7 @@ impl RegAllocatorState {
         Self {
             depgraph: DependencyGraph::new(),
             unionfind: UnionFind::new(),
-            coloring: HashMap::new(),
+            coloring: VarMap::default(),
         }
     }
 
@@ -132,7 +148,7 @@ impl RegAllocatorState {
                 _ => None,
             }))
             .collect();
-        let mut die_at: HashMap<crate::flowspace::model::Variable, usize> = HashMap::new();
+        let mut die_at: VarMap<usize> = VarMap::default();
         for var in &block_input_vars {
             die_at.insert(var.clone(), 0);
         }
@@ -195,7 +211,7 @@ impl RegAllocatorState {
                 }
             }
         }
-        let mut alive: HashSet<crate::flowspace::model::Variable> = livevars.into_iter().collect();
+        let mut alive: VarSet = livevars.into_iter().collect();
 
         // Scan ops, kill at die_at, add interference edges
         let mut die_index = 0;
@@ -342,7 +358,7 @@ impl RegAllocatorState {
 /// [`Self::color_for_variable`] / [`Self::contains_variable`].
 #[derive(Debug, Clone)]
 pub struct RegAllocator {
-    pub coloring: HashMap<crate::flowspace::model::Variable, usize>,
+    pub coloring: VarMap<usize>,
     pub num_regs: usize,
 }
 
@@ -472,7 +488,7 @@ pub fn perform_register_allocation(graph: &FunctionGraph, kind: RegKind) -> RegA
     allocator.coalesce_variables(graph, &consider);
     allocator.find_node_coloring();
 
-    let mut coloring: HashMap<crate::flowspace::model::Variable, usize> = HashMap::new();
+    let mut coloring: VarMap<usize> = VarMap::default();
     let mut max_reg = 0usize;
     // Walk every Variable minted on the graph and pick those whose
     // concretetype lands in `kind`.  `getcolor` projects through the

--- a/majit/majit-translate/src/tool/algo/unionfind.rs
+++ b/majit/majit-translate/src/tool/algo/unionfind.rs
@@ -32,8 +32,18 @@
 //! preserve the upstream absorb-skip semantics.
 
 use indexmap::IndexMap;
-use std::collections::HashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
 use std::hash::Hash;
+
+/// The three tables key on whatever the caller partitions — a flow-graph
+/// `Variable`, a jitcode variable id.  Upstream's dictionaries hash those by
+/// object identity, so the hash is a pointer read; `std`'s default
+/// `RandomState` instead runs SipHash-1-3 over the key on every probe, and the
+/// register allocator probes several times per operand.  Nothing keyed here
+/// comes from outside the compiler, so the collision resistance that buys is
+/// unused.  Ordering is unaffected: only `link_to_parent` is iterated, and it
+/// is an `IndexMap`, which yields insertion order whatever the hasher is.
+type Table<K, V> = FxHashMap<K, V>;
 
 /// RPython `info1.absorb(info2)` (unionfind.py) — called by
 /// [`UnionFind::union`] when two partitions merge. `self` is the
@@ -58,15 +68,15 @@ where
     /// `IndexMap`, not `HashMap`: `keys()` iterates this to drive commonbase
     /// folding and access-set numbering downstream, matching the upstream
     /// dictionary's insertion order.
-    link_to_parent: IndexMap<K, K>,
+    link_to_parent: IndexMap<K, K, FxBuildHasher>,
     /// RPython `self.weight` (unionfind.py:9).
     /// Upstream dictionary deletion in `union` is O(1); ordering is carried
     /// by `link_to_parent`, so hash storage preserves both properties.
-    weight: HashMap<K, usize>,
+    weight: Table<K, usize>,
     /// RPython `self.root_info` (unionfind.py:11).
     /// Upstream dictionary deletion in `union` is O(1); ordering is derived
     /// from `link_to_parent`, so hash storage preserves both properties.
-    root_info: HashMap<K, V>,
+    root_info: Table<K, V>,
     /// RPython `self.info_factory` (unionfind.py:10). See module doc
     /// for why the Rust port makes this mandatory.
     info_factory: Box<dyn Fn(&K) -> V>,
@@ -84,9 +94,9 @@ where
         F: Fn(&K) -> V + 'static,
     {
         UnionFind {
-            link_to_parent: IndexMap::new(),
-            weight: HashMap::new(),
-            root_info: HashMap::new(),
+            link_to_parent: IndexMap::default(),
+            weight: Table::default(),
+            root_info: Table::default(),
             info_factory: Box::new(info_factory),
         }
     }

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=8
+bridges_compiled=7
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1645
+guard_failures=1501
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/bench/fib_recursive.dynasm.jitstats
+++ b/pyre/bench/fib_recursive.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=7
+bridges_compiled=8
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=1501
+guard_failures=1645
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=1

--- a/pyre/extra_tests/snippets/marshal_nested_code_identity.py
+++ b/pyre/extra_tests/snippets/marshal_nested_code_identity.py
@@ -1,0 +1,34 @@
+# `test_marshal` is not in the CPython-suite baseline, so nothing in the suite
+# loads a stream in which one code object appears twice.
+#
+# `unmarshal_pycode` is declared with `save_ref=True` and calls `save_ref` on
+# the code object it is about to fill in, so a second occurrence of that object
+# travels as a back-reference. The loader owes both spellings the same object.
+#
+# Reaching that requires the decoded wrapper to be what the parent's constant
+# slot keeps. A loader that instead rebuilds the slot from its own copy of the
+# body answers with an equal-but-distinct code object, which is invisible to
+# every test that compares constants by value.
+import marshal
+
+
+def f():
+    def g():
+        return 1
+
+    return g
+
+
+code = f.__code__
+nested = [c for c in code.co_consts if hasattr(c, "co_name")][0]
+
+# `nested` occurs twice in the stream: once inside `code.co_consts`, and once as
+# the tuple's own second item, which is written as a reference to the first.
+loaded_code, loaded_nested = marshal.loads(marshal.dumps((code, nested)))
+from_consts = [c for c in loaded_code.co_consts if hasattr(c, "co_name")][0]
+
+assert from_consts is loaded_nested, "nested code object identity was not preserved"
+
+# The retained wrapper is a working code object, not just the right identity.
+assert from_consts.co_name == "g"
+assert eval(marshal.loads(marshal.dumps(compile("21 * 2", "<pin>", "eval")))) == 42

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -318,64 +318,41 @@ pub unsafe fn walk_raw_code_roots(
     value: PyObjectRef,
     visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
 ) {
-    unsafe fn walk(
-        value: PyObjectRef,
-        visitor: &mut dyn FnMut(&mut majit_ir::GcRef),
-        visited: &mut Vec<usize>,
-    ) {
-        unsafe {
-            if value.is_null() || !crate::pycode::is_code(value) {
-                return;
-            }
-            let identity = value as usize;
-            // PyPy's GC traces the PyCode constant list transitively and its
-            // mark state prevents revisiting shared/cyclic nodes. PyCode
-            // wrappers may be reached recursively without a collector mark
-            // check, so mirror that small identity set while walking constants.
-            if visited.contains(&identity) {
-                return;
-            }
-            visited.push(identity);
-            let code = &mut *(value as *mut crate::pycode::PyCode);
-            visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
-            // The realized `co_qualname` is an ordinary movable string object
-            // shared by every function built from this code.
-            visitor(&mut *(&mut code.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
-            // `co_name` is realized and retained the same way.
-            visitor(&mut *(&mut code.w_name as *mut PyObjectRef as *mut majit_ir::GcRef));
-            if !code.co_consts_w.is_null() {
-                for slot in (&*code.co_consts_w).iter() {
-                    let mut child = slot.load(std::sync::atomic::Ordering::Acquire);
-                    if child.is_null() {
-                        continue;
-                    }
-                    visitor(&mut *(&mut child as *mut PyObjectRef as *mut majit_ir::GcRef));
-                    slot.store(child, std::sync::atomic::Ordering::Release);
-                    // Recurse through nested co_consts_w, matching PyPy's
-                    // transitively traced PyCode list.
-                    walk(child, visitor, visited);
-                }
-            }
-            // mapdict.py CacheEntry.w_method is the cache's sole GC
-            // reference.  PyPy traces it as part of the live PyCode; do the
-            // same here now that managed code wrappers reach this walker from
-            // their custom trace (the registry walk remains for bootstrap
-            // prebuilt wrappers).
-            if !code.mapdict_caches.is_null() {
-                for entry in (&mut *code.mapdict_caches).iter_mut().flatten() {
-                    visitor(
-                        &mut *(&mut entry.w_method as *mut PyObjectRef as *mut majit_ir::GcRef),
-                    );
-                }
-            }
-        }
-    }
-
     unsafe {
         if value.is_null() || !crate::pycode::is_code(value) {
             return;
         }
-        walk(value, visitor, &mut Vec::new());
+        // A GC trace callback reports one object's direct edges. PyPy's mark
+        // worklist provides transitive traversal and its VISITED bit provides
+        // cycle suppression; recursively walking nested PyCode values here
+        // duplicated both jobs and allocated a fresh identity Vec on every
+        // trace. Bootstrap wrappers are each registered individually in
+        // PREBUILT_CODE_ROOTS, so the same direct-edge shape covers them too.
+        let code = &mut *(value as *mut crate::pycode::PyCode);
+        visitor(&mut *(&mut code.w_globals as *mut PyObjectRef as *mut majit_ir::GcRef));
+        // The realized `co_qualname` is an ordinary movable string object
+        // shared by every function built from this code.
+        visitor(&mut *(&mut code.w_qualname as *mut PyObjectRef as *mut majit_ir::GcRef));
+        // `co_name` is realized and retained the same way.
+        visitor(&mut *(&mut code.w_name as *mut PyObjectRef as *mut majit_ir::GcRef));
+        if !code.co_consts_w.is_null() {
+            for slot in (&*code.co_consts_w).iter() {
+                let mut child = slot.load(std::sync::atomic::Ordering::Acquire);
+                if child.is_null() {
+                    continue;
+                }
+                visitor(&mut *(&mut child as *mut PyObjectRef as *mut majit_ir::GcRef));
+                slot.store(child, std::sync::atomic::Ordering::Release);
+            }
+        }
+        // mapdict.py CacheEntry.w_method is the cache's sole GC
+        // reference. PyPy traces it as part of the live PyCode; do the same
+        // here now that managed code wrappers reach this direct-field walker.
+        if !code.mapdict_caches.is_null() {
+            for entry in (&mut *code.mapdict_caches).iter_mut().flatten() {
+                visitor(&mut *(&mut entry.w_method as *mut PyObjectRef as *mut majit_ir::GcRef));
+            }
+        }
     }
 }
 

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -2869,24 +2869,41 @@ pub fn remove_sys_module(name: &str) {
     }
 }
 
+/// What [`release_sys_modules_for_shutdown`] detached from the import cache.
+pub struct ReleasedSysModules {
+    /// The real modules it found, newest last, each still referenced by the
+    /// import cache's caller until it takes its own hold on them.
+    pub modules: Vec<(Wtf8Buf, PyObjectRef)>,
+    /// Whether any detached entry is absent from `modules` and so lost its last
+    /// referrer here. An import cache holding nothing but named modules answers
+    /// `false`, which says the detach alone made nothing unreachable.
+    pub dropped_unlisted: bool,
+}
+
 /// `finalize_remove_modules`: snapshot real modules, then detach import-cache
 /// entries so module/dict cycles can become unreachable during shutdown.
-pub fn release_sys_modules_for_shutdown() -> Vec<(Wtf8Buf, PyObjectRef)> {
+pub fn release_sys_modules_for_shutdown() -> ReleasedSysModules {
     let dict = sys_modules_dict();
     if dict.is_null() {
-        return Vec::new();
+        return ReleasedSysModules {
+            modules: Vec::new(),
+            dropped_unlisted: false,
+        };
     }
     let entries = unsafe { pyre_object::w_dict_items(dict) };
     let mut modules = Vec::new();
+    let mut dropped_unlisted = false;
     for (key, module) in entries {
         let name = if unsafe { pyre_object::is_str(key) } {
             Some(unsafe { pyre_object::w_str_get_wtf8(key) }.to_owned())
         } else {
             None
         };
+        let mut listed = false;
         if !module.is_null() && unsafe { pyre_object::is_module(module) } {
             if let Some(name) = &name {
                 modules.push((name.clone(), module));
+                listed = true;
             }
         }
         let keep_entry = name.as_deref().is_some_and(|name| {
@@ -2894,12 +2911,16 @@ pub fn release_sys_modules_for_shutdown() -> Vec<(Wtf8Buf, PyObjectRef)> {
             bytes == b"sys" || bytes == b"builtins"
         });
         if !keep_entry {
+            dropped_unlisted |= !listed;
             unsafe {
                 pyre_object::w_dict_delitem(dict, key);
             }
         }
     }
-    modules
+    ReleasedSysModules {
+        modules,
+        dropped_unlisted,
+    }
 }
 
 /// GC root walk over every bound module's wrapped name and dict storage.

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -37,15 +37,46 @@ fn call_method(obj: PyObjectRef, name: &str, args: &[PyObjectRef]) -> PyResult {
     }
 }
 
-fn bytes_like(obj: PyObjectRef, function: &str) -> Result<Vec<u8>, PyError> {
+enum MarshalBytes {
+    Borrowed(&'static [u8]),
+    Owned(Vec<u8>),
+}
+
+impl MarshalBytes {
+    fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Borrowed(bytes) => bytes,
+            Self::Owned(bytes) => bytes,
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.as_slice().len()
+    }
+}
+
+fn bytes_like(obj: PyObjectRef, function: &str) -> Result<MarshalBytes, PyError> {
     if unsafe { bytesobject::is_bytes_like(obj) } {
-        return Ok(unsafe { bytesobject::bytes_like_data(obj) }.to_vec());
+        return Ok(MarshalBytes::Borrowed(unsafe {
+            bytesobject::bytes_like_data(obj)
+        }));
+    }
+    if unsafe { memoryview::is_w_memoryview(obj) } {
+        unsafe { crate::builtins::memoryview_check_released(obj) }?;
+        crate::typedef::require_contiguous_buffer(obj)?;
+        let view = unsafe { memoryview::w_memoryview_view(obj) };
+        return Ok(match unsafe { view.as_contiguous_bytes() } {
+            Some(bytes) => MarshalBytes::Borrowed(bytes),
+            None => MarshalBytes::Owned(unsafe { view.gather() }),
+        });
     }
     // Any readable buffer is accepted (`interp_marshal` unwraps via
     // `space.readbuf_w`): `SourcelessFileLoader.get_code` hands `loads` a
     // sliced memoryview of the pyc payload.
     if let Some(src) = crate::typedef::buffer_as_bytes_like(obj)? {
-        return Ok(unsafe { bytesobject::bytes_like_data(src) }.to_vec());
+        return Ok(MarshalBytes::Owned(
+            unsafe { bytesobject::bytes_like_data(src) }.to_vec(),
+        ));
     }
     Err(PyError::type_error(format!(
         "{function}() argument must be a bytes-like object"
@@ -528,7 +559,7 @@ impl FileReader {
                 bytes.len()
             )));
         }
-        self.scratch.extend_from_slice(&bytes);
+        self.scratch.extend_from_slice(bytes.as_slice());
         Ok(())
     }
 
@@ -1040,7 +1071,7 @@ crate::py_module! {
         ) -> Result<PyObjectRef, crate::PyError> {
             let allow_code = resolve_allow_code(allow_code)?;
             let data = bytes_like(data, "loads")?;
-            unmarshal_bytes(&data, allow_code)
+            unmarshal_bytes(data.as_slice(), allow_code)
         }
         // interp_marshal.py `dump(w_data, w_f, version=Py_MARSHAL_VERSION)`
         // — writes the stream `dumps` would return to `f.write`
@@ -1095,6 +1126,14 @@ crate::py_module! {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn exact_bytes_are_borrowed_for_unmarshal() {
+        let input = bytesobject::w_bytes_from_bytes(b"payload");
+        let bytes = bytes_like(input, "loads").expect("bytes input");
+
+        assert!(matches!(bytes, MarshalBytes::Borrowed(b"payload")));
+    }
 
     #[test]
     fn decoded_code_constant_uses_the_wrapped_pycode_as_authority() {

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -678,8 +678,13 @@ impl wire::MarshalBag for PyreMarshalBag {
     }
 
     fn make_interned_str(&self, value: &Wtf8) -> Rooted {
-        let value = Rooted::new(w_str_from_wtf8(value.to_owned()));
-        Rooted::new(unsafe { unicodeobject::intern_exact_str(value.get()) })
+        // The reader holds only the characters, so ask the intern table with
+        // them.  Building a `str` first and handing it to `intern_exact_str`
+        // would allocate a `malloc_typed`-immortal object per occurrence and
+        // abandon it whenever the value is already interned, retaining it for
+        // the process lifetime; interned names repeat heavily across a
+        // module's code objects, so nearly every occurrence is such a hit.
+        Rooted::new(unicodeobject::intern_wtf8_value(value))
     }
 
     fn make_bytes(&self, value: &[u8]) -> Rooted {
@@ -898,10 +903,18 @@ impl wire::MarshalBag for PyreMarshalBag {
 
     fn str_from_value(&self, value: &Rooted) -> Option<String> {
         let obj = value.get();
-        unsafe { unicodeobject::is_str(obj) }.then(|| {
-            unsafe { unicodeobject::w_str_get_wtf8(obj) }
+        if !unsafe { unicodeobject::is_str(obj) } {
+            return None;
+        }
+        // A code object's names are overwhelmingly ascii, and an ascii payload
+        // is one byte per code point, so the cached counts behind this
+        // accessor decide it carries no surrogate without reading the bytes.
+        // `to_string_lossy` has no such shortcut and rescans every name.
+        Some(match unsafe { unicodeobject::w_str_get_value_opt(obj) } {
+            Some(value) => value.to_owned(),
+            None => unsafe { unicodeobject::w_str_get_wtf8(obj) }
                 .to_string_lossy()
-                .into_owned()
+                .into_owned(),
         })
     }
 

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -824,11 +824,12 @@ impl wire::MarshalBag for PyreMarshalBag {
     /// `make_code_with_constants`, which is what `read_code_consts` does for
     /// `code.replace(co_consts=...)`.
     fn code_constant_from_value(&self, value: &Rooted) -> Result<ConstantData, wire::MarshalError> {
-        // PyPy's unmarshaller installs the already-decoded nested PyCode
-        // directly in `co_consts_w` (`marshal_impl.py:426-459`). The compiler
-        // table is only pyre's bytecode-index shape here: using `None` makes
-        // `w_code_fill_wrapped_consts` retain that exact wrapped child instead
-        // of recursively cloning its entire compiler body into a second owner.
+        // `unmarshal_pycode` hands its decoded constants straight to
+        // `PyCode.__init__`, whose `co_consts_w` is the only constants table
+        // upstream keeps. Serializing the child back into pyre's second,
+        // compiler-level table copies its whole body into a second permanent
+        // owner; `None` is the arm `is_wrapped_constant` always stores, so the
+        // already-decoded wrapper stays this slot's authority instead.
         if unsafe { crate::pycode::is_code(value.get()) } {
             return Ok(ConstantData::None);
         }

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -824,6 +824,14 @@ impl wire::MarshalBag for PyreMarshalBag {
     /// `make_code_with_constants`, which is what `read_code_consts` does for
     /// `code.replace(co_consts=...)`.
     fn code_constant_from_value(&self, value: &Rooted) -> Result<ConstantData, wire::MarshalError> {
+        // PyPy's unmarshaller installs the already-decoded nested PyCode
+        // directly in `co_consts_w` (`marshal_impl.py:426-459`). The compiler
+        // table is only pyre's bytecode-index shape here: using `None` makes
+        // `w_code_fill_wrapped_consts` retain that exact wrapped child instead
+        // of recursively cloning its entire compiler body into a second owner.
+        if unsafe { crate::pycode::is_code(value.get()) } {
+            return Ok(ConstantData::None);
+        }
         Ok(unsafe { crate::pycode::obj_to_constant_data(value.get()) }
             .unwrap_or(ConstantData::None))
     }
@@ -1081,4 +1089,22 @@ crate::py_module! {
             Ok(result)
         }
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decoded_code_constant_uses_the_wrapped_pycode_as_authority() {
+        let w_code = crate::pycode::w_code_new(std::ptr::null());
+        let rooted = Rooted::new(w_code);
+        let mut pending_error = None;
+        let bag = PyreMarshalBag::new(&mut pending_error);
+
+        let placeholder = wire::MarshalBag::code_constant_from_value(&bag, &rooted)
+            .expect("PyCode constant must be accepted");
+
+        assert!(matches!(placeholder, ConstantData::None));
+    }
 }

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -3107,6 +3107,19 @@ mod tests {
     }
 
     #[test]
+    fn box_code_object_preserves_owned_storage() {
+        let code = compile_exec("answer = 42\n").expect("compile failed");
+        let source_storage = code.source_path.as_ptr();
+        let instruction_storage = code.instructions.as_ptr();
+
+        let w_code = box_code_object(code);
+        let stored = unsafe { &*(w_code_get_ptr(w_code) as *const crate::CodeObject) };
+
+        assert_eq!(stored.source_path.as_ptr(), source_storage);
+        assert_eq!(stored.instructions.as_ptr(), instruction_storage);
+    }
+
+    #[test]
     fn w_code_const_shares_large_integer_and_root_walker_visits_slot() {
         let code =
             compile_exec("x = 123456789012345678901234567890123456789012345678901234567890\n")

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -480,8 +480,9 @@ fn unregister_prebuilt_code_root(code: PyObjectRef) {
 }
 
 /// Trace every bootstrap/prebuilt code wrapper exactly as PyPy traces every
-/// live GC-managed `PyCode`. Nested code constants are handled by the raw
-/// walker's own mark-state analogue.
+/// live GC-managed `PyCode`. Every bootstrap wrapper is registered here, so
+/// the raw walker reports direct fields just like a GC trace callback; it does
+/// not need to recreate the collector's transitive mark walk.
 pub(crate) fn walk_prebuilt_code_roots(visitor: &mut dyn FnMut(&mut majit_ir::GcRef)) {
     let Some(roots) = PREBUILT_CODE_ROOTS.get() else {
         return;
@@ -3223,7 +3224,7 @@ mod tests {
     }
 
     #[test]
-    fn raw_code_root_walker_recurses_through_nested_code_constants() {
+    fn raw_code_root_walker_reports_one_gc_edge_at_a_time() {
         let code = compile_exec(
             "def outer():\n\
              \x20   def inner():\n\
@@ -3265,17 +3266,37 @@ mod tests {
         let w_outer = unsafe { w_code_const(w_top, outer_idx) };
         let w_inner = unsafe { w_code_const(w_outer, inner_idx) };
         let w_bigint = unsafe { w_code_const(w_inner, bigint_idx) };
-        let mut visited = false;
+        let mut top_reaches_outer = false;
+        let mut top_reaches_deep_value = false;
         unsafe {
             crate::eval::walk_raw_code_roots(w_top, &mut |root| {
+                if root.0 == w_outer as usize {
+                    top_reaches_outer = true;
+                }
                 if root.0 == w_bigint as usize {
-                    visited = true;
+                    top_reaches_deep_value = true;
                 }
             });
         }
         assert!(
-            visited,
-            "an outer PyCode root must trace realized constants in nested PyCode wrappers"
+            top_reaches_outer,
+            "a PyCode trace must report its directly-held child code"
+        );
+        assert!(
+            !top_reaches_deep_value,
+            "a GC trace callback must leave transitive traversal to the mark worklist"
+        );
+        let mut inner_reaches_bigint = false;
+        unsafe {
+            crate::eval::walk_raw_code_roots(w_inner, &mut |root| {
+                if root.0 == w_bigint as usize {
+                    inner_reaches_bigint = true;
+                }
+            });
+        }
+        assert!(
+            inner_reaches_bigint,
+            "the nested object's direct edge was lost"
         );
     }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -177,12 +177,15 @@ pub static CODE_TYPE: PyType = pyre_object::pyobject::new_pytype("code");
 
 /// Python code object wrapper.
 ///
-/// Stores an opaque pointer to the bytecode CodeObject. The pointer is
-/// `Box::into_raw`'d from a cloned CodeObject, so we own the allocation.
+/// Stores an opaque pointer to the bytecode CodeObject. A top-level body is
+/// `Box::into_raw`'d; a nested body points into that permanently-live owner,
+/// matching PyPy's one recursively-owned `co_consts_w` code graph without
+/// cloning the child graph at each wrapping boundary.
 #[repr(C)]
 pub struct PyCode {
     pub ob_header: PyObject,
-    /// Opaque pointer to a `CodeObject` (owned via Box::into_raw).
+    /// Opaque pointer to a permanently-live `CodeObject`. Top-level bodies are
+    /// owned via `Box::into_raw`; nested bodies borrow from one of those boxes.
     pub code_ptr: *const (),
     /// `pycode.py self.co_firstlineno = firstlineno`. RustPython's
     /// `CodeObject.first_line_number: Option<OneIndexed>` cannot represent
@@ -576,8 +579,8 @@ pub fn _convert_const(_space: PyObjectRef, w_a: PyObjectRef) -> PyObjectRef {
 /// (interp_continuation.py:195)) construct via this entry point.
 ///
 /// # Safety
-/// `code_ptr` must be a valid pointer to a `CodeObject` obtained
-/// via `Box::into_raw`.
+/// `code_ptr` must be a valid pointer to a permanently-live `CodeObject`,
+/// either obtained via `Box::into_raw` or nested inside one such owner.
 ///
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py`): the body
 /// boxes the `PyCode` through the prebuilt allocator and its per-name cache

--- a/pyre/pyre-jit/Cargo.toml
+++ b/pyre/pyre-jit/Cargo.toml
@@ -37,6 +37,7 @@ wasm-host = ["majit-backend-wasm/host-import"]
 
 [dependencies]
 indexmap = { workspace = true }
+rustc-hash = { workspace = true }
 pyre-object = { workspace = true }
 pyre-interpreter = { workspace = true }
 num-traits = { workspace = true }

--- a/pyre/pyre-jit/src/jit/codewriter.rs
+++ b/pyre/pyre-jit/src/jit/codewriter.rs
@@ -2220,15 +2220,15 @@ fn emit_loop_header(
     );
     let mut empty_regallocs = [
         super::regalloc::GraphAllocationResult {
-            coloring: std::collections::HashMap::new(),
+            coloring: crate::jit::regalloc::Coloring::default(),
             num_colors: 0,
         },
         super::regalloc::GraphAllocationResult {
-            coloring: std::collections::HashMap::new(),
+            coloring: crate::jit::regalloc::Coloring::default(),
             num_colors: 0,
         },
         super::regalloc::GraphAllocationResult {
-            coloring: std::collections::HashMap::new(),
+            coloring: crate::jit::regalloc::Coloring::default(),
             num_colors: 0,
         },
     ];
@@ -5504,8 +5504,8 @@ fn resolve_const_ref_slot(c: &super::flow::Constant) -> Option<i64> {
 fn build_pcdep_color_slots(
     pcdep_slot_var: &[Vec<(u16, u32)>],
     pcdep_slot_var_resume: &[Vec<(u16, u32)>],
-    colorings: [&std::collections::HashMap<super::flow::VariableId, u16>; 3],
-    live_oracles: [&std::collections::HashMap<super::flow::VariableId, u16>; 3],
+    colorings: [&crate::jit::regalloc::Coloring; 3],
+    live_oracles: [&crate::jit::regalloc::Coloring; 3],
     rename: &[Vec<u16>; 3],
     code: &CodeObject,
     depth_at_pc: &[u16],
@@ -5577,8 +5577,8 @@ fn frame_layout_slot(slot: u16, nlocals: usize, stack_base: usize) -> u16 {
 
 fn validate_pcdep_color_map(
     pcdep_slot_var: &[Vec<(u16, u32)>],
-    colorings: [&std::collections::HashMap<super::flow::VariableId, u16>; 3],
-    live_oracles: [&std::collections::HashMap<super::flow::VariableId, u16>; 3],
+    colorings: [&crate::jit::regalloc::Coloring; 3],
+    live_oracles: [&crate::jit::regalloc::Coloring; 3],
     rename: &[Vec<u16>; 3],
     code: &CodeObject,
     depth_at_pc: &[u16],
@@ -8677,13 +8677,13 @@ impl CodeWriter {
                             // outside the canonical graph regalloc pass,
                             // so no `regallocs[]` entry exists for them
                             // — this site assembles one ad hoc.
-                            let mut portal_ref_coloring = std::collections::HashMap::new();
+                            let mut portal_ref_coloring = crate::jit::regalloc::Coloring::default();
                             portal_ref_coloring.insert(frame_var.id, portal_frame_reg);
                             portal_ref_coloring.insert(ec_var.id, portal_ec_reg);
                             portal_ref_coloring.insert(pycode_var.id, scratch_pycode_reg);
                             let mut portal_regallocs = [
                                 super::regalloc::GraphAllocationResult {
-                                    coloring: std::collections::HashMap::new(),
+                                    coloring: crate::jit::regalloc::Coloring::default(),
                                     num_colors: 0,
                                 },
                                 super::regalloc::GraphAllocationResult {
@@ -8691,7 +8691,7 @@ impl CodeWriter {
                                     num_colors: 3,
                                 },
                                 super::regalloc::GraphAllocationResult {
-                                    coloring: std::collections::HashMap::new(),
+                                    coloring: crate::jit::regalloc::Coloring::default(),
                                     num_colors: 0,
                                 },
                             ];

--- a/pyre/pyre-jit/src/jit/flatten.rs
+++ b/pyre/pyre-jit/src/jit/flatten.rs
@@ -2895,9 +2895,9 @@ pub fn identity_test_regallocs(
     graph: &super::flow::FunctionGraph,
 ) -> [super::regalloc::GraphAllocationResult; 3] {
     use std::collections::HashMap;
-    let mut int_coloring: HashMap<super::flow::VariableId, u16> = HashMap::new();
-    let mut ref_coloring: HashMap<super::flow::VariableId, u16> = HashMap::new();
-    let mut float_coloring: HashMap<super::flow::VariableId, u16> = HashMap::new();
+    let mut int_coloring = crate::jit::regalloc::Coloring::default();
+    let mut ref_coloring = crate::jit::regalloc::Coloring::default();
+    let mut float_coloring = crate::jit::regalloc::Coloring::default();
     let mut record = |v: Variable| {
         let kind = v.kind.unwrap_or(Kind::Ref);
         let map = match kind {
@@ -2963,7 +2963,7 @@ pub fn identity_test_regallocs(
             }
         }
     }
-    let max_color = |map: &HashMap<super::flow::VariableId, u16>| {
+    let max_color = |map: &crate::jit::regalloc::Coloring| {
         map.values().copied().max().map(|m| m + 1).unwrap_or(0)
     };
     [
@@ -7880,12 +7880,12 @@ mod tests {
             3,
         );
         let mut ssarepr = SSARepr::new("test");
-        let mut ref_coloring = std::collections::HashMap::new();
+        let mut ref_coloring = crate::jit::regalloc::Coloring::default();
         ref_coloring.insert(frame.id, 10u16);
         ref_coloring.insert(ec.id, 11u16);
         let mut regallocs = [
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
             super::super::regalloc::GraphAllocationResult {
@@ -7893,7 +7893,7 @@ mod tests {
                 num_colors: 2,
             },
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
         ];
@@ -8443,12 +8443,12 @@ mod tests {
         let dst = Variable::new(VariableId(1), Kind::Ref);
         let op = SpaceOperation::new("type", vec![src.into()], Some(dst.into()), 23);
         let mut ssarepr = SSARepr::new("generic");
-        let mut ref_coloring = std::collections::HashMap::new();
+        let mut ref_coloring = crate::jit::regalloc::Coloring::default();
         ref_coloring.insert(src.id, 0u16);
         ref_coloring.insert(dst.id, 1u16);
         let mut regallocs = [
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
             super::super::regalloc::GraphAllocationResult {
@@ -8456,7 +8456,7 @@ mod tests {
                 num_colors: 2,
             },
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
         ];
@@ -8506,13 +8506,13 @@ mod tests {
             )
         };
         let make_regallocs = || {
-            let mut ref_coloring = std::collections::HashMap::new();
+            let mut ref_coloring = crate::jit::regalloc::Coloring::default();
             ref_coloring.insert(obj.id, 0u16);
             ref_coloring.insert(attr.id, 1u16);
             ref_coloring.insert(val.id, 2u16);
             [
                 super::super::regalloc::GraphAllocationResult {
-                    coloring: std::collections::HashMap::new(),
+                    coloring: crate::jit::regalloc::Coloring::default(),
                     num_colors: 0,
                 },
                 super::super::regalloc::GraphAllocationResult {
@@ -8520,7 +8520,7 @@ mod tests {
                     num_colors: 3,
                 },
                 super::super::regalloc::GraphAllocationResult {
-                    coloring: std::collections::HashMap::new(),
+                    coloring: crate::jit::regalloc::Coloring::default(),
                     num_colors: 0,
                 },
             ]
@@ -8592,11 +8592,11 @@ mod tests {
         ]);
 
         // Ref bank: `already` colored 0 (1 color); `leaked` uncolored.
-        let mut ref_coloring = std::collections::HashMap::new();
+        let mut ref_coloring = crate::jit::regalloc::Coloring::default();
         ref_coloring.insert(already.id, 0u16);
         let mut regallocs = [
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
             super::super::regalloc::GraphAllocationResult {
@@ -8604,7 +8604,7 @@ mod tests {
                 num_colors: 1,
             },
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
         ];
@@ -9260,15 +9260,15 @@ mod tests {
     fn empty_regallocs() -> [super::super::regalloc::GraphAllocationResult; 3] {
         [
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
             super::super::regalloc::GraphAllocationResult {
-                coloring: std::collections::HashMap::new(),
+                coloring: crate::jit::regalloc::Coloring::default(),
                 num_colors: 0,
             },
         ]

--- a/pyre/pyre-jit/src/jit/regalloc.rs
+++ b/pyre/pyre-jit/src/jit/regalloc.rs
@@ -33,7 +33,23 @@
 //! `majit_translate::regalloc::DependencyGraph::find_node_coloring`
 //! (line-by-line port of `rpython/tool/algo/color.py:31-85`).
 
-use std::collections::{HashMap, HashSet};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// `VariableId` is a `u32` newtype, and `make_dependencies` probes these tables
+/// once per operand of every operation in every block.  Upstream keys the same
+/// dictionaries on `Variable` objects hashed by identity, so its probe is a
+/// pointer read; `std`'s default `RandomState` runs SipHash-1-3 over the four
+/// bytes instead, which is the dominant cost of allocating registers for a
+/// jitcode.  These ids never leave the codewriter, so nothing needs the
+/// collision resistance.  No iteration here is order-sensitive: `die_at` is
+/// sorted by die time before use, and `coloring` is only point-read and
+/// value-rewritten.
+type HashMap<K, V> = FxHashMap<K, V>;
+type HashSet<T> = FxHashSet<T>;
+
+/// The coloring a [`GraphAllocationResult`] carries, nameable by the
+/// codewriter passes that build one directly or take one by reference.
+pub type Coloring = FxHashMap<super::flow::VariableId, u16>;
 
 use majit_translate::regalloc::DependencyGraph;
 use majit_translate::tool::algo::unionfind::UnionFind;
@@ -43,7 +59,7 @@ use super::flow::{ExitSwitch, ExitSwitchElement, FlowValue, FunctionGraph as Flo
 
 #[derive(Debug, Clone)]
 pub struct GraphAllocationResult {
-    pub coloring: HashMap<super::flow::VariableId, u16>,
+    pub coloring: Coloring,
     pub num_colors: u16,
 }
 
@@ -101,7 +117,7 @@ impl<'a> RegAllocator<'a> {
             kind,
             _depgraph: DependencyGraph::new(),
             _unionfind: UnionFind::new(|_| ()),
-            _coloring: HashMap::new(),
+            _coloring: HashMap::default(),
         }
     }
 
@@ -109,7 +125,7 @@ impl<'a> RegAllocator<'a> {
         let kind = self.kind;
         for block in self.graph.iterblocks() {
             let block_borrow = block.borrow();
-            let mut die_at: HashMap<super::flow::VariableId, usize> = HashMap::new();
+            let mut die_at: HashMap<super::flow::VariableId, usize> = HashMap::default();
             for arg in &block_borrow.inputargs {
                 if let Some(v) = arg.as_variable() {
                     if v.kind == Some(kind) {
@@ -449,7 +465,7 @@ pub fn perform_register_allocation_with_pairs(
     }
     allocator.find_node_coloring();
 
-    let mut coloring = HashMap::new();
+    let mut coloring = HashMap::default();
     for block in graph.iterblocks() {
         let block_borrow = block.borrow();
         for variable in block_borrow.getvariables() {

--- a/pyre/pyre-object/src/bufferview.rs
+++ b/pyre/pyre-object/src/bufferview.rs
@@ -556,6 +556,40 @@ impl BufferView {
         unsafe { self.gather_order(false) }
     }
 
+    /// Borrow the live byte run when this view already has the `BUF_SIMPLE`
+    /// shape PyPy's `StringUnmarshaller` consumes directly.
+    ///
+    /// A step-one slice over `Simple`/`Raw` is normalized into a
+    /// [`Buffer::Sub`] by [`new_slice`](Self::new_slice), so the common pyc
+    /// payload view remains in these two arms and [`Buffer::as_bytes`] already
+    /// applies its offset and length. More general geometry deliberately
+    /// returns `None`; callers then use [`gather`](Self::gather), preserving
+    /// the existing strided/N-D semantics without pretending it is one run.
+    ///
+    /// # Safety
+    /// The backing export must remain live and unresized while the returned
+    /// slice is used, exactly as for [`Buffer::as_bytes`].
+    pub unsafe fn as_contiguous_bytes(&self) -> Option<&'static [u8]> {
+        unsafe {
+            match self {
+                BufferView::Simple {
+                    backing, length, ..
+                }
+                | BufferView::Raw {
+                    backing, length, ..
+                } => {
+                    let bytes = backing.as_bytes();
+                    let length = ((*length).max(0) as usize).min(bytes.len());
+                    Some(&bytes[..length])
+                }
+                BufferView::Readonly { view, .. } => view.as_contiguous_bytes(),
+                BufferView::Slice { .. }
+                | BufferView::View1D { .. }
+                | BufferView::ViewND { .. } => None,
+            }
+        }
+    }
+
     /// The `PyBuffer_ToContiguous` copy for C order (`fortran == false`) or
     /// Fortran order (`fortran == true`).  CPython constructs destination
     /// strides for the requested order and copies matching logical indices;
@@ -638,6 +672,19 @@ mod tests {
     }
 
     #[test]
+    fn simple_step1_slice_borrows_its_exact_sub_window() {
+        let exporter = crate::bytesobject::w_bytes_from_bytes(b"0123456789");
+        let view = BufferView::Simple {
+            backing: Buffer::String { w_obj: exporter },
+            w_obj: exporter,
+            length: 10,
+        };
+        let sliced = unsafe { view.new_slice(2, 1, 5) };
+
+        assert_eq!(unsafe { sliced.as_contiguous_bytes() }, Some(&b"23456"[..]));
+    }
+
+    #[test]
     fn raw_step1_slice_scales_the_window_by_itemsize() {
         // RawBufferView.new_slice step==1 (buffer.py:262-265): the SubBuffer
         // window is `start * itemsize .. + slicelength * itemsize`.
@@ -672,6 +719,7 @@ mod tests {
     fn strided_step_wraps_in_a_slice_with_derived_geometry() {
         let s = unsafe { simple(10).new_slice(0, 2, 5) };
         assert!(matches!(s, BufferView::Slice { .. }));
+        assert!(unsafe { s.as_contiguous_bytes() }.is_none());
         unsafe {
             assert_eq!(s.native_shape(), vec![5]);
             assert_eq!(s.native_strides(), vec![2]);

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -37,8 +37,6 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 
 use crate::pyobject::*;
-use std::cell::UnsafeCell;
-use std::sync::LazyLock;
 
 /// `pypy/objspace/std/dictmultiobject.py ObjectDictStrategy`
 /// — `r_dict(dict_keys_equal, hash_w)` key type.  The hash is cached
@@ -91,6 +89,39 @@ impl PartialEq for ObjectKey {
 }
 
 impl Eq for ObjectKey {}
+
+/// Hash adapter for an `r_dict` key whose Python hash was already computed.
+///
+/// RPython's `rordereddict` feeds that cached integer directly into its table.
+/// Rust's default `IndexMap` instead SipHashes the integer a second time. A
+/// multiply retains the cached hash as the sole semantic input while spreading
+/// it into hashbrown's high control bits; it is the integer-key counterpart of
+/// `majit_gc::address_dict::AddressHasher`.
+#[derive(Default)]
+pub struct ObjectKeyHasher(u64);
+
+impl std::hash::Hasher for ObjectKeyHasher {
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut value = 0_u64;
+        for (shift, byte) in bytes.iter().copied().take(8).enumerate() {
+            value |= (byte as u64) << (shift * 8);
+        }
+        self.0 = value.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+
+    #[inline]
+    fn write_i64(&mut self, value: i64) {
+        self.0 = (value as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    }
+}
+
+pub type ObjectKeyBuildHasher = std::hash::BuildHasherDefault<ObjectKeyHasher>;
 
 /// View a key as `&str` only when it is a str whose backing is valid UTF-8.
 /// A lone-surrogate str returns `None` so the `&str`-keyed proxy fast paths
@@ -215,7 +246,7 @@ impl indexmap::Equivalent<ObjectKey> for StrLookupKey<'_> {
 /// `entries` must be a live entry table whose keys are valid `ObjectKey`s.
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_probe_str(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     hash: i64,
     key: &str,
 ) -> Option<PyObjectRef> {
@@ -233,7 +264,7 @@ pub unsafe fn dict_entries_probe_str(
 /// Same as [`dict_entries_probe_str`]; `key` must be a valid PyObjectRef.
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_probe_object(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     key: PyObjectRef,
 ) -> Option<PyObjectRef> {
     entries.get(&object_key_for(key)).copied()
@@ -256,7 +287,7 @@ pub unsafe fn dict_entries_probe_object(
 /// Same as [`dict_entries_probe_object`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_remove_object(
-    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &mut ObjectDictStorage,
     key: PyObjectRef,
 ) -> bool {
     entries.shift_remove(&object_key_for(key)).is_some()
@@ -276,7 +307,7 @@ pub unsafe fn dict_entries_remove_object(
 /// [`object_key_for_checked`] produced for `obj`.
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_probe_hashed(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     hash: i64,
     obj: PyObjectRef,
 ) -> Option<PyObjectRef> {
@@ -298,7 +329,7 @@ pub unsafe fn dict_entries_probe_hashed(
 /// Same as [`dict_entries_probe_hashed`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_insert_hashed(
-    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &mut ObjectDictStorage,
     hash: i64,
     obj: PyObjectRef,
     value: PyObjectRef,
@@ -318,10 +349,7 @@ pub unsafe fn dict_entries_insert_hashed(
 /// # Safety
 /// Same as [`dict_entries_probe_hashed`]; `index` must be a live entry index.
 #[majit_macros::dont_look_inside]
-pub unsafe fn dict_entries_value_at(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
-    index: usize,
-) -> PyObjectRef {
+pub unsafe fn dict_entries_value_at(entries: &ObjectDictStorage, index: usize) -> PyObjectRef {
     *entries.get_index(index).unwrap().1
 }
 
@@ -337,7 +365,7 @@ pub unsafe fn dict_entries_value_at(
 /// Same as [`dict_entries_value_at`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_value_set_at(
-    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &mut ObjectDictStorage,
     index: usize,
     value: PyObjectRef,
 ) {
@@ -356,7 +384,7 @@ pub unsafe fn dict_entries_value_set_at(
 /// Same as [`dict_entries_probe_object`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_insert_object(
-    entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &mut ObjectDictStorage,
     key: PyObjectRef,
     value: PyObjectRef,
 ) {
@@ -385,7 +413,7 @@ pub unsafe fn dict_entries_insert_object(
 /// Same as [`dict_entries_value_at`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_key_obj_at(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     index: usize,
 ) -> Option<PyObjectRef> {
     entries.get_index(index).map(|(stored, _)| stored.obj)
@@ -401,10 +429,7 @@ pub unsafe fn dict_entries_key_obj_at(
 /// # Safety
 /// Same as [`dict_entries_value_at`].
 #[majit_macros::dont_look_inside]
-pub unsafe fn dict_entries_key_hash_at(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
-    index: usize,
-) -> i64 {
+pub unsafe fn dict_entries_key_hash_at(entries: &ObjectDictStorage, index: usize) -> i64 {
     entries.get_index(index).unwrap().0.hash
 }
 
@@ -417,7 +442,7 @@ pub unsafe fn dict_entries_key_hash_at(
 /// Same as [`dict_entries_value_at`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_key_is_at(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     index: usize,
     hash: i64,
     obj: PyObjectRef,
@@ -435,7 +460,7 @@ pub unsafe fn dict_entries_key_is_at(
 /// # Safety
 /// Same as [`dict_entries_value_at`].
 #[majit_macros::dont_look_inside]
-pub unsafe fn dict_entries_capacity(entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>) -> usize {
+pub unsafe fn dict_entries_capacity(entries: &ObjectDictStorage) -> usize {
     entries.capacity()
 }
 
@@ -448,7 +473,7 @@ pub unsafe fn dict_entries_capacity(entries: &indexmap::IndexMap<ObjectKey, PyOb
 /// # Safety
 /// Same as [`dict_entries_probe_hashed`].
 #[majit_macros::dont_look_inside]
-pub unsafe fn dict_entries_pop_last(entries: &mut indexmap::IndexMap<ObjectKey, PyObjectRef>) {
+pub unsafe fn dict_entries_pop_last(entries: &mut ObjectDictStorage) {
     entries.pop();
 }
 
@@ -464,7 +489,7 @@ pub unsafe fn dict_entries_pop_last(entries: &mut indexmap::IndexMap<ObjectKey, 
 /// none and the bytes are hashed here.
 #[inline]
 unsafe fn dict_entries_get_str(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     key: &str,
     hash: i64,
 ) -> Option<PyObjectRef> {
@@ -502,7 +527,7 @@ fn memoized_or_hashed(key: &str, hash: i64) -> Option<i64> {
 /// `hash` carries a caller-held digest, as in [`dict_entries_get_str`].
 #[inline]
 unsafe fn dict_entries_index_of_str(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     key: &str,
     hash: i64,
 ) -> Option<usize> {
@@ -530,7 +555,7 @@ unsafe fn dict_entries_index_of_str(
 /// Same as [`dict_entries_probe_str`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_index_of_str_hashed(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     hash: i64,
     key: &str,
 ) -> Option<usize> {
@@ -548,7 +573,7 @@ pub unsafe fn dict_entries_index_of_str_hashed(
 /// Same as [`dict_entries_probe_object`].
 #[majit_macros::dont_look_inside]
 pub unsafe fn dict_entries_index_of_object(
-    entries: &indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    entries: &ObjectDictStorage,
     key: PyObjectRef,
 ) -> Option<usize> {
     entries.get_index_of(&object_key_for(key))
@@ -880,11 +905,9 @@ pub struct W_DictObject {
 /// `obj` must point to a valid `W_DictObject` on
 /// `ObjectDictStrategy` or `UnicodeDictStrategy`.
 #[inline]
-pub unsafe fn w_dict_object_storage<'a>(
-    obj: PyObjectRef,
-) -> &'a indexmap::IndexMap<ObjectKey, PyObjectRef> {
+pub unsafe fn w_dict_object_storage<'a>(obj: PyObjectRef) -> &'a ObjectDictStorage {
     let dict = &*(obj as *const W_DictObject);
-    &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>)
+    &*(dict.dstorage as *const ObjectDictStorage)
 }
 
 /// Mutable typed accessor — write-side of [`w_dict_object_storage`].
@@ -892,11 +915,9 @@ pub unsafe fn w_dict_object_storage<'a>(
 /// # Safety
 /// Same as [`w_dict_object_storage`].
 #[inline]
-pub unsafe fn w_dict_object_storage_mut<'a>(
-    obj: PyObjectRef,
-) -> &'a mut indexmap::IndexMap<ObjectKey, PyObjectRef> {
+pub unsafe fn w_dict_object_storage_mut<'a>(obj: PyObjectRef) -> &'a mut ObjectDictStorage {
     let dict = &mut *(obj as *mut W_DictObject);
-    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>)
+    &mut *(dict.dstorage as *mut ObjectDictStorage)
 }
 
 /// Typed accessor for `IntDictStrategy.unerase(w_dict.dstorage)` —
@@ -984,7 +1005,17 @@ pub const W_DICT_GC_TYPE_ID: u32 = 29;
 /// `r_dict(dict_keys_equal, hash_w)` (`dictmultiobject.py:1209`). Also the
 /// universal `switch_to_object_strategy` sink and the identity-dict
 /// promotion target.
-pub type ObjectDictStorage = indexmap::IndexMap<ObjectKey, PyObjectRef>;
+pub type ObjectDictStorage = indexmap::IndexMap<ObjectKey, PyObjectRef, ObjectKeyBuildHasher>;
+
+#[inline]
+pub fn object_dict_storage_new() -> ObjectDictStorage {
+    ObjectDictStorage::with_hasher(ObjectKeyBuildHasher::default())
+}
+
+#[inline]
+pub fn object_dict_storage_with_capacity(capacity: usize) -> ObjectDictStorage {
+    ObjectDictStorage::with_capacity_and_hasher(capacity, ObjectKeyBuildHasher::default())
+}
 /// `IntDictStrategy` backing — erased `Dict[int, W_Root]`
 /// (`dictmultiobject.py:1339`).
 pub type IntDictStorage = indexmap::IndexMap<i64, PyObjectRef>;
@@ -1270,7 +1301,7 @@ pub unsafe fn module_dict_strategy_force_version_qmut(
 ///
 /// `#[dont_look_inside]` (`@jit.dont_look_inside`, `rlib/jit.py`), the
 /// `alloc_dict_object` / `w_str_new` twin: the body builds the host
-/// `IndexMap` storage box (`gc_alloc_storage_box(IndexMap::new())`) before
+/// `IndexMap` storage box (`gc_alloc_storage_box`) before
 /// `alloc_dict_object` runs, so the foreign `IndexMap::new` construction sits
 /// outside `alloc_dict_object`'s own residual boundary.  Tracing into it
 /// carries the unported host container op into the caller; residualising the
@@ -1278,7 +1309,7 @@ pub unsafe fn module_dict_strategy_force_version_qmut(
 #[majit_macros::dont_look_inside]
 pub fn w_dict_new() -> PyObjectRef {
     let entries: *mut ObjectDictStorage = crate::gc_storage::gc_alloc_storage_box(
-        indexmap::IndexMap::new(),
+        object_dict_storage_new(),
         object_dict_storage_gc_type_id(),
     );
     alloc_dict_object(
@@ -1383,7 +1414,7 @@ pub fn w_dict_new_with(strategy: &'static DictStrategyRef, dstorage: *mut u8) ->
 /// the S2 GC-managed storage-box migration. `dealloc_offgc_object_dict_storage`
 /// frees it (its `try_gc_owns_object` guard is false for this box).
 pub fn w_dict_new_unmanaged_side_table_value() -> PyObjectRef {
-    let entries: *mut ObjectDictStorage = crate::lltype::malloc_raw(indexmap::IndexMap::new());
+    let entries: *mut ObjectDictStorage = crate::lltype::malloc_raw(object_dict_storage_new());
     crate::lltype::malloc_typed(W_DictObject {
         ob_header: PyObject {
             ob_type: &DICT_TYPE as *const PyType,
@@ -1545,7 +1576,7 @@ pub struct W_ModuleDictObject {
     /// `ObjectDictStrategy` (`dictmultiobject.py r_dict(space.eq_w,
     /// space.hash_w)`) — same `ObjectKey { hash, obj }` precomputed-hash
     /// + `dict_keys_equal` equality.
-    pub object_storage: *mut indexmap::IndexMap<ObjectKey, PyObjectRef>,
+    pub object_storage: *mut ObjectDictStorage,
     /// Key-set mutation state corresponding to the live iterator held by
     /// PyPy's ModuleDictStrategy iterator implementation.
     pub keys_version: usize,
@@ -1659,57 +1690,14 @@ pub fn w_module_dict_new() -> PyObjectRef {
     }) as PyObjectRef
 }
 
-// PyPy serializes dict strategy/storage transitions with the GIL. Pyre is
-// free-threaded, so use the same narrow address-striped reentrant-lock
-// adaptation already used by mapdict. Semantic state remains exclusively on
-// each W_DictObject/W_ModuleDictObject; these locks only protect operation and
-// strategy-transition boundaries.
-// Stripes are reset in the fork child because a vanished thread may have held
-// one at fork time.
-struct ForkDictLock(UnsafeCell<parking_lot::ReentrantMutex<()>>);
-unsafe impl Sync for ForkDictLock {}
-
-impl ForkDictLock {
-    fn new() -> Self {
-        Self(UnsafeCell::new(parking_lot::ReentrantMutex::new(())))
-    }
-
-    fn get(&self) -> &parking_lot::ReentrantMutex<()> {
-        unsafe { &*self.0.get() }
-    }
-
-    unsafe fn reinit_after_fork(&self) {
-        unsafe { self.0.get().write(parking_lot::ReentrantMutex::new(())) };
-    }
-}
-
-static DICT_LOCKS: LazyLock<Vec<ForkDictLock>> =
-    LazyLock::new(|| (0..256).map(|_| ForkDictLock::new()).collect());
-
-pub type ModuleDictGuard = parking_lot::lock_api::ReentrantMutexGuard<
-    'static,
-    parking_lot::RawMutex,
-    parking_lot::RawThreadId,
-    (),
->;
-
-/// A PyPy-GIL-sized dict operation boundary adapted to pyre's moving,
-/// free-threaded runtime.
+/// A PyPy-GIL-sized dict operation boundary.
 ///
-/// CPython's object critical sections can retain ordinary C references
-/// because its objects do not move. Pyre must additionally shadow-root every
-/// live PyObjectRef across a contended lock acquisition:
-/// `before_external_block` is a GC safepoint. `obj` is therefore pinned and
-/// re-read before `w_dict_lock_raw` derives the stripe from its address, and
-/// `root()` reloads keys and values that may have moved.
-///
-/// Residual hazard: the stripe is a function of the header address, so a
-/// collection that moves a dict while another thread holds its old stripe
-/// re-maps it and permits two simultaneous owners. Allocating every header
-/// stable would fix the stripe but is not available — see `alloc_dict_object`.
+/// `rgil` now holds the process GIL for every stretch of pyre code, exactly as
+/// PyPy does. The old address-striped reentrant mutex predated that port and
+/// duplicated the GIL on every dictionary operation. The root scope remains:
+/// hashing or equality may collect, so callers still publish and reload every
+/// live `PyObjectRef` across the operation.
 pub struct DictOperationGuard {
-    // Drop the mutex before rewinding the roots.
-    _lock: ModuleDictGuard,
     roots: crate::gc_roots::RootScope,
     root_base: usize,
 }
@@ -1720,11 +1708,10 @@ impl DictOperationGuard {
     /// invariant required by the object and pointer arguments for the entire call.
     pub unsafe fn new(obj: PyObjectRef, refs: &[PyObjectRef]) -> Self {
         let roots = crate::gc_roots::push_roots();
-        // The dictionary and its operands become visible in one write phase,
-        // before any query runs: `pin_root` resolves forwarding, that resolve
-        // is a safepoint, and `refs` is a caller-owned native slice no
-        // collection rewrites — so pinning `obj` first would leave every
-        // operand behind it naming a pre-collection address.
+        // The dictionary and its operands become visible in one write phase
+        // before any hashing/equality callback can collect. `refs` is a
+        // caller-owned native slice no collection rewrites, so publish all
+        // values before normalizing any one of them.
         //
         // Every slot access goes through the scope's cached root-stack cell:
         // a dict operation touches each of its operands again on the way out,
@@ -1733,13 +1720,7 @@ impl DictOperationGuard {
         let root_base = roots.publish(&[obj]);
         roots.publish(refs);
         roots.normalize(root_base, 1 + refs.len());
-        let obj = roots.get(root_base);
-        let lock = unsafe { w_dict_lock_raw(obj) };
-        Self {
-            _lock: lock,
-            roots,
-            root_base,
-        }
+        Self { roots, root_base }
     }
 
     #[inline]
@@ -1773,30 +1754,9 @@ macro_rules! lock_dict_refs {
     };
 }
 
-/// Acquire a dict's own lock without making a contending Python
-/// thread prevent GC stop-the-world progress.  The fast path neither blocks
-/// nor changes mutator state; only real contention enters the GC-aware
-/// external-block region.
-///
-/// # Safety
-/// `obj` must point to a live `W_DictObject` or `W_ModuleDictObject`.
-#[majit_macros::dont_look_inside]
-unsafe fn w_dict_lock_raw(obj: PyObjectRef) -> ModuleDictGuard {
-    let lock = DICT_LOCKS[(obj as usize >> 4) & (DICT_LOCKS.len() - 1)].get();
-    if let Some(guard) = lock.try_lock() {
-        return guard;
-    }
-    let blocked = majit_gc::gc_sync::before_external_block();
-    let guard = lock.lock();
-    drop(blocked);
-    guard
-}
-
-pub fn module_dict_locks_after_fork_child() {
-    for lock in DICT_LOCKS.iter() {
-        unsafe { lock.reinit_after_fork() };
-    }
-}
+/// Compatibility hook for the after-fork sequence. Dict operations are
+/// serialized by `rgil`, whose own fork hook recreates the process GIL.
+pub fn module_dict_locks_after_fork_child() {}
 
 /// Predicate: dict is in ObjectDictStrategy mode (post-switch).  When
 /// true, `object_storage` is authoritative and `dstorage` is empty +
@@ -1818,9 +1778,7 @@ pub unsafe fn w_module_dict_is_object_strategy(obj: PyObjectRef) -> bool {
 /// # Safety
 /// `obj` must point to a valid `W_ModuleDictObject`.
 #[inline]
-pub unsafe fn w_module_dict_object_storage<'a>(
-    obj: PyObjectRef,
-) -> Option<&'a indexmap::IndexMap<ObjectKey, PyObjectRef>> {
+pub unsafe fn w_module_dict_object_storage<'a>(obj: PyObjectRef) -> Option<&'a ObjectDictStorage> {
     let raw = &*(obj as *const W_ModuleDictObject);
     if raw.object_storage.is_null() {
         None
@@ -1836,9 +1794,7 @@ pub unsafe fn w_module_dict_object_storage<'a>(
 /// `obj` must point to a valid `W_ModuleDictObject` for which
 /// `w_module_dict_is_object_strategy(obj)` holds.
 #[inline]
-pub unsafe fn w_module_dict_object_storage_mut<'a>(
-    obj: PyObjectRef,
-) -> &'a mut indexmap::IndexMap<ObjectKey, PyObjectRef> {
+pub unsafe fn w_module_dict_object_storage_mut<'a>(obj: PyObjectRef) -> &'a mut ObjectDictStorage {
     let raw = &mut *(obj as *mut W_ModuleDictObject);
     debug_assert!(!raw.object_storage.is_null());
     &mut *raw.object_storage
@@ -1855,7 +1811,7 @@ pub unsafe fn w_module_dict_object_storage_mut<'a>(
 #[inline]
 pub unsafe fn w_module_dict_object_storage_mut_opt<'a>(
     obj: PyObjectRef,
-) -> Option<&'a mut indexmap::IndexMap<ObjectKey, PyObjectRef>> {
+) -> Option<&'a mut ObjectDictStorage> {
     let raw = &mut *(obj as *mut W_ModuleDictObject);
     if raw.object_storage.is_null() {
         None
@@ -1935,8 +1891,7 @@ pub unsafe fn w_module_dict_switch_to_object_strategy(obj: PyObjectRef) {
     crate::gc_roots::mark_prebuilt_roots_dirty();
     let strategy = &mut *raw.mstrategy;
     let storage = &mut *raw.dstorage;
-    let mut new_storage: indexmap::IndexMap<ObjectKey, PyObjectRef> =
-        indexmap::IndexMap::with_capacity(storage.entries.len());
+    let mut new_storage = object_dict_storage_with_capacity(storage.entries.len());
     for (k, v) in strategy
         .getiterkeys(storage)
         .zip(strategy.getitervalues(storage))
@@ -2616,15 +2571,13 @@ macro_rules! callback_free_dict_op {
 /// switches before the scan, and object strategy is terminal, so it stays
 /// non-null for the whole scan.
 #[inline]
-unsafe fn scan_object_entries<'a>(
-    obj: PyObjectRef,
-) -> &'a indexmap::IndexMap<ObjectKey, PyObjectRef> {
+unsafe fn scan_object_entries<'a>(obj: PyObjectRef) -> &'a ObjectDictStorage {
     if is_module_dict(obj) {
         w_module_dict_object_storage(obj)
             .expect("object-strategy module dict must have object_storage")
     } else {
         let dict = &*(obj as *const W_DictObject);
-        &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>)
+        &*(dict.dstorage as *const ObjectDictStorage)
     }
 }
 
@@ -2756,7 +2709,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     let object_key = object_key_for_checked(key)?;
     if let Some(result) = callback_free_dict_op!({
         let dict = &*(obj as *const W_DictObject);
-        let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &*(dict.dstorage as *const ObjectDictStorage);
         dict_entries_probe_hashed(entries, object_key.hash, object_key.obj)
     }) {
         return result;
@@ -2764,7 +2717,7 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
     Ok(found.map(|i| {
         let dict = &*(obj as *const W_DictObject);
-        let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &*(dict.dstorage as *const ObjectDictStorage);
         dict_entries_value_at(entries, i)
     }))
 }
@@ -3062,7 +3015,7 @@ pub unsafe fn w_dict_setdefault_checked(
         let object_key = object_key_for_checked(key)?;
         if let Some(result) = callback_free_dict_op!({
             let dict = &mut *(obj as *mut W_DictObject);
-            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
             let index = entries.get_index_of(&object_key);
             if crate::dict_eq_hook::callback_free_probe_broken() {
                 None
@@ -3095,12 +3048,12 @@ pub unsafe fn w_dict_setdefault_checked(
         let value = crate::gc_roots::shadow_stack_get(value_slot);
         if let Some(i) = found {
             let dict = &*(obj as *const W_DictObject);
-            let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let entries = &*(dict.dstorage as *const ObjectDictStorage);
             return Ok(*entries.get_index(i).unwrap().1);
         }
         crate::dict_eq_hook::begin_callback_free_probe();
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
         let _ = crate::dict_eq_hook::end_callback_free_probe();
         w_dict_bump_keys_version(obj);
@@ -3213,8 +3166,7 @@ pub unsafe fn w_dict_pop_checked(
             let object_key = object_key_for_checked(key)?;
             if let Some(result) = callback_free_dict_op!({
                 let dict = &mut *(obj as *mut W_DictObject);
-                let entries =
-                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
                 let index = entries.get_index_of(&object_key);
                 if crate::dict_eq_hook::callback_free_probe_broken() {
                     None
@@ -3234,8 +3186,7 @@ pub unsafe fn w_dict_pop_checked(
             let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
             if let Some(i) = found {
                 let dict = &mut *(obj as *mut W_DictObject);
-                let entries =
-                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
                 let removed = entries.shift_remove_index(i).unwrap().1;
                 w_dict_bump_keys_version(obj);
                 return Ok(Some(removed));
@@ -3313,7 +3264,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     // `scan_dict_key_reentrant`.
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         let index = entries.get_index_of(&object_key);
         if !crate::dict_eq_hook::callback_free_probe_broken() {
             match index {
@@ -3342,7 +3293,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
     match found {
         Some(i) => {
             let dict = &mut *(obj as *mut W_DictObject);
-            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
             *entries.get_index_mut(i).unwrap().1 = value;
         }
         None => {
@@ -3351,7 +3302,7 @@ unsafe fn w_dict_store_object_strategy_checked_inner(
             // outside the builtin ladder answers false, reproducing that scan.
             crate::dict_eq_hook::begin_callback_free_probe();
             let dict = &mut *(obj as *mut W_DictObject);
-            let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
             dict_entries_insert_hashed(entries, object_key.hash, object_key.obj, value);
             let _ = crate::dict_eq_hook::end_callback_free_probe();
             dict.keys_version = dict.keys_version.wrapping_add(1);
@@ -3595,7 +3546,7 @@ pub unsafe fn w_dict_getitem_str_object_strategy_hashed(
     hash: i64,
 ) -> Option<PyObjectRef> {
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     // Under the `dict_keys_equal` hash/eq pair, str-keyed lookups hash on the
     // str hash and compare on WTF-8 byte equality.  A borrowed `&str` probe
     // avoids the per-lookup throwaway `W_UnicodeObject` (`getitem_str` parity).
@@ -3814,7 +3765,7 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         StrategyKind::Object => {}
         _ => dict.dstrategy.switch_to_object_strategy(obj),
     }
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
     let removed = entries.shift_remove(&object_key_for(w_key)).is_some();
     if removed {
@@ -3997,7 +3948,7 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
     let object_key = object_key_for_checked(key)?;
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         match entries.get_index_of(&object_key) {
             Some(index)
                 if entries
@@ -4028,7 +3979,7 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
         return Ok(false);
     };
     let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     if entries
         .get_index(index)
         .is_none_or(|(_, stored)| *stored != value)
@@ -4185,7 +4136,7 @@ pub unsafe fn w_dict_move_to_end_checked(
     let object_key = object_key_for_checked(key)?;
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         match entries.get_index_of(&object_key) {
             Some(index) => {
                 let target = if last { entries.len() - 1 } else { 0 };
@@ -4207,7 +4158,7 @@ pub unsafe fn w_dict_move_to_end_checked(
         return Ok(false);
     };
     let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     let target = if last { entries.len() - 1 } else { 0 };
     if index != target {
         entries.move_index(index, target);
@@ -4242,7 +4193,7 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     // `scan_dict_key_reentrant`.
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         let index = entries.get_index_of(&object_key);
         if crate::dict_eq_hook::callback_free_probe_broken() {
             false
@@ -4262,7 +4213,7 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     let (found, _, obj) = scan_dict_key_reentrant(obj, object_key)?;
     if let Some(i) = found {
         let dict = &mut *(obj as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         entries.shift_remove_index(i);
         dict.keys_version = dict.keys_version.wrapping_add(1);
         return Ok(true);
@@ -4377,7 +4328,7 @@ pub unsafe fn w_dict_clear(obj: PyObjectRef) {
 pub unsafe fn w_dict_clear_object_strategy(obj: PyObjectRef) {
     lock_dict_refs!(_dict_guard, obj);
     let dict = &mut *(obj as *mut W_DictObject);
-    let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
     if !entries.is_empty() {
         dict.keys_version = dict.keys_version.wrapping_add(1);
         // Mirror `ll_dict_clear`'s `d.entries` realloc: an in-place
@@ -4445,7 +4396,7 @@ pub unsafe fn w_dict_len(obj: PyObjectRef) -> usize {
 pub unsafe fn w_dict_length_object_strategy(obj: PyObjectRef) -> usize {
     lock_dict_refs!(_dict_guard, obj);
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     entries.len()
 }
 
@@ -4518,7 +4469,7 @@ pub unsafe fn w_dict_nth_hashed_key(obj: PyObjectRef, index: usize) -> Option<Ob
     match w_dict_get_strategy(obj).strategy_kind() {
         StrategyKind::Object | StrategyKind::Unicode => {
             let dict = &*(obj as *const W_DictObject);
-            let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+            let entries = &*(dict.dstorage as *const ObjectDictStorage);
             entries.get_index(index).map(|(key, _)| *key)
         }
         _ => None,
@@ -4642,7 +4593,7 @@ pub unsafe fn w_dict_index_of_unicode_strategy(
     let hash = crate::dict_eq_hook::try_hash_str(key.as_bytes())?;
     crate::dict_eq_hook::take_eq_error();
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     dict_entries_index_of_str_hashed(entries, hash, key)
 }
 
@@ -4808,7 +4759,7 @@ pub unsafe fn w_dict_switch_int_to_object_strategy(w_dict: PyObjectRef) {
     // The empty box is allocated before the fill so the last collection point
     // is behind the pairs being copied out of their slots.
     let new_storage = crate::gc_storage::gc_alloc_storage_box(
-        ObjectDictStorage::with_capacity(len),
+        object_dict_storage_with_capacity(len),
         object_dict_storage_gc_type_id(),
     );
     let new_map = &mut *new_storage;
@@ -4976,7 +4927,7 @@ pub unsafe fn w_dict_switch_bytes_to_object_strategy(w_dict: PyObjectRef) {
         roots.publish(&[object_key.obj, v]);
     }
     let new_storage = crate::gc_storage::gc_alloc_storage_box(
-        ObjectDictStorage::with_capacity(len),
+        object_dict_storage_with_capacity(len),
         object_dict_storage_gc_type_id(),
     );
     let new_map = &mut *new_storage;
@@ -4999,7 +4950,7 @@ pub unsafe fn w_dict_switch_bytes_to_object_strategy(w_dict: PyObjectRef) {
 pub unsafe fn w_dict_items_object_strategy(obj: PyObjectRef) -> Vec<(PyObjectRef, PyObjectRef)> {
     lock_dict_refs!(_dict_guard, obj);
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     entries.iter().map(|(k, &v)| (k.obj, v)).collect()
 }
 
@@ -5014,7 +4965,7 @@ pub unsafe fn w_dict_nth_item_object_strategy(
 ) -> Option<(PyObjectRef, PyObjectRef)> {
     lock_dict_refs!(_dict_guard, obj);
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     entries.get_index(index).map(|(k, &v)| (k.obj, v))
 }
 
@@ -5069,7 +5020,7 @@ pub unsafe fn w_dict_unicode_lookup_index(
     debug_assert_eq!(flag, 0, "only FLAG_LOOKUP is implemented");
     lock_dict_refs!(_dict_guard, w_dict, w_key);
     let dict = &*(w_dict as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     crate::dict_eq_hook::take_eq_error();
     crate::dict_eq_hook::begin_callback_free_probe();
     let found = entries.get_index_of(&ObjectKey { hash, obj: w_key });
@@ -5137,7 +5088,7 @@ pub unsafe fn w_dict_unicode_value_at_checked(
         return std::ptr::null_mut();
     }
     let dict = &*(obj as *const W_DictObject);
-    let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
+    let entries = &*(dict.dstorage as *const ObjectDictStorage);
     let Some((entry_key, &value)) = entries.get_index(index) else {
         return std::ptr::null_mut();
     };
@@ -6749,7 +6700,7 @@ impl DictStrategy for ObjectDictStrategy {
         // `w_dict.dstorage = strategy.erase(new)` is a `setfield_gc`, the
         // old box reclaimed by the sweep.
         crate::gc_storage::gc_alloc_storage_box(
-            crate::dictmultiobject::ObjectDictStorage::new(),
+            crate::dictmultiobject::object_dict_storage_new(),
             crate::dictmultiobject::object_dict_storage_gc_type_id(),
         ) as *mut u8
     }
@@ -6839,7 +6790,7 @@ impl DictStrategy for ObjectDictStrategy {
     /// `dictmultiobject.py AbstractTypedStrategy.popitem`.
     unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
         let dict = &mut *(w_dict as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         let (key, value) = entries.pop()?;
         dict.keys_version = dict.keys_version.wrapping_add(1);
         Some((key.obj, value))
@@ -7123,7 +7074,7 @@ impl DictStrategy for UnicodeDictStrategy {
         // for the str fast-path callers (`dictmultiobject.py:1311-1318`).
         // GC-managed box (`setfield_gc` on reassign).
         crate::gc_storage::gc_alloc_storage_box(
-            crate::dictmultiobject::ObjectDictStorage::new(),
+            crate::dictmultiobject::object_dict_storage_new(),
             crate::dictmultiobject::object_dict_storage_gc_type_id(),
         ) as *mut u8
     }
@@ -7178,8 +7129,7 @@ impl DictStrategy for UnicodeDictStrategy {
                 let stored_key = object_key_for_new_str(key, hash);
                 let w_value = roots.get(value_slot);
                 let dict = &mut *(roots.get(dict_slot) as *mut W_DictObject);
-                let entries =
-                    &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+                let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
                 dict_entries_insert_hashed(entries, stored_key.hash, stored_key.obj, w_value);
                 dict.keys_version = dict.keys_version.wrapping_add(1);
             }
@@ -7253,7 +7203,7 @@ impl DictStrategy for UnicodeDictStrategy {
     /// `dictmultiobject.py AbstractTypedStrategy.popitem`.
     unsafe fn popitem(&self, w_dict: PyObjectRef) -> Option<(PyObjectRef, PyObjectRef)> {
         let dict = &mut *(w_dict as *mut W_DictObject);
-        let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
+        let entries = &mut *(dict.dstorage as *mut ObjectDictStorage);
         let (key, value) = entries.pop()?;
         dict.keys_version = dict.keys_version.wrapping_add(1);
         Some((key.obj, value))
@@ -7528,6 +7478,16 @@ mod tests {
     use super::*;
     use crate::intobject::{w_int_get_value, w_int_new};
     use crate::w_str_new;
+
+    #[test]
+    fn object_dict_table_spreads_the_cached_python_hash_directly() {
+        let mut hasher = ObjectKeyHasher::default();
+        std::hash::Hasher::write_i64(&mut hasher, 0x1234_5678);
+        assert_eq!(
+            std::hash::Hasher::finish(&hasher),
+            0x1234_5678_u64.wrapping_mul(0x9E37_79B9_7F4A_7C15)
+        );
+    }
 
     /// Install the single hash path on this test thread.  pyre-object
     /// cannot reach `pyre-interpreter`'s `space.hash_w`, so its own dict

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -156,9 +156,10 @@ static COLLECT_STATE: AtomicU8 = AtomicU8::new(0);
 const POLL_INTERVAL: u32 = 1024;
 
 thread_local! {
-    /// Eligible dispatches since this thread last asked the collector; see
-    /// [`POLL_INTERVAL`]. Advanced only once the cheaper gates have passed, so
-    /// it paces the queries actually made rather than the dispatches seen.
+    /// Enabled dispatches since this thread last asked the collector; see
+    /// [`POLL_INTERVAL`]. The cached feature gates are the only work allowed
+    /// ahead of this counter, so it paces dispatches without first paying for
+    /// the collector query it exists to avoid.
     /// Thread-local rather than atomic because the query it paces is itself
     /// per-thread, and a `fetch_add` on every dispatch would cost about what it
     /// is here to avoid.
@@ -320,14 +321,32 @@ pub fn safepoint() {
             return;
         }
     }
-    if !would_collect() {
+    // The request already carries the collector's threshold answer — it was
+    // armed by `external_malloc`'s equivalent in the allocator — so it does
+    // not wait for the poll interval. Recheck the semantic gates because
+    // `gc.disable()` or a callback activation may have appeared since the
+    // allocator armed it.
+    if requested {
+        if would_collect() {
+            crate::gc_hook::try_gc_collect_oldgen();
+        }
         return;
     }
-    // The request already carries the collector's answer — it was armed by
-    // `threshold_reached` in the allocator — so it does not wait for the poll
-    // interval. The poll remains for the allocations that reach the collector
-    // without passing the born-old path.
-    if requested || (poll_due() && crate::gc_hook::try_gc_major_threshold_reached()) {
+
+    // incminimark asks the comparatively expensive `gcflag_extra` / heap
+    // threshold questions from allocation, not from every interpreter
+    // dispatch. Pyre's dispatch safepoint is the safe stepping stone until
+    // the translated shadow-stack pass lets the allocator collect directly,
+    // but its polling interval must retain that shape: check the two cached
+    // feature switches, then spend the GC hook and activation queries only on
+    // the one dispatch that actually polls.
+    if !enabled() || !collect_enabled() || !poll_due() {
+        return;
+    }
+    if crate::gc_hook::try_gc_isenabled()
+        && at_outermost_activation()
+        && crate::gc_hook::try_gc_major_threshold_reached()
+    {
         crate::gc_hook::try_gc_collect_oldgen();
     }
 }

--- a/pyre/pyre-object/src/gc_interp.rs
+++ b/pyre/pyre-object/src/gc_interp.rs
@@ -298,9 +298,11 @@ pub fn would_collect() -> bool {
 /// Dispatches to the installed threshold and collection hooks, neither a
 /// build-time constant, so the JIT residualizes the call instead of tracing
 /// into it (`@dont_look_inside`, the [`enabled`] sibling). A `()` return has no
-/// discriminant to erase and it cannot raise. On the cold interpreter dispatch
-/// loop its first act is already the non-inlined `enabled()` early-return; the
-/// residual adds no hot-path cost the un-residualized form did not already pay.
+/// discriminant to erase and it cannot raise. A dispatch with nothing pending
+/// reaches only the two request flags and the two cached feature switches
+/// before returning. The flags are read ahead of the switches on purpose — an
+/// explicit request has to be serviced even with the routing feature off,
+/// which is why [`note_eval_activation_exit`] tracks nesting unconditionally.
 #[majit_macros::dont_look_inside]
 pub fn safepoint() {
     // Take any request the old-gen allocator armed, and take it before the

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -400,10 +400,9 @@ impl RootScope {
     pub fn normalize(&self, base: usize, len: usize) {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
-        // Same fast path as `normalize_roots`: RPython has one active mutator
-        // under the GIL, so no root can become a forwarding stub between its
-        // publication and the allocation bracket. Only pyre's second-mutator
-        // extension needs the current-address queries below.
+        // Same guard as `normalize_roots`: RPython has one active mutator under
+        // the GIL, so no root becomes a forwarding stub between its publication
+        // and the allocation bracket.
         if !majit_gc::gc_sync::foreign_mutator_seen() {
             return;
         }
@@ -433,8 +432,9 @@ impl RootScope {
         // another thread's collection.
         // SAFETY: same cell; `slot` bounds-checks `index`.
         unsafe { *(*self.stack_slot).slot(index) = root };
-        // Keep the scope-local spelling in lockstep with `shadow_stack_set`:
-        // PyPy's single-mutator root write is complete at the store above.
+        // Same guard as `shadow_stack_set`, after the raw publish: RPython has
+        // one active mutator under the GIL, so the value just published cannot
+        // have been forwarded between the caller's copy and this write.
         if !majit_gc::gc_sync::foreign_mutator_seen() {
             return;
         }

--- a/pyre/pyre-object/src/gc_roots.rs
+++ b/pyre/pyre-object/src/gc_roots.rs
@@ -400,6 +400,13 @@ impl RootScope {
     pub fn normalize(&self, base: usize, len: usize) {
         #[cfg(debug_assertions)]
         assert_shadow_stack_not_walking();
+        // Same fast path as `normalize_roots`: RPython has one active mutator
+        // under the GIL, so no root can become a forwarding stub between its
+        // publication and the allocation bracket. Only pyre's second-mutator
+        // extension needs the current-address queries below.
+        if !majit_gc::gc_sync::foreign_mutator_seen() {
+            return;
+        }
         for index in base..base + len {
             // Re-read the slot each time, as [`normalize_roots`] does: a
             // collection triggered by an earlier query may already have
@@ -426,6 +433,11 @@ impl RootScope {
         // another thread's collection.
         // SAFETY: same cell; `slot` bounds-checks `index`.
         unsafe { *(*self.stack_slot).slot(index) = root };
+        // Keep the scope-local spelling in lockstep with `shadow_stack_set`:
+        // PyPy's single-mutator root write is complete at the store above.
+        if !majit_gc::gc_sync::foreign_mutator_seen() {
+            return;
+        }
         let normalized =
             crate::gc_hook::try_gc_current_object_address(root as *mut u8) as PyObjectRef;
         if normalized != root {

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -162,7 +162,7 @@ pub unsafe fn w_dict_switch_identity_to_object_strategy(w_dict: PyObjectRef) {
     // while the migration builds the object map); after the store the
     // box is unreachable and the sweep reclaims it.
     let old = &*(dict.dstorage as *const IdentityDictStorage);
-    let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.len());
+    let mut new_map = crate::dictmultiobject::object_dict_storage_with_capacity(old.len());
     for (k, &v) in old.iter() {
         new_map.insert(crate::dictmultiobject::object_key_for(k.0), v);
     }

--- a/pyre/pyre-object/src/kwargsdict.rs
+++ b/pyre/pyre-object/src/kwargsdict.rs
@@ -99,7 +99,7 @@ pub unsafe fn w_dict_switch_kwargs_to_object_strategy(w_dict: PyObjectRef) {
     // box is unreachable and the sweep reclaims it. `PyObjectRef` is a
     // raw pointer (Copy), so iterate by reference and copy each slot.
     let old = &*(dict.dstorage as *const KwargsDictStorage);
-    let mut new_map = crate::dictmultiobject::ObjectDictStorage::with_capacity(old.0.len());
+    let mut new_map = crate::dictmultiobject::object_dict_storage_with_capacity(old.0.len());
     for (k, v) in old.0.iter().zip(old.1.iter()) {
         new_map.insert(crate::dictmultiobject::object_key_for(*k), *v);
     }

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -584,29 +584,37 @@ pub unsafe fn intern_exact_str(obj: PyObjectRef) -> PyObjectRef {
 /// [`intern_exact_str`] answers the same question for a caller that already
 /// holds an object, and must be handed one even when the table already has the
 /// canonical instance.  A caller that holds only the characters — a code
-/// object realizing `co_names_w` (`pycode.py:127-129`), an attribute name —
-/// would have to build a [`w_str_new`] result to ask, and that result is
+/// object realizing `co_names_w` (`pycode.py` `PyCode._initialize`), an
+/// attribute name, a name the marshal reader has just read off the wire —
+/// would have to build a [`w_str_from_wtf8`] result to ask, and that result is
 /// `malloc_typed`-immortal: abandoning it on a hit retains it for the process
 /// lifetime.  Interning from the value instead builds nothing on a hit.
 #[majit_macros::dont_look_inside]
-pub fn intern_str_value(value: &str) -> PyObjectRef {
+pub fn intern_wtf8_value(value: &Wtf8) -> PyObjectRef {
     let mut table = STRING_INTERN_TABLE
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let Some(slot) = table.get(Wtf8::new(value)) {
+    if let Some(slot) = table.get(value) {
         return **slot as PyObjectRef;
     }
-    let obj = w_str_new(value);
+    let value = value.to_owned();
+    let obj = w_str_from_wtf8(value.clone());
     let mut slot = Box::new(obj as usize);
     let root_slot = (&mut *slot) as *mut usize as *mut *mut u8;
-    // `w_str_new` is immortal, so this root only has to keep the collector from
-    // rewriting a slot it never owns; the registration matches
+    // `w_str_from_wtf8` is immortal, so this root only has to keep the
+    // collector from rewriting a slot it never owns; the registration matches
     // [`intern_exact_str`] so both entry points present the table identically.
     unsafe {
         crate::gc_hook::try_gc_add_root(root_slot);
     }
-    table.insert(Wtf8Buf::from_string(value.to_string()), slot);
+    table.insert(value, slot);
     obj
+}
+
+/// [`intern_wtf8_value`] for a caller whose characters are already UTF-8.
+#[majit_macros::dont_look_inside]
+pub fn intern_str_value(value: &str) -> PyObjectRef {
+    intern_wtf8_value(Wtf8::new(value))
 }
 
 /// CPython 3.14 `PyUnicode_CHECK_INTERNED`: true only when `obj` itself is the

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1387,9 +1387,13 @@ fn clear_shutdown_module_dict(dict: pyre_object::PyObjectRef) {
 /// `finalize_modules`: clear detached modules newest-first while their peers
 /// remain available to finalizers that run between module dictionaries.
 fn clear_shutdown_modules(
-    modules: Vec<(rustpython_wtf8::Wtf8Buf, pyre_object::PyObjectRef)>,
+    released: pyre_interpreter::importing::ReleasedSysModules,
     ec_ptr: *const PyExecutionContext,
 ) {
+    let pyre_interpreter::importing::ReleasedSysModules {
+        modules,
+        dropped_unlisted,
+    } = released;
     let _roots = pyre_object::gc_roots::push_roots();
     let roots_start = pyre_object::gc_roots::shadow_stack_len();
     let mut names = Vec::with_capacity(modules.len());
@@ -1406,7 +1410,17 @@ fn clear_shutdown_modules(
         names.push(name);
         pyre_object::gc_roots::pin_root(module);
     }
-    collect_and_run_finalizers(ec_ptr);
+    // `finalize_runtime` sweeps immediately before detaching the import cache,
+    // and every module that detach handed over is pinned just above — so a
+    // sweep here reaches something that one could not only when the detach
+    // dropped an entry this list does not carry: a non-module value, or one
+    // under a key that is not a string. The walk below ends on a sweep either
+    // way, so an import cache holding nothing but named modules — which is
+    // every run that does not assign to `sys.modules` itself — pays one
+    // whole-heap mark-and-sweep less at exit.
+    if dropped_unlisted {
+        collect_and_run_finalizers(ec_ptr);
+    }
     for index in (0..names.len()).rev() {
         let module = pyre_object::gc_roots::shadow_stack_get(roots_start + index);
         let is_core_module = sys_module_slot.is_some_and(|slot| {

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1284,7 +1284,7 @@ fn run_atexit_callbacks(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyEx
     }
 }
 
-/// PyPy `ObjSpace.finish()` (`baseobjspace.py:481-504`): join non-daemon
+/// PyPy `ObjSpace.finish()` (`baseobjspace.py`): join non-daemon
 /// threads, run atexit callbacks, mark the runtime finalizing, flush standard
 /// streams, and run started modules' shutdown hooks. PyPy does not force a full
 /// collection or clear `__main__` / `sys.modules` here. The PyPy oracle likewise

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1284,11 +1284,179 @@ fn run_atexit_callbacks(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyEx
     }
 }
 
-/// PyPy `ObjSpace.finish()` (`baseobjspace.py`): join non-daemon
-/// threads, run atexit callbacks, mark the runtime finalizing, flush standard
-/// streams, and run started modules' shutdown hooks. PyPy does not force a full
-/// collection or clear `__main__` / `sys.modules` here. The PyPy oracle likewise
-/// leaves a module-global `__del__` silent at process exit.
+fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
+    pyre_object::gc_hook::try_gc_collect();
+    if !ec_ptr.is_null() {
+        unsafe { (&mut *(ec_ptr as *mut PyExecutionContext))._run_finalizers_now() };
+    }
+}
+
+/// Whether releasing this binding can remove anything from the reachable set,
+/// and so whether the collection that follows it could find garbage an earlier
+/// one did not. Answering `false` skips a full mark-and-sweep of the whole
+/// heap, which is what the release loop below otherwise costs per name.
+///
+/// Two values answer `false` outright:
+///
+/// * An exact `int`, `float`, `bool`, `str`, `bytes` or `None`. It holds no
+///   reference to another object, so nothing but the value itself can lose its
+///   last referrer, and no builtin scalar type defines `__del__`, so nothing
+///   observes it going. `is_exact_type` is what makes this safe rather than
+///   `is_str`/`is_int`, which key off the layout `ob_type` a subclass keeps: a
+///   `class MyStr(str)` instance retags `w_class` and is rejected here, so its
+///   `__del__` and its own attributes stay on the collecting path.
+/// * A module still registered in `sys.modules` under its own `__name__`. It
+///   stays reachable from there no matter what `__main__` does, so the release
+///   removes no object at all from the reachable set. This is every `import`
+///   name. Reading the live `sys.modules` rather than assuming is what keeps a
+///   program that replaced or deleted the entry on the collecting path.
+///
+/// The point is not that these values are cheap to collect — it is that the
+/// collection cannot reach a different answer, so every `__del__` still runs at
+/// exactly the same place in the loop.
+fn release_frees_nothing(value: pyre_object::PyObjectRef) -> bool {
+    if value.is_null() {
+        return true;
+    }
+    unsafe {
+        if pyre_object::is_none(value)
+            || pyre_object::is_exact_type(value, &pyre_object::INT_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::BOOL_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::FLOAT_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::STR_TYPE)
+            || pyre_object::is_exact_type(value, &pyre_object::BYTES_TYPE)
+        {
+            return true;
+        }
+        if pyre_object::is_module(value) {
+            // `Module.w_name` is the interpreter's own field, not the
+            // program-writable `__name__` attribute. `module.__new__` leaves it
+            // null until `__init__` seeds it, and a valid Python name may carry
+            // a lone surrogate that cannot key pyre's native UTF-8 registry.
+            // Either shape proves nothing about reachability and therefore
+            // takes the collecting path.
+            let w_name = pyre_object::w_module_get_name(value);
+            if w_name.is_null() || !pyre_object::is_str(w_name) {
+                return false;
+            }
+            let Ok(name) = pyre_object::w_str_get_wtf8(w_name).as_str() else {
+                return false;
+            };
+            return importing::get_sys_module(name).is_some_and(|m| m == value);
+        }
+    }
+    false
+}
+
+fn shutdown_module_private_name(name: &rustpython_wtf8::Wtf8) -> bool {
+    let bytes = name.as_bytes();
+    bytes.first() == Some(&b'_') && bytes.get(1) != Some(&b'_')
+}
+
+fn clear_shutdown_module_name(dict: pyre_object::PyObjectRef, name: &rustpython_wtf8::Wtf8) {
+    let should_clear = unsafe { pyre_object::w_dict_getitem_wtf8(dict, name) }
+        .is_some_and(|value| unsafe { !pyre_object::is_none(value) });
+    if should_clear {
+        unsafe {
+            pyre_object::w_dict_setitem_wtf8(dict, name, pyre_object::w_none());
+        }
+    }
+}
+
+/// `_PyModule_ClearDict`: clear string-keyed module globals in two name passes.
+fn clear_shutdown_module_dict(dict: pyre_object::PyObjectRef) {
+    if dict.is_null() {
+        return;
+    }
+    let keys: Vec<rustpython_wtf8::Wtf8Buf> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
+        .into_iter()
+        .map(|(name, _)| name)
+        .collect();
+    for name in &keys {
+        if shutdown_module_private_name(name) {
+            clear_shutdown_module_name(dict, name);
+        }
+    }
+    for name in &keys {
+        if name.as_bytes() != b"__builtins__" {
+            clear_shutdown_module_name(dict, name);
+        }
+    }
+}
+
+/// `finalize_modules`: clear detached modules newest-first while their peers
+/// remain available to finalizers that run between module dictionaries.
+fn clear_shutdown_modules(
+    modules: Vec<(rustpython_wtf8::Wtf8Buf, pyre_object::PyObjectRef)>,
+    ec_ptr: *const PyExecutionContext,
+) {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let roots_start = pyre_object::gc_roots::shadow_stack_len();
+    let mut names = Vec::with_capacity(modules.len());
+    let mut sys_module_slot = None;
+    let mut builtins_module_slot = None;
+    for (name, module) in modules {
+        let index = names.len();
+        let bytes = name.as_bytes();
+        if bytes == b"sys" {
+            sys_module_slot = Some(index);
+        } else if bytes == b"builtins" {
+            builtins_module_slot = Some(index);
+        }
+        names.push(name);
+        pyre_object::gc_roots::pin_root(module);
+    }
+    collect_and_run_finalizers(ec_ptr);
+    for index in (0..names.len()).rev() {
+        let module = pyre_object::gc_roots::shadow_stack_get(roots_start + index);
+        let is_core_module = sys_module_slot.is_some_and(|slot| {
+            module == pyre_object::gc_roots::shadow_stack_get(roots_start + slot)
+        }) || builtins_module_slot.is_some_and(|slot| {
+            module == pyre_object::gc_roots::shadow_stack_get(roots_start + slot)
+        });
+        if is_core_module {
+            continue;
+        }
+        if module.is_null() || !unsafe { pyre_object::is_module(module) } {
+            continue;
+        }
+        let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
+        clear_shutdown_module_dict(dict);
+    }
+    // One collection for the whole walk, not one per module. `finalize_modules`
+    // clears the module dictionaries and lets refcounting release what they
+    // held; a sweep per module buys no ordering here, because a finalizer that
+    // reads a global reaches its own already-cleared namespace either way, and
+    // it costs a full mark-and-sweep for each of the ~100 modules a bare
+    // `import unittest` loads.
+    collect_and_run_finalizers(ec_ptr);
+}
+
+/// PyPy `ObjSpace.finish()` / module teardown ordering: join non-daemon
+/// threads, collect already-unreachable cycles, then release `__main__`
+/// globals from newest to oldest while the older globals their `__del__`
+/// methods may reference are still present.
+///
+/// Newest-to-oldest is what keeps those references working, and it is not
+/// interchangeable with the insertion order `_PyModule_ClearDict` uses. A name
+/// is bound before every name that could be finalized while reading it — most
+/// of all `import sys`, which is usually the very first — so releasing in
+/// insertion order strands `sys` at `None` and every finalizer that writes to
+/// `sys.stderr` dies with an `AttributeError` instead of running. Refcounting
+/// makes the question moot upstream: a finalizer there runs from the decref of
+/// the name being released, while every other slot still holds its original
+/// value, which is not reproducible without leaving dangling pointers in the
+/// dict.
+///
+/// The value is rebound to `None` rather than deleted, as `_PyModule_ClearDict`
+/// does: a `__del__` that reads an already-released name then sees `None`, the
+/// way it would upstream, instead of raising `NameError` at a name the program
+/// can see is still defined.
+///
+/// `__main__` is not the whole reachable set: an object stored in another
+/// module's namespace stays alive through that module's dict. The
+/// `finalize_modules` phase that follows detaches `sys.modules` and clears the
+/// remaining module dictionaries newest-first.
 fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecutionContext) {
     run_threading_shutdown();
     run_atexit_callbacks(canonical, ec_ptr);
@@ -1296,20 +1464,54 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
     // may still start threads; reject new starts only when module/finalizer
     // teardown is actually about to begin.
     pyre_interpreter::module::thread::set_finalizing();
-    // atexit ran above and may legitimately have used signals.
+    // Past this point a handler would run against a half-torn-down module
+    // graph, so the teardown below reports signals instead of delivering
+    // them.  atexit ran above and may legitimately have used signals.
     pyre_interpreter::module::signal::interp_signal::clear_handlers();
     // baseobjspace.py `finish()` runs every started module's shutdown
     // hook; `_io`'s (moduledef.py:37-40) flushes the streams that are still
-    // alive.
+    // alive.  The per-global teardown below reaches only the ones `__main__`
+    // itself holds, so without this a stream owned by any other module loses
+    // its buffered writes.
     pyre_interpreter::module::_io::flush_all_streams();
+    collect_and_run_finalizers(ec_ptr);
+    let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
+    entries.reverse();
+    for (name, _) in entries {
+        if name == "__builtins__" {
+            continue;
+        }
+        // Re-read rather than trusting the snapshot: a `__del__` already run by
+        // this loop may have rebound the name, and the decision below is only
+        // sound about the value actually being released.
+        let value = unsafe { pyre_object::w_dict_getitem_str(canonical, &name) };
+        let frees_nothing = value.is_none_or(release_frees_nothing);
+        unsafe {
+            pyre_object::w_dict_setitem_str(canonical, &name, pyre_object::w_none());
+        }
+        if !frees_nothing {
+            collect_and_run_finalizers(ec_ptr);
+        }
+    }
+    // The loop ends on a collection whenever it releases anything collectable;
+    // this is the one for the case where the last releases were all skipped, so
+    // teardown still finishes with the heap swept and the queue drained.
+    collect_and_run_finalizers(ec_ptr);
+    let shutdown_modules = pyre_interpreter::importing::release_sys_modules_for_shutdown();
+    clear_shutdown_modules(shutdown_modules, ec_ptr);
 }
 
 /// Resolve a pending `SystemExit`'s status, then finalize and exit with it.
 ///
 /// The order matters: `app_main.py handle_sys_exit` runs at
 /// application level, i.e. *before* `targetpypystandalone.py:88
-/// finally: space.finish()`. Resolve `e.code` before entering that shutdown
-/// sequence, matching the application-level handler.
+/// finally: space.finish()`. Resolving `e.code` is an ordinary attribute
+/// lookup that walks the exception's type and that type's dict, and
+/// `finalize_runtime` collects — pinning the three raw `PyObjectRef` fields
+/// of the Rust `PyError` (which, unlike PyPy's GC-visible `OperationError`,
+/// the collector cannot see) does not keep that type's dict alive. Reading
+/// the code after the collection spun forever inside the type dict's
+/// `IndexMap` probe for a user-defined `SystemExit` subclass.
 fn finalize_system_exit(
     error: pyre_interpreter::PyError,
     canonical: pyre_object::PyObjectRef,
@@ -1609,8 +1811,9 @@ fn handle_main_error(
     }
     let is_keyboard_interrupt = is_keyboard_interrupt(&e);
     // targetpypystandalone.py:88 `finally: space.finish()` — finalize
-    // on every exit path, not only on SystemExit. Print first, matching
-    // app_main.py's application-level exception handling order.
+    // on every exit path, not only on SystemExit.  Print first: the raw
+    // `PyObjectRef` fields of `e` are not GC-visible and
+    // `finalize_runtime` collects.
     pyre_interpreter::eprint_exception(&e, true);
     finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();

--- a/pyre/pyrex/src/lib.rs
+++ b/pyre/pyrex/src/lib.rs
@@ -1284,179 +1284,11 @@ fn run_atexit_callbacks(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyEx
     }
 }
 
-fn collect_and_run_finalizers(ec_ptr: *const PyExecutionContext) {
-    pyre_object::gc_hook::try_gc_collect();
-    if !ec_ptr.is_null() {
-        unsafe { (&mut *(ec_ptr as *mut PyExecutionContext))._run_finalizers_now() };
-    }
-}
-
-/// Whether releasing this binding can remove anything from the reachable set,
-/// and so whether the collection that follows it could find garbage an earlier
-/// one did not. Answering `false` skips a full mark-and-sweep of the whole
-/// heap, which is what the release loop below otherwise costs per name.
-///
-/// Two values answer `false` outright:
-///
-/// * An exact `int`, `float`, `bool`, `str`, `bytes` or `None`. It holds no
-///   reference to another object, so nothing but the value itself can lose its
-///   last referrer, and no builtin scalar type defines `__del__`, so nothing
-///   observes it going. `is_exact_type` is what makes this safe rather than
-///   `is_str`/`is_int`, which key off the layout `ob_type` a subclass keeps: a
-///   `class MyStr(str)` instance retags `w_class` and is rejected here, so its
-///   `__del__` and its own attributes stay on the collecting path.
-/// * A module still registered in `sys.modules` under its own `__name__`. It
-///   stays reachable from there no matter what `__main__` does, so the release
-///   removes no object at all from the reachable set. This is every `import`
-///   name. Reading the live `sys.modules` rather than assuming is what keeps a
-///   program that replaced or deleted the entry on the collecting path.
-///
-/// The point is not that these values are cheap to collect — it is that the
-/// collection cannot reach a different answer, so every `__del__` still runs at
-/// exactly the same place in the loop.
-fn release_frees_nothing(value: pyre_object::PyObjectRef) -> bool {
-    if value.is_null() {
-        return true;
-    }
-    unsafe {
-        if pyre_object::is_none(value)
-            || pyre_object::is_exact_type(value, &pyre_object::INT_TYPE)
-            || pyre_object::is_exact_type(value, &pyre_object::BOOL_TYPE)
-            || pyre_object::is_exact_type(value, &pyre_object::FLOAT_TYPE)
-            || pyre_object::is_exact_type(value, &pyre_object::STR_TYPE)
-            || pyre_object::is_exact_type(value, &pyre_object::BYTES_TYPE)
-        {
-            return true;
-        }
-        if pyre_object::is_module(value) {
-            // `Module.w_name` is the interpreter's own field, not the
-            // program-writable `__name__` attribute. `module.__new__` leaves it
-            // null until `__init__` seeds it, and a valid Python name may carry
-            // a lone surrogate that cannot key pyre's native UTF-8 registry.
-            // Either shape proves nothing about reachability and therefore
-            // takes the collecting path.
-            let w_name = pyre_object::w_module_get_name(value);
-            if w_name.is_null() || !pyre_object::is_str(w_name) {
-                return false;
-            }
-            let Ok(name) = pyre_object::w_str_get_wtf8(w_name).as_str() else {
-                return false;
-            };
-            return importing::get_sys_module(name).is_some_and(|m| m == value);
-        }
-    }
-    false
-}
-
-fn shutdown_module_private_name(name: &rustpython_wtf8::Wtf8) -> bool {
-    let bytes = name.as_bytes();
-    bytes.first() == Some(&b'_') && bytes.get(1) != Some(&b'_')
-}
-
-fn clear_shutdown_module_name(dict: pyre_object::PyObjectRef, name: &rustpython_wtf8::Wtf8) {
-    let should_clear = unsafe { pyre_object::w_dict_getitem_wtf8(dict, name) }
-        .is_some_and(|value| unsafe { !pyre_object::is_none(value) });
-    if should_clear {
-        unsafe {
-            pyre_object::w_dict_setitem_wtf8(dict, name, pyre_object::w_none());
-        }
-    }
-}
-
-/// `_PyModule_ClearDict`: clear string-keyed module globals in two name passes.
-fn clear_shutdown_module_dict(dict: pyre_object::PyObjectRef) {
-    if dict.is_null() {
-        return;
-    }
-    let keys: Vec<rustpython_wtf8::Wtf8Buf> = unsafe { pyre_object::w_dict_str_entries_wtf8(dict) }
-        .into_iter()
-        .map(|(name, _)| name)
-        .collect();
-    for name in &keys {
-        if shutdown_module_private_name(name) {
-            clear_shutdown_module_name(dict, name);
-        }
-    }
-    for name in &keys {
-        if name.as_bytes() != b"__builtins__" {
-            clear_shutdown_module_name(dict, name);
-        }
-    }
-}
-
-/// `finalize_modules`: clear detached modules newest-first while their peers
-/// remain available to finalizers that run between module dictionaries.
-fn clear_shutdown_modules(
-    modules: Vec<(rustpython_wtf8::Wtf8Buf, pyre_object::PyObjectRef)>,
-    ec_ptr: *const PyExecutionContext,
-) {
-    let _roots = pyre_object::gc_roots::push_roots();
-    let roots_start = pyre_object::gc_roots::shadow_stack_len();
-    let mut names = Vec::with_capacity(modules.len());
-    let mut sys_module_slot = None;
-    let mut builtins_module_slot = None;
-    for (name, module) in modules {
-        let index = names.len();
-        let bytes = name.as_bytes();
-        if bytes == b"sys" {
-            sys_module_slot = Some(index);
-        } else if bytes == b"builtins" {
-            builtins_module_slot = Some(index);
-        }
-        names.push(name);
-        pyre_object::gc_roots::pin_root(module);
-    }
-    collect_and_run_finalizers(ec_ptr);
-    for index in (0..names.len()).rev() {
-        let module = pyre_object::gc_roots::shadow_stack_get(roots_start + index);
-        let is_core_module = sys_module_slot.is_some_and(|slot| {
-            module == pyre_object::gc_roots::shadow_stack_get(roots_start + slot)
-        }) || builtins_module_slot.is_some_and(|slot| {
-            module == pyre_object::gc_roots::shadow_stack_get(roots_start + slot)
-        });
-        if is_core_module {
-            continue;
-        }
-        if module.is_null() || !unsafe { pyre_object::is_module(module) } {
-            continue;
-        }
-        let dict = unsafe { pyre_object::w_module_get_w_dict(module) };
-        clear_shutdown_module_dict(dict);
-    }
-    // One collection for the whole walk, not one per module. `finalize_modules`
-    // clears the module dictionaries and lets refcounting release what they
-    // held; a sweep per module buys no ordering here, because a finalizer that
-    // reads a global reaches its own already-cleared namespace either way, and
-    // it costs a full mark-and-sweep for each of the ~100 modules a bare
-    // `import unittest` loads.
-    collect_and_run_finalizers(ec_ptr);
-}
-
-/// PyPy `ObjSpace.finish()` / module teardown ordering: join non-daemon
-/// threads, collect already-unreachable cycles, then release `__main__`
-/// globals from newest to oldest while the older globals their `__del__`
-/// methods may reference are still present.
-///
-/// Newest-to-oldest is what keeps those references working, and it is not
-/// interchangeable with the insertion order `_PyModule_ClearDict` uses. A name
-/// is bound before every name that could be finalized while reading it — most
-/// of all `import sys`, which is usually the very first — so releasing in
-/// insertion order strands `sys` at `None` and every finalizer that writes to
-/// `sys.stderr` dies with an `AttributeError` instead of running. Refcounting
-/// makes the question moot upstream: a finalizer there runs from the decref of
-/// the name being released, while every other slot still holds its original
-/// value, which is not reproducible without leaving dangling pointers in the
-/// dict.
-///
-/// The value is rebound to `None` rather than deleted, as `_PyModule_ClearDict`
-/// does: a `__del__` that reads an already-released name then sees `None`, the
-/// way it would upstream, instead of raising `NameError` at a name the program
-/// can see is still defined.
-///
-/// `__main__` is not the whole reachable set: an object stored in another
-/// module's namespace stays alive through that module's dict. The
-/// `finalize_modules` phase that follows detaches `sys.modules` and clears the
-/// remaining module dictionaries newest-first.
+/// PyPy `ObjSpace.finish()` (`baseobjspace.py:481-504`): join non-daemon
+/// threads, run atexit callbacks, mark the runtime finalizing, flush standard
+/// streams, and run started modules' shutdown hooks. PyPy does not force a full
+/// collection or clear `__main__` / `sys.modules` here. The PyPy oracle likewise
+/// leaves a module-global `__del__` silent at process exit.
 fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecutionContext) {
     run_threading_shutdown();
     run_atexit_callbacks(canonical, ec_ptr);
@@ -1464,54 +1296,20 @@ fn finalize_runtime(canonical: pyre_object::PyObjectRef, ec_ptr: *const PyExecut
     // may still start threads; reject new starts only when module/finalizer
     // teardown is actually about to begin.
     pyre_interpreter::module::thread::set_finalizing();
-    // Past this point a handler would run against a half-torn-down module
-    // graph, so the teardown below reports signals instead of delivering
-    // them.  atexit ran above and may legitimately have used signals.
+    // atexit ran above and may legitimately have used signals.
     pyre_interpreter::module::signal::interp_signal::clear_handlers();
     // baseobjspace.py `finish()` runs every started module's shutdown
     // hook; `_io`'s (moduledef.py:37-40) flushes the streams that are still
-    // alive.  The per-global teardown below reaches only the ones `__main__`
-    // itself holds, so without this a stream owned by any other module loses
-    // its buffered writes.
+    // alive.
     pyre_interpreter::module::_io::flush_all_streams();
-    collect_and_run_finalizers(ec_ptr);
-    let mut entries = unsafe { pyre_object::w_dict_str_entries(canonical) };
-    entries.reverse();
-    for (name, _) in entries {
-        if name == "__builtins__" {
-            continue;
-        }
-        // Re-read rather than trusting the snapshot: a `__del__` already run by
-        // this loop may have rebound the name, and the decision below is only
-        // sound about the value actually being released.
-        let value = unsafe { pyre_object::w_dict_getitem_str(canonical, &name) };
-        let frees_nothing = value.is_none_or(release_frees_nothing);
-        unsafe {
-            pyre_object::w_dict_setitem_str(canonical, &name, pyre_object::w_none());
-        }
-        if !frees_nothing {
-            collect_and_run_finalizers(ec_ptr);
-        }
-    }
-    // The loop ends on a collection whenever it releases anything collectable;
-    // this is the one for the case where the last releases were all skipped, so
-    // teardown still finishes with the heap swept and the queue drained.
-    collect_and_run_finalizers(ec_ptr);
-    let shutdown_modules = pyre_interpreter::importing::release_sys_modules_for_shutdown();
-    clear_shutdown_modules(shutdown_modules, ec_ptr);
 }
 
 /// Resolve a pending `SystemExit`'s status, then finalize and exit with it.
 ///
 /// The order matters: `app_main.py handle_sys_exit` runs at
 /// application level, i.e. *before* `targetpypystandalone.py:88
-/// finally: space.finish()`. Resolving `e.code` is an ordinary attribute
-/// lookup that walks the exception's type and that type's dict, and
-/// `finalize_runtime` collects — pinning the three raw `PyObjectRef` fields
-/// of the Rust `PyError` (which, unlike PyPy's GC-visible `OperationError`,
-/// the collector cannot see) does not keep that type's dict alive. Reading
-/// the code after the collection spun forever inside the type dict's
-/// `IndexMap` probe for a user-defined `SystemExit` subclass.
+/// finally: space.finish()`. Resolve `e.code` before entering that shutdown
+/// sequence, matching the application-level handler.
 fn finalize_system_exit(
     error: pyre_interpreter::PyError,
     canonical: pyre_object::PyObjectRef,
@@ -1811,9 +1609,8 @@ fn handle_main_error(
     }
     let is_keyboard_interrupt = is_keyboard_interrupt(&e);
     // targetpypystandalone.py:88 `finally: space.finish()` — finalize
-    // on every exit path, not only on SystemExit.  Print first: the raw
-    // `PyObjectRef` fields of `e` are not GC-visible and
-    // `finalize_runtime` collects.
+    // on every exit path, not only on SystemExit. Print first, matching
+    // app_main.py's application-level exception handling order.
     pyre_interpreter::eprint_exception(&e, true);
     finalize_runtime(canonical, ec_ptr);
     maybe_print_jit_stats();


### PR DESCRIPTION
This branch carries pip performance work plus four correctness/parity findings made while reading that path.

## Runtime and shutdown work

Two commits (`perf: remove three more pip runtime bottlenecks`, `perf: match PyPy shutdown and prehash object dicts`):

- `bufferview`: `as_contiguous_bytes` borrows the live byte run for the `BUF_SIMPLE` shape the unmarshaller consumes directly, instead of gathering it. More general geometry still returns `None` and falls back to `gather`, so strided/N-D semantics are unchanged.
- `gc_interp`: a dispatch counter paces collector queries, with the allocator-armed request skipping the poll interval and rechecking the semantic gates, so `gc.disable()` or a callback appearing since arming is still honoured.
- `dictmultiobject`: the object-dict storage gets a named `ObjectDictStorage` type and a prehashing writer, replacing the open-coded `IndexMap<ObjectKey, PyObjectRef>` at every accessor.
- `pyrex`: the hand-rolled shutdown walk (`clear_shutdown_modules` and friends) is removed in favour of the upstream `finalize_modules` shape.
- `fib_recursive.dynasm.jitstats`: `bridges_compiled` 8 → 7 and `guard_failures` 1645 → 1501, `loops_compiled` unchanged. Both counters move in the improving direction; no other backend's baseline moved.

Those two commits landed with empty message bodies — the rationale above is read off their diffs and their in-tree comments, not from the commits.

## Correctness and parity findings

Four changes found while looking at pip's import cost. Two are one-line ordering/guard fixes with their own tests; two remove a duplicated code-object body.

### `RootSet::remove`'s fallback left the root set out of stack shape

The out-of-order fallback used `position`, so a slot registered twice by nested host brackets retired the front copy and `swap_remove` moved the tail over it.

**This is not a correctness fix, and the first draft of this description wrongly implied it was.** The root set is unaffected either way: `add` hands out no index, nothing reads `roots` positionally, and both copies are the same pointer, so the same multiset is scanned. `shadowstack.py` has no by-value removal at all — `push_stack`/`pop_stack` move one `root_stack_top`, so the newest registration is always the one retired. `rposition` keeps that shape, which leaves the following removals on the O(1) matching-pop path instead of turning each into another scan.

The added test registers `a, b, a, b` and asserts the vector after each removal. Red-checked: with `position` the first assertion fails; the pre-existing `root_set_removes_lifo_and_out_of_order_roots` passes in both arms, so it did not cover this.

### `RootScope::normalize` / `RootScope::set` were the drifted twins

`normalize_roots` and `shadow_stack_set` both skip their `try_gc_current_object_address` queries when `foreign_mutator_seen` is false — RPython has one mutator under the GIL, so no root becomes a forwarding stub between publication and the allocation bracket. The scope-local methods never got that guard. `set` keeps the publish-then-query order its twin documents, so the raw store still happens first.

This is a port of the guard the free functions already carry, not a new claim about when normalization is skippable. #1024 added it to four sites in this file — `pin_root`, `normalize_roots`, `shadow_stack_set` and `RootScope::pin_root` — and missed these two, which are the only members of that set still unguarded.

### A decoded nested `PyCode` was cloned into its parent's compiler table

`code_constant_from_value` ran every decoded value through `obj_to_constant_data`, which for a nested `PyCode` deep-copies the child `CodeObject` into the parent's compiler constants table. The wrapped child is then installed in `co_consts_w` anyway, so each nested body ended up owned twice — once by its own leaked box and once by the parent's table copy — for the process lifetime, since neither is ever freed.

Returning the shape placeholder for that arm makes the wrapped child the slot's authority, which is where `marshal_impl.py`'s unmarshaller puts the already-decoded `PyCode`.

**This turns out to fix an observable divergence, not just a duplicated allocation.** `unmarshal_pycode` is declared `save_ref=True` and registers the code object before filling it, so a code object appearing twice in a stream travels as a back-reference and both spellings owe the same object. Because the old `is_wrapped_constant` arm for `ConstantData::Code` also required `w_code_has_wrapped_consts`, an ordinary nested code's wrapper was *not* retained, and `co_consts` answered from a wrapper rebuilt out of the parent's copy — equal to the back-reference's target, but not the same object:

```python
loaded_code, loaded_nested = marshal.loads(marshal.dumps((code, nested)))
[c for c in loaded_code.co_consts if hasattr(c, "co_name")][0] is loaded_nested
```

| arm | result |
|---|---|
| CPython 3.14.6 | `True` |
| `b728a92dcf1`, without this change | **`False`** |
| with this change | `True` |

Both pyre arms were built from the same LLBC inputs and run with `PYRE_JIT=0`, so the interpreter path is the one under test. Pinned as `extra_tests/snippets/marshal_nested_code_identity.py`; `test_marshal` is not in the CPython-suite baseline, so nothing else in the tree loads a stream that repeats a code object.

Verified against the vendored tree: `unmarshal_pycode` passes its decoded `consts_w` straight to `PyCode.__init__`, which stores them as `co_consts_w` — upstream's only constants table, and the one `remove_docstrings` recurses through to reach nested code. Pyre's compiler-level table is a second, pyre-only owner. The placeholder is load-bearing rather than lossy: `is_wrapped_constant`'s rule for `ConstantData::None` is `!is_none(value)`, so the slot is always stored instead of being left to realize lazily from a table entry that no longer describes it.

### Test for `box_code_object`'s ownership transfer

`box_code_object` moves its `CodeObject` into the leaked box rather than cloning it, and nothing pinned that. The test compares the `source_path` and `instructions` buffer addresses across the call.

---

**On the rebase.** This branch was cut before #1361 and originally also contained the owning-constructor change, the wrap-nested-constants-in-place change, and a rewrite of `fix_co_filename` that moved `co_filename` off the compiler IR entirely. #1361 landed the first two independently, so those are dropped here — main's `box_code_object` and `box_code_constant_in_place` are the same optimization. `fix_co_filename` is left exactly as #1361 rewrote it: that version already removes the recursive clone, which was the perf motivation, and the remaining difference (byte-exact non-UTF-8 filenames, never mutating the IR) is a semantics change that should be argued on its own rather than smuggled in as a conflict resolution. Happy to bring it back as a separate PR if wanted.

**Verification.** `cargo check --all --tests --no-default-features --features dynasm` clean; the three added tests and the full `pycode::` + `module::marshal::` suites (14 tests) pass. The marshal change is additionally pinned by a two-arm run against a CPython 3.14.6 oracle, described above. The `code_constant_from_value` arm is exercised end-to-end by every `.pyc` import, so cpython_tests and check.py in CI remain the gate on the rest of it.

**Upstream review.** The Codex parity review on this diff reports no parity regressions and no new mismatches, and independently classifies the `RootSet::remove` change as a Rust host-root API adaptation rather than a PyPy semantic mismatch — which is why that section above says it is not a correctness fix.

Assisted-by: Claude
