### PR TITLE
cranelift `*_imm` deprecations, two dependency-signature warnings, and an abort census key

### DIFF
--- a/majit/majit-backend-cranelift/src/compiler.rs
+++ b/majit/majit-backend-cranelift/src/compiler.rs
@@ -3439,7 +3439,7 @@ fn emit_call_header_shadowstack(
         .ins()
         .store(MemFlagsData::trusted(), jf_as_ptr, rst, word as i32);
     // ADD ebx, 2*WORD
-    let new_rst = builder.ins().iadd_imm(rst, 2 * word);
+    let new_rst = builder.ins().iadd_imm_s(rst, 2 * word);
     // MOV [root_stack_top_addr], ebx
     builder
         .ins()
@@ -3464,7 +3464,7 @@ fn emit_call_footer_shadowstack(
     let rst = builder
         .ins()
         .load(ptr_type, MemFlagsData::trusted(), rst_addr_val, 0);
-    let new_rst = builder.ins().iadd_imm(rst, -(2 * word));
+    let new_rst = builder.ins().iadd_imm_s(rst, -(2 * word));
     builder
         .ins()
         .store(MemFlagsData::trusted(), new_rst, rst_addr_val, 0);
@@ -6028,7 +6028,7 @@ fn emit_scaled_index_addr(
     let with_base_offset = if base_offset == 0 {
         scaled_index
     } else {
-        builder.ins().iadd_imm(scaled_index, base_offset)
+        builder.ins().iadd_imm_s(scaled_index, base_offset)
     };
     builder.ins().iadd(base, with_base_offset)
 }
@@ -7150,10 +7150,10 @@ fn emit_attached_loop_dispatch(
     // target at the LABEL the JUMP names, not always the first.  The target
     // body's entry `br_table` reserves dispatch_key 0 for its preamble, so a
     // re-entry at LABEL L passes `label_block_id + 1`.
-    let label_selector = builder.ins().iadd_imm(lbid, 1);
+    let label_selector = builder.ins().iadd_imm_s(lbid, 1);
     let dispatch_key = builder
         .ins()
-        .bor_imm(label_selector, IN_CODE_ENTRY_KEY_FLAG as i64);
+        .bor_imm_u(label_selector, IN_CODE_ENTRY_KEY_FLAG as i64);
     builder.ins().return_call_indirect(
         target_sig_ref,
         target_code_ptr,
@@ -9614,7 +9614,7 @@ impl CraneliftBackend {
         let raw_dispatch_key = builder.block_params(entry_block)[1];
         let in_code_bit = builder
             .ins()
-            .band_imm(raw_dispatch_key, IN_CODE_ENTRY_KEY_FLAG as i64);
+            .band_imm_u(raw_dispatch_key, IN_CODE_ENTRY_KEY_FLAG as i64);
         let zero_key = builder.ins().iconst(cl_types::I32, 0);
         let is_in_code_entry = builder.ins().icmp(IntCC::NotEqual, in_code_bit, zero_key);
 
@@ -10238,7 +10238,7 @@ impl CraneliftBackend {
             let label_selector_mask = (!IN_CODE_ENTRY_KEY_FLAG) as i64;
             let dispatch_key = builder
                 .ins()
-                .band_imm(raw_dispatch_key, label_selector_mask);
+                .band_imm_u(raw_dispatch_key, label_selector_mask);
             let preamble_block = builder.create_block();
             let loaders: Vec<cranelift_codegen::ir::Block> = label_blocks
                 .iter()
@@ -11535,7 +11535,7 @@ impl CraneliftBackend {
                         resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
 
                     // Load header word from obj_ptr - GcHeader::SIZE
-                    let hdr_addr = builder.ins().iadd_imm(obj_ptr, -(GcHeader::SIZE as i64));
+                    let hdr_addr = builder.ins().iadd_imm_s(obj_ptr, -(GcHeader::SIZE as i64));
                     let hdr_word =
                         builder
                             .ins()
@@ -11615,7 +11615,9 @@ impl CraneliftBackend {
                     // majit's GC header sits at `obj - GcHeader::SIZE`
                     // (see the GuardGcType arm above); the typeid occupies
                     // the lower `TYPE_ID_BITS` of that header word.
-                    let hdr_addr = builder.ins().iadd_imm(loc_object, -(GcHeader::SIZE as i64));
+                    let hdr_addr = builder
+                        .ins()
+                        .iadd_imm_s(loc_object, -(GcHeader::SIZE as i64));
                     let hdr_word =
                         builder
                             .ins()
@@ -11633,7 +11635,7 @@ impl CraneliftBackend {
                     // assembler.py:1938-1939 addr_add(imm(base_type_info),
                     //     loc_typeid, scale=shift_by, offset=infobits_offset)
                     let shifted_typeid = if shift_by > 0 {
-                        builder.ins().ishl_imm(loc_typeid, shift_by as i64)
+                        builder.ins().ishl_imm_u(loc_typeid, shift_by as i64)
                     } else {
                         loc_typeid
                     };
@@ -11641,7 +11643,7 @@ impl CraneliftBackend {
                     let addr_without_off = builder.ins().iadd(base_val, shifted_typeid);
                     let loc_infobits = builder
                         .ins()
-                        .iadd_imm(addr_without_off, infobits_offset as i64);
+                        .iadd_imm_s(addr_without_off, infobits_offset as i64);
 
                     // assembler.py:1940 TEST8 [loc_infobits], IS_OBJECT_FLAG.
                     let byte =
@@ -11770,7 +11772,9 @@ impl CraneliftBackend {
                         //     MOV loc_tmp, [base_type_info
                         //         + (loc_tmp << shift_by)
                         //         + sizeof_ti + offset2]
-                        let hdr_addr = builder.ins().iadd_imm(loc_object, -(GcHeader::SIZE as i64));
+                        let hdr_addr = builder
+                            .ins()
+                            .iadd_imm_s(loc_object, -(GcHeader::SIZE as i64));
                         let hdr_word =
                             builder
                                 .ins()
@@ -11780,7 +11784,7 @@ impl CraneliftBackend {
                         let (base_type_info, shift_by, sizeof_ti) =
                             with_cranelift_gc_required(|gc| gc.get_translated_info_for_typeinfo());
                         let shifted = if shift_by > 0 {
-                            builder.ins().ishl_imm(typeid, shift_by as i64)
+                            builder.ins().ishl_imm_u(typeid, shift_by as i64)
                         } else {
                             typeid
                         };
@@ -11788,7 +11792,7 @@ impl CraneliftBackend {
                         let addr_base = builder.ins().iadd(base_val, shifted);
                         let addr = builder
                             .ins()
-                            .iadd_imm(addr_base, (sizeof_ti + offset2) as i64);
+                            .iadd_imm_s(addr_base, (sizeof_ti + offset2) as i64);
                         builder
                             .ins()
                             .load(cl_types::I64, MemFlagsData::trusted(), addr, 0)
@@ -11810,7 +11814,7 @@ impl CraneliftBackend {
 
                     // assembler.py:1976-1978 unsigned comparison:
                     //     (loc_tmp - check_min) <u (check_max - check_min)
-                    let sub = builder.ins().iadd_imm(loc_tmp, -check_min);
+                    let sub = builder.ins().iadd_imm_s(loc_tmp, -check_min);
                     let limit = builder.ins().iconst(cl_types::I64, check_max - check_min);
                     // assembler.py:1979 guard_success_cc = Conditions['B']:
                     // the guard passes when sub <u limit; the fail branch
@@ -12047,7 +12051,9 @@ impl CraneliftBackend {
                     // The callee's prologue pushes jf_ptr onto shadow stack,
                     // so GC tracks it during callee execution. After return,
                     let args_ptr = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let args_data_ptr = builder.ins().iadd_imm(args_ptr, JF_FRAME_ITEM0_OFS as i64);
+                    let args_data_ptr = builder
+                        .ins()
+                        .iadd_imm_s(args_ptr, JF_FRAME_ITEM0_OFS as i64);
                     let token_val = descr_token
                         .map(|token| token.number)
                         .or_else(|| call_descr.call_target_token())
@@ -12272,8 +12278,9 @@ impl CraneliftBackend {
                         // jitframe onto the shadow stack so GC can trace it during
                         // the helper call. Pop after the helper returns.
                         emit_call_header_shadowstack(&mut builder, ptr_type, result_jf);
-                        let result_jf_data =
-                            builder.ins().iadd_imm(result_jf, JF_FRAME_ITEM0_OFS as i64);
+                        let result_jf_data = builder
+                            .ins()
+                            .iadd_imm_s(result_jf, JF_FRAME_ITEM0_OFS as i64);
                         let result_jf_data_i64 =
                             ptr_arg_as_i64(&mut builder, result_jf_data, ptr_type);
                         // `compile.py:665 setattr(cpu, name, descr)` — bake the
@@ -13049,7 +13056,9 @@ impl CraneliftBackend {
                             ref_root_base_ofs,
                         );
                         emit_push_gcmap(&mut builder, jf_ptr, per_call_gcmap);
-                        let ps = builder.ins().iadd_imm(size_total, -(GcHeader::SIZE as i64));
+                        let ps = builder
+                            .ins()
+                            .iadd_imm_s(size_total, -(GcHeader::SIZE as i64));
                         let slow_r = emit_host_call(
                             &mut builder,
                             ptr_type,
@@ -13235,7 +13244,9 @@ impl CraneliftBackend {
                         ref_root_base_ofs,
                     );
                     emit_push_gcmap(&mut builder, jf_ptr, per_call_gcmap);
-                    let size = builder.ins().iadd_imm(size_total, -(GcHeader::SIZE as i64));
+                    let size = builder
+                        .ins()
+                        .iadd_imm_s(size_total, -(GcHeader::SIZE as i64));
                     let slow_result = emit_host_call(
                         &mut builder,
                         ptr_type,
@@ -13391,16 +13402,16 @@ impl CraneliftBackend {
                         builder.seal_block(card_mark_block);
                         let index = resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
                         let shift_plus_3 = (wb_card_shift + 3) as i64;
-                        let shifted = builder.ins().ushr_imm(index, shift_plus_3);
+                        let shifted = builder.ins().ushr_imm_u(index, shift_plus_3);
                         let byteofs_val = builder.ins().bnot(shifted);
-                        let bit_idx = builder.ins().ushr_imm(index, wb_card_shift as i64);
+                        let bit_idx = builder.ins().ushr_imm_u(index, wb_card_shift as i64);
                         let seven = builder.ins().iconst(cl_types::I64, 7);
                         let bit_idx = builder.ins().band(bit_idx, seven);
                         let one = builder.ins().iconst(cl_types::I64, 1);
                         let bit_mask = builder.ins().ishl(one, bit_idx);
                         let card_header_base = builder
                             .ins()
-                            .iadd_imm(obj, -(majit_gc::header::GcHeader::SIZE as i64));
+                            .iadd_imm_s(obj, -(majit_gc::header::GcHeader::SIZE as i64));
                         let card_addr = builder.ins().iadd(card_header_base, byteofs_val);
                         let card_byte =
                             builder
@@ -13669,7 +13680,7 @@ impl CraneliftBackend {
                         .expect("getfield descriptor must be a FieldDescr");
 
                     let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let addr = builder.ins().iadd_imm(base, fd.offset() as i64);
+                    let addr = builder.ins().iadd_imm_s(base, fd.offset() as i64);
                     let r = emit_load_from_addr(
                         &mut builder,
                         addr,
@@ -13691,7 +13702,7 @@ impl CraneliftBackend {
 
                     let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     let val = resolve_opref(&mut builder, &constants, op.arg(1).to_opref());
-                    let addr = builder.ins().iadd_imm(base, fd.offset() as i64);
+                    let addr = builder.ins().iadd_imm_s(base, fd.offset() as i64);
                     emit_store_to_addr(
                         &mut builder,
                         addr,
@@ -13864,7 +13875,7 @@ impl CraneliftBackend {
 
                     let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     if let Some(ld) = ad.len_descr() {
-                        let addr = builder.ins().iadd_imm(base, ld.offset() as i64);
+                        let addr = builder.ins().iadd_imm_s(base, ld.offset() as i64);
                         let r = emit_load_from_addr(
                             &mut builder,
                             addr,
@@ -13893,7 +13904,7 @@ impl CraneliftBackend {
 
                     let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     if let Some(ld) = ad.len_descr() {
-                        let addr = builder.ins().iadd_imm(base, ld.offset() as i64);
+                        let addr = builder.ins().iadd_imm_s(base, ld.offset() as i64);
                         let r = emit_load_from_addr(
                             &mut builder,
                             addr,
@@ -13922,7 +13933,7 @@ impl CraneliftBackend {
                         .expect("strhash/unicodehash descriptor must be a FieldDescr");
                     assert_eq!(fd.field_size(), std::mem::size_of::<usize>());
                     let base = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
-                    let addr = builder.ins().iadd_imm(base, fd.offset() as i64);
+                    let addr = builder.ins().iadd_imm_s(base, fd.offset() as i64);
                     let hash = emit_load_from_addr(
                         &mut builder,
                         addr,
@@ -14108,7 +14119,7 @@ impl CraneliftBackend {
                             builder.ins().imul(start, scale)
                         }
                     };
-                    let byte_offset = builder.ins().iadd_imm(start_bytes, ad.base_size() as i64);
+                    let byte_offset = builder.ins().iadd_imm_s(start_bytes, ad.base_size() as i64);
                     let byte_size = match scale_size {
                         0 => builder.ins().iconst(cl_types::I64, 0),
                         1 => size,
@@ -15148,7 +15159,7 @@ impl CraneliftBackend {
                 OpCode::LoadFromGcTable => {
                     let index = resolve_opref(&mut builder, &constants, op.arg(0).to_opref());
                     let base = builder.ins().iconst(cl_types::I64, gc_table_base as i64);
-                    let byte_ofs = builder.ins().ishl_imm(index, 3);
+                    let byte_ofs = builder.ins().ishl_imm_u(index, 3);
                     let slot_addr = builder.ins().iadd(base, byte_ofs);
                     let value = builder
                         .ins()

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -7184,7 +7184,14 @@ impl CallDescr for SimpleCallDescr {
 unsafe extern "C" {
     // llsupport/memcpy.py:3-5 — the host `memcpy` symbol that
     // `gc.py:39 self.memcpy_fn = memcpy_fn` binds via `rffi.llexternal`.
-    fn memcpy(dest: *mut u8, src: *const u8, n: usize) -> *mut u8;
+    // Spelled with `c_void` to match the runtime symbol's own signature;
+    // only its address is ever taken (`memcpy_fn_addr`), never a call
+    // through this declaration.
+    fn memcpy(
+        dest: *mut core::ffi::c_void,
+        src: *const core::ffi::c_void,
+        n: usize,
+    ) -> *mut core::ffi::c_void;
 }
 
 /// llsupport/gc.py:39 `GcLLDescr_framework.memcpy_fn` cast to a Signed

--- a/majit/majit-metainterp/src/optimizeopt/info.rs
+++ b/majit/majit-metainterp/src/optimizeopt/info.rs
@@ -229,7 +229,7 @@ pub use majit_ir::ptr_info::{
 /// Extension trait carrying the OptContext-coupled methods that used
 /// to live on `impl StrPtrInfo` in metainterp. The data type itself
 /// is in `majit-ir`; only methods that depend on metainterp-side
-/// helpers (`get_constant_int_or_bound`, `get_box_replacement_box`,
+/// helpers (`get_constant_int_or_bound`, `get_box_replacement_operand_opt`,
 /// `getptrinfo`) stay here as a trait.
 pub trait StrPtrInfoExt {
     fn getstrlen(&self, ctx: &crate::optimizeopt::OptContext, mode: u8) -> Option<i64>;

--- a/majit/majit-metainterp/src/optimizeopt/mod.rs
+++ b/majit/majit-metainterp/src/optimizeopt/mod.rs
@@ -2321,7 +2321,7 @@ impl OptContext {
     /// `resop_refs` so any `Forwarded::Op(_)` chain step targeting the
     /// slot has an upgradable `Weak<Op>` from the start of the
     /// optimization run. Absent this pre-pass, `getintbound_box` →
-    /// `get_box_replacement_box` (a `&self` reader) can land on an
+    /// `get_box_replacement_operand_opt` (a `&self` reader) can land on an
     /// unbound terminal and a subsequent `set_forwarded_info` write
     /// trips `write_forwarded`'s bound-precondition assert.
     ///
@@ -2494,7 +2494,7 @@ impl OptContext {
     /// so a subsequent `set_forwarded_*` lands on the canonical `Op._forwarded`
     /// host. `opref` must be a non-const, non-sentinel resop position whose
     /// producer is not yet emitted (a virgin alias). Callers reach this only on
-    /// the `None` arm of `get_box_replacement_box`; an already-minted or
+    /// the `None` arm of `get_box_replacement_operand_opt`; an already-minted or
     /// producer-backed opref resolves there. Mirrors `materialize_operand_at`'s resop
     /// lazy-alloc arm (`mint_synthetic_resop` + bind).
     pub(crate) fn mint_box_at(&mut self, opref: OpRef) -> Operand {
@@ -6000,7 +6000,7 @@ impl OptContext {
     /// resoperation.py:38 `same_box` (non-Const: `self is other`) +
     /// history.py:211 `Const.same_box` (value comparison via
     /// `same_constant`). Resolves both operands through
-    /// `get_box_replacement_box` then delegates to `Operand::same_box`. Falls
+    /// `get_box_replacement_operand_opt` then delegates to `Operand::same_box`. Falls
     /// back to resolved-`OpRef` identity plus constant-value comparison
     /// when either box is absent: two references to the same unresolved
     /// variable are still the same box (`self is other`), and a
@@ -8228,7 +8228,7 @@ impl OptContext {
         opref: OpRef,
     ) -> Option<&mut crate::optimizeopt::info::PtrInfo> {
         // Resolve the position to its canonical box, then delegate to the
-        // box-native form. `get_box_replacement_box` returns `None` for an
+        // box-native form. `get_box_replacement_operand_opt` returns `None` for an
         // unresolved position (the old `and_then`/`_ => return None` arm).
         let op = self.get_box_replacement_operand_opt(opref)?;
         self.get_const_info_mut_if_exists_box(&op)
@@ -9410,7 +9410,7 @@ mod boxref_forwarding_tests {
     /// operand-returning reader resolves the slot's bound InputArg.
     /// `resoperation.py:57-68` walker terminates on `None` immediately.
     #[test]
-    fn h3_2b_get_box_replacement_box_returns_pool_entry_when_no_forward() {
+    fn h3_2b_get_box_replacement_operand_opt_returns_pool_entry_when_no_forward() {
         let (ctx, _b0, _b1, ia_holder) = ctx_with_two_int_boxes();
         let got = ctx
             .get_box_replacement_operand_opt(OpRef::input_arg_typed(0, Type::Int))
@@ -9432,7 +9432,7 @@ mod boxref_forwarding_tests {
     /// identity is checked via the shared `InputArg` handle rather than
     /// outer `Rc<Box>` pointer equality.
     #[test]
-    fn h3_2b_get_box_replacement_box_walks_forwarded_chain() {
+    fn h3_2b_get_box_replacement_operand_opt_walks_forwarded_chain() {
         let (mut ctx, b0, b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.make_equal_to(&b0, &b1);
         let got = ctx
@@ -9451,7 +9451,7 @@ mod boxref_forwarding_tests {
     /// operand-returning reader returns `None`; the OpRef-returning walker
     /// cannot resolve a Box identity without a bound producer either.
     #[test]
-    fn h3_2b_get_box_replacement_box_returns_none_when_pool_empty() {
+    fn h3_2b_get_box_replacement_operand_opt_returns_none_when_pool_empty() {
         let ctx = OptContext::with_num_inputs_and_start_pos(0, 2, 0, 2);
         // No seeded producer: no Box identity to resolve.
         assert!(
@@ -9464,7 +9464,7 @@ mod boxref_forwarding_tests {
     /// has no Box to root the walk on. The OpRef-returning reader handles
     /// the sentinel independently by returning it unchanged.
     #[test]
-    fn h3_2b_get_box_replacement_box_handles_none_sentinel() {
+    fn h3_2b_get_box_replacement_operand_opt_handles_none_sentinel() {
         let (ctx, _b0, _b1, _ia_holder) = ctx_with_two_int_boxes();
         assert!(ctx.get_box_replacement_operand_opt(OpRef::NONE).is_none());
     }
@@ -9474,7 +9474,7 @@ mod boxref_forwarding_tests {
     /// walker stops before descending into Info, matching
     /// PyPy `resoperation.py:60 isinstance(next, AbstractInfo)`.
     #[test]
-    fn h3_2b_get_box_replacement_box_stops_at_info_terminal() {
+    fn h3_2b_get_box_replacement_operand_opt_stops_at_info_terminal() {
         let (mut ctx, b0, _b1, ia_holder) = ctx_with_two_int_boxes();
         ctx.setintbound(&b0, &IntBound::from_constant(7));
         let got = ctx
@@ -10248,7 +10248,7 @@ mod constant_ptr_info_tests {
         let opref = OpRef::ref_op(10_012);
         // Synthetic-OpRef test fixture: lazy-allocate the operand so the
         // operand-direct `make_nonnull_str` can write through it. Production
-        // callers obtain the box via `get_box_replacement_box`.
+        // callers obtain the box via `get_box_replacement_operand_opt`.
         let op_box = ctx.materialize_operand_at(opref);
 
         ctx.make_nonnull_str(&op_box, 0);

--- a/majit/majit-metainterp/src/optimizeopt/optimizer.rs
+++ b/majit/majit-metainterp/src/optimizeopt/optimizer.rs
@@ -786,12 +786,12 @@ impl Optimizer {
         // imported state through the caller-provided bound box: fresh
         // virtual-state leaves arrive minted via `reserve_virtual_box`,
         // imported label-arg leaves arrive resolved via
-        // `get_box_replacement_box`. Constants take the value-only path via
+        // `get_box_replacement_operand_opt`. Constants take the value-only path via
         // `make_constant_box`.
         match info {
             VirtualStateInfo::Constant(value) => {
                 // `box_` is a caller-provided bound box (reserve_virtual_box /
-                // get_box_replacement_box), so the Operand lowering is panic-free.
+                // get_box_replacement_operand_opt), so the Operand lowering is panic-free.
                 ctx.make_constant_box(box_, *value);
             }
             VirtualStateInfo::Virtual {
@@ -1156,7 +1156,7 @@ impl Optimizer {
         // aliased JUMP args sharing the same VirtualState position).
         // Keyed by the virtual head's producer identity (`Operand` ptr_eq).
         // A head is normally a NEW (virtual-alloc) ResOp with a producer, so
-        // `get_box_replacement_box` returns the memoized bound box and two
+        // `get_box_replacement_operand_opt` returns the memoized bound box and two
         // entries sharing a head dedupe. A producer-less head resolves to
         // None and is never dedupable (matching the prior fresh-unbound-box
         // behaviour); its `set_ptr_info` is skipped below anyway.
@@ -2547,7 +2547,7 @@ impl Optimizer {
         // (e.g. `OptIntBounds::getintbound_box`) reaches a
         // `set_forwarded_*` write. `TraceIterator::next()`
         // (`opencoder.rs`) plants unbound resop slots; without this
-        // pre-pass, `get_box_replacement_box(&self)` could return an
+        // pre-pass, `get_box_replacement_operand_opt(&self)` could return an
         // unbound terminal that fails `write_forwarded`'s bound-
         // precondition assert.
         ctx.bind_input_resops(ops);
@@ -7567,7 +7567,7 @@ mod tests {
 
     /// Imported virtual heads must carry their `PtrInfo::Virtual`. The
     /// label-args import used to allocate a bare head position and write
-    /// the info through `get_box_replacement_box(..)` guarded by `if let
+    /// the info through `get_box_replacement_operand_opt(..)` guarded by `if let
     /// Some(..)` — always `None` for a bare position, silently dropping
     /// the virtual-ness of the imported state.
     #[test]

--- a/majit/majit-metainterp/src/optimizeopt/pure.rs
+++ b/majit/majit-metainterp/src/optimizeopt/pure.rs
@@ -807,7 +807,7 @@ impl OptPure {
     fn force_box(&mut self, op: &Operand, ctx: &mut OptContext) -> OpRef {
         // Single resolve through the operand terminal; the OpRef view is the
         // terminal's `to_opref()` (keystone equivalence, #113), so the prior
-        // paired `get_box_replacement` + `get_box_replacement_box` of the
+        // paired `get_box_replacement` + `get_box_replacement_operand_opt` of the
         // same operand was a redundant double walk.
         let resolved_box = ctx.resolve_operand_operand_opt(op);
         let resolved = resolved_box
@@ -2691,7 +2691,7 @@ mod tests {
         op.setdescr(call_descr);
         // Register the dispatched op as the producer at its position so the
         // collapsed `from_bound_op(op_rc)` resolves to the same box the test
-        // reads back via `get_box_replacement_box(pos)` (mirrors production
+        // reads back via `get_box_replacement_operand_opt(pos)` (mirrors production
         // input-op binding).
         let op_rc = std::rc::Rc::new(op.clone());
         ctx.bind_input_resops(std::slice::from_ref(&op_rc));

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -1024,7 +1024,7 @@ impl OptRewrite {
     fn getnullness(&self, opref: OpRef, ctx: &mut OptContext) -> Nullness {
         // optimizer.py:127-135 `getnullness` has no missing-Box branch —
         // every `op` has a backing `AbstractValue` per
-        // `resoperation.py:233-248`. `get_box_replacement_box` resolves
+        // `resoperation.py:233-248`. `get_box_replacement_operand_opt` resolves
         // the opref to its bound host; the read-only `getnullness` below
         // never writes, so an unresolvable opref (OpRef::NONE sentinel,
         // no upstream equivalent) maps to `INFO_UNKNOWN`.

--- a/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
+++ b/majit/majit-metainterp/src/optimizeopt/shortpreamble.rs
@@ -2434,7 +2434,7 @@ impl ShortPreambleBuilder {
     /// compensated for invented-name replay-position aliasing; the carried box
     /// is invariant to that aliasing so the entries collapse to one. The prior
     /// "blocked" verdict (75 agree / 114 diverge) measured the WRONG box:
-    /// `get_box_replacement_box(source)`, a Phase-2 re-resolution that mints a
+    /// `get_box_replacement_operand_opt(source)`, a Phase-2 re-resolution that mints a
     /// fresh non-`ptr_eq` box. The carried Phase-1 res is shared across the
     /// peel boundary (an `Rc::clone` of the exported short-box res), so the
     /// box-identity lookup hits — PYRE_S8B_HARNESS measured 82/82 agreement

--- a/majit/majit-metainterp/src/optimizeopt/unroll.rs
+++ b/majit/majit-metainterp/src/optimizeopt/unroll.rs
@@ -867,7 +867,7 @@ impl UnrollOptimizer {
             // fresh Box identity set so _forwarded mutations cannot alias
             // across phases.
             //
-            // Const operands are NOT cached: `get_box_replacement_box`
+            // Const operands are NOT cached: `get_box_replacement_operand_opt`
             // allocates a fresh const operand per call from `const_pool`
             // (`history.py:220` ConstInt(value) per-call-site parity).
             // opt_p1's entry path seeds `const_pool` from the shared

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -312,7 +312,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         cst!("IPPROTO_PIM", libc::IPPROTO_PIM);
         cst!("IPPROTO_SCTP", libc::IPPROTO_SCTP);
         cst!("IPPROTO_RAW", libc::IPPROTO_RAW);
-        cst!("IPPROTO_MAX", libc::IPPROTO_MAX);
+        // libc deprecates this: the kernel raised the value and libc will
+        // follow upstream in a later release (rust-lang/libc#1896). Keep
+        // reading it from libc rather than freezing a literal, so the new
+        // value arrives with the dependency; `socketmodule.c` likewise takes
+        // whatever the platform header defines.
+        #[allow(deprecated)]
+        {
+            cst!("IPPROTO_MAX", libc::IPPROTO_MAX);
+        }
         cst!("IPPROTO_GRE", libc::IPPROTO_GRE);
         cst!("IPPROTO_RSVP", libc::IPPROTO_RSVP);
         // `_rsocket_rffi.py:234-241 constants_w_defaults` — SOL_IP/TCP/UDP

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/mod.rs
@@ -2708,7 +2708,16 @@ impl DispatchError {
             Self::BranchGuardKeptStackUnsupported { .. } => "BranchGuardKeptStackUnsupported",
             Self::BranchGuardKeptSlotUnsourced { .. } => "BranchGuardKeptSlotUnsourced",
             Self::ForceQuasiImmutable { .. } => "ForceQuasiImmutable",
-            Self::LoopBearingCalleeInlineUnsupported { .. } => "LoopBearingCalleeInlineUnsupported",
+            // Split on the discriminant: the two carry different recoveries —
+            // `false` routes to the CALL-forward carrier, `true` is owned by the
+            // general walk-abort leg — so one key cannot answer which fired.
+            Self::LoopBearingCalleeInlineUnsupported {
+                blackhole_required: true,
+                ..
+            } => "LoopBearingCalleeInlineUnsupported/blackhole",
+            Self::LoopBearingCalleeInlineUnsupported { .. } => {
+                "LoopBearingCalleeInlineUnsupported/carrier"
+            }
             Self::FieldDescrMissingParentDescr { .. } => "FieldDescrMissingParentDescr",
             Self::OrthodoxSubWalkTraceUnsupported { .. } => "OrthodoxSubWalkTraceUnsupported",
             Self::UnregisteredNewGcType { .. } => "UnregisteredNewGcType",


### PR DESCRIPTION
Four code commits. The comment-only work that was here has moved to a separate PR.

### 1. `cranelift` moves off the deprecated `*_imm` builders — 29 call sites

Each deprecated shim forwards to `build_imm_const(imm_ty, y, SIGNED)`, and the third argument is **per opcode**, not per crate:

| builder | replacement |
|---|---|
| `iadd_imm`, `imul_imm` | `_s` (Sextend) |
| `ishl_imm`, `ushr_imm`, `band_imm`, `bor_imm` | `_u` (Uextend) |

Read out of the generated `inst_builder.rs`. A blanket `_s` substitution would have changed the immediate extension on 4 of the 5 distinct opcodes; it is only observable for i128 controlling types, which is exactly the kind of difference that survives a green run.

### 2. Two dependency-signature warnings, no behaviour change

`libc::IPPROTO_MAX` is deprecated because the kernel raised the value and libc will follow. The read stays, under `#[allow(deprecated)]`, so the new value arrives with the dependency rather than being frozen into a literal here — `socketmodule.c` likewise takes whatever the platform header defines. ⚠️ This one is **not locally verifiable**: the deprecation exists only on linux-gnu, so a clean macOS run is not evidence for it.

`descr.rs`'s `memcpy` declaration trips `suspicious_runtime_symbol_definitions`. It is spelled with `c_void` to match the runtime symbol's own signature; only its address is ever taken (`memcpy_fn_addr`), never a call through the declaration.

### 3. The abort census could not answer which leg fired

`LoopBearingCalleeInlineUnsupported` has two recoveries — `blackhole_required: false` routes to the CALL-forward carrier, `true` is owned by the general walk-abort leg — and both were counted under one key. Split on the discriminant.

Over 126 fixtures: **41 `/carrier`, 0 `/blackhole`**.

### 4. `get_box_replacement_box` does not exist

The accessor is `get_box_replacement_operand_opt`. 21 mentions, including five test names that asserted about a symbol with no definition.

## Verification

`cargo fmt` clean, `cargo check --all --no-default-features --features dynasm` rc=0, warning count unchanged, zero broken intra-doc links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q