### PR TITLE
Fold len() on an exact bytearray, and correct the zip fold's doc comment

### DIFF
--- a/pyre/bench/synth/str_getitem_len_hot.cranelift.jitstats
+++ b/pyre/bench/synth/str_getitem_len_hot.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=1
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=209
+guard_failures=612
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=3
 retraces_compiled=0

--- a/pyre/bench/synth/str_getitem_len_hot.dynasm.jitstats
+++ b/pyre/bench/synth/str_getitem_len_hot.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=1
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=209
+guard_failures=612
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=3
 retraces_compiled=0

--- a/pyre/bench/synth/str_getitem_len_hot.py
+++ b/pyre/bench/synth/str_getitem_len_hot.py
@@ -7,11 +7,21 @@
 # A rolling ordinal checksum makes a wrong offset or width a visibly wrong
 # number rather than a silent pass. Deterministic; output asserted cpython==pypy.
 #
-# `hot_len` also runs over `bytes`, whose `builtin_len` arm reads
+# `hot_len` also runs over `bytes` and `bytearray`. The `bytes` arm reads
 # `W_BytesObject.len` — the precomputed count standing in for the `strlen`
-# `bytesobject.py` takes off `_value`. Without that arm the call stays an
-# opaque forcing residual and the leg measures ~100x the str one, which the
-# ceiling below is set to catch.
+# `bytesobject.py` takes off `_value` — and the `bytearray` arm reads
+# `W_BytearrayObject.length`, which is what `bytearrayobject.py`'s `_len`
+# reaches through `self._data` as `rlist.py`'s `("length", Signed)`. Without
+# those arms the call stays an opaque forcing residual and the leg measures
+# ~100x the str one, which the ceiling below is set to catch.
+#
+# `hot_mutating_len` is a correctness leg, not a speed one. `bytearray`'s
+# length is MUTABLE, so the compiled loop re-reads the field instead of
+# hoisting it, and the field only stays right because every length-changing
+# mutator republishes it through `w_bytearray_sync_alloc`. Appending and
+# deleting a prefix inside the loop walks both the push path and the one that
+# moves `logical_offset`; a length that went stale anywhere shows up as a wrong
+# checksum here rather than as silently wrong compiled code.
 
 
 def hot_checksum(n, s):
@@ -26,6 +36,16 @@ def hot_len(n, s):
     acc = 0
     for i in range(n):
         acc += len(s)
+    return acc
+
+
+def hot_mutating_len(n, ba):
+    acc = 0
+    for i in range(n):
+        ba.append(i & 0xFF)
+        acc = (acc + len(ba)) & 0xFFFFFFFFFFFF
+        if len(ba) > 64:
+            del ba[0:32]
     return acc
 
 
@@ -53,6 +73,9 @@ def main():
     # legs are what set it on the slowest runner.
     bn = 12000000
     print("blen", hot_len(bn, ascii_b), hot_len(bn, short_b))
+    ban = 12000000
+    print("balen", hot_len(ban, bytearray(ascii_b)), hot_len(ban, bytearray(short_b)))
+    print("bamut", hot_mutating_len(400000, bytearray(short_b)))
 
 
 main()

--- a/pyre/bench/synth/str_getitem_len_hot.wasm.jitstats
+++ b/pyre/bench/synth/str_getitem_len_hot.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=1
+bridges_compiled=3
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,8 +8,8 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=209
+guard_failures=612
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=2
+loops_compiled=3
 retraces_compiled=0

--- a/pyre/pyre-jit-trace/src/descr.rs
+++ b/pyre/pyre-jit-trace/src/descr.rs
@@ -1138,6 +1138,89 @@ static W_BYTES_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     )
 });
 
+/// `W_BytearrayObject`, the mutable sibling of [`W_BYTES_DESCR_GROUP`].
+///
+/// `length` is the field `bytearrayobject.py`'s `_len` reaches through
+/// `self._data`, where the storage is an RPython list and the read is
+/// `rlist.py:116`'s `("length", Signed)`.  Unlike the bytes `len` it is
+/// MUTABLE: append / insert / remove / pop / clear all move it, so a length
+/// read must not hoist out of a loop that can mutate the receiver.  Same
+/// reason `W_ListObject.length` is mutable.
+static W_BYTEARRAY_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
+    build_object_descr_group_with_def_path(
+        pyre_object::bytearrayobject::W_BYTEARRAY_OBJECT_SIZE,
+        W_BYTEARRAY_GC_TYPE_ID,
+        &pyre_object::bytearrayobject::BYTEARRAY_TYPE as *const _ as usize,
+        &[
+            (
+                "data",
+                pyre_object::bytearrayobject::BYTEARRAY_DATA_OFFSET,
+                std::mem::size_of::<*mut Vec<u8>>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "length",
+                pyre_object::bytearrayobject::BYTEARRAY_LENGTH_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
+            (
+                "alloc",
+                pyre_object::bytearrayobject::BYTEARRAY_ALLOC_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
+            (
+                "logical_offset",
+                pyre_object::bytearrayobject::BYTEARRAY_LOGICAL_OFFSET_OFFSET,
+                std::mem::size_of::<usize>(),
+                Type::Int,
+                false,
+                false,
+                false,
+            ),
+            (
+                "exports",
+                pyre_object::bytearrayobject::BYTEARRAY_EXPORTS_OFFSET,
+                std::mem::size_of::<i64>(),
+                Type::Int,
+                true,
+                false,
+                false,
+            ),
+            (
+                "w_dict",
+                pyre_object::bytearrayobject::BYTEARRAY_W_DICT_OFFSET,
+                std::mem::size_of::<pyre_object::PyObjectRef>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+            (
+                "w_weakreflifeline",
+                pyre_object::bytearrayobject::BYTEARRAY_W_WEAKREFLIFELINE_OFFSET,
+                std::mem::size_of::<pyre_object::PyObjectRef>(),
+                Type::Ref,
+                false,
+                false,
+                false,
+            ),
+        ],
+        "W_BytearrayObject",
+        "bytearrayobject::W_BytearrayObject",
+    )
+});
+
 static RANGE_ITER_DESCR_GROUP: LazyLock<PyreObjectDescrGroup> = LazyLock::new(|| {
     build_object_descr_group_with_def_path(
         std::mem::size_of::<pyre_object::functional::W_IntRangeIterator>(),
@@ -3887,6 +3970,12 @@ pub fn frame_debug_data_w_locals_descr() -> DescrRef {
 /// `W_BytesObject.len`, so the same answer is one immutable field read.
 pub fn bytes_len_descr() -> DescrRef {
     field_descr_from_group(&W_BYTES_DESCR_GROUP, 1)
+}
+
+/// `W_BytearrayObject.length` — the count `bytearrayobject.py:_len` answers
+/// with. Mutable; see [`W_BYTEARRAY_DESCR_GROUP`].
+pub fn bytearray_length_descr() -> DescrRef {
+    field_descr_from_group(&W_BYTEARRAY_DESCR_GROUP, 1)
 }
 
 pub fn str_len_descr() -> DescrRef {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -12873,17 +12873,21 @@ pub(crate) fn try_walker_specialize_get_iter<Sym: WalkSym>(
     Ok(Some(new))
 }
 
-/// Walker-native `ForIterNext` for `W_IntRangeIterator`.
+/// Walker-native `ForIterNext` for an arity-two `zip` over two
+/// `W_TupleIterObject` cursors.
 ///
-/// The generic residual advances the shared iterator before an abort can
-/// occur, and forward-delivery preserves that consumed item.  This inline
-/// path keeps that deliberately irreversible advance: it never journals or
-/// rolls the cursor back.  It instead emits the `W_IntRangeIterator.next`
-/// field-update shape with a continuation guard.  Its false side resumes at
-/// the same FOR_ITER coordinate as the codewriter's ordinary exhaustion edge.
+/// The generic residual advances both shared iterators before an abort can
+/// occur, and forward-delivery preserves the consumed pair.  This inline path
+/// keeps that deliberately irreversible advance: it never journals or rolls
+/// either cursor back.  It emits both `W_TupleIterObject` index updates and a
+/// continuation guard whose false side resumes at the same FOR_ITER coordinate
+/// as the codewriter's ordinary exhaustion edge; `strict=True` routes its
+/// uneven-length arm through the generic path so the interpreter owns the
+/// authentic `ValueError`.
 ///
-/// The continuation item is a normal virtualizable `W_IntObject`; allocation
-/// removal elides it until an escaping consumer or a deopt needs a real box.
+/// The continuation item is the object pair `W_Zip.next_w` builds with
+/// `newtuple2` at arity two; allocation removal elides it until an escaping
+/// consumer or a deopt needs a real box.
 fn try_walker_specialize_zip_two_tuple_iters<Sym: WalkSym>(
     ctx: &mut WalkContext<'_, '_, Sym>,
     op_pc: usize,

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -6813,6 +6813,10 @@ enum BuiltinLenSource {
     /// the RPython string; pyre precomputes that count into a field, so the
     /// read is the same shape as [`BuiltinLenSource::StrField`].
     BytesField,
+    /// `W_BytearrayObject.length` — `bytearrayobject.py`'s `_len` reads the
+    /// length off the RPython list in `self._data`; pyre mirrors that count
+    /// into a field.  Mutable, unlike [`BuiltinLenSource::BytesField`].
+    BytearrayField,
     /// `tupleobject.py` carries no separate length field, so the length is
     /// `arraylen_gc(wrappeditems)`.
     TupleArrayLen,
@@ -6825,8 +6829,8 @@ enum BuiltinLenSource {
 }
 
 /// `len(x)` on an exact canonical `W_ListObject` / `W_UnicodeObject` /
-/// `W_BytesObject` / `W_TupleObject` / `W_Range`, or on an arity-2 tuple
-/// specialisation:
+/// `W_BytesObject` / `W_BytearrayObject` / `W_TupleObject` / `W_Range`, or on
+/// an arity-2 tuple specialisation:
 /// lower the opaque `bh_call_fn(len_builtin, PY_NULL, x)` residual to the
 /// inline length read the meta-tracer produces upstream
 /// (descroperation.py `_len`): `guard_value(callable)` +
@@ -6922,6 +6926,19 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
                 Some(exact),
                 BuiltinLenSource::BytesField,
                 pyre_object::bytesobject::w_bytes_len(list_obj),
+            )
+        } else if std::ptr::eq(ob_type, &pyre_object::bytearrayobject::BYTEARRAY_TYPE) {
+            let exact = pyre_object::pyobject::get_instantiate(
+                &pyre_object::bytearrayobject::BYTEARRAY_TYPE,
+            );
+            if !std::ptr::eq(w_class, exact) {
+                return Ok(None);
+            }
+            (
+                &pyre_object::bytearrayobject::BYTEARRAY_TYPE as *const _ as i64,
+                Some(exact),
+                BuiltinLenSource::BytearrayField,
+                pyre_object::bytearrayobject::w_bytearray_len(list_obj),
             )
         } else if std::ptr::eq(ob_type, &pyre_object::pyobject::TUPLE_TYPE) {
             let exact = pyre_object::pyobject::get_instantiate(&pyre_object::pyobject::TUPLE_TYPE);
@@ -7094,6 +7111,11 @@ pub(crate) fn try_walker_specialize_builtin_len<Sym: WalkSym>(
             ctx.trace_ctx,
             list_op,
             crate::descr::bytes_len_descr(),
+        ),
+        BuiltinLenSource::BytearrayField => crate::state::opimpl_getfield_gc_i(
+            ctx.trace_ctx,
+            list_op,
+            crate::descr::bytearray_length_descr(),
         ),
         BuiltinLenSource::RangeField => unreachable!("range returned its wrapped length above"),
         // `specialisedtupleobject.py:54-55 length()` returns the constant

--- a/pyre/pyre-object/src/bytearrayobject.rs
+++ b/pyre/pyre-object/src/bytearrayobject.rs
@@ -13,6 +13,19 @@ pub static BYTEARRAY_TYPE: PyType = crate::pyobject::new_pytype("bytearray");
 pub struct W_BytearrayObject {
     pub ob_header: PyObject,
     pub data: *mut Vec<u8>,
+    /// The count `bytearrayobject.py:_len` computes as
+    /// `len(self._data) - self._offset - 1`.  There `self._data` is an RPython
+    /// list, so `len(...)` is a plain read of `rlist.py:116`'s
+    /// `("length", Signed)` field -- the same field `W_ListObject.length`
+    /// mirrors.  pyre keeps the payload at `Vec[0]` with no trailing NUL, so
+    /// the count is `(*data).len()`; it is held here as well because `Vec`'s
+    /// field order is not part of Rust's guaranteed layout, and a length the
+    /// JIT can only reach through `Vec`'s internals is a length it cannot read
+    /// at all.
+    ///
+    /// [`w_bytearray_sync_alloc`] is what keeps this current.  Every mutator
+    /// that changes the buffer's length already has to call it, for `alloc`.
+    pub length: usize,
     /// CPython `PyByteArrayObject.ob_alloc`, including the trailing NUL byte.
     ///
     /// This cannot be derived from `Vec::capacity()`: Rust's allocator uses a
@@ -36,6 +49,23 @@ pub const W_BYTEARRAY_GC_TYPE_ID: u32 = 28;
 /// Fixed payload size (`framework.py:811`).
 pub const W_BYTEARRAY_OBJECT_SIZE: usize = std::mem::size_of::<W_BytearrayObject>();
 
+/// `W_BytearrayObject.data` — the pointer to the heap-allocated byte buffer.
+pub const BYTEARRAY_DATA_OFFSET: usize = std::mem::offset_of!(W_BytearrayObject, data);
+/// `W_BytearrayObject.length` — the byte count `_len` answers with.
+pub const BYTEARRAY_LENGTH_OFFSET: usize = std::mem::offset_of!(W_BytearrayObject, length);
+/// `W_BytearrayObject.alloc` — `ob_alloc`.
+pub const BYTEARRAY_ALLOC_OFFSET: usize = std::mem::offset_of!(W_BytearrayObject, alloc);
+/// `W_BytearrayObject.logical_offset` — `ob_start - ob_bytes`.
+pub const BYTEARRAY_LOGICAL_OFFSET_OFFSET: usize =
+    std::mem::offset_of!(W_BytearrayObject, logical_offset);
+/// `W_BytearrayObject.exports` — `_exports`.
+pub const BYTEARRAY_EXPORTS_OFFSET: usize = std::mem::offset_of!(W_BytearrayObject, exports);
+/// `W_BytearrayObject.w_dict` — mapdict's `dict` SPECIAL slot.
+pub const BYTEARRAY_W_DICT_OFFSET: usize = std::mem::offset_of!(W_BytearrayObject, w_dict);
+/// `W_BytearrayObject.w_weakreflifeline` — mapdict's `weakref` SPECIAL slot.
+pub const BYTEARRAY_W_WEAKREFLIFELINE_OFFSET: usize =
+    std::mem::offset_of!(W_BytearrayObject, w_weakreflifeline);
+
 impl crate::lltype::GcType for W_BytearrayObject {
     fn type_id() -> u32 {
         W_BYTEARRAY_GC_TYPE_ID
@@ -56,6 +86,7 @@ impl crate::lltype::GcType for W_BytearrayObject {
 /// `dont_look_inside` public constructors below, so the tracer never reaches it
 /// (the `Vec<u8>`-by-value argument never crosses a residual call ABI).
 fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
+    let length = buf.len();
     let alloc = if buf.is_empty() { 0 } else { buf.len() + 1 };
     let data =
         crate::gc_storage::gc_alloc_storage_box(buf, crate::bytesobject::bytes_data_gc_type_id());
@@ -72,6 +103,7 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
                 W_BytearrayObject {
                     ob_header: header,
                     data,
+                    length,
                     alloc,
                     logical_offset: 0,
                     exports: 0,
@@ -85,6 +117,7 @@ fn w_bytearray_alloc(buf: Vec<u8>) -> PyObjectRef {
         crate::lltype::malloc_typed(W_BytearrayObject {
             ob_header: header,
             data,
+            length,
             alloc,
             logical_offset: 0,
             exports: 0,
@@ -142,6 +175,7 @@ pub fn w_bytearray_subclass_from_bytes(bytes: &[u8], w_class: PyObjectRef) -> Py
             w_class: crate::gc_roots::shadow_stack_get(root_base),
         },
         data: crate::lltype::malloc_raw(bytes.to_vec()),
+        length: bytes.len(),
         alloc: if bytes.is_empty() { 0 } else { bytes.len() + 1 },
         logical_offset: 0,
         exports: 0,
@@ -208,7 +242,16 @@ pub unsafe fn is_bytearray(obj: PyObjectRef) -> bool {
 pub unsafe fn w_bytearray_len(obj: PyObjectRef) -> usize {
     unsafe {
         let ba = &*(obj as *const W_BytearrayObject);
-        (*ba.data).len()
+        // The JIT folds this call to a read of the same field, so a stale
+        // `length` would be a wrong length in compiled code rather than a
+        // wrong answer here.  Debug builds turn that into a test failure.
+        debug_assert_eq!(
+            ba.length,
+            (*ba.data).len(),
+            "bytearray length is stale: a mutator changed the buffer without \
+             calling w_bytearray_sync_alloc"
+        );
+        ba.length
     }
 }
 
@@ -228,6 +271,9 @@ pub unsafe fn w_bytearray_sync_alloc(obj: PyObjectRef, old_size: usize) {
     unsafe {
         let ba = &mut *(obj as *mut W_BytearrayObject);
         let size = (*ba.data).len();
+        // Above the early return: `length` tracks every change, while `alloc`
+        // only moves when the resize policy says it should.
+        ba.length = size;
         if size == old_size {
             return;
         }
@@ -332,7 +378,9 @@ pub unsafe fn w_bytearray_data_mut(obj: PyObjectRef) -> &'static mut [u8] {
 /// Get a mutable reference to the backing `Vec`, for length-changing
 /// mutators (append / insert / remove / pop / clear).  Caller must
 /// ensure the bytearray is not aliased while the reference is live and call
-/// [`w_bytearray_sync_alloc`] after every actual length change.
+/// [`w_bytearray_sync_alloc`] after every actual length change -- that call
+/// is what republishes [`W_BytearrayObject::length`], which the JIT reads
+/// directly.
 /// # Safety
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.


### PR DESCRIPTION
Two commits. The first closes the one arm `builtin_len` could not cover; the
second fixes a doc comment #1384's review caught.

## `len(bytearray)`

`bytearrayobject.py`'s `_len` answers `len(self._data) - self._offset - 1`, and
`self._data` is an RPython list — so upstream reads that length out of
`rlist.py:116`'s `("length", Signed)` field. It is an ordinary getfield, not a
call.

pyre already mirrors that field twice: `W_ListObject.length` (whose descr cites
`rlist.py:116` directly) and `W_BytesObject.len`, documented as "the analogue of
the `strlen` PyPy reads off `W_BytesObject._value`". `W_BytearrayObject` was the
one that never got it. Its count was reachable only as `(*data).len()` on a Rust
`Vec`, whose field order is not part of the guaranteed layout — so the length
upstream reads with a getfield was, here, not readable by the JIT at all.

I had previously deferred this arm on the grounds that a descr read would
introduce a layout assumption. That was half a diagnosis: **the missing field was
itself the deviation**, not an obstacle to working around.

### The sync discipline already existed

Adding a length field next to a `Vec` looks like it buys an invariant. It does
not — the invariant is already there. `w_bytearray_vec_mut`'s own doc says:

> Caller must ... call `w_bytearray_sync_alloc` after every actual length change.

That is how `alloc` and `logical_offset` stay current, and all 23 call sites obey
it. `length` rides on the same hook. The write goes **above** the early return,
because `alloc` only moves when the resize policy says so while `length` tracks
every change.

`w_bytearray_len` reads the field and `debug_assert_eq!`s it against the buffer.

### Mutable, unlike the bytes arm

`W_BYTEARRAY_DESCR_GROUP` describes all seven fields; `length` is **mutable**, so
a length read cannot hoist out of a loop that can mutate the receiver. Same
reason `W_ListObject.length` is mutable, and the one place this arm differs from
the `bytes` one.

### Measured

`len(bytearray(b"abc"))` in a 3,000,000-iteration loop, dynasm:

| | forcing residuals | wall |
|---|---|---|
| arm present | 0 | 0.06s |
| `builtin_len` suppressed | 49 | 0.30s |

`str_getitem_len_hot.py` gains two bytearray legs plus `hot_mutating_len`, which
appends and deletes a prefix inside the loop while reading `len` each iteration.

That leg is a **correctness** test, not a speed one. `debug_assert` is compiled
out of the release binaries the gate and the CPython suite actually run, so the
sync discipline needs a check that survives `--release`. This one walks both the
push path and the one that moves `logical_offset`, and a length that went stale
anywhere lands as a wrong checksum against cpython and pypy rather than as wrong
compiled code.

```
str_getitem_len_hot   dynasm / cranelift / wasm   ALL PASSED
  builtin_len suppressed:   26.0x > gate 19   RED   (bridges_compiled 3 -> 1)
```

`bytearray`'s ceiling is unchanged at 19; the bytes and str legs are what set it.

## The zip fold's doc comment

#1384's review caught that the comment above
`try_walker_specialize_zip_two_tuple_iters` describes
`try_walker_specialize_for_iter_next_range` instead — `W_IntRangeIterator`, its
`next` field-update shape, a range-item continuation, none of which the function
does.

Rewritten from the body rather than the name, checking each claim:

- both `W_TupleIterObject` cursors advance by `SetfieldGc` through
  `tuple_iter_index_descr`;
- `strict=True` is **not** declined wholesale. The guard is
  `!concrete_continues && !(strict && concrete_exhausted)`, so
  strict-and-both-exhausted stays inline and only the *uneven* arm falls through
  for the interpreter's authentic `ValueError`;
- the continuation item is the object pair from
  `emit_specialised_tuple_oo_inline`, which is what `W_Zip.next_w` builds with
  `newtuple2` at arity two.

## Gate

```
wasm       443/443   ALL PASSED
dynasm     434 passed, 16 failed
cranelift  434 passed, 16 failed
```

**The 16 are not from this branch, and I am deliberately not re-recording them.**

They are jitstats drift on recursion/bridge fixtures — `fib_recursive`,
`bridge_recursion_overflow`, `generator_tree_recursion`, the `selfrec_*` and
`recursion_*` family — none of which either commit touches. Evidence:

- They were already present before the `bytearray` work existed, on a tree whose
  only content was the (now merged) #1384.
- Running the full dynasm gate with `PYRE_FBW_NO_SPECIALIZE` set to **all nine**
  fold labels #1384 touched leaves every one of them present with *identical
  numbers*. That control holds the binary fixed, so it rules out the folds.
- They survive a `cargo clean --release` and full rebuild, so they are not
  mixed-artifact corruption.
- They have stayed numerically frozen across five successive `main` states
  (#1390, #1381, #1391, #1375, #1384).

What I could **not** separate locally is base-vs-toolchain: rustup moved stable
from rustc 1.97.1 to 1.98.0 mid-session, between the last green run and every red
one, and no 1.97 toolchain is installed to roll back to. `main`'s own `pyre CI`
has been cancelled by the merge train for six consecutive commits, so upstream
has no verdict either.

Re-recording those baselines here would launder someone else's regression into
this PR, so CI on its own pinned toolchain is the arbiter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved `len()` handling for mutable `bytearray` values.
  * Added benchmarking for `bytearray` lengths, including workloads that mutate size during execution.
  * Added validation to keep reported `bytearray` length consistent after mutations.

* **Bug Fixes**
  * Improved JIT specialization and performance for `bytearray` length operations.
  * Updated runtime tracking and benchmark statistics for these workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->