### PR TITLE
warmstate: build the dead-token fixture without nulling the token slot

### DIFF
--- a/majit/majit-metainterp/src/warmstate.rs
+++ b/majit/majit-metainterp/src/warmstate.rs
@@ -6381,10 +6381,14 @@ mod tests {
     fn a_latched_cell_whose_token_died_is_still_removed_from_the_chain() {
         let mut ws = WarmEnterState::new(2);
         let token_num = ws.alloc_token_number();
+        // Seen once, held no longer. `set_procedure_token` stores only a
+        // weak handle (`_makeref`) and takes no ownership, and this fixture
+        // registers the token with no owner, so the weakref is already dead
+        // when `attach_procedure_to_interp` returns while the SLOT stays
+        // `Some` — which is the state `has_seen_a_procedure_token` reads.
+        // Nulling the slot with `clear_loop_token` would instead erase the
+        // record and make the cell read as "never had a token".
         ws.attach_procedure_to_interp(42, JitCellToken::new(token_num));
-        // Seen once, held no longer: `token` is a historical record and is
-        // never cleared, so `has_seen_a_procedure_token` stays true.
-        ws.clear_loop_token(42);
         for _ in 0..MAX_TRACE_ABORT_COUNT {
             ws.abort_tracing(42, false);
         }
@@ -6416,7 +6420,6 @@ mod tests {
         let key = GreenKey::new(vec![7, 11]);
         let token_num = ws.alloc_token_number();
         ws.attach_procedure_to_interp_for_key(&key, JitCellToken::new(token_num));
-        ws.clear_loop_token_for_key(&key);
         for _ in 0..MAX_TRACE_ABORT_COUNT {
             ws.abort_tracing_for_key(&key, false);
         }


### PR DESCRIPTION
`cargo test` is red on `main` on all three hosts:

```
warmstate::tests::a_latched_cell_whose_token_died_is_still_removed_from_the_chain
warmstate::tests::a_latched_typed_cell_whose_token_died_is_still_removed_from_the_chain
  panicked at warmstate.rs:6392 / :6426
  fixture: the token must be dead, not merely absent
```

Reproduced locally, 2/2, deterministic.

## Two PRs, five minutes apart

`git blame` puts the production line and the test line in different PRs:

| line | commit |
|---|---|
| `has_seen_a_procedure_token` body → `self.loop_token.is_some()` | #1390 `9736f8a9fa5` |
| the two tests and their `clear_loop_token` fixture | #1381 `3bd81e354098` |

#1390 moved the reading from the never-cleared `token: Option<u64>` mirror to
the weakref slot, matching `warmstate.py`'s `has_seen_a_procedure_token`
(`return self.wref_procedure_token is not None`). #1381's fixture builds its
"token is dead" state by calling `clear_loop_token`, which nulls that same
slot — so after #1390 the call also makes `has_seen_a_procedure_token()`
false, and the fixture asserts both.

They merged at 05:54 and 05:59, so neither PR's merge ref contained the other
and neither run could see it.

## The fix

`set_procedure_token` stores only a weak handle (`_makeref`) and takes no
ownership, and neither test registers the token with an owner — so the weakref
is already dead when `attach_procedure_to_interp` returns, while the slot
stays `Some`. That is exactly the state the fixture asserts; the
`clear_loop_token` calls were never needed and now destroy it.

`clear_loop_token`'s own doc already predicted this: "Clearing the SLOT
additionally erases `has_seen_a_procedure_token`, so a `JC_DONT_TRACE_HERE`
cell cleared this way reads as 'never had a token'."

Test-only; no production line changes.

## Verification

`cargo test -p majit-metainterp --no-default-features --features dynasm --lib`
— warmstate 98/98, crate 1608/1608.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MLkGH6Ee8dMtvQqFYU8k5Q