### PR TITLE
majit-macros: drop the empty-green-set expansion report

### DIFF
--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -2934,41 +2934,9 @@ fn rewrite_body(
                     // `parse2` below wants exactly one `Stmt`, and keeping the
                     // original tokens means the error reported is this one
                     // instead of a cascade of unresolved names.
-                    // A missing `greens` key is refused below. An explicit
-                    // `greens = []` remains supported, so the diagnostic also
-                    // explains the degenerate trace shape of that deliberate case.
-                    if self.default_greens.is_empty() {
-                        // This is emitted once per macro expansion because an
-                        // explicitly empty green set cannot provide a resume pc.
-                        let krate = std::env::var("CARGO_PKG_NAME").unwrap_or_else(|_| {
-                            "<crate unknown: CARGO_PKG_NAME unset>".to_string()
-                        });
-                        let site = self
-                            .merge_fn_name
-                            .to_string()
-                            .strip_prefix("__merge_")
-                            .map(str::to_owned)
-                            .unwrap_or_else(|| self.merge_fn_name.to_string());
-                        eprintln!(
-                            "warning: [{}] `fn {}` expands with an empty green set on its \
-                             `#[jit_interp]` attribute. Its merge point (`{}`) reports no \
-                             concrete pc, so the tracing walk never advances and every \
-                             trace attempt re-records one guard triple. Where the \
-                             attempts survive, that reaches `trace_limit * 4/5` and \
-                             ships a segmented trace whose compiled loop runs zero \
-                             iterations; where an arm on the loop's back edge is a \
-                             degraded stub, they abort inside it and nothing compiles \
-                             at all. Both outcomes are degenerate. The remedy is to \
-                             declare the greens the loop is keyed on, e.g. \
-                             `greens = [pc, program]` — that does not by itself make \
-                             the back edge lower, which is separate work. If the emptiness is deliberate and spelled \
-                             `greens = []`, this line is the expected report for it and \
-                             there is nothing to change.",
-                            krate,
-                            site,
-                            quote!(#driver)
-                        );
-                    }
+                    // Only a missing `greens` key is refused. An explicit
+                    // `greens = []` is a supported spelling — the fixtures that
+                    // grade the empty-greens encoding use it — and compiles.
                     let new_tokens = if !self.greens_declared {
                         let driver_name = quote!(#driver).to_string();
                         // State the required metadata rather than enumerating


### PR DESCRIPTION
`#[jit_interp]` printed a per-expansion `eprintln!` whenever `default_greens` was empty. That set is the union of two cases the macro already separates: an omitted `greens` key, which `compile_error!`s a few lines below, and an explicit `greens = []`, which is a supported spelling. In any build that compiles, only the second reaches the print, and the message ended by saying there is nothing to change.

The 25 sites that carry `greens = []` are all fixtures under `majit-metainterp/tests/`; there is no production site. Each CI leg compiles them once, so `cargo test` logged 50 copies of the paragraph per run.

Assisted-by: Claude

<!--
Thank you for contributing to Pyre.

Pyre is still a project that relies heavily on AI-assisted development.

For effective collaboration, please follow these rules.

1. The submitter is ultimately responsible for both the code and the discussion. Do not submit generated code or generated discussion without review.
2. Clearly separate the author's own judgment from generated suggestions. Do not submit generated discussion by itself without the author's own assessment.
-->

## Summary


## Self-review

<!--
Did you use AI to create this patch?
If the patch is not AI-generated, write: "This patch is not AI-generated."
Otherwise, please fill out this section.

Note: Do not run the review in the same session that generated the code.

If you are using Claude, a quick local review is `/parity to upstream/main`.

The currently recommended prompt for gpt-5.5 will be run automatically when this is ready for review.
The prompt is:

----
Assess by static analysis whether our changes in git diff main are equivalent
to the corresponding RPython/PyPy source code. The RPython and PyPy sources
are available locally.

If anything was ported incorrectly, report every instance in detail. After
collecting all differences, organize the report into separate sections:

1. Cases where our patch regressed PyPy parity compared to main
2. Other mismatches introduced by our patch
3. Mismatches that already existed before this patch
4. Structural adaptations

Exceptions: some differences cannot be ported 1:1 because of Python 3.11 vs
3.14 differences, opcode mismatches caused by using a CPython-compatible
compiler, GIL/free-threading differences, and fundamental implementation-
language differences between RPython and Rust. Mark those separately under
“Structural adaptations.”
-->

- [ ] I fully resolved all reasonable code review comments from Codex and CodeRabbit.
  - [ ] Auto-review section 1 is clear. This check is mandatory.
  - [ ] Auto-review section 2 is clear. If this is not checked, please add a comment explaining why.
- One of checkbox below must be checked.
  - [ ] I added `Assisted-by` to commit messages to the commits AI wrote.
  - [ ] I did not use AI to write the code of this patch.

