### PR TITLE
jit-trace: fix the builtin_zip fold's call_kw operand order; gate that a fixture still fires the folds it names

### DIFF
--- a/pyre/bench/synth/divmod_long_int_pair.py
+++ b/pyre/bench/synth/divmod_long_int_pair.py
@@ -1,4 +1,5 @@
 # pyre-check: max-pypy-ratio=4
+# pyre-check: spec-folds=builtin_divmod,builtin_divmod_long_int,binary_op_long_int_div
 # The ceiling sits between the two measured states: folded this runs 1.4x
 # pypy, and with `builtin_divmod` / `binary_op_long_int_div` suppressed
 # about 6.2x.

--- a/pyre/bench/synth/str_getitem_len_hot.py
+++ b/pyre/bench/synth/str_getitem_len_hot.py
@@ -1,4 +1,5 @@
 # pyre-check: max-pypy-ratio=19
+# pyre-check: spec-folds=builtin_len
 # Hot-loop str/unicode subscript and length over every string kind: ASCII /
 # latin1 (1-byte code units), BMP (2-byte), and non-BMP astral (4-byte). The
 # subscripts emit residual STRGETITEM/UNICODEGETITEM and the lengths STRLEN/

--- a/pyre/bench/synth/unspecialized_long_math_zip_paths.cranelift.jitstats
+++ b/pyre/bench/synth/unspecialized_long_math_zip_paths.cranelift.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=808
+guard_failures=1179
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=8

--- a/pyre/bench/synth/unspecialized_long_math_zip_paths.dynasm.jitstats
+++ b/pyre/bench/synth/unspecialized_long_math_zip_paths.dynasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=808
+guard_failures=1179
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=8

--- a/pyre/bench/synth/unspecialized_long_math_zip_paths.py
+++ b/pyre/bench/synth/unspecialized_long_math_zip_paths.py
@@ -1,4 +1,5 @@
 # pyre-check: max-pypy-ratio=6
+# pyre-check: spec-folds=builtin_zip,zip_two_tuple_iters,compare_op_long_int,truediv_op_long,binary_op_long_int_pow,binary_op_long_int_shift,math_frexp,math_ldexp
 # The throughput gate for eight hand-written trace-time folds that no other
 # fixture makes fire: `zip` over two tuples (positional and `strict=True`), a
 # long/int comparison, a two-bigint true-divide, `bigint ** int`,
@@ -10,6 +11,15 @@
 # how these eight were once retired as dead -- so this ceiling is the only
 # thing here that can. Loosen it rather than shrink the loops if a slower host
 # proves it flaky.
+#
+# Which folds a leg fires is a census question, not a reading of the source:
+# `PYRE_FBW_SPEC_CENSUS=1` prints `fold=<label> consulted=N fired=N` per label.
+# This fixture claimed eight and delivered seven for as long as `builtin_zip`
+# read its `call_kw` operands in the wrong order -- consulted once per run and
+# declined every time, so the leg written for it gated nothing and the ceiling
+# below was fitted without it. Read the census, not the leg names, before
+# trusting the coverage claim above; the `zip_strict` sensitivity quoted in the
+# next paragraph predates that fix.
 #
 # The legs are sized per leg, not uniformly, because sensitivity and cost run
 # opposite here: measured at a common 1M iterations, the folds worth the most

--- a/pyre/bench/synth/unspecialized_long_math_zip_paths.wasm.jitstats
+++ b/pyre/bench/synth/unspecialized_long_math_zip_paths.wasm.jitstats
@@ -1,4 +1,4 @@
-bridges_compiled=4
+bridges_compiled=5
 descr_set_absent=0
 descr_set_ambiguous=0
 descr_set_stale_absent=0
@@ -8,7 +8,7 @@ fbw_rolled_back_with_effects=0
 fbw_store_journal_rollback_failed=0
 field_pos_attached_misplaced=0
 field_pos_spec_misplaced=0
-guard_failures=808
+guard_failures=1179
 internal_compile_panics=0
 loops_aborted=0
 loops_compiled=8

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -1769,6 +1769,61 @@ def synth_ungated_jitstats(path):
     )
 
 
+def synth_spec_folds(path):
+    """Read an optional list of trace-time folds a fixture must make fire:
+        # pyre-check: spec-folds=builtin_zip,zip_two_tuple_iters
+
+    A throughput ceiling cannot gate one fold out of several. The legs of a
+    multi-fold fixture sum into one number, so retiring the least valuable one
+    moves that number by less than the span the same fixture reads across the
+    runners (`PERF_GATE_FLOOR_DIVISOR` records how wide that is). A jit-stats
+    baseline covers only part of the set: of the eight folds
+    `unspecialized_long_math_zip_paths` names, suppressing either zip fold
+    moves `bridges_compiled` and `guard_failures`, and suppressing any of the
+    other six alone moves no gated counter at all.
+
+    So this gates coverage instead, which is exact and the same on every host:
+    each named fold has to fire at least once. That is the failure the other
+    two instruments are blind to -- a fold that stops firing reads exactly
+    like a fold nobody wrote a leg for, and `builtin_zip` sat at `fired=0` in
+    the fixture written to gate it for as long as it read its `call_kw`
+    operands in the wrong order.
+
+    It does not claim the folds are worth their code; it claims the fixture
+    still reaches them. Pair it with the ceiling, which gates the sum.
+    """
+    found = _header_directive(path, "# pyre-check: spec-folds=")
+    if found is None:
+        return ()
+    raw, line = found
+    names = tuple(n for n in (part.strip() for part in raw.split(",")) if n)
+    if not names:
+        raise ValueError(f"empty fold list in {path}: {line.strip()}")
+    repeated = sorted({n for n in names if names.count(n) > 1})
+    if repeated:
+        raise ValueError(f"repeated fold label(s) {repeated} in {path}: {line.strip()}")
+    return names
+
+
+# `[spec-census] fold=<label> consulted=N fired=N suppressed=N site=... parent=...`
+SPEC_CENSUS_FOLD_RE = re.compile(r"^\[spec-census\] fold=(\S+) .*?\bfired=(\d+)\b", re.M)
+
+
+def spec_fold_census(binary, path, timeout_s):
+    """`({label: fired}, returncode)` for every fold the run registered.
+
+    The binary owns the label set, so a declared name absent from this map is
+    a typo rather than a fold that stayed quiet, and the caller reports the
+    two differently.
+    """
+    env = pyre_env()
+    env["PYRE_FBW_SPEC_CENSUS"] = "1"
+    _, _, code, err = run_timed([binary, path], timeout_s=timeout_s, env=env)
+    if code != 0:
+        return None, code
+    return {m.group(1): int(m.group(2)) for m in SPEC_CENSUS_FOLD_RE.finditer(err)}, 0
+
+
 def default_binary(backend):
     name = CARGO_CONFIG[backend]["bin"]
     return f"./target/release/{name}{EXE}"
@@ -3315,6 +3370,44 @@ class Check:
 
     # ── synthetic parity suite ──
 
+    def _check_spec_folds(self, name, path, spec_folds, timeout, t_cpython, t_pypy):
+        """True if every fold the fixture declares fired; else record and report.
+
+        The census reads the same on every backend that shares the trace
+        walker, so this runs once on a native backend rather than per backend.
+        A wasm-only run has no walker to census and says so instead of passing
+        quietly, which would make the gate vacuous exactly where it is not run.
+        """
+        sys.stdout.write(f"    {'folds':<10s}")
+        sys.stdout.flush()
+        backend = next(
+            (b for b in ALL_BACKENDS if self.enabled(b) and b != "wasm"), None
+        )
+        if backend is None:
+            print(dim("skip (no native backend enabled)"))
+            return True
+        census, code = spec_fold_census(default_binary(backend), path, timeout)
+        if census is None:
+            detail = f"spec-folds census run failed (exit {code})"
+            print(f"{red('FAIL')}  {detail}")
+        else:
+            unknown = [f for f in spec_folds if f not in census]
+            quiet = [f for f in spec_folds if census.get(f) == 0]
+            if unknown:
+                detail = f"unknown fold label(s): {', '.join(unknown)}"
+                print(f"{red('FAIL')}  {detail}")
+            elif quiet:
+                detail = f"declared fold(s) never fired: {', '.join(quiet)}"
+                print(f"{red('FAIL')}  {detail}")
+            else:
+                print(f"{dim('done')}  {len(spec_folds)} fired")
+                return True
+        for b in ALL_BACKENDS:
+            if self.enabled(b):
+                self._record(b, False, name, detail)
+                self._append_comparison(b, name, t_cpython, t_pypy, "FAIL")
+        return False
+
     def run_synthetic_bench(self, path, timeout):
         name = f"synth/{Path(path).stem}"
         effective_timeout = scaled_timeout(timeout, self.args.timeout_scale)
@@ -3324,6 +3417,7 @@ class Check:
             skip_backends = synth_skip_backends(path)
             skip_cpython = synth_skip_cpython(path)
             no_cpython = synth_no_cpython(path)
+            spec_folds = synth_spec_folds(path)
         except ValueError as e:
             print(f"{red('ERROR')}: {e}")
             sys.exit(1)
@@ -3394,6 +3488,11 @@ class Check:
                     self._append_comparison(
                         backend, name, t_cpython, t_pypy, "BASEFAIL",
                     )
+            return
+
+        if spec_folds and not self._check_spec_folds(
+            name, path, spec_folds, effective_timeout, t_cpython, t_pypy,
+        ):
             return
 
         for backend in ALL_BACKENDS:

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -7646,27 +7646,44 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     r_args: &[OpRef],
     dst: usize,
 ) -> Result<Option<()>, DispatchError> {
-    // CALL_KW keeps the keyword-name tuple after all argument values:
-    // [callable, null_or_self, p, q, strict, kwnames].
+    // A `call_kw` residual leads with its keyword-name tuple rather than
+    // trailing it: `[callable, self_or_null, kwnames, arg0..argN-1]`, the
+    // order `eval.rs call_kw` pushes and `fold_call_kw_permutation` reads.
+    // So `zip(p, q, strict=True)` arrives as
+    // [zip, self_or_null, ("strict",), p, q, True].
     if r_args.len() != 6 {
         return Ok(None);
     }
     let arg_concretes = read_ref_var_list_concrete(code, op, 1, ctx);
     let [
         ConcreteValue::Ref(callable),
-        ConcreteValue::Ref(null_or_self),
+        self_or_null,
+        ConcreteValue::Ref(kwnames),
         ConcreteValue::Ref(tuple0),
         ConcreteValue::Ref(tuple1),
         ConcreteValue::Ref(strict),
-        ConcreteValue::Ref(kwnames),
     ] = arg_concretes.as_slice()
     else {
         return Ok(None);
     };
+    // The receiver slot has two spellings for the same "no bound receiver".
+    // A keyword call lowers it to a const `PY_NULL` (`ConstPtr(GcRef(0))`),
+    // whose concrete shadow is `ConcreteValue::Null` because constant pool
+    // slots carry no `Ref` shadow; a positional call takes the slot off the
+    // value stack, where it reads `Ref(null)`.  Only the first reaches here,
+    // since `strict=` is what brings this fold in at all.
+    let self_is_null = match self_or_null {
+        ConcreteValue::Ref(p) => p.is_null(),
+        ConcreteValue::Null => matches!(
+            ctx.trace_ctx.box_value(r_args[1]),
+            Some(majit_ir::Value::Ref(majit_ir::GcRef(0)))
+        ),
+        _ => false,
+    };
     let zip_callable = pyre_interpreter::typedef::gettypeobject(&pyre_object::functional::ZIP_TYPE);
     if callable.is_null()
         || !std::ptr::eq(*callable, zip_callable)
-        || !null_or_self.is_null()
+        || !self_is_null
         || kwnames.is_null()
         || unsafe { !pyre_object::is_tuple(*kwnames) }
         || unsafe { pyre_object::w_tuple_len(*kwnames) } != 1
@@ -7729,7 +7746,7 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
     let zip_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
 
     walker_guard_builtin_callable_identity(ctx, op.pc, r_args[0], *callable)?;
-    for (arg_op, concrete) in [(r_args[5], *kwnames), (r_args[4], *strict)] {
+    for (arg_op, concrete) in [(r_args[2], *kwnames), (r_args[5], *strict)] {
         if !arg_op.is_constant() {
             let expected = ctx.trace_ctx.const_ref(concrete as i64);
             walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[arg_op, expected])?;
@@ -7739,7 +7756,7 @@ pub(crate) fn try_walker_specialize_builtin_zip<Sym: WalkSym>(
 
     let zero = ctx.trace_ctx.const_int(0);
     let mut iterator_ops = Vec::with_capacity(2);
-    for (tuple_op, concrete_slot) in [(r_args[2], iter0_slot), (r_args[3], iter1_slot)] {
+    for (tuple_op, concrete_slot) in [(r_args[3], iter0_slot), (r_args[4], iter1_slot)] {
         walker_guard_class(ctx, op.pc, tuple_op, tuple_type as i64)?;
         walker_guard_exact_w_class(ctx, op.pc, tuple_op, tuple_class)?;
         let iterator = ctx.trace_ctx.record_op_with_descr(


### PR DESCRIPTION
Two commits: a specialization fold that could never fire, and the gate that would have caught it.

## `builtin_zip` had never fired

`try_walker_specialize_builtin_zip` read a `call_kw` residual's operands as
`[callable, self_or_null, p, q, strict, kwnames]`. A `call_kw` residual leads with the
keyword-name tuple instead — `[callable, self_or_null, kwnames, arg0..argN-1]` — the order
`fold_call_kw_permutation` reads. Three layers were wrong, and each had to be fixed:

| layer | symptom |
|---|---|
| the destructure | `tuple0` named the kwnames tuple, `strict` named the second operand tuple |
| the receiver slot | required `ConcreteValue::Ref(null)`, but a keyword call lowers the slot to a const `PY_NULL` whose shadow is `ConcreteValue::Null` — this alone declined every input |
| the guard emission | `r_args` indices still positional, so the two iterators were built over the wrong sequences |

Fixing only the first two makes the fold *fire and compute the wrong answer*, which is what the
census showed while that intermediate state was in the tree.

`PYRE_FBW_SPEC_CENSUS=1` recorded `fired=0` for this fold on every shape tried — hoisted,
in-loop, sliced, and runtime-built operands — including in the fixture that names it. Output now
matches cpython and pypy on those shapes plus `strict=False`, a list operand, empty operands,
`list(zip(...))`, and the uneven-length `strict=True` `ValueError` message.

`bridges_compiled` 4 → 5 and `guard_failures` 808 → 1179, identically on all three backends, is
the fold's guards entering the trace; the baselines are re-recorded to that.

## `# pyre-check: spec-folds=<labels>`

This closes the two Codex P2 comments from #1384, though not in the form they asked for. A
per-fold *throughput* gate is not expressible here:

- Equalising leg contribution across a multi-fold fixture puts the per-fold detection margin at
  about **1.07x**, against a runner-to-runner span the harness itself documents at `PERF_GATE_FLOOR_DIVISOR`
  (one fixture reading 1.0x and 17.8x).
- A jit-stats baseline covers only part of the set: of the eight folds
  `unspecialized_long_math_zip_paths` names, suppressing any of **six** alone moves no gated counter.

So the directive gates *coverage*, which is exact and host-independent: each named fold has to
fire at least once. A label the census does not list is reported as an unknown label rather than
as a quiet fold, so a typo cannot read as coverage.

Declared on the three fixtures that exist to gate folds, naming what each header already says it
gates. **Acceptance criterion from #1384, met:** suppressing any one of the twelve labels alone
turns its fixture red and names that fold — no misses, no false positives.

## Verification

- `pyre/check.py`: the three fixtures pass on dynasm / cranelift / wasm, with the `folds` gate
  reading 8 / 1 / 3 fired.
- `cargo test --all --no-default-features --features dynasm,cpyext` (the CI invocation): 164
  suites, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019gCeUzbGWCK8S6vqnXh416
