### PR TITLE
_abc: weak-set membership without the app-level frame

### DIFF
--- a/pyre/bench/synth/abc_instancecheck_weak_cache.cranelift.jitstats
+++ b/pyre/bench/synth/abc_instancecheck_weak_cache.cranelift.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=202
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/abc_instancecheck_weak_cache.dynasm.jitstats
+++ b/pyre/bench/synth/abc_instancecheck_weak_cache.dynasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=202
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/abc_instancecheck_weak_cache.py
+++ b/pyre/bench/synth/abc_instancecheck_weak_cache.py
@@ -1,0 +1,84 @@
+# pyre-check: max-pypy-ratio=40
+# `_abc_instancecheck` answers from two per-class weak-set caches, and a
+# question that hits one is meant to cost the probe and nothing else.  This
+# drives both answers in a hot loop: a class that matches (positive cache) and
+# one that never will (negative cache), plus the stdlib `collections.abc`
+# checks, whose caches are shared with everything else that asks them.
+#
+# A `register` partway through discards every negative cache by bumping the
+# invalidation counter, so the second half re-walks and refills rather than
+# reading the entries the first half recorded.  Deterministic.
+import collections.abc as cabc
+from abc import ABCMeta
+
+
+class Shape(metaclass=ABCMeta):
+    pass
+
+
+class Circle(Shape):
+    pass
+
+
+class Square(Shape):
+    pass
+
+
+class Blob:
+    pass
+
+
+class LateBlob:
+    pass
+
+
+N = 72000
+SWITCH = N // 2
+
+
+def main():
+    circle = Circle()
+    square = Square()
+    blob = Blob()
+    late = LateBlob()
+    seq = [1, 2, 3]
+    mapping = {"k": 1}
+    hits = 0
+    misses = 0
+    for i in range(N):
+        # Positive cache: two classes so the probe is not answered by a single
+        # resident entry.
+        if isinstance(circle, Shape):
+            hits += 1
+        if isinstance(square, Shape):
+            hits += 1
+        # Negative cache, and the class the mid-loop `register` moves across.
+        if isinstance(blob, Shape):
+            hits += 1
+        else:
+            misses += 1
+        if isinstance(late, Shape):
+            hits += 1
+        else:
+            misses += 1
+        # The stdlib ABCs, asked against a matching and a non-matching type.
+        if isinstance(seq, cabc.Sequence):
+            hits += 1
+        if isinstance(mapping, cabc.Mapping):
+            hits += 1
+        if isinstance(seq, cabc.Mapping):
+            hits += 1
+        else:
+            misses += 1
+        if i == SWITCH:
+            Shape.register(LateBlob)
+    return hits, misses
+
+
+hits, misses = main()
+# `late` misses until the registration and hits after it; `blob` never hits.
+expected_hits = N * 4 + (N - SWITCH - 1)
+expected_misses = N * 2 + (SWITCH + 1)
+assert hits == expected_hits, "hits %r != %r" % (hits, expected_hits)
+assert misses == expected_misses, "misses %r != %r" % (misses, expected_misses)
+print(hits, misses)

--- a/pyre/bench/synth/abc_instancecheck_weak_cache.wasm.jitstats
+++ b/pyre/bench/synth/abc_instancecheck_weak_cache.wasm.jitstats
@@ -1,0 +1,15 @@
+bridges_compiled=1
+descr_set_absent=0
+descr_set_ambiguous=0
+descr_set_stale_absent=0
+fbw_blackhole_adopted_multi_frame=0
+fbw_blackhole_adopted_single_frame=0
+fbw_rolled_back_with_effects=0
+fbw_store_journal_rollback_failed=0
+field_pos_attached_misplaced=0
+field_pos_spec_misplaced=0
+guard_failures=202
+internal_compile_panics=0
+loops_aborted=0
+loops_compiled=1
+retraces_compiled=0

--- a/pyre/bench/synth/inline_freevar_after_mayforce.cranelift.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.cranelift.jitstats
@@ -11,5 +11,5 @@ field_pos_spec_misplaced=0
 guard_failures=1008
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=7
 retraces_compiled=0

--- a/pyre/bench/synth/inline_freevar_after_mayforce.dynasm.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.dynasm.jitstats
@@ -11,5 +11,5 @@ field_pos_spec_misplaced=0
 guard_failures=1004
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=7
 retraces_compiled=0

--- a/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
+++ b/pyre/bench/synth/inline_freevar_after_mayforce.wasm.jitstats
@@ -11,5 +11,5 @@ field_pos_spec_misplaced=0
 guard_failures=1004
 internal_compile_panics=0
 loops_aborted=0
-loops_compiled=6
+loops_compiled=7
 retraces_compiled=0

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -231,6 +231,60 @@ def a_mutated_contains_body_is_consulted():
         collection.__contains__.__code__ = original
 
 
+def a_non_function_contains_declines():
+    class Guarded(metaclass=ABCMeta):
+        pass
+
+    class Impl(Guarded):
+        pass
+
+    assert isinstance(Impl(), Guarded) is True
+
+    collection = type(Guarded._abc_cache)
+    original = collection.__contains__
+
+    class Descriptor:
+        def __get__(self, obj, objtype=None):
+            return lambda item: True
+
+    # Not a function at all.  Reading the code object off the installed method
+    # is only defined for a function, so the shortcut has to reject this before
+    # the read rather than by comparing whatever the read returned.
+    collection.__contains__ = Descriptor()
+    try:
+        assert isinstance(Plain(), Guarded) is True, 'a non-function __contains__ was read past'
+    finally:
+        collection.__contains__ = original
+
+
+def a_mutated_ref_global_is_consulted():
+    class Watched(metaclass=ABCMeta):
+        pass
+
+    class Impl(Watched):
+        pass
+
+    assert isinstance(Impl(), Watched) is True
+
+    collection = type(Watched._abc_cache)
+    namespace = collection.__contains__.__globals__
+    original = namespace['ref']
+    calls = []
+
+    def watching_ref(item, *rest):
+        calls.append(item)
+        return original(item, *rest)
+
+    # `ref` is the whole free-variable surface of the app-level body, and
+    # rebinding it moves neither the method nor its code object.
+    namespace['ref'] = watching_ref
+    try:
+        isinstance(Impl(), Watched)
+        assert calls, 'the rebound `ref` global was not consulted'
+    finally:
+        namespace['ref'] = original
+
+
 empty_collection_answers_then_fills()
 unweakreferenceable_class_reaches_the_subclass_check()
 a_raising_hash_runs_once()
@@ -241,4 +295,6 @@ if hasattr(ABCMeta('_Probe', (), {}), '_abc_cache'):
     replaced_data_is_consulted()
     a_data_subclass_keeps_its_override()
     a_mutated_contains_body_is_consulted()
+    a_non_function_contains_declines()
+    a_mutated_ref_global_is_consulted()
 print('OK')

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -1,21 +1,22 @@
 # CPython-suite gap: `test_abc` asks membership only through classes whose
-# caches it never inspects, so it covers neither the empty-collection answer
-# nor an item that cannot carry a weakref, and it cannot cover a replaced
-# collection at all -- the reference build keeps the three collections in the
-# type's own struct, so there is no attribute there to rebind.
+# caches it never inspects, so it covers neither the empty-collection answer,
+# nor an item that cannot carry a weakref, nor a class whose hash raises, and
+# it cannot cover a replaced collection at all -- the reference build keeps the
+# three collections in the type's own struct, so there is no attribute there to
+# rebind.
 #
 # `_abc_instancecheck` answers membership without entering
 # `SimpleWeakSet.__contains__`, which is sound only while the receiver really
-# is the collection `_abc_init` installed.  A rebound cache, or one whose
-# `data` is no longer a set, must take the membership protocol and answer
-# whatever the replacement spells.
+# is the collection `_abc_init` installed and its `data` really is a `set`.
+# Anything else must take the membership protocol and answer whatever the
+# replacement spells -- including a subclass whose `__contains__` lies.
 #
-# parity-tests reason: every arm is a silent wrong answer rather than a crash.
-# An empty collection that answered "present", or a replaced one read as if it
-# were still the original, reports a class as registered when it is not, and
-# nothing downstream would notice.
+# parity-tests reason: every arm is a silent wrong answer or a doubled side
+# effect rather than a crash.  A collection read past its own override reports
+# a class as registered when it is not, and a probe that answers and then
+# re-asks evaluates an observable `__hash__` twice.
 #
-# The last two arms name a collection this implementation spells as a class
+# The last three arms name a collection this implementation spells as a class
 # attribute; where it is not spellable there is nothing to replace and the arm
 # does not apply.
 import _abc
@@ -26,6 +27,9 @@ from abc import ABCMeta
 
 class Plain:
     pass
+
+
+calls = []
 
 
 def empty_collection_answers_then_fills():
@@ -65,6 +69,42 @@ def unweakreferenceable_class_reaches_the_subclass_check():
         else:
             raise AssertionError('a non-class __class__ must reach the check')
         assert isinstance(Impl(), Target) is True
+
+
+def a_raising_hash_runs_once():
+    class Boom(type):
+        def __hash__(cls):
+            calls.append(cls)
+            raise ValueError('boom')
+
+    class Fused(ABCMeta, Boom):
+        pass
+
+    class Warm(metaclass=ABCMeta):
+        pass
+
+    class Member(Warm):
+        pass
+
+    class Unhashable(metaclass=Fused):
+        pass
+
+    class Claims:
+        __class__ = Unhashable
+
+    # A populated collection, so the probe is really built and really hashed.
+    assert isinstance(Member(), Warm) is True
+    del calls[:]
+    try:
+        isinstance(Claims(), Warm)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('the raising hash was swallowed')
+    # The membership expression evaluates the hash once.  Answering the probe
+    # and then re-asking through the protocol would evaluate it twice, which is
+    # observable here and in any hash carrying a side effect.
+    assert len(calls) == 1, 'hash ran %d times' % (len(calls),)
 
 
 def a_collected_entry_stops_matching():
@@ -120,10 +160,28 @@ def replaced_data_is_consulted():
     assert isinstance(obj, Swapped) is True, 'a replaced data must still answer'
 
 
+def a_data_subclass_keeps_its_override():
+    class Shadowed(metaclass=ABCMeta):
+        pass
+
+    class Lying(set):
+        def __contains__(self, item):
+            return True
+
+    # An empty table whose `__contains__` claims every member.  Reading the
+    # table would answer False; the override answers True, and the override is
+    # what the membership protocol reaches -- a subclass keeps the base layout,
+    # so a layout test alone does not tell the two apart.
+    Shadowed._abc_cache.data = Lying()
+    assert isinstance(Plain(), Shadowed) is True, 'a data subclass was read past'
+
+
 empty_collection_answers_then_fills()
 unweakreferenceable_class_reaches_the_subclass_check()
+a_raising_hash_runs_once()
 a_collected_entry_stops_matching()
 if hasattr(ABCMeta('_Probe', (), {}), '_abc_cache'):
     rebound_collection_is_consulted()
     replaced_data_is_consulted()
+    a_data_subclass_keeps_its_override()
 print('OK')

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -107,6 +107,36 @@ def a_raising_hash_runs_once():
     assert len(calls) == 1, 'hash ran %d times' % (len(calls),)
 
 
+def a_raising_hash_names_a_set_element():
+    class Unhashable(ABCMeta):
+        __hash__ = None
+
+    class Warm(metaclass=ABCMeta):
+        pass
+
+    class Member(Warm):
+        pass
+
+    class Refuses(metaclass=Unhashable):
+        pass
+
+    class Claims:
+        __class__ = Refuses
+
+    # A populated collection, so the probe is really built and really hashed.
+    assert isinstance(Member(), Warm) is True
+    try:
+        isinstance(Claims(), Warm)
+    except TypeError as exc:
+        message = str(exc)
+    else:
+        raise AssertionError('an unhashable class was accepted')
+    # The collection is a set and the failure names the operand as one.  The
+    # dict spelling of the same recovery renames it, which is what a reader of
+    # the message sees.
+    assert 'as a set element' in message, message
+
+
 def a_collected_entry_stops_matching():
     class Held(metaclass=ABCMeta):
         pass
@@ -176,12 +206,39 @@ def a_data_subclass_keeps_its_override():
     assert isinstance(Plain(), Shadowed) is True, 'a data subclass was read past'
 
 
+def a_mutated_contains_body_is_consulted():
+    class Mutated(metaclass=ABCMeta):
+        pass
+
+    class Impl(Mutated):
+        pass
+
+    assert isinstance(Impl(), Mutated) is True
+
+    collection = type(Mutated._abc_cache)
+    original = collection.__contains__.__code__
+
+    def claims_everything(self, item):
+        return True
+
+    # Assigning `__code__` leaves the same function installed on the same
+    # class, so an identity test over the method alone still matches while the
+    # body it runs no longer does.
+    collection.__contains__.__code__ = claims_everything.__code__
+    try:
+        assert isinstance(Plain(), Mutated) is True, 'the mutated body was read past'
+    finally:
+        collection.__contains__.__code__ = original
+
+
 empty_collection_answers_then_fills()
 unweakreferenceable_class_reaches_the_subclass_check()
 a_raising_hash_runs_once()
+a_raising_hash_names_a_set_element()
 a_collected_entry_stops_matching()
 if hasattr(ABCMeta('_Probe', (), {}), '_abc_cache'):
     rebound_collection_is_consulted()
     replaced_data_is_consulted()
     a_data_subclass_keeps_its_override()
+    a_mutated_contains_body_is_consulted()
 print('OK')

--- a/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
+++ b/pyre/extra_tests/parity_tests/abc_weak_cache_membership.py
@@ -1,0 +1,129 @@
+# CPython-suite gap: `test_abc` asks membership only through classes whose
+# caches it never inspects, so it covers neither the empty-collection answer
+# nor an item that cannot carry a weakref, and it cannot cover a replaced
+# collection at all -- the reference build keeps the three collections in the
+# type's own struct, so there is no attribute there to rebind.
+#
+# `_abc_instancecheck` answers membership without entering
+# `SimpleWeakSet.__contains__`, which is sound only while the receiver really
+# is the collection `_abc_init` installed.  A rebound cache, or one whose
+# `data` is no longer a set, must take the membership protocol and answer
+# whatever the replacement spells.
+#
+# parity-tests reason: every arm is a silent wrong answer rather than a crash.
+# An empty collection that answered "present", or a replaced one read as if it
+# were still the original, reports a class as registered when it is not, and
+# nothing downstream would notice.
+#
+# The last two arms name a collection this implementation spells as a class
+# attribute; where it is not spellable there is nothing to replace and the arm
+# does not apply.
+import _abc
+import gc
+import weakref
+from abc import ABCMeta
+
+
+class Plain:
+    pass
+
+
+def empty_collection_answers_then_fills():
+    class Fresh(metaclass=ABCMeta):
+        pass
+
+    class Late(Fresh):
+        pass
+
+    obj = Late()
+    # The first question is asked against an empty collection, which holds no
+    # entry to match; the same question after the walk recorded one must flip.
+    assert isinstance(Plain(), Fresh) is False
+    assert isinstance(obj, Fresh) is True
+    assert isinstance(obj, Fresh) is True, 'the recorded entry was not found'
+
+
+def unweakreferenceable_class_reaches_the_subclass_check():
+    class Target(metaclass=ABCMeta):
+        pass
+
+    class Impl(Target):
+        pass
+
+    class Claims:
+        __class__ = 3
+
+    # An empty collection and a populated one reach the probe differently, and
+    # neither may turn the missing weakref into an answer of its own: the
+    # membership tests report "absent" and the subclass check that follows is
+    # what raises.
+    for _ in range(2):
+        try:
+            isinstance(Claims(), Target)
+        except TypeError:
+            pass
+        else:
+            raise AssertionError('a non-class __class__ must reach the check')
+        assert isinstance(Impl(), Target) is True
+
+
+def a_collected_entry_stops_matching():
+    class Held(metaclass=ABCMeta):
+        pass
+
+    class Doomed(Held):
+        pass
+
+    assert isinstance(Doomed(), Held) is True
+    entries = _abc._get_dump(Held)[1]
+    assert len(entries) == 1, 'the hit was not recorded: %r' % (entries,)
+    del Doomed
+    gc.collect()
+    live = [ref for ref in _abc._get_dump(Held)[1] if ref() is not None]
+    assert not live, 'a dead entry stayed in the cache: %r' % (live,)
+
+
+def rebound_collection_is_consulted():
+    class Asked(metaclass=ABCMeta):
+        pass
+
+    class Liar:
+        def __init__(self):
+            self.asked = []
+
+        def __contains__(self, item):
+            self.asked.append(item)
+            return True
+
+        def add(self, item):
+            raise AssertionError('a hit records nothing')
+
+    cache = Liar()
+    Asked._abc_cache = cache
+    assert isinstance(Plain(), Asked) is True, 'the replacement was bypassed'
+    assert cache.asked, 'the replacement was never asked'
+
+
+def replaced_data_is_consulted():
+    class Swapped(metaclass=ABCMeta):
+        pass
+
+    class Impl(Swapped):
+        pass
+
+    obj = Impl()
+    assert isinstance(obj, Swapped) is True
+    # A list answers `in` by a linear scan rather than by a hashed probe, and a
+    # callback-less weakref compares equal to the callback-carrying one the hit
+    # above stored, so the entry is still found -- by the other route.
+    Swapped._abc_cache.data = [weakref.ref(Impl)]
+    assert isinstance(obj, Swapped) is True, 'a replaced data must still answer'
+
+
+empty_collection_answers_then_fills()
+unweakreferenceable_class_reaches_the_subclass_check()
+a_collected_entry_stops_matching()
+if hasattr(ABCMeta('_Probe', (), {}), '_abc_cache'):
+    rebound_collection_is_consulted()
+    replaced_data_is_consulted()
+print('OK')

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -126,6 +126,27 @@ pub fn clear_method_cache() {
 /// through unchanged.
 #[majit_macros::dont_look_inside]
 pub fn take_pending_dict_key_error(key: PyObjectRef) -> PyError {
+    take_pending_hash_error_for(key, wrap_dict_key_hash_error)
+}
+
+/// The set-element counterpart, for a caller that reached the shared hash
+/// table through a set.  The two containers name the operand differently in
+/// the message they raise, so a set caller taking the dict recovery reports a
+/// dict key for an element that never was one.
+#[majit_macros::dont_look_inside]
+pub fn take_pending_set_element_error(item: PyObjectRef) -> PyError {
+    take_pending_hash_error_for(item, wrap_set_element_hash_error)
+}
+
+/// Recover the exception a failed hash left pending and give it the calling
+/// container's context.  [`take_pending_hash_error`] is the same recovery
+/// without the context, for a caller with no operand to name.  An error from
+/// anywhere but the hash is returned as raised: only hashing is what the
+/// wrappers describe.
+fn take_pending_hash_error_for(
+    subject: PyObjectRef,
+    wrap: fn(PyObjectRef, PyError) -> PyError,
+) -> PyError {
     let from_hash = PENDING_ERROR_FROM_HASH.with(|cell| cell.replace(false));
     let err = PENDING_HASH_ERROR.with(|cell| {
         cell.take()
@@ -134,7 +155,7 @@ pub fn take_pending_dict_key_error(key: PyObjectRef) -> PyError {
     if !from_hash {
         return err;
     }
-    wrap_dict_key_hash_error(key, err)
+    wrap(subject, err)
 }
 
 /// The direct-hash counterpart of [`take_pending_dict_key_error`], used by

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -30,11 +30,31 @@ fn simple_weak_set_type() -> PyObjectRef {
         .expect("_abc.SimpleWeakSet must be installed at module init") as PyObjectRef
 }
 
-/// The `__contains__` `app_abc.py` defines, stashed beside its type.  The
-/// class is an ordinary heap type, so the method is rebindable, and answering
-/// natively is only sound while the one installed here is still the one a
-/// membership test would reach.
-static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+/// The `__contains__` `app_abc.py` defines and the code object it was defined
+/// with, stashed beside its type.  The class is an ordinary heap type, so the
+/// method is rebindable and the function it holds is mutable in place;
+/// answering natively is only sound while the body a membership test would
+/// reach is still the one written in `app_abc.py`.
+///
+/// The pair is what a rebind and a `__code__` assignment respectively move.  A
+/// function has further mutable state that neither covers — its globals, its
+/// defaults — so this narrows the native answer to the untouched collection
+/// rather than proving the app-level body could not have been redirected.
+static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<(usize, usize)> = std::sync::OnceLock::new();
+
+/// The installed `__contains__` and the code object it currently holds, as the
+/// pair [`SIMPLE_WEAK_SET_CONTAINS`] stores.  A missing method reads as
+/// `(0, 0)`, which no stash can equal.
+fn simple_weak_set_contains_identity() -> (usize, usize) {
+    let Some(method) =
+        (unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set_type(), "__contains__") })
+    else {
+        return (0, 0);
+    };
+    (method as usize, unsafe {
+        crate::function_get_code(method) as usize
+    })
+}
 
 /// `SimpleWeakSet()` — the empty collection `_abc_init` installs and the
 /// invalidation in `subclass_of` rebinds to.
@@ -82,12 +102,13 @@ fn simple_weak_set_contains(
         return Ok(None);
     }
     // The receiver being that class is not enough: rebinding the class's own
-    // `__contains__` leaves every instance an exact `SimpleWeakSet` while
-    // changing what a membership test answers.
-    let installed = SIMPLE_WEAK_SET_CONTAINS.get().copied().unwrap_or(0);
-    let current =
-        unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set_type(), "__contains__") };
-    if installed == 0 || current.map_or(0, |m| m as usize) != installed {
+    // `__contains__`, or assigning that function a different `__code__`, leaves
+    // every instance an exact `SimpleWeakSet` while changing what a membership
+    // test answers.
+    let Some(&installed) = SIMPLE_WEAK_SET_CONTAINS.get() else {
+        return Ok(None);
+    };
+    if simple_weak_set_contains_identity() != installed {
         return Ok(None);
     }
     let roots = pyre_object::gc_roots::push_roots();
@@ -132,8 +153,9 @@ fn simple_weak_set_contains(
         // raises arrives here.  Recover that exception rather than declining:
         // the protocol would build a second probe and run the same observable
         // `__hash__` again before raising, and the expression it stands in for
-        // runs it once.
-        Err(_) => Err(crate::baseobjspace::take_pending_dict_key_error(
+        // runs it once.  `wr in self.data` is a set membership test, so the
+        // recovered error names a set element.
+        Err(_) => Err(crate::baseobjspace::take_pending_set_element_error(
             roots.get(probe_slot),
         )),
     }
@@ -681,10 +703,9 @@ crate::py_module! {
         let simple_weak_set = crate::module_ns_get(ns, "SimpleWeakSet")
             .expect("_abc.SimpleWeakSet must be installed by appleveldefs");
         let _ = SIMPLE_WEAK_SET_TYPE.set(simple_weak_set as usize);
-        if let Some(contains) =
-            unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set, "__contains__") }
-        {
-            let _ = SIMPLE_WEAK_SET_CONTAINS.set(contains as usize);
+        let installed = simple_weak_set_contains_identity();
+        if installed != (0, 0) {
+            let _ = SIMPLE_WEAK_SET_CONTAINS.set(installed);
         }
     },
 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -50,7 +50,69 @@ fn weak_cache_contains(
     let item_slot = roots.publish(&[item]);
     let cache = cache_attr(roots.get(cls_slot), name)?;
     let cache_slot = roots.publish(&[cache]);
+    if let Some(found) = simple_weak_set_contains(roots.get(cache_slot), roots.get(item_slot))? {
+        return Ok(found);
+    }
     crate::baseobjspace::contains(roots.get(cache_slot), roots.get(item_slot))
+}
+
+/// `app_abc.py SimpleWeakSet.__contains__` without the app-level frame,
+/// for the collection `_abc_init` installed and nothing has replaced.
+///
+/// `None` means the receiver is not that collection — a rebound `_abc_cache`, or
+/// one whose `data` is no longer a set — so the caller takes the membership
+/// protocol and whatever the replacement spells.
+///
+/// `_abc_instancecheck` runs this once on a hit and twice on a miss, and the
+/// frame it replaces is most of what the check costs: the body is three
+/// operations, and entering Python to run them is the rest.
+fn simple_weak_set_contains(
+    cache: PyObjectRef,
+    item: PyObjectRef,
+) -> Result<Option<bool>, crate::PyError> {
+    if !crate::typedef::r#type(cache)
+        .is_some_and(|actual| std::ptr::eq(actual.as_ptr(), simple_weak_set_type()))
+    {
+        return Ok(None);
+    }
+    let roots = pyre_object::gc_roots::push_roots();
+    let cache_slot = roots.publish(&[cache]);
+    let item_slot = roots.publish(&[item]);
+    let data = crate::baseobjspace::getattr_str(roots.get(cache_slot), "data")?;
+    if !unsafe { pyre_object::is_set(data) } {
+        return Ok(None);
+    }
+    let data_slot = roots.publish(&[data]);
+    // An empty collection holds no entry to match, and building the probe has
+    // no other effect, so the two answers agree.  `_in_weak_set` takes the same
+    // shortcut on `PySet_GET_SIZE(set) == 0`.
+    if unsafe { pyre_object::w_set_len(roots.get(data_slot)) } == 0 {
+        return Ok(Some(false));
+    }
+    // `wr = ref(item)`.  The app-level spelling answers False for an item that
+    // cannot carry a weakref and lets every other error out, so match both.
+    let probe = match crate::module::_weakref::interp__weakref::descr__new__weakref(
+        crate::module::_weakref::interp__weakref::weakref_type(),
+        &[roots.get(item_slot)],
+    ) {
+        Ok(probe) => probe,
+        Err(err) if matches!(err.kind, crate::error::PyErrorKind::TypeError) => {
+            return Ok(Some(false));
+        }
+        Err(err) => return Err(err),
+    };
+    let probe_slot = roots.publish(&[probe]);
+    // `wr in self.data`.  The probe carries no callback, and a weakref hashes
+    // and compares by its referent, so it finds the callback-carrying entry
+    // `add` stored.
+    match unsafe {
+        pyre_object::w_set_contains_checked(roots.get(data_slot), roots.get(probe_slot))
+    } {
+        Ok(found) => Ok(Some(found)),
+        // A weakref is hashable, so this is unreachable; leave the faithful
+        // error to the membership protocol rather than inventing one here.
+        Err(_) => Ok(None),
+    }
 }
 
 /// `app_abc.py SimpleWeakSet.add` — `self.data.add(ref(item, self._remove))`.

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -30,30 +30,50 @@ fn simple_weak_set_type() -> PyObjectRef {
         .expect("_abc.SimpleWeakSet must be installed at module init") as PyObjectRef
 }
 
-/// The `__contains__` `app_abc.py` defines and the code object it was defined
-/// with, stashed beside its type.  The class is an ordinary heap type, so the
-/// method is rebindable and the function it holds is mutable in place;
-/// answering natively is only sound while the body a membership test would
-/// reach is still the one written in `app_abc.py`.
+/// The `__contains__` `app_abc.py` defines, stashed beside its type as the
+/// three words a caller can move independently: the method itself, the code
+/// object it holds, and the one global its body reads.  The class is an
+/// ordinary heap type, so the method is rebindable and the function it holds is
+/// mutable in place; answering natively is only sound while the body a
+/// membership test would reach is still the one written in `app_abc.py`.
 ///
-/// The pair is what a rebind and a `__code__` assignment respectively move.  A
-/// function has further mutable state that neither covers — its globals, its
-/// defaults — so this narrows the native answer to the untouched collection
-/// rather than proving the app-level body could not have been redirected.
-static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<(usize, usize)> = std::sync::OnceLock::new();
+/// The body is `try: wr = ref(item) / except TypeError: return False / return
+/// wr in self.data`, so `ref` is its whole free-variable surface and pinning it
+/// is what makes rebinding `__globals__["ref"]` decline.  Defaults are not
+/// pinned because the body takes none.
+static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<(usize, usize, usize)> =
+    std::sync::OnceLock::new();
 
-/// The installed `__contains__` and the code object it currently holds, as the
-/// pair [`SIMPLE_WEAK_SET_CONTAINS`] stores.  A missing method reads as
-/// `(0, 0)`, which no stash can equal.
-fn simple_weak_set_contains_identity() -> (usize, usize) {
+/// The installed `__contains__`, the code object it currently holds and its
+/// `ref` global, as the triple [`SIMPLE_WEAK_SET_CONTAINS`] stores.  Anything
+/// that is not a function reads as `(0, 0, 0)`, which no stash can equal:
+/// [`crate::function_get_code`] reads the `code` field without checking the
+/// type, so a `__contains__` rebound to a non-function must be rejected before
+/// the read rather than by comparing what the read returned.
+fn simple_weak_set_contains_identity() -> (usize, usize, usize) {
+    const NONE: (usize, usize, usize) = (0, 0, 0);
     let Some(method) =
         (unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set_type(), "__contains__") })
     else {
-        return (0, 0);
+        return NONE;
     };
-    (method as usize, unsafe {
-        crate::function_get_code(method) as usize
-    })
+    if !unsafe { crate::is_function(method) } {
+        return NONE;
+    }
+    let globals = unsafe { crate::function_get_globals_obj(method) };
+    if globals.is_null() {
+        return NONE;
+    }
+    let Some(ref_global) =
+        (unsafe { pyre_object::dictmultiobject::w_dict_getitem_str(globals, "ref") })
+    else {
+        return NONE;
+    };
+    (
+        method as usize,
+        unsafe { crate::function_get_code(method) as usize },
+        ref_global as usize,
+    )
 }
 
 /// `SimpleWeakSet()` — the empty collection `_abc_init` installs and the
@@ -102,9 +122,9 @@ fn simple_weak_set_contains(
         return Ok(None);
     }
     // The receiver being that class is not enough: rebinding the class's own
-    // `__contains__`, or assigning that function a different `__code__`, leaves
-    // every instance an exact `SimpleWeakSet` while changing what a membership
-    // test answers.
+    // `__contains__`, assigning that function a different `__code__`, or
+    // rebinding the `ref` its body calls, each leaves every instance an exact
+    // `SimpleWeakSet` while changing what a membership test answers.
     let Some(&installed) = SIMPLE_WEAK_SET_CONTAINS.get() else {
         return Ok(None);
     };
@@ -704,7 +724,7 @@ crate::py_module! {
             .expect("_abc.SimpleWeakSet must be installed by appleveldefs");
         let _ = SIMPLE_WEAK_SET_TYPE.set(simple_weak_set as usize);
         let installed = simple_weak_set_contains_identity();
-        if installed != (0, 0) {
+        if installed != (0, 0, 0) {
             let _ = SIMPLE_WEAK_SET_CONTAINS.set(installed);
         }
     },

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -30,6 +30,12 @@ fn simple_weak_set_type() -> PyObjectRef {
         .expect("_abc.SimpleWeakSet must be installed at module init") as PyObjectRef
 }
 
+/// The `__contains__` `app_abc.py` defines, stashed beside its type.  The
+/// class is an ordinary heap type, so the method is rebindable, and answering
+/// natively is only sound while the one installed here is still the one a
+/// membership test would reach.
+static SIMPLE_WEAK_SET_CONTAINS: std::sync::OnceLock<usize> = std::sync::OnceLock::new();
+
 /// `SimpleWeakSet()` — the empty collection `_abc_init` installs and the
 /// invalidation in `subclass_of` rebinds to.
 fn new_simple_weak_set() -> Result<PyObjectRef, crate::PyError> {
@@ -73,6 +79,15 @@ fn simple_weak_set_contains(
     if !crate::typedef::r#type(cache)
         .is_some_and(|actual| std::ptr::eq(actual.as_ptr(), simple_weak_set_type()))
     {
+        return Ok(None);
+    }
+    // The receiver being that class is not enough: rebinding the class's own
+    // `__contains__` leaves every instance an exact `SimpleWeakSet` while
+    // changing what a membership test answers.
+    let installed = SIMPLE_WEAK_SET_CONTAINS.get().copied().unwrap_or(0);
+    let current =
+        unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set_type(), "__contains__") };
+    if installed == 0 || current.map_or(0, |m| m as usize) != installed {
         return Ok(None);
     }
     let roots = pyre_object::gc_roots::push_roots();
@@ -666,5 +681,10 @@ crate::py_module! {
         let simple_weak_set = crate::module_ns_get(ns, "SimpleWeakSet")
             .expect("_abc.SimpleWeakSet must be installed by appleveldefs");
         let _ = SIMPLE_WEAK_SET_TYPE.set(simple_weak_set as usize);
+        if let Some(contains) =
+            unsafe { crate::baseobjspace::lookup_in_type(simple_weak_set, "__contains__") }
+        {
+            let _ = SIMPLE_WEAK_SET_CONTAINS.set(contains as usize);
+        }
     },
 }

--- a/pyre/pyre-interpreter/src/module/_abc/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_abc/mod.rs
@@ -79,7 +79,11 @@ fn simple_weak_set_contains(
     let cache_slot = roots.publish(&[cache]);
     let item_slot = roots.publish(&[item]);
     let data = crate::baseobjspace::getattr_str(roots.get(cache_slot), "data")?;
-    if !unsafe { pyre_object::is_set(data) } {
+    // Exactly a `set`, not merely one by layout: a subclass keeps the base
+    // layout in `ob_type` and retags `w_class`, and `contains` dispatches such
+    // a subclass's `__contains__` override through `subclass_special_override`.
+    // Reading the table directly would answer past the override.
+    if !unsafe { pyre_object::is_exact_type(data, &pyre_object::setobject::SET_TYPE) } {
         return Ok(None);
     }
     let data_slot = roots.publish(&[data]);
@@ -109,9 +113,14 @@ fn simple_weak_set_contains(
         pyre_object::w_set_contains_checked(roots.get(data_slot), roots.get(probe_slot))
     } {
         Ok(found) => Ok(Some(found)),
-        // A weakref is hashable, so this is unreachable; leave the faithful
-        // error to the membership protocol rather than inventing one here.
-        Err(_) => Ok(None),
+        // The probe hashes by its referent, so a metaclass `__hash__` that
+        // raises arrives here.  Recover that exception rather than declining:
+        // the protocol would build a second probe and run the same observable
+        // `__hash__` again before raising, and the expression it stands in for
+        // runs it once.
+        Err(_) => Err(crate::baseobjspace::take_pending_dict_key_error(
+            roots.get(probe_slot),
+        )),
     }
 }
 

--- a/pyre/pyre-interpreter/src/pycode.rs
+++ b/pyre/pyre-interpreter/src/pycode.rs
@@ -2428,16 +2428,13 @@ fn code_locations_cache()
 /// `co_firstlineno_raw` stamp that follows `CodeType(...)` and `code.replace`)
 /// simply corrects the recorded line number.
 fn release_code_locations(code_ptr: *mut crate::CodeObject, firstlineno_raw: i32) {
-    // A code object with no instructions has no rows to decode.
-    let code = unsafe { &mut *code_ptr };
-    if code.instructions.is_empty() {
-        return;
-    }
     // Nested constants are wrapped in place, so two threads realizing one
-    // `co_consts_w` slot reach the same `CodeObject`. Whoever creates the
-    // record owns the drop; the array is read and written only under this
-    // lock. A second wrapper over an already-released object must keep the
-    // record the first made — re-deferring would abandon rows a reader has
+    // `co_consts_w` slot reach the same `CodeObject` before either wrapper is
+    // published. The lock is taken and the vacant entry claimed before the
+    // pointer is dereferenced, so only the thread that owns the record ever
+    // forms a `&mut` to the object: the array is read and written under this
+    // lock alone. A second wrapper over an already-released object must keep
+    // the record the first made — re-deferring would abandon rows a reader has
     // since decoded.
     let mut cache = code_locations_cache()
         .lock()
@@ -2445,7 +2442,10 @@ fn release_code_locations(code_ptr: *mut crate::CodeObject, firstlineno_raw: i32
     let std::collections::hash_map::Entry::Vacant(entry) = cache.entry(code_ptr as usize) else {
         return;
     };
-    if code.locations.is_empty() {
+    let code = unsafe { &mut *code_ptr };
+    // A code object with no instructions has no rows to decode, and one that
+    // holds no array has nothing to release.
+    if code.instructions.is_empty() || code.locations.is_empty() {
         return;
     }
     entry.insert(CodeLocations::Deferred(firstlineno_raw));

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -7524,6 +7524,218 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     Ok(Some(inlined))
 }
 
+/// Inline a plain Python `__contains__` after the compare specializations
+/// decline.
+///
+/// `CONTAINS_OP` reaches the walker through the same `compare_fn` residual as
+/// the six rich comparisons — tag 6 is `in`, tag 7 is `not in`, and the
+/// operands are lowered `[item, container]` — but `compare_op_from_tag` names
+/// only tags 0-5, so [`try_walker_inline_user_compareop`] declines both and a
+/// membership test stays opaque even when the container's `__contains__` is
+/// ordinary Python code.
+///
+/// This is the walker counterpart of the instance arm of
+/// `baseobjspace::contains_slot` (`descroperation.py contains_w`): look
+/// `__contains__` up on the receiver's class, call it with the needle, then
+/// apply `space.is_true` to what came back.  Only an instance receiver is
+/// admitted, which is the one arm that reaches a Python body — the builtin
+/// containers answer membership by layout further up `contains_slot` and never
+/// consult a Python `__contains__`.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    op_tag: i64,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst: usize,
+    dst_bank: char,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    if !ctx.is_authoritative_executor || dst_bank != 'r' || r_args.len() != 2 {
+        return Ok(None);
+    }
+    let negate = match op_tag {
+        6 => false,
+        7 => true,
+        _ => return Ok(None),
+    };
+
+    let needle = r_args[0];
+    let haystack = r_args[1];
+    let Some(concrete_needle) = walker_concrete_ref_object(ctx, needle) else {
+        return Ok(None);
+    };
+    let Some(concrete_haystack) = walker_concrete_ref_object(ctx, haystack) else {
+        return Ok(None);
+    };
+    // A tagged immediate has no heap header to pin, and its membership is not
+    // a Python body.  Inert behind `CAN_BE_TAGGED` (default false).
+    if pyre_object::tagged_int::CAN_BE_TAGGED
+        && (pyre_object::tagged_int::is_tagged_int(concrete_needle)
+            || pyre_object::tagged_int::is_tagged_int(concrete_haystack))
+    {
+        return Ok(None);
+    }
+    if !unsafe { pyre_object::is_instance(concrete_haystack) } {
+        return Ok(None);
+    }
+    let w_class = unsafe { pyre_object::w_instance_get_type(concrete_haystack) };
+    if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
+        return Ok(None);
+    }
+    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_class) };
+    if version_tag == 0 {
+        return Ok(None);
+    }
+    let Some(method) =
+        (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_class, "__contains__") })
+    else {
+        return Ok(None);
+    };
+    // `__contains__ = None` blocks both the slot and the iterator fallback and
+    // raises; leave that to the residual.
+    if unsafe { pyre_object::is_none(method) } {
+        return Ok(None);
+    }
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
+        return Ok(None);
+    };
+    if nparams != 2 {
+        return Ok(None);
+    }
+
+    let arg_concretes = vec![
+        ConcreteValue::Ref(method),
+        ConcreteValue::Null,
+        ConcreteValue::Ref(concrete_haystack),
+        ConcreteValue::Ref(concrete_needle),
+    ];
+    let method_const = ctx.trace_ctx.const_ref(method as i64);
+    // Read before the body runs, so the result check below can tell a body that
+    // applied nothing from one that did.
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    let effects_before = fbw_executed_effect_count();
+    let unjournaled_before = fbw_has_unjournaled_effect();
+    // The needle's class carries no dispatch decision here — unlike a
+    // rich-compare rhs, whose type decides reflected-dunder priority — so it is
+    // left unpinned and the callee body guards whatever it actually reads.
+    let Some(inlined) = try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        method_const,
+        r_args,
+        call_descr,
+        'r',
+        dst,
+        method,
+        method_const,
+        method,
+        arg_concretes,
+        vec![haystack, needle],
+        vec![
+            ConcreteValue::Ref(concrete_haystack),
+            ConcreteValue::Ref(concrete_needle),
+        ],
+        true,
+        None,
+        w_code,
+        nparams,
+        has_closure,
+        Some((haystack, concrete_haystack, w_class, version_tag)),
+        None,
+        false,
+        false,
+        None,
+    )?
+    else {
+        if fbw_inline_diag_enabled() {
+            eprintln!("[contains-inline-decline] pc={} why=callee inline of {}.__contains__ declined",
+                op.pc,
+                unsafe { pyre_object::typeobject::w_type_get_name(w_class) });
+        }
+        return Ok(None);
+    };
+    if !matches!(inlined.0, DispatchOutcome::Continue) {
+        return Ok(Some(inlined));
+    }
+
+    // `contains_slot` ends in `space.is_true(result)`, and `CONTAINS_OP` wraps
+    // that back up with `w_bool_from`.  Pinning the returned object to the
+    // `bool` layout collapses both to a pointer test against `w_True`, and for
+    // `in` the wrap is then the identity: the object the body returned already
+    // IS the singleton the opcode produces.
+    let result = ctx.registers_r[dst];
+    let w_true = pyre_object::w_bool_from(true);
+    let ConcreteValue::Ref(observed) = concrete_from_recorded_opref(ctx, result) else {
+        return Err(DispatchError::callee_inline_unsupported(op.pc));
+    };
+    let found = if std::ptr::eq(observed, w_true) {
+        true
+    } else if std::ptr::eq(observed, pyre_object::w_bool_from(false)) {
+        false
+    } else {
+        // Anything else needs the `__bool__` / `__len__` dispatch this route
+        // cannot emit.  A body that applied nothing is rewound and the whole
+        // membership test goes back to its residual — the same all-clear test
+        // the orthodox sub-walk rollback above uses, and the same one that
+        // licenses re-executing the body from the caller boundary. A body that
+        // did apply something cannot be rewound, so it keeps the abort.
+        let rewindable = fbw_executed_effect_count() == effects_before
+            && !unjournaled_before
+            && !fbw_has_unjournaled_effect();
+        if fbw_inline_diag_enabled() {
+            eprintln!(
+                "[contains-inline-nonbool] pc={} class={} disp={}",
+                op.pc,
+                unsafe { pyre_object::typeobject::w_type_get_name(w_class) },
+                if rewindable { "rollback" } else { "abort" },
+            );
+        }
+        if !rewindable {
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
+        }
+        ctx.trace_ctx.cut_trace(pre_fold_pos);
+        ctx.trace_ctx.heap_cache_mut().reset();
+        bool_box_truth_reset();
+        return Ok(None);
+    };
+
+    if !result.is_constant() {
+        let bool_type =
+            unsafe { (*(w_true as *const pyre_object::pyobject::PyObject)).ob_type } as usize as i64;
+        if !ctx.trace_ctx.heap_cache().is_class_known(result) {
+            let bool_type_const = ctx.trace_ctx.const_int(bool_type);
+            ctx.trace_ctx
+                .record_guard(OpCode::GuardClass, &[result, bool_type_const], 0);
+            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
+            ctx.trace_ctx
+                .heap_cache_mut()
+                .class_now_known(result, bool_type);
+        }
+    }
+    let true_const = ctx.trace_ctx.const_ref(w_true as i64);
+    let cmp = if negate { OpCode::PtrNe } else { OpCode::PtrEq };
+    let truth = ctx.trace_ctx.record_op(cmp, &[result, true_const]);
+    let value = found != negate;
+    ctx.trace_ctx
+        .set_opref_concrete(truth, majit_ir::Value::Int(value as i64));
+    let boxed = if negate {
+        let boxed = crate::helpers::emit_trace_bool_value_from_truth(ctx.trace_ctx, truth, false);
+        ctx.trace_ctx.set_opref_concrete(
+            boxed,
+            majit_ir::Value::Ref(majit_ir::GcRef(pyre_object::w_bool_from(value) as usize)),
+        );
+        boxed
+    } else {
+        result
+    };
+    bool_box_truth_record(boxed, truth);
+    write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, boxed)?;
+    Ok(Some(inlined))
+}
+
 /// Allocate the callee's three symbolic register banks for a sub-walk
 /// entered through any `inline_call_*` arm.
 ///

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3104,7 +3104,6 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         constructor_result,
         None,
         false,
-        false,
         None,
     )
 }
@@ -3157,7 +3156,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     constructor_result: Option<(OpRef, ConcreteValue)>,
     intermediate_result: Option<&mut Option<(OpRef, ConcreteValue)>>,
     require_exact_int_result: bool,
-    require_bool_result: bool,
     instance_next_foriter_green_key: Option<u64>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     // `_compute_flatcall` (`pycode.py`) leaves `fast_natural_arity`
@@ -5407,34 +5405,6 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     );
                     return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
-                if require_bool_result
-                    && !matches!(
-                        concrete_for_shadow,
-                        ConcreteValue::Ref(obj)
-                            if std::ptr::eq(obj, pyre_object::w_bool_from(true))
-                                || std::ptr::eq(obj, pyre_object::w_bool_from(false))
-                    )
-                {
-                    // The membership-shaped routes reduce `space.is_true` to a
-                    // pointer test against `w_True`, which holds only for the two
-                    // singletons; anything else needs the `__bool__` / `__len__`
-                    // dispatch they cannot emit, so the call goes back to its
-                    // residual.  The body has already run at this point, so latch
-                    // the caller's CALL boundary first — returning the error
-                    // unlatched replays the loop from entry and runs the body a
-                    // second time.
-                    latch_abort_call_resume(
-                        code,
-                        op,
-                        ctx,
-                        call_descr,
-                        is_top_inline,
-                        unjournaled_before_subwalk,
-                        executed_effects_before,
-                        abort_flush_call_jitcode_coord,
-                    );
-                    return Err(DispatchError::callee_inline_unsupported(op.pc));
-                }
                 if require_exact_int_result
                     && !matches!(
                         concrete_for_shadow,
@@ -6906,7 +6876,6 @@ pub(crate) fn try_walker_inline_index<Sym: WalkSym>(
         None,
         Some(&mut result),
         true,
-        false,
         None,
     )?;
     match (inlined, result) {
@@ -7151,7 +7120,6 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
         false,
         None,
         None,
-        false,
         false,
         Some(foriter_green_key),
     );
@@ -7553,254 +7521,6 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
             walker_emit_guard_with_snapshot(ctx, op.pc, OpCode::GuardFalse, &[is_not_implemented])?;
         }
     }
-    Ok(Some(inlined))
-}
-
-/// Run an effect-free straight-line dunder once, before any IR is emitted, and
-/// report whether it answered with one of the two `bool` singletons.
-///
-/// The two membership-shaped routes reduce `space.is_true` to a pointer test
-/// against `w_True`, which only holds for those singletons.  Sampling first is
-/// what lets a body that answers otherwise decline with nothing recorded to
-/// undo; `try_walker_inline_exception_string_override` samples its own override
-/// the same way, under the same `exc_override_sample_safe` gate.
-fn walker_sampled_result_is_bool(
-    method: pyre_object::PyObjectRef,
-    args: &[pyre_object::PyObjectRef],
-) -> bool {
-    let sampled = {
-        let _plain_guard = pyre_interpreter::call::force_plain_eval();
-        pyre_interpreter::call::call_function_impl_result(method, args)
-    };
-    matches!(sampled, Ok(result)
-        if std::ptr::eq(result, pyre_object::w_bool_from(true))
-            || std::ptr::eq(result, pyre_object::w_bool_from(false)))
-}
-
-/// Inline a plain Python `__contains__` after the compare specializations
-/// decline.
-///
-/// `CONTAINS_OP` reaches the walker through the same `compare_fn` residual as
-/// the six rich comparisons — tag 6 is `in`, tag 7 is `not in`, and the
-/// operands are lowered `[item, container]` — but `compare_op_from_tag` names
-/// only tags 0-5, so [`try_walker_inline_user_compareop`] declines both and a
-/// membership test stays opaque even when the container's `__contains__` is
-/// ordinary Python code.
-///
-/// This is the walker counterpart of the instance arm of
-/// `baseobjspace::contains_slot` (`descroperation.py contains_w`): look
-/// `__contains__` up on the receiver's class, call it with the needle, then
-/// apply `space.is_true` to what came back.  Only an instance receiver is
-/// admitted, which is the one arm that reaches a Python body — the builtin
-/// containers answer membership by layout further up `contains_slot` and never
-/// consult a Python `__contains__`.
-#[allow(clippy::too_many_arguments)]
-pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    op: &DecodedOp,
-    code: &[u8],
-    op_tag: i64,
-    r_args: &[OpRef],
-    call_descr: &dyn majit_ir::descr::CallDescr,
-    dst: usize,
-    dst_bank: char,
-) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
-    if !ctx.is_authoritative_executor || dst_bank != 'r' || r_args.len() != 2 {
-        return Ok(None);
-    }
-    let negate = match op_tag {
-        6 => false,
-        7 => true,
-        _ => return Ok(None),
-    };
-
-    let needle = r_args[0];
-    let haystack = r_args[1];
-    let Some(concrete_needle) = walker_concrete_ref_object(ctx, needle) else {
-        return Ok(None);
-    };
-    let Some(concrete_haystack) = walker_concrete_ref_object(ctx, haystack) else {
-        return Ok(None);
-    };
-    // A tagged immediate has no heap header to pin, and its membership is not
-    // a Python body.  Inert behind `CAN_BE_TAGGED` (default false).
-    if pyre_object::tagged_int::CAN_BE_TAGGED
-        && (pyre_object::tagged_int::is_tagged_int(concrete_needle)
-            || pyre_object::tagged_int::is_tagged_int(concrete_haystack))
-    {
-        return Ok(None);
-    }
-    if !unsafe { pyre_object::is_instance(concrete_haystack) } {
-        return Ok(None);
-    }
-    let w_class = unsafe { pyre_object::w_instance_get_type(concrete_haystack) };
-    if w_class.is_null() || !unsafe { pyre_object::is_type(w_class) } {
-        return Ok(None);
-    }
-    let version_tag = unsafe { pyre_object::typeobject::w_type_get_version_tag(w_class) };
-    if version_tag == 0 {
-        return Ok(None);
-    }
-    let Some(method) =
-        (unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_class, "__contains__") })
-    else {
-        return Ok(None);
-    };
-    // `__contains__ = None` blocks both the slot and the iterator fallback and
-    // raises; leave that to the residual.
-    if unsafe { pyre_object::is_none(method) } {
-        return Ok(None);
-    }
-    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(method) }) else {
-        return Ok(None);
-    };
-    if nparams != 2 {
-        return Ok(None);
-    }
-
-    let Some(body_facts) = sub_jitcode_body_facts_for_code(w_code) else {
-        return Ok(None);
-    };
-    // The same admission the `hash` and `str`/`repr` builtin routes take.  A
-    // body that can leave the walk other than by returning — a raise above all —
-    // has already entered its frame when that becomes known, and neither the
-    // decline nor the latched abort can undo a frame entry.
-    if !body_facts.exc_override_straight_line {
-        return Ok(None);
-    }
-    if body_facts.exc_override_sample_safe
-        && !walker_sampled_result_is_bool(method, &[concrete_haystack, concrete_needle])
-    {
-        return Ok(None);
-    }
-
-    let arg_concretes = vec![
-        ConcreteValue::Ref(method),
-        ConcreteValue::Null,
-        ConcreteValue::Ref(concrete_haystack),
-        ConcreteValue::Ref(concrete_needle),
-    ];
-    let method_const = ctx.trace_ctx.const_ref(method as i64);
-    // The needle's class carries no dispatch decision here — unlike a
-    // rich-compare rhs, whose type decides reflected-dunder priority — so it is
-    // left unpinned and the callee body guards whatever it actually reads.
-    let Some(inlined) = try_walker_inline_resolved_user_call_inner(
-        ctx,
-        op,
-        code,
-        method_const,
-        r_args,
-        call_descr,
-        'r',
-        dst,
-        method,
-        method_const,
-        method,
-        arg_concretes,
-        vec![haystack, needle],
-        vec![
-            ConcreteValue::Ref(concrete_haystack),
-            ConcreteValue::Ref(concrete_needle),
-        ],
-        true,
-        None,
-        w_code,
-        nparams,
-        has_closure,
-        Some((haystack, concrete_haystack, w_class, version_tag)),
-        None,
-        false,
-        false,
-        None,
-        None,
-        false,
-        // A body answering with anything but a `bool` singleton has already run
-        // by the time this is known, so the check belongs inside, where the
-        // caller's CALL boundary can be latched before the abort.
-        true,
-        None,
-    )?
-    else {
-        if fbw_inline_diag_enabled() {
-            eprintln!(
-                "[contains-inline-decline] pc={} why=callee inline of {}.__contains__ declined",
-                op.pc,
-                unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
-            );
-        }
-        return Ok(None);
-    };
-    if !matches!(inlined.0, DispatchOutcome::Continue) {
-        return Ok(Some(inlined));
-    }
-
-    // `contains_slot` ends in `space.is_true(result)`, and `CONTAINS_OP` wraps
-    // that back up with `w_bool_from`.  Pinning the returned object to the
-    // `bool` layout collapses both to a pointer test against `w_True`, and for
-    // `in` the wrap is then the identity: the object the body returned already
-    // IS the singleton the opcode produces.
-    // `require_bool_result` above already rejected anything that is not one of
-    // the two singletons, and it did so where the CALL boundary can still be
-    // latched.  Both arms below are therefore unreachable on this path; they
-    // stay as the shape's classification, and abort rather than guess if a
-    // future change relaxes that check — an unlatched abort is the weaker
-    // disposition, so the assertion is what keeps it from becoming live.
-    let result = ctx.registers_r[dst];
-    let w_true = pyre_object::w_bool_from(true);
-    let observed = match concrete_from_recorded_opref(ctx, result) {
-        ConcreteValue::Ref(observed) => observed,
-        _ => {
-            debug_assert!(false, "require_bool_result admitted a non-Ref result");
-            return Err(DispatchError::callee_inline_unsupported(op.pc));
-        }
-    };
-    let found = if std::ptr::eq(observed, w_true) {
-        true
-    } else if std::ptr::eq(observed, pyre_object::w_bool_from(false)) {
-        false
-    } else {
-        // Anything else needs the `__bool__` / `__len__` dispatch this route
-        // cannot emit.
-        if fbw_inline_diag_enabled() {
-            eprintln!("[contains-inline-nonbool] pc={} class={}", op.pc, unsafe {
-                pyre_object::typeobject::w_type_get_name(w_class)
-            });
-        }
-        debug_assert!(false, "require_bool_result admitted a non-singleton result");
-        return Err(DispatchError::callee_inline_unsupported(op.pc));
-    };
-
-    if !result.is_constant() {
-        let bool_type = unsafe { (*(w_true as *const pyre_object::pyobject::PyObject)).ob_type }
-            as usize as i64;
-        if !ctx.trace_ctx.heap_cache().is_class_known(result) {
-            let bool_type_const = ctx.trace_ctx.const_int(bool_type);
-            ctx.trace_ctx
-                .record_guard(OpCode::GuardClass, &[result, bool_type_const], 0);
-            walker_capture_snapshot_for_last_guard(ctx, op.pc)?;
-            ctx.trace_ctx
-                .heap_cache_mut()
-                .class_now_known(result, bool_type);
-        }
-    }
-    let true_const = ctx.trace_ctx.const_ref(w_true as i64);
-    let cmp = if negate { OpCode::PtrNe } else { OpCode::PtrEq };
-    let truth = ctx.trace_ctx.record_op(cmp, &[result, true_const]);
-    let value = found != negate;
-    ctx.trace_ctx
-        .set_opref_concrete(truth, majit_ir::Value::Int(value as i64));
-    let boxed = if negate {
-        let boxed = crate::helpers::emit_trace_bool_value_from_truth(ctx.trace_ctx, truth, false);
-        ctx.trace_ctx.set_opref_concrete(
-            boxed,
-            majit_ir::Value::Ref(majit_ir::GcRef(pyre_object::w_bool_from(value) as usize)),
-        );
-        boxed
-    } else {
-        result
-    };
-    bool_box_truth_record(boxed, truth);
-    write_residual_call_result_to_dst(ctx, op.pc, dst, dst_bank, boxed)?;
     Ok(Some(inlined))
 }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -3104,6 +3104,7 @@ pub(crate) fn try_walker_inline_resolved_user_call<Sym: WalkSym>(
         constructor_result,
         None,
         false,
+        false,
         None,
     )
 }
@@ -3156,6 +3157,7 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
     constructor_result: Option<(OpRef, ConcreteValue)>,
     intermediate_result: Option<&mut Option<(OpRef, ConcreteValue)>>,
     require_exact_int_result: bool,
+    require_bool_result: bool,
     instance_next_foriter_green_key: Option<u64>,
 ) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
     // `_compute_flatcall` (`pycode.py`) leaves `fast_natural_arity`
@@ -5405,6 +5407,34 @@ fn try_walker_inline_resolved_user_call_inner<Sym: WalkSym>(
                     );
                     return Err(DispatchError::callee_inline_unsupported(op.pc));
                 }
+                if require_bool_result
+                    && !matches!(
+                        concrete_for_shadow,
+                        ConcreteValue::Ref(obj)
+                            if std::ptr::eq(obj, pyre_object::w_bool_from(true))
+                                || std::ptr::eq(obj, pyre_object::w_bool_from(false))
+                    )
+                {
+                    // The membership-shaped routes reduce `space.is_true` to a
+                    // pointer test against `w_True`, which holds only for the two
+                    // singletons; anything else needs the `__bool__` / `__len__`
+                    // dispatch they cannot emit, so the call goes back to its
+                    // residual.  The body has already run at this point, so latch
+                    // the caller's CALL boundary first — returning the error
+                    // unlatched replays the loop from entry and runs the body a
+                    // second time.
+                    latch_abort_call_resume(
+                        code,
+                        op,
+                        ctx,
+                        call_descr,
+                        is_top_inline,
+                        unjournaled_before_subwalk,
+                        executed_effects_before,
+                        abort_flush_call_jitcode_coord,
+                    );
+                    return Err(DispatchError::callee_inline_unsupported(op.pc));
+                }
                 if require_exact_int_result
                     && !matches!(
                         concrete_for_shadow,
@@ -7024,6 +7054,7 @@ pub(crate) fn try_walker_inline_index<Sym: WalkSym>(
         None,
         Some(&mut result),
         true,
+        false,
         None,
     )?;
     match (inlined, result) {
@@ -7268,6 +7299,7 @@ pub(crate) fn try_walker_specialize_instance_next<Sym: WalkSym>(
         false,
         None,
         None,
+        false,
         false,
         Some(foriter_green_key),
     );
@@ -7672,6 +7704,27 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
     Ok(Some(inlined))
 }
 
+/// Run an effect-free straight-line dunder once, before any IR is emitted, and
+/// report whether it answered with one of the two `bool` singletons.
+///
+/// The two membership-shaped routes reduce `space.is_true` to a pointer test
+/// against `w_True`, which only holds for those singletons.  Sampling first is
+/// what lets a body that answers otherwise decline with nothing recorded to
+/// undo; `try_walker_inline_exception_string_override` samples its own override
+/// the same way, under the same `exc_override_sample_safe` gate.
+fn walker_sampled_result_is_bool(
+    method: pyre_object::PyObjectRef,
+    args: &[pyre_object::PyObjectRef],
+) -> bool {
+    let sampled = {
+        let _plain_guard = pyre_interpreter::call::force_plain_eval();
+        pyre_interpreter::call::call_function_impl_result(method, args)
+    };
+    matches!(sampled, Ok(result)
+        if std::ptr::eq(result, pyre_object::w_bool_from(true))
+            || std::ptr::eq(result, pyre_object::w_bool_from(false)))
+}
+
 /// Inline a plain Python `__contains__` after the compare specializations
 /// decline.
 ///
@@ -7753,6 +7806,22 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
         return Ok(None);
     }
 
+    let Some(body_facts) = sub_jitcode_body_facts_for_code(w_code) else {
+        return Ok(None);
+    };
+    // The same admission the `hash` and `str`/`repr` builtin routes take.  A
+    // body that can leave the walk other than by returning — a raise above all —
+    // has already entered its frame when that becomes known, and neither the
+    // decline nor the latched abort can undo a frame entry.
+    if !body_facts.exc_override_straight_line {
+        return Ok(None);
+    }
+    if body_facts.exc_override_sample_safe
+        && !walker_sampled_result_is_bool(method, &[concrete_haystack, concrete_needle])
+    {
+        return Ok(None);
+    }
+
     let arg_concretes = vec![
         ConcreteValue::Ref(method),
         ConcreteValue::Null,
@@ -7760,15 +7829,10 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
         ConcreteValue::Ref(concrete_needle),
     ];
     let method_const = ctx.trace_ctx.const_ref(method as i64);
-    // Read before the body runs, so the result check below can tell a body that
-    // applied nothing from one that did.
-    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
-    let effects_before = fbw_executed_effect_count();
-    let unjournaled_before = fbw_has_unjournaled_effect();
     // The needle's class carries no dispatch decision here — unlike a
     // rich-compare rhs, whose type decides reflected-dunder priority — so it is
     // left unpinned and the callee body guards whatever it actually reads.
-    let Some(inlined) = try_walker_inline_resolved_user_call(
+    let Some(inlined) = try_walker_inline_resolved_user_call_inner(
         ctx,
         op,
         code,
@@ -7795,6 +7859,13 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
         None,
         false,
         false,
+        None,
+        None,
+        false,
+        // A body answering with anything but a `bool` singleton has already run
+        // by the time this is known, so the check belongs inside, where the
+        // caller's CALL boundary can be latched before the abort.
+        true,
         None,
     )?
     else {
@@ -7827,29 +7898,14 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
         false
     } else {
         // Anything else needs the `__bool__` / `__len__` dispatch this route
-        // cannot emit.  A body that applied nothing is rewound and the whole
-        // membership test goes back to its residual — the same all-clear test
-        // the orthodox sub-walk rollback above uses, and the same one that
-        // licenses re-executing the body from the caller boundary. A body that
-        // did apply something cannot be rewound, so it keeps the abort.
-        let rewindable = fbw_executed_effect_count() == effects_before
-            && !unjournaled_before
-            && !fbw_has_unjournaled_effect();
+        // cannot emit.  Only a body the sample above could not run reaches here,
+        // so the walk is already committed and the call aborts to its residual.
         if fbw_inline_diag_enabled() {
-            eprintln!(
-                "[contains-inline-nonbool] pc={} class={} disp={}",
-                op.pc,
-                unsafe { pyre_object::typeobject::w_type_get_name(w_class) },
-                if rewindable { "rollback" } else { "abort" },
-            );
+            eprintln!("[contains-inline-nonbool] pc={} class={}", op.pc, unsafe {
+                pyre_object::typeobject::w_type_get_name(w_class)
+            });
         }
-        if !rewindable {
-            return Err(DispatchError::callee_inline_unsupported(op.pc));
-        }
-        ctx.trace_ctx.cut_trace(pre_fold_pos);
-        ctx.trace_ctx.heap_cache_mut().reset();
-        bool_box_truth_reset();
-        return Ok(None);
+        return Err(DispatchError::callee_inline_unsupported(op.pc));
     };
 
     if !result.is_constant() {

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5976,9 +5976,11 @@ fn try_walker_inline_type_call_via_new<Sym: WalkSym>(
         walker_pin_type_version_tag(ctx, op.pc, metaclass_const)?;
     }
     if fbw_inline_diag_enabled() {
-        eprintln!("[type-call-inline] pc={} class={} via=__new__", op.pc, unsafe {
-            pyre_object::w_type_get_name(w_type)
-        });
+        eprintln!(
+            "[type-call-inline] pc={} class={} via=__new__",
+            op.pc,
+            unsafe { pyre_object::w_type_get_name(w_type) }
+        );
     }
 
     let inlined = try_walker_inline_resolved_user_call(
@@ -7797,9 +7799,11 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
     )?
     else {
         if fbw_inline_diag_enabled() {
-            eprintln!("[contains-inline-decline] pc={} why=callee inline of {}.__contains__ declined",
+            eprintln!(
+                "[contains-inline-decline] pc={} why=callee inline of {}.__contains__ declined",
                 op.pc,
-                unsafe { pyre_object::typeobject::w_type_get_name(w_class) });
+                unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+            );
         }
         return Ok(None);
     };
@@ -7849,8 +7853,8 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
     };
 
     if !result.is_constant() {
-        let bool_type =
-            unsafe { (*(w_true as *const pyre_object::pyobject::PyObject)).ob_type } as usize as i64;
+        let bool_type = unsafe { (*(w_true as *const pyre_object::pyobject::PyObject)).ob_type }
+            as usize as i64;
         if !ctx.trace_ctx.heap_cache().is_class_known(result) {
             let bool_type_const = ctx.trace_ctx.const_int(bool_type);
             ctx.trace_ctx

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -1953,6 +1953,42 @@ fn fbw_unpack_call_function_ex_args<Sym: WalkSym>(
 /// answering them here is the difference between one scan per callee and one
 /// per call site. `None` when the code has no installed jitcode body or descr
 /// pool, which is the same condition the callers already decline on.
+/// Whether `w_code` commits nothing a discarded sub-walk would double.
+///
+/// A route whose entry opcode is not a call boundary — `COMPARE_OP`,
+/// `BINARY_OP` — has no sound abort once the body has run.
+/// [`latch_abort_call_resume`] resumes *at* the call and so re-executes it,
+/// which is why it refuses as soon as `fbw_executed_effect_count()` has moved;
+/// and a bare `Err` leaves the walk driver replaying the loop from entry with
+/// the body's effects already applied.  Only a body that commits nothing can be
+/// thrown away either way, so admission is what has to carry the decision.
+///
+/// `DeferredCall` is not enough here.  Its promise is that a residual the lever
+/// cannot inline aborts and rewinds to the enclosing CALL, and the FOR_ITER
+/// gate already records why that rewind does not reach a `BINARY_OP` /
+/// `COMPARE_OP` entry: the flush resumes one operand short.
+fn callee_body_commits_nothing(w_code: *const ()) -> bool {
+    let Some(body) = crate::state::sub_jitcode_body_for_code(w_code) else {
+        return false;
+    };
+    let Some((descr_refs, _, _)) = crate::state::sub_jitcode_descr_pool_for_code(w_code) else {
+        return false;
+    };
+    matches!(
+        fbw_callee_body_replay_safety(
+            body.code,
+            &[],
+            body.num_regs_i,
+            body.constants_i,
+            body.num_regs_r,
+            body.constants_r,
+            &descr_refs,
+            false,
+        ),
+        CalleeReplaySafety::Clean
+    )
+}
+
 fn sub_jitcode_body_facts_for_code(code: *const ()) -> Option<crate::pyjitcode::InlineBodyFacts> {
     let body = crate::state::sub_jitcode_body_for_code(code)?;
     let (descr_refs, _, _) = crate::state::sub_jitcode_descr_pool_for_code(code)?;
@@ -7305,6 +7341,15 @@ pub(crate) fn try_walker_inline_user_binop<Sym: WalkSym>(
             pyre_object::typeobject::w_type_get_name(w_class)
         }));
     }
+    // A `NotImplemented` result below is discarded with a bare `Err`, and this
+    // entry opcode is not a boundary that abort can rewind to, so a body that
+    // commits anything would have its effects replayed by the walk driver.
+    if !callee_body_commits_nothing(w_code) {
+        decline!(format_args!(
+            "{}.{dunder} commits a replayable effect",
+            unsafe { pyre_object::typeobject::w_type_get_name(w_class) }
+        ));
+    }
 
     let arg_concretes = vec![
         ConcreteValue::Ref(method),
@@ -7459,6 +7504,12 @@ pub(crate) fn try_walker_inline_user_compareop<Sym: WalkSym>(
         return Ok(None);
     };
     if nparams != 2 {
+        return Ok(None);
+    }
+    // A `NotImplemented` result below is discarded with a bare `Err`, and this
+    // entry opcode is not a boundary that abort can rewind to, so a body that
+    // commits anything would have its effects replayed by the walk driver.
+    if !callee_body_commits_nothing(w_code) {
         return Ok(None);
     }
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5957,7 +5957,16 @@ fn try_walker_inline_type_call_via_new<Sym: WalkSym>(
         return type_call_decline("__new__ overridden but unresolvable");
     };
     // Type creation wraps a class's own `__new__` in `staticmethod`; `descr_call`'s
-    // `space.get` unwraps it before calling, and so must this.
+    // `space.get` unwraps it before calling, and so must this.  Only an exact
+    // one may be unwrapped in place of that `space.get`: a subclass keeps the
+    // base layout in `ob_type`, so it answers the same layout test, and its
+    // `__get__` may bind something other than the function it wraps.
+    if unsafe {
+        pyre_object::function::is_staticmethod(tp_new)
+            && !pyre_object::function::is_exact_staticmethod(tp_new)
+    } {
+        return type_call_decline("__new__ wrapped in a staticmethod subclass");
+    }
     let w_new = unsafe {
         if pyre_object::function::is_staticmethod(tp_new) {
             pyre_object::function::w_staticmethod_get_func(tp_new)

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5733,7 +5733,23 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
     let tp_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__new__") };
     let obj_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__new__") };
     if tp_new != obj_new {
-        return type_call_decline("__new__ overridden");
+        // `descr_call` does not allocate: it calls whatever `__new__` resolved
+        // to and takes the instance back from it.  So an overridden `__new__`
+        // is not the end of the road — it is a different route, one whose
+        // allocation happens inside the callee.
+        return try_walker_inline_type_call_via_new(
+            ctx,
+            op,
+            code,
+            funcptr,
+            r_args,
+            call_descr,
+            dst_bank,
+            dst,
+            w_type,
+            tp_new,
+            metaclass_to_pin,
+        );
     }
     let tp_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__init__") };
     let obj_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__init__") };
@@ -5867,6 +5883,136 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
         if fbw_inline_diag_enabled() {
             eprintln!(
                 "[type-call-rewind] pc={} class={} why=__init__ sub-walk declined",
+                op.pc,
+                unsafe { pyre_object::w_type_get_name(w_type) },
+            );
+        }
+        ctx.trace_ctx.cut_trace(pre_fold_pos);
+        ctx.trace_ctx.heap_cache_mut().reset();
+    }
+    Ok(inlined)
+}
+
+/// `type.__call__` for a class whose `__new__` is overridden Python code.
+///
+/// `typeobject.py`'s `W_TypeObject.descr_call` never allocates: it resolves `__new__`
+/// through the descriptor protocol, calls it with the class as the first
+/// argument, and takes the instance back from whatever came out. The
+/// `object.__new__` arm above can emit the allocation itself only because that
+/// one `__new__` is `w_instance_new` and nothing else; here the allocation is
+/// the callee's business, so this route is the ordinary resolved-callee inline
+/// of the `__new__` body with the class pinned.
+///
+/// A class carrying its own `__init__` as well declines: `descr_call` runs it
+/// only when the result is an instance of the class, and folding a second
+/// sub-walk under one rewind point is a separate change. A class whose
+/// `__init__` is still `object`'s has nothing to run — `object_descr_init`
+/// accepts the surplus arguments precisely because `__new__` is overridden —
+/// so the `__new__` result is already the whole of the call.
+#[allow(clippy::too_many_arguments)]
+fn try_walker_inline_type_call_via_new<Sym: WalkSym>(
+    ctx: &mut WalkContext<'_, '_, Sym>,
+    op: &DecodedOp,
+    code: &[u8],
+    funcptr: OpRef,
+    r_args: &[OpRef],
+    call_descr: &dyn majit_ir::descr::CallDescr,
+    dst_bank: char,
+    dst: usize,
+    w_type: pyre_object::PyObjectRef,
+    tp_new: Option<pyre_object::PyObjectRef>,
+    metaclass_to_pin: Option<pyre_object::PyObjectRef>,
+) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
+    let Some(tp_new) = tp_new else {
+        return type_call_decline("__new__ overridden but unresolvable");
+    };
+    // Type creation wraps a class's own `__new__` in `staticmethod`; `descr_call`'s
+    // `space.get` unwraps it before calling, and so must this.
+    let w_new = unsafe {
+        if pyre_object::function::is_staticmethod(tp_new) {
+            pyre_object::function::w_staticmethod_get_func(tp_new)
+        } else {
+            tp_new
+        }
+    };
+    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(w_new) }) else {
+        return type_call_decline("__new__ overridden and not inlinable");
+    };
+    let w_object = pyre_interpreter::typedef::w_object();
+    let tp_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__init__") };
+    let obj_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__init__") };
+    if tp_init != obj_init {
+        return type_call_decline("__new__ overridden alongside __init__");
+    }
+    // The class occupies the first parameter, so the body needs one slot per
+    // argument the call site passes on top of it.
+    if nparams != r_args.len() - 1 {
+        return type_call_decline("__new__ arity does not match the call");
+    }
+
+    let mut arg_concretes = vec![ConcreteValue::Ref(w_type), ConcreteValue::Null];
+    let mut callee_args = vec![r_args[0]];
+    let mut callee_arg_concretes = vec![ConcreteValue::Ref(w_type)];
+    for (i, &arg) in r_args[2..].iter().enumerate() {
+        let Some(concrete) = walker_concrete_ref_object(ctx, arg) else {
+            return type_call_decline(&format!("argument {i} is not a concrete ref"));
+        };
+        arg_concretes.push(ConcreteValue::Ref(concrete));
+        callee_args.push(arg);
+        callee_arg_concretes.push(ConcreteValue::Ref(concrete));
+    }
+
+    // Everything below emits; cut back to here if the sub-walk declines, the
+    // same rewind point the `object.__new__` arm keeps.
+    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
+    let type_const = ctx.trace_ctx.const_ref(w_type as i64);
+    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[r_args[0], type_const])?;
+    ctx.trace_ctx
+        .heap_cache_mut()
+        .replace_box(r_args[0], type_const);
+    walker_pin_type_version_tag(ctx, op.pc, type_const)?;
+    if let Some(w_metaclass) = metaclass_to_pin {
+        let metaclass_const = ctx.trace_ctx.const_ref(w_metaclass as i64);
+        walker_pin_type_version_tag(ctx, op.pc, metaclass_const)?;
+    }
+    if fbw_inline_diag_enabled() {
+        eprintln!("[type-call-inline] pc={} class={} via=__new__", op.pc, unsafe {
+            pyre_object::w_type_get_name(w_type)
+        });
+    }
+
+    let inlined = try_walker_inline_resolved_user_call(
+        ctx,
+        op,
+        code,
+        funcptr,
+        r_args,
+        call_descr,
+        dst_bank,
+        dst,
+        w_new,
+        r_args[0],
+        w_type,
+        arg_concretes,
+        callee_args,
+        callee_arg_concretes,
+        true,
+        None,
+        w_code,
+        nparams,
+        has_closure,
+        None,
+        None,
+        true,
+        false,
+        // The callee's own return value IS the instance, unlike the `__init__`
+        // sub-walk whose result is discarded in favour of the emitted one.
+        None,
+    )?;
+    if inlined.is_none() {
+        if fbw_inline_diag_enabled() {
+            eprintln!(
+                "[type-call-rewind] pc={} class={} why=__new__ sub-walk declined",
                 op.pc,
                 unsafe { pyre_object::w_type_get_name(w_type) },
             );

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/inline_call.rs
@@ -5763,23 +5763,7 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
     let tp_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__new__") };
     let obj_new = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__new__") };
     if tp_new != obj_new {
-        // `descr_call` does not allocate: it calls whatever `__new__` resolved
-        // to and takes the instance back from it.  So an overridden `__new__`
-        // is not the end of the road — it is a different route, one whose
-        // allocation happens inside the callee.
-        return try_walker_inline_type_call_via_new(
-            ctx,
-            op,
-            code,
-            funcptr,
-            r_args,
-            call_descr,
-            dst_bank,
-            dst,
-            w_type,
-            tp_new,
-            metaclass_to_pin,
-        );
+        return type_call_decline("__new__ overridden");
     }
     let tp_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__init__") };
     let obj_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__init__") };
@@ -5913,147 +5897,6 @@ pub(crate) fn try_walker_inline_type_call<Sym: WalkSym>(
         if fbw_inline_diag_enabled() {
             eprintln!(
                 "[type-call-rewind] pc={} class={} why=__init__ sub-walk declined",
-                op.pc,
-                unsafe { pyre_object::w_type_get_name(w_type) },
-            );
-        }
-        ctx.trace_ctx.cut_trace(pre_fold_pos);
-        ctx.trace_ctx.heap_cache_mut().reset();
-    }
-    Ok(inlined)
-}
-
-/// `type.__call__` for a class whose `__new__` is overridden Python code.
-///
-/// `typeobject.py`'s `W_TypeObject.descr_call` never allocates: it resolves `__new__`
-/// through the descriptor protocol, calls it with the class as the first
-/// argument, and takes the instance back from whatever came out. The
-/// `object.__new__` arm above can emit the allocation itself only because that
-/// one `__new__` is `w_instance_new` and nothing else; here the allocation is
-/// the callee's business, so this route is the ordinary resolved-callee inline
-/// of the `__new__` body with the class pinned.
-///
-/// A class carrying its own `__init__` as well declines: `descr_call` runs it
-/// only when the result is an instance of the class, and folding a second
-/// sub-walk under one rewind point is a separate change. A class whose
-/// `__init__` is still `object`'s has nothing to run — `object_descr_init`
-/// accepts the surplus arguments precisely because `__new__` is overridden —
-/// so the `__new__` result is already the whole of the call.
-#[allow(clippy::too_many_arguments)]
-fn try_walker_inline_type_call_via_new<Sym: WalkSym>(
-    ctx: &mut WalkContext<'_, '_, Sym>,
-    op: &DecodedOp,
-    code: &[u8],
-    funcptr: OpRef,
-    r_args: &[OpRef],
-    call_descr: &dyn majit_ir::descr::CallDescr,
-    dst_bank: char,
-    dst: usize,
-    w_type: pyre_object::PyObjectRef,
-    tp_new: Option<pyre_object::PyObjectRef>,
-    metaclass_to_pin: Option<pyre_object::PyObjectRef>,
-) -> Result<Option<(DispatchOutcome, usize)>, DispatchError> {
-    let Some(tp_new) = tp_new else {
-        return type_call_decline("__new__ overridden but unresolvable");
-    };
-    // Type creation wraps a class's own `__new__` in `staticmethod`; `descr_call`'s
-    // `space.get` unwraps it before calling, and so must this.  Only an exact
-    // one may be unwrapped in place of that `space.get`: a subclass keeps the
-    // base layout in `ob_type`, so it answers the same layout test, and its
-    // `__get__` may bind something other than the function it wraps.
-    if unsafe {
-        pyre_object::function::is_staticmethod(tp_new)
-            && !pyre_object::function::is_exact_staticmethod(tp_new)
-    } {
-        return type_call_decline("__new__ wrapped in a staticmethod subclass");
-    }
-    let w_new = unsafe {
-        if pyre_object::function::is_staticmethod(tp_new) {
-            pyre_object::function::w_staticmethod_get_func(tp_new)
-        } else {
-            tp_new
-        }
-    };
-    let Some((w_code, nparams, has_closure)) = (unsafe { resolve_inlinable_callee(w_new) }) else {
-        return type_call_decline("__new__ overridden and not inlinable");
-    };
-    let w_object = pyre_interpreter::typedef::w_object();
-    let tp_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_type, "__init__") };
-    let obj_init = unsafe { pyre_interpreter::baseobjspace::lookup_in_type(w_object, "__init__") };
-    if tp_init != obj_init {
-        return type_call_decline("__new__ overridden alongside __init__");
-    }
-    // The class occupies the first parameter, so the body needs one slot per
-    // argument the call site passes on top of it.
-    if nparams != r_args.len() - 1 {
-        return type_call_decline("__new__ arity does not match the call");
-    }
-
-    let mut arg_concretes = vec![ConcreteValue::Ref(w_type), ConcreteValue::Null];
-    let mut callee_args = vec![r_args[0]];
-    let mut callee_arg_concretes = vec![ConcreteValue::Ref(w_type)];
-    for (i, &arg) in r_args[2..].iter().enumerate() {
-        let Some(concrete) = walker_concrete_ref_object(ctx, arg) else {
-            return type_call_decline(&format!("argument {i} is not a concrete ref"));
-        };
-        arg_concretes.push(ConcreteValue::Ref(concrete));
-        callee_args.push(arg);
-        callee_arg_concretes.push(ConcreteValue::Ref(concrete));
-    }
-
-    // Everything below emits; cut back to here if the sub-walk declines, the
-    // same rewind point the `object.__new__` arm keeps.
-    let pre_fold_pos = ctx.trace_ctx.get_trace_position();
-    let type_const = ctx.trace_ctx.const_ref(w_type as i64);
-    walker_emit_fold_guard_with_snapshot(ctx, op.pc, OpCode::GuardValue, &[r_args[0], type_const])?;
-    ctx.trace_ctx
-        .heap_cache_mut()
-        .replace_box(r_args[0], type_const);
-    walker_pin_type_version_tag(ctx, op.pc, type_const)?;
-    if let Some(w_metaclass) = metaclass_to_pin {
-        let metaclass_const = ctx.trace_ctx.const_ref(w_metaclass as i64);
-        walker_pin_type_version_tag(ctx, op.pc, metaclass_const)?;
-    }
-    if fbw_inline_diag_enabled() {
-        eprintln!(
-            "[type-call-inline] pc={} class={} via=__new__",
-            op.pc,
-            unsafe { pyre_object::w_type_get_name(w_type) }
-        );
-    }
-
-    let inlined = try_walker_inline_resolved_user_call(
-        ctx,
-        op,
-        code,
-        funcptr,
-        r_args,
-        call_descr,
-        dst_bank,
-        dst,
-        w_new,
-        r_args[0],
-        w_type,
-        arg_concretes,
-        callee_args,
-        callee_arg_concretes,
-        true,
-        None,
-        w_code,
-        nparams,
-        has_closure,
-        None,
-        None,
-        true,
-        false,
-        // The callee's own return value IS the instance, unlike the `__init__`
-        // sub-walk whose result is discarded in favour of the emitted one.
-        None,
-    )?;
-    if inlined.is_none() {
-        if fbw_inline_diag_enabled() {
-            eprintln!(
-                "[type-call-rewind] pc={} class={} why=__new__ sub-walk declined",
                 op.pc,
                 unsafe { pyre_object::w_type_get_name(w_type) },
             );
@@ -7896,10 +7739,20 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
     // `bool` layout collapses both to a pointer test against `w_True`, and for
     // `in` the wrap is then the identity: the object the body returned already
     // IS the singleton the opcode produces.
+    // `require_bool_result` above already rejected anything that is not one of
+    // the two singletons, and it did so where the CALL boundary can still be
+    // latched.  Both arms below are therefore unreachable on this path; they
+    // stay as the shape's classification, and abort rather than guess if a
+    // future change relaxes that check — an unlatched abort is the weaker
+    // disposition, so the assertion is what keeps it from becoming live.
     let result = ctx.registers_r[dst];
     let w_true = pyre_object::w_bool_from(true);
-    let ConcreteValue::Ref(observed) = concrete_from_recorded_opref(ctx, result) else {
-        return Err(DispatchError::callee_inline_unsupported(op.pc));
+    let observed = match concrete_from_recorded_opref(ctx, result) {
+        ConcreteValue::Ref(observed) => observed,
+        _ => {
+            debug_assert!(false, "require_bool_result admitted a non-Ref result");
+            return Err(DispatchError::callee_inline_unsupported(op.pc));
+        }
     };
     let found = if std::ptr::eq(observed, w_true) {
         true
@@ -7907,13 +7760,13 @@ pub(crate) fn try_walker_inline_user_contains<Sym: WalkSym>(
         false
     } else {
         // Anything else needs the `__bool__` / `__len__` dispatch this route
-        // cannot emit.  Only a body the sample above could not run reaches here,
-        // so the walk is already committed and the call aborts to its residual.
+        // cannot emit.
         if fbw_inline_diag_enabled() {
             eprintln!("[contains-inline-nonbool] pc={} class={}", op.pc, unsafe {
                 pyre_object::typeobject::w_type_get_name(w_class)
             });
         }
+        debug_assert!(false, "require_bool_result admitted a non-singleton result");
         return Err(DispatchError::callee_inline_unsupported(op.pc));
     };
 

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -7330,13 +7330,6 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                     )? {
                         return Ok(inlined);
                     }
-                    // CONTAINS_OP rides the same residual under tags 6 / 7,
-                    // which the rich-compare route above does not name.
-                    if let Some(inlined) = try_walker_inline_user_contains(
-                        ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
-                    )? {
-                        return Ok(inlined);
-                    }
                 }
             }
         }

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -7330,6 +7330,13 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                     )? {
                         return Ok(inlined);
                     }
+                    // CONTAINS_OP rides the same residual under tags 6 / 7,
+                    // which the rich-compare route above does not name.
+                    if let Some(inlined) = try_walker_inline_user_contains(
+                        ctx, op, code, op_tag, &r_args, call_descr, dst, dst_bank,
+                    )? {
+                        return Ok(inlined);
+                    }
                 }
             }
         }

--- a/pyre/pyre-object/src/unicodeobject.rs
+++ b/pyre/pyre-object/src/unicodeobject.rs
@@ -765,19 +765,41 @@ pub unsafe fn w_str_get_wtf8(obj: PyObjectRef) -> &'static Wtf8 {
 /// `obj` must be a `W_UnicodeObject`.
 #[inline]
 pub unsafe fn w_str_get_hash(obj: PyObjectRef) -> i64 {
-    unsafe { (*(obj as *const W_UnicodeObject)).hash }
+    unsafe { hash_slot(obj) }.load(std::sync::atomic::Ordering::Relaxed)
 }
 
-/// Publish a computed digest into the memo slot, `rstr.py:411-412`.  Racing
-/// writers store the same value, so no ordering is required; upstream
+/// The memo slot, reached as an atomic.
+///
+/// One interned string now answers every thread that names it, so the read in
+/// [`w_str_hash_memoized`] and the write below genuinely run concurrently. The
+/// field stays a plain `i64` — an `AtomicI64` would nest a by-value struct in
+/// `W_UnicodeObject` and renumber the field descrs the JIT addresses it by —
+/// and [`std::sync::atomic::AtomicI64::from_ptr`] is what makes those accesses
+/// well defined; every read and write of `hash` goes through this helper.
+///
+/// `Relaxed` carries the whole ordering requirement: racing writers store the
+/// identical digest, and nothing is published through the slot, so a reader
+/// either sees zero and recomputes or sees the one value anyone would write.
+///
+/// # Safety
+/// `obj` must be a `W_UnicodeObject`.
+#[inline]
+unsafe fn hash_slot<'a>(obj: PyObjectRef) -> &'a std::sync::atomic::AtomicI64 {
+    unsafe {
+        std::sync::atomic::AtomicI64::from_ptr(&raw mut (*(obj as *mut W_UnicodeObject)).hash)
+    }
+}
+
+/// Publish a computed digest into the memo slot, `rstr.py:411-412`.  Upstream
 /// reaches the field through `conditional_call_elidable`, which likewise
-/// tolerates a repeated computation.
+/// tolerates a repeated computation; [`hash_slot`] carries why a racing
+/// repeat is harmless here.
 ///
 /// # Safety
 /// `obj` must be a `W_UnicodeObject`.
 #[inline]
 pub unsafe fn w_str_set_hash(obj: PyObjectRef, hash: i64) {
-    unsafe { (*(obj as *mut W_UnicodeObject)).hash = hash }
+    unsafe { hash_slot(obj) }.store(hash, std::sync::atomic::Ordering::Relaxed);
 }
 
 /// `rstr.py ll_strhash` — read the memo, and compute the digest only


### PR DESCRIPTION
Twelve commits. One lands something; the rest are review response and support.

**`_abc`** — `weak_cache_contains` bounced out to app-level
`SimpleWeakSet.__contains__` for every membership test, and that one frame was
1.11 µs of `_abc_instancecheck`'s 1.67 µs. `simple_weak_set_contains` answers
natively and declines to the membership protocol otherwise.

Measured warmed, 3 interleaved rounds, 3/3 consistent:

| | before | after |
|---|---|---|
| `_abc_instancecheck` hit | 1.261 µs | 0.627 µs |
| `_abc_instancecheck` miss | 2.319 µs | 1.039 µs |
| `isinstance(obj, ABC)` | 1.636 µs | 1.034 µs |

Answering natively is sound only while every part of the collection is still
the one `_abc_init` installed, and review found four ways it was not. It now
declines unless the receiver's class is exactly `SimpleWeakSet`, that class's
`__contains__` is still the method `app_abc.py` installed *and still holds the
code object it was defined with*, and `data` is exactly a `set` — not merely one
by layout, which a subclass overriding `__contains__` also satisfies. A failed
probe hash recovers the pending exception instead of re-asking through the
protocol, which would have run an observable metaclass `__hash__` a second time,
and it recovers it through the set spelling, so the message names a set element
rather than a dict key.

The guard is the triple `(method, code, ref_global)`. The app-level body is
`try: wr = ref(item) / except TypeError: return False / return wr in self.data`,
so `ref` is its whole free-variable surface and it takes no defaults — pinning
those three is exhaustive for this body rather than a narrowing. Reading the code
object off the installed method is defined only for a function, so a
`__contains__` rebound to a non-function is rejected before that read, not by
comparing what the read returned.

**Withdrawn: both walker inline routes.** The branch added two and takes both
back out, so the net walker diff is empty and each case declines as `main` does.

- *`__contains__` from the `CONTAINS_OP` residual* (`723fe5edaed`, removed in
  `1312fe209b5`). Its `CompareOp` descriptor cannot be latched by
  `latch_abort_call_resume`, which reconstructs only `CallFn`/`CallFunctionEx`,
  so a non-bool result aborted the walk after the body's effects had run and the
  loop replayed from entry: 3002 body runs for a 3000-turn `while` loop, on both
  backends. Gating on `exc_override_sample_safe` as review proposed was measured
  to admit constant-returning bodies and nothing else — `self.a`, `x + 1` and
  `len(self.items)` all decline — which retires the route's whole win. A sound
  fix needs the object-level truth conversion (`PyreHelperKind::Truth`) minted
  from a walker route, which no helper does today. Removing the route also lets
  that loop compile: `loops_compiled=1 loops_aborted=0`, previously `0` and `2`.
- *An overridden `__new__` in the walker's type call* (`5af05b0b78a`, removed in
  `06ee51ff535`). It decided `__init__` from the requested class, while
  `descr_call` calls it on the returned object's class: a `__new__` returning an
  instance of a subclass with its own `__init__` ran that initializer 1041 of
  40000 times, the interpreted iterations only. Guarding the result needs the
  `w_class` word rather than the layout `ob_type` that a `GuardClass` reads,
  which is more than the route is worth while its original target fixture is
  blocked upstream of it for an unrelated reason.

The sibling rich-compare route `try_walker_inline_user_compareop` on `main` has
the same unlatched-abort shape — an effectful `__lt__` returning `NotImplemented`
also runs 3002 times against CPython's 3000. That is pre-existing and belongs in
its own issue.

**Fixture** — no bench in the corpus reached `_abc` at all: counting
`ABCMeta.__instancecheck__` calls across `pyre/bench/synth` returned zero for
every script. `abc_instancecheck_weak_cache` drives both caches plus a mid-loop
`register`, with baselines for all three backends. Note its ratio prints with a
`?` when pypy's exec time lands under `FLOOR_GATE_MIN_BASELINE_S`, which happens
on a quiet machine; the ceiling applies either way.

**Tests** — `pyre/extra_tests/parity_tests/abc_weak_cache_membership.py` covers
the empty-collection answer, an item that cannot carry a weakref, a metaclass
`__hash__` that raises (once, not twice) and is reported as a set element, a
collected entry, and the arms that must decline: a rebound collection, a
replaced `data`, a `data` that is a `set` subclass whose `__contains__` lies,
and a `__contains__` whose `__code__` was reassigned in place. The arms that
name the collection are guarded, since parity tests run under CPython too and
CPython does not expose `_abc_cache`.

**Known, not fixed here.** Both predate this branch and both are confirmed:

- A `staticmethod` subclass overriding `__get__`, installed as a class's
  `__new__`, is bypassed once the loop compiles — `{'bound': 2104, 'real':
  37896}` where CPython gives `{'bound': 40000}`. It reproduces with the
  withdrawn route entirely removed, and `pypyjit.set_param("off")` makes it
  correct, so it is a trace-time fold elsewhere in the type-call path. Repro in
  the review thread.
- `_abc._reset_registry(cls)` leaves a registered virtual subclass answering
  `True` where CPython answers `False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QCct5Z2Yn3Be6Pz22GgNZw


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ABC cache membership handling, including cache updates, invalidation, and unusual class behaviors.
  - Preserved accurate error reporting when hashing fails for dictionary keys or set elements.
  - Improved thread safety for cached string hash values.
  - Strengthened cleanup behavior during concurrent code execution.
  - Prevented unsafe replay behavior during certain optimized operations.

- **Tests**
  - Added comprehensive compatibility tests for ABC weak-cache behavior.
  - Added a benchmark covering positive and negative instance checks, cache invalidation, and runtime performance statistics.
  - Updated performance statistics for loop compilation benchmarks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->