### PR TITLE
gc: root the receivers and operands the dict, set and sequence paths hold across a hash or a coercion

### DIFF
--- a/pyre/extra_tests/snippets/bytearray_justify_reads_the_resized_receiver.py
+++ b/pyre/extra_tests/snippets/bytearray_justify_reads_the_resized_receiver.py
@@ -1,0 +1,27 @@
+# pyre-check: gate=1
+"""A width argument's `__index__` may resize a bytearray receiver.
+
+`ljust`/`rjust`/`center`/`zfill`/`replace` coerce their arguments before
+reading the receiver's bytes, so the result describes the receiver as it is
+once every coercion has run.
+"""
+
+
+class Resize:
+    def __init__(self, target, width):
+        self.target = target
+        self.width = width
+
+    def __index__(self):
+        self.target[:] = b"Z" * 64
+        return self.width
+
+
+for name in ("ljust", "rjust", "center", "zfill"):
+    ba = bytearray(b"abcdefgh")
+    got = getattr(ba, name)(Resize(ba, 40))
+    assert got == b"Z" * 64, (name, bytes(got[:32]))
+
+ba = bytearray(b"abcdefgh")
+got = ba.replace(b"Z", b"y", Resize(ba, 3))
+assert got == b"y" * 3 + b"Z" * 61, bytes(got[:32])

--- a/pyre/extra_tests/snippets/bytes_replace_checks_operands_before_count.py
+++ b/pyre/extra_tests/snippets/bytes_replace_checks_operands_before_count.py
@@ -1,0 +1,44 @@
+# pyre-check: gate=1
+"""`bytes.replace` rejects a bad `old`/`new` before it coerces `count`.
+
+The clinic signature converts the two buffers ahead of the integer, so a
+non-bytes-like operand raises `TypeError` without ever reaching the third
+argument's `__index__`.  The payload slices are still taken after the
+coercion, because a `bytearray` operand resized there reallocates the buffer
+they point into.
+"""
+
+
+class Counter:
+    def __init__(self):
+        self.calls = 0
+
+    def __index__(self):
+        self.calls += 1
+        return 1
+
+
+for receiver in (b"abcabc", bytearray(b"abcabc")):
+    for old, new in ((1, b"z"), (b"a", 2), (None, None)):
+        count = Counter()
+        try:
+            receiver.replace(old, new, count)
+        except TypeError as exc:
+            print(type(receiver).__name__, type(exc).__name__, exc)
+        else:
+            print(type(receiver).__name__, "no error")
+        print("  __index__ calls:", count.calls)
+
+
+class Grow:
+    def __init__(self, target):
+        self.target = target
+
+    def __index__(self):
+        self.target += b"Q" * 64
+        return 2
+
+
+target = bytearray(b"abcabcabc")
+print(target.replace(b"a", b"zz", Grow(target)))
+print(len(target))

--- a/pyre/extra_tests/snippets/gc_builtin_operand_survives_its_coercion.py
+++ b/pyre/extra_tests/snippets/gc_builtin_operand_survives_its_coercion.py
@@ -1,0 +1,63 @@
+# pyre-check: gate=1
+"""A builtin's other operand outlives the argument it coerces first.
+
+`operator.length_hint`, `array.index`, `sorted` and `ContextVar.set` each run
+Python for one argument — `__index__`, `__bool__`, or a mapping update — while
+still holding another that the caller may have passed as a list or a dict.
+"""
+
+import array
+import contextvars
+import gc
+import operator
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Idx:
+    def __init__(self, n):
+        self.n = n
+
+    def __index__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+
+class Truth:
+    def __bool__(self):
+        gc.collect()
+        churn()
+        return False
+
+
+assert operator.length_hint([1, 2, 3], Idx(7)) == 3
+assert operator.length_hint({"a": 1}, Idx(7)) == 1
+
+numbers = array.array("i", [1, 2, 3, 4, 5])
+assert numbers.index(4, Idx(0)) == 3
+try:
+    found = numbers.index([4], Idx(0))
+except (ValueError, TypeError):
+    found = "absent"
+assert found == "absent", found
+
+assert sorted([[3], [1], [2]], key=lambda x: x[0], reverse=Truth()) == [[1], [2], [3]]
+assert sorted([[3], [1]], reverse=Truth()) == [[1], [3]]
+
+variable = contextvars.ContextVar("gate")
+variable.set([1, 2, 3])
+for _ in range(20):
+    churn()
+    gc.collect()
+token = variable.set([4, 5, 6])
+gc.collect()
+churn()
+assert token.old_value == [1, 2, 3], token.old_value
+variable.reset(token)
+assert variable.get() == [1, 2, 3], variable.get()

--- a/pyre/extra_tests/snippets/gc_codec_lookup_roots_its_object.py
+++ b/pyre/extra_tests/snippets/gc_codec_lookup_roots_its_object.py
@@ -1,0 +1,47 @@
+# pyre-check: gate=1
+"""A codec lookup runs Python, so the object being decoded must survive it.
+
+`codecs.register` search functions run while the decode is already under way:
+an uncached name imports its `encodings` module and calls every registered
+search function before the codec's own `decode` is reached.  The object handed
+to that decode is a copy the interpreter made of the source bytes, so it has to
+stay rooted across the lookup rather than only across the final call.
+"""
+import codecs
+import gc
+
+SRC = bytes(range(128))
+TEXT = "".join(chr(i) for i in range(128))
+seen = []
+
+
+def probe_decode(b, errors="strict"):
+    raw = bytes(b)
+    seen.append(raw)
+    return (raw.decode("latin-1"), len(raw))
+
+
+def probe_encode(u, errors="strict"):
+    seen.append(u)
+    return (u.encode("latin-1"), len(u))
+
+
+def make_search(name):
+    def search(query):
+        if query != name:
+            return None
+        for _ in range(3):
+            gc.collect()
+        return codecs.CodecInfo(name=name, encode=probe_encode, decode=probe_decode)
+
+    return search
+
+
+codecs.register(make_search("pyreprobedec"))
+codecs.register(make_search("pyreprobeenc"))
+
+assert str(SRC, "pyreprobedec") == TEXT
+assert seen[-1] == SRC, seen[-1]
+
+assert TEXT.encode("pyreprobeenc") == SRC
+assert seen[-1] == TEXT, seen[-1]

--- a/pyre/extra_tests/snippets/gc_dict_default_survives_the_key_hash.py
+++ b/pyre/extra_tests/snippets/gc_dict_default_survives_the_key_hash.py
@@ -1,0 +1,46 @@
+# pyre-check: gate=1
+"""`dict.get` / `dict.pop` return their default after hashing the key.
+
+Hashing is user code, and the default is only consumed once it has run, so a
+default that is itself a list or a dict has to come back from the root stack
+rather than from the argument copy the call started with.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Key:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+    def __eq__(self, other):
+        return isinstance(other, Key) and other.n == self.n
+
+
+for _round in range(20):
+    numbers = {i: i for i in range(20)}
+
+    assert numbers.get(Key(7), [1, 2, 3]) == [1, 2, 3]
+    assert numbers.get(Key(7), {"a": 1}) == {"a": 1}
+    assert numbers.pop(Key(7), [4, 5, 6]) == [4, 5, 6]
+    assert numbers.pop(Key(7), {"b": 2}) == {"b": 2}
+
+    fallback = [7, 8, 9]
+    assert numbers.get(Key(7), fallback) is fallback
+    assert numbers.setdefault(Key(7), [1]) == [1]
+    assert numbers[Key(7)] == [1]
+
+    numbers[Key(9)] = [3, 2, 1]
+    assert numbers.get(Key(9), None) == [3, 2, 1]

--- a/pyre/extra_tests/snippets/gc_dict_fromkeys_roots_the_new_dict.py
+++ b/pyre/extra_tests/snippets/gc_dict_fromkeys_roots_the_new_dict.py
@@ -1,0 +1,42 @@
+# pyre-check: gate=1
+"""`dict.fromkeys` builds its dict before it drains the iterable.
+
+Draining runs the iterable's own Python, and a dict is nursery-allocated, so
+the dict has to be rooted for that window and read back afterwards — a store
+into the pre-move address hands the write barrier an object that is no longer
+there.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+def keys(items):
+    for item in items:
+        gc.collect()
+        churn()
+        yield item
+
+
+
+class Sub(dict):
+    pass
+
+
+for _round in range(30):
+    built = dict.fromkeys(keys(["a", "b", "c"]))
+    assert sorted(built) == ["a", "b", "c"], built
+    assert all(value is None for value in built.values()), built
+
+    built = dict.fromkeys(keys([1, 2, 3]), "v")
+    assert built == {1: "v", 2: "v", 3: "v"}, built
+
+
+    built = Sub.fromkeys(keys([1, 2, 3]), 0)
+    assert isinstance(built, Sub) and built == {1: 0, 2: 0, 3: 0}, built

--- a/pyre/extra_tests/snippets/gc_dict_probe_reloads_its_container.py
+++ b/pyre/extra_tests/snippets/gc_dict_probe_reloads_its_container.py
@@ -1,0 +1,63 @@
+# pyre-check: gate=1
+"""A dict operation re-reads its receiver after the key's `__hash__`.
+
+Every checked dict entry point holds the dictionary in a native local while it
+hashes the key and while it promotes a typed strategy to the object strategy.
+Both allocate, and a dictionary still in the nursery moves when they do, so the
+probe that follows has to name the address the collector left behind rather
+than the one the call started with.
+
+Each operation gets its own loop: the crash needs the receiver to still be
+young at the probe, and the surrounding allocation is what decides that, so
+sequencing several probes over one dictionary hides them.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Key:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+    def __eq__(self, other):
+        return isinstance(other, Key) and other.n == self.n
+
+
+ROUNDS = 40
+
+for _round in range(ROUNDS):
+    numbers = {i: i for i in range(20)}
+    print(repr(Key(9) in numbers))
+
+for _round in range(ROUNDS):
+    numbers = {i: i for i in range(20)}
+    assert numbers.get(Key(9)) is None
+
+for _round in range(ROUNDS):
+    numbers = {i: i for i in range(20)}
+    assert numbers.get(Key(9), "absent") == "absent"
+
+for _round in range(ROUNDS):
+    numbers = {i: i for i in range(20)}
+    assert numbers.pop(Key(9), "absent") == "absent"
+
+for _round in range(ROUNDS):
+    numbers = {i: i for i in range(20)}
+    assert numbers.setdefault(Key(9), "fresh") == "fresh"
+    assert numbers[9] == 9
+
+for _round in range(ROUNDS):
+    words = {str(i): i for i in range(20)}
+    assert words.get(Key(3), "absent") == "absent"

--- a/pyre/extra_tests/snippets/gc_list_index_argument_roots_its_receiver.py
+++ b/pyre/extra_tests/snippets/gc_list_index_argument_roots_its_receiver.py
@@ -1,0 +1,46 @@
+# pyre-check: gate=1
+"""A list method reads its receiver back after the index argument runs Python.
+
+The gateway hands the body a stack copy of the arguments.  A minor collection
+rewrites the shadow-stack slots, not that copy, so the receiver read out of it
+after an `__index__` dispatch is a pre-move address.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Idx:
+    def __init__(self, n):
+        self.n = n
+
+    def __index__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+
+numbers = list(range(8))
+assert numbers.pop(Idx(2)) == 2
+assert numbers == [0, 1, 3, 4, 5, 6, 7], numbers
+
+numbers.insert(Idx(2), 99)
+assert numbers == [0, 1, 99, 3, 4, 5, 6, 7], numbers
+
+numbers = [1, 2, 3]
+numbers *= Idx(2)
+assert numbers == [1, 2, 3, 1, 2, 3], numbers
+
+assert [1, 2, 3] * Idx(2) == [1, 2, 3, 1, 2, 3]
+assert Idx(2) * [1, 2, 3] == [1, 2, 3, 1, 2, 3]
+
+buf = bytearray(b"abcdefgh")
+assert buf.pop(Idx(2)) == 99
+buf.insert(Idx(2), 67)
+assert buf == bytearray(b"abCdefgh"), buf

--- a/pyre/extra_tests/snippets/gc_list_remove_reloads_its_receiver.py
+++ b/pyre/extra_tests/snippets/gc_list_remove_reloads_its_receiver.py
@@ -1,0 +1,37 @@
+# pyre-check: gate=1
+"""`list.remove` addresses the live receiver after its equality scan.
+
+The scan runs the elements' `__eq__`, which is a collection point, and a
+`W_ListObject` header moves.  The scan helper pins and reloads for its own
+loop, but that scope drops when it returns, so the length read and the pop
+below it addressed a pre-move header.
+
+The element has to actually match: with an `__eq__` that always reports unequal
+the scan raises before the pop is ever reached, and the defective line does not
+run.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Match:
+    """Collects, then reports equal, so `remove` reaches its pop."""
+
+    def __eq__(self, other):
+        churn()
+        return True
+
+
+for _ in range(30):
+    victim = [1, 2, 3, 4, 5]
+    victim.remove(Match())
+    print(len(victim), victim)

--- a/pyre/extra_tests/snippets/gc_oserror_args_roots.py
+++ b/pyre/extra_tests/snippets/gc_oserror_args_roots.py
@@ -1,0 +1,22 @@
+# pyre-check: gate=1
+"""OSError stores the arguments it was given, not the ones it started with.
+
+Building the message runs every argument's `__repr__`, and the tuple is
+stored afterwards, so an argument that moved while a `__repr__` ran must
+still be stored correctly.
+"""
+
+
+class R:
+    def __repr__(self):
+        for _ in range(300):
+            [0] * 64
+        return "R"
+
+
+for _ in range(200):
+    payload = [1, 2, 3]
+    err = OSError(payload, R())
+    assert err.args[0] == [1, 2, 3], repr(err.args)
+    assert err.args[0] is payload, repr(err.args)
+    assert repr(err.args[1]) == "R", repr(err.args)

--- a/pyre/extra_tests/snippets/gc_percent_format_roots_its_operands.py
+++ b/pyre/extra_tests/snippets/gc_percent_format_roots_its_operands.py
@@ -1,0 +1,63 @@
+# pyre-check: gate=1
+"""`%` formatting keeps its operands alive and current across a conversion.
+
+Two separate holes, both reached through the same operand column:
+
+* `BINARY_OP %` pops the format string and the operand off the value stack
+  before dispatching, so on `b"%a" % (Collects(),)` nothing refers to the
+  operand tuple while `__repr__` runs.  A tuple never moves, but an
+  unreachable one is still collected.
+* Every conversion runs Python, and the operands are drained into a plain
+  native column first.  A list or dict still waiting its turn moves under a
+  collection triggered by an earlier conversion, so it would be formatted at
+  a pre-move address.  This one bites on the method form too, where the
+  argument slice is already pinned.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Collects:
+    def __str__(self):
+        churn()
+        return "s"
+
+    def __repr__(self):
+        churn()
+        return "r"
+
+    def __format__(self, spec):
+        churn()
+        return "f"
+
+
+# Liveness: the operand tuple is a temporary the operator has already popped.
+for _ in range(30):
+    print(b"%a-%a" % (Collects(), Collects()))
+    print("%s-%s" % (Collects(), Collects()))
+    print("{}-{}".format(Collects(), Collects()))
+
+# Staleness: a movable operand queued behind a collecting one, through the
+# operator and through the method form whose argument slice is pinned.
+for _ in range(30):
+    print(b"%a|%a|%a" % (Collects(), [1, 2, 3], {4: 5}))
+    print("%s|%s|%s" % (Collects(), [1, 2, 3], {4: 5}))
+    print(bytes.__mod__(b"%a|%a|%a", (Collects(), [1, 2, 3], {4: 5})))
+    print(str.__mod__("%s|%s|%s", (Collects(), [1, 2, 3], {4: 5})))
+
+# A `*` width reads its own operand through the same column.
+for _ in range(30):
+    print("%*s|%s" % (4, Collects(), [1, 2, 3]))
+
+# The keyed form holds the mapping itself across every lookup.
+for _ in range(30):
+    print("%(a)s|%(b)s" % {"a": Collects(), "b": [1, 2, 3]})

--- a/pyre/extra_tests/snippets/gc_set_membership_roots_a_temporary_receiver.py
+++ b/pyre/extra_tests/snippets/gc_set_membership_roots_a_temporary_receiver.py
@@ -1,0 +1,49 @@
+# pyre-check: gate=1
+"""`x in <set>` keeps the set alive across the element's `__hash__`.
+
+`CONTAINS_OP` pops the container off the operand stack before dispatching, so
+on a set that is only a temporary nothing refers to it while the element
+hashes. A set is an old-gen allocation and never moves, but an unreachable one
+is still collected, so it has to be pinned for liveness even though there is
+no address to reload.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Key:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+    def __eq__(self, other):
+        return isinstance(other, Key) and other.n == self.n
+
+
+ROUNDS = 30
+
+for _round in range(ROUNDS):
+    print(repr(Key(9) in {i for i in range(20)}))
+
+for _round in range(ROUNDS):
+    print(repr(Key(9) in frozenset(range(20))))
+
+for _round in range(ROUNDS):
+    print(repr(Key(9) not in {i for i in range(20)}))
+
+# A named receiver is rooted by the frame and was never the failing shape;
+# it is here so the pair stays visible.
+for _round in range(ROUNDS):
+    numbers = {i for i in range(20)}
+    assert (Key(9) in numbers) is False

--- a/pyre/extra_tests/snippets/gc_set_subset_walk_roots_its_receiver.py
+++ b/pyre/extra_tests/snippets/gc_set_subset_walk_roots_its_receiver.py
@@ -1,0 +1,68 @@
+# pyre-check: gate=1
+"""A set subset walk keeps its receiver alive across an element's `__eq__`.
+
+`set_is_subset_of` probes with the digest each element was stored under, so
+the walk hashes nothing — but a bucket match still runs the elements'
+`__eq__`, and `COMPARE_OP` popped both operands before dispatching.  A set is
+old-gen and never moves, so nothing crashes and no answer changes: the
+receiver is simply collected while the walk is still using it.
+
+A crash probe cannot see that, because it needs the freed memory reused before
+the dangling read.  This asks the collector instead — a weakref-able cell is
+placed inside the set as its only referrer, so if the set dies during the hop
+the weakref clears.
+"""
+
+import gc
+import weakref
+
+REF = None
+KEEP = None
+SEEN = set()
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Cell:
+    pass
+
+
+def tracked():
+    """A fresh cell whose only referrer will be the set under test."""
+    global REF
+    c = Cell()
+    REF = weakref.ref(c)
+    return c
+
+
+class Probe:
+    """Collects, then records the receiver's liveness from inside the hop."""
+
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        churn()
+        SEEN.add(REF() is not None)
+        return False
+
+
+# `<=` takes the subset walk whatever the lengths are, while `==`
+# short-circuits on the length the tracking cell changes.  Which element the
+# walk reaches first — and so whether `__eq__` runs at all for a given form —
+# follows set iteration order, so the observations are pooled across every form
+# and every round and reported once.  What is asserted is that no form ever
+# reaches `__eq__` with the receiver already collected, not how often any
+# particular one gets there.
+for _ in range(20):
+    print(frozenset({Probe(), tracked()}) <= {Probe(), 1, 2})
+    print({Probe(), tracked()} <= {Probe(), 1, 2})
+    print({Probe(), tracked()}.issubset([Probe(), 1, 2]))
+    print({Probe(), tracked()} == {Probe(): 1, 2: 2}.keys())
+
+print("receiver liveness observed during the subset walks:", sorted(SEEN))

--- a/pyre/extra_tests/snippets/gc_set_update_operand_roots.py
+++ b/pyre/extra_tests/snippets/gc_set_update_operand_roots.py
@@ -1,0 +1,36 @@
+# pyre-check: gate=1
+"""set.update/union/difference_update read every operand once, up front.
+
+Each operand is drained through a user `__hash__`/`__iter__`, so an operand
+still waiting its turn must be reachable afterwards rather than re-read from
+whatever the call started with.
+"""
+
+
+class H:
+    def __init__(self, n):
+        self.n = n
+
+    def __hash__(self):
+        for _ in range(200):
+            [0] * 64
+        return self.n
+
+    def __eq__(self, other):
+        return isinstance(other, H) and other.n == self.n
+
+
+for _ in range(50):
+    first = [H(i) for i in range(8)]
+    second = [H(100 + i) for i in range(8)]
+
+    s = set()
+    s.update(first, second)
+    assert len(s) == 16, len(s)
+
+    u = set().union(first, second)
+    assert len(u) == 16, len(u)
+
+    d = set(first) | set(second)
+    d.difference_update(first, second)
+    assert len(d) == 0, len(d)

--- a/pyre/extra_tests/snippets/gc_slice_bounds_root_the_second_operand.py
+++ b/pyre/extra_tests/snippets/gc_slice_bounds_root_the_second_operand.py
@@ -1,0 +1,50 @@
+# pyre-check: gate=1
+"""A start/stop pair is converted one bound at a time.
+
+The first bound's `__index__` runs Python, so the second must be reachable
+across it.  A window call that supplies only `start` is the sharp case: the
+implicit `stop` is a freshly built int nothing else holds.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    """Take the freed boxes, so a sweep that frees is not invisible."""
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Idx:
+    def __init__(self, n):
+        self.n = n
+
+    def __index__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+
+for _round in range(30):
+    numbers = list(range(40))
+    assert numbers.index(5, Idx(2)) == 5
+    assert numbers.index(5, Idx(2), Idx(30)) == 5
+
+    pairs = tuple(range(40))
+    assert pairs.index(5, Idx(2)) == 5
+
+    text = "abcdefgh" * 4
+    assert text.find("c", Idx(2)) == 2
+    assert text.count("a", Idx(2)) == 3
+    assert text.startswith("c", Idx(2)) is True
+    assert text.rfind("a", Idx(2)) == 24
+
+    raw = b"abcdefgh" * 4
+    assert raw.find(b"c", Idx(2)) == 2
+    assert raw.count(b"a", Idx(2)) == 3
+    assert raw.endswith(b"h", Idx(2)) is True
+
+    buf = bytearray(b"abcdefgh" * 4)
+    assert buf.find(b"c", Idx(2)) == 2

--- a/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
+++ b/pyre/extra_tests/snippets/gc_subscript_roots_its_container.py
@@ -1,0 +1,65 @@
+# pyre-check: gate=1
+"""Item access keeps its container reachable across the key's `__index__`.
+
+`BINARY_SUBSCR` / `STORE_SUBSCR` / `DELETE_SUBSCR` pop every operand before
+the dispatch reaches the by-layout arm, so a container the operand stack was
+the only holder of has nothing rooting it while `__index__` runs Python.  A
+list is nursery-allocated on top of that: a collection there moves it, and the
+address the arm started with is the pre-move one.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    """Take the freed boxes, so a sweep that frees is not invisible."""
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Idx:
+    def __init__(self, n):
+        self.n = n
+
+    def __index__(self):
+        gc.collect()
+        churn()
+        return self.n
+
+
+# Temporaries: nothing but the operand stack ever held these containers.
+assert [10, 20, 30][Idx(1)] == 20
+assert (10, 20, 30)[Idx(1)] == 20
+assert "abcd"[Idx(1)] == "b"
+assert b"abcd"[Idx(1)] == 98
+assert bytearray(b"abcd")[Idx(1)] == 98
+assert range(10, 20)[Idx(1)] == 11
+assert list(range(8))[Idx(2) :] == [2, 3, 4, 5, 6, 7]
+assert bytearray(b"abcdefgh")[Idx(2) : Idx(6)] == bytearray(b"cdef")
+
+# The assigned value is read after the key's `__index__` has already run.
+target = bytearray(b"abcd")
+target[Idx(1)] = 65
+assert target == bytearray(b"aAcd"), target
+
+held = [10, 20, 30]
+held[Idx(1)] = 99
+assert held == [10, 99, 30], held
+
+held = [10, 20, 30]
+del held[Idx(1)]
+assert held == [10, 30], held
+
+held = list(range(12))
+del held[Idx(2) : Idx(8)]
+assert held == [0, 1, 8, 9, 10, 11], held
+
+held = list(range(12))
+del held[Idx(2) : Idx(10) : Idx(3)]
+assert held == [0, 1, 3, 4, 6, 7, 9, 10, 11], held
+
+held = bytearray(b"abcdefgh")
+held[Idx(2) : Idx(4)] = b"ZZZ"
+assert held == bytearray(b"abZZZefgh"), held

--- a/pyre/extra_tests/snippets/mutating_index_bound_reads_the_live_length.py
+++ b/pyre/extra_tests/snippets/mutating_index_bound_reads_the_live_length.py
@@ -1,0 +1,59 @@
+# pyre-check: gate=1
+"""A bound's own `__index__` may resize the sequence it bounds.
+
+Converting the bounds is the step that runs Python, so the length that folds a
+negative bound and clamps a slice has to be read after that step, not before.
+"""
+
+
+def grow(target, value):
+    class Bound:
+        def __index__(self):
+            target.extend(range(100, 120))
+            return value
+
+    return Bound()
+
+
+numbers = list(range(10))
+assert numbers[grow(numbers, 8) :] == [8, 9] + list(range(100, 120)), numbers[8:]
+
+numbers = list(range(10))
+assert numbers[grow(numbers, -3) :] == [117, 118, 119]
+
+numbers = list(range(10))
+assert numbers[grow(numbers, -3) : -1] == [117, 118]
+
+numbers = list(range(10))
+del numbers[grow(numbers, 8) :]
+assert numbers == list(range(8)), numbers
+
+numbers = list(range(10))
+numbers[grow(numbers, 8) :] = [1]
+assert numbers == list(range(8)) + [1], numbers
+
+# A negative `start` folds against the length the conversion left behind, so
+# the value at index 15 is outside the window that starts at 25.
+numbers = list(range(10))
+try:
+    found = numbers.index(105, grow(numbers, -5))
+except ValueError:
+    found = "not in list"
+assert found == "not in list", found
+
+numbers = list(range(10))
+assert numbers.index(105, grow(numbers, 0)) == 15
+
+buf = bytearray(b"abcdefghij")
+
+
+def grow_buf(value):
+    class Bound:
+        def __index__(self):
+            buf.extend(b"Z" * 20)
+            return value
+
+    return Bound()
+
+
+assert buf.find(b"Z", grow_buf(-5)) == 25

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1758,13 +1758,22 @@ fn string_index_type_error(index: PyObjectRef) -> PyError {
 
 #[inline(never)]
 unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
+    let mut obj = obj;
     if is_slice(index) {
         let len = w_list_len(obj) as i64;
-        let (rs, rp, st) = crate::sliceobject::slice_unpack(
-            w_slice_get_start(index),
-            w_slice_get_stop(index),
-            w_slice_get_step(index),
-        )?;
+        let (rs, rp, st) = {
+            // Every slice component goes through `__index__`, so this runs
+            // Python and a minor collection can move the list underneath.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let unpacked = crate::sliceobject::slice_unpack(
+                w_slice_get_start(index),
+                w_slice_get_stop(index),
+                w_slice_get_step(index),
+            )?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            unpacked
+        };
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut items = Vec::new();
@@ -1788,7 +1797,17 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
+            // before dispatching here, so nothing else roots it across the
+            // call. A list is nursery-allocated, so read the address back —
+            // a minor collection during the call moves it.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+            let indexed = space_index(index)?;
+            obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+            indexed
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -1823,11 +1842,17 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     if is_slice(index) {
         // tupleobject.py descr_getslice → slice.indices.
         let len = w_tuple_len(obj) as i64;
-        let (rs, rp, st) = crate::sliceobject::slice_unpack(
-            w_slice_get_start(index),
-            w_slice_get_stop(index),
-            w_slice_get_step(index),
-        )?;
+        let (rs, rp, st) = {
+            // `slice_unpack` runs each component's `__index__`; the tuple is
+            // rooted for that window and does not move.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            crate::sliceobject::slice_unpack(
+                w_slice_get_start(index),
+                w_slice_get_stop(index),
+                w_slice_get_step(index),
+            )?
+        };
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut items = Vec::new();
@@ -1847,7 +1872,15 @@ unsafe fn getitem_tuple(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
+            // before dispatching here, so nothing else roots it across the
+            // call. A tuple never moves, so the root is for liveness alone
+            // and the address in hand stays correct.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            space_index(index)?
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -1893,11 +1926,17 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         // → `slice.indices(len)` (`pypy/objspace/std/sliceobject.py`).
         // Use the shared adjusted slice count so very large steps do not
         // overflow the index loop.
-        let (rs, rp, st) = crate::sliceobject::slice_unpack(
-            w_slice_get_start(index),
-            w_slice_get_stop(index),
-            w_slice_get_step(index),
-        )?;
+        let (rs, rp, st) = {
+            // `slice_unpack` runs each component's `__index__`; the string is
+            // rooted for that window and does not move.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            crate::sliceobject::slice_unpack(
+                w_slice_get_start(index),
+                w_slice_get_stop(index),
+                w_slice_get_step(index),
+            )?
+        };
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len as i64);
         // `_unicode_sliced` (unicodeobject.py) cuts the utf8
@@ -1927,7 +1966,15 @@ unsafe fn getitem_str(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
+            // before dispatching here, so nothing else roots it across the
+            // call. A str never moves, so the root is for liveness alone
+            // and the address in hand stays correct.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            space_index(index)?
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -1970,11 +2017,18 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         // mutate a bytearray), then use `adjust_indices`' explicit slice
         // length.  Iterating by that count also avoids overflowing on the
         // final `start + step` for a step near `sys.maxsize`.
-        let (rs, rp, st) = crate::sliceobject::slice_unpack(
-            w_slice_get_start(index),
-            w_slice_get_stop(index),
-            w_slice_get_step(index),
-        )?;
+        let (rs, rp, st) = {
+            // `slice_unpack` runs each component's `__index__`; the operand is
+            // rooted for that window and neither `bytes` nor `bytearray`
+            // moves.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            crate::sliceobject::slice_unpack(
+                w_slice_get_start(index),
+                w_slice_get_stop(index),
+                w_slice_get_step(index),
+            )?
+        };
         let len = pyre_object::bytesobject::bytes_like_len(obj) as i64;
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
@@ -2014,7 +2068,15 @@ unsafe fn getitem_bytes_like(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `__index__` is user code: `BINARY_SUBSCR` pops the receiver
+            // before dispatching here, so nothing else roots it across the
+            // call. A bytes-like operand never moves, so the root is for liveness alone
+            // and the address in hand stays correct.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            space_index(index)?
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -2179,7 +2241,14 @@ unsafe fn getitem_range(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
         return range_compute_slice(obj, index);
     }
     // `_compute_item` — `space.index(w_index)` then bounds-check.
-    let w_index = space_index(index)?;
+    let w_index = {
+        // `_compute_item` runs `__index__`, which is user code; the range is
+        // popped off the operand stack before this dispatch, so it needs the
+        // root to survive a collection there.
+        let _roots = pyre_object::gc_roots::push_roots();
+        pyre_object::gc_roots::pin_root(obj);
+        space_index(index)?
+    };
     let idx = pyre_object::range_obj_to_bigint(w_index);
     match pyre_object::w_range_compute_item(obj, &idx) {
         Some(v) => Ok(v),
@@ -3859,6 +3928,8 @@ pub(crate) fn setitem_slot(obj: PyObjectRef, index: PyObjectRef, value: PyObject
 
 #[inline(never)]
 unsafe fn setitem_list(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
+    let mut obj = obj;
+    let mut value = value;
     if is_slice(index) {
         return setitem_list_slice(obj, index, value);
     }
@@ -3867,7 +3938,18 @@ unsafe fn setitem_list(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef)
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `STORE_SUBSCR` pops all three operands before dispatching here,
+            // so nothing roots the list or the assigned value across this
+            // `__index__` call. Both are read back: the list is
+            // nursery-allocated, and the value is whatever the caller wrote.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let base = pyre_object::gc_roots::pin_roots(&[obj, value]);
+            let indexed = space_index(index)?;
+            obj = pyre_object::gc_roots::shadow_stack_get(base);
+            value = pyre_object::gc_roots::shadow_stack_get(base + 1);
+            indexed
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -4084,6 +4166,7 @@ pub(crate) unsafe fn getindex_w_index(index: PyObjectRef) -> Result<i64, PyError
 
 #[inline(never)]
 unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjectRef) -> PyResult {
+    let mut value = value;
     if is_slice(index) {
         return setitem_bytearray_slice(obj, index, value);
     }
@@ -4098,7 +4181,17 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     let idx = if is_int(index) {
         w_int_get_value(index)
     } else if pyre_object::pyobject::is_int_or_long(index) || lookup(index, "__index__").is_some() {
-        let indexed = space_index(index)?;
+        let indexed = {
+            // `STORE_SUBSCR` pops all three operands before dispatching here.
+            // The bytearray needs the root to stay alive across this
+            // `__index__`; the assigned value additionally gets read back,
+            // since the caller may have written a movable object.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let base = pyre_object::gc_roots::pin_roots(&[obj, value]);
+            let indexed = space_index(index)?;
+            value = pyre_object::gc_roots::shadow_stack_get(base + 1);
+            indexed
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -4122,7 +4215,13 @@ unsafe fn setitem_bytearray(obj: PyObjectRef, index: PyObjectRef, value: PyObjec
     let v = if is_int(value) {
         w_int_get_value(value)
     } else {
-        let indexed = space_index(value)?;
+        let indexed = {
+            // The value's own `__index__` runs Python too, and the bytearray
+            // written below is still unrooted at this point.
+            let _roots = pyre_object::gc_roots::push_roots();
+            pyre_object::gc_roots::pin_root(obj);
+            space_index(value)?
+        };
         if is_int(indexed) {
             w_int_get_value(indexed)
         } else {
@@ -4244,12 +4343,22 @@ unsafe fn setitem_bytearray_slice(
     // components' `__index__` may mutate the bytearray, and the bounds must be
     // clamped against the post-mutation length. (`x[:] = x` stays safe — the
     // source is copied into `sequence2`.)
-    let sequence2 = bytearray_assign_source(value)?;
-    let (rs, rp, st) = crate::sliceobject::slice_unpack(
-        w_slice_get_start(index),
-        w_slice_get_stop(index),
-        w_slice_get_step(index),
-    )?;
+    // Both steps run Python — draining an arbitrary iterable source, then
+    // every slice component's `__index__` — and `STORE_SUBSCR` popped the
+    // receiver and the slice before dispatching here, so root them across the
+    // pair. A bytearray does not move; the root is for liveness alone.
+    let (sequence2, rs, rp, st) = {
+        let _roots = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::pin_roots(&[obj, index]);
+        let sequence2 = bytearray_assign_source(value)?;
+        let index = pyre_object::gc_roots::shadow_stack_get(base + 1);
+        let (rs, rp, st) = crate::sliceobject::slice_unpack(
+            w_slice_get_start(index),
+            w_slice_get_stop(index),
+            w_slice_get_step(index),
+        )?;
+        (sequence2, rs, rp, st)
+    };
     let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
     let (start, stop, step, slicelength) =
         crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
@@ -19366,13 +19475,24 @@ pub fn delitem(obj: PyObjectRef, index: PyObjectRef) -> Result<(), PyError> {
 pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), PyError> {
     use pyre_object::*;
     unsafe {
+        // `DELETE_SUBSCR` pops both operands before dispatching here, so the
+        // container below is a bare address for the rest of this function.
+        let mut obj = obj;
         if is_list(obj) {
             if is_slice(index) {
-                let (raw_start, raw_stop, step) = crate::sliceobject::slice_unpack(
-                    w_slice_get_start(index),
-                    w_slice_get_stop(index),
-                    w_slice_get_step(index),
-                )?;
+                let (raw_start, raw_stop, step) = {
+                    // Every slice component runs `__index__`, so a minor
+                    // collection there moves this nursery-allocated list.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+                    let unpacked = crate::sliceobject::slice_unpack(
+                        w_slice_get_start(index),
+                        w_slice_get_stop(index),
+                        w_slice_get_step(index),
+                    )?;
+                    obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                    unpacked
+                };
                 let len = w_list_len(obj) as i64;
                 let (start, stop, step, slicelength) =
                     crate::sliceobject::slice_adjust_indices(raw_start, raw_stop, step, len);
@@ -19432,7 +19552,15 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
             let i = if is_int(index) {
                 w_int_get_value(index)
             } else {
-                subscript_index_w("list", index)?
+                {
+                    // `__index__` is user code; the list moves under a minor
+                    // collection taken there.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let obj_slot = pyre_object::gc_roots::pin_roots(&[obj]);
+                    let i = subscript_index_w("list", index)?;
+                    obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
+                    i
+                }
             };
             let len = w_list_len(obj) as i64;
             let idx = if i < 0 { len + i } else { i };
@@ -19459,11 +19587,17 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
             // delete shrinks the buffer) while an export is outstanding.
             crate::builtins::bytearray_check_exports(obj)?;
             if is_slice(index) {
-                let (rs, rp, st) = crate::sliceobject::slice_unpack(
-                    w_slice_get_start(index),
-                    w_slice_get_stop(index),
-                    w_slice_get_step(index),
-                )?;
+                let (rs, rp, st) = {
+                    // Rooted for the components' `__index__` calls; a
+                    // bytearray does not move, so this is liveness alone.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    pyre_object::gc_roots::pin_root(obj);
+                    crate::sliceobject::slice_unpack(
+                        w_slice_get_start(index),
+                        w_slice_get_stop(index),
+                        w_slice_get_step(index),
+                    )?
+                };
                 let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
                 let (start, stop, step, slicelength) =
                     crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
@@ -19499,7 +19633,11 @@ pub(crate) fn delitem_slot(obj: PyObjectRef, index: PyObjectRef) -> Result<(), P
                 pyre_object::bytearrayobject::w_bytearray_sync_alloc(obj, old_size);
                 return Ok(());
             }
-            let i = subscript_index_w("bytearray", index)?;
+            let i = {
+                let _roots = pyre_object::gc_roots::push_roots();
+                pyre_object::gc_roots::pin_root(obj);
+                subscript_index_w("bytearray", index)?
+            };
             let len = pyre_object::bytearrayobject::w_bytearray_len(obj) as i64;
             let idx = if i < 0 { len + i } else { i };
             if idx >= 0 && idx < len {

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -1760,7 +1760,6 @@ fn string_index_type_error(index: PyObjectRef) -> PyError {
 unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
     let mut obj = obj;
     if is_slice(index) {
-        let len = w_list_len(obj) as i64;
         let (rs, rp, st) = {
             // Every slice component goes through `__index__`, so this runs
             // Python and a minor collection can move the list underneath.
@@ -1774,6 +1773,10 @@ unsafe fn getitem_list(obj: PyObjectRef, index: PyObjectRef) -> PyResult {
             obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
             unpacked
         };
+        // The length is read after the unpack, not before: a component's
+        // `__index__` may have appended to or truncated this very list, and
+        // the bounds are clamped against what it holds now.
+        let len = w_list_len(obj) as i64;
         let (start, _stop, step, slicelength) =
             crate::sliceobject::slice_adjust_indices(rs, rp, st, len);
         let mut items = Vec::new();

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -6450,8 +6450,16 @@ fn os_error_build(
     args: &[PyObjectRef],
 ) -> PyObjectRef {
     use pyre_object::interp_exceptions;
-    let exc = if args.len() == 1 && unsafe { pyre_object::is_str(args[0]) } {
-        let w = unsafe { pyre_object::w_str_get_wtf8(args[0]) };
+    // Published before the first `__repr__` runs.  `args` is the stack copy
+    // the gateway built, and a minor rewrites the shadow slots rather than
+    // that copy, so an element formatted early is a pre-move address by the
+    // time the run below is stored — every element of it, since the store
+    // reads the whole slice after the last dispatch.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(args);
+    let arg = |index: usize| pyre_object::gc_roots::shadow_stack_get(args_base + index);
+    let exc = if args.len() == 1 && unsafe { pyre_object::is_str(arg(0)) } {
+        let w = unsafe { pyre_object::w_str_get_wtf8(arg(0)) };
         interp_exceptions::w_exception_new_wtf8(kind, w)
     } else {
         let msg: rustpython_wtf8::Wtf8Buf = if args.is_empty() {
@@ -6460,14 +6468,16 @@ fn os_error_build(
             // exception construction is non-raising machinery, per the F7
             // display policy; a raising __str__/__repr__ on the args degrades
             // to the empty string rather than propagating.
-            unsafe { crate::display::py_str_wtf8(args[0]) }.unwrap_or_default()
+            unsafe { crate::display::py_str_wtf8(arg(0)) }.unwrap_or_default()
         } else {
             let mut parts = rustpython_wtf8::Wtf8Buf::from_string("(".to_string());
-            for (index, &a) in args.iter().enumerate() {
+            for index in 0..args.len() {
                 if index > 0 {
                     parts.push_str(", ");
                 }
-                parts.push_wtf8(&unsafe { crate::display::py_repr_wtf8(a) }.unwrap_or_default());
+                parts.push_wtf8(
+                    &unsafe { crate::display::py_repr_wtf8(arg(index)) }.unwrap_or_default(),
+                );
             }
             parts.push_str(")");
             parts
@@ -6475,8 +6485,13 @@ fn os_error_build(
         interp_exceptions::w_exception_new_wtf8(kind, &msg)
     };
     // Seed `args_w` so a deferred-init instance (`_use_init`, no `__new__`
-    // slot fill) still reports the empty tuple until `__init__` runs.
-    let args_list = pyre_object::interp_exceptions::w_exception_args_new(args.to_vec());
+    // slot fill) still reports the empty tuple until `__init__` runs.  `exc`
+    // is pinned over the tuple mint: it holds no heap edge yet, and building
+    // a tuple instantiates the type's lazy map.  An instance is old-gen, so
+    // the pin is for liveness and the value is used as it is.
+    pyre_object::gc_roots::pin_root(exc);
+    let args_list =
+        pyre_object::interp_exceptions::w_exception_args_new((0..args.len()).map(arg).collect());
     unsafe { interp_exceptions::w_exception_set_args(exc, args_list) };
     exc
 }
@@ -6643,25 +6658,33 @@ fn os_error_parsed_errno(args: &[PyObjectRef]) -> Option<PyObjectRef> {
 /// see the resolved class.
 fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
     use pyre_object::interp_exceptions;
+    // Both the errno parse and the `BlockingIOError` test below run `int_w`,
+    // which is a user `__index__`, so the arguments are read off the root
+    // stack rather than out of the caller's slice once either has run.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(args);
+    pyre_object::gc_roots::pin_root(exc);
+    let arg = |index: usize| pyre_object::gc_roots::shadow_stack_get(args_base + index);
+    let arg_opt = |index: usize| (index < args.len()).then(|| arg(index));
     // `_parse_init_args`: only a 2..=5 argument call carries errno/strerror
     // (and optionally filename/filename2); outside that range every argument
     // stays in `args_w` and no slot is filled.
-    let mut args_w = args.to_vec();
-    if let Some(w_errno) = os_error_parsed_errno(args) {
+    let parsed = os_error_parsed_errno(args);
+    let mut trimmed = false;
+    if let Some(w_errno) = parsed {
         // The parse also decides the errno the args tuple carries, so
         // `e.args[0]` and `e.errno` agree even where a Windows error code in
         // the fourth argument replaced the one that was passed.
-        args_w[0] = w_errno;
         unsafe {
             interp_exceptions::w_exception_set_errno(exc, w_errno);
-            interp_exceptions::w_exception_set_strerror(exc, args[1]);
+            interp_exceptions::w_exception_set_strerror(exc, arg(1));
             #[cfg(windows)]
-            if let Some(w_winerror) = args.get(3).copied() {
+            if let Some(w_winerror) = arg_opt(3) {
                 interp_exceptions::w_exception_set_winerror(exc, w_winerror);
             }
             // idx 2 = filename, idx 3 = winerror (unread off Windows),
             // idx 4 = filename2.
-            let w_filename = args.get(2).copied().filter(|&f| !pyre_object::is_none(f));
+            let w_filename = arg_opt(2).filter(|&f| !pyre_object::is_none(f));
             // `_init_error` line 636-643: for an exact `BlockingIOError`, a
             // numeric third argument is `characters_written`, not a filename —
             // it stays in `args_w` and the tuple is not trimmed.
@@ -6675,14 +6698,23 @@ fn os_error_fill_slots(exc: PyObjectRef, args: &[PyObjectRef]) {
                 interp_exceptions::w_exception_set_blocking_written_arg(exc);
             } else if let Some(fname) = w_filename {
                 interp_exceptions::w_exception_set_filename(exc, fname);
-                if let Some(f2) = args.get(4).copied().filter(|&f| !pyre_object::is_none(f)) {
+                if let Some(f2) = arg_opt(4).filter(|&f| !pyre_object::is_none(f)) {
                     interp_exceptions::w_exception_set_filename2(exc, f2);
                 }
                 // `_init_error`: filename is removed from the args tuple.
-                args_w = vec![w_errno, args[1]];
+                trimmed = true;
             }
         }
     }
+    // Assembled from the root stack, after the last `int_w`: the caller's
+    // slice is a pre-move view of the operands by then.
+    let args_w: Vec<PyObjectRef> = match (parsed, trimmed) {
+        (Some(w_errno), true) => vec![w_errno, arg(1)],
+        (Some(w_errno), false) => std::iter::once(w_errno)
+            .chain((1..args.len()).map(&arg))
+            .collect(),
+        (None, _) => (0..args.len()).map(&arg).collect(),
+    };
     let args_list = interp_exceptions::w_exception_args_new(args_w);
     unsafe { interp_exceptions::w_exception_set_args(exc, args_list) };
 }
@@ -7490,11 +7522,23 @@ fn os_error_family_new(
     // When `_use_init`, `__new__` allocates without parsing the args — the
     // errno/strerror/filename slots and `args_w` stay unset for `__init__` to
     // fill (line 608-611).  Otherwise `__new__` parses them itself.
+    // `ctor` formats the message, which runs every argument's `__repr__`, and
+    // both readers below consult the arguments again afterwards.  `positional`
+    // borrows the stack copy the gateway built, and a minor rewrites the
+    // shadow slots rather than that copy, so the operands are taken off the
+    // root stack once the Python is done.  `exc` joins them because
+    // `os_error_fill_slots` runs `int_w`, which is Python of its own.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let positional_base = pyre_object::gc_roots::pin_roots(positional);
     let exc = ctor(if use_init { &[] } else { positional })?;
+    pyre_object::gc_roots::pin_root(exc);
+    let positional: Vec<PyObjectRef> = (0..positional.len())
+        .map(|index| pyre_object::gc_roots::shadow_stack_get(positional_base + index))
+        .collect();
     // Only the exact OSError type remaps the errno to a subclass; resolve the
     // retag target (subclass on a recognised errno, else the called class).
     let w_target = if is_exact_os_error {
-        os_error_errno_subclass_for(positional)
+        os_error_errno_subclass_for(&positional)
             .and_then(lookup_exc_class)
             .or(cls)
     } else {
@@ -7506,7 +7550,7 @@ fn os_error_family_new(
     // Fill the slots after the retag so `os_error_fill_slots` can see the
     // resolved class (the `BlockingIOError` numeric-filename special-case).
     if !use_init {
-        os_error_fill_slots(exc, positional);
+        os_error_fill_slots(exc, &positional);
     }
     Ok(exc)
 }

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -14818,6 +14818,14 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     kwarg_reject_unknown(kwargs, &["key", "reverse"], "sort")?;
     let iterable = positional[0];
     let key_fn = kwarg_get(kwargs, "key").filter(|k| unsafe { !pyre_object::is_none(*k) });
+    // `reverse=` runs a user `__bool__`, and building the list drains the
+    // iterable's own Python, so the iterable and the key callable are pinned
+    // before either and reloaded after, exactly as `list_method_sort` does.
+    // `PY_NULL` stands in when no key was given, keeping the two roots
+    // adjacent so one base covers both.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base =
+        pyre_object::gc_roots::pin_roots(&[iterable, key_fn.unwrap_or(pyre_object::PY_NULL)]);
     let reverse = kwarg_get(kwargs, "reverse")
         .map(crate::baseobjspace::is_true)
         .transpose()?
@@ -14826,10 +14834,10 @@ pub(crate) fn builtin_sorted(args: &[PyObjectRef]) -> Result<PyObjectRef, crate:
     // `sorted_lst.sort(key=key, reverse=reverse)`, so the built list picks its
     // storage strategy first and the sort runs through the same body
     // `list.sort` uses.
-    let w_list = builtin_list_ctor(&[iterable])?;
-    let _roots = pyre_object::gc_roots::push_roots();
+    let w_list = builtin_list_ctor(&[pyre_object::gc_roots::shadow_stack_get(base)])?;
     let list_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(w_list);
+    let key_fn = key_fn.map(|_| pyre_object::gc_roots::shadow_stack_get(base + 1));
     sort_list_in_place(list_slot, key_fn, reverse)?;
     Ok(pyre_object::gc_roots::shadow_stack_get(list_slot))
 }

--- a/pyre/pyre-interpreter/src/listobject.rs
+++ b/pyre/pyre-interpreter/src/listobject.rs
@@ -89,6 +89,13 @@ pub fn w_list_find_or_count(
 /// index when still within bounds (listobject.py:791 guard against
 /// `eq_w`-triggered mutations), raises `ValueError` otherwise.
 pub fn w_list_remove(obj: PyObjectRef, w_value: PyObjectRef) -> Result<(), PyError> {
+    // The scan runs the elements' `__eq__`, which is a collection point.
+    // `w_list_find_or_count` pins and reloads for its own loop, but that scope
+    // drops when it returns, so the length read and the pop below would
+    // address the list at its pre-move header.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(obj);
     let i = match w_list_find_or_count(obj, w_value, 0, i64::MAX, false)? {
         FindOrCountResult::Index(i) => i,
         FindOrCountResult::NotFound => {
@@ -100,6 +107,7 @@ pub fn w_list_remove(obj: PyObjectRef, w_value: PyObjectRef) -> Result<(), PyErr
         FindOrCountResult::Count(_) => unreachable!("find_or_count with count=false returns Count"),
     };
     // listobject.py: `if i < self.length():  # otherwise list was mutated`
+    let obj = pyre_object::gc_roots::shadow_stack_get(obj_slot);
     let length = unsafe { pyre_object::w_list_len(obj) } as i64;
     if i < length {
         unsafe {

--- a/pyre/pyre-interpreter/src/module/_codecs/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_codecs/mod.rs
@@ -695,6 +695,10 @@ pub(crate) fn encode_text_codec(
     encoding: &str,
     errors: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // Rooted for the same window as `decode_text_codec`: the lookup runs
+    // Python while `w_obj` is still whatever the caller handed over.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
     let w_codec_info = lookup_text_codec("encode", encoding)?;
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;
@@ -715,6 +719,15 @@ pub(crate) fn decode_text_codec(
     encoding: &str,
     errors: &str,
 ) -> Result<PyObjectRef, crate::PyError> {
+    // The lookup runs Python: an uncached name imports its `encodings` module
+    // and calls every registered search function, and only `call_codec` below
+    // publishes `w_obj` as a root.  Callers reach here with a value that has
+    // no heap edge — `decode_bytes_to_wtf8` copies the source bytes into a
+    // fresh one — and old-gen buys immobility, not survival, so the copy is
+    // swept mid-lookup and the decoder is handed a reused box.  Bytes do not
+    // move, so the pin is for liveness alone and the value is used as it is.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_obj);
     let w_codec_info = lookup_text_codec("decode", encoding)?;
     if crate::importing::dev_mode_flag() {
         validate_error_handler(errors)?;

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -184,9 +184,24 @@ fn context_var_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
         Err(err) if err.kind == crate::PyErrorKind::KeyError => token_missing(),
         Err(err) => return Err(err),
     };
-    let updated_data = call_method_result(data, "set", &[args[0], args[1]])?;
+    // The replacement and the store both run Python, and the token below is
+    // the only thing that will ever hold the old binding — nothing roots it
+    // across those two calls, and it is whatever the caller last set, a list
+    // or a dict included.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[context, data, old_value]);
+    let updated_data = call_method_result(
+        pyre_object::gc_roots::shadow_stack_get(base + 1),
+        "set",
+        &[args[0], args[1]],
+    )?;
+    let context = pyre_object::gc_roots::shadow_stack_get(base);
     crate::baseobjspace::setattr_str(context, "_data", updated_data)?;
-    new_token(context, args[0], old_value)
+    new_token(
+        pyre_object::gc_roots::shadow_stack_get(base),
+        args[0],
+        pyre_object::gc_roots::shadow_stack_get(base + 2),
+    )
 }
 
 fn context_var_reset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {

--- a/pyre/pyre-interpreter/src/module/array/mod.rs
+++ b/pyre/pyre-interpreter/src/module/array/mod.rs
@@ -692,9 +692,13 @@ fn array_find(obj: PyObjectRef, w_value: PyObjectRef) -> Result<Option<usize>, P
 fn array_index_method(args: &[PyObjectRef]) -> PyResult {
     check_arity_range(args, 2, 4, "array.index")?;
     let obj = args[0];
-    let w_value = args[1];
     let len = unsafe { arr::w_array_len(obj) } as i64;
     // Optional start/stop, unwrapped via __index__, clamped like descr_index.
+    // Their `__index__` is user code and `args` is the gateway's stack copy,
+    // so the searched-for value is read back from the shadow stack: the caller
+    // may have passed a list, which a minor moves.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
     let mut start = if args.len() >= 3 {
         crate::builtins::getindex_w(args[2])?
     } else {
@@ -705,6 +709,7 @@ fn array_index_method(args: &[PyObjectRef]) -> PyResult {
     } else {
         len
     };
+    let w_value = pyre_object::gc_roots::shadow_stack_get(base + 1);
     if start < 0 {
         start += len;
         if start < 0 {

--- a/pyre/pyre-interpreter/src/module/operator/mod.rs
+++ b/pyre/pyre-interpreter/src/module/operator/mod.rs
@@ -33,9 +33,16 @@ fn op_length_hint(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
             args.len()
         )));
     }
-    let w_iterable = args[0];
+    let mut w_iterable = args[0];
     let default = if let Some(&w_default) = args.get(1) {
+        // The default's `__index__` is user code, and `args` is the stack copy
+        // the gateway built: a minor rewrites the shadow slots and not that
+        // copy, so a list or dict iterable read out of it afterwards is a
+        // pre-move address.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let base = pyre_object::gc_roots::pin_roots(args);
         let w_index = crate::baseobjspace::space_index(w_default)?;
+        w_iterable = pyre_object::gc_roots::shadow_stack_get(base);
         crate::baseobjspace::int_w(w_index)?
     } else {
         0

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -3581,6 +3581,13 @@ pub fn mod_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
         // an exact-builtin right operand (the usual format argument) skips the
         // subtype probe.
         if is_str_lhs || is_bytes_lhs {
+            // Both override probes run Python, and the formatter runs more of
+            // it for every conversion.  The operands were popped off the value
+            // stack before this dispatch, so publish the pair: the receiver is
+            // immobile and only needs to stay reachable, while the operand may
+            // be a dict and is read back from its slot.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let operands = pyre_object::gc_roots::pin_roots(&[a, b]);
             if !pyre_object::is_exact_builtin_instance(b)
                 && let (Some(at), Some(bt)) = (crate::typedef::r#type(a), crate::typedef::r#type(b))
                 && at != bt
@@ -3589,9 +3596,15 @@ pub fn mod_(mut a: PyObjectRef, mut b: PyObjectRef) -> PyResult {
             {
                 return Ok(result);
             }
-            if let Some(result) = try_subclass_binop_override(a, b, "__mod__")? {
+            if let Some(result) = try_subclass_binop_override(
+                pyre_object::gc_roots::shadow_stack_get(operands),
+                pyre_object::gc_roots::shadow_stack_get(operands + 1),
+                "__mod__",
+            )? {
                 return Ok(result);
             }
+            let a = pyre_object::gc_roots::shadow_stack_get(operands);
+            let b = pyre_object::gc_roots::shadow_stack_get(operands + 1);
             return if is_str_lhs {
                 crate::objspace::std::formatting::str_format_percent(a, b)
             } else {

--- a/pyre/pyre-interpreter/src/objspace/descroperation.rs
+++ b/pyre/pyre-interpreter/src/objspace/descroperation.rs
@@ -5214,8 +5214,15 @@ pub fn compare_slot(a: PyObjectRef, b: PyObjectRef, op: CompareOp) -> PyResult {
                         &crate::type_methods::dict_view_snapshot(obj),
                     )
                 };
+                // Building the second set hashes every element it stores,
+                // which runs Python, and a set `as_set` had to mint is not
+                // held by anything else — it is old-gen, so it never moves,
+                // but an unreachable one is still swept.
+                let _roots = pyre_object::gc_roots::push_roots();
                 let a_set = as_set(a)?;
+                pyre_object::gc_roots::pin_root(a_set);
                 let b_set = as_set(b)?;
+                pyre_object::gc_roots::pin_root(b_set);
                 let la = pyre_object::w_set_len(a_set);
                 let lb = pyre_object::w_set_len(b_set);
                 let a_subset_b = || crate::typedef::set_is_subset_of(a_set, b_set);

--- a/pyre/pyre-interpreter/src/objspace/std/formatting.rs
+++ b/pyre/pyre-interpreter/src/objspace/std/formatting.rs
@@ -27,6 +27,14 @@ use rustpython_wtf8::{CodePoint, Wtf8Buf};
 /// positional slot if any remains, and surplus positional values are an
 /// error only when the operand is not itself a mapping.
 pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> PyResult {
+    // The conversions below run Python, and `BINARY_OP %` popped both operands
+    // before dispatching here, so neither the format string nor the operand
+    // is rooted by the frame any more.  A str is immobile and read directly
+    // once pinned; `args` may be a dict and is read back from its slot.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(fmt);
+    let args_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args);
     let fmt_str = w_str_get_wtf8(fmt);
     let format = CFormatWtf8::parse_from_wtf8(fmt_str)
         .map_err(|err| PyError::value_error(err.to_string()))?;
@@ -37,11 +45,11 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     // order; any other operand is the single positional value.
     let args_is_tuple = is_tuple(args);
     let dict = if !args_is_tuple && !is_str(args) && has_getitem(args) {
-        Some(args)
+        Some(args_slot)
     } else {
         None
     };
-    let positional: Vec<PyObjectRef> = if args_is_tuple {
+    let items: Vec<PyObjectRef> = if args_is_tuple {
         let n = w_tuple_len(args);
         (0..n)
             .filter_map(|i| w_tuple_getitem(args, i as i64))
@@ -49,7 +57,11 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     } else {
         vec![args]
     };
-    let mut pos = positional.into_iter().peekable();
+    let mut pos = OperandColumn {
+        base: pyre_object::gc_roots::pin_roots(&items),
+        len: items.len(),
+        cursor: 0,
+    };
 
     let mut result = Wtf8Buf::new();
     let mut saw_specifier = false;
@@ -63,10 +75,13 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
             }) => {
                 saw_specifier = true;
                 let value = if let Some(key) = mapping_key {
-                    let Some(dict) = dict else {
+                    let Some(dict_slot) = dict else {
                         return Err(PyError::type_error("format requires a mapping"));
                     };
-                    let w_value = crate::baseobjspace::getitem(dict, w_str_from_wtf8(key))?;
+                    let w_value = crate::baseobjspace::getitem(
+                        pyre_object::gc_roots::shadow_stack_get(dict_slot),
+                        w_str_from_wtf8(key),
+                    )?;
                     // A keyed spec still consumes a positional slot when one
                     // is available (`%(k)s %s` leaves nothing for the `%s`).
                     let _ = pos.next();
@@ -95,9 +110,9 @@ pub(crate) unsafe fn str_format_percent(fmt: PyObjectRef, args: PyObjectRef) -> 
     // empty tuple / a mapping is allowed but any other non-empty operand is
     // surplus.
     let surplus = if saw_specifier {
-        pos.peek().is_some()
+        pos.has_next()
     } else {
-        !(args_is_tuple && w_tuple_len(args) == 0)
+        !(args_is_tuple && w_tuple_len(pyre_object::gc_roots::shadow_stack_get(args_slot)) == 0)
     };
     if dict.is_none() && surplus {
         return Err(PyError::type_error(
@@ -126,6 +141,14 @@ pub(crate) unsafe fn bytes_format_percent(fmt: PyObjectRef, args: PyObjectRef) -
 }
 
 unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyResult {
+    // As `str_format_percent`: the conversions run Python and `BINARY_OP %`
+    // popped both operands, so nothing else roots them.  `fmt` is pinned for
+    // the borrow below — a bytes-like object never moves, but an unreachable
+    // one is still swept, and the slice points into its payload.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(fmt);
+    let args_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args);
     let fmt_bytes = pyre_object::bytesobject::bytes_like_data(fmt);
     let format = CFormatBytes::parse_from_bytes(fmt_bytes)
         .map_err(|err| PyError::value_error(err.to_string()))?;
@@ -159,8 +182,10 @@ unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyR
                 CFormatPart::Literal(literal) => result.extend(literal),
                 CFormatPart::Spec(CFormatSpecKeyed { mapping_key, spec }) => {
                     let key = mapping_key.expect("mapping spec carries a key");
-                    let value =
-                        crate::baseobjspace::getitem(args, pyre_object::w_bytes_from_bytes(&key))?;
+                    let value = crate::baseobjspace::getitem(
+                        pyre_object::gc_roots::shadow_stack_get(args_slot),
+                        pyre_object::w_bytes_from_bytes(&key),
+                    )?;
                     result.extend(spec_format_bytes(&spec, value)?);
                 }
             }
@@ -168,7 +193,7 @@ unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyR
         return Ok(bytes_format_result(fmt, &result));
     }
 
-    let positional: Vec<PyObjectRef> = if pyre_object::is_tuple(args) {
+    let items: Vec<PyObjectRef> = if pyre_object::is_tuple(args) {
         let n = pyre_object::w_tuple_len(args);
         (0..n)
             .filter_map(|i| pyre_object::w_tuple_getitem(args, i as i64))
@@ -176,7 +201,11 @@ unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyR
     } else {
         vec![args]
     };
-    let mut pos = positional.into_iter().peekable();
+    let mut pos = OperandColumn {
+        base: pyre_object::gc_roots::pin_roots(&items),
+        len: items.len(),
+        cursor: 0,
+    };
 
     for (_, part) in format {
         match part {
@@ -194,7 +223,7 @@ unsafe fn bytes_format_percent_inner(fmt: PyObjectRef, args: PyObjectRef) -> PyR
         }
     }
 
-    if pos.peek().is_some() {
+    if pos.has_next() {
         Err(PyError::type_error(
             "not all arguments converted during bytes formatting",
         ))
@@ -625,8 +654,39 @@ unsafe fn has_dunder(obj: PyObjectRef, name: &str) -> bool {
 
 /// `peel_num` — a `*` field width reads its value (and, when negative, the
 /// left-align flag) from the next positional argument.
+/// The positional operands, addressed by shadow slot rather than held in a
+/// `Vec`.
+///
+/// Every conversion runs Python — `__str__`, `__repr__`, `__format__`, and a
+/// `*` width's `__index__` — so each one is a collection point.  A plain `Vec`
+/// of operands is not something the collector rewrites, so an entry still
+/// waiting its turn would be formatted at a pre-move address once it is a list
+/// or a dict.  The column is pinned once by the caller and each operand is
+/// read back from its slot when its turn comes.
+struct OperandColumn {
+    base: usize,
+    len: usize,
+    cursor: usize,
+}
+
+impl OperandColumn {
+    fn next(&mut self) -> Option<PyObjectRef> {
+        if self.cursor >= self.len {
+            return None;
+        }
+        let operand = pyre_object::gc_roots::shadow_stack_get(self.base + self.cursor);
+        self.cursor += 1;
+        Some(operand)
+    }
+
+    /// Whether any operand is still unconsumed — the `checkconsumed` test.
+    fn has_next(&self) -> bool {
+        self.cursor < self.len
+    }
+}
+
 unsafe fn update_quantity_from_tuple(
-    pos: &mut std::iter::Peekable<std::vec::IntoIter<PyObjectRef>>,
+    pos: &mut OperandColumn,
     quantity: &mut Option<CFormatQuantity>,
     flags: &mut CConversionFlags,
 ) -> Result<(), PyError> {
@@ -644,7 +704,7 @@ unsafe fn update_quantity_from_tuple(
 /// `peel_num` — a `*` precision reads its value from the next positional
 /// argument (a negative precision is treated as absent).
 unsafe fn update_precision_from_tuple(
-    pos: &mut std::iter::Peekable<std::vec::IntoIter<PyObjectRef>>,
+    pos: &mut OperandColumn,
     precision: &mut Option<CFormatPrecision>,
 ) -> Result<(), PyError> {
     if !matches!(

--- a/pyre/pyre-interpreter/src/runtime_ops.rs
+++ b/pyre/pyre-interpreter/src/runtime_ops.rs
@@ -770,18 +770,24 @@ pub fn binary_slice_values(
         let start = roots.get(start_slot);
         let stop = roots.get(stop_slot);
         if pyre_object::is_list(obj) {
-            let len = pyre_object::w_list_len(obj) as i64;
             let s = if pyre_object::is_none(start) {
                 0
             } else {
                 crate::sliceobject::eval_slice_index(start)?
             };
             let stop = roots.get(stop_slot);
-            let e = if pyre_object::is_none(stop) {
-                len
+            let raw_e = if pyre_object::is_none(stop) {
+                None
             } else {
-                crate::sliceobject::eval_slice_index(stop)?
+                Some(crate::sliceobject::eval_slice_index(stop)?)
             };
+            // The length comes after both bounds have been converted: a
+            // bound's own `__index__` may have resized this very list, and it
+            // is what the omitted `stop` defaults to and what a negative bound
+            // folds against.  Read off the root slot, since the same call is
+            // what may have moved the list.
+            let len = pyre_object::w_list_len(roots.get(obj_slot)) as i64;
+            let e = raw_e.unwrap_or(len);
             let s = if s < 0 { (len + s).max(0) } else { s.min(len) } as usize;
             let e = if e < 0 { (len + e).max(0) } else { e.min(len) } as usize;
             // A fetch off an unboxed strategy boxes the element it returns, so

--- a/pyre/pyre-interpreter/src/sliceobject.rs
+++ b/pyre/pyre-interpreter/src/sliceobject.rs
@@ -65,8 +65,20 @@ pub fn unwrap_start_stop_not_none(
     w_start: PyObjectRef,
     w_end: PyObjectRef,
 ) -> Result<(i64, i64), crate::PyError> {
-    let start = adapt_bound(size, eval_slice_index_not_none(w_start)?);
-    let end = adapt_bound(size, eval_slice_index_not_none(w_end)?);
+    // Converted one at a time, as `slice_unpack`: the first bound's
+    // `__index__` is user code that can collect, so the second is read back
+    // from the shadow stack rather than carried in the argument it arrived
+    // in. A caller that roots the container does not root these two.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[w_start, w_end]);
+    let start = adapt_bound(
+        size,
+        eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base))?,
+    );
+    let end = adapt_bound(
+        size,
+        eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base + 1))?,
+    );
     Ok((start, end))
 }
 
@@ -90,11 +102,17 @@ pub fn unwrap_start_stop(
     w_start: PyObjectRef,
     w_end: PyObjectRef,
 ) -> Result<(i64, i64), crate::PyError> {
+    // Rooted and read back for the same reason as
+    // `unwrap_start_stop_not_none`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(&[w_start, w_end]);
+    let w_start = pyre_object::gc_roots::shadow_stack_get(base);
     let start = if unsafe { is_none(w_start) } {
         0
     } else {
         adapt_lower_bound(size, w_start)?
     };
+    let w_end = pyre_object::gc_roots::shadow_stack_get(base + 1);
     let end = if unsafe { is_none(w_end) } {
         debug_assert!(size >= 0);
         size

--- a/pyre/pyre-interpreter/src/sliceobject.rs
+++ b/pyre/pyre-interpreter/src/sliceobject.rs
@@ -65,21 +65,31 @@ pub fn unwrap_start_stop_not_none(
     w_start: PyObjectRef,
     w_end: PyObjectRef,
 ) -> Result<(i64, i64), crate::PyError> {
+    let (start, end) = index_bounds_not_none(w_start, w_end)?;
+    Ok(adapt_start_stop(size, start, end))
+}
+
+/// The conversion half of [`unwrap_start_stop_not_none`], for a receiver whose
+/// length a bound's own `__index__` can change: convert both bounds here, read
+/// the length afterwards, and normalize with [`adapt_start_stop`].
+pub fn index_bounds_not_none(
+    w_start: PyObjectRef,
+    w_end: PyObjectRef,
+) -> Result<(i64, i64), crate::PyError> {
     // Converted one at a time, as `slice_unpack`: the first bound's
     // `__index__` is user code that can collect, so the second is read back
     // from the shadow stack rather than carried in the argument it arrived
     // in. A caller that roots the container does not root these two.
     let _roots = pyre_object::gc_roots::push_roots();
     let base = pyre_object::gc_roots::pin_roots(&[w_start, w_end]);
-    let start = adapt_bound(
-        size,
-        eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base))?,
-    );
-    let end = adapt_bound(
-        size,
-        eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base + 1))?,
-    );
+    let start = eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base))?;
+    let end = eval_slice_index_not_none(pyre_object::gc_roots::shadow_stack_get(base + 1))?;
     Ok((start, end))
+}
+
+/// The normalization half: fold negative bounds by `size` and floor at 0.
+pub fn adapt_start_stop(size: i64, start: i64, end: i64) -> (i64, i64) {
+    (adapt_bound(size, start), adapt_bound(size, end))
 }
 
 /// The negative-index normalization `adapt_lower_bound` applies once the

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -854,9 +854,9 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let list = args[0];
     let value = args[1];
     // listobject.py:799 unwrap_spec defaults: w_start=0 / w_stop=sys.maxint.
-    // listobject.py:803 unwrap_start_stop handles negative normalization,
-    // __index__ coercion and TypeError for non-index arguments.
-    let size = unsafe { pyre_object::w_list_len(list) } as i64;
+    // listobject.py:803 `unwrap_start_stop` folds the negative bounds against
+    // the length it was handed; the two halves are called separately below so
+    // the length can be read after the coercion instead.
     let w_start = if args.len() >= 3 {
         args[2]
     } else {
@@ -876,9 +876,13 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let sp = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(list);
     pyre_object::gc_roots::pin_root(value);
-    let (start, stop) = crate::sliceobject::unwrap_start_stop_not_none(size, w_start, w_stop)?;
+    let (raw_start, raw_stop) = crate::sliceobject::index_bounds_not_none(w_start, w_stop)?;
     let list = pyre_object::gc_roots::shadow_stack_get(sp);
     let value = pyre_object::gc_roots::shadow_stack_get(sp + 1);
+    // The length that folds a negative bound is read after the bounds have
+    // been converted: their `__index__` may have resized this very list.
+    let size = unsafe { pyre_object::w_list_len(list) } as i64;
+    let (start, stop) = crate::sliceobject::adapt_start_stop(size, raw_start, raw_stop);
     match crate::listobject::w_list_find_or_count(list, value, start, stop, false)? {
         crate::listobject::FindOrCountResult::Index(i) => Ok(w_int_new(i)),
         crate::listobject::FindOrCountResult::NotFound => {

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -709,8 +709,19 @@ pub fn list_method_insert(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::Py
     // `@unwrap_spec(index='index')` → getindex_w(index, OverflowError): coerce
     // through `__index__`; `get_positive_index` then clamps to `[0, len]`
     // inside `w_list_insert`.
+    // `args` is the copy the gateway built on the stack; a minor rewrites the
+    // shadow slots and not that copy, so the receiver and the item read out of
+    // it after `__index__` has run are pre-move addresses.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
     let index = unsafe { crate::baseobjspace::getindex_w_index(args[1])? };
-    unsafe { pyre_object::listobject::w_list_insert(args[0], index, args[2]) };
+    unsafe {
+        pyre_object::listobject::w_list_insert(
+            pyre_object::gc_roots::shadow_stack_get(base),
+            index,
+            pyre_object::gc_roots::shadow_stack_get(base + 2),
+        )
+    };
     Ok(w_none())
 }
 
@@ -724,12 +735,17 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     arity_at_most(args, "pop", 1)?;
     // `@unwrap_spec(index='index')` → getindex_w(index, OverflowError): coerce
     // through `__index__`.
+    // Rooted as `list_method_insert`: the receiver read out of `args` after
+    // `__index__` has run is a pre-move address.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
     let index = if args.len() > 1 {
         unsafe { crate::baseobjspace::getindex_w_index(args[1])? }
     } else {
         -1
     };
-    let length = unsafe { pyre_object::w_list_len(args[0]) } as i64;
+    let list = pyre_object::gc_roots::shadow_stack_get(base);
+    let length = unsafe { pyre_object::w_list_len(list) } as i64;
     if length == 0 {
         return Err(crate::PyError::new(
             crate::PyErrorKind::IndexError,
@@ -739,7 +755,7 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     // listobject.py — clearly distinguish list.pop() from the
     // general list.pop(index) path.
     if index == -1 {
-        return match unsafe { pyre_object::listobject::w_list_pop_end(args[0]) } {
+        return match unsafe { pyre_object::listobject::w_list_pop_end(list) } {
             Some(v) => Ok(v),
             None => Err(crate::PyError::new(
                 crate::PyErrorKind::IndexError,
@@ -747,7 +763,7 @@ pub fn list_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             )),
         };
     }
-    match unsafe { pyre_object::listobject::w_list_pop(args[0], index) } {
+    match unsafe { pyre_object::listobject::w_list_pop(list, index) } {
         Some(v) => Ok(v),
         None => Err(crate::PyError::new(
             crate::PyErrorKind::IndexError,

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6462,11 +6462,22 @@ pub fn dict_method_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     arity_at_most(args, "get", 2)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
-    let default = args.get(2).copied().unwrap_or_else(w_none);
     if dict.is_null() {
-        return Ok(default);
+        return Ok(args.get(2).copied().unwrap_or_else(w_none));
     }
-    Ok(dict_lookup_checked(dict, key)?.unwrap_or(default))
+    // The lookup hashes and compares the key, which is user code. `args` is
+    // the stack copy the gateway built, so a default read out of it after that
+    // is a pre-move address whenever the caller passed a list or a dict.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
+    let found = dict_lookup_checked(dict, key)?;
+    Ok(found.unwrap_or_else(|| {
+        if args.len() >= 3 {
+            pyre_object::gc_roots::shadow_stack_get(base + 2)
+        } else {
+            w_none()
+        }
+    }))
 }
 
 /// `pypy/objspace/std/dictmultiobject.py:descr_keys` parity — returns
@@ -6930,7 +6941,10 @@ pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
     arity_at_most(args, "pop", 2)?;
     let dict = resolve_dict_backing(args[0]);
     let key = args[1];
-    let default = args.get(2).copied();
+    // Rooted as `dict_method_get`: the removal hashes the key, and the default
+    // is only consumed once that has run.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
     if !dict.is_null() {
         unsafe {
             match pyre_object::dictmultiobject::w_dict_pop_checked(dict, key) {
@@ -6940,7 +6954,10 @@ pub fn dict_method_pop(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
             }
         }
     }
-    default.ok_or_else(|| crate::PyError::key_error_with_key(key))
+    if args.len() >= 3 {
+        return Ok(pyre_object::gc_roots::shadow_stack_get(base + 2));
+    }
+    Err(crate::PyError::key_error_with_key(key))
 }
 
 /// `dictmultiobject.py` `W_DictMultiObject.descr_popitem`:

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -6409,8 +6409,13 @@ pub(crate) fn dict_store_checked(
 /// pointer, so hashing inside the key build (`object_key_for_checked`) captures
 /// the pre-move pointer — the reason `object_key_hashed` exists. The element is
 /// rooted across the hash and reloaded, matching the add path
-/// (`builtin_set_add_items`); the set needs no rooting, being an old-gen
-/// allocation that keeps its address across a collection.
+/// (`builtin_set_add_items`).
+///
+/// The set is rooted too, but only pinned: an old-gen allocation keeps its
+/// address across a collection, so there is nothing to reload — what it needs
+/// is to stay reachable.  `CONTAINS_OP` pops the container off the operand
+/// stack before dispatching here, so on `x in {...}` the hash below runs with
+/// nothing else referring to the set at all.
 unsafe fn set_lookup_checked(
     set: PyObjectRef,
     item: PyObjectRef,
@@ -6422,6 +6427,7 @@ unsafe fn set_lookup_checked(
     let _roots = pyre_object::gc_roots::push_roots();
     let sp = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(item);
+    pyre_object::gc_roots::pin_root(set);
     let hash = crate::builtins::try_hash_value(pyre_object::gc_roots::shadow_stack_get(sp))
         .map_err(|err| {
             crate::baseobjspace::wrap_set_element_hash_error(

--- a/pyre/pyre-interpreter/src/type_methods.rs
+++ b/pyre/pyre-interpreter/src/type_methods.rs
@@ -854,9 +854,10 @@ pub fn list_method_index(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyE
     let list = args[0];
     let value = args[1];
     // listobject.py:799 unwrap_spec defaults: w_start=0 / w_stop=sys.maxint.
-    // listobject.py:803 `unwrap_start_stop` folds the negative bounds against
-    // the length it was handed; the two halves are called separately below so
-    // the length can be read after the coercion instead.
+    // `W_ListObject.descr_index` hands `unwrap_start_stop` the length it read
+    // first, and that call is what folds the negative bounds; the two halves
+    // are called separately below so the length can be read after the
+    // coercion instead.
     let w_start = if args.len() >= 3 {
         args[2]
     } else {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5392,11 +5392,17 @@ fn init_list_type(ns: PyObjectRef) {
                     // runs, so a non-index operand raises here rather than
                     // reporting NotImplemented.
                     crate::type_methods::arity_slot(args, 1)?;
+                    // `args` is the gateway's stack copy: a minor rewrites the
+                    // shadow slots and not that copy, so the list read out of
+                    // it after `__index__` is a pre-move address.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let base = pyre_object::gc_roots::pin_roots(args);
                     let w_count = crate::baseobjspace::getindex_repeat(args[1])?;
+                    let w_list = pyre_object::gc_roots::shadow_stack_get(base);
                     unsafe {
-                        crate::objspace::descroperation::list_inplace_repeat(args[0], w_count)?
+                        crate::objspace::descroperation::list_inplace_repeat(w_list, w_count)?
                     };
-                    Ok(args[0])
+                    Ok(pyre_object::gc_roots::shadow_stack_get(base))
                 },
                 2,
             ),
@@ -5484,8 +5490,14 @@ fn list_descr_mul_impl(args: &[PyObjectRef], name: &str) -> Result<PyObjectRef, 
     crate::type_methods::arity_slot(args, 1)?;
     // `wrap_indexargfunc` reduces the count through `__index__` before
     // `sq_repeat` runs, so a non-index operand raises here.
+    // `args` is the gateway's stack copy: a minor rewrites the shadow slots
+    // and not that copy, so the list read out of it after `__index__` is a
+    // pre-move address.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::pin_roots(args);
     let w_count = crate::baseobjspace::getindex_repeat(args[1])?;
-    unsafe { crate::objspace::descroperation::list_repeat(args[0], w_count) }
+    let w_list = pyre_object::gc_roots::shadow_stack_get(base);
+    unsafe { crate::objspace::descroperation::list_repeat(w_list, w_count) }
 }
 
 // ── Str TypeDef ──────────────────────────────────────────────────────

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7171,9 +7171,10 @@ fn init_dict_type(ns: PyObjectRef) {
         // each key; for a dict subclass, construct an instance via `cls()`
         // and route through `space.setitem` so the result is an instance
         // of the subclass.
+        let mut value = value;
         let w_dict_type = crate::typedef::gettypeobject(&pyre_object::pyobject::DICT_TYPE);
         if cls.is_null() || crate::baseobjspace::is_w(cls, w_dict_type) {
-            let d = pyre_object::w_dict_new();
+            let mut d = pyre_object::w_dict_new();
             // Python 3.14's exact-set/frozenset fast path carries each
             // entry's cached hash into the new exact dict.  This is the
             // reverse of `set_update_dict_lock_held` and avoids a
@@ -7204,7 +7205,18 @@ fn init_dict_type(ns: PyObjectRef) {
                 }
                 return Ok(pyre_object::gc_roots::shadow_stack_get(sp));
             }
-            let items = crate::builtins::collect_iterable(iterable)?;
+            let items = {
+                // Draining the iterable runs Python. `d` is a fresh dict with
+                // no heap edge yet and dicts are nursery-allocated, so it is
+                // rooted and read back here — the loop below re-roots what it
+                // is handed, which cannot cover this window.
+                let _roots = pyre_object::gc_roots::push_roots();
+                let base = pyre_object::gc_roots::pin_roots(&[d, value]);
+                let items = crate::builtins::collect_iterable(iterable)?;
+                d = pyre_object::gc_roots::shadow_stack_get(base);
+                value = pyre_object::gc_roots::shadow_stack_get(base + 1);
+                items
+            };
             // `try_hash_value` may run a user `__hash__` that allocates
             // and triggers a moving minor collection; `d`, the shared
             // `value` (reused across every key), and every not-yet-added

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -26566,6 +26566,16 @@ pub(crate) fn set_is_subset_of(
     w_set: pyre_object::PyObjectRef,
     w_other: pyre_object::PyObjectRef,
 ) -> Result<bool, crate::PyError> {
+    // The probe compares with the digest each element was stored under, so the
+    // walk hashes nothing — but a bucket match still runs the elements'
+    // `__eq__`, which is a collection point.  Both operands are pinned here
+    // because a caller cannot be relied on to hold them: `COMPARE_OP` pops
+    // them, and `set_operand_as_set` hands over a set it has just minted.  A
+    // set is old-gen and never moves, so this is liveness only and neither
+    // local is reloaded; `key` stays reachable through the pinned `w_set`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    pyre_object::gc_roots::pin_root(w_set);
+    pyre_object::gc_roots::pin_root(w_other);
     unsafe {
         let mut i = 0;
         while let Some(key) = pyre_object::w_set_key_at(w_set, i) {

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -21972,18 +21972,32 @@ pub(crate) fn require_contiguous_buffer(obj: PyObjectRef) -> Result<(), crate::P
     Ok(())
 }
 
-/// Require `obj` to be a bytes-like object, returning its bytes; raises
-/// the CPython `a bytes-like object is required, not '<type>'` TypeError
-/// otherwise.  A memoryview is accepted through its backing buffer.
-fn require_bytes_like(obj: PyObjectRef) -> Result<&'static [u8], crate::PyError> {
+/// Resolve `obj` to the bytes-like object backing it; raises the
+/// `a bytes-like object is required, not '<type>'` TypeError otherwise.
+/// A memoryview is accepted through its backing buffer.
+///
+/// Separate from `require_bytes_like` so a caller that must reject a bad
+/// operand *before* running a later argument's `__index__` can do the type
+/// check here and take the payload slice afterwards.  The array, mmap and
+/// ctypes arms mint a fresh `bytes` snapshot, so a result held across a
+/// Python hop needs a root of its own.
+fn require_bytes_like_source(obj: PyObjectRef) -> Result<PyObjectRef, crate::PyError> {
     require_contiguous_buffer(obj)?;
     match buffer_as_bytes_like(obj)? {
-        Some(src) => Ok(unsafe { pyre_object::bytesobject::bytes_like_data(src) }),
+        Some(src) => Ok(src),
         None => Err(crate::PyError::type_error(format!(
             "a bytes-like object is required, not '{}'",
             type_name_of(obj)
         ))),
     }
+}
+
+/// Require `obj` to be a bytes-like object, returning its bytes; raises
+/// the CPython `a bytes-like object is required, not '<type>'` TypeError
+/// otherwise.  A memoryview is accepted through its backing buffer.
+fn require_bytes_like(obj: PyObjectRef) -> Result<&'static [u8], crate::PyError> {
+    let src = require_bytes_like_source(obj)?;
+    Ok(unsafe { pyre_object::bytesobject::bytes_like_data(src) })
 }
 
 /// The Python-visible class name of `obj` (its `w_class`/type name), used in
@@ -22244,6 +22258,14 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
     crate::type_methods::arity_at_least(pos, "replace", 2)?;
     crate::type_methods::arity_at_most(pos, "replace", 3)?;
+    // `old` and `new` are rejected before `count` is coerced: the clinic
+    // signature converts the two buffers ahead of the integer, so
+    // `b"".replace(1, b"y", idx)` raises the TypeError without running
+    // `idx.__index__`.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let src_base = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[1])?);
+    pyre_object::gc_roots::pin_root(require_bytes_like_source(pos[2])?);
     let limit = match pos.get(3) {
         Some(&w_count) if !w_count.is_null() => {
             let c = crate::builtins::space_index_w(w_count)?;
@@ -22251,12 +22273,19 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         }
         _ => usize::MAX,
     };
-    // Borrowed after the coercions, as `bytes_method_ljust`: all three
+    // Borrowed after the coercion, as `bytes_method_ljust`: all three
     // operands may be bytearrays, and the `__index__` above can resize any of
-    // them.
+    // them.  The two sources come back off their root slots, since a snapshot
+    // minted by `require_bytes_like_source` had nothing else holding it.
     let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
-    let old = require_bytes_like(pos[1])?;
-    let new = require_bytes_like(pos[2])?;
+    let old = unsafe {
+        pyre_object::bytesobject::bytes_like_data(pyre_object::gc_roots::shadow_stack_get(src_base))
+    };
+    let new = unsafe {
+        pyre_object::bytesobject::bytes_like_data(pyre_object::gc_roots::shadow_stack_get(
+            src_base + 1,
+        ))
+    };
     let (out, replacements) = replace_bytes(data, old, new, limit);
     // `descr_replace` returns `self` when nothing was replaced
     // (unicodeobject.py for the str twin) — keyed on the count, so

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -26084,13 +26084,16 @@ pub(crate) fn set_method_union(
     // crosses two full drains. `set_init_from_iterable_impl` pins for the same
     // reason: the set body is non-moving old-gen storage, but it still has to
     // be marked live instead of swept while Rust holds the only reference.
+    // The operands go on in one phase for a second reason: `args` is the stack
+    // copy the gateway built, and a minor rewrites the shadow slots rather
+    // than that copy, so reading operand two out of it after operand one has
+    // run a user `__hash__` answers a pre-move address.
     let _roots = pyre_object::gc_roots::push_roots();
-    let result_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(result);
-    for other in &args[1..] {
-        let _operand_root = pyre_object::gc_roots::push_roots();
-        let operand_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(*other);
+    let operand_base = pyre_object::gc_roots::publish_roots(&args[1..]);
+    let result_slot = pyre_object::gc_roots::publish_roots(&[result]);
+    pyre_object::gc_roots::normalize_roots(operand_base, args.len());
+    for index in 0..args.len() - 1 {
+        let operand_slot = operand_base + index;
         if unsafe {
             pyre_object::is_set_or_frozenset(pyre_object::gc_roots::shadow_stack_get(operand_slot))
         } {
@@ -26561,15 +26564,13 @@ fn set_method_update(
     // Rooted as `set_method_union`, except that the operands merge into
     // `args[0]` itself: a raw Rust slice the collector cannot see either.
     let _roots = pyre_object::gc_roots::push_roots();
-    let set_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(args[0]);
+    let set_slot = pyre_object::gc_roots::pin_roots(args);
+    let operand_base = set_slot + 1;
     // `setobject.py _descr_update` — a set operand's storage merges in
     // as it stands; only another iterable is walked and hashed element by
     // element.
-    for other in &args[1..] {
-        let _operand_root = pyre_object::gc_roots::push_roots();
-        let operand_slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(*other);
+    for index in 0..args.len() - 1 {
+        let operand_slot = operand_base + index;
         if unsafe {
             pyre_object::is_set_or_frozenset(pyre_object::gc_roots::shadow_stack_get(operand_slot))
         } {
@@ -26603,10 +26604,21 @@ fn set_method_difference_update(
     if args.is_empty() {
         return Ok(pyre_object::w_none());
     }
-    for other in &args[1..] {
-        let w_other_as_set = set_operand_as_set(*other)?;
-        unsafe { pyre_object::w_set_difference_update_from_set(args[0], w_other_as_set) }
-            .map_err(crate::baseobjspace::map_set_update_error)?;
+    // Rooted as `set_method_update`: turning an operand into a set hashes its
+    // elements, so `args` is read once here and every later use comes off the
+    // root stack.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let set_slot = pyre_object::gc_roots::pin_roots(args);
+    for index in 1..args.len() {
+        let w_other_as_set =
+            set_operand_as_set(pyre_object::gc_roots::shadow_stack_get(set_slot + index))?;
+        unsafe {
+            pyre_object::w_set_difference_update_from_set(
+                pyre_object::gc_roots::shadow_stack_get(set_slot),
+                w_other_as_set,
+            )
+        }
+        .map_err(crate::baseobjspace::map_set_update_error)?;
     }
     Ok(pyre_object::w_none())
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -22220,9 +22220,6 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
     }
     crate::type_methods::arity_at_least(pos, "replace", 2)?;
     crate::type_methods::arity_at_most(pos, "replace", 3)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
-    let old = require_bytes_like(pos[1])?;
-    let new = require_bytes_like(pos[2])?;
     let limit = match pos.get(3) {
         Some(&w_count) if !w_count.is_null() => {
             let c = crate::builtins::space_index_w(w_count)?;
@@ -22230,6 +22227,12 @@ fn bytes_method_replace(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyEr
         }
         _ => usize::MAX,
     };
+    // Borrowed after the coercions, as `bytes_method_ljust`: all three
+    // operands may be bytearrays, and the `__index__` above can resize any of
+    // them.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(pos[0]) };
+    let old = require_bytes_like(pos[1])?;
+    let new = require_bytes_like(pos[2])?;
     let (out, replacements) = replace_bytes(data, old, new, limit);
     // `descr_replace` returns `self` when nothing was replaced
     // (unicodeobject.py for the str twin) — keyed on the count, so
@@ -22496,9 +22499,12 @@ fn bytes_fill_char(args: &[PyObjectRef], idx: usize, method: &str) -> Result<u8,
 /// `stringmethods.py:descr_ljust` — left-justify within `width`.
 fn bytes_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_between(args, "ljust", 1, 2)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "ljust")?;
+    // Borrowed after the coercions, not before: `__index__` on `width` runs
+    // Python, and a `bytearray` receiver resized there reallocates the buffer
+    // this slice points into.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let len = data.len() as i64;
     if width <= len {
         return Ok(new_bytes_like(args[0], data));
@@ -22512,9 +22518,10 @@ fn bytes_method_ljust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// `stringmethods.py:descr_rjust` — right-justify within `width`.
 fn bytes_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_between(args, "rjust", 1, 2)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "rjust")?;
+    // Borrowed after the coercions, as `bytes_method_ljust`.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let len = data.len() as i64;
     if width <= len {
         return Ok(new_bytes_like(args[0], data));
@@ -22530,9 +22537,10 @@ fn bytes_method_rjust(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErro
 /// left-offset.
 fn bytes_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_between(args, "center", 1, 2)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
     let fill = bytes_fill_char(args, 2, "center")?;
+    // Borrowed after the coercions, as `bytes_method_ljust`.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let len = data.len() as i64;
     if width <= len {
         return Ok(new_bytes_like(args[0], data));
@@ -22550,8 +22558,9 @@ fn bytes_method_center(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyErr
 /// keeping a leading `+`/`-` sign ahead of the zeros.
 fn bytes_method_zfill(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
     crate::type_methods::arity_exact(args, "zfill", 1)?;
-    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let width = crate::builtins::space_index_w(args[1])?;
+    // Borrowed after the coercions, as `bytes_method_ljust`.
+    let data = unsafe { pyre_object::bytesobject::bytes_like_data(args[0]) };
     let len = data.len() as i64;
     if width <= len {
         return Ok(new_bytes_like(args[0], data));

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -1742,6 +1742,14 @@ impl DictOperationGuard {
         }
     }
 
+    /// Re-read a rooted operand.
+    ///
+    /// The collector rewrites this scope's slots in place, so calling this
+    /// again after a step that can collect is what keeps a raw local naming
+    /// the dictionary's current address — a `W_DictObject` header comes from
+    /// the movable `try_gc_alloc` hook.  Two steps in this file collect: a
+    /// strategy promotion, which re-stores every key through a fresh box, and
+    /// `object_key_for_checked`, which runs the key's own `__hash__`.
     #[inline]
     pub fn root(&self, index: usize) -> PyObjectRef {
         self.roots.get(self.root_base + index)
@@ -1756,6 +1764,13 @@ macro_rules! lock_dict_refs {
     ($guard:ident, $obj:ident, $one:ident) => {
         let $guard = unsafe { DictOperationGuard::new($obj, &[$one]) };
         let $obj = $guard.root(0);
+        let $one = $guard.root(1);
+    };
+    // Receiver deliberately left unbound: a body whose first touch of the
+    // dictionary follows a step that collects reads it off `root(0)` there,
+    // and a binding here would only offer the pre-collection word.
+    (defer $guard:ident, $obj:ident, $one:ident) => {
+        let $guard = unsafe { DictOperationGuard::new($obj, &[$one]) };
         let $one = $guard.root(1);
     };
     ($guard:ident, $obj:ident, $one:ident, $two:ident) => {
@@ -2531,6 +2546,7 @@ pub unsafe fn w_dict_lookup_checked(
             return Ok(None);
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_lookup_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::dictmultiobject::UNICODE_DICT_STRATEGY) {
@@ -2551,6 +2567,7 @@ pub unsafe fn w_dict_lookup_checked(
             return Ok(None);
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_lookup_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::identitydict::IDENTITY_DICT_STRATEGY) {
@@ -2558,6 +2575,7 @@ pub unsafe fn w_dict_lookup_checked(
             return Ok(strategy.getitem(obj, key));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_lookup_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::kwargsdict::KWARGS_DICT_STRATEGY) {
@@ -2565,6 +2583,7 @@ pub unsafe fn w_dict_lookup_checked(
             return Ok(strategy.getitem(obj, key));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_lookup_object_strategy_checked(obj, key);
     }
     let result = strategy.getitem(obj, key);
@@ -2600,6 +2619,34 @@ macro_rules! callback_free_dict_op {
         } else {
             Some(Ok(result))
         }
+    }};
+}
+
+/// Evaluate `$body` with `$obj` published, then rebind `$obj` to the address
+/// it has afterwards and yield the body's value.
+///
+/// The re-read [`DictOperationGuard::root`] documents, for the helpers that
+/// run below a caller's guard and so cannot reach its slots.
+///
+/// A macro rather than a helper taking `impl FnOnce`, for the reason
+/// `callback_free_dict_op!` gives: a closure has no lifted counterpart, so
+/// every dict graph that reached one would stop there.
+macro_rules! with_dict_rooted {
+    ($obj:ident, $value:ident, $body:expr) => {{
+        let _scope = crate::gc_roots::push_roots();
+        let base = crate::gc_roots::pin_roots(&[$obj, $value]);
+        let result = $body;
+        $obj = crate::gc_roots::shadow_stack_get(base);
+        $value = crate::gc_roots::shadow_stack_get(base + 1);
+        result
+    }};
+    ($obj:ident, $body:expr) => {{
+        let _scope = crate::gc_roots::push_roots();
+        let slot = crate::gc_roots::shadow_stack_len();
+        crate::gc_roots::pin_root($obj);
+        let result = $body;
+        $obj = crate::gc_roots::shadow_stack_get(slot);
+        result
     }};
 }
 
@@ -2752,8 +2799,13 @@ pub unsafe fn w_dict_lookup_object_strategy_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
-    lock_dict_refs!(_dict_guard, obj, key);
+    lock_dict_refs!(defer _dict_guard, obj, key);
     let object_key = object_key_for_checked(key)?;
+    // `object_key_for_checked` runs the key's own `__hash__`, so the
+    // dictionary read below is the first use after a collection point: a
+    // `W_DictObject` header comes from the movable `try_gc_alloc` hook, and
+    // the guard's slot is what the collector rewrites.
+    let obj = _dict_guard.root(0);
     if let Some(result) = callback_free_dict_op!({
         let dict = &*(obj as *const W_DictObject);
         let entries = &*(dict.dstorage as *const indexmap::IndexMap<ObjectKey, PyObjectRef>);
@@ -2797,6 +2849,7 @@ pub unsafe fn w_module_dict_lookup_inner(
         return None;
     }
     w_module_dict_switch_to_object_strategy(obj);
+    let obj = _module_guard.root(0);
     w_module_dict_lookup_object_entries(obj, key)
 }
 
@@ -2834,8 +2887,11 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
     key: PyObjectRef,
 ) -> Result<Option<PyObjectRef>, DictKeyError> {
     lock_dict_refs!(_module_guard, obj, key);
-    if let Some(entries) = w_module_dict_object_storage(obj) {
+    if w_module_dict_object_storage(obj).is_some() {
         let object_key = object_key_for_checked(key)?;
+        // The storage is interior to the dictionary, so it is derived from the
+        // reloaded receiver rather than carried across the hash above.
+        let entries = w_module_dict_object_storage(_module_guard.root(0)).ok_or(DictKeyError)?;
         let hit = dict_entries_probe_hashed(entries, object_key.hash, object_key.obj);
         if take_dict_key_error() {
             return Err(DictKeyError);
@@ -2849,8 +2905,9 @@ pub unsafe fn w_module_dict_lookup_inner_checked(
         return Ok(None);
     }
     w_module_dict_switch_to_object_strategy(obj);
-    let entries = w_module_dict_object_storage(obj).ok_or(DictKeyError)?;
     let object_key = object_key_for_checked(key)?;
+    // Derived after the hash, for the reason the branch above gives.
+    let entries = w_module_dict_object_storage(_module_guard.root(0)).ok_or(DictKeyError)?;
     let hit = dict_entries_probe_hashed(entries, object_key.hash, object_key.obj);
     if take_dict_key_error() {
         return Err(DictKeyError);
@@ -2914,9 +2971,9 @@ pub unsafe fn w_dict_store_hashed_checked(
 }
 
 unsafe fn w_dict_store_checked_inner(
-    obj: PyObjectRef,
+    mut obj: PyObjectRef,
     key: PyObjectRef,
-    value: PyObjectRef,
+    mut value: PyObjectRef,
     hash: Option<i64>,
 ) -> Result<(), DictKeyError> {
     debug_assert!(!value.is_null(), "w_dict_store_checked: null value");
@@ -2943,7 +3000,7 @@ unsafe fn w_dict_store_checked_inner(
             w_dict_store_bytes_strategy(obj, key, value);
             return Ok(());
         }
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::dictmultiobject::UNICODE_DICT_STRATEGY) {
@@ -2957,7 +3014,7 @@ unsafe fn w_dict_store_checked_inner(
             w_dict_store_int_strategy(obj, key, value);
             return Ok(());
         }
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::identitydict::IDENTITY_DICT_STRATEGY) {
@@ -2965,7 +3022,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy_is(strategy, &crate::kwargsdict::KWARGS_DICT_STRATEGY) {
@@ -2973,7 +3030,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     if strategy.strategy_kind() == StrategyKind::Map {
@@ -2988,7 +3045,7 @@ unsafe fn w_dict_store_checked_inner(
             strategy.setitem(obj, key, value);
             return Ok(());
         }
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
         return w_dict_store_object_strategy_checked_inner(obj, key, value, hash);
     }
     strategy.setitem(obj, key, value);
@@ -3060,6 +3117,8 @@ pub unsafe fn w_dict_setdefault_checked(
         // comparison the builtin ladder cannot settle withholds the insert and
         // re-runs the probe over `scan_dict_key_reentrant`.
         let object_key = object_key_for_checked(key)?;
+        let obj = _dict_guard.root(0);
+        let value = _dict_guard.root(2);
         if let Some(result) = callback_free_dict_op!({
             let dict = &mut *(obj as *mut W_DictObject);
             let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
@@ -3119,6 +3178,7 @@ pub unsafe fn w_dict_setdefault_checked(
             return Ok(strategy.setdefault(obj, key, value));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_setdefault_checked(obj, key, value);
     }
     // `dictmultiobject.py DictStrategy.setdefault` is `getitem`
@@ -3211,6 +3271,7 @@ pub unsafe fn w_dict_pop_checked(
             // withholds the removal and re-runs it over
             // `scan_dict_key_reentrant`.
             let object_key = object_key_for_checked(key)?;
+            let obj = _dict_guard.root(0);
             if let Some(result) = callback_free_dict_op!({
                 let dict = &mut *(obj as *mut W_DictObject);
                 let entries =
@@ -3383,6 +3444,8 @@ pub unsafe fn w_module_dict_store_inner(obj: PyObjectRef, key: PyObjectRef, valu
     if !w_module_dict_is_object_strategy(obj) {
         w_module_dict_switch_to_object_strategy(obj);
     }
+    let obj = _module_guard.root(0);
+    let value = _module_guard.root(2);
     let entries = w_module_dict_object_storage_mut(obj);
     let object_key = object_key_for(key);
     let inserted =
@@ -3414,6 +3477,8 @@ pub unsafe fn w_module_dict_store_inner_checked(
         w_module_dict_switch_to_object_strategy(obj);
     }
     let object_key = object_key_for_checked(key)?;
+    let obj = _module_guard.root(0);
+    let value = _module_guard.root(2);
     let entries = w_module_dict_object_storage_mut(obj);
     // Single setitem probe; on an `__eq__` raise mid-probe `insert` appends
     // a spurious entry, so drop it with `pop` and leave the dict unchanged
@@ -3793,6 +3858,7 @@ pub unsafe fn w_dict_delitem_wtf8_no_proxy(obj: PyObjectRef, key: &rustpython_wt
         if !w_module_dict_is_object_strategy(obj) {
             w_module_dict_switch_to_object_strategy(obj);
         }
+        let obj = _dict_guard.root(0);
         let entries = w_module_dict_object_storage_mut(obj);
         let w_key = crate::w_str_from_wtf8(key.to_wtf8_buf());
         let removed = entries.shift_remove(&object_key_for(w_key)).is_some();
@@ -3892,6 +3958,7 @@ pub unsafe fn w_dict_delitem_checked(
             return Ok(w_dict_delitem_bytes_strategy(obj, key));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_delitem_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::dictmultiobject::UNICODE_DICT_STRATEGY) {
@@ -3906,6 +3973,7 @@ pub unsafe fn w_dict_delitem_checked(
             return Ok(w_dict_delitem_int_strategy(obj, key));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_delitem_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::identitydict::IDENTITY_DICT_STRATEGY) {
@@ -3913,10 +3981,12 @@ pub unsafe fn w_dict_delitem_checked(
             return Ok(strategy.delitem(obj, key));
         }
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_delitem_object_strategy_checked(obj, key);
     }
     if strategy_is(strategy, &crate::kwargsdict::KWARGS_DICT_STRATEGY) {
         strategy.switch_to_object_strategy(obj);
+        let obj = _dict_guard.root(0);
         return w_dict_delitem_object_strategy_checked(obj, key);
     }
     let removed = strategy.delitem(obj, key);
@@ -3934,15 +4004,15 @@ pub unsafe fn w_dict_delitem_checked(
 /// The caller must uphold every validity, runtime-type, aliasing, and lifetime
 /// invariant required by the object and pointer arguments for the entire call.
 pub unsafe fn w_dict_delitem_if_value_is_checked(
-    obj: PyObjectRef,
+    mut obj: PyObjectRef,
     key: PyObjectRef,
-    value: PyObjectRef,
+    mut value: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
     if is_module_dict(obj) {
         if !w_module_dict_is_object_strategy(obj) {
-            w_module_dict_switch_to_object_strategy(obj);
+            with_dict_rooted!(obj, value, w_module_dict_switch_to_object_strategy(obj));
         }
-        let object_key = object_key_for_checked(key)?;
+        let object_key = with_dict_rooted!(obj, value, object_key_for_checked(key)?);
         if let Some(result) = callback_free_dict_op!({
             let entries = w_module_dict_object_storage_mut(obj);
             match entries.get_index_of(&object_key) {
@@ -3992,9 +4062,9 @@ pub unsafe fn w_dict_delitem_if_value_is_checked(
 
     let strategy = (*(obj as *const W_DictObject)).dstrategy.imp;
     if strategy.strategy_kind() != StrategyKind::Object {
-        strategy.switch_to_object_strategy(obj);
+        with_dict_rooted!(obj, value, strategy.switch_to_object_strategy(obj));
     }
-    let object_key = object_key_for_checked(key)?;
+    let object_key = with_dict_rooted!(obj, value, object_key_for_checked(key)?);
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
@@ -4098,6 +4168,7 @@ pub unsafe fn w_dict_move_to_end_checked(
             w_module_dict_switch_to_object_strategy(obj);
         }
         let object_key = object_key_for_checked(key)?;
+        let obj = _dict_guard.root(0);
         if let Some(result) = callback_free_dict_op!({
             let entries = w_module_dict_object_storage_mut(obj);
             match entries.get_index_of(&object_key) {
@@ -4183,6 +4254,7 @@ pub unsafe fn w_dict_move_to_end_checked(
         strategy.switch_to_object_strategy(obj);
     }
     let object_key = object_key_for_checked(key)?;
+    let obj = _dict_guard.root(0);
     if let Some(result) = callback_free_dict_op!({
         let dict = &mut *(obj as *mut W_DictObject);
         let entries = &mut *(dict.dstorage as *mut indexmap::IndexMap<ObjectKey, PyObjectRef>);
@@ -4234,8 +4306,9 @@ pub unsafe fn w_dict_delitem_object_strategy_checked(
     obj: PyObjectRef,
     key: PyObjectRef,
 ) -> Result<bool, DictKeyError> {
-    lock_dict_refs!(_dict_guard, obj, key);
+    lock_dict_refs!(defer _dict_guard, obj, key);
     let object_key = object_key_for_checked(key)?;
+    let obj = _dict_guard.root(0);
     // Single delitem probe, run callback-free so no user `__eq__` mutates the
     // dict while the `IndexMap` borrow is live.  A comparison the builtin
     // ladder cannot settle withholds the removal and re-runs the probe over
@@ -4301,6 +4374,7 @@ pub unsafe fn w_module_dict_delitem_inner(obj: PyObjectRef, key: PyObjectRef) ->
         return false;
     }
     w_module_dict_switch_to_object_strategy(obj);
+    let obj = _module_guard.root(0);
     let entries = w_module_dict_object_storage_mut(obj);
     if dict_entries_remove_object(entries, key) {
         let strategy = &mut *(*(obj as *mut W_ModuleDictObject)).mstrategy;
@@ -4321,6 +4395,7 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
     lock_dict_refs!(_module_guard, obj, key);
     if w_module_dict_is_object_strategy(obj) {
         let object_key = object_key_for_checked(key)?;
+        let obj = _module_guard.root(0);
         let entries = w_module_dict_object_storage_mut(obj);
         let removed = entries.shift_remove(&object_key).is_some();
         if take_dict_key_error() {
@@ -4342,6 +4417,7 @@ pub unsafe fn w_module_dict_delitem_inner_checked(
     }
     w_module_dict_switch_to_object_strategy(obj);
     let object_key = object_key_for_checked(key)?;
+    let obj = _module_guard.root(0);
     let entries = w_module_dict_object_storage_mut(obj);
     let removed = entries.shift_remove(&object_key).is_some();
     if take_dict_key_error() {


### PR DESCRIPTION
Nineteen rooting/ordering defects found by auditing the paths that hold a container in a native local across a step that can collect. Each commit is one concern; each is reproduced on a control binary and covered by a gated snippet.

## The audit filter

Two argument-delivery paths reach native container code with opposite failure modes:

- A gateway builtin's `args` is already pinned by `call_builtin_code_positional`, so the arguments stay alive for the whole builtin. Only **staleness** matters there, and only for the kinds that move (`W_ListObject`, `W_DictObject`).
- `BINARY_SUBSCR` / `STORE_SUBSCR` / `DELETE_SUBSCR` / `CONTAINS_OP` **pop** their operands before dispatching, so the slot body holds a container nothing roots. **Liveness** matters there for every kind, movable or not.

`root-for-liveness-always-read-back-only-for-movable-kinds` is the shape of every fix: read back for `W_ListObject`/`W_DictObject`, pin only for the rest.

## What is fixed

**The checked-dict surface in `pyre-object` (37 sites, pre-existing).** `w_dict_{lookup,store,setdefault,pop,delitem,move_to_end}_checked` and the module-dict twins held the receiver across two steps that collect: `object_key_for_checked`, which runs the key's own `__hash__`, and `switch_to_object_strategy`, which boxes every key it re-stores. `Key(9) in numbers`, `d.get`, `d.pop`, `d.setdefault` and `d[k]` reach SIGSEGV or SIGBUS on a young dict. Five of those sites also wrote the stored `value` through a pre-hash word, which surfaces as a NULL operand inside `descroperation::compare`. The collector rewrites this scope's shadow slots in place, so `guard.root(0)` after the hop is the whole fix at a guarded site; helpers running below a caller's guard get a `with_dict_rooted!` **macro** — not a helper taking `impl FnOnce`, since `callback_free_dict_op!`'s own doc records that a closure has no lifted counterpart and stops the dict graph there.

**A set membership test's receiver.** `set_lookup_checked` pinned the element and carried a comment arguing the set needs no rooting, being an old-gen allocation that keeps its address across a collection. That is true and answers the wrong question: old-gen means it never moves, but an unreachable old-gen object is still swept. `Key(9) in {i for i in range(20)}` — a temporary set — SIGSEGVs when the element's `__hash__` collects.

**Operands held across a coercion.** `sorted(seq, reverse=Truth())`, `operator.length_hint([1,2,3], Idx())`, `array.index([4], Idx())`, `dict.get`/`dict.pop`'s default, `dict.fromkeys(gen)`'s freshly minted dict, the subscript container while the key runs `__index__`, `OSError`'s arguments across the message build, `bytes`' payload borrow across the width and fill coercions, the set update/union operands before the first drain, and the object held across a text codec lookup.

**`ContextVar.set(new)` — silent corruption, no crash.** The reachable operand is the token's `old_value`, not the value being set; it read back as `[]` instead of `[1,2,3]`, and `reset(token)` restored the wrong list.

## The neighbouring visibility defect

The same read-before-the-hop shape also answers against a pre-mutation length when the hop mutates the container. `lst[Grow():]` and `lst.index(x, Grow(-5))` read the size before converting the bounds. Both CPython and PyPy read it after for the slice case; for `list.index` CPython reads it after and PyPy does not, and pyre already sides with CPython in the neighbouring `bytearray.find` family. The length is now read after both bounds have been converted, off the root slot — the same call is what may have moved the list.

Note that `a[b:c]` compiles to `BINARY_SLICE`, so the executed path is `runtime_ops::binary_slice_values`; `getitem_list`'s slice arm is reached only through an explicit `slice` object. Both are fixed.

## Honest negatives

`context_var_reset`, `posix_spawn`, `w_list_find_or_count` and `getitem_bytes_like` were probed and are already correct. The set displays and set operators are fine because their arguments come through a pinned gateway slice. `builtin_print`'s `file_obj` is reachable only on an error path and is left alone.

## Gates

Five new snippets under `pyre/extra_tests/snippets/`, each carrying `# pyre-check: gate=1`, each verified red on a control binary and green on CPython:

- `mutating_index_bound_reads_the_live_length.py`
- `gc_dict_default_survives_the_key_hash.py`
- `gc_builtin_operand_survives_its_coercion.py`
- `gc_dict_probe_reloads_its_container.py`
- `gc_set_membership_roots_a_temporary_receiver.py`

The dict and set probes are written as per-operation loops rather than one sequenced script: sequencing several probes over one dictionary hides the crash, and an assertion-only form was green on a binary where `print(repr(...))` was red.

Local lanes were green on the previous base (gated snippets 82/82 across cpython/dynasm/cranelift; `cargo test --all --no-default-features --features dynasm`; parity; `cargo fmt --all -- --check`; LLBC `--check`; the new-line citation gate). CI is the gate on this base.

— *authored by Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
