### PR TITLE
wasm: bind the FINISH descrs to reserved exits, and set WASM_MAX_DYNASM_RATIO to 3.5

### DIFF
--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -2728,20 +2728,6 @@ pub fn build_wasm_module(
         return Err(BackendError::Unsupported(reason));
     }
 
-    // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`): `bridge_finish_fi` is
-    // THIS bridge's own DoneWithThisFrame index (the recursive return), which the
-    // CA arm accepts as a clean callee finish alongside the source loop's
-    // base-case finish. Widen the callee-frame reservation to also fit this
-    // bridge's frame: the source loop's guard-exit chains into this bridge
-    // reusing the same arena frame, so an undersized frame would let the bridge's
-    // home-slot writes overflow into the next arena slot.
-    let bridge_finish_fi = guards
-        .iter()
-        .find(|g| {
-            g.is_finish && !crate::failguard::meta_descr_is_exit_frame_with_exception(&g.meta_descr)
-        })
-        .map(|g| g.fail_index)
-        .unwrap_or(crate::failguard::WASM_CA_FINISH_FI_UNKNOWN);
     // CA frames execute the source loop and this bridge on the same frozen
     // geometry.  `compile_bridge` rejects a bridge that needs more slots, so
     // no global floor or speculative slack is needed here.
@@ -3016,7 +3002,6 @@ pub fn build_wasm_module(
         &float_residual_type_indices,
         true_void_residual_max_arity.map(|_| true_void_residual_type_base),
         ca.clone(),
-        bridge_finish_fi,
         ca_helper_type_idx,
         *trace_entry_census,
     )?;
@@ -3076,9 +3061,6 @@ fn build_function(
     // Self-recursive CALL_ASSEMBLER arm (`PYRE_WASM_CA`). `ca.emit_ca` off keeps
     // the body byte-identical.
     ca: CaParams,
-    // This bridge's own DoneWithThisFrame Finish index (the recursive return);
-    // the CA arm accepts it or `ca.loop_finish_fi` as a clean callee finish.
-    bridge_finish_fi: u32,
     // wasm type index of the CA deopt helper `(i64, i64) -> i64`, declared in the
     // module type section when `ca.emit_ca`. The CA arm uses it to `call_indirect`
     // `ca.deopt_helper_slot` for a deopted callee.
@@ -5194,15 +5176,34 @@ fn build_function(
                 sink.i64_load(mem64(0));
                 sink.i32_wrap_i64();
                 sink.local_set(ca_fi_local);
-                // is_finish = (fi == loop_finish_fi) | (fi == bridge_finish_fi)
+                // A clean finish is any exit the global table flags as a
+                // DoneWithThisFrame that is not an ExitFrameWithException —
+                // `fi < len && flags[fi] != 0`, with the out-of-range arm
+                // falling through to the host rather than reading a stray byte.
+                // Naming the two indices this build happens to know would send
+                // every other finish of the same chain to `wasm_ca_resume_deopt`
+                // to be decoded and handed straight back.
+                let clean_finish_table = crate::failguard::clean_finish_table_addr() as i32;
                 sink.local_get(ca_fi_local);
-                sink.i32_const(dispatch_entry);
-                sink.i32_load(mem32(crate::failguard::WASM_CA_DISPATCH_LOOP_FINISH_FI_OFS));
-                sink.i32_eq();
+                sink.i32_const(clean_finish_table);
+                sink.i32_load(mem32(crate::failguard::WASM_CLEAN_FINISH_LEN_OFS));
+                sink.i32_lt_u();
+                sink.if_(BlockType::Result(ValType::I32));
+                sink.i32_const(clean_finish_table);
+                sink.i32_load(mem32(crate::failguard::WASM_CLEAN_FINISH_BASE_OFS));
                 sink.local_get(ca_fi_local);
-                sink.i32_const(bridge_finish_fi as i32);
-                sink.i32_eq();
-                sink.i32_or();
+                sink.i32_add();
+                sink.i32_load8_u(memarg(0, 0));
+                sink.else_();
+                sink.i32_const(0);
+                sink.end();
+                // The host arm takes the exception cell on every return; a
+                // short-circuit leaves it set, so a finish that somehow carries
+                // a pending exception must still go there.
+                sink.i32_const(crate::jit_exc_value_addr() as i32);
+                sink.i64_load(mem64(0));
+                sink.i64_eqz();
+                sink.i32_and();
                 sink.if_(BlockType::Result(ValType::I64));
                 // clean finish: result Ref = F'[1] (output slot 0).
                 sink.local_get(ca_cfp_local);

--- a/majit/majit-backend-wasm/src/codegen.rs
+++ b/majit/majit-backend-wasm/src/codegen.rs
@@ -5176,34 +5176,18 @@ fn build_function(
                 sink.i64_load(mem64(0));
                 sink.i32_wrap_i64();
                 sink.local_set(ca_fi_local);
-                // A clean finish is any exit the global table flags as a
-                // DoneWithThisFrame that is not an ExitFrameWithException —
-                // `fi < len && flags[fi] != 0`, with the out-of-range arm
-                // falling through to the host rather than reading a stray byte.
-                // Naming the two indices this build happens to know would send
-                // every other finish of the same chain to `wasm_ca_resume_deopt`
-                // to be decoded and handed straight back.
-                let clean_finish_table = crate::failguard::clean_finish_table_addr() as i32;
+                // `_call_assembler_check_descr` — every clean finish of this
+                // result kind writes the one `done_with_this_frame_descr_<kind>`
+                // the cpu was handed, so the check is a compare against that
+                // single value. A raising callee writes
+                // `exit_frame_with_exception_descr_ref` and a guard deopt writes
+                // its own exit, so both fail this compare and take the helper
+                // path, which is what propagates the exception.
                 sink.local_get(ca_fi_local);
-                sink.i32_const(clean_finish_table);
-                sink.i32_load(mem32(crate::failguard::WASM_CLEAN_FINISH_LEN_OFS));
-                sink.i32_lt_u();
-                sink.if_(BlockType::Result(ValType::I32));
-                sink.i32_const(clean_finish_table);
-                sink.i32_load(mem32(crate::failguard::WASM_CLEAN_FINISH_BASE_OFS));
-                sink.local_get(ca_fi_local);
-                sink.i32_add();
-                sink.i32_load8_u(memarg(0, 0));
-                sink.else_();
-                sink.i32_const(0);
-                sink.end();
-                // The host arm takes the exception cell on every return; a
-                // short-circuit leaves it set, so a finish that somehow carries
-                // a pending exception must still go there.
-                sink.i32_const(crate::jit_exc_value_addr() as i32);
-                sink.i64_load(mem64(0));
-                sink.i64_eqz();
-                sink.i32_and();
+                sink.i32_const(crate::failguard::done_with_this_frame_exit_index(
+                    op.opcode.result_type(),
+                ) as i32);
+                sink.i32_eq();
                 sink.if_(BlockType::Result(ValType::I64));
                 // clean finish: result Ref = F'[1] (output slot 0).
                 sink.local_get(ca_cfp_local);
@@ -7067,7 +7051,22 @@ fn emit_guard_spill(
     op: &Op,
 ) {
     emit_guard_fail_args_spill(sink, constants, value_types, op);
-    emit_guard_fail_index_store(sink, guard_idx);
+    emit_guard_fail_index_store(sink, exit_index(op, guard_idx));
+}
+
+/// The exit a failing `op` writes into `frame[0]`.
+///
+/// `compile_done_with_this_frame` / `compile_exit_frame_with_exception` stamp
+/// the FINISH with the singleton the cpu was handed, so every trace that
+/// finishes the same way names the same exit and `_call_assembler_check_descr`
+/// can recognise it with one compare. Guards, and the N-ary finishes pyre adds
+/// on top of the `_DoneWithThisFrameDescr` family's 0/1-result classes, have no
+/// shared identity and keep their own exit.
+fn exit_index(op: &Op, guard_idx: u32) -> u32 {
+    if op.opcode != OpCode::Finish {
+        return guard_idx;
+    }
+    crate::failguard::attached_finish_exit_index(&op.getdescr()).unwrap_or(guard_idx)
 }
 
 fn emit_guard_fail_args_spill(

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -154,6 +154,7 @@ mod tests {
     use majit_ir::GcRef;
 
     use super::{Type, WasmFailDescr, WasmFrameData};
+    use super::{fail_descr_base, fail_index_is_clean_finish, register_fail_descrs};
 
     struct RootCountingGc(Arc<AtomicUsize>);
 
@@ -238,6 +239,38 @@ mod tests {
             is_finish: false,
             meta_descr: None,
         })
+    }
+
+    #[test]
+    fn clean_finish_flags_stay_indexed_by_fail_index() {
+        // The emitted CALL_ASSEMBLER arm indexes the flags with the same
+        // `fail_index` that indexes `FAIL_DESCR_REGISTRY`, so a registration
+        // that grew one and not the other would answer for the wrong exit.
+        let base = fail_descr_base();
+        // The third entry is the one a two-index whitelist used to miss.
+        let is_finish = [true, false, true];
+        let descrs: Vec<Arc<WasmFailDescr>> = is_finish
+            .iter()
+            .enumerate()
+            .map(|(i, &is_finish)| {
+                Arc::new(WasmFailDescr {
+                    fail_index: base + i as u32,
+                    trace_id: 0,
+                    fail_arg_types: vec![Type::Ref],
+                    is_finish,
+                    meta_descr: None,
+                })
+            })
+            .collect();
+        register_fail_descrs(&descrs);
+        for (i, &expected) in is_finish.iter().enumerate() {
+            assert_eq!(
+                fail_index_is_clean_finish(base + i as u32),
+                expected,
+                "flag {i} disagrees with its descr"
+            );
+        }
+        assert!(!fail_index_is_clean_finish(base + is_finish.len() as u32));
     }
 
     #[test]
@@ -339,6 +372,50 @@ pub const WASM_CA_DISPATCH_FUNC_HANDLE_OFS: u64 = 0;
 pub const WASM_CA_DISPATCH_LOOP_FINISH_FI_OFS: u64 = 4;
 pub const WASM_CA_DISPATCH_COMPILED_PTR_OFS: u64 = 8;
 pub const WASM_CA_FINISH_FI_UNKNOWN: u32 = u32::MAX;
+
+/// Header of the byte-per-`fail_index` clean-finish table the CALL_ASSEMBLER
+/// return arm reads. Boxed for the same reason as `WASM_CA_DISPATCH`: emitted
+/// modules bake the header address, and `base` moves whenever the table grows.
+#[repr(C)]
+pub struct WasmCleanFinishTable {
+    /// Address of the flag bytes, or 0 before the first registration.
+    pub base: AtomicU32,
+    /// Flags behind `base`, one per registered `fail_index`.
+    pub len: AtomicU32,
+}
+
+pub const WASM_CLEAN_FINISH_BASE_OFS: u64 = 0;
+pub const WASM_CLEAN_FINISH_LEN_OFS: u64 = 4;
+
+static CLEAN_FINISH_FLAGS: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
+static CLEAN_FINISH_HEADER: std::sync::OnceLock<Box<WasmCleanFinishTable>> =
+    std::sync::OnceLock::new();
+
+fn clean_finish_header() -> &'static WasmCleanFinishTable {
+    CLEAN_FINISH_HEADER.get_or_init(|| {
+        Box::new(WasmCleanFinishTable {
+            base: AtomicU32::new(0),
+            len: AtomicU32::new(0),
+        })
+    })
+}
+
+/// Guest address of the clean-finish header, stable for the process. A trace
+/// emitted before any descr is registered reads `len == 0`, so every exit
+/// takes the host deopt path until the first registration publishes the table.
+pub fn clean_finish_table_addr() -> u32 {
+    clean_finish_header() as *const WasmCleanFinishTable as usize as u32
+}
+
+/// Whether `fail_index` names a clean DoneWithThisFrame exit — the predicate
+/// the CALL_ASSEMBLER arm short-circuits on.
+pub fn fail_index_is_clean_finish(fail_index: u32) -> bool {
+    CLEAN_FINISH_FLAGS
+        .lock()
+        .unwrap()
+        .get(fail_index as usize)
+        .is_some_and(|flag| *flag != 0)
+}
 
 /// Stable, guest-memory dispatch entries, keyed by CALL_ASSEMBLER token.
 /// `Box` is intentional: an emitted module bakes the entry address.
@@ -506,6 +583,10 @@ pub fn fail_descr_base() -> u32 {
 pub fn register_fail_descrs(descrs: &[Arc<WasmFailDescr>]) {
     let mut reg = FAIL_DESCR_REGISTRY.lock().unwrap();
     let vec = reg.get_or_insert_with(Default::default);
+    // Grown in the same loop as the registry so the two cannot drift: the
+    // emitted CALL_ASSEMBLER arm indexes the flags by the `fail_index` that
+    // indexes this vector.
+    let mut flags = CLEAN_FINISH_FLAGS.lock().unwrap();
     for d in descrs {
         debug_assert_eq!(
             d.fail_index as usize,
@@ -513,7 +594,15 @@ pub fn register_fail_descrs(descrs: &[Arc<WasmFailDescr>]) {
             "fail descr registered out of lockstep with its global fail_index"
         );
         vec.push(Arc::clone(d));
+        flags.push(u8::from(
+            d.is_finish && !meta_descr_is_exit_frame_with_exception(&d.meta_descr),
+        ));
     }
+    let header = clean_finish_header();
+    header
+        .base
+        .store(flags.as_ptr() as usize as u32, Ordering::Release);
+    header.len.store(flags.len() as u32, Ordering::Release);
 }
 
 /// Resolve a `frame[0]` value through the global fail-index space.

--- a/majit/majit-backend-wasm/src/failguard.rs
+++ b/majit/majit-backend-wasm/src/failguard.rs
@@ -25,21 +25,6 @@ pub struct WasmFailDescr {
     pub meta_descr: Option<DescrRef>,
 }
 
-/// `compile.py` ExitFrameWithExceptionDescrRef parity: whether a FINISH
-/// exit is an ExitFrameWithException (the callee raised; slot 0 holds the
-/// exception) rather than a DoneWithThisFrame. `is_finish` alone is true for
-/// both, so the self-recursive CALL_ASSEMBLER arm must exclude the exception
-/// variant when it picks the "clean callee finish" `fail_index` — an
-/// ExitFrameWithException must route to `wasm_ca_resume_deopt`, which propagates
-/// the exception, not be short-circuited to its output slot.
-pub fn meta_descr_is_exit_frame_with_exception(meta_descr: &Option<DescrRef>) -> bool {
-    meta_descr
-        .as_ref()
-        .and_then(|d| d.as_fail_descr())
-        .map(|fd| fd.is_exit_frame_with_exception())
-        .unwrap_or(false)
-}
-
 impl Descr for WasmFailDescr {
     fn index(&self) -> u32 {
         self.fail_index
@@ -154,7 +139,7 @@ mod tests {
     use majit_ir::GcRef;
 
     use super::{Type, WasmFailDescr, WasmFrameData};
-    use super::{fail_descr_base, fail_index_is_clean_finish, register_fail_descrs};
+    use super::{fail_descr_base, global_fail_descr, register_fail_descrs};
 
     struct RootCountingGc(Arc<AtomicUsize>);
 
@@ -242,35 +227,68 @@ mod tests {
     }
 
     #[test]
-    fn clean_finish_flags_stay_indexed_by_fail_index() {
-        // The emitted CALL_ASSEMBLER arm indexes the flags with the same
-        // `fail_index` that indexes `FAIL_DESCR_REGISTRY`, so a registration
-        // that grew one and not the other would answer for the wrong exit.
+    fn a_finish_singleton_resolves_to_its_reserved_exit() {
+        // The emitted FINISH writes the index this returns and the emitted
+        // CALL_ASSEMBLER check compares against the same constant, so a
+        // singleton that failed to bind would send every clean callee finish
+        // back to the host to be decoded and handed straight over.
+        let descr: majit_ir::DescrRef = Arc::new(majit_backend::DoneWithThisFrameDescrRef::new());
+        super::attach_finish_descr(super::FINISH_EXIT_INDEX_REF, Arc::clone(&descr));
+        assert_eq!(
+            super::attached_finish_exit_index(&Some(Arc::clone(&descr))),
+            Some(super::FINISH_EXIT_INDEX_REF),
+        );
+        assert_eq!(
+            super::done_with_this_frame_exit_index(Type::Ref),
+            super::FINISH_EXIT_INDEX_REF,
+        );
+        // A descr this cpu was never handed has no shared identity, so it keeps
+        // its own exit.
+        let unattached: majit_ir::DescrRef =
+            Arc::new(majit_backend::DoneWithThisFrameDescrRef::new());
+        assert_eq!(super::attached_finish_exit_index(&Some(unattached)), None);
+    }
+
+    #[test]
+    fn the_reserved_finish_exits_precede_every_trace_base() {
+        // The emitted CALL_ASSEMBLER check compares against a baked reserved
+        // index, so a trace whose own exits started below the reserved block
+        // would collide with it.
         let base = fail_descr_base();
-        // The third entry is the one a two-index whitelist used to miss.
-        let is_finish = [true, false, true];
-        let descrs: Vec<Arc<WasmFailDescr>> = is_finish
-            .iter()
-            .enumerate()
-            .map(|(i, &is_finish)| {
+        assert!(base >= super::FINISH_EXIT_INDEX_COUNT);
+        for (index, types) in [
+            (super::FINISH_EXIT_INDEX_VOID, &[][..]),
+            (super::FINISH_EXIT_INDEX_INT, &[Type::Int][..]),
+            (super::FINISH_EXIT_INDEX_REF, &[Type::Ref][..]),
+            (super::FINISH_EXIT_INDEX_FLOAT, &[Type::Float][..]),
+            (super::FINISH_EXIT_INDEX_EXC, &[Type::Ref][..]),
+        ] {
+            let descr = global_fail_descr(index).expect("reserved finish exit is unregistered");
+            assert_eq!(descr.fail_index, index);
+            assert!(descr.is_finish, "reserved exit {index} is not a finish");
+            assert_eq!(descr.fail_arg_types, types, "reserved exit {index} layout");
+        }
+
+        let descrs: Vec<Arc<WasmFailDescr>> = (0..3)
+            .map(|i| {
                 Arc::new(WasmFailDescr {
-                    fail_index: base + i as u32,
+                    fail_index: base + i,
                     trace_id: 0,
                     fail_arg_types: vec![Type::Ref],
-                    is_finish,
+                    is_finish: false,
                     meta_descr: None,
                 })
             })
             .collect();
         register_fail_descrs(&descrs);
-        for (i, &expected) in is_finish.iter().enumerate() {
+        for i in 0..3 {
             assert_eq!(
-                fail_index_is_clean_finish(base + i as u32),
-                expected,
-                "flag {i} disagrees with its descr"
+                global_fail_descr(base + i)
+                    .expect("trace exit is unregistered")
+                    .fail_index,
+                base + i,
             );
         }
-        assert!(!fail_index_is_clean_finish(base + is_finish.len() as u32));
     }
 
     #[test]
@@ -341,7 +359,6 @@ pub struct CallAssemblerTarget {
     pub input_types: Vec<Type>,
     pub callee_frame_bytes: u32,
     pub callee_gcmap_ptr: i64,
-    pub loop_finish_fi: u32,
     pub compiled_ptr: u64,
 }
 
@@ -362,59 +379,115 @@ pub static CALL_ASSEMBLER_TARGETS: std::sync::Mutex<
 pub struct WasmCaDispatchEntry {
     /// `__indirect_function_table` slot. Zero means pending/unavailable.
     pub func_handle: AtomicU32,
-    /// Callee DoneWithThisFrame fail index. `u32::MAX` means not installed.
-    pub loop_finish_fi: AtomicU32,
     /// `CompiledWasmLoop` address for the deopt helper, in wasm32 memory.
     pub compiled_ptr: AtomicU32,
 }
 
 pub const WASM_CA_DISPATCH_FUNC_HANDLE_OFS: u64 = 0;
-pub const WASM_CA_DISPATCH_LOOP_FINISH_FI_OFS: u64 = 4;
-pub const WASM_CA_DISPATCH_COMPILED_PTR_OFS: u64 = 8;
-pub const WASM_CA_FINISH_FI_UNKNOWN: u32 = u32::MAX;
+pub const WASM_CA_DISPATCH_COMPILED_PTR_OFS: u64 = 4;
 
-/// Header of the byte-per-`fail_index` clean-finish table the CALL_ASSEMBLER
-/// return arm reads. Boxed for the same reason as `WASM_CA_DISPATCH`: emitted
-/// modules bake the header address, and `base` moves whenever the table grows.
-#[repr(C)]
-pub struct WasmCleanFinishTable {
-    /// Address of the flag bytes, or 0 before the first registration.
-    pub base: AtomicU32,
-    /// Flags behind `base`, one per registered `fail_index`.
-    pub len: AtomicU32,
+/// `make_and_attach_done_descrs` gives every cpu one `DoneWithThisFrame*` per
+/// result kind plus one `ExitFrameWithExceptionDescrRef`, and
+/// `compile_done_with_this_frame` / `compile_exit_frame_with_exception` stamp
+/// that singleton on the FINISH — so every trace that finishes the same way
+/// writes the same `jf_descr`, and `_call_assembler_check_descr` recognises a
+/// clean callee finish by comparing against one value.
+///
+/// A wasm frame slot holds an index into the global exit space rather than a
+/// descr pointer, so the shared identity is a reserved index. The five sit at
+/// the front of [`FAIL_DESCR_REGISTRY`], claimed before any trace takes a
+/// `fail_descr_base`, and carry the attached `Arc` as their `meta_descr` so
+/// `get_latest_descr_arc` still answers with the metainterp's own descr.
+pub const FINISH_EXIT_INDEX_VOID: u32 = 0;
+pub const FINISH_EXIT_INDEX_INT: u32 = 1;
+pub const FINISH_EXIT_INDEX_REF: u32 = 2;
+pub const FINISH_EXIT_INDEX_FLOAT: u32 = 3;
+pub const FINISH_EXIT_INDEX_EXC: u32 = 4;
+const FINISH_EXIT_INDEX_COUNT: u32 = 5;
+
+/// Reserved exit index for the `done_with_this_frame_descr_*` of `ty`.
+pub fn done_with_this_frame_exit_index(ty: Type) -> u32 {
+    match ty {
+        Type::Void => FINISH_EXIT_INDEX_VOID,
+        Type::Int => FINISH_EXIT_INDEX_INT,
+        Type::Ref => FINISH_EXIT_INDEX_REF,
+        Type::Float => FINISH_EXIT_INDEX_FLOAT,
+    }
 }
 
-pub const WASM_CLEAN_FINISH_BASE_OFS: u64 = 0;
-pub const WASM_CLEAN_FINISH_LEN_OFS: u64 = 4;
+/// The four `DoneWithThisFrameDescr*` classes carry the one result of their
+/// kind; `ExitFrameWithExceptionDescrRef` carries the exception Ref.
+fn reserved_fail_arg_types(exit_index: u32) -> Vec<Type> {
+    match exit_index {
+        FINISH_EXIT_INDEX_VOID => Vec::new(),
+        FINISH_EXIT_INDEX_INT => vec![Type::Int],
+        FINISH_EXIT_INDEX_FLOAT => vec![Type::Float],
+        _ => vec![Type::Ref],
+    }
+}
 
-static CLEAN_FINISH_FLAGS: std::sync::Mutex<Vec<u8>> = std::sync::Mutex::new(Vec::new());
-static CLEAN_FINISH_HEADER: std::sync::OnceLock<Box<WasmCleanFinishTable>> =
-    std::sync::OnceLock::new();
-
-fn clean_finish_header() -> &'static WasmCleanFinishTable {
-    CLEAN_FINISH_HEADER.get_or_init(|| {
-        Box::new(WasmCleanFinishTable {
-            base: AtomicU32::new(0),
-            len: AtomicU32::new(0),
-        })
+fn reserved_finish_descr(exit_index: u32, meta_descr: Option<DescrRef>) -> Arc<WasmFailDescr> {
+    Arc::new(WasmFailDescr {
+        fail_index: exit_index,
+        trace_id: 0,
+        fail_arg_types: reserved_fail_arg_types(exit_index),
+        is_finish: true,
+        meta_descr,
     })
 }
 
-/// Guest address of the clean-finish header, stable for the process. A trace
-/// emitted before any descr is registered reads `len == 0`, so every exit
-/// takes the host deopt path until the first registration publishes the table.
-pub fn clean_finish_table_addr() -> u32 {
-    clean_finish_header() as *const WasmCleanFinishTable as usize as u32
+/// Claim the reserved block if the registry has not been opened yet. Called
+/// under the registry lock from every entry point that can grow or read it, so
+/// a trace can never take a `fail_descr_base` below `FINISH_EXIT_INDEX_COUNT`.
+fn reserve_finish_exit_block(vec: &mut Vec<Arc<WasmFailDescr>>) {
+    if !vec.is_empty() {
+        return;
+    }
+    for index in 0..FINISH_EXIT_INDEX_COUNT {
+        vec.push(reserved_finish_descr(index, None));
+    }
 }
 
-/// Whether `fail_index` names a clean DoneWithThisFrame exit — the predicate
-/// the CALL_ASSEMBLER arm short-circuits on.
-pub fn fail_index_is_clean_finish(fail_index: u32) -> bool {
-    CLEAN_FINISH_FLAGS
-        .lock()
-        .unwrap()
-        .get(fail_index as usize)
-        .is_some_and(|flag| *flag != 0)
+fn thin_descr_ptr(descr: &DescrRef) -> usize {
+    Arc::as_ptr(descr) as *const () as usize
+}
+
+/// `make_and_attach_done_descrs` pointer identity: the reserved exit index for
+/// `descr` when it is one of the five singletons this cpu was handed, else
+/// `None`.
+/// Mirrors `AttachedDescrPtrs::is_done_with_this_frame_descr`, which is how the
+/// native backends recognise the same descrs on the FINISH fast path.
+///
+/// Answered from the reserved entries themselves, so an index this returns
+/// always names a registry entry carrying `descr` — `get_latest_descr_arc`
+/// keeps its `AbstractDescr` identity whatever order attachment and the first
+/// compile happened in.
+pub fn attached_finish_exit_index(descr: &Option<DescrRef>) -> Option<u32> {
+    let ptr = thin_descr_ptr(descr.as_ref()?);
+    let mut reg = FAIL_DESCR_REGISTRY.lock().unwrap();
+    let vec = reg.get_or_insert_with(Default::default);
+    reserve_finish_exit_block(vec);
+    vec[..FINISH_EXIT_INDEX_COUNT as usize]
+        .iter()
+        .position(|reserved| {
+            reserved
+                .meta_descr
+                .as_ref()
+                .is_some_and(|attached| thin_descr_ptr(attached) == ptr)
+        })
+        .map(|index| index as u32)
+}
+
+/// `make_and_attach_done_descrs`' per-target attachment for one of the five.
+/// Binds the singleton to its reserved exit, which is what the emitted FINISH
+/// writes and the emitted CALL_ASSEMBLER check compares against. Rebinding an
+/// already-claimed entry keeps the fast path available to a process that
+/// compiled something before the attachment landed.
+pub fn attach_finish_descr(exit_index: u32, descr: DescrRef) {
+    let mut reg = FAIL_DESCR_REGISTRY.lock().unwrap();
+    let vec = reg.get_or_insert_with(Default::default);
+    reserve_finish_exit_block(vec);
+    vec[exit_index as usize] = reserved_finish_descr(exit_index, Some(descr));
 }
 
 /// Stable, guest-memory dispatch entries, keyed by CALL_ASSEMBLER token.
@@ -433,7 +506,6 @@ pub fn ca_dispatch_slot(number: u64) -> u32 {
         .or_insert_with(|| {
             Box::new(WasmCaDispatchEntry {
                 func_handle: AtomicU32::new(0),
-                loop_finish_fi: AtomicU32::new(WASM_CA_FINISH_FI_UNKNOWN),
                 compiled_ptr: AtomicU32::new(0),
             })
         });
@@ -451,7 +523,7 @@ pub fn ca_dispatch_exists(number: u64) -> bool {
 /// Publish an installed loop after its module has acquired a shared-table
 /// slot. Release stores pair with the runtime loads in emitted trace modules;
 /// wasm execution cannot begin until this compile call returns.
-pub fn ca_dispatch_publish(number: u64, func_handle: u32, loop_finish_fi: u32, compiled_ptr: u32) {
+pub fn ca_dispatch_publish(number: u64, func_handle: u32, compiled_ptr: u32) {
     let _ = ca_dispatch_slot(number);
     let table = WASM_CA_DISPATCH.lock().unwrap();
     let entry = table
@@ -459,20 +531,12 @@ pub fn ca_dispatch_publish(number: u64, func_handle: u32, loop_finish_fi: u32, c
         .and_then(|table| table.get(&number))
         .expect("CALL_ASSEMBLER dispatch entry disappeared while publishing");
     entry.compiled_ptr.store(compiled_ptr, Ordering::Release);
-    entry
-        .loop_finish_fi
-        .store(loop_finish_fi, Ordering::Release);
     entry.func_handle.store(func_handle, Ordering::Release);
 }
 
 /// Redirect existing callers of `old_number` to the installed target.
-pub fn ca_dispatch_redirect(
-    old_number: u64,
-    func_handle: u32,
-    loop_finish_fi: u32,
-    compiled_ptr: u32,
-) {
-    ca_dispatch_publish(old_number, func_handle, loop_finish_fi, compiled_ptr);
+pub fn ca_dispatch_redirect(old_number: u64, func_handle: u32, compiled_ptr: u32) {
+    ca_dispatch_publish(old_number, func_handle, compiled_ptr);
 }
 
 /// Remove every dispatch entry that still resolves to `compiled_ptr`.  This
@@ -521,7 +585,6 @@ pub fn register_pending_call_assembler_target(number: u64, input_types: Vec<Type
             input_types,
             callee_frame_bytes: 0,
             callee_gcmap_ptr: 0,
-            loop_finish_fi: WASM_CA_FINISH_FI_UNKNOWN,
             compiled_ptr: 0,
         },
     );
@@ -570,11 +633,10 @@ static FAIL_DESCR_REGISTRY: std::sync::Mutex<Option<Vec<Arc<WasmFailDescr>>>> =
 /// `register_fail_descrs`. The wasm host is single-threaded, so no other
 /// compile can interleave between the two calls.
 pub fn fail_descr_base() -> u32 {
-    FAIL_DESCR_REGISTRY
-        .lock()
-        .unwrap()
-        .as_ref()
-        .map_or(0, |v| v.len() as u32)
+    let mut reg = FAIL_DESCR_REGISTRY.lock().unwrap();
+    let vec = reg.get_or_insert_with(Default::default);
+    reserve_finish_exit_block(vec);
+    vec.len() as u32
 }
 
 /// Append a compile's exit descrs to the global space. Each descr's
@@ -583,10 +645,7 @@ pub fn fail_descr_base() -> u32 {
 pub fn register_fail_descrs(descrs: &[Arc<WasmFailDescr>]) {
     let mut reg = FAIL_DESCR_REGISTRY.lock().unwrap();
     let vec = reg.get_or_insert_with(Default::default);
-    // Grown in the same loop as the registry so the two cannot drift: the
-    // emitted CALL_ASSEMBLER arm indexes the flags by the `fail_index` that
-    // indexes this vector.
-    let mut flags = CLEAN_FINISH_FLAGS.lock().unwrap();
+    reserve_finish_exit_block(vec);
     for d in descrs {
         debug_assert_eq!(
             d.fail_index as usize,
@@ -594,15 +653,7 @@ pub fn register_fail_descrs(descrs: &[Arc<WasmFailDescr>]) {
             "fail descr registered out of lockstep with its global fail_index"
         );
         vec.push(Arc::clone(d));
-        flags.push(u8::from(
-            d.is_finish && !meta_descr_is_exit_frame_with_exception(&d.meta_descr),
-        ));
     }
-    let header = clean_finish_header();
-    header
-        .base
-        .store(flags.as_ptr() as usize as u32, Ordering::Release);
-    header.len.store(flags.len() as u32, Ordering::Release);
 }
 
 /// Resolve a `frame[0]` value through the global fail-index space.

--- a/majit/majit-backend-wasm/src/lib.rs
+++ b/majit/majit-backend-wasm/src/lib.rs
@@ -2120,23 +2120,13 @@ impl WasmBackend {
             &inputs.ops,
             inputs.bridge_entry_arity,
         );
-        let loop_finish_fi = descrs
-            .iter()
-            .find(|descr| {
-                descr.is_finish
-                    && !failguard::meta_descr_is_exit_frame_with_exception(&descr.meta_descr)
-            })
-            .map(|descr| descr.fail_index)
-            .unwrap_or(failguard::WASM_CA_FINISH_FI_UNKNOWN);
         ca_dispatch_publish(
             token.number,
             old_handle,
-            loop_finish_fi,
             compiled as *const CompiledWasmLoop as usize as u32,
         );
         if let Some(mut target) = call_assembler_target(token.number) {
             target.func_handle = old_handle;
-            target.loop_finish_fi = loop_finish_fi;
             target.compiled_ptr = compiled as *const CompiledWasmLoop as usize as u64;
             publish_call_assembler_target(token.number, target);
         }
@@ -2354,7 +2344,6 @@ fn general_int_call_assembler_target(
                 input_types: self_.input_types.to_vec(),
                 callee_frame_bytes: self_.frame.ca_frame_bytes,
                 callee_gcmap_ptr,
-                loop_finish_fi: failguard::WASM_CA_FINISH_FI_UNKNOWN,
                 compiled_ptr: 0,
             }
         } else {
@@ -2369,12 +2358,7 @@ fn general_int_call_assembler_target(
                     return None;
                 }
                 registered.func_handle = handle;
-                ca_dispatch_publish(
-                    target_token,
-                    handle,
-                    registered.loop_finish_fi,
-                    registered.compiled_ptr as u32,
-                );
+                ca_dispatch_publish(target_token, handle, registered.compiled_ptr as u32);
                 publish_call_assembler_target(target_token, registered.clone());
             }
             if registered.input_types.as_slice() != arg_types
@@ -3018,16 +3002,6 @@ impl majit_backend::Backend for WasmBackend {
             .get()
             .and_then(|compiled| compiled.downcast_ref::<CompiledWasmLoop>())
             .expect("newly compiled wasm loop is missing");
-        let loop_finish_fi = compiled
-            .fail_descrs
-            .borrow()
-            .iter()
-            .find(|descr| {
-                descr.is_finish
-                    && !failguard::meta_descr_is_exit_frame_with_exception(&descr.meta_descr)
-            })
-            .map(|descr| descr.fail_index)
-            .unwrap_or(failguard::WASM_CA_FINISH_FI_UNKNOWN);
         // For a pending self target this is the exact map already embedded in
         // the module's CA arm. Reuse it for the published metadata so the
         // loop and its self-callee have demonstrably identical geometry. A
@@ -3050,7 +3024,6 @@ impl majit_backend::Backend for WasmBackend {
         ca_dispatch_publish(
             token.number,
             compiled.eager_func_handle(),
-            loop_finish_fi,
             compiled as *const CompiledWasmLoop as usize as u32,
         );
         publish_call_assembler_target(
@@ -3061,7 +3034,6 @@ impl majit_backend::Backend for WasmBackend {
                 input_types: compiled.input_types.clone(),
                 callee_frame_bytes: compiled.frame.ca_frame_bytes,
                 callee_gcmap_ptr,
-                loop_finish_fi,
                 compiled_ptr: compiled as *const CompiledWasmLoop as usize as u64,
             },
         );
@@ -3087,6 +3059,32 @@ impl majit_backend::Backend for WasmBackend {
 
     fn set_next_trace_id(&mut self, trace_id: u64) {
         self.trace_counter = trace_id;
+    }
+
+    // `make_and_attach_done_descrs` — the FINISH fast path
+    // needs the singletons' identity, so this backend takes the attachment
+    // instead of the trait's no-op default. Where a native backend publishes
+    // `Arc::as_ptr` to its comparison sites, a wasm frame slot holds an exit
+    // index rather than a pointer, so each singleton is bound to a reserved
+    // index in the global exit space (`failguard::FINISH_EXIT_INDEX_*`).
+    fn set_done_with_this_frame_descr_void(&mut self, descr: Arc<dyn majit_ir::Descr>) {
+        failguard::attach_finish_descr(failguard::FINISH_EXIT_INDEX_VOID, descr);
+    }
+
+    fn set_done_with_this_frame_descr_int(&mut self, descr: Arc<dyn majit_ir::Descr>) {
+        failguard::attach_finish_descr(failguard::FINISH_EXIT_INDEX_INT, descr);
+    }
+
+    fn set_done_with_this_frame_descr_ref(&mut self, descr: Arc<dyn majit_ir::Descr>) {
+        failguard::attach_finish_descr(failguard::FINISH_EXIT_INDEX_REF, descr);
+    }
+
+    fn set_done_with_this_frame_descr_float(&mut self, descr: Arc<dyn majit_ir::Descr>) {
+        failguard::attach_finish_descr(failguard::FINISH_EXIT_INDEX_FLOAT, descr);
+    }
+
+    fn set_exit_frame_with_exception_descr_ref(&mut self, descr: Arc<dyn majit_ir::Descr>) {
+        failguard::attach_finish_descr(failguard::FINISH_EXIT_INDEX_EXC, descr);
     }
 
     // `set_next_header_pc` uses the trait default (no-op) — wasm does
@@ -4292,12 +4290,7 @@ impl majit_backend::Backend for WasmBackend {
                 )));
             }
             new_target.func_handle = handle;
-            ca_dispatch_publish(
-                new.number,
-                handle,
-                new_target.loop_finish_fi,
-                new_target.compiled_ptr as u32,
-            );
+            ca_dispatch_publish(new.number, handle, new_target.compiled_ptr as u32);
             publish_call_assembler_target(new.number, new_target.clone());
         }
         let movable_callee = new_target.callee_frame_bytes != 0
@@ -4320,7 +4313,6 @@ impl majit_backend::Backend for WasmBackend {
         ca_dispatch_redirect(
             old.number,
             new_target.func_handle,
-            new_target.loop_finish_fi,
             new_target.compiled_ptr as u32,
         );
         transfer_call_assembler_target_activity(&old_target, &new_target);

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -145,18 +145,15 @@ WASM_TIMEOUT_SCALE = 4.0
 # below that the denominator is startup noise, and the comparison table marks
 # the ratio `~` the way the pypy gates already do.
 #
-# 4x rather than the 3x this started at, because 3x was not where the backend
-# is. Four fixtures had already been carved out of it one at a time -- fannkuch
-# 3.6, fib_recursive 3.6, raise_catch_loop 3.8, short_circuit_value_kept_stack
-# 3.7 -- every one for the same structural reason (`wasm_ratio_gate` below
-# spells it out), and more kept arriving: one main run failed
-# `if_else_jump_forward` at 3.9x and `loop_callee_shared_mutation` at 3.3x with
-# no allowance written for either. A ceiling that the fixtures above it are
-# exempted from individually is collecting exemptions rather than measuring the
-# backend. At 4x the gate means what it says, all four of those allowances come
-# out, and one stays genuinely above it
-# (`global_quasiimmut_invalidation`, 6).
-WASM_MAX_DYNASM_RATIO = 4.0
+# The number is meant to be a target the backend is held to, so it moves only
+# when the backend does, and never to bless a fixture: it started at 3x, went to
+# 4x when 3x was collecting per-fixture `max-wasm-ratio` allowances one at a
+# time (fannkuch, fib_recursive, raise_catch_loop,
+# short_circuit_value_kept_stack) rather than measuring anything, and came back
+# to 3.5 once every one of those allowances had been removed and the fixture
+# that still exceeded it -- fib_recursive, at 3.87x -- was fixed rather than
+# exempted. No fixture carries an allowance today.
+WASM_MAX_DYNASM_RATIO = 3.5
 # Native Windows CI can spend substantially more wall time than reported
 # process user-CPU while antivirus and concurrent matrix jobs contend for the
 # runner.  Keep the timeout as a hang guard by granting native backends 2x

--- a/pyre/check.py
+++ b/pyre/check.py
@@ -150,9 +150,10 @@ WASM_TIMEOUT_SCALE = 4.0
 # 4x when 3x was collecting per-fixture `max-wasm-ratio` allowances one at a
 # time (fannkuch, fib_recursive, raise_catch_loop,
 # short_circuit_value_kept_stack) rather than measuring anything, and came back
-# to 3.5 once every one of those allowances had been removed and the fixture
-# that still exceeded it -- fib_recursive, at 3.87x -- was fixed rather than
-# exempted. No fixture carries an allowance today.
+# to 3.5 once every one of those allowances had been removed and the fixtures
+# that still exceeded it -- fib_recursive and loop_callee_shared_mutation, both
+# bound by CALL_ASSEMBLER returns -- were fixed rather than exempted. No fixture
+# carries an allowance today.
 WASM_MAX_DYNASM_RATIO = 3.5
 # Native Windows CI can spend substantially more wall time than reported
 # process user-CPU while antivirus and concurrent matrix jobs contend for the


### PR DESCRIPTION
## The defect

`majit-backend`'s `Cpu` trait documents the contract: a backend that uses
pointer identity for the FINISH fast path overrides the
`set_done_with_this_frame_descr_*` setters to store the `Arc` and publish
`Arc::as_ptr` to its comparison sites. The wasm backend overrode none of the
five, so the singletons `make_and_attach_done_descrs` builds never reached it.

With no shared identity, every FINISH took its own dense `fail_index`. The
`CALL_ASSEMBLER` return arm therefore could not recognise a clean callee finish
by comparing against one value, and read a side table instead — six wasm ops
per return where `_call_assembler_check_descr` spends one compare.

The metainterp side was already correct: `compile_finish_from_active_session`
takes its descr from `done_with_this_frame_descr_from_types`, commented "for
pointer identity parity with the backend". Only the wasm cpu dropped it.

## The fix

This backend now takes the attachment. A wasm frame slot holds an exit index
rather than a descr pointer, so each singleton is bound to a reserved index at
the front of the global exit space (`failguard::FINISH_EXIT_INDEX_*`), carrying
the attached `Arc` as its `meta_descr` so `get_latest_descr_arc` still answers
with the metainterp's own descr. A FINISH writes the exit of the descr stamped
on it, and the CA return arm becomes one `i32.eq`.

The exception conjunct is dropped rather than kept: a raising callee writes
`exit_frame_with_exception_descr_ref`'s index and a guard deopt writes its own
exit, so both already fail that compare. A FINISH still consumes its dense
slot, so the bridge-cell offset arithmetic is unchanged. The clean-finish table
and the `loop_finish_fi` plumbing it needed are removed with it.

`WASM_MAX_DYNASM_RATIO` drops to 3.5. No fixture carries an allowance.

## Measured (macOS, exec-only wasm/dynasm, both startup-subtracted)

The seven fixtures that exceeded 3.5, all bound by CALL_ASSEMBLER returns:

| fixture | before | after |
| --- | --- | --- |
| `fib_recursive` | 3.64–3.98 | 2.44 |
| `p2_local_result_bridge` | ≤4.18 | 2.23 |
| `foriter_make_function_body` | ≤3.54 | 1.87 |
| `loop_callee_shared_mutation` | 3.39–5.16 | 1.82 |
| `if_else_jump_forward` | ≤3.52 | 1.70 |
| `recursion_past_unroll_bound_from_loop` | ≤3.60 | 1.70 |
| `global_quasiimmut_invalidation` | ≤3.81 | 1.16 |

Across the whole gated set: n=223, max 3.31 (`synth/pickle_terminal_raise_resume`),
mean 1.35, none above 3.5. `wasm 443/443`. 81 exception-path fixtures pass on
wasm, which is what covers dropping the exception conjunct.

`fib_recursive` and `recursion_past_unroll_bound_from_loop` were measured
directly: they print `SNAPDIFF` instead of a dynasm time on a tree where main's
jit-stats baselines are stale, and a fixture with no dynasm time leaves the
ratio table entirely.

## Not addressed here

main carries 16 dynasm jit-stats failures — #1384 changed those fixtures' trace
shapes without re-recording their baselines, and main's own CI shows
`cargo test (macos-latest)` failing. This branch touches only
`majit-backend-wasm/` and `pyre/check.py`, which cannot alter a dynasm trace
shape, and does not re-record them.
