### PR TITLE
interpreter: reload the frame in PyFrame::push instead of anchoring each opcode

### DIFF
--- a/pyre/pyre-interpreter/src/pyframe.rs
+++ b/pyre/pyre-interpreter/src/pyframe.rs
@@ -3171,12 +3171,33 @@ impl PyFrame {
 
     // ── Stack operations ──────────────────────────────────────────────
 
+    /// Reload `self` the way RPython's GC transform reloads every livevar from
+    /// the shadow stack after a safepoint.
+    ///
+    /// pyre has no such pass — `gc_current_object_address` calls that gap a
+    /// documented TODO — so a `&mut PyFrame` held across an allocating call
+    /// names the abandoned nursery copy once a minor collection relocates a
+    /// JIT-created frame. Following the forwarding stub here is what lets the
+    /// opcode bodies keep the `pop; op; push` shape `pyopcode.py` uses instead
+    /// of each call site carrying an anchor of its own.
+    ///
+    /// Cheap on the common path: a nursery range compare, and the header read
+    /// only for an address the nursery owns.
+    #[inline]
+    fn live_mut(&mut self) -> &mut Self {
+        let addr = self as *mut Self as *mut u8;
+        unsafe { &mut *(pyre_object::gc_hook::try_gc_current_object_address(addr) as *mut Self) }
+    }
+
     #[inline]
     pub fn push(&mut self, value: PyObjectRef) {
-        self.assert_stack_index(self.valuestackdepth);
-        let idx = self.valuestackdepth;
-        self.set_locals_w(idx, value);
-        self.valuestackdepth += 1;
+        // Both writes below — the stack slot and the depth — have to land on
+        // the live frame, so reload once and use it for both.
+        let frame = self.live_mut();
+        frame.assert_stack_index(frame.valuestackdepth);
+        let idx = frame.valuestackdepth;
+        frame.set_locals_w(idx, value);
+        frame.valuestackdepth = idx + 1;
     }
 
     #[inline]

--- a/pyre/pyre-interpreter/src/pyopcode.rs
+++ b/pyre/pyre-interpreter/src/pyopcode.rs
@@ -727,10 +727,8 @@ pub fn opcode_swap<H: StackOpcodeHandler + ?Sized>(
 
 pub fn opcode_get_iter<H: IterOpcodeHandler + ?Sized>(handler: &mut H) -> Result<(), PyError> {
     let iterable = handler.pop_value()?;
-    // A user-defined `__iter__` allocates, so the push goes through the anchor.
-    let anchor = handler.anchor();
     let iterator = handler.iter_value(iterable)?;
-    H::push_anchored(&anchor, iterator)
+    handler.push_value(iterator)
 }
 
 pub fn opcode_for_iter<H: IterOpcodeHandler + ControlFlowOpcodeHandler + ?Sized>(
@@ -1168,13 +1166,10 @@ pub trait OpcodeStepExecutor: SharedOpcodeHandler {
         Self: SharedOpcodeHandler + NamespaceOpcodeHandler,
     {
         let obj = self.pop_value()?;
-        // The lookup runs descriptor code, so it can allocate and relocate a
-        // moving frame; both pushes go through the anchor.
-        let anchor = self.anchor();
         let attr = SharedOpcodeHandler::load_special_attr(self, obj, name)?;
-        Self::push_anchored(&anchor, attr)?;
+        self.push_value(attr)?;
         let null = self.null_value()?;
-        Self::push_anchored(&anchor, null)
+        self.push_value(null)
     }
 
     fn store_attr(&mut self, name: &str) -> Result<(), PyError>

--- a/pyre/pyre-interpreter/src/shared_opcode.rs
+++ b/pyre/pyre-interpreter/src/shared_opcode.rs
@@ -75,9 +75,8 @@ fn pop_n<H: SharedOpcodeHandler + ?Sized>(
 
 pub fn opcode_make_function<H: SharedOpcodeHandler + ?Sized>(handler: &mut H) -> OpcodeResult<()> {
     let code_obj = handler.pop_value()?;
-    let anchor = handler.anchor();
     let func = handler.make_function(code_obj)?;
-    H::push_anchored(&anchor, func)
+    handler.push_value(func)
 }
 
 pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
@@ -92,26 +91,23 @@ pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
         0 => {
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
-            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[])?;
-            H::push_anchored(&anchor, result)
+            handler.push_value(result)
         }
         1 => {
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
-            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0])?;
-            H::push_anchored(&anchor, result)
+            handler.push_value(result)
         }
         2 => {
             let a1 = handler.pop_value()?;
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
-            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0, a1])?;
-            H::push_anchored(&anchor, result)
+            handler.push_value(result)
         }
         3 => {
             let a2 = handler.pop_value()?;
@@ -119,17 +115,15 @@ pub fn opcode_call<H: SharedOpcodeHandler + ?Sized>(
             let a0 = handler.pop_value()?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
-            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &[a0, a1, a2])?;
-            H::push_anchored(&anchor, result)
+            handler.push_value(result)
         }
         _ => {
             let args = pop_n(handler, nargs)?;
             let _null_or_self = handler.pop_value()?;
             let callable = handler.pop_value()?;
-            let anchor = handler.anchor();
             let result = handler.call_callable(callable, &args)?;
-            H::push_anchored(&anchor, result)
+            handler.push_value(result)
         }
     }
 }
@@ -139,9 +133,8 @@ pub fn opcode_build_list<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size)?;
-    let anchor = handler.anchor();
     let list = handler.build_list(&items)?;
-    H::push_anchored(&anchor, list)
+    handler.push_value(list)
 }
 
 pub fn opcode_build_tuple<H: SharedOpcodeHandler + ?Sized>(
@@ -149,9 +142,8 @@ pub fn opcode_build_tuple<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size)?;
-    let anchor = handler.anchor();
     let tuple = handler.build_tuple(&items)?;
-    H::push_anchored(&anchor, tuple)
+    handler.push_value(tuple)
 }
 
 pub fn opcode_build_map<H: SharedOpcodeHandler + ?Sized>(
@@ -159,9 +151,8 @@ pub fn opcode_build_map<H: SharedOpcodeHandler + ?Sized>(
     size: usize,
 ) -> OpcodeResult<()> {
     let items = pop_n(handler, size * 2)?;
-    let anchor = handler.anchor();
     let dict = handler.build_map(&items)?;
-    H::push_anchored(&anchor, dict)
+    handler.push_value(dict)
 }
 
 pub fn opcode_store_subscr<H: SharedOpcodeHandler + ?Sized>(handler: &mut H) -> OpcodeResult<()> {
@@ -188,10 +179,9 @@ pub fn opcode_unpack_sequence<H: SharedOpcodeHandler + ?Sized>(
     count: usize,
 ) -> OpcodeResult<()> {
     let seq = handler.pop_value()?;
-    let anchor = handler.anchor();
     let items = handler.unpack_sequence(seq, count)?;
     for item in items.into_iter().rev() {
-        H::push_anchored(&anchor, item)?;
+        handler.push_value(item)?;
     }
     Ok(())
 }
@@ -201,9 +191,8 @@ pub fn opcode_load_attr<H: SharedOpcodeHandler + ?Sized>(
     name: &str,
 ) -> OpcodeResult<()> {
     let obj = handler.pop_value()?;
-    let anchor = handler.anchor();
     let attr = handler.load_attr(obj, name)?;
-    H::push_anchored(&anchor, attr)
+    handler.push_value(attr)
 }
 
 pub fn opcode_store_attr<H: SharedOpcodeHandler + ?Sized>(


### PR DESCRIPTION
## What

`PyFrame::push` wrote the stack slot and the depth through the caller's `&mut self`. An opcode body that allocates between its `pop` and its `push` can relocate a JIT-created frame, so both writes landed on the abandoned nursery copy — the failure recorded as `GC BUG: invalid type_id=4294967254 site=remember_young_pointer_insert`.

`push` now resolves the frame through `gc_current_object_address` before either write. That is the one-word form of the livevar reload RPython's GC transform performs at every safepoint; `pyre-object`'s `current_gc_ref` already cites the same rule for the descended list-append body.

## Why not more anchors

#1359 fixed this class by taking a `FrameAnchor` at each call site and pushing through it, applied to 8 helpers in `shared_opcode.rs`. `pypy/interpreter/pyopcode.py` gives `BUILD_LIST`, `unaryoperation` and `binaryoperation` the **identical** `pop -> allocating op -> pushvalue` shape, and `anchor|refetch|forwarded` has **zero** hits across `pyopcode.py` + `pyframe.py` — upstream needs no anchor anywhere, because RPython updates `self` for free.

So the per-site anchor is scaffolding with no upstream counterpart that has to be replicated by hand, and it had already rotted: **14 helpers in `pyopcode.rs` still carried the unfixed shape**, among them `opcode_unary_negative`, `opcode_binary_op`, `opcode_compare_op` and `opcode_for_iter`. Disassembling the shipped binary found 26 sites in `eval_loop_jit` still emitting `bl <allocating call>` / `ldp x0, xN, [x24, #0x20]` / `bl set_ref`.

Reloading inside `push` closes all of them at once and lets the generic bodies return to upstream's shape. `opcode_build_list` is now literally `pypy`'s `BUILD_LIST`.

`eval.rs` still carries 38 now-redundant `push_anchored` call sites; removing those and the trait scaffolding is left for a separate change.

## Verification

`extra_tests/parity_tests/re_jit_call_resume.py`, darwin-arm64, `PYPY_GC_MIN=268435456`, 10 runs per size, both arms measured in the same load window:

| nursery | pre-anchor control | this branch |
|---|---|---|
| 16384 | **10/10 crash** | 0/10 |
| 32768 | **10/10** `minor_custom_trace_target` | 0/10 |
| 49152 | 0/10 | 0/10 |
| 65536 | **10/10** `remember_young_pointer_insert` | 0/10 |
| 98304 | 0/10 | 0/10 |

The control still crashes, so the clean arm is a result and not a quiet harness.

## Baselines

Ten synth benches move because the anchor's shadow-stack push/pop leaves the traced bodies. Each recorded value is bit-identical over five runs, so none is the bimodal kind that must not be recorded. `--synthetic-only` kept the top-level suite out; the 624 files that gained only `retraces_compiled=0` were reverted.

## check.py

`dynasm 450/450`, `wasm 443/443`, `cranelift 449/450`.

The one failure is a ratio gate, not a correctness or jitstats gate: `synth/generator_tree_recursion` on cranelift straddles its `max-pypy-ratio=7.6` (8.8x / 7.5x / 11.6x over three reps on a machine at load 29-93). It is **not** attributable to this branch — interleaving the fixture across four cranelift binaries puts this one fastest:

| arm | median |
|---|---|
| this branch | **741 ms** |
| perf-bridge | 758 ms |
| perf-exc | 778 ms |
| ec-wiring | 849 ms |

dynasm passes the same fixture in every rep. The gate is left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interpreter reliability when stack frames are relocated during memory management.
  * Fixed stack operations to consistently target the active frame after relocation.
  * Improved iterator creation, attribute loading, function calls, collection construction, and sequence unpacking by using more direct stack handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->