### PR TITLE
jit: enter a bridge at the guard's own jitcode position

### DIFF
--- a/majit/majit-macros/src/jit_interp/codegen_state.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_state.rs
@@ -2975,6 +2975,33 @@ fn generate_state_fields_jit_state(config: &JitInterpConfig, func: &ItemFn) -> T
             // fields like `selected` to `Const`, so only the identity register
             // reliably names the field).  Box → `input_arg(n)` + `fail_values[n]`;
             // Const → a folded pool constant.  MAJIT_BRIDGE_DEBUG dumps it.
+            // `pyjitpl.py rebuild_state_after_failure` →
+            // `MIFrame.setup_resume_at_op(pc)`: put the walk back at the
+            // guard's own jitcode position so the rest of the opcode it sits
+            // inside is traced rather than run where the trace cannot see it.
+            // The registers arrive already decoded; nothing here is
+            // machine-specific except the `Sym` type, which is why this
+            // forwards rather than generating a walk of its own.
+            fn trace_from_guard_resume_position<__R: majit_metainterp::JitCodeRuntime>(
+                ctx: &mut majit_metainterp::TraceCtx,
+                sym: &mut #sym_ty,
+                dispatch_jitcode: &majit_metainterp::JitCode,
+                resume_pc: usize,
+                outer_program_pc: usize,
+                runtime: &__R,
+                regs: &[majit_metainterp::GuardResumeReg],
+            ) -> Option<majit_metainterp::TraceAction> {
+                Some(majit_metainterp::trace_jitcode_at_resume_position(
+                    ctx,
+                    sym,
+                    dispatch_jitcode,
+                    resume_pc,
+                    outer_program_pc,
+                    runtime,
+                    regs,
+                ))
+            }
+
             #[allow(clippy::reversed_empty_ranges)]
             fn setup_bridge_sym(
                 sym: &mut #sym_ty,

--- a/majit/majit-metainterp/src/blackhole.rs
+++ b/majit/majit-metainterp/src/blackhole.rs
@@ -243,6 +243,16 @@ pub struct BlackholeInterpreter {
     /// Unlike `aborted`, this indicates a Python-level exception that
     /// should propagate up the blackhole chain, not a JIT infrastructure error.
     pub got_exception: bool,
+    /// Set when this frame made a residual call.
+    ///
+    /// A guard's bridge is recorded from the merge point the resume walk stops
+    /// at, so everything the walk ran to get there is work the bridge does not
+    /// contain and will skip on every later failure. Values are safe — the
+    /// bridge re-derives them from the state the walk left behind — but a call
+    /// out of the interpreter is not: it happened once, here, and never again.
+    /// `back_edge_internal` reads this to decide whether the guard may source a
+    /// bridge at all.
+    pub called_residual: std::cell::Cell<bool>,
     /// Position of the last dispatched opcode (before position advances past operands).
     /// Used by handle_exception_in_frame for handler lookup — the faulting instruction
     /// PC, not the next instruction PC. Public so caller-chain propagation in
@@ -408,6 +418,7 @@ impl Default for BlackholeInterpreter {
             aborted: false,
             abort_permanent_bail: false,
             got_exception: false,
+            called_residual: std::cell::Cell::new(false),
             last_opcode_position: 0,
             entry_position: 0,
             exception_last_value: 0,
@@ -1762,6 +1773,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> i64 {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_i(func, None, Some(args_r), None, calldescr)
     }
@@ -1773,6 +1785,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> majit_ir::GcRef {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_r(func, None, Some(args_r), None, calldescr)
     }
@@ -1784,6 +1797,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_v(func, None, Some(args_r), None, calldescr);
     }
@@ -1796,6 +1810,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> i64 {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_i(func, Some(args_i), Some(args_r), None, calldescr)
     }
@@ -1808,6 +1823,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> majit_ir::GcRef {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_r(func, Some(args_i), Some(args_r), None, calldescr)
     }
@@ -1820,6 +1836,7 @@ impl BlackholeInterpreter {
         args_r: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_v(func, Some(args_i), Some(args_r), None, calldescr);
     }
@@ -1833,6 +1850,7 @@ impl BlackholeInterpreter {
         args_f: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> i64 {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_i(func, Some(args_i), Some(args_r), Some(args_f), calldescr)
     }
@@ -1846,6 +1864,7 @@ impl BlackholeInterpreter {
         args_f: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> majit_ir::GcRef {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_r(func, Some(args_i), Some(args_r), Some(args_f), calldescr)
     }
@@ -1859,6 +1878,7 @@ impl BlackholeInterpreter {
         args_f: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) -> f64 {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_f(func, Some(args_i), Some(args_r), Some(args_f), calldescr)
     }
@@ -1872,6 +1892,7 @@ impl BlackholeInterpreter {
         args_f: &[i64],
         calldescr: &majit_translate::jitcode::BhCallDescr,
     ) {
+        self.called_residual.set(true);
         self.cpu()
             .bh_call_v(func, Some(args_i), Some(args_r), Some(args_f), calldescr);
     }

--- a/majit/majit-metainterp/src/jit_state.rs
+++ b/majit/majit-metainterp/src/jit_state.rs
@@ -163,6 +163,24 @@ pub fn bridge_decode_red(
     (OpRef::input_arg_typed(n as u32, kind), fail_values[n])
 }
 
+/// One live jitcode register as a guard's resume data described it.
+///
+/// `pyjitpl.py rebuild_state_after_failure` rebuilds a `MIFrame` per encoded
+/// section and `resume.py ResumeDataBoxReader.consume_boxes` fills every live
+/// register of each from the guard's numbering.  This is one such register:
+/// `bank` says which of the three banks `index` addresses, `opref` is the
+/// symbolic value the trace continues with — a bridge `InputArg` for a
+/// failarg, a pool constant for one the guard already carried folded — and
+/// `value` is its concrete shadow, which the walk needs because the walk is
+/// what executes.
+#[derive(Debug, Clone, Copy)]
+pub struct GuardResumeReg {
+    pub bank: Type,
+    pub index: u32,
+    pub opref: OpRef,
+    pub value: i64,
+}
+
 /// Interpreter-specific JIT state contract.
 pub trait JitState: Sized {
     type Meta: Clone;
@@ -372,6 +390,36 @@ pub trait JitState: Sized {
         _fail_values: &[i64],
         _fail_types: &[Type],
     ) {
+    }
+
+    /// Enter the walk at the jitcode position a guard failed on.
+    ///
+    /// `pyjitpl.py handle_guard_failure` reaches
+    /// `rebuild_state_after_failure`, whose per-frame
+    /// `setup_resume_at_op(pc)` puts the rebuilt frame back at the guard, and
+    /// then keeps interpreting from there.  The rest of the opcode the guard
+    /// sits inside is therefore recorded, which is the whole difference
+    /// between it and a resume that hands the interpreter a later position:
+    /// the tail runs once either way, but only here does it also land in the
+    /// trace.
+    ///
+    /// `regs` is the rebuilt register file — the walk cannot re-derive it,
+    /// because a guard is not a position the interpreter is re-enterable at.
+    ///
+    /// The default declines.  A state with no dispatch jitcode has no position
+    /// to enter, and declining is not a loss: `compile.py handle_fail` treats
+    /// bridging and the blackhole as alternatives, so the caller takes the
+    /// other one.
+    fn trace_from_guard_resume_position<R: crate::pyjitpl::JitCodeRuntime>(
+        _ctx: &mut crate::trace_ctx::TraceCtx,
+        _sym: &mut Self::Sym,
+        _dispatch_jitcode: &crate::jitcode::JitCode,
+        _resume_pc: usize,
+        _outer_program_pc: usize,
+        _runtime: &R,
+        _regs: &[GuardResumeReg],
+    ) -> Option<crate::TraceAction> {
+        None
     }
 
     /// resume.py rebuild_from_resumedata: decode rd_numb to

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1546,6 +1546,17 @@ fn install_state_field_fvc(data: &StateFieldFvcData) {
     });
 }
 
+/// The identity slots `base .. base + count` of a blackhole register bank,
+/// clamped to what the bank actually holds.
+///
+/// A frame whose jitcode declares fewer registers than the layout describes is
+/// not a frame the state can have been written through, so a clamped-empty span
+/// compares equal and says so.
+fn bank_span(bank_len: usize, base: usize, count: usize) -> std::ops::Range<usize> {
+    let start = base.min(bank_len);
+    start..(start + count).min(bank_len)
+}
+
 impl<S: JitState> JitDriver<S> {
     /// Create a new JitDriver with the given hot-counting threshold.
     pub fn new(threshold: u32) -> Self {
@@ -5232,14 +5243,30 @@ impl<S: JitState> JitDriver<S> {
                     // (resume.py:1028-1038 seeded it in slot order) and resume
                     // at the CRN green pc.
                     let mut cur_exc = exc;
-                    // Where the guard's resume coordinate sits, against which
-                    // the merge point the walk stops at is compared below.
-                    // `set_position` seeds `last_opcode_position` with it, and
-                    // `run_inner` overwrites that per dispatched op, so the two
-                    // stay equal exactly when the first op the blackhole
-                    // dispatches is the one that raises CRN.
-                    let bh_start_position = bh.position;
                     let mut bh_frames_popped = 0usize;
+                    bh.called_residual.set(false);
+                    // The state fields as the walk found them: the identity
+                    // slots of each bank, which for the int bank is the scalars
+                    // and every array element both.
+                    let bh_sf = state.state_field_layout();
+                    let sf_i = bank_span(
+                        bh.registers_i.len(),
+                        bh_sf.int_scalar_base,
+                        bh_sf.total_slots(),
+                    );
+                    let sf_r = bank_span(
+                        bh.registers_r.len(),
+                        bh_sf.ref_scalar_base,
+                        bh_sf.num_ref_scalars,
+                    );
+                    let sf_f = bank_span(
+                        bh.registers_f.len(),
+                        bh_sf.float_scalar_base,
+                        bh_sf.num_float_scalars,
+                    );
+                    let sf_before_i = bh.registers_i[sf_i.clone()].to_vec();
+                    let sf_before_r = bh.registers_r[sf_r.clone()].to_vec();
+                    let sf_before_f = bh.registers_f[sf_f.clone()].to_vec();
                     let outcome = loop {
                         match bh.resume_mainloop(cur_exc) {
                             Ok(next_exc) => match bh.nextblackholeinterp.take() {
@@ -5263,26 +5290,38 @@ impl<S: JitState> JitDriver<S> {
                     if crate::majit_log_enabled() {
                         eprintln!("[bh] back_edge_internal: chain resume → {:?}", outcome);
                     }
-                    // Whether the guard failed AT the merge point rather than
-                    // partway through the opcode that reaches it.
+                    // Whether the guard may source a bridge.
                     //
                     // A bridge is entered from the guard, and it is recorded
                     // from the green pc the walk below reports — the NEXT merge
-                    // point. Everything the blackhole ran to get there is work
-                    // the guard's own opcode still owed, and a bridge that
-                    // starts after it does not contain it: the first failure
-                    // runs it here and every later one jumps into the bridge
-                    // and skips it. A `chain_push` behind a red condition, an
-                    // eviction, a store — each simply stops happening, and
-                    // nothing reports it, because the guard, the recovery
-                    // layout and this resume are all correct.
+                    // point. Everything the walk ran to get there is the tail of
+                    // the opcode the guard sits inside, and the bridge does not
+                    // contain it: the first failure runs it here and every later
+                    // one jumps into the bridge and skips it.
                     //
-                    // The walk stopping on the very op it started on is what
-                    // says the opcode owed nothing, and only then may the guard
-                    // source a bridge. A walk that crossed a frame boundary
-                    // cannot be judged by one frame's coordinate, so it is not.
-                    let guard_at_merge_point =
-                        bh_frames_popped == 0 && bh.last_opcode_position == bh_start_position;
+                    // Values the tail computed are not the problem. The bridge
+                    // is recorded against the state the walk LEFT, so whatever
+                    // the tail derived it derives again. Two things do not come
+                    // back that way:
+                    //
+                    //   * a residual call, which left the interpreter once and
+                    //     is not a value the bridge can recompute, and
+                    //   * a state field the tail wrote, because the bridge is
+                    //     ENTERED with the guard's failargs, which hold the
+                    //     value from before the tail ran.
+                    //
+                    // Neither announces itself: the guard, the recovery layout
+                    // and this resume are all correct, and the loop keeps
+                    // running. Only a count of how often the opcode's tail
+                    // actually happened records it.
+                    //
+                    // A walk that crossed a frame boundary is not judged by one
+                    // frame's registers, so it does not qualify.
+                    let tail_wrote_state = bh.registers_i[sf_i] != sf_before_i[..]
+                        || bh.registers_r[sf_r] != sf_before_r[..]
+                        || bh.registers_f[sf_f] != sf_before_f[..];
+                    let guard_may_bridge =
+                        bh_frames_popped == 0 && !bh.called_residual.get() && !tail_wrote_state;
                     let mut portal_crn_handled = false;
                     let resume_pc = match outcome {
                         // Next merge point reached (loop back-edge): flush the
@@ -5442,7 +5481,7 @@ impl<S: JitState> JitDriver<S> {
                         // already recovered `state` to the resume point, so the
                         // bridge sees the post-guard-failure values.
                         if should_bridge
-                            && guard_at_merge_point
+                            && guard_may_bridge
                             && !portal_crn_handled
                             && pc != usize::MAX
                         {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -6403,6 +6403,16 @@ impl<S: JitState> JitDriver<S> {
         self.meta.set_on_compile_loop(f);
     }
 
+    /// Set a callback for bridge compilation events.
+    ///
+    /// `f` receives `(green_key, fail_index, num_ops)`. The loop sibling above
+    /// cannot stand in for it: a guard that declines to bridge still deopts
+    /// through the blackhole and the loop keeps running, so only this count
+    /// distinguishes a bridge that was built from one that was passed over.
+    pub fn set_on_compile_bridge(&mut self, f: impl Fn(u64, u32, usize) + Send + 'static) {
+        self.meta.set_on_compile_bridge(f);
+    }
+
     /// Set a callback for guard failure events.
     pub fn set_on_guard_failure(&mut self, f: impl Fn(u64, u32, u32) + Send + 'static) {
         self.meta.set_on_guard_failure(f);

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -5232,10 +5232,19 @@ impl<S: JitState> JitDriver<S> {
                     // (resume.py:1028-1038 seeded it in slot order) and resume
                     // at the CRN green pc.
                     let mut cur_exc = exc;
+                    // Where the guard's resume coordinate sits, against which
+                    // the merge point the walk stops at is compared below.
+                    // `set_position` seeds `last_opcode_position` with it, and
+                    // `run_inner` overwrites that per dispatched op, so the two
+                    // stay equal exactly when the first op the blackhole
+                    // dispatches is the one that raises CRN.
+                    let bh_start_position = bh.position;
+                    let mut bh_frames_popped = 0usize;
                     let outcome = loop {
                         match bh.resume_mainloop(cur_exc) {
                             Ok(next_exc) => match bh.nextblackholeinterp.take() {
                                 Some(caller) => {
+                                    bh_frames_popped += 1;
                                     // Layout + vinfo were seeded across the
                                     // whole chain before the loop started.
                                     bh_builder.release_interp(bh);
@@ -5254,6 +5263,26 @@ impl<S: JitState> JitDriver<S> {
                     if crate::majit_log_enabled() {
                         eprintln!("[bh] back_edge_internal: chain resume → {:?}", outcome);
                     }
+                    // Whether the guard failed AT the merge point rather than
+                    // partway through the opcode that reaches it.
+                    //
+                    // A bridge is entered from the guard, and it is recorded
+                    // from the green pc the walk below reports — the NEXT merge
+                    // point. Everything the blackhole ran to get there is work
+                    // the guard's own opcode still owed, and a bridge that
+                    // starts after it does not contain it: the first failure
+                    // runs it here and every later one jumps into the bridge
+                    // and skips it. A `chain_push` behind a red condition, an
+                    // eviction, a store — each simply stops happening, and
+                    // nothing reports it, because the guard, the recovery
+                    // layout and this resume are all correct.
+                    //
+                    // The walk stopping on the very op it started on is what
+                    // says the opcode owed nothing, and only then may the guard
+                    // source a bridge. A walk that crossed a frame boundary
+                    // cannot be judged by one frame's coordinate, so it is not.
+                    let guard_at_merge_point =
+                        bh_frames_popped == 0 && bh.last_opcode_position == bh_start_position;
                     let mut portal_crn_handled = false;
                     let resume_pc = match outcome {
                         // Next merge point reached (loop back-edge): flush the
@@ -5412,7 +5441,11 @@ impl<S: JitState> JitDriver<S> {
                         // from — nothing to bridge, just exit. The blackhole has
                         // already recovered `state` to the resume point, so the
                         // bridge sees the post-guard-failure values.
-                        if should_bridge && !portal_crn_handled && pc != usize::MAX {
+                        if should_bridge
+                            && guard_at_merge_point
+                            && !portal_crn_handled
+                            && pc != usize::MAX
+                        {
                             let bridge_ok =
                                 self.start_bridge_tracing(&descr_arc, state, env, &raw_values, pc);
                             if crate::majit_log_enabled() {

--- a/majit/majit-metainterp/src/jitdriver.rs
+++ b/majit/majit-metainterp/src/jitdriver.rs
@@ -1347,6 +1347,15 @@ pub struct JitDriver<S: JitState> {
     /// `register_descriptor` (each of which clears this cache), and no
     /// `JitState::driver_descriptor` implementation reads its `meta` argument.
     descriptor_cache: Option<Option<std::sync::Arc<JitDriverStaticData>>>,
+    /// Whether the live bridge trace was entered at a guard's own jitcode
+    /// position rather than at a merge point the blackhole walked to.
+    ///
+    /// The abort handling in [`Self::merge_point`] skips its resume handoff
+    /// for a bridge, because a bridge used to be started only after the
+    /// blackhole had already resumed the interpreter. A bridge entered at the
+    /// guard has had no such resume — the walk is the only thing that ran —
+    /// so it needs the handoff like a fresh trace does.
+    bridge_entered_at_guard_resume: bool,
     /// resume.py: result of rebuild_from_resumedata for bridge tracing.
     /// RPython stores this in MIFrame registers; pyre stores it here
     /// for the caller to initialize PyreSym slot-to-OpRef mapping.
@@ -1571,6 +1580,7 @@ impl<S: JitState> JitDriver<S> {
             continue_running_normally_payload: None,
             descriptor: None,
             descriptor_cache: None,
+            bridge_entered_at_guard_resume: false,
             resume_data_result: None,
             last_bridge_is_exception_guard: false,
             bridge_body_start_op_count: None,
@@ -2308,6 +2318,7 @@ impl<S: JitState> JitDriver<S> {
         // fallback when the run produced none.
         if terminal.is_some() {
             self.meta.single_pass_scalar_values = None;
+            self.meta.single_pass_ref_scalar_values = None;
             self.meta.single_pass_virt_array_values = None;
         } else if crate::majit_log_enabled() {
             eprintln!(
@@ -2490,6 +2501,23 @@ impl<S: JitState> JitDriver<S> {
         }
     }
 
+    /// Push the walk's ref state fields into native `state`.
+    ///
+    /// The ref twin of [`Self::writeback_scalar_state_fields`], and its
+    /// consumer is the one the twin does not have: a resume whose native
+    /// `state` was left behind by a compiled run rather than kept current by
+    /// the interpreter. Consumes (`take`s) the stash; no-op when the close
+    /// staged none or the state declares no ref fields.
+    #[inline]
+    pub fn writeback_ref_scalar_state_fields(&mut self, state: &mut S) {
+        let Some(values) = self.meta.single_pass_ref_scalar_values.take() else {
+            return;
+        };
+        for (index, value) in values.into_iter().enumerate() {
+            state.writeback_live_ref_scalar_state_field(index, value);
+        }
+    }
+
     /// Push the walk's loop-carried virtualizable-array element values into
     /// native `state`, the array analog of `writeback_scalar_state_fields`. The
     /// walk mutates the array on the trace-ctx shadow; native `state`'s array is
@@ -2532,6 +2560,7 @@ impl<S: JitState> JitDriver<S> {
     pub fn discard_single_pass_resume(&mut self) {
         self.meta.single_pass_compiled_key = None;
         self.meta.single_pass_scalar_values = None;
+        self.meta.single_pass_ref_scalar_values = None;
         self.meta.single_pass_virt_array_values = None;
         self.meta.single_pass_compact_label_values = None;
         self.meta.single_pass_full_live_values = None;
@@ -3091,6 +3120,11 @@ impl<S: JitState> JitDriver<S> {
                     if let Some(sym) = self.sym.as_ref() {
                         let scalars = S::collect_scalar_state_field_values(sym);
                         self.meta.single_pass_scalar_values = Some(scalars);
+                        // The ref twin, for the one consumer whose native
+                        // `state` is not already current — see
+                        // `single_pass_ref_scalar_values`.
+                        let ref_scalars = S::collect_ref_scalar_state_field_values(sym);
+                        self.meta.single_pass_ref_scalar_values = Some(ref_scalars);
                     }
                     // Capture the walk-final loop-carried virt-array element values
                     // off the still-live trace ctx (the walk mutated the ctx shadow,
@@ -3376,6 +3410,7 @@ impl<S: JitState> JitDriver<S> {
                                 // at the bottom of this arm.
                                 self.meta.single_pass_outcome = None;
                                 self.meta.single_pass_scalar_values = None;
+                                self.meta.single_pass_ref_scalar_values = None;
                                 self.meta.single_pass_virt_array_values = None;
                                 continue;
                             }
@@ -3696,6 +3731,7 @@ impl<S: JitState> JitDriver<S> {
                         // next walk segment still has to record.
                         self.meta.single_pass_outcome = None;
                         self.meta.single_pass_scalar_values = None;
+                        self.meta.single_pass_ref_scalar_values = None;
                         self.meta.single_pass_virt_array_values = None;
                         // pyjitpl.py:1571/1574 `saved_pc` — the resumed walk
                         // re-enters at the merge point's own guest pc, so the
@@ -4218,8 +4254,17 @@ impl<S: JitState> JitDriver<S> {
                     // Bridge/compiled guard-failure recovery owns a separate
                     // blackhole resume path below `back_edge_internal`; do not
                     // feed that path through this fresh-trace handoff.
+                    //
+                    // Unless the bridge was entered at the guard's own position
+                    // — then there was no separate resume: the walk is the only
+                    // thing that ran, and it ran the failing opcode's tail. Its
+                    // frames are the sole record of where that left the
+                    // interpreter, so this bridge needs the handoff for the
+                    // same reason a fresh trace does.
                     if matches!(action, TraceAction::Abort)
-                        && (self.meta.bridge_info().is_none() || self.bridge_attempt_declined)
+                        && (self.meta.bridge_info().is_none()
+                            || self.bridge_attempt_declined
+                            || self.bridge_entered_at_guard_resume)
                     {
                         // This gate asks whether the session still has a bridge
                         // artifact to resume into, which is the PHASE, not the
@@ -4606,6 +4651,228 @@ impl<S: JitState> JitDriver<S> {
             env,
             pre_run,
         ))
+    }
+
+    /// `compile.py handle_fail`'s bridging arm.
+    ///
+    /// Upstream's `handle_fail` is an if/else: a guard that `must_compile()`
+    /// traces a bridge, and one that does not resumes in the blackhole. Never
+    /// both. Tracing starts at the guard itself —
+    /// `initialize_state_from_guard_failure` → `rebuild_state_after_failure`
+    /// rebuilds the frames and `setup_resume_at_op(pc)` puts each back at its
+    /// own position — so the rest of the opcode the guard sits inside is
+    /// recorded into the bridge.
+    ///
+    /// Reaching the same point through the blackhole instead cannot record it:
+    /// the blackhole stops at the next merge point and the bridge is grown
+    /// from THAT position, so the opcode's tail runs once, here, and every
+    /// later failure jumps into a bridge that does not contain it.
+    ///
+    /// Returns the interpreter position to resume at, or `None` when the
+    /// bridge could not be entered AT ALL — the caller then takes the
+    /// blackhole arm, which is upstream's other branch. Every decline is
+    /// therefore sited BEFORE the walk: once the walk has run, the tail has
+    /// happened, and handing the same guard to the blackhole would apply it a
+    /// second time.
+    fn bridge_from_guard_resume_position(
+        &mut self,
+        descr_arc: &std::sync::Arc<dyn majit_ir::Descr>,
+        state: &mut S,
+        env: &S::Env,
+        raw_values: &[i64],
+        target_pc: usize,
+    ) -> Option<usize> {
+        use majit_ir::resumedata::RebuiltValue;
+        // Only a state whose machine IS a dispatch jitcode has a guard
+        // position to re-enter at; every other JitState resumes through its
+        // own frontend.
+        let dispatch = self.dispatch_jitcode().cloned()?;
+        if !self.start_bridge_tracing(descr_arc, state, env, raw_values, target_pc) {
+            return None;
+        }
+        // From here the trace session is LIVE, so a decline has to tear it
+        // down rather than return through it.
+        let seeded = (|| {
+            let resume = self.resume_data_result.as_ref()?;
+            let frame = resume.frames.first()?;
+            // `resume.py:1338` `jitcode = jitcodes[jitcode_pos]`: the position
+            // is an offset into the jitcode the frame NAMES. Entering a
+            // different one at that offset lands mid-instruction in unrelated
+            // code, and the walk decodes whatever byte is there. Only the
+            // dispatch jitcode is enterable here, so a frame that names any
+            // other one is a decline.
+            if frame.jitcode_index as usize != dispatch.try_index()? {
+                return None;
+            }
+            // `resume.py _prepare_pendingfields` replays the guard's deferred
+            // heap writes through `execute_and_record` — it applies them to the
+            // heap AND puts them in the trace. majit's replay
+            // (`replay_pending_fields`) only records: the applying half was the
+            // blackhole's, because until now a bridge was only ever started
+            // after the blackhole had run. Entering at the guard skips the
+            // blackhole, so nothing applies them, and the interpreter resumes
+            // against a heap where the elided half of a push is missing — a
+            // committed size with a null chain.
+            //
+            // Decline while that half is missing. The blackhole arm is then the
+            // answer for these guards, which is where they were already served.
+            if resume
+                .storage
+                .as_ref()
+                .is_some_and(|storage| !storage.rd_pendingfields.is_empty())
+            {
+                return None;
+            }
+            let fail_types = resume.fail_arg_types.clone();
+            let values = frame.values.clone();
+            let resume_pc = usize::try_from(frame.pc).ok()?;
+            let ctx = self.meta.tracing.as_mut()?;
+            let reg_indices = ctx.bridge_reg_indices()?.clone();
+            // `consume_boxes` fills every live register of the frame, so a
+            // count that disagrees means the two sides read different
+            // liveness and no per-register pairing off them is trustworthy.
+            if reg_indices.total_len() != values.len() {
+                return None;
+            }
+            let banks: [(majit_ir::Type, &Vec<u32>, usize); 3] = [
+                (majit_ir::Type::Int, &reg_indices.int, 0),
+                (
+                    majit_ir::Type::Ref,
+                    &reg_indices.ref_,
+                    reg_indices.int.len(),
+                ),
+                (
+                    majit_ir::Type::Float,
+                    &reg_indices.float,
+                    reg_indices.int.len() + reg_indices.ref_.len(),
+                ),
+            ];
+            let mut regs = Vec::with_capacity(values.len());
+            for (bank, indices, base) in banks {
+                for (i, &index) in indices.iter().enumerate() {
+                    let (opref, value) = match &values[base + i] {
+                        RebuiltValue::Box(n, kind) => {
+                            crate::jit_state::bridge_decode_red(*n, *kind, raw_values, &fail_types)
+                        }
+                        RebuiltValue::Const(c) => {
+                            let bits = c.as_raw_i64();
+                            let opref = match bank {
+                                majit_ir::Type::Ref => ctx.const_ref(bits),
+                                majit_ir::Type::Float => ctx.const_float(bits),
+                                _ => ctx.const_int(bits),
+                            };
+                            (opref, bits)
+                        }
+                        // A virtual has an OpRef but no concrete value, and an
+                        // unassigned slot has neither. The walk executes, so a
+                        // register it cannot read a value out of is not a
+                        // register it can run past — decline the whole frame
+                        // rather than enter it half-seeded.
+                        RebuiltValue::Virtual(_) | RebuiltValue::Unassigned => return None,
+                    };
+                    regs.push(crate::jit_state::GuardResumeReg {
+                        bank,
+                        index,
+                        opref,
+                        value,
+                    });
+                }
+            }
+            Some((resume_pc, regs))
+        })();
+        let Some((resume_pc, regs)) = seeded else {
+            self.meta.abort_trace(false);
+            self.clear_tracing_session_state();
+            self.resume_data_result = None;
+            self.last_bridge_is_exception_guard = false;
+            return None;
+        };
+
+        self.bridge_entered_at_guard_resume = true;
+        let mut entered = false;
+        self.merge_point(|meta, sym| {
+            // `merge_point` re-enters its closure for the `saved_pc`
+            // resumption a declined close asks for. The guard's position is a
+            // one-off; a resumption is an ordinary merge-point entry, which
+            // the `jit_merge_point!` wrapper owns. Returning here leaves
+            // tracing live and hands it over.
+            if std::mem::replace(&mut entered, true) {
+                return TraceAction::Continue;
+            }
+            meta.with_trace_ctx_and_token_resolver(
+                |ctx,
+                 resolve,
+                 rec_target,
+                 rec_decision,
+                 rec_exec,
+                 rec_exec_ref,
+                 rec_exec_float,
+                 rec_exec_void| {
+                    let runtime = crate::pyjitpl::ClosureRuntimeWithResolver::new(
+                        |pc: usize| pc,
+                        resolve,
+                        rec_target,
+                        rec_decision,
+                        rec_exec,
+                        rec_exec_ref,
+                        rec_exec_float,
+                        rec_exec_void,
+                    );
+                    S::trace_from_guard_resume_position(
+                        ctx, sym, &dispatch, resume_pc, target_pc, &runtime, &regs,
+                    )
+                    .unwrap_or(TraceAction::Abort)
+                },
+            )
+            .unwrap_or(TraceAction::Abort)
+        });
+        self.bridge_entered_at_guard_resume = false;
+
+        // Where the interpreter goes next. This is the `jit_merge_point!`
+        // hook's own single-pass handoff, in the same order and with the same
+        // steps: the walk advanced the state on the sym, so whichever arm
+        // answers has to push it into native `state` before the interpreter
+        // reads it. The hook runs for a walk that ended at a merge point; a
+        // walk that started at a guard ends the same way and owes the same
+        // transfer.
+        let mut outcome = self.take_single_pass_outcome();
+        // `pyjitpl.py:2954 convert_and_run_from_pyjitpl`: the walk stopped
+        // somewhere that is not a source-opcode boundary, so the half-executed
+        // opcodes are finished in the blackhole and the position comes from
+        // the merge point they reach. It outranks the walk's own pc for the
+        // same reason it does in the hook.
+        if let Some(pc) = self.run_pending_abort_blackhole(state, env) {
+            outcome = Some((pc, Vec::new()));
+        }
+        if let Some((pc, reds)) = outcome {
+            self.writeback_scalar_state_fields(state);
+            self.writeback_ref_scalar_state_fields(state);
+            self.writeback_virt_array_state_fields(state);
+            if !reds.is_empty() {
+                let resumed_meta = state.build_meta(pc, env);
+                state.restore_values(&resumed_meta, &reds);
+            }
+            state.recover_after_compiled_run();
+            self.log_single_pass_parity_resume(pc, state, env);
+            self.arm_single_pass_label_entry_on_next_back_edge(state);
+            self.discard_single_pass_resume();
+            // A terminal dispatch return means the interpreted function has
+            // returned. The hook `break`s out of the native loop for it; the
+            // back edge's own spelling of that is the out-of-range position
+            // its caller assigns to `pc`, which fails the loop's `pc < len`.
+            if self.take_single_pass_finish() {
+                return Some(usize::MAX);
+            }
+            return Some(pc);
+        }
+        // Neither handoff answered. The walk has already run the tail, so the
+        // blackhole arm is not available and the loop header is the only
+        // position left — it re-executes the opcodes between it and the guard.
+        // The counter is what says whether that ever happens; nothing else
+        // distinguishes this from a clean resume.
+        crate::mc_diag_bump(79); // guard_resume_bridge_no_handoff
+        state.recover_after_compiled_run();
+        Some(target_pc)
     }
 
     /// RPython warmstate.py:482-501 / compile.py:711 parity.
@@ -5061,23 +5328,37 @@ impl<S: JitState> JitDriver<S> {
                 .map(|pc| pc as usize)
                 .unwrap_or(target_pc);
 
-            // compile.py handle_fail. PyPy: `must_compile() and not
+            // compile.py handle_fail. `must_compile() and not
             // stack_almost_full()` → `_trace_and_compile_from_bridge`, else
             // `resume_in_blackhole`; the two are mutually exclusive and
             // neither returns. majit adapts by returning the interpreter
             // resume pc.
-            // Bridge tracing is deferred until AFTER the blackhole resume below
-            // computes the *green* resume pc. `guard_resume_pc`
-            // (`get_merge_point_pc`) is the guard's recovery `header_pc`, which
-            // for a `#[jit_interp]` state-field consumer is a byte offset into
-            // the dispatch *jitcode*, not an index into the interpreter's green
-            // `program`. Resuming the macro mainloop at that jitcode offset
-            // indexes `program[]` out of bounds. The blackhole walk re-derives
-            // the real green pc (the merge point the resumed jitcode reaches),
-            // and the bridge must be recorded from THAT pc — see `should_bridge`
-            // at the `ContinueRunningNormally` arm below. `back_edge_structured`
-            // is the macro-only back edge; pyre-jit-trace bridges via its own
-            // eval.rs path, so this does not touch the rustpython JIT.
+            //
+            // The bridging arm enters the walk at the guard's own jitcode
+            // position, so the rest of the opcode the guard sits inside is
+            // recorded rather than run where the bridge cannot see it. It
+            // declines — and only before running anything — for a state with
+            // no dispatch jitcode, a resume frame it cannot seed a register
+            // file from, or a bridge setup that gave up; the blackhole arm
+            // below is then the answer, exactly as when the guard does not
+            // `must_compile` at all.
+            if should_bridge
+                && let Some(pc) = self.bridge_from_guard_resume_position(
+                    &descr_arc,
+                    state,
+                    env,
+                    &raw_values,
+                    target_pc,
+                )
+            {
+                if crate::majit_log_enabled() {
+                    eprintln!(
+                        "[bridge] guard-resume bridge key={} trace={} fail={} resume_pc={}",
+                        green_key, trace_id, fail_index, pc,
+                    );
+                }
+                return Some(pc);
+            }
 
             // compile.py:711 resume_in_blackhole
             // compile.py `ResumeGuardDescr` storage — borrow
@@ -5290,14 +5571,18 @@ impl<S: JitState> JitDriver<S> {
                     if crate::majit_log_enabled() {
                         eprintln!("[bh] back_edge_internal: chain resume → {:?}", outcome);
                     }
-                    // Whether the guard may source a bridge.
+                    // Whether the guard may source a bridge FROM HERE.
                     //
-                    // A bridge is entered from the guard, and it is recorded
-                    // from the green pc the walk below reports — the NEXT merge
-                    // point. Everything the walk ran to get there is the tail of
-                    // the opcode the guard sits inside, and the bridge does not
+                    // This is the fallback bridge — the one recorded from the
+                    // green pc the walk below reports, taken only when
+                    // `bridge_from_guard_resume_position` declined and the
+                    // blackhole ran. Its entry is the NEXT merge point, so
+                    // everything the walk ran to get there is the tail of the
+                    // opcode the guard sits inside, and the bridge does not
                     // contain it: the first failure runs it here and every later
-                    // one jumps into the bridge and skips it.
+                    // one jumps into the bridge and skips it. A bridge entered
+                    // at the guard's own position has no such gap and is not
+                    // gated.
                     //
                     // Values the tail computed are not the problem. The bridge
                     // is recorded against the state the walk LEFT, so whatever

--- a/majit/majit-metainterp/src/lib.rs
+++ b/majit/majit-metainterp/src/lib.rs
@@ -169,7 +169,7 @@ pub use io_buffer::{
     io_buffer_write_fmt, jit_write_number_i64, jit_write_utf8_codepoint,
 };
 pub use jit_state::{
-    DeoptMaterializationCache, JitState, PendingFieldWriteLayout, ResumeDataResult,
+    DeoptMaterializationCache, GuardResumeReg, JitState, PendingFieldWriteLayout, ResumeDataResult,
     bridge_decode_red,
 };
 pub use jitcode::{
@@ -211,8 +211,8 @@ pub use pyjitpl::{
     resolve_exception_context_for_recording, resolve_exception_context_hook_address,
     set_record_application_traceback_hook, set_record_discarded_level_traceback_hook,
     set_record_inline_application_traceback_hook, set_resolve_exception_context_hook,
-    trace_jitcode, trace_jitcode_from_merge_point, trace_jitcode_with_args,
-    trace_jitcode_with_args_and_runtime,
+    trace_jitcode, trace_jitcode_at_resume_position, trace_jitcode_from_merge_point,
+    trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
 };
 pub use resume_box_reader::{
     BridgeVirtualCache, decode_fieldnum, default_bridge_array_descr, emit_pending_field_op,
@@ -1288,7 +1288,7 @@ pub fn register_stack_almost_full_hook(f: fn() -> bool) {
 
 /// Number of `MC_DIAG` slots. Declared once so the counter array and
 /// `MC_DIAG_LABELS` cannot drift in length — a mismatch is a compile error.
-pub const MC_DIAG_SLOTS: usize = 79;
+pub const MC_DIAG_SLOTS: usize = 80;
 
 /// Diagnostic-only guard-failure → bridge-trace gate tallies, read out via
 /// the `pyre_jit_mc_diag` guest export. Index legend: 0 = must_compile_with_values
@@ -1636,6 +1636,11 @@ pub const MC_DIAG_LABELS: [&str; MC_DIAG_SLOTS] = [
     // runnable today, so a zero here is the difference between "the resumption
     // is correct" and "the resumption has never run".
     "retrace_close_resumed",
+    // A bridge entered at a guard's own position whose walk left no resume
+    // handoff behind — neither the single-pass outcome nor the abort
+    // conversion answered. The fallback re-executes the opcodes between the
+    // loop header and the guard, so a non-zero here is a defect, not a cost.
+    "guard_resume_bridge_no_handoff",
 ];
 
 /// Render every [`MC_DIAG`] tally as space-separated `label=count` pairs.

--- a/majit/majit-metainterp/src/pyjitpl.rs
+++ b/majit/majit-metainterp/src/pyjitpl.rs
@@ -5,7 +5,8 @@ pub use dispatch::build_state_field_snapshot;
 pub use dispatch::{
     ClosureRuntime, ClosureRuntimeWithResolver, JitCodeMachine, JitCodeRuntime, JitCodeSym,
     StandaloneFrameStack, residual_write_effect_info, trace_jitcode,
-    trace_jitcode_from_merge_point, trace_jitcode_with_args, trace_jitcode_with_args_and_runtime,
+    trace_jitcode_at_resume_position, trace_jitcode_from_merge_point, trace_jitcode_with_args,
+    trace_jitcode_with_args_and_runtime,
 };
 pub use dispatch::{build_vable_snapshot_boxes, build_vref_snapshot_boxes};
 pub use dispatch::{
@@ -1476,6 +1477,16 @@ pub struct MetaInterp<M: Clone> {
     /// via `writeback_scalar_state_fields_from_values`. `None` outside
     /// single-pass or when the state has no scalar fields.
     pub(crate) single_pass_scalar_values: Option<Vec<i64>>,
+    /// The ref twin of [`Self::single_pass_scalar_values`], stashed at the
+    /// same point and in ref-scalar index order.
+    ///
+    /// The `jit_merge_point!` hook does not read it, and does not need to: it
+    /// runs with a native `state` whose ref fields the interpreter itself has
+    /// been keeping current. A bridge entered at a guard has no such
+    /// interpreter — the compiled run left native `state` at its trace-start
+    /// image and only the guard's failargs describe the real one — so the
+    /// walk's ref fields are the only current copy and have to travel.
+    pub(crate) single_pass_ref_scalar_values: Option<Vec<i64>>,
     /// Single-pass tracing: the walk-final concrete values of the loop-carried
     /// virtualizable ARRAY elements, captured off the active `TraceCtx`
     /// (`collect_virtualizable_element_values`) at the CloseLoop point. The walk
@@ -3147,6 +3158,7 @@ impl<M: Clone> MetaInterp<M> {
             single_pass_finish: false,
             back_edge_finish: None,
             single_pass_scalar_values: None,
+            single_pass_ref_scalar_values: None,
             single_pass_virt_array_values: None,
             pending_abort_blackhole: None,
             single_pass_compact_label_values: None,

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -9464,22 +9464,36 @@ where
     let action = machine.run_to_end(ctx, sym, runtime);
     drop(machine);
 
-    // A fresh trace executes the portal JitCode forward against the real
-    // interpreter-owned heap.  If that walk aborts, its root frame still has
-    // the source interpreter pc in i0: dispatch advances i0 before executing
-    // the opcode arm.  Preserve that position before the temporary frame is
-    // dropped so the jit_merge_point single-pass handoff can resume after the
-    // committed prefix instead of replaying it from the trace header.
-    //
-    // i0 alone only names a sound resume position when the walk stopped at a
-    // source-opcode boundary; `pyjitpl.py:2949
-    // run_blackhole_interp_to_cancel_tracing` does not depend on that, because
-    // `blackhole.py convert_and_run_from_pyjitpl` finishes the current
-    // jitcode frames in the blackhole and takes the resume position from the
-    // `jit_merge_point` they reach.  Hand the whole framestack to the abort
-    // consumer so it can do that; i0 stays as the fallback for a consumer that
-    // declines the conversion.  CloseLoop and Finish already capture their own
-    // positions; only Abort needs this recovery handoff.
+    publish_walk_abort_handoff(ctx, &action, &mut standalone);
+    action
+}
+
+/// Publish an aborted walk's resume handoff onto the trace ctx.
+///
+/// The walk executes the portal JitCode forward against the real
+/// interpreter-owned heap.  If it aborts, its root frame still has the source
+/// interpreter pc in i0: dispatch advances i0 before executing the opcode arm.
+/// Preserve that position before the temporary frame is dropped so the
+/// jit_merge_point single-pass handoff can resume after the committed prefix
+/// instead of replaying it from the trace header.
+///
+/// i0 alone only names a sound resume position when the walk stopped at a
+/// source-opcode boundary; `pyjitpl.py:2949
+/// run_blackhole_interp_to_cancel_tracing` does not depend on that, because
+/// `blackhole.py convert_and_run_from_pyjitpl` finishes the current jitcode
+/// frames in the blackhole and takes the resume position from the
+/// `jit_merge_point` they reach.  Hand the whole framestack to the abort
+/// consumer so it can do that; i0 stays as the fallback for a consumer that
+/// declines the conversion.  CloseLoop and Finish already capture their own
+/// positions; only Abort needs this recovery handoff.
+///
+/// Shared by every walk entry: where the walk started does not change what a
+/// consumer needs in order to resume from where it stopped.
+fn publish_walk_abort_handoff(
+    ctx: &mut TraceCtx,
+    action: &TraceAction,
+    standalone: &mut StandaloneFrameStack,
+) {
     if matches!(action, TraceAction::Abort) && !standalone.frames.is_empty() {
         if let Some(pc) = standalone.frames.frames[0]
             .int_values
@@ -9551,6 +9565,71 @@ where
             ctx.aborted_framestack = Some(std::mem::take(&mut standalone.frames));
         }
     }
+}
+
+/// Enter the walk at the jitcode position a guard failed on.
+///
+/// `pyjitpl.py handle_guard_failure` →
+/// `initialize_state_from_guard_failure` → `rebuild_state_after_failure`
+/// rebuilds one `MIFrame` per encoded resume section, fills its live registers
+/// from the guard's numbering, and calls `setup_resume_at_op(pc)` on each —
+/// whose whole body is `self.pc = pc`.  `interpret()` then continues the walk
+/// from there, so everything the failing opcode had left to do is recorded
+/// into the bridge instead of being run somewhere the bridge cannot see.
+///
+/// The other entries in this file start a walk at a position the interpreter
+/// is re-enterable at — jitcode entry, or a merge point — and derive the
+/// register file by running forward from it.  A guard is neither: it sits
+/// mid-opcode, so the register file cannot be re-derived and has to be handed
+/// over.  `regs` is that file, one entry per live register.
+///
+/// `outer_program_pc` is the interpreter-space anchor `run_to_end` reports
+/// portal positions against; the guard's own position is jitcode-space and
+/// says nothing about it.
+pub fn trace_jitcode_at_resume_position<S, R>(
+    ctx: &mut TraceCtx,
+    sym: &mut S,
+    jitcode: &JitCode,
+    resume_pc: usize,
+    outer_program_pc: usize,
+    runtime: &R,
+    regs: &[crate::jit_state::GuardResumeReg],
+) -> TraceAction
+where
+    S: JitCodeSym,
+    R: JitCodeRuntime,
+{
+    let jitcode_arc = Arc::new(jitcode.clone());
+    let mut frame = MIFrame::setup(jitcode_arc, resume_pc, None, Some(ctx));
+    for reg in regs {
+        let index = reg.index as usize;
+        let (bank_regs, bank_values) = match reg.bank {
+            majit_ir::Type::Ref => (&mut frame.ref_regs, &mut frame.ref_values),
+            majit_ir::Type::Float => (&mut frame.float_regs, &mut frame.float_values),
+            _ => (&mut frame.int_regs, &mut frame.int_values),
+        };
+        // A register the jitcode does not declare is one the guard cannot have
+        // been holding, so there is no value to lose by skipping it — and
+        // indexing past the bank would panic on a mismatch that is already
+        // recoverable.
+        if index >= bank_regs.len() {
+            continue;
+        }
+        bank_regs[index] = Some(reg.opref);
+        bank_values[index] = Some(reg.value);
+    }
+    // The walker reads from `code_cursor`; `pc` is what a snapshot taken
+    // inside this frame reports. `setup_resume_at_op` is both.
+    frame.code_cursor = resume_pc;
+    frame.pc = resume_pc;
+
+    let mut standalone = StandaloneFrameStack::new();
+    standalone.frames.push(frame);
+    let mut machine = JitCodeMachine::<S, _>::with_framestack(&mut standalone.frames, &[], &[]);
+    machine.set_outer_program_pc(outer_program_pc);
+    let action = machine.run_to_end(ctx, sym, runtime);
+    drop(machine);
+    publish_walk_abort_handoff(ctx, &action, &mut standalone);
     action
 }
 

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -1121,6 +1121,29 @@ pub struct ClosureRuntime<FLabel> {
     label_at: FLabel,
 }
 
+/// Refuse a residual call whose target is still a `symbolic_fnaddr_for_path`
+/// placeholder.
+///
+/// A placeholder means the host never bound that callee's path, so the address
+/// is a hash of the path rather than code. Jumping to it faults somewhere with
+/// no trace of which callee was missing, and answering 0 (the null-target arm
+/// below) would quietly substitute a wrong result. `blackhole.rs` already
+/// declines the same shape on its own residual-call handlers; this is the
+/// tracing side of that check.
+fn reject_symbolic_residual_call_target(func: usize, arg_classes: &str) -> ! {
+    // Aborts rather than panics: the unwind would cross the metainterp frames the
+    // trace is being recorded through, and the report is already complete here.
+    // A symbolic target is a host configuration error, not a runtime condition.
+    eprintln!(
+        "residual call target {func:#x} is a symbolic path hash, not a code address \
+         (arg classes {arg_classes:?}). The host did not bind this callee's path — add \
+         it to the fnaddr bindings passed to \
+         `EmbeddedJitCodeTable::materialize_with_symbolic_fnaddrs`, and look the hash up \
+         in the host's symbolic-path table to see which path it names."
+    );
+    std::process::abort();
+}
+
 impl<FLabel> ClosureRuntime<FLabel> {
     pub fn new(label_at: FLabel) -> Self {
         Self { label_at }
@@ -6856,6 +6879,12 @@ where
                 // other dispatch sites in `blackhole.rs`.
                 if effectinfo.oopspecindex == majit_ir::descr::OopSpecIndex::NotInTrace {
                     self.clear_exception();
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     if !concrete_ptr.is_null() {
                         unsafe {
                             majit_backend::call_stub::bh_call_v_by_classes(
@@ -6948,6 +6977,12 @@ where
                     //    `bh_call_i_dispatch` (which transmutes to
                     //    `extern "C" fn(...) -> i64` and reads garbage from
                     //    rax/x0).
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     if !concrete_ptr.is_null() {
                         unsafe {
                             majit_backend::call_stub::bh_call_v_by_classes(
@@ -7164,6 +7199,12 @@ where
                     // through `bh_call_v_dispatch`, do not write back the
                     // int destination register, and abort on exception.
                     self.clear_exception();
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     if !concrete_ptr.is_null() {
                         unsafe {
                             majit_backend::call_stub::bh_call_v_by_classes(
@@ -7235,6 +7276,12 @@ where
                     // Concrete execute via `bh_call_i_dispatch` (i64
                     // return) — RPython `executor.execute_varargs` →
                     // `cpu.bh_call_i`.
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     let concrete = if concrete_ptr.is_null() {
                         0
                     } else {
@@ -7447,6 +7494,12 @@ where
                     // the int sibling at the corresponding NotInTrace
                     // branch for the full citation.
                     self.clear_exception();
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     if !concrete_ptr.is_null() {
                         unsafe {
                             majit_backend::call_stub::bh_call_v_by_classes(
@@ -7514,6 +7567,12 @@ where
                     } else {
                         None
                     };
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     let concrete = if concrete_ptr.is_null() {
                         0
                     } else {
@@ -7688,6 +7747,12 @@ where
                     // the int sibling at the corresponding NotInTrace
                     // branch for the full citation.
                     self.clear_exception();
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     if !concrete_ptr.is_null() {
                         unsafe {
                             majit_backend::call_stub::bh_call_v_by_classes(
@@ -7744,6 +7809,12 @@ where
                     } else {
                         None
                     };
+                    if majit_translate::codewriter::call::is_symbolic_fnaddr(concrete_ptr as i64) {
+                        reject_symbolic_residual_call_target(
+                            concrete_ptr as usize,
+                            &calldescr.arg_classes,
+                        );
+                    }
                     let concrete = if concrete_ptr.is_null() {
                         0.0f64
                     } else {

--- a/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
+++ b/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
@@ -1,0 +1,191 @@
+//! A residual call that sits after a red-conditional branch inside one opcode
+//! stops running once a bridge is compiled for that branch.
+//!
+//! The interpreter shape is the smallest one that can hold the defect: a single
+//! scalar state field, one opcode whose body is `if <red condition> { <call> }`,
+//! and a back edge. Nothing here is exotic — no virtualizable array, no virtual
+//! object, no exception path — so any `jit_interp` interpreter with a
+//! conditionally-effectful opcode is in range.
+//!
+//! What the run must produce is arithmetic, not a crash. `OP_PUSH` hands the
+//! displaced word to `chain_push` on every trip past `CAP`, so after `N` pushes
+//! the chain has seen exactly `N - CAP` words and their sum is fixed. Both are
+//! computed twice: once with the threshold out of reach, which fixes the
+//! answer, and once warm.
+//!
+//! ⛔ OPEN DEFECT — this test is `#[ignore]`d because it FAILS. Measured with
+//! `N = 2000` and `CAP = 8`: interpreted 1992 words, compiled 202. The 202 are
+//! the trips before the branch earned a bridge; from the bridge onwards the
+//! call never runs again. `MAJIT_NO_BRIDGE=1` and `MAJIT_MAX_BRIDGES=0` both
+//! make it pass, which places the loss in bridge tracing rather than in the
+//! guard, the recovery layout or the blackhole resume.
+//!
+//! The mechanism is a position mismatch. The failing guard's resume state is
+//! mid-opcode — its failargs carry `sp` ALREADY incremented, so the point it
+//! describes is after `state.sp = state.sp + 1` and before the call.
+//! `JitDriver::start_bridge_tracing` seeds the bridge with
+//! `state.build_meta(resume_pc, env)`, and `resume_pc` is a green pc, which can
+//! only ever name an opcode BOUNDARY. So the bridge begins at the next opcode
+//! and the tail of the one that failed — here the call, and the store after it
+//! — is never recorded. `resume_in_blackhole` does not have this problem
+//! because it resumes at a jitcode position rather than a pc, which is why
+//! turning bridges off repairs the count.
+use core::sync::atomic::{AtomicU32, Ordering};
+
+pub type Bytecode = [u8];
+
+/// The depth past which a push displaces a word. Small, so the branch flips
+/// early and stays taken for the rest of the run.
+const CAP: usize = 8;
+
+const OP_PUSH: u8 = 1;
+const OP_BACK: u8 = 2;
+const OP_RET: u8 = 3;
+
+static COMPILES: AtomicU32 = AtomicU32::new(0);
+
+/// Counts and sums what it is handed. A count alone cannot tell a lost word
+/// from a duplicated one; the sum can.
+#[repr(C)]
+struct Chain {
+    size: i64,
+    sum: i64,
+}
+
+extern "C" fn chain_push(chain: usize, value: i64) {
+    let chain = unsafe { &mut *(chain as *mut Chain) };
+    chain.size += 1;
+    chain.sum += value;
+}
+
+struct PlainStack {
+    /// The one word the machine keeps; everything below it has gone to the
+    /// chain.
+    top: i64,
+    sp: usize,
+    counter: i64,
+    chain: usize,
+}
+
+#[majit_macros::jit_interp(
+    state = PlainStack,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        top: int,
+        sp: int(usize),
+        counter: int,
+        chain: ref(Chain),
+    },
+    calls = {
+        chain_push => residual_void,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32, chain: usize) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<PlainStack> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = PlainStack {
+        top: 0i64,
+        sp: 0usize,
+        counter: iterations,
+        chain,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH => {
+                // A red, and a different one each trip, so a word that never
+                // reaches the chain is missing from the sum rather than hidden
+                // by a repeat.
+                let value = state.counter;
+                state.sp = state.sp + 1;
+                if state.sp > CAP {
+                    // The displaced word. This call and the store below are
+                    // the same opcode's work as the test above them, so a
+                    // guard between them owes its resume all three.
+                    chain_push(state.chain, state.top);
+                }
+                state.top = value;
+            }
+            OP_BACK => {
+                state.counter = state.counter - 1;
+                if state.counter != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_RET => break,
+            _ => unreachable!(),
+        }
+    }
+
+    state.sp as i64
+}
+
+fn run(program: &[u8], iterations: i64, threshold: u32) -> (i64, i64, i64) {
+    let mut chain = Chain { size: 0, sum: 0 };
+    let height = mainloop(
+        program,
+        iterations,
+        threshold,
+        &mut chain as *mut Chain as usize,
+    );
+    (height, chain.size, chain.sum)
+}
+
+#[test]
+#[ignore = "open defect: a bridge traced from a mid-opcode guard drops the rest of that opcode"]
+fn a_residual_call_after_a_mid_opcode_guard_survives_a_bridge() {
+    let program = vec![OP_PUSH, OP_BACK, OP_RET];
+    // Deep enough that the branch is taken for far longer than the
+    // trace-eagerness window it needs to earn a bridge.
+    const ITERATIONS: i64 = 2000;
+
+    COMPILES.store(0, Ordering::Relaxed);
+    // Unreachable threshold, so this run fixes the answer without the JIT.
+    let cold = run(&program, ITERATIONS, u32::MAX);
+    assert_eq!(
+        COMPILES.load(Ordering::Relaxed),
+        0,
+        "the cold run must not have compiled anything"
+    );
+    assert_eq!(
+        cold.1,
+        ITERATIONS - CAP as i64,
+        "cold run: every push past the first {CAP} displaces one word"
+    );
+
+    let warm = run(&program, ITERATIONS, 3);
+    assert!(
+        COMPILES.load(Ordering::Relaxed) >= 1,
+        "the loop did not compile"
+    );
+    assert_eq!(
+        warm.1, cold.1,
+        "a conditional residual call inside an opcode ran a different NUMBER of \
+         times compiled than interpreted"
+    );
+    assert_eq!(
+        warm.2, cold.2,
+        "a conditional residual call inside an opcode was handed different WORDS \
+         compiled than interpreted"
+    );
+    assert_eq!(warm.0, cold.0, "compiled height");
+}

--- a/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
+++ b/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
@@ -43,6 +43,10 @@ const OP_BACK: u8 = 2;
 const OP_RET: u8 = 3;
 
 static COMPILES: AtomicU32 = AtomicU32::new(0);
+/// Bridges compiled. The counts below hold whether or not a bridge is ever
+/// built — declining to bridge keeps them right too — so without this the
+/// fixture cannot tell the repair from the refusal.
+static BRIDGES: AtomicU32 = AtomicU32::new(0);
 
 /// Counts and sums what it is handed. A count alone cannot tell a lost word
 /// from a duplicated one; the sum can.
@@ -87,6 +91,9 @@ pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32, chain: usiz
         majit_metainterp::JitDriver::new(threshold);
     driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
         COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    driver.set_on_compile_bridge(|_green_key, _fail_index, _num_ops| {
+        BRIDGES.fetch_add(1, Ordering::Relaxed);
     });
     let mut pc: usize = 0;
     let mut state = PlainStack {
@@ -159,6 +166,7 @@ fn a_residual_call_after_a_mid_opcode_guard_survives_a_bridge() {
     const ITERATIONS: i64 = 2000;
 
     COMPILES.store(0, Ordering::Relaxed);
+    BRIDGES.store(0, Ordering::Relaxed);
     // Unreachable threshold, so this run fixes the answer without the JIT.
     let cold = run(&program, ITERATIONS, u32::MAX);
     assert_eq!(
@@ -188,4 +196,10 @@ fn a_residual_call_after_a_mid_opcode_guard_survives_a_bridge() {
          compiled than interpreted"
     );
     assert_eq!(warm.0, cold.0, "compiled height");
+    assert!(
+        BRIDGES.load(Ordering::Relaxed) >= 1,
+        "the mid-opcode guard sourced no bridge, so the counts above agree for \
+         the wrong reason: they say the tail still ran, not that it ran from \
+         inside a bridge"
+    );
 }

--- a/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
+++ b/majit/majit-metainterp/tests/jit_interp_bridge_drops_opcode_tail.rs
@@ -13,12 +13,12 @@
 //! computed twice: once with the threshold out of reach, which fixes the
 //! answer, and once warm.
 //!
-//! ⛔ OPEN DEFECT — this test is `#[ignore]`d because it FAILS. Measured with
-//! `N = 2000` and `CAP = 8`: interpreted 1992 words, compiled 202. The 202 are
-//! the trips before the branch earned a bridge; from the bridge onwards the
-//! call never runs again. `MAJIT_NO_BRIDGE=1` and `MAJIT_MAX_BRIDGES=0` both
-//! make it pass, which places the loss in bridge tracing rather than in the
-//! guard, the recovery layout or the blackhole resume.
+//! It measured 202 of 1992 before the fix, with `N = 2000` and `CAP = 8`: the
+//! 202 are the trips before the branch earned a bridge, and from the bridge
+//! onwards the call never ran again. `MAJIT_NO_BRIDGE=1` and
+//! `MAJIT_MAX_BRIDGES=0` both made it pass, which placed the loss in bridge
+//! tracing rather than in the guard, the recovery layout or the blackhole
+//! resume.
 //!
 //! The mechanism is a position mismatch. The failing guard's resume state is
 //! mid-opcode — its failargs carry `sp` ALREADY incremented, so the point it
@@ -151,7 +151,7 @@ fn run(program: &[u8], iterations: i64, threshold: u32) -> (i64, i64, i64) {
 }
 
 #[test]
-#[ignore = "open defect: a bridge traced from a mid-opcode guard drops the rest of that opcode"]
+
 fn a_residual_call_after_a_mid_opcode_guard_survives_a_bridge() {
     let program = vec![OP_PUSH, OP_BACK, OP_RET];
     // Deep enough that the branch is taken for far longer than the

--- a/majit/majit-metainterp/tests/jit_interp_two_virt_arrays_runtime_indexed.rs
+++ b/majit/majit-metainterp/tests/jit_interp_two_virt_arrays_runtime_indexed.rs
@@ -1,0 +1,191 @@
+//! Two virtualizable arrays, each addressed by a RUNTIME index.
+//!
+//! `virtualizable.py`'s accessors reach an element as "the array's base slot
+//! plus the element index", and the base slot of array N is the summed length
+//! of arrays 0..N-1 (`get_index_in_array`). One array cannot observe that sum:
+//! its base is always the static field count. Two can, and only if something
+//! actually indexes the second one at run time — a constant index folds before
+//! the sum is ever consulted.
+//!
+//! The two fixtures that already stand leave exactly this square empty.
+//! `jit_interp_virt_array_stack_has_no_memory_ops` indexes ONE array by a
+//! running depth; `jit_interp_two_virt_arrays_with_scalar` declares TWO arrays
+//! but reaches both at constant index 0. So "two arrays" and "runtime index"
+//! are each covered alone and neither is covered together.
+//!
+//! The shape here is a two-pool stack machine: `vals` is a ring holding each
+//! pool's top `CAP` words at `pool * CAP + (h & CAP_MASK)`, and `depths` parks a
+//! pool's height while another pool is selected. Both indices are reds. The
+//! lengths differ (`POOLS * CAP` against `POOLS`) so a base computed as anything
+//! other than the real sum lands inside the wrong array rather than out of
+//! bounds, which is the failure that stays silent.
+//!
+//! The assertion is compiled-equals-interpreted. A cold run pins the answer with
+//! the JIT unable to reach its threshold; the warm run must agree.
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+/// Two pools, so `depths` has something to park.
+const POOLS: usize = 2;
+/// A power of two: a pool's slot for height `h` is `h & CAP_MASK`.
+const CAP: usize = 4;
+const CAP_MASK: usize = CAP - 1;
+
+const OP_PUSH: u8 = 1;
+const OP_DRAIN: u8 = 2;
+const OP_SWITCH: u8 = 3;
+const OP_BACK: u8 = 4;
+const OP_RET: u8 = 5;
+
+static COMPILES: AtomicU32 = AtomicU32::new(0);
+
+struct TwoPools {
+    /// `pool * CAP + (h & CAP_MASK)`.
+    vals: VirtArray<i64>,
+    /// One parked height per pool. Shorter than `vals`, so the two arrays
+    /// cannot share a base by coincidence.
+    depths: VirtArray<i64>,
+    sel: usize,
+    sp: usize,
+    counter: i64,
+    acc: i64,
+}
+
+#[majit_macros::jit_interp(
+    state = TwoPools,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        vals: [int; virt],
+        depths: [int; virt],
+        sel: int(usize),
+        sp: int(usize),
+        counter: int,
+        acc: int,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<TwoPools> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = TwoPools {
+        vals: VirtArray::filled(0i64, POOLS * CAP),
+        depths: VirtArray::filled(0i64, POOLS),
+        sel: 0usize,
+        sp: 0usize,
+        counter: iterations,
+        acc: 0i64,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH => {
+                // The operand is what distinguishes the two pools' contents, so
+                // a read that lands in the wrong pool changes the answer.
+                let value = program[pc] as i64;
+                pc += 1;
+                let slot = state.sel * CAP + (state.sp & CAP_MASK);
+                state.vals[slot] = value;
+                state.sp = state.sp + 1;
+            }
+            OP_DRAIN => {
+                state.sp = state.sp - 1;
+                let slot = state.sel * CAP + (state.sp & CAP_MASK);
+                state.acc = state.acc + state.vals[slot];
+            }
+            OP_SWITCH => {
+                // Park the outgoing pool's height and take the incoming one's
+                // back. Both reach `depths` at a runtime index.
+                state.depths[state.sel] = state.sp as i64;
+                state.sel = (state.sel + 1) & (POOLS - 1);
+                state.sp = state.depths[state.sel] as usize;
+            }
+            OP_BACK => {
+                state.counter = state.counter - 1;
+                if state.counter != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_RET => break,
+            _ => unreachable!(),
+        }
+    }
+    state.acc
+}
+
+/// Each iteration stacks pool 0 three deep, leaves it parked across a switch,
+/// works pool 1, and only then drains pool 0 back down.
+///
+/// The depth is what this fixture is for. A machine that pushes one word reaches
+/// its array at two indices, and two indices is not a runtime index — the
+/// promotion that stands in for one is exercised by how MANY values the index
+/// takes. Pool 0 walks slots 0..3 and pool 1 slots 4..6, so seven distinct
+/// element slots and both `depths` entries are reached at run time.
+fn program() -> Vec<u8> {
+    vec![
+        OP_PUSH, 7, // pool 0: sp 0 -> 1
+        OP_PUSH, 8, // sp 1 -> 2
+        OP_PUSH, 9,         // sp 2 -> 3
+        OP_SWITCH, // park pool 0 at 3, select pool 1
+        OP_PUSH, 5, // pool 1: sp 0 -> 1
+        OP_PUSH, 6,         // sp 1 -> 2
+        OP_DRAIN,  // 6
+        OP_DRAIN,  // 5
+        OP_SWITCH, // park pool 1 at 0, select pool 0 and take 3 back
+        OP_DRAIN,  // 9
+        OP_DRAIN,  // 8
+        OP_DRAIN,  // 7
+        OP_BACK, OP_RET,
+    ]
+}
+
+/// 6 + 5 + 9 + 8 + 7. Every term comes from a different element slot, so a read
+/// that lands one slot off changes the sum rather than repeating a value.
+const PER_ITERATION: i64 = 35;
+
+#[test]
+fn two_runtime_indexed_virt_arrays_agree_with_the_interpreter() {
+    let program = program();
+    const ITERATIONS: i64 = 200;
+
+    COMPILES.store(0, Ordering::Relaxed);
+    // Unreachable threshold, so this run fixes the answer without the JIT.
+    let cold = mainloop(&program, ITERATIONS, u32::MAX);
+    assert_eq!(cold, ITERATIONS * PER_ITERATION, "cold interpretation");
+    assert_eq!(
+        COMPILES.load(Ordering::Relaxed),
+        0,
+        "the cold run must not have compiled anything"
+    );
+
+    let warm = mainloop(&program, ITERATIONS, 3);
+    assert_eq!(
+        warm, cold,
+        "a second virtualizable array reached at a runtime index must read the \
+         same words compiled as interpreted"
+    );
+    assert!(
+        COMPILES.load(Ordering::Relaxed) >= 1,
+        "two runtime-indexed `[int; virt]` arrays did not compile the hot loop"
+    );
+}

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_ring_index_advances.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_ring_index_advances.rs
@@ -1,0 +1,199 @@
+//! A virtualizable ring whose index ADVANCES, spilling every evicted word to a
+//! chain reached through a `ref(T)` state field.
+//!
+//! `jit_interp_virt_array_spills_to_ref_chain` covers the same split stack, but
+//! its program returns to the same depth every iteration, so the ring slot each
+//! access reaches is the same on every trip. A vable array's index is promoted,
+//! and a promoted value that never changes is free: the guard is recorded once
+//! and passes forever. That is the blind spot. A stack that only grows reaches
+//! a DIFFERENT slot each trip, so the promote's guard fails every iteration,
+//! and each failure has to resume at the boundary of the opcode that computed
+//! the index — before the eviction the same opcode still owes the chain.
+//!
+//! ⛔ OPEN DEFECT — `#[ignore]`d because it FAILS: interpreted 1992 words,
+//! compiled 201. It is the virtualizable-array face of the defect
+//! `jit_interp_bridge_drops_opcode_tail` reproduces with one scalar field, and
+//! it is kept because the ring is what makes the guard fail EVERY trip: the
+//! promoted index is a different value each time, so the branch behind it never
+//! settles.
+//!
+//! What makes a missed resume invisible without this fixture is that nothing
+//! observable goes wrong at the moment it happens: the ring keeps answering,
+//! the chain stays internally consistent, and the loop keeps running. Only the
+//! COUNT of words that reached the chain records it. So the assertion is
+//! arithmetic on the whole run rather than a crash: after `N` pushes the chain
+//! must hold exactly `N - CAP` words, and their sum must be the sum of the
+//! first `N - CAP` values pushed — one skipped eviction changes both.
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+/// A power of two, and small, so the ring index takes every one of its values
+/// within a few trips rather than once per run.
+const CAP: usize = 8;
+const CAP_MASK: usize = CAP - 1;
+
+const OP_PUSH: u8 = 1;
+const OP_BACK: u8 = 2;
+const OP_RET: u8 = 3;
+
+static COMPILES: AtomicU32 = AtomicU32::new(0);
+
+/// The overflow half of the stack. It keeps a count and a sum instead of nodes
+/// because the test grades how many words arrived and which, not their order.
+#[repr(C)]
+struct Chain {
+    size: i64,
+    sum: i64,
+}
+
+extern "C" fn chain_push(chain: usize, value: i64) {
+    let chain = unsafe { &mut *(chain as *mut Chain) };
+    chain.size += 1;
+    chain.sum += value;
+}
+
+struct GrowingStack {
+    /// The top `CAP` words: the word at absolute height `h` is at
+    /// `(h - 1) & CAP_MASK`.
+    vals: VirtArray<i64>,
+    /// The whole height, ring and chain together. The chain holds
+    /// `max(0, sp - CAP)` words.
+    sp: usize,
+    counter: i64,
+    /// Declared after the array, so its slot index depends on the array's
+    /// declared length.
+    chain: usize,
+}
+
+#[majit_macros::jit_interp(
+    state = GrowingStack,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        vals: [int; virt],
+        sp: int(usize),
+        counter: int,
+        chain: ref(Chain),
+    },
+    calls = {
+        chain_push => residual_void,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32, chain: usize) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<GrowingStack> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = GrowingStack {
+        vals: VirtArray::filled(0i64, CAP),
+        sp: 0usize,
+        counter: iterations,
+        chain,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH => {
+                // A red, and a different one every trip, so a word that never
+                // reaches the chain is missing from the sum rather than hidden
+                // by a repeat.
+                let value = state.counter;
+                state.sp = state.sp + 1;
+                let free_slot = (state.sp - 1) & CAP_MASK;
+                if state.sp > CAP {
+                    // The ring is full: the word in this slot is the oldest
+                    // one it holds and leaves for the chain. The eviction and
+                    // the store below are the same opcode's work, so a guard
+                    // between them owes its resume the whole pair.
+                    chain_push(state.chain, state.vals[free_slot]);
+                }
+                state.vals[free_slot] = value;
+            }
+            OP_BACK => {
+                state.counter = state.counter - 1;
+                if state.counter != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_RET => break,
+            _ => unreachable!(),
+        }
+    }
+
+    state.sp as i64
+}
+
+fn program() -> Vec<u8> {
+    vec![OP_PUSH, OP_BACK, OP_RET]
+}
+
+fn run(program: &[u8], iterations: i64, threshold: u32) -> (i64, i64, i64) {
+    let mut chain = Chain { size: 0, sum: 0 };
+    let height = mainloop(
+        program,
+        iterations,
+        threshold,
+        &mut chain as *mut Chain as usize,
+    );
+    (height, chain.size, chain.sum)
+}
+
+#[test]
+#[ignore = "open defect: a bridge traced from a mid-opcode guard drops the rest of that opcode"]
+fn an_advancing_ring_index_spills_every_word_it_evicts() {
+    let program = program();
+    // Deep enough that the ring index has cycled hundreds of times after the
+    // loop is compiled, so a per-iteration loss accumulates into a plain
+    // arithmetic difference.
+    const ITERATIONS: i64 = 2000;
+
+    COMPILES.store(0, Ordering::Relaxed);
+    // Unreachable threshold, so this run fixes the answer without the JIT.
+    let cold = run(&program, ITERATIONS, u32::MAX);
+    assert_eq!(
+        COMPILES.load(Ordering::Relaxed),
+        0,
+        "the cold run must not have compiled anything"
+    );
+    assert_eq!(cold.0, ITERATIONS, "cold height");
+    assert_eq!(
+        cold.1,
+        ITERATIONS - CAP as i64,
+        "cold run: every word but the ring's last {CAP} belongs to the chain"
+    );
+
+    let warm = run(&program, ITERATIONS, 3);
+    assert!(
+        COMPILES.load(Ordering::Relaxed) >= 1,
+        "the growing-ring loop did not compile"
+    );
+    assert_eq!(
+        warm.1, cold.1,
+        "compiled run spilled a different NUMBER of words than the interpreter: \
+         a push whose ring-index promote failed did not finish its eviction"
+    );
+    assert_eq!(
+        warm.2, cold.2,
+        "compiled run spilled different WORDS than the interpreter"
+    );
+    assert_eq!(warm.0, cold.0, "compiled height");
+}

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_ring_index_advances.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_ring_index_advances.rs
@@ -10,8 +10,8 @@
 //! and each failure has to resume at the boundary of the opcode that computed
 //! the index — before the eviction the same opcode still owes the chain.
 //!
-//! ⛔ OPEN DEFECT — `#[ignore]`d because it FAILS: interpreted 1992 words,
-//! compiled 201. It is the virtualizable-array face of the defect
+//! It measured 201 of 1992 before the fix. It is the virtualizable-array face
+//! of the defect
 //! `jit_interp_bridge_drops_opcode_tail` reproduces with one scalar field, and
 //! it is kept because the ring is what makes the guard fail EVERY trip: the
 //! promoted index is a different value each time, so the branch behind it never
@@ -158,7 +158,7 @@ fn run(program: &[u8], iterations: i64, threshold: u32) -> (i64, i64, i64) {
 }
 
 #[test]
-#[ignore = "open defect: a bridge traced from a mid-opcode guard drops the rest of that opcode"]
+
 fn an_advancing_ring_index_spills_every_word_it_evicts() {
     let program = program();
     // Deep enough that the ring index has cycled hundreds of times after the

--- a/majit/majit-metainterp/tests/jit_interp_virt_array_spills_to_ref_chain.rs
+++ b/majit/majit-metainterp/tests/jit_interp_virt_array_spills_to_ref_chain.rs
@@ -1,0 +1,270 @@
+//! One logical stack split between a virtualizable ring and a heap chain
+//! reached through a `ref(T)` state field.
+//!
+//! `jit_interp_two_virt_arrays_runtime_indexed` covers two `[int; virt]` arrays
+//! at runtime indices and nothing else: every value it ever reads lives in a
+//! box, so the whole machine is answerable without touching memory. That is
+//! also its blind spot. A ring only holds the top `CAP` words; a stack deeper
+//! than that keeps its remainder somewhere else, and reaching that somewhere
+//! else brings in the two things the boxed-only machine never has —
+//!
+//! * a `ref(T)` state scalar, which shares the flat virtualizable slot space
+//!   with the int scalars and the array elements but is carried in the ref
+//!   register bank, and
+//! * residual calls sitting BETWEEN element accesses, so the boxes have to
+//!   survive a call boundary rather than only a guard.
+//!
+//! The interesting property is that the two halves of the stack are kept
+//! consistent by a RED condition (`sp > CAP` / `sp >= CAP`). A trace recorded
+//! while the ring alone was enough compiles that condition to a guard and
+//! contains no chain traffic at all. Everything about whether the split stays
+//! coherent therefore rests on the state the guard restores: if `sp` comes back
+//! disagreeing with the chain by even one, the interpreter either pops a chain
+//! that is empty or leaks a word into one that should be.
+//!
+//! So the assertion is not only compiled-equals-interpreted on the sum. The
+//! chain must also be empty at the end of the run: every word the ring spilled
+//! has to come back exactly once.
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use majit_metainterp::virt_array::VirtArray;
+
+pub type Bytecode = [u8];
+
+const POOLS: usize = 2;
+/// A power of two, and small, so the program crosses the ring boundary in both
+/// directions several times per iteration instead of once per run.
+const CAP: usize = 4;
+const CAP_MASK: usize = CAP - 1;
+
+const OP_PUSH: u8 = 1;
+const OP_DRAIN: u8 = 2;
+const OP_SWITCH: u8 = 3;
+const OP_BACK: u8 = 4;
+const OP_RET: u8 = 5;
+
+static COMPILES: AtomicU32 = AtomicU32::new(0);
+
+/// The overflow half of the stack. Headed by a raw chain so a push and a pop
+/// are the plainest possible residual calls.
+#[repr(C)]
+struct Chain {
+    head: *mut Node,
+    size: i64,
+}
+
+#[repr(C)]
+struct Node {
+    value: i64,
+    next: *mut Node,
+}
+
+extern "C" fn chain_push(chain: usize, value: i64) {
+    let chain = unsafe { &mut *(chain as *mut Chain) };
+    let node = Box::into_raw(Box::new(Node {
+        value,
+        next: chain.head,
+    }));
+    chain.head = node;
+    chain.size += 1;
+}
+
+extern "C" fn chain_pop(chain: usize) -> i64 {
+    let chain = unsafe { &mut *(chain as *mut Chain) };
+    assert!(
+        !chain.head.is_null(),
+        "the interpreter reached the chain with nothing on it: the restored \
+         `sp` claims the ring has spilled words that were never pushed"
+    );
+    let node = unsafe { Box::from_raw(chain.head) };
+    chain.head = node.next;
+    chain.size -= 1;
+    node.value
+}
+
+struct SplitStack {
+    /// `pool * CAP + (h & CAP_MASK)` — the top `CAP` words of each pool.
+    vals: VirtArray<i64>,
+    /// One parked height per pool. Shorter than `vals`.
+    depths: VirtArray<i64>,
+    sel: usize,
+    /// The selected pool's total height, ring and chain together. The chain
+    /// holds `max(0, sp - CAP)` words.
+    sp: usize,
+    counter: i64,
+    acc: i64,
+    /// Declared last, after both arrays: a ref-kind slot at the far end of the
+    /// flat layout is the one whose index depends on every length before it.
+    chain: usize,
+}
+
+#[majit_macros::jit_interp(
+    state = SplitStack,
+    env = Bytecode,
+    greens = [pc, program],
+    state_fields = {
+        vals: [int; virt],
+        depths: [int; virt],
+        sel: int(usize),
+        sp: int(usize),
+        counter: int,
+        acc: int,
+        chain: ref(Chain),
+    },
+    calls = {
+        chain_push => residual_void,
+        chain_pop => residual_int,
+    },
+)]
+#[allow(unused_assignments, unused_variables)]
+pub fn mainloop(program: &Bytecode, iterations: i64, threshold: u32, chain: usize) -> i64 {
+    let mut driver: majit_metainterp::JitDriver<SplitStack> =
+        majit_metainterp::JitDriver::new(threshold);
+    driver.set_on_compile_loop(|_green_key, _before, _after, _opcodes| {
+        COMPILES.fetch_add(1, Ordering::Relaxed);
+    });
+    let mut pc: usize = 0;
+    let mut state = SplitStack {
+        vals: VirtArray::filled(0i64, POOLS * CAP),
+        depths: VirtArray::filled(0i64, POOLS),
+        sel: 0usize,
+        sp: 0usize,
+        counter: iterations,
+        acc: 0i64,
+        chain,
+    };
+    {
+        use majit_metainterp::JitState as _;
+        state
+            .build_meta(0, program)
+            .install_canonical_liveness(&mut driver);
+    }
+
+    while pc < program.len() {
+        jit_merge_point!(driver, program, pc; state);
+
+        let opcode = program[pc];
+        pc += 1;
+
+        match opcode {
+            OP_PUSH => {
+                let value = program[pc] as i64;
+                pc += 1;
+                state.sp = state.sp + 1;
+                // `sp` is the height after the push, so the new word takes the
+                // slot of height `sp - 1`.
+                let free_slot = state.sel * CAP + ((state.sp - 1) & CAP_MASK);
+                if state.sp > CAP {
+                    // The ring is full: the word in this slot is the pool's
+                    // oldest and leaves for the chain.
+                    chain_push(state.chain, state.vals[free_slot]);
+                }
+                state.vals[free_slot] = value;
+            }
+            OP_DRAIN => {
+                let top_slot = state.sel * CAP + ((state.sp - 1) & CAP_MASK);
+                state.acc = state.acc + state.vals[top_slot];
+                state.sp = state.sp - 1;
+                // The slot just vacated is the one height `sp - CAP` wants
+                // back; `sp & CAP_MASK` names it because the ring wraps.
+                let refill_slot = state.sel * CAP + (state.sp & CAP_MASK);
+                if state.sp >= CAP {
+                    state.vals[refill_slot] = chain_pop(state.chain);
+                }
+            }
+            OP_SWITCH => {
+                state.depths[state.sel] = state.sp as i64;
+                state.sel = (state.sel + 1) & (POOLS - 1);
+                state.sp = state.depths[state.sel] as usize;
+            }
+            OP_BACK => {
+                state.counter = state.counter - 1;
+                if state.counter != 0 {
+                    can_enter_jit!(driver, 0usize, &mut state, program, || {});
+                    pc = 0;
+                    continue;
+                }
+            }
+            OP_RET => break,
+            _ => unreachable!(),
+        }
+    }
+    state.acc
+}
+
+/// Pool 0 is driven `CAP + 2` deep, so two words spill to the chain; the run
+/// then leaves it parked across a switch, works pool 1 entirely inside its
+/// ring, and only afterwards drains pool 0 back down through both refills.
+///
+/// Pool 1 never spills. That asymmetry is deliberate: the chain belongs to
+/// pool 0, and a machine where both pools spilled would need one chain each
+/// before the answer meant anything.
+fn program() -> Vec<u8> {
+    vec![
+        OP_PUSH, 1, // pool 0, heights 0..5 — the first two spill on the way up
+        OP_PUSH, 2, OP_PUSH, 3, OP_PUSH, 4, OP_PUSH, 5, // height 4: spills height 0
+        OP_PUSH, 6,         // height 5: spills height 1
+        OP_SWITCH, // park pool 0 at 6, select pool 1
+        OP_PUSH, 7, OP_PUSH, 8, OP_DRAIN,  // 8
+        OP_DRAIN,  // 7
+        OP_SWITCH, // park pool 1 at 0, take pool 0's 6 back
+        OP_DRAIN,  // 6, then refill slot 1 from the chain
+        OP_DRAIN,  // 5, then refill slot 0 from the chain
+        OP_DRAIN,  // 4
+        OP_DRAIN,  // 3
+        OP_DRAIN,  // 2 — came back from the chain
+        OP_DRAIN,  // 1 — came back from the chain
+        OP_BACK, OP_RET,
+    ]
+}
+
+/// 1+2+3+4+5+6 from pool 0 and 7+8 from pool 1. Every term is distinct, so a
+/// read that lands one slot off changes the sum instead of repeating a value.
+const PER_ITERATION: i64 = 36;
+
+fn run(program: &[u8], iterations: i64, threshold: u32) -> (i64, i64) {
+    let mut chain = Chain {
+        head: core::ptr::null_mut(),
+        size: 0,
+    };
+    let acc = mainloop(
+        program,
+        iterations,
+        threshold,
+        &mut chain as *mut Chain as usize,
+    );
+    (acc, chain.size)
+}
+
+#[test]
+fn a_ring_that_spills_to_a_ref_chain_agrees_with_the_interpreter() {
+    let program = program();
+    const ITERATIONS: i64 = 200;
+
+    COMPILES.store(0, Ordering::Relaxed);
+    // Unreachable threshold, so this run fixes the answer without the JIT.
+    let (cold, cold_left) = run(&program, ITERATIONS, u32::MAX);
+    assert_eq!(cold, ITERATIONS * PER_ITERATION, "cold interpretation");
+    assert_eq!(cold_left, 0, "cold run left words on the chain");
+    assert_eq!(
+        COMPILES.load(Ordering::Relaxed),
+        0,
+        "the cold run must not have compiled anything"
+    );
+
+    let (warm, warm_left) = run(&program, ITERATIONS, 3);
+    assert_eq!(
+        warm, cold,
+        "a virtualizable ring spilling through a `ref(T)` state field must read \
+         the same words compiled as interpreted"
+    );
+    assert_eq!(
+        warm_left, 0,
+        "the compiled run left words on the chain: the ring and the chain \
+         disagree about how deep the stack is"
+    );
+    assert!(
+        COMPILES.load(Ordering::Relaxed) >= 1,
+        "the split-stack loop did not compile"
+    );
+}

--- a/pyre/pyre-wasm-runner/src/main.rs
+++ b/pyre/pyre-wasm-runner/src/main.rs
@@ -931,6 +931,7 @@ fn run(module_path: &Path, source: &str, script: &Path) -> Result<i32> {
                 "qmut_deps_entry_bridge",
                 "qmut_deps_blackhole_arm",
                 "retrace_close_resumed",
+                "guard_resume_bridge_no_handoff",
             ];
             let mut parts = Vec::new();
             for (i, lbl) in labels.iter().enumerate() {


### PR DESCRIPTION
`compile.py handle_fail` is an if/else — a guard that `must_compile` traces a bridge, one that does not resumes in the blackhole — and the bridge starts **at the guard**: `rebuild_state_after_failure` rebuilds the frames and `setup_resume_at_op(pc)` puts each back at its own position before `interpret()` continues.

majit ran **both**. The blackhole walked to the next merge point and the bridge was recorded from *there*, so everything the walk ran to get there — the tail of the opcode the guard sits inside — could not be in the bridge. The first failure ran it; every later one jumped into the bridge and skipped it.

## What this does

- **`trace_jitcode_at_resume_position`** (`pyjitpl/dispatch.rs`) — seeds a `MIFrame`'s register file from the guard's decoded resume data and starts the walk at the guard's jitcode pc. Modelled on `trace_jitcode_from_merge_point`, not on `..._with_args_and_runtime` (`setup_call` resets `pc` to 0).
- **`JitState::trace_from_guard_resume_position`** — declining default, implemented by the `#[jit_interp]` macro. No new codegen was needed: the entry is generic over the sym, so the macro impl forwards.
- **`back_edge_internal`** takes it before the blackhole and returns through the `jit_merge_point!` hook's own single-pass handoff, in that hook's order.
- The abort tail of `trace_jitcode_with_args_and_runtime` is extracted as `publish_walk_abort_handoff` and shared by both entries.

## Declines, all sited before the walk

Once the walk runs, the tail has happened, so handing the same guard to the blackhole would apply it twice. Every decline therefore precedes it: no dispatch jitcode; a frame naming another jitcode; a register file that cannot be seeded (length mismatch, `Virtual`, `Unassigned`); or **a guard carrying pending fields**.

That last one is a real gap this work uncovered. `resume.py _prepare_pendingfields` replays through `execute_and_record` — `ResumeDataBoxReader.setfield` calls `metainterp.execute_setfield_gc`, which applies the write to the heap *and* records it. majit's `replay_pending_fields` is symbolic-only; the applying half was the blackhole's. Entering at the guard skips the blackhole, so the interpreter resumed against a heap holding a committed `size` with a null chain — a SIGSEGV, reproduced on `pi.jinseo`. Declining keeps those guards on the blackhole arm, where they were already served; executing the replay for real is separate work.

A decline falls through to the blackhole arm, whose own green-pc bridge **keeps** the narrow tail gate — that gate now guards the fallback, which still has the gap.

## Two adjacent fixes it needed

- **`single_pass_ref_scalar_values`** — `collect_scalar_state_field_values` is int+float only. The `jit_merge_point!` hook never needed the refs because the interpreter kept them current; a compiled run that exits through a guard leaves native `state` at its trace-start image, so here the walk's refs are the only current copy. (The abort path already stashed `ref_scalar_values`; that asymmetry was the clue.)
- **The abort handoff gate** in `merge_point` skipped bridges because guard-failure recovery "owns a separate blackhole resume path below `back_edge_internal`". A bridge entered at the guard has no such resume, so the gate gained `|| bridge_entered_at_guard_resume`.

## Test

`jit_interp_bridge_drops_opcode_tail`'s counts hold whether or not a guard bridges — declining keeps the residual call running too, which is how the narrow gate made it pass. It now counts bridges through a new `JitDriver::set_on_compile_bridge` passthrough and asserts the warm run built one. Verified to fail when the new entry is disabled.

## Measured

- majit gate: 47 test binaries, 0 failures; all 13 `#[jit_interp]` examples green.
- aheui corpus: 69 programs agree with `--no-jit` across four band arms; 4 not graded (no-jit does not finish); 1 differs only in output length under the nursery limit and is prefix-identical.
- `logo`: 996310 bytes / exit 42 / md5 `7fcdbfff0af449c4283c008e3ca317ce`; its one bridge now comes from the new entry.
- `undefined/2steps-reflect`: jit-vs-interpreter **39x → 3.9x**.
- `guard_resume_bridge_no_handoff` (the new mc_diag slot for a walk that left no resume handoff — a defect, not a cost) reads 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NLDxh1mE6nALnJFaCZNoJ