### PR TITLE
socket.ioctl, if_nameindex over IP Helper, _locale.getencoding, the legacy Windows filesystem codec, and 13 posix interpreter-release guards

### DIFF
--- a/pyre/pyre-interpreter/Cargo.toml
+++ b/pyre/pyre-interpreter/Cargo.toml
@@ -108,6 +108,8 @@ windows-sys = { version = "0.61", features = [
     "Win32_Foundation",
     "Win32_Globalization",
     "Win32_Media_Audio",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
     "Win32_Networking_WinSock",
     "Win32_Storage_FileSystem",
     "Win32_Security",

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -17360,16 +17360,16 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
     // The console stream is a host-console type, so a sandbox build — which
     // compiles it out — keeps the plain `FileIO` construction.
     #[cfg(all(windows, feature = "host_env", not(feature = "sandbox")))]
-    let raw_type = {
+    let (raw_type, console) = {
         let file = pyre_object::gc_roots::shadow_stack_get(file_slot);
         if crate::module::_io::winconsoleio::pyio_get_console_type(file) != '\0' {
-            crate::module::_io::windows_console_io_type()
+            (crate::module::_io::windows_console_io_type(), true)
         } else {
-            crate::module::_io::fileio_type()
+            (crate::module::_io::fileio_type(), false)
         }
     };
     #[cfg(not(all(windows, feature = "host_env", not(feature = "sandbox"))))]
-    let raw_type = crate::module::_io::fileio_type();
+    let (raw_type, console) = (crate::module::_io::fileio_type(), false);
     let raw = crate::call::call_function_impl_result(
         raw_type,
         &[
@@ -17445,12 +17445,20 @@ pub fn builtin_open(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError>
             return Ok(pyre_object::gc_roots::shadow_stack_get(buffer_slot));
         }
 
-        // This native open call does not add a Python frame between the user
-        // and `_io.text_encoding`; one frame of warning stack depth is enough.
-        let resolved_encoding = crate::module::_io::text_encoding(
-            pyre_object::gc_roots::shadow_stack_get(encoding_slot),
-            1,
-        )?;
+        // `_open` writes `encoding = "utf-8"` in the same step that picks the
+        // console class, ahead of the argument the caller gave: a console
+        // stream reports no other codec, and never counts as relying on the
+        // default one.  Everything else goes through `_io.text_encoding`, and
+        // this native open call adds no Python frame between the user and it,
+        // so one frame of warning stack depth is enough.
+        let resolved_encoding = if console {
+            w_str_new("utf-8")
+        } else {
+            crate::module::_io::text_encoding(
+                pyre_object::gc_roots::shadow_stack_get(encoding_slot),
+                1,
+            )?
+        };
         pyre_object::gc_roots::pin_root(resolved_encoding);
         let resolved_encoding_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
         let wrapper = crate::call::call_function_impl_result(

--- a/pyre/pyre-interpreter/src/gateway.rs
+++ b/pyre/pyre-interpreter/src/gateway.rs
@@ -1612,6 +1612,51 @@ pub fn fsencode_os_str(name: &std::ffi::OsStr) -> Vec<u8> {
     }
 }
 
+/// A path argument the caller spelled as `bytes`, in the units the
+/// interpreter carries a name in.
+///
+/// `path_converter` decodes such an argument with `PyUnicode_DecodeFSDefault`
+/// and keeps only the wide string it produced, so the code page pair
+/// `sys._enablelegacywindowsfsencoding` installs is read here, at the
+/// boundary, and never again downstream: everything past this point — the
+/// stored `co_filename`, the `wide_path` each syscall takes — holds the one
+/// spelling a `str` argument already arrives in.  The two spellings coincide
+/// outside that mode, where the bytes are their own answer.
+pub fn fs_arg_bytes(data: Vec<u8>) -> Result<Vec<u8>, crate::PyError> {
+    #[cfg(windows)]
+    if crate::typedef::legacy_windows_fs_encoding() {
+        return crate::unicodehelper_win32::decode_code_page(
+            windows_sys::Win32::Globalization::CP_ACP,
+            &data,
+            "replace",
+            true,
+        )
+        .map(|(text, _)| text.as_bytes().to_vec());
+    }
+    Ok(data)
+}
+
+/// [`fs_arg_bytes`]'s other direction: a host name handed back to a caller
+/// that asked for its path in `bytes`, which each of those sites spells with
+/// `PyUnicode_EncodeFSDefault` over the name it read as wide.
+///
+/// Total, like [`fsencode_os_str`]: the name came from the host, and the
+/// substitution `replace` makes is the answer rather than a failure.  Only a
+/// Win32 error ends the encode, and there is no caller here to report one to,
+/// so the interpreter's own spelling stands in for it.
+pub fn fs_result_bytes(data: &[u8]) -> Vec<u8> {
+    #[cfg(windows)]
+    if crate::typedef::legacy_windows_fs_encoding()
+        && let Ok(bytes) = crate::unicodehelper_win32::encode_code_page_replace(
+            windows_sys::Win32::Globalization::CP_ACP,
+            &crate::typedef::fsdecode_wtf8_total(data),
+        )
+    {
+        return bytes;
+    }
+    data.to_vec()
+}
+
 /// [`fsencode_os_str`]'s other direction: the host name filesystem bytes
 /// spell, for a caller that has to hand them to an API taking an `OsStr`.
 pub fn os_string_from_fs_bytes(data: &[u8]) -> std::ffi::OsString {
@@ -1763,7 +1808,7 @@ fn path_or_fd_w(
             // `bytearray` is now turned away by the same message every other
             // rejected type gets.
             (
-                pyre_object::bytesobject::w_bytes_data(obj).to_vec(),
+                fs_arg_bytes(pyre_object::bytesobject::w_bytes_data(obj).to_vec())?,
                 obj_slot,
                 -1,
             )
@@ -1845,7 +1890,7 @@ fn path_or_fd_w(
             // `__fspath__`; a `bytearray` is a readable buffer but not a path.
             if pyre_object::bytesobject::is_bytes(result) {
                 (
-                    pyre_object::bytesobject::w_bytes_data(result).to_vec(),
+                    fs_arg_bytes(pyre_object::bytesobject::w_bytes_data(result).to_vec())?,
                     result_slot,
                     -1,
                 )

--- a/pyre/pyre-interpreter/src/importing.rs
+++ b/pyre/pyre-interpreter/src/importing.rs
@@ -3138,6 +3138,12 @@ pub fn set_runtime_flags(flags: &crate::launch_env::LaunchFlags) {
     SYS_ISOLATED.store(flags.isolated, Ordering::Relaxed);
     SYS_DEV_MODE.store(flags.dev_mode, Ordering::Relaxed);
     SYS_WARN_DEFAULT_ENCODING.store(flags.warn_default_encoding, Ordering::Relaxed);
+    // The filesystem codec is picked in `preconfig_read`, ahead of every
+    // import, so `os`'s own `_fscodec` closes over the legacy pair rather than
+    // the one `sys._enablelegacywindowsfsencoding` leaves it holding.
+    #[cfg(windows)]
+    crate::typedef::LEGACY_WINDOWS_FS_ENCODING
+        .store(flags.legacy_windows_fs_encoding, Ordering::Relaxed);
     SYS_UTF8_MODE.store(flags.utf8_mode.unwrap_or(0), Ordering::Relaxed);
     SYS_SAFE_PATH.store(flags.safe_path, Ordering::Relaxed);
     SYS_OPTIMIZE.store(flags.optimize, Ordering::Relaxed);

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -168,6 +168,12 @@ fn locale_implies_utf8_mode() -> bool {
 pub struct PreConfigError(pub &'static str);
 
 fn resolve_utf8_mode(flags: &LaunchFlags) -> Result<i64, PreConfigError> {
+    // `preconfig_init_utf8_mode` opens with this, ahead of every other source:
+    // the legacy filesystem codec and UTF-8 mode cannot both be on, and the
+    // codec turns the mode off whether `-X utf8` or `PYTHONUTF8` asked for it.
+    if flags.legacy_windows_fs_encoding {
+        return Ok(0);
+    }
     if let Some(value) = flags.utf8_mode {
         return Ok(value);
     }
@@ -242,6 +248,17 @@ fn fold_presence_flag(flags: &LaunchFlags, set: bool, name: &str) -> bool {
 /// Fold the environment over the options a command line named. An embedding
 /// without a command line passes `LaunchFlags::default()`.
 pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
+    // Read in `preconfig_read`, so it takes the same integer fold as the
+    // other variables there rather than the presence one: `=0` leaves the
+    // filesystem codec on the PEP 529 pair.
+    #[cfg(windows)]
+    {
+        flags.legacy_windows_fs_encoding = fold_int_flag(
+            &flags,
+            flags.legacy_windows_fs_encoding,
+            "PYTHONLEGACYWINDOWSFSENCODING",
+        );
+    }
     flags.utf8_mode = Some(resolve_utf8_mode(&flags)?);
     flags.optimize = resolve_optimize(&flags);
     // Which of the two shapes a name takes is per-variable, not a category:
@@ -261,17 +278,6 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
         flags.warn_default_encoding,
         "PYTHONWARNDEFAULTENCODING",
     );
-    // Read in `preconfig_read`, so it takes the same integer fold as the
-    // other variables there rather than the presence one: `=0` leaves the
-    // filesystem codec on the PEP 529 pair.
-    #[cfg(windows)]
-    {
-        flags.legacy_windows_fs_encoding = fold_int_flag(
-            &flags,
-            flags.legacy_windows_fs_encoding,
-            "PYTHONLEGACYWINDOWSFSENCODING",
-        );
-    }
     flags.stdio_encoding = if flags.ignore_environment {
         None
     } else {

--- a/pyre/pyre-interpreter/src/launch_env.rs
+++ b/pyre/pyre-interpreter/src/launch_env.rs
@@ -25,6 +25,10 @@ pub struct LaunchFlags {
     pub isolated: bool,
     pub dev_mode: bool,
     pub warn_default_encoding: bool,
+    /// PYTHONLEGACYWINDOWSFSENCODING, which no command-line option spells.
+    /// Read only on Windows, the only platform whose `PyPreConfig` carries it,
+    /// and left false everywhere else.
+    pub legacy_windows_fs_encoding: bool,
     /// `None` until [`finalize`] resolves it; a command line that named
     /// `-X utf8` carries that value through instead.
     pub utf8_mode: Option<i64>,
@@ -83,6 +87,7 @@ pub const LAUNCH_ENV_NAMES: &[&str] = &[
     "PYTHONDONTWRITEBYTECODE",
     "PYTHONUTF8",
     "PYTHONWARNDEFAULTENCODING",
+    "PYTHONLEGACYWINDOWSFSENCODING",
     "PYTHONWARNINGS",
     "PYTHONIOENCODING",
     "LC_ALL",
@@ -256,6 +261,17 @@ pub fn finalize(mut flags: LaunchFlags) -> Result<LaunchFlags, PreConfigError> {
         flags.warn_default_encoding,
         "PYTHONWARNDEFAULTENCODING",
     );
+    // Read in `preconfig_read`, so it takes the same integer fold as the
+    // other variables there rather than the presence one: `=0` leaves the
+    // filesystem codec on the PEP 529 pair.
+    #[cfg(windows)]
+    {
+        flags.legacy_windows_fs_encoding = fold_int_flag(
+            &flags,
+            flags.legacy_windows_fs_encoding,
+            "PYTHONLEGACYWINDOWSFSENCODING",
+        );
+    }
     flags.stdio_encoding = if flags.ignore_environment {
         None
     } else {

--- a/pyre/pyre-interpreter/src/module/_io/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_io/mod.rs
@@ -1350,7 +1350,7 @@ pub(crate) fn text_encoding(
     }
     if crate::importing::warn_default_encoding_flag() {
         crate::warn::warn_category(
-            "'encoding' argument not specified.",
+            "'encoding' argument not specified",
             "EncodingWarning",
             stacklevel + 1,
         )?;

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -415,11 +415,14 @@ impl W_TextIOWrapper {
         Ok(())
     }
 
-    /// `encoding="locale"` selects the current locale's encoding; the sandbox
-    /// and default environment resolve that to UTF-8.
+    /// `encoding="locale"` selects the current locale's encoding, which is
+    /// what `_Py_GetLocaleEncodingObject` answers for it and for the
+    /// unspecified argument that resolves to it.  A sandbox build has no host
+    /// locale to ask and reads utf-8, the answer a `_Py_FORCE_UTF8_LOCALE`
+    /// build gives without asking one.
     fn resolve_locale_encoding(encoding: String) -> String {
         if encoding == "locale" {
-            "utf-8".to_string()
+            crate::module::_locale::interp_locale::locale_encoding()
         } else {
             encoding
         }
@@ -1056,8 +1059,23 @@ impl W_TextIOWrapper {
         self.w_buffer = PY_NULL;
         pyre_object::gc_hook::try_gc_write_barrier(self as *mut Self as *mut u8);
 
+        // An unspecified `encoding` reads the locale's, unless UTF-8 mode has
+        // already answered the question.  `_io.text_encoding` is not on this
+        // path - a direct `TextIOWrapper(...)` call reaches the constructor
+        // itself - so the warning that argument's absence carries is raised
+        // here, at this frame.
+        if unsafe { pyre_object::is_none(encoding) }
+            && crate::importing::warn_default_encoding_flag()
+        {
+            crate::warn::warn_category("'encoding' argument not specified", "EncodingWarning", 1)?;
+        }
+        let unspecified = if crate::importing::utf8_mode_flag() != 0 {
+            "utf-8"
+        } else {
+            "locale"
+        };
         let encoding =
-            Self::resolve_locale_encoding(Self::checked_text0(encoding, "utf-8", "encoding")?);
+            Self::resolve_locale_encoding(Self::checked_text0(encoding, unspecified, "encoding")?);
         let errors = Self::checked_text0(errors, "strict", "errors")?;
         Self::io_check_errors(&errors)?;
         let newline_value = Self::unwrap_newline(newline)?;

--- a/pyre/pyre-interpreter/src/module/_io/textio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/textio.rs
@@ -1053,6 +1053,26 @@ impl W_TextIOWrapper {
         #[default(pyre_object::w_bool_from(false))] line_buffering: PyObjectRef,
         #[default(pyre_object::w_bool_from(false))] write_through: PyObjectRef,
     ) -> Result<(), crate::PyError> {
+        // Every argument is converted before the body runs, in the order the
+        // signature gives them: `encoding` and `newline` are accepted only as
+        // `str` or `None`, and the two flags are truth-tested.  3.14's
+        // constructor uses the `bool` converter for those, unlike
+        // `reconfigure`'s `int` one — an object with `__bool__` but no
+        // `__index__` is accepted here — and a `__bool__` that raises ends
+        // the call before `self->ok = 0`, leaving a stream that was already
+        // open still open.
+        let unspecified = if crate::importing::utf8_mode_flag() != 0 {
+            "utf-8"
+        } else {
+            "locale"
+        };
+        let encoding_text = Self::checked_text0(encoding, unspecified, "encoding")?;
+        if !unsafe { pyre_object::is_none(newline) || pyre_object::is_str(newline) } {
+            return Err(crate::PyError::type_error("illegal newline type"));
+        }
+        let line_buffering = crate::baseobjspace::is_true(line_buffering)?;
+        let write_through = crate::baseobjspace::is_true(write_through)?;
+
         // PyPy starts every initialization attempt in STATE_ZERO.  A failed
         // reinitialization must leave all I/O operations uninitialized.
         self.state = STATE_ZERO;
@@ -1069,24 +1089,11 @@ impl W_TextIOWrapper {
         {
             crate::warn::warn_category("'encoding' argument not specified", "EncodingWarning", 1)?;
         }
-        let unspecified = if crate::importing::utf8_mode_flag() != 0 {
-            "utf-8"
-        } else {
-            "locale"
-        };
-        let encoding =
-            Self::resolve_locale_encoding(Self::checked_text0(encoding, unspecified, "encoding")?);
         let errors = Self::checked_text0(errors, "strict", "errors")?;
         Self::io_check_errors(&errors)?;
         let newline_value = Self::unwrap_newline(newline)?;
+        let encoding = Self::resolve_locale_encoding(encoding_text);
         let codec = Self::lookup_text_codec(&encoding)?;
-        // 3.14's constructor uses the `bool` Argument Clinic converter (truth
-        // testing), unlike `reconfigure`'s `int` converter — an object with
-        // `__bool__` but no `__index__` is accepted here.  Argument parsing
-        // runs before the body, so an object whose `__bool__` raises leaves
-        // the stream unattached rather than half filled in.
-        let line_buffering = crate::baseobjspace::is_true(line_buffering)?;
-        let write_through = crate::baseobjspace::is_true(write_through)?;
 
         self.attach_buffer(
             buffer,

--- a/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
+++ b/pyre/pyre-interpreter/src/module/_io/winconsoleio.rs
@@ -235,7 +235,12 @@ impl W_WindowsConsoleIO {
                     "Cannot use closefd=False with file name",
                 ));
             }
-            let path = crate::gateway::fsencode_path_w(name_obj)?;
+            // `closefd` is whatever the caller passed, so `is_true` can run a
+            // `__bool__` and a moving collection with it: the name comes back
+            // out of its slot rather than from the borrow taken above.
+            let path = crate::gateway::fsencode_path_w(pyre_object::gc_roots::shadow_stack_get(
+                name_slot,
+            ))?;
             let os_name = crate::gateway::os_string_from_fs_bytes(&path.as_bytes);
             let mut kind = host_nt::console_type_from_name(&os_name.to_string_lossy());
             if kind == 'x' {
@@ -293,8 +298,10 @@ impl W_WindowsConsoleIO {
         // `W_IOBase.__init__` installs the per-instance closed flag.  A
         // successful second `__init__` reopens the same object, so its base
         // flush/close methods must observe the new live state as well as this
-        // payload's fd-backed `closed` property.
-        super::iobase_set_internal_closed(this.self_obj(), false)?;
+        // payload's fd-backed `closed` property.  Storing `name` allocates
+        // the instance dict, so the receiver is read back out of its slot
+        // rather than taken from the borrow held across that store.
+        super::iobase_set_internal_closed(Self::from_slot(self_slot).self_obj(), false)?;
         Ok(())
     }
 

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -20,6 +20,48 @@ type CollationArg = Vec<u16>;
 #[cfg(not(windows))]
 type CollationArg = std::ffi::CString;
 
+/// `_Py_GetLocaleEncoding` — the codeset the active `LC_CTYPE` names.
+///
+/// `locale.py` takes `_locale.getencoding` when the module carries it and
+/// falls back to `sys.getfilesystemencoding()` when it does not, and the two
+/// are different answers wherever the filesystem encoding is not the locale
+/// one — every Windows host, where PEP 529 makes the filesystem utf-8.
+#[cfg(all(windows, not(feature = "sandbox")))]
+fn locale_encoding() -> String {
+    // The active ANSI code page, spelled `cp<n>` whatever it is: code page
+    // 65001 answers `cp65001`, not `utf-8`.
+    format!("cp{}", unsafe {
+        windows_sys::Win32::Globalization::GetACP()
+    })
+}
+
+#[cfg(all(
+    unix,
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(any(target_os = "ios", target_os = "android", target_os = "redox"))
+))]
+fn locale_encoding() -> String {
+    match rustpython_host_env::locale::nl_langinfo_codeset() {
+        // An empty codeset answers utf-8: `nl_langinfo` returns one on macOS
+        // when the `LC_CTYPE` locale is not supported.
+        Some(bytes) if !bytes.is_empty() => String::from_utf8_lossy(&bytes).into_owned(),
+        _ => "utf-8".to_string(),
+    }
+}
+
+#[cfg(not(any(all(windows, not(feature = "sandbox")), all(
+    unix,
+    feature = "host_env",
+    not(feature = "sandbox"),
+    not(any(target_os = "ios", target_os = "android", target_os = "redox"))
+))))]
+fn locale_encoding() -> String {
+    // No host locale to ask, which is the answer `_Py_FORCE_UTF8_LOCALE`
+    // builds give without asking one.
+    "utf-8".to_string()
+}
+
 fn collation_arg(obj: pyre_object::PyObjectRef) -> Result<CollationArg, crate::PyError> {
     let text = crate::baseobjspace::str_utf8_w(obj)?.to_string();
     #[cfg(windows)]
@@ -599,12 +641,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             1,
         ),
     );
+    // `_locale.getencoding` — `_Py_GetLocaleEncodingObject`.
     crate::module_ns_store(
         ns,
         "getencoding",
         crate::make_builtin_function_with_arity(
             "getencoding",
-            |_| Ok(pyre_object::w_str_new("utf-8")),
+            |_| Ok(pyre_object::w_str_new(&locale_encoding())),
             0,
         ),
     );

--- a/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
+++ b/pyre/pyre-interpreter/src/module/_locale/interp_locale.rs
@@ -26,8 +26,11 @@ type CollationArg = std::ffi::CString;
 /// falls back to `sys.getfilesystemencoding()` when it does not, and the two
 /// are different answers wherever the filesystem encoding is not the locale
 /// one — every Windows host, where PEP 529 makes the filesystem utf-8.
+///
+/// `_io.TextIOWrapper` reads it as well, for the `encoding="locale"` its
+/// unspecified argument resolves to.
 #[cfg(all(windows, not(feature = "sandbox")))]
-fn locale_encoding() -> String {
+pub(crate) fn locale_encoding() -> String {
     // The active ANSI code page, spelled `cp<n>` whatever it is: code page
     // 65001 answers `cp65001`, not `utf-8`.
     format!("cp{}", unsafe {
@@ -41,7 +44,7 @@ fn locale_encoding() -> String {
     not(feature = "sandbox"),
     not(any(target_os = "ios", target_os = "android", target_os = "redox"))
 ))]
-fn locale_encoding() -> String {
+pub(crate) fn locale_encoding() -> String {
     match rustpython_host_env::locale::nl_langinfo_codeset() {
         // An empty codeset answers utf-8: `nl_langinfo` returns one on macOS
         // when the `LC_CTYPE` locale is not supported.
@@ -56,7 +59,7 @@ fn locale_encoding() -> String {
     not(feature = "sandbox"),
     not(any(target_os = "ios", target_os = "android", target_os = "redox"))
 ))))]
-fn locale_encoding() -> String {
+pub(crate) fn locale_encoding() -> String {
     // No host locale to ask, which is the answer `_Py_FORCE_UTF8_LOCALE`
     // builds give without asking one.
     "utf-8".to_string()

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -3488,10 +3488,41 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 socket_init_state(obj, fd, family, ty, proto);
                 return Ok(pyre_object::w_none());
             }
+            let fileno_obj = fileno_obj.unwrap();
+            // A socket handed over by `share` arrives as the bytes of the
+            // `WSAPROTOCOL_INFOW` that wrote it, and re-opening it is what
+            // `WSASocketW` under `FROM_PROTOCOL_INFO` does.  The three
+            // arguments the caller gave are not read at all: the structure
+            // names the family, type and protocol itself, so `fromshare`
+            // reaches this with `socket(0, 0, 0, info)`.
+            #[cfg(all(windows, feature = "host_env"))]
+            if unsafe { pyre_object::is_bytes(fileno_obj) } {
+                // Copied out before the interpreter is released: the borrow
+                // would not survive a collection running in another thread.
+                let data = unsafe { pyre_object::bytesobject::w_bytes_data(fileno_obj) }.to_vec();
+                let size = rustpython_host_env::socket::protocol_info_size();
+                if data.len() != size {
+                    return Err(crate::PyError::value_error(format!(
+                        "socket descriptor string has wrong size, should be {size} bytes."
+                    )));
+                }
+                let shared = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    rustpython_host_env::socket::socket_from_share_data(&data)
+                }
+                .map_err(socket_io_err)?;
+                socket_init_state(
+                    obj,
+                    shared.raw,
+                    shared.family,
+                    shared.socket_type,
+                    shared.protocol,
+                );
+                return Ok(pyre_object::w_none());
+            }
             // `interp_socket.py:253-265` — wrap an existing fd.  A float
             // fileno is a TypeError, a negative fd a ValueError, and any
             // -1 family/type/proto is derived from the descriptor itself.
-            let fileno_obj = fileno_obj.unwrap();
             if unsafe { pyre_object::is_float(fileno_obj) } {
                 return Err(crate::PyError::type_error(
                     "integer argument expected, got float",
@@ -5046,6 +5077,35 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 Some(returned) => Ok(pyre_object::w_int_new(i64::from(returned))),
                 None => Err(socket_last_error()),
             }
+        }),
+    ) };
+
+    // `sock_share` sits beside `ioctl`, published on the same Windows-only
+    // footing: `WSADuplicateSocketW` writes a `WSAPROTOCOL_INFOW` describing
+    // the socket for the process named, and the bytes of that structure are
+    // the whole answer.  `socket.py` grows `fromshare` as soon as the method
+    // exists, and hands the blob straight back to the constructor.
+    #[cfg(all(windows, feature = "host_env"))]
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+        ns,
+        "share",
+        crate::make_builtin_function("share", |args| {
+            // `METH_O`, so a wrong count is reported by the call machinery
+            // rather than by a converter naming the method.
+            if args.len() != 2 {
+                return Err(crate::PyError::type_error(format!(
+                    "function takes exactly 1 argument ({} given)",
+                    args.len().saturating_sub(1)
+                )));
+            }
+            let fd = socket_fd(args[0])?;
+            let process_id = masked_ulong_w(args[1])?;
+            let info = {
+                let _blocked = crate::module::thread::before_external_block();
+                rustpython_host_env::socket::share_socket(fd, process_id)
+            }
+            .map_err(socket_io_err)?;
+            Ok(pyre_object::w_bytes_from_bytes(&info))
         }),
     ) };
 

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -1620,21 +1620,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "if_nameindex",
             crate::make_builtin_function_with_arity(
                 "if_nameindex",
-                |_| {
-                    let entries = rustpython_host_env::socket::if_nameindex()
-                        .map_err(interface_io_error)?;
-                    Ok(pyre_object::w_list_new(
-                        entries
-                            .into_iter()
-                            .map(|(index, name)| {
-                                pyre_object::w_tuple_new(vec![
-                                    pyre_object::w_int_new(index as i64),
-                                    pyre_object::w_str_new(&name),
-                                ])
-                            })
-                            .collect(),
-                    ))
-                },
+                |_| windows_if_nameindex(),
                 0,
             ),
         );
@@ -2680,6 +2666,140 @@ fn socket_get_so_protocol(_fd: rffi::Socket) -> Result<libc::c_int, crate::PyErr
 /// length that is not name.
 #[cfg(unix)]
 const SUN_PATH_OFFSET: usize = core::mem::offset_of!(libc::sockaddr_un, sun_path);
+
+/// `NDIS_IF_MAX_STRING_SIZE` (`ifdef.h`) — the room
+/// `ConvertInterfaceLuidToNameW` is given for a name.
+#[cfg(all(windows, feature = "host_env"))]
+const NDIS_IF_MAX_STRING_SIZE: usize = 255;
+
+/// The Windows arm of `socket_if_nameindex`: `GetIfTable2Ex` for the table,
+/// then `ConvertInterfaceLuidToNameW` per row, appended to a list built empty.
+///
+/// `rustpython_host_env::socket::if_nameindex` walks the same table but hands
+/// each name back through `String::from_utf16_lossy`, which spends an unpaired
+/// surrogate on U+FFFD; `Py_BuildValue("Iu", ...)` keeps what the call wrote,
+/// so the wide buffer is read as WTF-8 here instead.
+#[cfg(all(windows, feature = "host_env"))]
+fn windows_if_nameindex() -> Result<pyre_object::PyObjectRef, crate::PyError> {
+    use windows_sys::Win32::Foundation::NO_ERROR;
+    use windows_sys::Win32::NetworkManagement::IpHelper as ip;
+
+    // Both calls answer with a status of their own instead of setting the last
+    // error, and that status is the one reported.
+    let win32 = |status| interface_io_error(std::io::Error::from_raw_os_error(status as i32));
+
+    let mut table: *mut ip::MIB_IF_TABLE2 = core::ptr::null_mut();
+    let status = unsafe { ip::GetIfTable2Ex(ip::MibIfTableRaw, &mut table) };
+    if status != NO_ERROR {
+        return Err(win32(status));
+    }
+    // The list is built empty and appended to, so no freshly boxed row waits
+    // in a plain vector while the next allocation runs.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let list_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(pyre_object::w_list_new_empty());
+    let outcome = (|| {
+        for index in 0..unsafe { (*table).NumEntries } as usize {
+            let row = unsafe { &*(*table).Table.as_ptr().add(index) };
+            let mut name = [0u16; NDIS_IF_MAX_STRING_SIZE + 1];
+            let status = unsafe {
+                ip::ConvertInterfaceLuidToNameW(&row.InterfaceLuid, name.as_mut_ptr(), name.len())
+            };
+            if status != NO_ERROR {
+                return Err(win32(status));
+            }
+            let end = name.iter().position(|&unit| unit == 0).unwrap_or(name.len());
+            let entry = pyre_object::w_tuple_new(vec![
+                pyre_object::w_int_new(i64::from(row.InterfaceIndex)),
+                pyre_object::w_str_from_wtf8(rustpython_wtf8::Wtf8Buf::from_wide(&name[..end])),
+            ]);
+            unsafe {
+                pyre_object::listobject::w_list_append(
+                    pyre_object::gc_roots::shadow_stack_get(list_slot),
+                    entry,
+                )
+            };
+        }
+        Ok(())
+    })();
+    // `FreeMibTable` runs whichever way the walk ended, as it does there.
+    unsafe { ip::FreeMibTable(table.cast()) };
+    outcome?;
+    Ok(pyre_object::gc_roots::shadow_stack_get(list_slot))
+}
+
+/// `k` — the low `unsigned long` of an integer, which is what
+/// `PyArg_ParseTuple` stores for that code: the conversion is
+/// `PyLong_AsUnsignedLongMask`, so a command outside the range wraps into it
+/// rather than being reported, and only a value with no `__index__` at all is
+/// turned away.
+#[cfg(windows)]
+fn ioctl_command_w(obj: pyre_object::PyObjectRef) -> Result<u32, crate::PyError> {
+    if !unsafe { pyre_object::pyobject::is_int_or_long(obj) }
+        && unsafe { crate::baseobjspace::lookup(obj, "__index__") }.is_none()
+    {
+        return Err(crate::PyError::type_error(format!(
+            "ioctl() argument 1 must be int, not {}",
+            crate::type_methods::clinic_arg_type_name(obj)
+        )));
+    }
+    Ok(crate::baseobjspace::truncatedint_w(obj)? as u32)
+}
+
+/// `I` — the low `unsigned int`, masked the same way and reported with the
+/// message `PyNumber_Index` raises rather than one naming the position.
+#[cfg(windows)]
+fn ioctl_value_w(obj: pyre_object::PyObjectRef) -> Result<u32, crate::PyError> {
+    if !unsafe { pyre_object::pyobject::is_int_or_long(obj) }
+        && unsafe { crate::baseobjspace::lookup(obj, "__index__") }.is_none()
+    {
+        return Err(crate::PyError::type_error(format!(
+            "'{}' object cannot be interpreted as an integer",
+            crate::type_methods::arg_type_name(obj)
+        )));
+    }
+    Ok(crate::baseobjspace::truncatedint_w(obj)? as u32)
+}
+
+/// `(kkk)` — the three fields `tcp_keepalive` carries.  A parenthesised group
+/// reads its argument through `PySequence_Check` and `PySequence_GetItem`, so
+/// a list or a range serves as well as a tuple, and it reports the two
+/// failures differently: a wrong length names the length, anything that is
+/// not a sequence names the type.
+#[cfg(windows)]
+fn ioctl_keepalive_w(obj: pyre_object::PyObjectRef) -> Result<[u32; 3], crate::PyError> {
+    // `PySequence_Check` guards the group, with `str` turned away beside the
+    // objects that answer no subscript at all: a three-character string is a
+    // sequence of length three and would otherwise be read as one.
+    let is_sequence = !unsafe { pyre_object::is_dict(obj) }
+        && !unsafe { pyre_object::is_str(obj) }
+        && unsafe { crate::baseobjspace::lookup(obj, "__getitem__") }.is_some();
+    if !is_sequence {
+        return Err(crate::PyError::type_error(format!(
+            "ioctl() argument 2 must be 3-item tuple, not {}",
+            crate::type_methods::clinic_arg_type_name(obj)
+        )));
+    }
+    let items = crate::baseobjspace::unpackiterable(obj, -1)?;
+    if items.len() != 3 {
+        return Err(crate::PyError::type_error(format!(
+            "ioctl() argument 2 must be tuple of length 3, not {}",
+            items.len()
+        )));
+    }
+    // Reading one item can run `__index__`, so all three are published before
+    // the first conversion rather than held as a plain vector across it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let base = pyre_object::gc_roots::shadow_stack_len();
+    for &item in &items {
+        pyre_object::gc_roots::pin_root(item);
+    }
+    let mut values = [0u32; 3];
+    for (index, value) in values.iter_mut().enumerate() {
+        *value = ioctl_value_w(pyre_object::gc_roots::shadow_stack_get(base + index))?;
+    }
+    Ok(values)
+}
 
 /// One `%X` conversion of the scan `setbdaddr` runs: blanks, an optional sign,
 /// an optional `0x` prefix, then hex digits accumulated into the `unsigned
@@ -4864,6 +4984,65 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 }
                 buf.truncate(sz as usize);
                 Ok(pyre_object::bytesobject::w_bytes_from_bytes(&buf))
+            }
+        }),
+    ) };
+
+    // `sock_ioctl` is published where `SIO_RCVALL` is defined, which is
+    // Windows.  It is `WSAIoctl` under a socket method, and the three commands
+    // it names are the ones whose input is a value rather than a buffer.
+    #[cfg(windows)]
+    unsafe { pyre_object::dictmultiobject::w_dict_setitem_str_no_proxy(
+        ns,
+        "ioctl",
+        crate::make_builtin_function("ioctl", |args| {
+            use windows_sys::Win32::Networking::WinSock as ws;
+
+            if args.len() != 3 {
+                return Err(crate::PyError::type_error(format!(
+                    "ioctl() takes exactly 2 arguments ({} given)",
+                    args.len().saturating_sub(1)
+                )));
+            }
+            let fd = socket_fd(args[0])?;
+            let cmd = ioctl_command_w(args[1])?;
+            let returned = match cmd {
+                ws::SIO_RCVALL | ws::SIO_LOOPBACK_FAST_PATH => {
+                    let value = ioctl_value_w(args[2])?;
+                    unsafe {
+                        rffi::wsa_ioctl(
+                            fd,
+                            cmd,
+                            (&raw const value).cast(),
+                            core::mem::size_of::<u32>() as u32,
+                        )
+                    }
+                }
+                ws::SIO_KEEPALIVE_VALS => {
+                    let [onoff, keepalivetime, keepaliveinterval] = ioctl_keepalive_w(args[2])?;
+                    let keepalive = ws::tcp_keepalive {
+                        onoff,
+                        keepalivetime,
+                        keepaliveinterval,
+                    };
+                    unsafe {
+                        rffi::wsa_ioctl(
+                            fd,
+                            cmd,
+                            (&raw const keepalive).cast(),
+                            core::mem::size_of::<ws::tcp_keepalive>() as u32,
+                        )
+                    }
+                }
+                _ => {
+                    return Err(crate::PyError::value_error(format!(
+                        "invalid ioctl command {cmd}"
+                    )));
+                }
+            };
+            match returned {
+                Some(returned) => Ok(pyre_object::w_int_new(i64::from(returned))),
+                None => Err(socket_last_error()),
             }
         }),
     ) };

--- a/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/interp_socket.rs
@@ -2728,37 +2728,36 @@ fn windows_if_nameindex() -> Result<pyre_object::PyObjectRef, crate::PyError> {
     Ok(pyre_object::gc_roots::shadow_stack_get(list_slot))
 }
 
-/// `k` — the low `unsigned long` of an integer, which is what
-/// `PyArg_ParseTuple` stores for that code: the conversion is
-/// `PyLong_AsUnsignedLongMask`, so a command outside the range wraps into it
-/// rather than being reported, and only a value with no `__index__` at all is
-/// turned away.
+/// `PyLong_AsUnsignedLongMask`: `PyNumber_Index` first, so `__index__`
+/// decides the value and `__int__` is never asked for one, and then the low
+/// bits of what it answered.  This is `ioctl`'s `I` code, the `k` code behind
+/// its `PyIndex_Check`, and the `unsigned_long(bitwise=True)` converter
+/// `share` reads its process id through — one width on a host where
+/// `unsigned int`, `unsigned long` and `DWORD` are all 32 bits.  Carrying no
+/// `PyIndex_Check` of its own, it names an object answering neither the way
+/// `PyNumber_Index` does rather than by giving the argument's position.
 #[cfg(windows)]
-fn ioctl_command_w(obj: pyre_object::PyObjectRef) -> Result<u32, crate::PyError> {
+fn masked_ulong_w(obj: pyre_object::PyObjectRef) -> Result<u32, crate::PyError> {
+    Ok(crate::baseobjspace::truncatedint_w(crate::baseobjspace::space_index(obj)?)? as u32)
+}
+
+/// `k` — [`masked_ulong_w`] behind a `PyIndex_Check` that reports the
+/// argument it was reading.  `converttuple` nests the position, so an item of
+/// the `(kkk)` group names itself as `argument 2, item 0`.
+#[cfg(windows)]
+fn ioctl_command_w(
+    obj: pyre_object::PyObjectRef,
+    argument: &str,
+) -> Result<u32, crate::PyError> {
     if !unsafe { pyre_object::pyobject::is_int_or_long(obj) }
         && unsafe { crate::baseobjspace::lookup(obj, "__index__") }.is_none()
     {
         return Err(crate::PyError::type_error(format!(
-            "ioctl() argument 1 must be int, not {}",
+            "ioctl() {argument} must be int, not {}",
             crate::type_methods::clinic_arg_type_name(obj)
         )));
     }
-    Ok(crate::baseobjspace::truncatedint_w(obj)? as u32)
-}
-
-/// `I` — the low `unsigned int`, masked the same way and reported with the
-/// message `PyNumber_Index` raises rather than one naming the position.
-#[cfg(windows)]
-fn ioctl_value_w(obj: pyre_object::PyObjectRef) -> Result<u32, crate::PyError> {
-    if !unsafe { pyre_object::pyobject::is_int_or_long(obj) }
-        && unsafe { crate::baseobjspace::lookup(obj, "__index__") }.is_none()
-    {
-        return Err(crate::PyError::type_error(format!(
-            "'{}' object cannot be interpreted as an integer",
-            crate::type_methods::arg_type_name(obj)
-        )));
-    }
-    Ok(crate::baseobjspace::truncatedint_w(obj)? as u32)
+    masked_ulong_w(obj)
 }
 
 /// `(kkk)` — the three fields `tcp_keepalive` carries.  A parenthesised group
@@ -2796,7 +2795,10 @@ fn ioctl_keepalive_w(obj: pyre_object::PyObjectRef) -> Result<[u32; 3], crate::P
     }
     let mut values = [0u32; 3];
     for (index, value) in values.iter_mut().enumerate() {
-        *value = ioctl_value_w(pyre_object::gc_roots::shadow_stack_get(base + index))?;
+        *value = ioctl_command_w(
+            pyre_object::gc_roots::shadow_stack_get(base + index),
+            &format!("argument 2, item {index}"),
+        )?;
     }
     Ok(values)
 }
@@ -5005,10 +5007,10 @@ fn init_socket_type(ns: pyre_object::PyObjectRef) {
                 )));
             }
             let fd = socket_fd(args[0])?;
-            let cmd = ioctl_command_w(args[1])?;
+            let cmd = ioctl_command_w(args[1], "argument 1")?;
             let returned = match cmd {
                 ws::SIO_RCVALL | ws::SIO_LOOPBACK_FAST_PATH => {
-                    let value = ioctl_value_w(args[2])?;
+                    let value = masked_ulong_w(args[2])?;
                     unsafe {
                         rffi::wsa_ioctl(
                             fd,

--- a/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
+++ b/pyre/pyre-interpreter/src/module/_socket/rsocket_rffi.rs
@@ -760,26 +760,51 @@ pub unsafe fn getsockopt(
     unsafe { ws::getsockopt(s, level, option, value.cast(), len) }
 }
 
-/// `SIO_TCP_SET_ACK_FREQUENCY`, which is what `TCP_QUICKACK` names here.
-/// It is an ioctl rather than a socket option, so `setsockopt` answers
-/// `WSAENOPROTOOPT` for it and the flag has to travel through `WSAIoctl`.
-/// Nothing reads it back: WinSock exposes no query for the current setting.
+/// `WSAIoctl` with an input value and no output buffer, which is the shape
+/// every command `sock_ioctl` takes is issued in.  Answers the `DWORD` the
+/// call reports as returned, or `None` with `WSAGetLastError` set.
+///
+/// # Safety
+/// `value` must address `len` initialised bytes for the duration of the call.
 #[cfg(windows)]
-pub unsafe fn set_ack_frequency(s: Socket, flag: libc::c_int) -> libc::c_int {
+pub unsafe fn wsa_ioctl(
+    s: Socket,
+    code: u32,
+    value: *const core::ffi::c_void,
+    len: u32,
+) -> Option<u32> {
     let mut returned: u32 = 0;
-    unsafe {
+    let result = unsafe {
         ws::WSAIoctl(
             s,
-            ws::SIO_TCP_SET_ACK_FREQUENCY,
-            (&raw const flag).cast(),
-            core::mem::size_of::<libc::c_int>() as u32,
+            code,
+            value,
+            len,
             core::ptr::null_mut(),
             0,
             &mut returned,
             core::ptr::null_mut(),
             None,
         )
-    }
+    };
+    (result != ws::SOCKET_ERROR).then_some(returned)
+}
+
+/// `SIO_TCP_SET_ACK_FREQUENCY`, which is what `TCP_QUICKACK` names here.
+/// It is an ioctl rather than a socket option, so `setsockopt` answers
+/// `WSAENOPROTOOPT` for it and the flag has to travel through `WSAIoctl`.
+/// Nothing reads it back: WinSock exposes no query for the current setting.
+#[cfg(windows)]
+pub unsafe fn set_ack_frequency(s: Socket, flag: libc::c_int) -> libc::c_int {
+    let sent = unsafe {
+        wsa_ioctl(
+            s,
+            ws::SIO_TCP_SET_ACK_FREQUENCY,
+            (&raw const flag).cast(),
+            core::mem::size_of::<libc::c_int>() as u32,
+        )
+    };
+    if sent.is_some() { 0 } else { ws::SOCKET_ERROR }
 }
 
 #[cfg(unix)]

--- a/pyre/pyre-interpreter/src/module/_winapi/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_winapi/mod.rs
@@ -80,7 +80,10 @@ fn masked_int_w(w_value: pyre_object::PyObjectRef, argument: IntArg<'_>) -> Resu
             IntArg::Element => format!("argument must be int, not {got}"),
         }));
     }
-    crate::baseobjspace::truncatedint_w(w_value)
+    // `PyLong_AsNativeBytes` reads the value under
+    // `Py_ASNATIVEBYTES_ALLOW_INDEX`, so `__index__` decides it and `__int__`
+    // is never asked for one.
+    crate::baseobjspace::truncatedint_w(crate::baseobjspace::space_index(w_value)?)
 }
 
 /// [`masked_int_w`] for a `HANDLE` parameter.

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -878,12 +878,15 @@ mod win_nt {
         Ok((path, as_bytes, resolved))
     }
 
+    /// The wide name these helpers read, answered as the caller spelled the
+    /// path it asked about: `PyUnicode_FromWideChar`, and
+    /// `PyUnicode_EncodeFSDefault` over that when the argument was `bytes`.
     fn wrap_path(s: &std::ffi::OsStr, as_bytes: bool) -> PyObjectRef {
         // One decode feeds both arms: the bytes form is the filesystem
         // encoding of the same text, not the UTF-8 of a lossy rendering of it.
         let text = crate::gateway::fsdecode_os_str_wtf8(s);
         if as_bytes {
-            pyre_object::w_bytes_from_bytes(text.as_bytes())
+            pyre_object::w_bytes_from_bytes(&crate::gateway::fs_result_bytes(text.as_bytes()))
         } else {
             pyre_object::w_str_from_wtf8(text)
         }
@@ -924,9 +927,15 @@ mod win_nt {
     /// (`ntpath.py:648-655`). Only the leaf is returned; the caller splits the
     /// parent off itself.
     pub fn _findfirstfile(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
-        let (path, as_bytes, resolved) = arg_path(args, "_findfirstfile")?;
+        let (path, _as_bytes, resolved) = arg_path(args, "_findfirstfile")?;
         match host_nt::find_first_file_name(&path) {
-            Ok(name) => Ok(wrap_path(&name, as_bytes)),
+            // The one name here that is answered as `str` whatever the
+            // argument was: `os__findfirstfile_impl` reports `cFileName`
+            // through `PyUnicode_FromWideChar` and asks no codec for a
+            // `bytes` spelling of it.
+            Ok(name) => Ok(pyre_object::w_str_from_wtf8(
+                crate::gateway::fsdecode_os_str_wtf8(&name),
+            )),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
     }

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -903,7 +903,14 @@ mod win_nt {
     /// backup-semantics handle so directories open too.
     pub fn _getfinalpathname(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, as_bytes, resolved) = arg_path(args, "_getfinalpathname")?;
-        match host_nt::getfinalpathname(&path) {
+        // `os__getfinalpathname_impl` leaves the interpreter for the handle it
+        // opens and for `GetFinalPathNameByHandleW`, either of which blocks
+        // while a network path answers.
+        let final_path = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::getfinalpathname(&path)
+        };
+        match final_path {
             Ok(result) => Ok(wrap_path(&result, as_bytes)),
             Err(error) => Err(io_err_with_filename(&error, resolved.w_path())),
         }
@@ -954,7 +961,13 @@ mod win_nt {
     /// (ERROR_DIRECTORY).
     pub fn _getdiskusage(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> {
         let (path, _, resolved) = arg_path(args, "_getdiskusage")?;
-        match host_nt::getdiskusage(&path) {
+        // `os__getdiskusage_impl` leaves the interpreter for
+        // `GetDiskFreeSpaceExW`, which reaches the volume itself.
+        let usage = {
+            let _blocked = crate::module::thread::before_external_block();
+            host_nt::getdiskusage(&path)
+        };
+        match usage {
             Ok((total, free)) => Ok(pyre_object::w_tuple_new(vec![
                 pyre_object::w_int_new(total as i64),
                 pyre_object::w_int_new(free as i64),
@@ -10271,7 +10284,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         return Err(crate::PyError::type_error("dup() requires 1 argument"));
                     }
                     let fd = crate::baseobjspace::c_int_w(args[0])?;
-                    match host_nt::dup(fd) {
+                    // `_Py_dup` leaves the interpreter for the duplication.
+                    let duplicated = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::dup(fd)
+                    };
+                    match duplicated {
                         Ok(n) => Ok(pyre_object::w_int_new(n as i64)),
                         Err(e) => Err(errno_err(crt_errno_of(&e), "")),
                     }
@@ -10295,7 +10313,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 Some(w) => crate::baseobjspace::is_true(w)?,
                 None => true,
             };
-            match host_nt::dup2(fd, fd2, inheritable) {
+            // `_Py_dup2`, like `_Py_dup`, runs outside the interpreter.
+            let duplicated = {
+                let _blocked = crate::module::thread::before_external_block();
+                host_nt::dup2(fd, fd2, inheritable)
+            };
+            match duplicated {
                 Ok(n) => Ok(pyre_object::w_int_new(n as i64)),
                 Err(e) => Err(errno_err(crt_errno_of(&e), "")),
             }
@@ -10451,10 +10474,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 {
                     return Err(argument_unavailable("access", "follow_symlinks"));
                 }
-                Ok(pyre_object::w_bool_from(host_nt::access(
-                    path_from_bytes(&path.as_bytes).as_ref(),
-                    mode,
-                )))
+                // `os_access_impl` leaves the interpreter for
+                // `GetFileAttributesW`, which blocks on a network path.
+                let allowed = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    host_nt::access(path_from_bytes(&path.as_bytes).as_ref(), mode)
+                };
+                Ok(pyre_object::w_bool_from(allowed))
             }),
         );
 
@@ -10653,7 +10679,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                 // modifier applies to it and it dispatches straight to
                 // `os.fchmod` (`interp_posix.py`).
                 if path.as_fd != -1 {
-                    return match host_nt::fchmod(path.as_fd, mode, S_IWRITE) {
+                    let changed = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::fchmod(path.as_fd, mode, S_IWRITE)
+                    };
+                    return match changed {
                         Ok(()) => Ok(pyre_object::w_none()),
                         Err(e) => Err(handle_err(&e)),
                     };
@@ -10663,13 +10693,19 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     None => true,
                 };
                 let wide = wide_path(&path.as_bytes)?;
-                let result = if follow_symlinks {
-                    host_nt::chmod_follow(&wide, mode, S_IWRITE)
-                } else {
-                    // `SetFileAttributesW` on the name itself, which is what
-                    // "modify the link rather than its target" means where the
-                    // mode is one attribute bit.
-                    host_nt::win32_lchmod(&wide, mode, S_IWRITE)
+                // `os_chmod_impl` holds one `Py_BEGIN_ALLOW_THREADS` region
+                // around the whole attribute read-modify-write, whichever of
+                // the three forms the path selected.
+                let result = {
+                    let _blocked = crate::module::thread::before_external_block();
+                    if follow_symlinks {
+                        host_nt::chmod_follow(&wide, mode, S_IWRITE)
+                    } else {
+                        // `SetFileAttributesW` on the name itself, which is
+                        // what "modify the link rather than its target" means
+                        // where the mode is one attribute bit.
+                        host_nt::win32_lchmod(&wide, mode, S_IWRITE)
+                    }
                 };
                 result.map_err(|e| fs_err_with_filename(e, path.w_path()))?;
                 Ok(pyre_object::w_none())
@@ -10692,8 +10728,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     )?;
                     let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
                     let wide = wide_path(&path.as_bytes)?;
-                    host_nt::win32_lchmod(&wide, mode, S_IWRITE)
-                        .map_err(|error| fs_err_with_filename(error, path.w_path()))?;
+                    // `os_lchmod_impl` runs the same call outside the
+                    // interpreter that `os_chmod_impl` does.
+                    let changed = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::win32_lchmod(&wide, mode, S_IWRITE)
+                    };
+                    changed.map_err(|error| fs_err_with_filename(error, path.w_path()))?;
                     Ok(pyre_object::w_none())
                 },
                 2,
@@ -10713,8 +10754,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     let fd = crate::baseobjspace::c_int_w(args[0])?;
                     let mode = crate::baseobjspace::c_int_w(args[1])? as u32;
                     // Every failure here is the handle call's, reported the
-                    // Win32 way (`os_fchmod_impl`).
-                    match host_nt::fchmod(fd, mode, S_IWRITE) {
+                    // Win32 way (`os_fchmod_impl`), which also leaves the
+                    // interpreter for it.
+                    let changed = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::fchmod(fd, mode, S_IWRITE)
+                    };
+                    match changed {
                         Ok(()) => Ok(pyre_object::w_none()),
                         Err(e) => Err(handle_err(&e)),
                     }
@@ -11060,7 +11106,13 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     }
                     let pid = crate::baseobjspace::int_w(args[0])? as isize;
                     let options = crate::baseobjspace::c_int_w(args[1])?;
-                    match host_nt::cwait(pid, options) {
+                    // `os_waitpid_impl` waits outside the interpreter, which is
+                    // what lets another thread run while a child is still up.
+                    let waited = {
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::cwait(pid, options)
+                    };
+                    match waited {
                         Ok((pid, status)) => Ok(pyre_object::w_tuple_new(vec![
                             pyre_object::w_int_new(pid as i64),
                             pyre_object::w_int_new((status as i64) << 8),
@@ -11123,7 +11175,15 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "listdrives",
             crate::make_builtin_function_with_arity(
                 "listdrives",
-                |_| name_list(host_nt::listdrives()),
+                // `os_listdrives_impl` leaves the interpreter for
+                // `GetLogicalDriveStringsW`, as the two volume calls below do
+                // for theirs.
+                |_| {
+                    name_list({
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::listdrives()
+                    })
+                },
                 0,
             ),
         );
@@ -11132,7 +11192,12 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
             "listvolumes",
             crate::make_builtin_function_with_arity(
                 "listvolumes",
-                |_| name_list(host_nt::listvolumes()),
+                |_| {
+                    name_list({
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::listvolumes()
+                    })
+                },
                 0,
             ),
         );
@@ -11151,7 +11216,11 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                         ));
                     }
                     let volume = crate::gateway::fsencode_path_w(args[0])?;
-                    name_list(host_nt::listmounts(&wide_path(&volume.as_bytes)?))
+                    let wide = wide_path(&volume.as_bytes)?;
+                    name_list({
+                        let _blocked = crate::module::thread::before_external_block();
+                        host_nt::listmounts(&wide)
+                    })
                 },
                 1,
             ),

--- a/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
+++ b/pyre/pyre-interpreter/src/module/posix/interp_posix.rs
@@ -2318,7 +2318,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
     /// `b"bad_\xff"` still names the file on disk instead of carrying U+FFFD.
     fn fs_name_obj(bytes_mode: bool, name: &[u8]) -> PyObjectRef {
         if bytes_mode {
-            pyre_object::bytesobject::w_bytes_from_bytes(name)
+            pyre_object::bytesobject::w_bytes_from_bytes(&crate::gateway::fs_result_bytes(name))
         } else {
             crate::gateway::fsdecode_filename_bytes(name)
         }
@@ -5685,7 +5685,9 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     {
                         if let Ok(cwd) = host_os::current_dir() {
                             return Ok(pyre_object::w_bytes_from_bytes(
-                                cwd.as_os_str().as_encoded_bytes(),
+                                &crate::gateway::fs_result_bytes(
+                                    cwd.as_os_str().as_encoded_bytes(),
+                                ),
                             ));
                         }
                     }

--- a/pyre/pyre-interpreter/src/module/sys/vm.rs
+++ b/pyre/pyre-interpreter/src/module/sys/vm.rs
@@ -10,10 +10,6 @@ use crate::{
 use pyre_object::*;
 use std::sync::OnceLock;
 
-#[cfg(windows)]
-static LEGACY_WINDOWS_FS_ENCODING: std::sync::atomic::AtomicBool =
-    std::sync::atomic::AtomicBool::new(false);
-
 const GETSIZEOF_DOC: &str = "getsizeof(object [, default]) -> int\n\n\
 Return the size of object in bytes.";
 
@@ -3018,13 +3014,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "getfilesystemencoding",
         make_builtin_function_with_arity(
             "getfilesystemencoding",
-            |_| {
-                #[cfg(windows)]
-                if LEGACY_WINDOWS_FS_ENCODING.load(std::sync::atomic::Ordering::Relaxed) {
-                    return Ok(w_str_new("mbcs"));
-                }
-                Ok(w_str_new("utf-8"))
-            },
+            |_| Ok(w_str_new(crate::typedef::fs_encoding())),
             0,
         ),
     );
@@ -3037,13 +3027,7 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
         "getfilesystemencodeerrors",
         make_builtin_function_with_arity(
             "getfilesystemencodeerrors",
-            |_| {
-                #[cfg(windows)]
-                if LEGACY_WINDOWS_FS_ENCODING.load(std::sync::atomic::Ordering::Relaxed) {
-                    return Ok(w_str_new("replace"));
-                }
-                Ok(w_str_new(crate::typedef::FS_ERRORS))
-            },
+            |_| Ok(w_str_new(crate::typedef::fs_errors())),
             0,
         ),
     );
@@ -3059,16 +3043,16 @@ pub fn register_module(ns: pyre_object::PyObjectRef) {
                     "DeprecationWarning",
                     1,
                 )?;
-                // `_PyUnicode_EnableLegacyWindowsFSEncoding` also re-runs
-                // `init_fs_codec`, so every path converter switches to
-                // mbcs/replace with it.  Here the flag reaches only the two
-                // getters.  Switching `gateway::fsencode` and
-                // `typedef::FS_ERRORS` as well is not enough on its own: pyre
-                // carries host names as WTF-8 through `fsencode_os_str` and
-                // `os_string_from_fs_bytes`, so the app-level converters and
-                // the host bridge have to change together or a name stops
-                // round-tripping between them.
-                LEGACY_WINDOWS_FS_ENCODING
+                // `_PyUnicode_EnableLegacyWindowsFSEncoding` re-runs
+                // `init_fs_codec`, so the flag moves the two conversions the
+                // codec names as well as the getters that report it:
+                // `gateway::fs_arg_bytes` for a path spelled as `bytes` and
+                // `gateway::fs_result_bytes` for a name reported back as one.
+                // A `str` path is untouched, as `path_converter` keeps the
+                // wide string it was given and asks no codec for it — measured
+                // at 3.14: `os.stat` still finds a name the code page cannot
+                // spell, while `os.listdir(b'.')` reports it as `b'?'`.
+                crate::typedef::LEGACY_WINDOWS_FS_ENCODING
                     .store(true, std::sync::atomic::Ordering::Relaxed);
                 Ok(w_none())
             },

--- a/pyre/pyre-interpreter/src/module/thread/mod.rs
+++ b/pyre/pyre-interpreter/src/module/thread/mod.rs
@@ -498,10 +498,22 @@ pub(crate) fn current_frames() -> PyObjectRef {
         }
     });
     let result = w_dict_new();
+    pyre_object::gc_roots::pin_root(result);
+    let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for (index, ident) in entries.into_iter().enumerate() {
-        let frame = pyre_object::gc_roots::shadow_stack_get(base + index);
-        unsafe { w_dict_setitem(result, ident, frame) };
+        // The key is built first: `w_int_new` allocates, so a dict or a value
+        // read before it would be a pre-collection address by the time the
+        // store runs.
+        let key = pyre_object::w_int_new(ident);
+        unsafe {
+            w_dict_store(
+                pyre_object::gc_roots::shadow_stack_get(result_slot),
+                key,
+                pyre_object::gc_roots::shadow_stack_get(base + index),
+            )
+        };
     }
+    let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
     drop(roots);
     result
 }
@@ -518,8 +530,11 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
     majit_gc::gc_sync::request_stw(|_| {
         let contexts = EXECUTION_CONTEXTS.lock();
         for (&ident, &ec) in contexts.iter() {
-            let exception =
-                unsafe { (*(ec as *const crate::PyExecutionContext)).current_exception() };
+            // `sys_exc_info`, not the flat `sys_exc_value`: a thread inside a
+            // generator entered from an `except` handler has its exception
+            // parked on the generator, and `_get_topmost_exception` is what
+            // reads it back.
+            let exception = unsafe { (*(ec as *const crate::PyExecutionContext)).sys_exc_info() };
             pyre_object::gc_roots::pin_root(if exception.is_null() {
                 w_none()
             } else {
@@ -529,15 +544,22 @@ pub(crate) fn current_exceptions() -> PyObjectRef {
         }
     });
     let result = w_dict_new();
+    pyre_object::gc_roots::pin_root(result);
+    let result_slot = pyre_object::gc_roots::shadow_stack_len() - 1;
     for (index, ident) in entries.into_iter().enumerate() {
+        // The key is built first: `w_int_new` allocates, so a dict or a value
+        // read before it would be a pre-collection address by the time the
+        // store runs.
+        let key = pyre_object::w_int_new(ident);
         unsafe {
-            w_dict_setitem(
-                result,
-                ident,
+            w_dict_store(
+                pyre_object::gc_roots::shadow_stack_get(result_slot),
+                key,
                 pyre_object::gc_roots::shadow_stack_get(base + index),
             )
         };
     }
+    let result = pyre_object::gc_roots::shadow_stack_get(result_slot);
     drop(roots);
     result
 }

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -23618,6 +23618,48 @@ pub(crate) const FS_ERRORS: &str = if cfg!(windows) {
     "surrogateescape"
 };
 
+/// Whether `sys._enablelegacywindowsfsencoding` has been called.
+///
+/// `_PyUnicode_EnableLegacyWindowsFSEncoding` re-runs `init_fs_codec`, so the
+/// flag has to reach the conversions that codec names and not only the two
+/// `sys` getters reporting it: `gateway::fs_arg_bytes` and
+/// `gateway::fs_result_bytes`, the two points a path crosses between the
+/// caller's `bytes` and the units the interpreter carries a name in.
+#[cfg(windows)]
+pub(crate) static LEGACY_WINDOWS_FS_ENCODING: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
+/// Whether the filesystem codec is the ANSI code page pair rather than the
+/// PEP 529 one.  Always false off Windows, which has no legacy pair to name.
+pub(crate) fn legacy_windows_fs_encoding() -> bool {
+    #[cfg(windows)]
+    {
+        LEGACY_WINDOWS_FS_ENCODING.load(std::sync::atomic::Ordering::Relaxed)
+    }
+    #[cfg(not(windows))]
+    {
+        false
+    }
+}
+
+/// The filesystem codec's name, which `sys.getfilesystemencoding` reports.
+pub(crate) fn fs_encoding() -> &'static str {
+    if legacy_windows_fs_encoding() {
+        "mbcs"
+    } else {
+        "utf-8"
+    }
+}
+
+/// [`FS_ERRORS`], or the `replace` the legacy code page codec is built with.
+pub(crate) fn fs_errors() -> &'static str {
+    if legacy_windows_fs_encoding() {
+        "replace"
+    } else {
+        FS_ERRORS
+    }
+}
+
 /// `unicodehelper.py fsdecode` — filesystem bytes to text.
 ///
 /// `surrogateescape` rescues every byte, so this only ever fails under

--- a/pyre/pyre-interpreter/src/unicodehelper_win32.rs
+++ b/pyre/pyre-interpreter/src/unicodehelper_win32.rs
@@ -7,7 +7,7 @@
 //! `win32_code_page_search_function` builds land here.
 
 use pyre_object::{PY_NULL, PyObjectRef};
-use rustpython_wtf8::Wtf8Buf;
+use rustpython_wtf8::{Wtf8, Wtf8Buf};
 use windows_sys::Win32::Foundation::{
     ERROR_INSUFFICIENT_BUFFER, ERROR_INVALID_FLAGS, ERROR_NO_UNICODE_TRANSLATION,
 };
@@ -301,6 +301,59 @@ fn encode_fail() -> CodePageFail {
     }
 }
 
+/// One code point through `WideCharToMultiByte`, appended to `out`.
+///
+/// `Ok(false)` is the code page having no spelling for it, which is the error
+/// handler's business; `Err` is the system reporting anything else.  The walk
+/// is over code points rather than the code units behind them, so an astral
+/// character fails once instead of once per surrogate.
+fn encode_one(
+    code_page: u32,
+    flags: u32,
+    takes_default: bool,
+    ch: u32,
+    out: &mut Vec<u8>,
+) -> Result<bool, crate::PyError> {
+    let mut chars = [0u16; 2];
+    let charsize = if ch < 0x10000 {
+        chars[0] = ch as u16;
+        1
+    } else {
+        chars[0] = (0xD800 - (0x10000 >> 10) + (ch >> 10)) as u16;
+        chars[1] = (0xDC00 + (ch & 0x3FF)) as u16;
+        2
+    };
+    let mut used_default = 0i32;
+    let used_default_ptr = if takes_default {
+        &raw mut used_default
+    } else {
+        std::ptr::null_mut()
+    };
+    // 4 is the longest sequence any code page spells one character in.
+    let mut buffer = [0u8; 4];
+    let outsize = unsafe {
+        WideCharToMultiByte(
+            code_page,
+            flags,
+            chars.as_ptr(),
+            charsize,
+            buffer.as_mut_ptr(),
+            buffer.len() as i32,
+            std::ptr::null(),
+            used_default_ptr,
+        )
+    };
+    if outsize > 0 {
+        if used_default == 0 {
+            out.extend_from_slice(&buffer[..outsize as usize]);
+            return Ok(true);
+        }
+    } else if last_win32_error() != ERROR_NO_UNICODE_TRANSLATION {
+        return Err(win32_error());
+    }
+    Ok(false)
+}
+
 /// `encode_code_page_errors` — one character at a time, so the error handler
 /// sees the character that failed.
 fn encode_errors(
@@ -326,44 +379,9 @@ fn encode_errors(
     let mut out: Vec<u8> = Vec::with_capacity(code_points.len());
     let mut pos = 0usize;
     while pos < code_points.len() {
-        let ch = code_points[pos];
-        let mut chars = [0u16; 2];
-        let charsize = if ch < 0x10000 {
-            chars[0] = ch as u16;
-            1
-        } else {
-            chars[0] = (0xD800 - (0x10000 >> 10) + (ch >> 10)) as u16;
-            chars[1] = (0xDC00 + (ch & 0x3FF)) as u16;
-            2
-        };
-        let mut used_default = 0i32;
-        let used_default_ptr = if takes_default {
-            &raw mut used_default
-        } else {
-            std::ptr::null_mut()
-        };
-        // 4 is the longest sequence any code page spells one character in.
-        let mut buffer = [0u8; 4];
-        let outsize = unsafe {
-            WideCharToMultiByte(
-                code_page,
-                flags,
-                chars.as_ptr(),
-                charsize,
-                buffer.as_mut_ptr(),
-                buffer.len() as i32,
-                std::ptr::null(),
-                used_default_ptr,
-            )
-        };
-        if outsize > 0 {
-            if used_default == 0 {
-                out.extend_from_slice(&buffer[..outsize as usize]);
-                pos += 1;
-                continue;
-            }
-        } else if last_win32_error() != ERROR_NO_UNICODE_TRANSLATION {
-            return Err(win32_error());
+        if encode_one(code_page, flags, takes_default, code_points[pos], &mut out)? {
+            pos += 1;
+            continue;
         }
         let (replacement, newpos) = crate::type_methods::call_registered_encode_error_handler(
             errors,
@@ -399,6 +417,32 @@ fn encode_errors(
         pos = newpos;
     }
     Ok(out)
+}
+
+/// [`encode_code_page`] for a caller holding a name rather than a `str`
+/// object, under the one handler that never has to be shown the character it
+/// failed on: `replace` answers a `?` per code point, which is written here
+/// instead of being fetched from the error registry.
+pub fn encode_code_page_replace(code_page: u32, text: &Wtf8) -> Result<Vec<u8>, crate::PyError> {
+    let wide: Vec<u16> = text.encode_wide().collect();
+    if wide.is_empty() {
+        return Ok(Vec::new());
+    }
+    match encode_strict(code_page, &wide) {
+        Ok(bytes) => Ok(bytes),
+        Err(CodePageFail::NoTranslation) => {
+            let flags = encode_code_page_flags(code_page, Some("replace"));
+            let takes_default = uses_default_char(code_page);
+            let mut out: Vec<u8> = Vec::with_capacity(wide.len());
+            for point in text.code_points() {
+                if !encode_one(code_page, flags, takes_default, point.to_u32(), &mut out)? {
+                    out.push(b'?');
+                }
+            }
+            Ok(out)
+        }
+        Err(CodePageFail::Os(error)) => Err(error),
+    }
 }
 
 /// `PyUnicode_EncodeCodePage`.


### PR DESCRIPTION
Seven Windows gaps, each measured against CPython 3.14.2 on a cp949 host.

## `socket.socket.ioctl`

`sock_ioctl` was absent, which is what `test_sock_ioctl` and
`test_sio_loopback_fast_path` errored on.  It is `WSAIoctl` under a socket
method, published where `SIO_RCVALL` is defined: `SIO_RCVALL` and
`SIO_LOOPBACK_FAST_PATH` take an `I` value, `SIO_KEEPALIVE_VALS` a `(kkk)`
group, and every other command is a `ValueError`.  Both integer codes are
`PyLong_AsUnsignedLongMask`, so `2**80` wraps to `0` rather than overflowing,
and the group takes any `PySequence_Check` object except `str` — a
three-character string would otherwise read as three values.

`set_ack_frequency` issues its own command through the same `wsa_ioctl` helper
now, rather than spelling out the nine-argument call a second time.

Measured over 31 cases — arity, a non-int command, a non-index value, a
short / long / `None` / `str` / generator / dict / `range` group, a negative
and an oversized command, an `__index__` object, and the three commands
themselves — with results identical to 3.14.2, down to `must be int, not None`
naming `None` rather than its type where `must be 3-item tuple, not
list_iterator` names the type.

Both tests pass; `TestSocketSharing` still errors, as `socket.share` and
`socket.fromshare` remain absent.

## `socket.if_nameindex`

It went through `rustpython_host_env::socket::if_nameindex`, which hands each
name back through `String::from_utf16_lossy` and so spends an unpaired
surrogate on U+FFFD.  `Py_BuildValue("Iu", ...)` keeps what
`ConvertInterfaceLuidToNameW` wrote, so the wide buffer is read as WTF-8 here
instead: `GetIfTable2Ex` for the table, `ConvertInterfaceLuidToNameW` per row,
`FreeMibTable` whichever way the walk ended, and both statuses reported the
Win32 way `PyErr_SetFromWindowsErr` gives them.  All 46 entries this host
reports match 3.14.2, and `if_nametoindex` round-trips every one of them.

## `_locale.getencoding`

It was a fixed `utf-8`.  `_Py_GetLocaleEncoding` is `cp<GetACP()>` on Windows
and `nl_langinfo(CODESET)` elsewhere, with an empty codeset reading as utf-8.
`locale.py` takes it directly, so `locale.getpreferredencoding()` answers
`cp949` here where it answered `utf-8` — the two are different answers on
every Windows host, because PEP 529 makes the filesystem encoding utf-8 while
the locale's is not.

## The legacy Windows filesystem codec

`sys._enablelegacywindowsfsencoding` reached only `getfilesystemencoding` and
`getfilesystemencodeerrors`.  `_PyUnicode_EnableLegacyWindowsFSEncoding`
re-runs `init_fs_codec`, and measuring 3.14.2 shows that moves exactly two
conversions:

* a path argument spelled as `bytes` is decoded through `CP_ACP`/`replace`
  rather than UTF-8, and
* a name reported back as `bytes` is encoded through it.

A `str` path is untouched — `path_converter` keeps the wide string it was
given and asks no codec for it — so `os.stat("🐍.txt")` still finds the file
while `os.listdir(b'.')` reports it as `b'?.txt'`.  `os.fsencode` and
`os.fsdecode` do not move either, because `os._fscodec` closes over the codec
at import; that is why the environment variable is the documented spelling and
the function is deprecated.

The pair lands in `gateway::fs_arg_bytes` and `gateway::fs_result_bytes`, so
everything downstream keeps carrying a name in the one spelling a `str`
argument already arrives in — the stored `co_filename`, the `wide_path` each
syscall takes.  `unicodehelper_win32::encode_code_page_replace` is the encode
direction for a caller holding a name and no `str` object; the per-code-point
walk it shares with `encode_code_page_errors` is extracted into `encode_one`,
so an astral character spends one `?` rather than one per surrogate.

PYTHONLEGACYWINDOWSFSENCODING is read in `launch_env::finalize` with the same
integer fold `preconfig_read` gives it — `=0` off, `=1` and `=x` on, `-E`
suppressing it — ahead of every import, so `os`'s own `_fscodec` closes over
the legacy pair when it is set.

A 30-case probe over both modes — the two getters, `os.fsencode`/`os.fsdecode`,
`os.listdir` in both modes, `os.getcwdb`, `os.stat`/`open` on a `bytes` path,
`compile()` with a `str` and a `bytes` filename — is byte-identical to 3.14.2,
as is a 13-case probe over a name the code page cannot spell.

## The default text encoding

Publishing `_locale.getencoding` turned `test_io`'s
`CTextIOWrapperTest.test_default_encoding` red, because
`TextIOWrapper.resolve_locale_encoding` answered a hardcoded `utf-8` and an
unspecified `encoding` never reached it at all — `checked_text0` defaulted to
`utf-8` as well.  `_io_TextIOWrapper___init___impl` reads
`_Py_GetLocaleEncodingObject` for both, unless UTF-8 mode has already answered
the question, and raises the `EncodingWarning` at its own frame because a
direct `TextIOWrapper(...)` call does not pass through `_io.text_encoding`;
that warning's text also carried a trailing period the C one does not.

So on this cp949 host `open(path).encoding`, `io.TextIOWrapper(b).encoding`
and `encoding="locale"` all answer `cp949` now, matching 3.14.2, and `-X utf8`
answers `utf-8` on both.  `cargo test` and a cold `check.py` are green with
that default in place.

## 13 more interpreter-release guards in `posix`

`_getfinalpathname`, `_getdiskusage`, `dup`, `dup2`, `access`, `chmod` on both
a descriptor and a path, `lchmod`, `fchmod`, `waitpid`, `listdrives`,
`listvolumes` and `listmounts` each ran their host call with the interpreter
held.  `os_chmod_impl` keeps one region around the whole attribute
read-modify-write, so the follow/no-follow choice sits inside the guard rather
than each arm carrying its own.  The guard count in that file goes 7 to 20.

## Review round on #1392

`_io_open_impl` writes `encoding = "utf-8"` in the same step that picks
`_io._WindowsConsoleIO`, ahead of the argument the caller gave, and does not
route that argument through `_io.text_encoding`: measured,
`open("CONOUT$", "w", encoding="cp949").encoding` is `utf-8` and the call
raises no `EncodingWarning` under `-X warn_default_encoding`.

`W_WindowsConsoleIO.__init__` held two borrows across move points — `is_true`
on the caller's `closefd` can run a `__bool__`, and storing `name` allocates
the instance dict — so the name argument and the receiver are read back out of
their slots now.

`_thread._current_frames` and `_current_exceptions` built their dict without
rooting it: `w_int_new` for the key allocates, so the dict and the value read
before it were pre-collection addresses by the time the store ran.
`_current_exceptions` also reported the flat `sys_exc_value`; a thread
suspended inside a generator entered from an `except` handler has its
exception parked on the generator, which `_get_topmost_exception` is what
reads back.  The probe now reports `ValueError('parked on the generator')` on
both interpreters.

## `socket.socket.share`

`sock_share` is `WSADuplicateSocketW` under a socket method: it writes a
`WSAPROTOCOL_INFOW` describing the socket for the process named and answers
the bytes of that structure.  `socket.py` publishes `fromshare` as soon as the
method exists, and reads the blob back through `socket(0, 0, 0, info)` — so
the constructor grows the `bytes` fileno branch that re-opens the socket with
`WSASocketW` under `FROM_PROTOCOL_INFO`, taking the family, type and protocol
from the structure rather than from the three arguments and rejecting a blob
of the wrong length with the size in the message.  The process id reads
through `PyLong_AsUnsignedLongMask` with no `PyIndex_Check` of its own, which
is what `unsigned_long(bitwise=True)` generates.

`test_socket`'s `TestSocketSharing` runs its four tests, including the
transfer to a `multiprocessing` child.  A probe over the arity, a non-index
process id, an oversized and a negative one, four wrong blob lengths and the
round trip matches 3.14.2 except for the docstring, which no socket method in
this file carries.

## Review round on #1415

**`__index__`, not `__int__`, for a masked integer.**  `ioctl`'s `k` and `I`
codes and every `_winapi` handle and `DWORD` parameter went to
`truncatedint_w`, whose conversion is `space.int`.  `PyLong_AsNativeBytes`
reads its argument under `Py_ASNATIVEBYTES_ALLOW_INDEX`, which is
`PyNumber_Index`: measured, `sock.ioctl(x, 0)` for an `x` answering 3 from
`__index__` and 7 from `__int__` read 7 where 3.14.2 reads 3, an `__index__`
that raises was silently replaced by the other method's answer, and
`_winapi.WaitForSingleObject` did the same.  `converttuple` nests the position
it reports, so an item of the `(kkk)` group names itself as
`ioctl() argument 2, item 0 must be int, not str`; that message carried no
position at all.

**The legacy codec reaches every `bytes` path result.**  `_getfullpathname`
and `_getfinalpathname` answer a `bytes` argument with
`PyUnicode_EncodeFSDefault` over the wide name they read.  `wrap_path` handed
back the interpreter's own UTF-8, which `fs_arg_bytes` then read as a code
page string on the way back in: `os.path.realpath` on a `bytes` path kept the
`\\?\` prefix in that mode because its verification call could not match the
two spellings.  Both directions are byte-identical to 3.14.2 now, in both
modes.  `os__findfirstfile_impl` turns out to report `cFileName` through
`PyUnicode_FromWideChar` and ask no codec for a `bytes` form of it, so that
one answers `str` whatever the argument was.

**`TextIOWrapper`'s arguments are converted before its body.**  Argument
Clinic accepts `encoding` and `newline` only as `str` or `None` and
truth-tests the two flags before `_io_TextIOWrapper___init___impl` runs, whose
first statement is `self->ok = 0` and whose second is the `EncodingWarning`.
Measured at 3.14.2: a `line_buffering` whose `__bool__` raises reports that
exception rather than the warning, an unknown `encoding` or an illegal
`newline` value does not preempt it, and a re-initialization that fails this
way leaves an already-open stream usable.

**The legacy filesystem codec turns UTF-8 mode off.**  From the parity review.
`preconfig_init_utf8_mode` opens by reading `legacy_windows_fs_encoding` and
setting `utf8_mode` to 0, ahead of `-X utf8`, `PYTHONUTF8` and the locale
alike — and ahead of the `PYTHONUTF8` value check, so `PYTHONUTF8=strict`
beside the variable is not the fatal error it is on its own.  `finalize`
resolved the mode before folding the variable in, so the flag stayed 1 while
the codec moved to `mbcs`/`replace`.  `test_utf8_mode` goes from three
failures to one, and eight combinations of the two variables, `-X utf8` and
`-E` are identical to 3.14.2.

The parity review's four other second-section entries are `[3.14-spec]`
rather than defects, each measured against 3.14.2 before it was written:
`_locale.getencoding` answering `cp<GetACP()>` is `_Py_GetLocaleEncoding`
where PyPy has no `nl_langinfo`; `SIO_KEEPALIVE_VALS` rejecting a dict or a
`str` is `PySequence_Check` where PyPy takes `unpackiterable`; the `k`/`I`
masking is `PyLong_AsNativeBytes` where PyPy's `int_w` overflows; and
`if_nameindex` keeping the wide name is `Py_BuildValue("Iu", ...)` where PyPy
runs `wcstombs_s`.

## Verification

`cargo test --all --no-default-features --features dynasm,cpyext` — 168 result
blocks, 8062 passed, 0 failed.  A cold `check.py --backend dynasm` — ALL
PASSED, dynasm 456/456.  `cargo fmt --check` and the citation check are clean.

CI runs the vendored CPython suite on Linux alone, so the modules these
commits touch were run here by hand, against 3.14.2 on a cp949 host.

* `test_locale` — OK, 66 tests, 6 skipped.
* `test_utf8_mode` — three failures down to one, the remaining `test_stdio`
  being the standard-stream encoding listed below.
* `test_socket` — errors 6 down to 2: `TestSocketSharing`'s four now run,
  including the transfer to a `multiprocessing` child, and the two ioctl tests
  keep passing.  The 14 failures are the ones already on main —
  `getservbyname`, `idna`, the `NtoH` range checks.
* `test_os` — 19 failures and 6 errors, unchanged: the `os.spawn*` and
  `os.waitpid` stubs, junctions, scandir and `os.fspath`.
* `test_ntpath` — 8 failures and 4 errors, unchanged, all of them the missing
  `nt._path_*` helpers below.
* `test_sys` — 8 failures, unchanged; none encoding-driven, see the standard
  streams below.
* `test_io` — unchanged: it still stalls in
  `PyTextIOWrapperTest.test_seek_and_tell`, and `test_append_bom` errors on
  `'PyTextIOWrapperTest' object has no attribute 'open'`, the `_pyio` mixin
  rather than an encoding.  The C variants pass.
* `test_codecs` — the same 11 failures and 40 errors it has on main, confirmed
  by re-running it under `-X utf8`, which restores the previous default
  encoding and changes nothing.

Probes compared byte-for-byte with 3.14.2: 31 ioctl cases, 46 `if_nameindex`
entries plus the `if_nametoindex` round trip, 30 legacy-filesystem cases in
both modes, 13 more over a name the code page cannot spell, the three
`_getfullpathname` / `_getfinalpathname` / `_findfirstfile` helpers over three
names in both modes, 5 `PYTHONLEGACYWINDOWSFSENCODING` cases, 8 combinations
of that variable with `PYTHONUTF8`, `-X utf8` and `-E`, 15 `__index__` /
`__int__` cases across `ioctl` and `_winapi`, the `TextIOWrapper` conversion
order, 3 console-encoding cases, the parked-generator exception, and the
`socket.share` round trip.  The only remaining differences are the two
pre-existing message texts and the missing `share.__doc__` listed below.

## Not addressed

* `nt._path_*`. pyre publishes only `_path_splitroot` where 3.14 has ten —
  `_path_normpath`, `_path_splitroot_ex`, and
  `_path_isdir` / `isfile` / `exists` / `islink` / `lexists` / `isjunction` /
  `isdevdrive`. `ntpath` therefore keeps its own Python `splitroot`,
  `normpath` and the `genericpath` predicates, none of which raise the
  `UnicodeDecodeError` the C ones do on an undecodable `bytes` path. That is
  every one of `test_ntpath`'s 8 failures and 4 errors here, including
  `test_realpath_invalid_unicode_paths`, whose error only reaches `realpath`
  late because `normpath` let it through. It predates this branch;
  `pyre/cpython_tests/baseline.json` records `test_ntpath` as PASS because the
  suite is recorded on Linux, where those paths are skipped.
* The standard streams. pyre's stdio is `utf-8`/`strict`;
  `config_init_stdio_encoding` reads the locale encoding unless UTF-8 mode
  answered first, and `config_get_stdio_errors` is `surrogateescape` on
  Windows unconditionally, so 3.14.2 gives `cp949`/`surrogateescape` on a
  redirected stream here and `utf-8` only on a console, where `create_stdio`
  overrides it for `_WindowsConsoleIO`. That is `test_utf8_mode`'s remaining
  `test_stdio` and `test_sys`'s 8 failures. Decided in the Rust `initstdio`,
  and wide enough to want its own change.
* `os.spawn*` and `os.waitpid` are still stubs, which is what most of
  `test_os`'s remaining failures are.
* `TextIOWrapper() argument 'encoding' must be str or None, not int` — pyre
  says `encoding must be a str`, and `illegal newline type` for the other.
  PyPy's texts, in `checked_text0` / `unwrap_newline`, shared with every `_io`
  class; the *order* those checks run in is fixed here, the wording is not.
* `socket.socket.share.__doc__` is `None`. No socket method in
  `interp_socket.rs` carries a docstring, and PyPy's `share_w` has none
  either.
## The red `pyre/check.py (ubuntu-24.04)`

Inherited from `main`, not from this branch.  The whole failure is one line:

```
FAIL wasm synth/str_getitem_len_hot  exec 1.93s > dynasm 0.54s  ratio 3.6x > gate 3.5x
FAILED: wasm 1 failed, 446 passed
```

#1410, #1405 and #1393 were each merged into `main` today with that same
fixture, the same 3.6x, and the same `wasm 1 failed, 446 passed`.  #1384,
#1397 and #1403 grew the fixture — `hot_len` gained `bytes` and `bytearray`
arms and a `hot_mutating_len` leg, which took its CPython time from 0.04s to
2.55s — and #1407 lowered `WASM_MAX_DYNASM_RATIO` from 4 to 3.5.  This branch
changes 17 files, all under `pyre/pyre-interpreter/src`, and touches nothing in
`majit/`, `pyre/bench/`, `pyre/check.py` or the wasm backend.

No allowance was added: `wasm_ratio_gate`'s own comment says a
`max-wasm-ratio` line is "an allowance carved out of a gate that already
applies", and that the fixtures which last exceeded the gate were fixed rather
than exempted.  The shape the fixture grew into — `bytearray.append` and a
slice deletion inside the loop — is the allocation-dominated one that comment
describes, so whether it is fixed or exempted is a call for whoever owns
#1407.

Every other leg passes: `cargo test` and `pyre/check.py` on all three
platforms bar this one, `sandbox e2e + wasm web build`, `cpyext ABI`,
`cargo fmt --check` and `pre-commit`.

## Review notes

CodeRabbit asks for the default-encoding resolution and the `EncodingWarning`
to be extracted into one helper shared by the constructor and
`_io.text_encoding`.  Declined: `_io_text_encoding_impl` and
`_io_TextIOWrapper___init___impl` each carry their own copy upstream, and they
are not the same code — `text_encoding` warns at the caller's `stacklevel` and
answers the string `locale`, while the constructor warns at its own frame and
resolves `locale` through `_Py_GetLocaleEncodingObject`.  Folding them
together would be a structural deviation from both C and PyPy.
