### PR TITLE
gc: root the values six paths hand back or hold across an application-level call

### DIFF
--- a/pyre/extra_tests/snippets/gc_contextvar_operands_survive_the_mapping_calls.py
+++ b/pyre/extra_tests/snippets/gc_contextvar_operands_survive_the_mapping_calls.py
@@ -1,0 +1,73 @@
+# pyre-check: gate=1
+"""`ContextVar.set`/`reset`/`get` address their operands at their live places.
+
+Every step of these three is application-level Python: the Context mapping's
+`__getitem__`/`set`/`delete`, and the attribute reads around them.  The values
+that outlive one of those calls -- the Context, its `_data` mapping, the old
+binding, and the caller's own variable and value -- were taken by copy before
+it.  The gateway hands a builtin a native argument array it rebuilt from its
+own roots, so `args` is not rewritten by a collection either.
+
+`reset` compares addresses to decide whether the token belongs to this
+variable and this Context, so an operand that moved there does not merely
+crash: it reports a token as belonging to a different ContextVar.
+
+The stored value has to be MOVABLE -- `set(1)` interns an immortal int and
+stays clean whatever happens.
+
+The collection point is a `sys.settrace` callback that allocates: these steps
+are attribute reads and small mapping calls, so on their own they do not move
+the nursery far enough to relocate what the caller is holding.  A tracer makes
+every one of them a collection point, which is what the operands have to
+survive.
+"""
+
+import contextvars
+import gc
+import sys
+
+KEEP = None
+TICKS = 0
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+def tracer(frame, event, arg):
+    global TICKS
+    TICKS += 1
+    if TICKS % 11 == 0:
+        churn()
+    return tracer
+
+
+variable = contextvars.ContextVar("gate")
+held = []
+sys.settrace(tracer)
+for i in range(30):
+    churn()
+    token = variable.set([i, i + 1])
+    held.append(token)
+    assert variable.get() == [i, i + 1], variable.get()
+
+churn()
+for i, token in enumerate(reversed(held)):
+    variable.reset(token)
+
+churn()
+missing = contextvars.ContextVar("absent")
+for i in range(30):
+    churn()
+    assert missing.get([i]) == [i], missing.get([i])
+
+sys.settrace(None)
+churn()
+for token in held:
+    value = token.old_value
+    if type(value) is list:
+        value.append(0)
+print(len(held), held[0].old_value, held[-1].old_value)

--- a/pyre/extra_tests/snippets/gc_inplace_extend_returns_the_live_receiver.py
+++ b/pyre/extra_tests/snippets/gc_inplace_extend_returns_the_live_receiver.py
@@ -1,0 +1,71 @@
+# pyre-check: gate=1
+"""`list +=` and `dict |=` hand back the receiver at its current address.
+
+Both slots delegate to the shared update helper and then return the receiver
+out of the gateway's stack copy of the arguments.  The helper runs user code —
+a `__next__` for the list, `keys`/`__getitem__`/`__hash__` for the dict — and a
+minor rewrites the shadow slots rather than that copy, so what came back was a
+pre-move word.  The interpreter then stores it into the assignment target,
+which is how a root ends up pointing at a stale header.
+
+`extend` and `update` are unaffected: they answer `None`, so there is no
+receiver to hand back.  That is why only the operator forms fail.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Counting:
+    """An iterator whose `__next__` collects between yields."""
+
+    def __init__(self):
+        self.n = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        self.n += 1
+        churn()
+        if self.n > 3:
+            raise StopIteration
+        return self.n
+
+
+class Mapping:
+    """A mapping whose `keys` and `__getitem__` collect."""
+
+    def keys(self):
+        churn()
+        return ["a", "b"]
+
+    def __getitem__(self, key):
+        churn()
+        return 1
+
+
+for _ in range(25):
+    seq = [1, 2]
+    seq += Counting()
+    print(len(seq), seq)
+
+    mapping = {1: 2}
+    mapping |= Mapping()
+    print(len(mapping), sorted(map(str, mapping)))
+
+    # The method forms answer None and take a different route to the same
+    # helper; they are here so a regression in the helper itself shows up too.
+    seq2 = [1, 2]
+    seq2.extend(Counting())
+    mapping2 = {1: 2}
+    mapping2.update(Mapping())
+    print(len(seq2), len(mapping2))

--- a/pyre/extra_tests/snippets/gc_min_max_default_survives_the_iter_call.py
+++ b/pyre/extra_tests/snippets/gc_min_max_default_survives_the_iter_call.py
@@ -1,0 +1,51 @@
+# pyre-check: gate=1
+"""`min`/`max` slot their `default` before running the argument's `__iter__`.
+
+`iter(sequence)` runs a `__iter__` written in Python, which is a collection
+point.  `default` and `key` are copies taken out of the pinned argument array,
+and a minor rewrites the array rather than the copies, so both named pre-move
+headers by the time they were pinned.
+
+Pinning a stale word is worse than reading one: the next collection walks the
+root slot as if it named an object, which is why this shows up as a bare
+segfault rather than a wrong answer.  That also makes a NON-EMPTY iterable
+enough to trigger it -- the defective root is published whether or not
+`default` is the value that comes back.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class CollectingIter:
+    """Collects from `__iter__`, before `min`/`max` has slotted its default."""
+
+    def __init__(self, items):
+        self.items = items
+
+    def __iter__(self):
+        churn()
+        return iter(self.items)
+
+
+held = []
+for i in range(30):
+    held.append(max(CollectingIter([1, 2, 3]), default=[]))
+    held.append(min(CollectingIter([1, 2, 3]), default=[]))
+    held.append(max(CollectingIter([]), default=[i]))
+    held.append(min(CollectingIter([]), default=[i]))
+
+churn()
+for value in held:
+    if type(value) is list:
+        value.append(0)
+churn()
+print(len(held), held[:4], held[-2:])

--- a/pyre/extra_tests/snippets/gc_module_dict_setdefault_reloads_its_receiver.py
+++ b/pyre/extra_tests/snippets/gc_module_dict_setdefault_reloads_its_receiver.py
@@ -1,0 +1,48 @@
+# pyre-check: gate=1
+"""A module dict's `setdefault` addresses the live dictionary after its lookup.
+
+A key that is not a `str` sends the lookup through the object strategy, which
+hashes it, and a `__hash__` written in Python is a collection point that moves
+the module dict.  The store below the lookup was handed the receiver, the key
+and the default as they stood before it.
+
+The dictionary has to be EMPTY when the collecting hash runs: a module dict
+that already survived one collection is promoted, and an immobile receiver
+hides the defect.
+"""
+
+import gc
+import types
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class CollectingKey:
+    """Not a `str`, so the lookup switches strategy and hashes it."""
+
+    def __hash__(self):
+        churn()
+        return 7
+
+    def __eq__(self, other):
+        return self is other
+
+
+held = []
+for i in range(30):
+    module = types.ModuleType("probe%d" % i)
+    key = CollectingKey()
+    stored = vars(module).setdefault(key, [])
+    stored.append(i)
+    held.append((module, key, stored))
+
+for module, key, stored in held:
+    assert vars(module)[key] is stored, "setdefault stored into a stale receiver"
+    print(stored)

--- a/pyre/extra_tests/snippets/gc_setdefault_returns_the_live_default.py
+++ b/pyre/extra_tests/snippets/gc_setdefault_returns_the_live_default.py
@@ -1,0 +1,46 @@
+# pyre-check: gate=1
+"""`dict.setdefault` hands back the default at its live address.
+
+The store hashes the key, and a `__hash__` written in Python is a collection
+point that moves a nursery-allocated default.  The empty-dict arms of the
+checked setdefault returned the by-value word taken before the store, so the
+caller was handed a pre-move header.
+
+The caller has to KEEP what comes back: a run that discards the return value
+never dereferences the stale word and stays clean either way.
+"""
+
+import gc
+
+KEEP = None
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class CollectingKey:
+    """Collects while being hashed, which is what moves the default."""
+
+    def __hash__(self):
+        churn()
+        return 7
+
+    def __eq__(self, other):
+        return self is other
+
+
+held = []
+for _ in range(30):
+    victim = {}
+    key = CollectingKey()
+    stored = dict.setdefault(victim, key, [])
+    stored.append(1)
+    held.append((victim, key, stored))
+
+for victim, key, stored in held:
+    assert victim[key] is stored, "setdefault returned a value the dict does not hold"
+    print(len(victim), stored)

--- a/pyre/extra_tests/snippets/gc_symmetric_difference_roots_its_receiver.py
+++ b/pyre/extra_tests/snippets/gc_symmetric_difference_roots_its_receiver.py
@@ -1,0 +1,53 @@
+# pyre-check: gate=1
+"""`set ^ set` keeps its receiver alive while the walk runs `__eq__`.
+
+`union` and `difference` copy the receiver before any Python runs, so it is
+never held across a hop.  `symmetric_difference` resolves the *operand* first —
+which drains an iterable — and only then walks the receiver, and `COMPARE_OP`
+popped that receiver off the value stack.  Nothing moves and no answer changes,
+so a weakref-able cell placed in the set as its only referrer is what makes it
+observable.
+"""
+
+import gc
+import weakref
+
+REF = None
+KEEP = None
+SEEN = set()
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+    gc.collect()
+    KEEP = [[i] * 24 for i in range(60)] + [bytearray(b"Q" * 96) for _ in range(30)]
+
+
+class Cell:
+    pass
+
+
+def tracked():
+    global REF
+    c = Cell()
+    REF = weakref.ref(c)
+    return c
+
+
+class Probe:
+    def __hash__(self):
+        return 7
+
+    def __eq__(self, other):
+        churn()
+        SEEN.add(REF() is not None)
+        return False
+
+
+for _ in range(25):
+    print(len({Probe(), tracked()} ^ {Probe()}))
+    print(len({Probe(), tracked()}.symmetric_difference([Probe()])))
+    print(len(frozenset({Probe(), tracked()}) ^ frozenset({Probe()})))
+
+print("receiver liveness observed:", sorted(SEEN))

--- a/pyre/extra_tests/snippets/gc_traced_return_value_is_read_back.py
+++ b/pyre/extra_tests/snippets/gc_traced_return_value_is_read_back.py
@@ -1,0 +1,66 @@
+# pyre-check: gate=1
+"""A traced frame hands back its return value at the value's live address.
+
+`sys.settrace`'s `return` callback and `sys.setprofile`'s `leaveframe`
+callback are application-level Python, so a freshly allocated return value
+moves under them.  Both hooks were handed the value by copy and the caller
+was given back the word taken before the callback ran.
+
+Three things are load-bearing:
+  * the value must be freshly allocated and MOVABLE -- returning an argument
+    or an int leaves nothing for a minor collection to relocate;
+  * the caller must KEEP it, since a discarded result is never dereferenced;
+  * the callback must allocate and collect, which is what moves it.
+"""
+
+import gc
+import sys
+
+KEEP = None
+TICKS = 0
+
+
+def churn():
+    global KEEP
+    KEEP = [[i] * 12 for i in range(20)] + [bytearray(b"Q" * 64) for _ in range(10)]
+    gc.collect()
+    KEEP = [[i] * 12 for i in range(20)] + [bytearray(b"Q" * 64) for _ in range(10)]
+
+
+def tracer(frame, event, arg):
+    global TICKS
+    TICKS += 1
+    if TICKS % 7 == 0:
+        churn()
+    return tracer
+
+
+def make_list(n):
+    return [n]
+
+
+def make_dict(n):
+    return {n: n}
+
+
+held = []
+sys.settrace(tracer)
+for i in range(40):
+    held.append(make_list(i))
+    held.append(make_dict(i))
+sys.settrace(None)
+
+sys.setprofile(tracer)
+for i in range(40):
+    held.append(make_list(i))
+sys.setprofile(None)
+
+churn()
+for value in held:
+    if type(value) is list:
+        value.append(0)
+    else:
+        value["z"] = 0
+churn()
+print(len(held), sorted({type(v).__name__ for v in held}))
+print(held[0], held[1], held[-1])

--- a/pyre/pyre-interpreter/src/builtins.rs
+++ b/pyre/pyre-interpreter/src/builtins.rs
@@ -5176,6 +5176,20 @@ fn min_max_sequence(
     let _roots = pyre_object::gc_roots::push_roots();
     let sequence_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(sequence);
+    // `iter` below runs the argument's `__iter__`.  The gateway pins the
+    // argument array, but `key` and `default` are copies taken out of it and a
+    // minor rewrites the array rather than the copies, so both take slots of
+    // their own before anything can collect.  Publishing a stale word as a
+    // root is worse than reading one: the next collection walks it as if it
+    // named an object.
+    let key_fn_slot = key_fn.map(|key| {
+        let slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(key);
+        slot
+    });
+    let has_default = default.is_some();
+    let default_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(default.unwrap_or_else(pyre_object::w_none));
     let it = crate::baseobjspace::iter(pyre_object::gc_roots::shadow_stack_get(sequence_slot))?;
     let iterator_slot = pyre_object::gc_roots::shadow_stack_len();
     pyre_object::gc_roots::pin_root(it);
@@ -5193,14 +5207,8 @@ fn min_max_sequence(
         };
         pyre_object::gc_roots::pin_root(w_dict);
     }
-    let key_fn_slot = key_fn.map(|key| {
-        let slot = pyre_object::gc_roots::shadow_stack_len();
-        pyre_object::gc_roots::pin_root(key);
-        slot
-    });
-    let has_default = default.is_some();
     let best_item_slot = pyre_object::gc_roots::shadow_stack_len();
-    pyre_object::gc_roots::pin_root(default.unwrap_or_else(pyre_object::w_none));
+    pyre_object::gc_roots::pin_root(pyre_object::gc_roots::shadow_stack_get(default_slot));
     let best_key_slot = if key_fn_slot.is_some() {
         let slot = pyre_object::gc_roots::shadow_stack_len();
         pyre_object::gc_roots::pin_root(pyre_object::w_none());

--- a/pyre/pyre-interpreter/src/eval.rs
+++ b/pyre/pyre-interpreter/src/eval.rs
@@ -2178,9 +2178,15 @@ pub(crate) fn eval_frame_plain_with_resume(
         // Python finally: a finally-block exception replaces any
         // pending exception from the try-body. Only the all-OK path
         // advances to `got_exception = false`.
+        // Both hooks hand the exit value back at its live address, and both
+        // the local and `inner_result` carry the word taken before the
+        // callback ran, so each result is rebuilt from what came back.
         let combined = match return_trace_result {
             Err(rt_err) => Err(rt_err),
-            Ok(()) => inner_result,
+            Ok(live) => {
+                w_exitvalue = live;
+                inner_result.map(|_| live)
+            }
         };
         if combined.is_ok() {
             got_exception = false;
@@ -2190,7 +2196,7 @@ pub(crate) fn eval_frame_plain_with_resume(
     let leave_result = execution_context.leave(frame as *mut PyFrame, w_exitvalue, got_exception);
     match leave_result {
         Err(leave_err) => Err(leave_err),
-        Ok(()) => outer_result,
+        Ok(live) => outer_result.map(|_| live),
     }
 }
 

--- a/pyre/pyre-interpreter/src/executioncontext.rs
+++ b/pyre/pyre-interpreter/src/executioncontext.rs
@@ -622,12 +622,14 @@ impl ExecutionContext {
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Hands back the exit value at its live address: the profile callback is
+    /// application-level Python, so a movable value moves under it.
     pub fn leave(
         &mut self,
         frame: *mut PyFrame,
         w_exitvalue: PyObjectRef,
         got_exception: bool,
-    ) -> Result<(), crate::PyError> {
+    ) -> Result<PyObjectRef, crate::PyError> {
         // pypy/interpreter/executioncontext.py leave parity.
         // The original wraps `_trace('leaveframe', …)` in try/finally so
         // the topframeref restore and the vref dance always run.  We
@@ -636,8 +638,17 @@ impl ExecutionContext {
         // `_trace` runs the profile callback, which is application-level
         // Python; the chain surgery below reads the frame's own fields.
         let anchor = unsafe { crate::eval::FrameAnchor::from_raw(frame) };
+        let mut w_exitvalue = w_exitvalue;
         let trace_result = if self.profilefunc.is_some() {
-            self._trace(frame, "leaveframe", w_exitvalue, None)
+            // The exit value rides a root slot for the callback's duration.
+            // Nothing runs Python without a profiler installed, so the slot is
+            // taken on this arm rather than for every frame that leaves.
+            let _roots = pyre_object::gc_roots::push_roots();
+            let exit_slot = pyre_object::gc_roots::shadow_stack_len();
+            pyre_object::gc_roots::pin_root(w_exitvalue);
+            let result = self._trace(frame, "leaveframe", w_exitvalue, None);
+            w_exitvalue = pyre_object::gc_roots::shadow_stack_get(exit_slot);
+            result
         } else {
             Ok(())
         };
@@ -668,7 +679,7 @@ impl ExecutionContext {
         // records VIRTUAL_REF_FINISH during tracing.
         // `if self.space.reverse_debugging: self._revdb_leave(got_exception)`
         // (executioncontext.py) folds away with the arm in `enter`.
-        trace_result
+        trace_result.map(|()| w_exitvalue)
     }
 
     /// executioncontext.py — `c_call_trace(self, frame, w_func, args=None)`.
@@ -767,16 +778,21 @@ impl ExecutionContext {
         Ok(())
     }
 
+    /// Hands back the returned value at its live address: the callback is
+    /// application-level Python, so a movable value moves under it.
     pub fn return_trace(
         &mut self,
         frame: *mut PyFrame,
         w_retval: PyObjectRef,
-    ) -> Result<(), crate::PyError> {
-        let _ = (frame, w_retval);
-        if !self.gettrace().is_null() {
-            self._trace(frame, "return", w_retval, None)?;
+    ) -> Result<PyObjectRef, crate::PyError> {
+        if self.gettrace().is_null() {
+            return Ok(w_retval);
         }
-        Ok(())
+        let _roots = pyre_object::gc_roots::push_roots();
+        let retval_slot = pyre_object::gc_roots::shadow_stack_len();
+        pyre_object::gc_roots::pin_root(w_retval);
+        self._trace(frame, "return", w_retval, None)?;
+        Ok(pyre_object::gc_roots::shadow_stack_get(retval_slot))
     }
 
     #[inline(always)]

--- a/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
+++ b/pyre/pyre-interpreter/src/module/_contextvars/mod.rs
@@ -124,22 +124,30 @@ fn context_var_get(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
             args.len()
         )));
     }
+    // The lookup runs the Context mapping's `__getitem__`, which is
+    // application-level Python.  The default handed back below it is whatever
+    // the caller passed -- a list or a dict included -- and the gateway's
+    // argument array is a native copy a collection does not rewrite, so both
+    // operands are read back from their slots.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(args);
+    let var = || pyre_object::gc_roots::shadow_stack_get(args_base);
     if let Some(context) = current_context(false)? {
-        match crate::baseobjspace::getitem(context, args[0]) {
+        match crate::baseobjspace::getitem(context, var()) {
             Ok(value) => return Ok(value),
             Err(err) if err.kind == crate::PyErrorKind::KeyError => {}
             Err(err) => return Err(err),
         }
     }
-    if let Some(&default) = args.get(1) {
+    if args.len() > 1 {
+        return Ok(pyre_object::gc_roots::shadow_stack_get(args_base + 1));
+    }
+    if let Some(default) = crate::baseobjspace::findattr_result(var(), "_default")? {
         return Ok(default);
     }
-    if let Some(default) = crate::baseobjspace::findattr_result(args[0], "_default")? {
-        return Ok(default);
-    }
-    Err(crate::PyError::lookup_error(context_var_repr_string(
-        args[0],
-    )?))
+    Err(crate::PyError::lookup_error(
+        context_var_repr_string(var())?,
+    ))
 }
 
 fn call_method_result(
@@ -177,30 +185,42 @@ fn context_var_set(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError> 
     // PyPy lib_pypy/_contextvars.py ContextVar.set, line by line: read the
     // old binding, persistently replace Context._data, and return a token
     // tied to this exact Context.
-    let context = current_context(true)?.expect("create=true returns a Context");
-    let data = crate::baseobjspace::getattr_str(context, "_data")?;
-    let old_value = match crate::baseobjspace::getitem(data, args[0]) {
+    // Every step here runs Python, so each value takes its root slot before
+    // the call it has to outlive rather than after.  Pinning afterwards
+    // publishes a word a minor has already moved, and the collector then walks
+    // that slot as if it named an object.
+    //
+    // The gateway hands this function a native array it rebuilt from its own
+    // roots, so `args` is not rewritten by a collection either: the variable
+    // and the value are read back too.  The value is whatever the caller
+    // passed, a list or a dict included, and the token at the end is the only
+    // thing that will ever hold the old binding.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(&[args[0], args[1]]);
+    let var = || pyre_object::gc_roots::shadow_stack_get(args_base);
+    let value = || pyre_object::gc_roots::shadow_stack_get(args_base + 1);
+
+    let context_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(current_context(true)?.expect("create=true returns a Context"));
+    let context = || pyre_object::gc_roots::shadow_stack_get(context_slot);
+
+    let data_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
+    let data = || pyre_object::gc_roots::shadow_stack_get(data_slot);
+
+    let old_value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(match crate::baseobjspace::getitem(data(), var()) {
         Ok(value) => value,
         Err(err) if err.kind == crate::PyErrorKind::KeyError => token_missing(),
         Err(err) => return Err(err),
-    };
-    // The replacement and the store both run Python, and the token below is
-    // the only thing that will ever hold the old binding — nothing roots it
-    // across those two calls, and it is whatever the caller last set, a list
-    // or a dict included.
-    let _roots = pyre_object::gc_roots::push_roots();
-    let base = pyre_object::gc_roots::pin_roots(&[context, data, old_value]);
-    let updated_data = call_method_result(
-        pyre_object::gc_roots::shadow_stack_get(base + 1),
-        "set",
-        &[args[0], args[1]],
-    )?;
-    let context = pyre_object::gc_roots::shadow_stack_get(base);
-    crate::baseobjspace::setattr_str(context, "_data", updated_data)?;
+    });
+
+    let updated_data = call_method_result(data(), "set", &[var(), value()])?;
+    crate::baseobjspace::setattr_str(context(), "_data", updated_data)?;
     new_token(
-        pyre_object::gc_roots::shadow_stack_get(base),
-        args[0],
-        pyre_object::gc_roots::shadow_stack_get(base + 2),
+        context(),
+        var(),
+        pyre_object::gc_roots::shadow_stack_get(old_value_slot),
     )
 }
 
@@ -212,34 +232,56 @@ fn context_var_reset(args: &[PyObjectRef]) -> Result<PyObjectRef, crate::PyError
             crate::type_methods::arg_type_name(token),
         )));
     }
-    if crate::baseobjspace::is_true(crate::baseobjspace::getattr_str(token, "_used")?)? {
+    // Each attribute read and each mapping call is application-level Python.
+    // Both identity tests below compare addresses, so an operand that moved
+    // under one of these calls does not merely crash -- it reports a token as
+    // belonging to a different ContextVar or Context.  Everything that
+    // outlives a call is therefore read back from its slot, `args` included:
+    // the gateway rebuilt that array from its own roots, so a collection does
+    // not rewrite it.
+    let _roots = pyre_object::gc_roots::push_roots();
+    let args_base = pyre_object::gc_roots::pin_roots(&[args[0], token]);
+    let var = || pyre_object::gc_roots::shadow_stack_get(args_base);
+    let token = || pyre_object::gc_roots::shadow_stack_get(args_base + 1);
+
+    if crate::baseobjspace::is_true(crate::baseobjspace::getattr_str(token(), "_used")?)? {
         return Err(crate::PyError::runtime_error(crate::display::wtf8_format!(
-            token_repr_string(token)?,
+            token_repr_string(token())?,
             " has already been used once",
         )));
     }
-    let token_var = crate::baseobjspace::getattr_str(token, "_var")?;
-    if !std::ptr::eq(token_var, args[0]) {
+    let token_var_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_var")?);
+    let token_var = || pyre_object::gc_roots::shadow_stack_get(token_var_slot);
+    if !std::ptr::eq(token_var(), var()) {
         return Err(crate::PyError::value_error(
             "Token was created by a different ContextVar",
         ));
     }
-    let context = current_context(true)?.expect("create=true returns a Context");
-    let token_context = crate::baseobjspace::getattr_str(token, "_context")?;
-    if !std::ptr::eq(token_context, context) {
+    let context_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(current_context(true)?.expect("create=true returns a Context"));
+    let context = || pyre_object::gc_roots::shadow_stack_get(context_slot);
+    if !std::ptr::eq(
+        crate::baseobjspace::getattr_str(token(), "_context")?,
+        context(),
+    ) {
         return Err(crate::PyError::value_error(
             "Token was created in a different Context",
         ));
     }
-    let data = crate::baseobjspace::getattr_str(context, "_data")?;
-    let old_value = crate::baseobjspace::getattr_str(token, "_old_value")?;
-    let updated_data = if std::ptr::eq(old_value, token_missing()) {
-        call_method_result(data, "delete", &[token_var])?
+    let data_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(context(), "_data")?);
+    let data = || pyre_object::gc_roots::shadow_stack_get(data_slot);
+    let old_value_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(crate::baseobjspace::getattr_str(token(), "_old_value")?);
+    let old_value = || pyre_object::gc_roots::shadow_stack_get(old_value_slot);
+    let updated_data = if std::ptr::eq(old_value(), token_missing()) {
+        call_method_result(data(), "delete", &[token_var()])?
     } else {
-        call_method_result(data, "set", &[token_var, old_value])?
+        call_method_result(data(), "set", &[token_var(), old_value()])?
     };
-    crate::baseobjspace::setattr_str(context, "_data", updated_data)?;
-    crate::baseobjspace::setattr_str(token, "_used", w_bool_from(true))?;
+    crate::baseobjspace::setattr_str(context(), "_data", updated_data)?;
+    crate::baseobjspace::setattr_str(token(), "_used", w_bool_from(true))?;
     Ok(w_none())
 }
 

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -5372,8 +5372,16 @@ fn init_list_type(ns: PyObjectRef) {
                     // reports "expected 1 argument, got M" rather than the
                     // `extend` message surfaced by the shared implementation.
                     crate::type_methods::arity_slot(args, 1)?;
+                    // `extend` drains a user iterator, so the receiver handed
+                    // back has to come off its root slot: `args` is the stack
+                    // copy the gateway built, and a minor rewrites the shadow
+                    // slots rather than that copy.  Returning the pre-move word
+                    // stores it into the assignment target, where the next
+                    // minor finds a root pointing at a stale header.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let base = pyre_object::gc_roots::pin_roots(args);
                     crate::type_methods::list_method_extend(args)?;
-                    Ok(args[0])
+                    Ok(pyre_object::gc_roots::shadow_stack_get(base))
                 },
                 2,
             ),
@@ -7026,11 +7034,17 @@ fn init_dict_type(ns: PyObjectRef) {
                     // `dictmultiobject.py descr_ior`: in-place update via
                     // `update1`, returns self.
                     crate::type_methods::arity_slot(args, 1)?;
+                    // The update runs the operand's `keys`/`__getitem__` and
+                    // the keys' `__hash__`, so the receiver handed back is read
+                    // off its root slot rather than out of the gateway's stack
+                    // copy, as `list.__iadd__` does.
+                    let _roots = pyre_object::gc_roots::push_roots();
+                    let base = pyre_object::gc_roots::pin_roots(args);
                     let self_ = crate::type_methods::resolve_dict_backing(args[0]);
                     if !self_.is_null() {
                         crate::type_methods::dict_update1(self_, args[1])?;
                     }
-                    Ok(args[0])
+                    Ok(pyre_object::gc_roots::shadow_stack_get(base))
                 },
                 2,
             ),

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -26418,10 +26418,19 @@ pub(crate) fn set_method_symmetric_difference(
     // in a set of self's class.  Each set below is freshly minted with no
     // referrer and outlives a further allocation, so each takes the
     // lifetime pin the intersection path takes; sets never move.
+    // The receiver needs the pin too, not just the minted sets: unlike
+    // `set_method_union` and `set_method_difference`, which copy it before any
+    // Python runs, this one drains the operand first and only then walks the
+    // receiver — and `COMPARE_OP` popped it off the value stack.
     let _roots = pyre_object::gc_roots::push_roots();
+    let receiver_slot = pyre_object::gc_roots::shadow_stack_len();
+    pyre_object::gc_roots::pin_root(args[0]);
     let w_other_as_set = set_operand_as_set(args[1])?;
     pyre_object::gc_roots::pin_root(w_other_as_set);
-    let w_new = set_symmetric_difference_storage(args[0], w_other_as_set)?;
+    let w_new = set_symmetric_difference_storage(
+        pyre_object::gc_roots::shadow_stack_get(receiver_slot),
+        w_other_as_set,
+    )?;
     pyre_object::gc_roots::pin_root(w_new);
     unsafe {
         if pyre_object::is_frozenset(args[0]) {

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -3036,8 +3036,17 @@ pub unsafe fn w_dict_setdefault_checked(
         if let Some(existing) = w_module_dict_lookup_inner_checked(obj, key)? {
             return Ok(existing);
         }
-        w_module_dict_store_inner_checked(obj, key, value)?;
-        return Ok(value);
+        // A non-str key sends the lookup above through the object strategy,
+        // which hashes it, and a `__hash__` written in Python is a collection
+        // point that moves the module dict.  Every word the store is handed
+        // comes off its root slot, and so does the result: the by-value words
+        // taken before the lookup name pre-move headers.
+        w_module_dict_store_inner_checked(
+            _dict_guard.root(0),
+            _dict_guard.root(1),
+            _dict_guard.root(2),
+        )?;
+        return Ok(_dict_guard.root(2));
     }
     let strategy = (*(obj as *const W_DictObject)).dstrategy.imp;
     // `dictmultiobject.py EmptyDictStrategy.setdefault`:
@@ -3053,7 +3062,7 @@ pub unsafe fn w_dict_setdefault_checked(
     if strategy_is(strategy, &crate::dictmultiobject::EMPTY_DICT_STRATEGY) {
         crate::dictmultiobject::EMPTY_DICT_STRATEGY.switch_to_correct_strategy(obj, key);
         w_dict_store_checked(obj, key, value)?;
-        return Ok(value);
+        return Ok(_dict_guard.root(2));
     }
     if strategy_is(
         strategy,
@@ -3061,7 +3070,7 @@ pub unsafe fn w_dict_setdefault_checked(
     ) {
         crate::dictmultiobject::EMPTY_KWARGS_DICT_STRATEGY.switch_to_correct_strategy(obj, key);
         w_dict_store_checked(obj, key, value)?;
-        return Ok(value);
+        return Ok(_dict_guard.root(2));
     }
     if strategy_is(strategy, &crate::dictmultiobject::OBJECT_DICT_STRATEGY) {
         // `AbstractTypedStrategy.setdefault` (`dictmultiobject.py`) runs


### PR DESCRIPTION
Six rooting defects, found by two instruments that earlier rounds of this audit did not have. Each commit is one concern; each is reproduced on a control binary built from the parent commit and covered by a gated snippet.

| commit | defect |
|---|---|
| `typedef` | `list.__iadd__` / `dict.__ior__` returned the gateway's stack copy of the receiver after `extend` / `update1` ran Python |
| `set` | `set.symmetric_difference` read its receiver out of `args[0]` after `set_operand_as_set` ran a user iterator |
| `dict` | `dict.setdefault` returned the default word taken before the store hashed the key; the module-dict arm also stored through a pre-lookup receiver |
| `executioncontext` | a traced frame handed back the exit value taken before the `return` / `leaveframe` callback ran |
| `builtins` | `min` / `max` published a stale `default` and `key` as GC roots across the argument's `__iter__` |
| `_contextvars` | `ContextVar.set` / `reset` / `get` held their operands across the mapping calls; `reset` had no rooting at all |

## Two instruments, and what they invalidate

**1. A discarded result is a blind spot.** Earlier rounds wrote every probe as a bare expression statement, so a defect in a *returned* value was invisible to 120 cases at once — nothing ever dereferenced the returned word. `dict.setdefault(d, H(), [])` measured clean at top level for a whole round and surfaced only through `collections.defaultdict`, whose `__missing__` *returns* `dict.setdefault(self, key, factory())`. Rewriting each loop-body expression to `keep(<expr>)` and dereferencing the held values after a churn found it. Re-running the corpus that way (102 cases) found the setdefault defect and nothing else, so the blind spot was real but narrow.

**2. A churning `sys.settrace` callback is the broadest instrument so far.** It makes every traced event a collection point without a hand-written collecting dunder per protocol slot, and it caught a defect that ~280 targeted cases had missed. The corroboration is that the same fix already existed one layer over: the builtin call path publishes its result around `c_return_trace` and reads it back, which is exactly why a `setprofile` probe over builtins is clean and one over Python functions was not. Both hooks now take the root slot only on the arm where a callback exists, so a frame leaving with nothing installed touches no slot.

The last two commits came out of that second instrument. `contextvars` is the one whose blast radius is wider than its snippet: `syntax_async_comprehension.py` was a hard SEGV under a churning tracer, and it is green now, because asyncio runs on contextvars. An earlier attempt to reduce that SEGV to an async-comprehension repro failed — the defect was never in the comprehension.

## Pinning a stale word is worse than reading one

`min`/`max` is the first case in this audit of a second failure mode. A *read* after a collection point names a pre-move address and gives a wrong answer. A **pin** after a collection point publishes a pre-move address as a GC root, and the next collection walks that slot as if it named an object — a bare SEGV inside the collector, with no line of Python to point at. `min(seq, default=[1], key=f)` took `default` and `key` as copies out of the gateway's argument array, pinned them after `iter()` had already run the argument's `__iter__`, and so rooted two words that no longer named anything.

Gateway arguments are the reason the copies go stale: `call_builtin_code_positional` pins the arguments on the shadow stack and hands the builtin a freshly rebuilt native array, so a minor collection rewrites the shadow slots and not the array the builtin holds. Liveness is guaranteed there; staleness is not.

## Negatives recorded, so they are not re-filed

The `exception` trace event, the generator `yield` path, `setprofile` over builtin calls (`c_call` / `c_return`); every module-dict entry point other than `setdefault`; the returned-default family (12 cases: `dict.get`/`pop` defaults, `getattr`/`next`/`sum`, `list.pop`); container-building builtins (22 cases); descriptors, context managers, generators, metaclass creation, exception construction (22 cases); the operator-level iteration paths (unpacking, star-args, `**` merge, `for`, comprehensions, genexps, displays, `in`); movable keyword operands (`zip_longest(fillvalue=)`, `accumulate(initial=)`); finalizers, cyclic `__del__`, weakref callbacks; a JIT-hot variant of the whole corpus; and 338 composed `settrace` cases across two sweeps.

A static scan for the pin-after-collect shape returned ~136 sites, nearly all false positives, which is why the instruments above did the work instead.

Noticed while validating an instrument and **not** part of these commits: `gc.callbacks` is exposed as a real list but never invoked, so a registered callback silently never fires. PyPy has no such attribute; CPython fires it around every collection.

## Gates

Seven new snippets under `pyre/extra_tests/snippets/`, each carrying `# pyre-check: gate=1`, each verified red on a control binary and green on CPython:

- `gc_inplace_extend_returns_the_live_receiver.py`
- `gc_symmetric_difference_roots_its_receiver.py`
- `gc_setdefault_returns_the_live_default.py`
- `gc_module_dict_setdefault_reloads_its_receiver.py`
- `gc_traced_return_value_is_read_back.py`
- `gc_min_max_default_survives_the_iter_call.py`
- `gc_contextvar_operands_survive_the_mapping_calls.py`

Two of these needed the tracer to be red at all. The first `contextvars` snippet, written without one, was green before the fix; rewritten around a churning `sys.settrace` it is red 5/5 on both backends. `gc_min_max_default_survives_the_iter_call.py` is tracing-free — it collects from the argument's own `__iter__`.

Local lanes green on the base immediately before this one: gated snippets 93/93 across cpython/dynasm/cranelift, parity, `cargo test --all --no-default-features --features dynasm` (164 suites / 8078 tests), `cargo fmt --all -- --check`, LLBC `--check`, the new-line citation gate. The branch was rebased again onto a base carrying #1393 and #1405 after that run, which voids the binaries it was taken on; `fmt` and the citation gate are re-run and green here, and the rebuild plus the snippet, parity and test lanes are being re-run on this base. CI is the gate.

One thing the rebase did **not** silently merge, checked by hand: every file these commits touch was also touched by main in between. `#1396` moved `exception_trace` and `_trace`, which are not the `return_trace` / `leave` pair changed here; `#1394`'s `dictmultiobject.rs` work is ~2000 lines away from `w_dict_setdefault_checked`; and `#1393`'s `gc_roots` change is a single-mutator fast path around forwarding-stub normalization, which leaves the pin-then-read-back contract these commits rely on unchanged.

— *authored by Claude*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
