### PR TITLE
error: per-format-code oefmt conversions and new_exception_class's failure channel; the locals fold's measured refusal reason

### DIFF
--- a/pyre/README.md
+++ b/pyre/README.md
@@ -16,30 +16,30 @@ The deeper goal is to **reproduce RPython in Rust**. RPython's real value was ne
 
 ## Status
 
-pyre is under active development. Loop tracing and function inlining work, and the JIT fires on integer-, float-, and exception-heavy loops alike. On the CI benchmark set the default backend runs nine of the ten programs at 2.0x of PyPy or better, and `float_loop` faster than PyPy; `fannkuch` is the widest remaining gap at 2.5x. Many Python features are not yet implemented.
+pyre is under active development. Loop tracing and function inlining work, and the JIT fires on integer-, float-, and exception-heavy loops alike. On the CI benchmark set the default backend runs eight of the ten programs at 2.0x of PyPy or better, and `float_loop` faster than PyPy; `fannkuch` is the widest remaining gap at 2.5x. Many Python features are not yet implemented.
 
 ## Benchmarks
 
-Copied from the `pyre/check.py (ubuntu-24.04)` job of [CI run 32465640260](https://github.com/youknowone/pyre/actions/runs/32465640260), a single-core GitHub Actions `ubuntu-24.04` runner. The figure in parentheses is check.py's ratio against PyPy.
+Copied from the `pyre/check.py (ubuntu-24.04)` job of [CI run 32534726733](https://github.com/youknowone/pyre/actions/runs/32534726733), a single-core GitHub Actions `ubuntu-24.04` runner. The figure in parentheses is check.py's ratio against PyPy.
 
 | Benchmark | CPython 3.14 | PyPy 7.3 | dynasm | cranelift | wasm |
 |-----------|--------------|----------|--------|-----------|------|
-| int_loop | – | 0.32s | 0.43s (1.0x) | 0.58s (1.5x) | 0.47s (1.4x) |
-| float_loop | – | 0.42s | 0.31s (0.5x) | 0.37s (0.7x) | 0.25s (0.5x) |
+| int_loop | – | 0.32s | 0.43s (1.0x) | 0.59s (1.5x) | 0.48s (1.4x) |
+| float_loop | – | 0.41s | 0.31s (0.5x) | 0.37s (0.7x) | 0.24s (0.5x) |
 | fib_loop | 0.20s | 0.12s | 0.27s (1.6x) | 0.27s (1.5x) | 0.26s (2.1x) |
-| inline_helper | – | 0.22s | 0.35s (1.2x) | 0.35s (1.2x) | 0.41s (1.7x) |
-| fib_recursive | 1.92s | 0.31s | 0.72s (2.0x) | 1.03s (3.1x) | 2.38s (7.8x) |
-| nested_loop | – | 0.30s | 0.51s (1.4x) | 0.74s (2.2x) | 0.82s (2.7x) |
-| raise_catch | – | 0.82s | 0.93s (1.0x) | 1.65s (1.9x) | 1.50s (1.8x) |
-| spectral_norm | – | 0.13s | 0.31s (1.7x) | 0.42s (2.6x) | 0.36s (2.6x) |
-| nbody | – | 0.30s | 0.60s (1.7x) | 0.77s (2.3x) | 0.83s (2.7x) |
-| fannkuch | 2.71s | 0.34s | 0.94s (2.5x) | 1.77s (5.1x) | 1.87s (5.6x) |
+| inline_helper | – | 0.22s | 0.35s (1.2x) | 0.35s (1.2x) | 0.42s (1.8x) |
+| fib_recursive | 1.91s | 0.32s | 0.76s (2.1x) | 1.03s (3.0x) | 1.47s (4.7x) |
+| nested_loop | – | 0.31s | 0.50s (1.3x) | 0.75s (2.2x) | 0.83s (2.7x) |
+| raise_catch | – | 0.83s | 0.91s (1.0x) | 1.65s (1.9x) | 1.50s (1.8x) |
+| spectral_norm | – | 0.13s | 0.32s (1.7x) | 0.42s (2.6x) | 0.36s (2.7x) |
+| nbody | – | 0.30s | 0.60s (1.7x) | 0.77s (2.3x) | 0.75s (2.5x) |
+| fannkuch | 2.78s | 0.34s | 0.93s (2.5x) | 1.77s (5.0x) | 1.89s (5.6x) |
 
 `dynasm` is the default backend of the `pyre` binary; `cranelift` and `wasm` are the other two MaJIT code generators.
 
-Reading the table: the printed times are user CPU time — `check.py`'s `run_timed` reports `ru_utime` on Unix and `TotalUserTime` on Windows — and include interpreter startup, which on that runner was 0.010s for CPython, 0.013s for PyPy, 0.109s for dynasm, 0.106s for cranelift and 0.046s for wasm. The ratios divide execution-only times, so they are not the quotient of the printed columns — that startup difference is why `int_loop` prints a third more than PyPy's time yet ratios at 1.0x. A `–` in the CPython column means check.py ran no CPython reference for that benchmark, not that it timed out: it measures one only where a vs-CPython gate is configured, and `--full` measures it everywhere. Absolute times are runner-dependent and only comparable within one table; the ratios are the part that carries across runs.
+Reading the table: the printed times are user CPU time — `check.py`'s `run_timed` reports `ru_utime` on Unix and `TotalUserTime` on Windows — and include interpreter startup, which on that runner was 0.009s for CPython, 0.014s for PyPy, 0.109s for dynasm, 0.112s for cranelift and 0.047s for wasm. The ratios divide execution-only times, so they are not the quotient of the printed columns — that startup difference is why `int_loop` prints a third more than PyPy's time yet ratios at 1.0x. A `–` in the CPython column means check.py ran no CPython reference for that benchmark, not that it timed out: it measures one only where a vs-CPython gate is configured, and `--full` measures it everywhere. Absolute times are runner-dependent and only comparable within one table. The ratios carry further, but not perfectly: the PyPy reference is measured on the same shared runner and its own time for a benchmark has been seen to move by up to 3x between runs of identical code — `fib_recursive` measured 0.31s on the run above and 0.92s on another `ubuntu-24.04` run — so a ratio carries the reference's noise as well as pyre's. Read one run's table as indicative rather than reproducible to the digit.
 
-On execution-only time the default backend is at 2.0x of PyPy or better on nine of the ten. `float_loop` beats PyPy on all three backends, and `int_loop` and `raise_catch` reach parity on dynasm. `fannkuch` is the widest gap. Cranelift trails dynasm on eight of the ten — widest on `fannkuch` (~2.0x) and `raise_catch` (~1.9x) — and matches it only on `fib_loop` and `inline_helper`. Where CPython was measured, pyre runs `fannkuch` ~3.3x and `fib_recursive` ~3.1x faster than it, and `fib_loop` ~1.2x.
+On execution-only time the default backend is at 2.0x of PyPy or better on eight of the ten, and within 2.5x on all ten. `float_loop` beats PyPy on all three backends, and `int_loop` and `raise_catch` reach parity on dynasm. `fannkuch` is the widest gap. Cranelift trails dynasm on eight of the ten — widest on `fannkuch` (~2.0x) and `raise_catch` (~1.9x) — and matches it only on `fib_loop` and `inline_helper`. Where CPython was measured, pyre runs `fannkuch` ~3.4x and `fib_recursive` ~2.9x faster than it, and `fib_loop` ~1.2x.
 
 Run `python pyre/check.py` to reproduce all benchmarks with CPython / PyPy / pyre comparison on your machine. If the release backend binaries are already built, pass `--no-build` to skip the Cargo build phase.
 

--- a/pyre/bench/synth/dict_update_hot.py
+++ b/pyre/bench/synth/dict_update_hot.py
@@ -1,9 +1,15 @@
-# pyre-check: max-pypy-ratio=15
-# The ceiling sits between the two measured states: folded this runs 11.4x
-# pypy, and with `builtin_dict_get` suppressed about 20.2x. That 1.8x gap is
-# the whole `builtin_dict_get` effect, so the margin either side is only
-# ~1.3x -- loosen this ceiling rather than delete the loop if a slower host
-# proves it flaky.
+# pyre-check: max-pypy-ratio=20
+# The ceiling sits between the two measured states. Re-measured 2026-08-22 on
+# darwin-arm64, user CPU less startup, median of 3: pypy 0.169s, folded 1.996s
+# (11.8x), and with `builtin_dict_get` suppressed 4.596s (27.2x). The fold is
+# worth 2.3x, wider than the 1.8x first recorded here, so suppressing it stays
+# far outside the ceiling.
+# The ceiling moved 15 -> 20 because the ubuntu-24.04 runner measures the
+# FOLDED state at 14.6x, 15.5x and 15.6x across three runs -- it straddled the
+# old ceiling and flipped the gate run to run while the fold was working. 20
+# clears the worst folded reading by 1.25x and stays 1.36x under the suppressed
+# state, which restores the margin the old ceiling had against the host it was
+# first measured on.
 # N/ITERS are sized to prove the opcode compiles and to drive the compiled
 # loop thousands of times, not to race pypy.
 # A hot exact `dict.get` loop rides along: without the `builtin_dict_get` fold

--- a/pyre/pyre-interpreter/src/argument.rs
+++ b/pyre/pyre-interpreter/src/argument.rs
@@ -16,24 +16,11 @@
 
 use pyre_object::PyObjectRef;
 
-/// PyPy `oefmt(..., "%T", w_obj)` — resolves the wrapped object's
-/// type name for diagnostic messages, mirroring
-/// `space.type(w_obj).getname(space)`.  Used by the `*args` /
-/// `**kwargs` parity messages below ("argument after * must be an
-/// iterable, not %T", "argument after ** must be a mapping, not %T",
-/// "keywords must be strings, not '%T'").
-fn type_name_of(w_obj: PyObjectRef) -> String {
-    // A tagged int immediate is an exact builtin int; skip the ob_type deref.
-    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(w_obj) {
-        return "int".to_string();
-    }
-    unsafe {
-        match crate::typedef::r#type(w_obj) {
-            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
-            None => (*(*w_obj).ob_type).name.to_string(),
-        }
-    }
-}
+/// The `%T` conversion `oefmt` applies, for the `*args` / `**kwargs` parity
+/// messages below ("argument after * must be an iterable, not %T", "argument
+/// after ** must be a mapping, not %T", "keywords must be strings, not '%T'")
+/// — which are `oefmt(..., "%T", w_obj)` upstream.
+use crate::error::type_name_of;
 
 /// pypy/interpreter/argument.py `raise_type_error`.
 ///

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3473,26 +3473,29 @@ pub fn get_converted_unexpected_exception(
 
 /// pypy/interpreter/error.py `decompose_valuefmt`.
 ///
-/// Upstream splits on `'%'` and asserts `len(parts) == len(formats) + 1`:
-/// every format code has a literal part on each side, so a format string that
-/// ends in one still contributes a trailing empty part.  `_compute_value`
-/// relies on that — it walks the parts and the formats in lockstep.
+/// Every format code has a literal part on each side, so a format string that
+/// ends in one still contributes a trailing empty part. `_compute_value`
+/// relies on that — it walks the parts and the formats in lockstep — and
+/// `get_operrcls2` asserts the resulting relationship.
 pub fn decompose_valuefmt(valuefmt: &str) -> (Vec<String>, Vec<String>) {
+    const FMTS: &str = "8NRSTds";
+
     let mut strings = Vec::new();
     let mut formats = Vec::new();
     let mut current = String::new();
 
-    let mut iter = valuefmt.chars().peekable();
+    let mut iter = valuefmt.chars();
     while let Some(ch) = iter.next() {
         if ch == '%' {
-            if let Some('%') = iter.peek() {
-                let _ = iter.next();
-                current.push('%');
-                continue;
-            }
-            strings.push(std::mem::take(&mut current));
-            if let Some(spec) = iter.next() {
-                formats.push(spec.to_string());
+            match iter.next() {
+                Some('%') => current.push('%'),
+                Some(spec) if FMTS.contains(spec) => {
+                    strings.push(std::mem::take(&mut current));
+                    formats.push(spec.to_string());
+                }
+                Some(_) | None => {
+                    panic!("invalid format string (only %8, %N, %R, %S, %T, %d or %s supported)")
+                }
             }
         } else {
             current.push(ch);
@@ -3503,11 +3506,13 @@ pub fn decompose_valuefmt(valuefmt: &str) -> (Vec<String>, Vec<String>) {
     // that makes `strings` one longer than `formats`.
     strings.push(current);
 
+    assert!(!formats.is_empty(), "unsupported: no % command found");
     (strings, formats)
 }
 
 pub fn get_operrcls2(valuefmt: &str) -> (PyObjectRef, Vec<String>) {
-    let (strings, _formats) = decompose_valuefmt(valuefmt);
+    let (strings, formats) = decompose_valuefmt(valuefmt);
+    assert_eq!(strings.len(), formats.len() + 1);
     (std::ptr::null_mut(), strings)
 }
 
@@ -3748,7 +3753,14 @@ pub fn new_exception_class(
         let exc_slot = pyre_object::gc_roots::shadow_stack_len();
         _roots.pin_root(w_exc);
         let w_module = pyre_object::w_str_new(module);
-        let _ = crate::baseobjspace::setattr_str(_roots.get(exc_slot), "__module__", w_module);
+        // `space.setattr` propagates its failure through the same bare-return
+        // channel as the class call above.
+        if let Err(err) =
+            crate::baseobjspace::setattr_str(_roots.get(exc_slot), "__module__", w_module)
+        {
+            crate::call::set_call_error(err);
+            return std::ptr::null_mut();
+        }
         return _roots.get(exc_slot);
     }
     w_exc
@@ -3899,8 +3911,6 @@ mod tests {
             "cannot do %s to %s",
             "%s leads",
             "trails %s",
-            "no format codes",
-            "",
             "%N takes %R and %T",
         ] {
             let (strings, formats) = super::decompose_valuefmt(valuefmt);
@@ -3910,6 +3920,22 @@ mod tests {
                 "{valuefmt:?} -> {strings:?} / {formats:?}"
             );
         }
+    }
+
+    #[test]
+    fn decompose_valuefmt_rejects_no_format_command() {
+        for valuefmt in ["no format codes", ""] {
+            let panic = std::panic::catch_unwind(|| super::decompose_valuefmt(valuefmt));
+            assert!(panic.is_err(), "accepted {valuefmt:?}");
+        }
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "invalid format string (only %8, %N, %R, %S, %T, %d or %s supported)"
+    )]
+    fn decompose_valuefmt_rejects_an_invalid_code() {
+        let _ = super::decompose_valuefmt("cannot use %q");
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3585,18 +3585,85 @@ fn operation_error_from_class(w_type: PyObjectRef, message: &str) -> OperationEr
 /// is left is the step upstream takes in both arms — build the error **from
 /// `w_type`**.
 ///
-/// The arguments arrive rendered, one per format code, because the format
-/// codes themselves (`%T`, `%N`, `%R`, …) name object-space spellings a
-/// `Display` already carries.  They stay a sequence rather than one joined
-/// value: a single `Display` handed to a `valuefmt` with several codes reports
-/// the same text in every one of them.
-pub fn oefmt(
-    w_type: PyObjectRef,
-    valuefmt: &str,
-    args: &[&dyn std::fmt::Display],
-) -> OperationError {
-    use std::fmt::Write as _;
+/// Each format code keeps the operand kind that
+/// `get_operrcls2.OpErrFmt._compute_value` expects, so conversion is selected
+/// by the code rather than by one common display implementation.
+pub enum FmtArg<'a> {
+    /// `%s`: text copied as-is.
+    Text(&'a str),
+    /// `%d`: an integer rendered in decimal.
+    Int(i64),
+    /// `%8`: raw bytes decoded as UTF-8 with replacement.
+    Bytes(&'a [u8]),
+    /// `%R`, `%S`, `%T`, and `%N`: a wrapped object.
+    Obj(PyObjectRef),
+}
 
+impl FmtArg<'_> {
+    fn kind_name(&self) -> &'static str {
+        match self {
+            Self::Text(_) => "Text",
+            Self::Int(_) => "Int",
+            Self::Bytes(_) => "Bytes",
+            Self::Obj(_) => "Obj",
+        }
+    }
+}
+
+fn expected_fmt_arg(format: char) -> &'static str {
+    match format {
+        's' => "Text",
+        'd' => "Int",
+        '8' => "Bytes",
+        'R' | 'S' | 'T' | 'N' => "Obj",
+        _ => unreachable!("decompose_valuefmt accepted an unknown format code"),
+    }
+}
+
+/// The shared `%R` / `%S` conversion and rescue from
+/// `get_operrcls2.OpErrFmt._compute_value`.
+fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
+    let _roots = pyre_object::gc_roots::push_roots();
+    let obj_slot = _roots.base();
+    _roots.pin_root(obj);
+    let obj = || _roots.get(obj_slot);
+
+    let (rendered, fallback) = if format == 'R' {
+        (
+            unsafe { crate::display::py_repr_wtf8(obj()) },
+            "<repr raised>",
+        )
+    } else {
+        (
+            unsafe { crate::display::py_str_wtf8(obj()) },
+            "<str raised>",
+        )
+    };
+    match rendered.and_then(|rendered| {
+        let w_rendered = pyre_object::w_str_from_wtf8_managed(rendered);
+        crate::baseobjspace::utf8_w(w_rendered).map(str::to_owned)
+    }) {
+        Ok(rendered) => rendered,
+        Err(mut error) => {
+            error.write_unraisable(
+                pyre_object::w_none(),
+                rustpython_wtf8::Wtf8::new("exception formatting: "),
+                obj(),
+            );
+            fallback.to_owned()
+        }
+    }
+}
+
+/// `W_Root.getname`: read `__name__` as UTF-8 and suppress a failing lookup
+/// or conversion with `?`.
+fn format_obj_name(obj: PyObjectRef) -> String {
+    let name =
+        crate::baseobjspace::getattr_str(obj, "__name__").and_then(crate::baseobjspace::utf8_w);
+    name.unwrap_or("?").to_owned()
+}
+
+pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> OperationError {
     // `OpErrFmtNoArgs(w_type, valuefmt)` — no argument, so the format string is
     // the message verbatim, `%` sequences and all.
     let message = if args.is_empty() {
@@ -3606,14 +3673,62 @@ pub fn oefmt(
         // `_compute_value` makes over them: a literal part, the argument
         // belonging to the format code that followed it, and so on to the
         // trailing part `decompose_valuefmt` guarantees.
-        let (_op_err_fmt, strings) = get_operr_class(valuefmt);
-        let mut message = String::new();
-        for (i, part) in strings.iter().enumerate() {
-            message.push_str(part);
-            if let Some(arg) = args.get(i) {
-                let _ = write!(message, "{arg}");
+        let (strings, formats) = decompose_valuefmt(valuefmt);
+        assert_eq!(
+            args.len(),
+            formats.len(),
+            "oefmt argument count mismatch: {} format codes but {} arguments",
+            formats.len(),
+            args.len()
+        );
+
+        // Pin every object before the first object-space conversion can move
+        // any later operand. The argument slice itself contains raw pointers
+        // and is not a GC root.
+        let _roots = pyre_object::gc_roots::push_roots();
+        let mut rooted_obj_count = 0;
+        for arg in args {
+            if let FmtArg::Obj(obj) = arg {
+                _roots.pin_root(*obj);
+                rooted_obj_count += 1;
             }
         }
+        let first_obj_slot = _roots.base();
+        let mut next_obj_slot = first_obj_slot;
+        let mut message = String::new();
+        for (i, part) in strings[..formats.len()].iter().enumerate() {
+            message.push_str(part);
+            let format = formats[i].chars().next().unwrap();
+            let arg = &args[i];
+            let rendered = match (format, arg) {
+                ('d', FmtArg::Int(value)) => value.to_string(),
+                ('s', FmtArg::Text(value)) => (*value).to_owned(),
+                ('8', FmtArg::Bytes(value)) => String::from_utf8_lossy(value).into_owned(),
+                ('T', FmtArg::Obj(_)) => {
+                    let obj = _roots.get(next_obj_slot);
+                    next_obj_slot += 1;
+                    unsafe { pyre_object::pyobject::type_name_of(obj) }.to_owned()
+                }
+                ('N', FmtArg::Obj(_)) => {
+                    let obj = _roots.get(next_obj_slot);
+                    next_obj_slot += 1;
+                    format_obj_name(obj)
+                }
+                ('R' | 'S', FmtArg::Obj(_)) => {
+                    let obj = _roots.get(next_obj_slot);
+                    next_obj_slot += 1;
+                    format_obj_as_utf8(obj, format)
+                }
+                _ => panic!(
+                    "oefmt format %{format} requires {} argument, got {}",
+                    expected_fmt_arg(format),
+                    arg.kind_name()
+                ),
+            };
+            message.push_str(&rendered);
+        }
+        debug_assert_eq!(next_obj_slot - first_obj_slot, rooted_obj_count);
+        message.push_str(&strings[formats.len()]);
         message
     };
     operation_error_from_class(w_type, &message)
@@ -3954,7 +4069,11 @@ mod tests {
 
     #[test]
     fn oefmt_interleaves_the_rendered_argument() {
-        let err = super::oefmt(std::ptr::null_mut(), "cannot add %s", &[&"int"]);
+        let err = super::oefmt(
+            std::ptr::null_mut(),
+            "cannot add %s",
+            &[super::FmtArg::Text("int")],
+        );
         assert_eq!(err.render_exception(), "RuntimeError: cannot add int");
     }
 
@@ -3965,11 +4084,44 @@ mod tests {
         let err = super::oefmt(
             std::ptr::null_mut(),
             "cannot add %s to %s",
-            &[&"int", &"str"],
+            &[super::FmtArg::Text("int"), super::FmtArg::Text("str")],
         );
         assert_eq!(
             err.render_exception(),
             "RuntimeError: cannot add int to str"
+        );
+    }
+
+    #[test]
+    fn oefmt_applies_scalar_conversion_per_format_code() {
+        let err = super::oefmt(
+            std::ptr::null_mut(),
+            "%d %s",
+            &[super::FmtArg::Int(-42), super::FmtArg::Text("items")],
+        );
+        assert_eq!(err.render_exception(), "RuntimeError: -42 items");
+    }
+
+    #[test]
+    fn oefmt_replaces_invalid_utf8_for_percent_8() {
+        let err = super::oefmt(
+            std::ptr::null_mut(),
+            "bad bytes: %8",
+            &[super::FmtArg::Bytes(b"left\xffright")],
+        );
+        assert_eq!(
+            err.render_exception(),
+            "RuntimeError: bad bytes: left\u{fffd}right"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "oefmt format %d requires Int argument, got Text")]
+    fn oefmt_rejects_an_operand_of_the_wrong_kind() {
+        let _ = super::oefmt(
+            std::ptr::null_mut(),
+            "count: %d",
+            &[super::FmtArg::Text("not an integer")],
         );
     }
 

--- a/pyre/pyre-interpreter/src/error.rs
+++ b/pyre/pyre-interpreter/src/error.rs
@@ -3639,11 +3639,15 @@ fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
             "<str raised>",
         )
     };
-    match rendered.and_then(|rendered| {
-        let w_rendered = pyre_object::w_str_from_wtf8_managed(rendered);
-        crate::baseobjspace::utf8_w(w_rendered).map(str::to_owned)
-    }) {
-        Ok(rendered) => rendered,
+    match rendered {
+        // `space.utf8_w(w_s)` hands back the string's own buffer, which is what
+        // `py_repr_wtf8` already returned, so only a repr or str that *raised*
+        // takes the rescue below.  Reading it back through a `&str` view
+        // instead would divert a lone surrogate — legal in that buffer — into
+        // the rescue as well, reporting `<repr raised>` for a repr that
+        // succeeded.  The surrogate itself does not survive the last step: the
+        // message this builds is a Rust `String`.
+        Ok(rendered) => rendered.to_string_lossy().into_owned(),
         Err(mut error) => {
             error.write_unraisable(
                 pyre_object::w_none(),
@@ -3655,12 +3659,37 @@ fn format_obj_as_utf8(obj: PyObjectRef, format: char) -> String {
     }
 }
 
-/// `W_Root.getname`: read `__name__` as UTF-8 and suppress a failing lookup
-/// or conversion with `?`.
+/// `W_Root.getname`: read `__name__` and answer `?` when the lookup raises —
+/// for any `OperationError`, not just the two an attribute miss produces.
+///
+/// The name is read off the string's own buffer for the reason
+/// [`format_obj_as_utf8`] gives: a `&str` view would turn a lone surrogate in
+/// `__name__` into a raise, and this function reports a raise as `?`.
 fn format_obj_name(obj: PyObjectRef) -> String {
-    let name =
-        crate::baseobjspace::getattr_str(obj, "__name__").and_then(crate::baseobjspace::utf8_w);
-    name.unwrap_or("?").to_owned()
+    match crate::baseobjspace::getattr_str(obj, "__name__")
+        .and_then(crate::baseobjspace::text_wtf8_w)
+    {
+        Ok(name) => name.to_string_lossy().into_owned(),
+        Err(_) => "?".to_owned(),
+    }
+}
+
+/// `space.type(w_obj).getname(space)` — the `%T` spelling.
+///
+/// The Python-visible type, which is `w_class`; `ob_type` names the storage a
+/// value is laid out as, and a class deriving from a builtin shares its
+/// storage while presenting its own name.
+pub(crate) fn type_name_of(w_obj: PyObjectRef) -> String {
+    // A tagged int immediate is an exact builtin int; skip the ob_type deref.
+    if pyre_object::tagged_int::CAN_BE_TAGGED && pyre_object::tagged_int::is_tagged_int(w_obj) {
+        return "int".to_string();
+    }
+    unsafe {
+        match crate::typedef::r#type(w_obj) {
+            Some(tp) => pyre_object::w_type_get_name(tp.as_ptr()).to_string(),
+            None => (*(*w_obj).ob_type).name.to_string(),
+        }
+    }
 }
 
 pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> OperationError {
@@ -3707,7 +3736,7 @@ pub fn oefmt(w_type: PyObjectRef, valuefmt: &str, args: &[FmtArg<'_>]) -> Operat
                 ('T', FmtArg::Obj(_)) => {
                     let obj = _roots.get(next_obj_slot);
                     next_obj_slot += 1;
-                    unsafe { pyre_object::pyobject::type_name_of(obj) }.to_owned()
+                    type_name_of(obj)
                 }
                 ('N', FmtArg::Obj(_)) => {
                     let obj = _roots.get(next_obj_slot);

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/specialize.rs
@@ -8530,9 +8530,14 @@ pub(crate) fn try_walker_specialize_builtin_locals<Sym: WalkSym>(
     } else {
         return Ok(None);
     };
-    // The modelled reads answer from `virtualizable_boxes`, which describe the
-    // PORTAL frame only.  An inline sub-walk publishes a different concrete
-    // frame whose locals live in the callee shadow, not in those boxes.
+    // A pre-filter for the frame-identity test below, which is what actually
+    // decides this shape: `locals()` reports on `gettopframe_nohidden()`, and
+    // inside an inline sub-walk or an inlined callee body that frame is not
+    // the standard virtualizable the modelled reads answer from, so the test
+    // below declines the same shapes one step later.  Refusing here as well
+    // keeps a sub-walk from emitting this fold's guards at all, the property
+    // `walker_inline_guard_resumes_in_callee` qualifies for the folds that do
+    // run under one.
     if ctx.fbw_mode.inline_subwalk || current_inline_concrete_frame() != 0 {
         return Ok(None);
     }


### PR DESCRIPTION
Six commits: three on `pyre-interpreter/src/error.rs`, one comment correction in
the JIT's builtin-`locals()` fold, one benchmark ceiling, and a re-sourced README
table.

### `error.rs`

**`oefmt` converts each operand by its own format code.** It previously took
`&[&dyn Display]` and rendered every operand the same way, so one value reported
identical text under every code it was passed to. `OpErrFmt._compute_value`
selects a conversion per code, so the operands now arrive as a `FmtArg` naming
the kind each code expects — `%d` an integer, `%s` text, `%8` bytes decoded with
replacement, and `%R`/`%S`/`%T`/`%N` a wrapped object.

* `%R` and `%S` go through repr and str and fall back to `<repr raised>` /
  `<str raised>` after `write_unraisable`.
* `%T` reports the type name; `%N` reads `__name__` through `getname`, which
  answers `?` when the lookup raises — including for a non-`TypeError`, matching
  `W_Root.getname`'s bare `except OperationError`.
* A code paired with the wrong operand kind panics. `oefmt` has no production
  callers yet, so this is a construction check on the call sites that will come.
* Objects are pinned before the first conversion runs: a conversion can allocate,
  and the argument slice holds raw pointers rather than roots.

**Two conversions read the wrong thing, found by the parity review and fixed
here.** `%T` reported `(*ob_type).name`, which names the storage a value is laid
out as — `space.type(value)` is the class, so an instance of a class deriving
from a builtin presented the builtin's name. `argument.rs` already carried the
correct resolution for the same conversion, so its private copy became the
shared one and the two spellings can no longer drift. Separately, `%R`, `%S` and
`%N` took a `&str` view of the string the repr, str or `__name__` lookup had
just produced; that view does not exist for a lone surrogate, which the buffer
holds legally, so a repr that *succeeded* was reported as `<repr raised>` and a
`__name__` carrying one as `?`. They now read the buffer the string already
holds, which is what `space.utf8_w` hands back. The surrogate still does not
survive the last step, because the message is a Rust `String` — that carrier
limitation is pre-existing and tracked separately.

**`new_exception_class` reports its `__module__` failure.** The class-call arm
already routed its failure through `set_call_error`; the `setattr` that follows
dropped one, which would let a caller read whatever an earlier call left in the
thread-local cell. `decompose_valuefmt` also now rejects an unknown code and a
format string with no code at all, as `decompose_valuefmt` and `get_operrcls2`
do upstream.

### JIT — builtin `locals()` fold

`try_walker_specialize_builtin_locals`'s early bail carried a claim that measured
false: it said the modelled reads answer from `virtualizable_boxes`, which
describe the portal frame only. The **code is unchanged**; only the comment is,
and it now states the measured reason — the bail is a pre-filter for the
frame-identity test below, which declines the same shapes one step later.

That was verified rather than argued: a behaviour-free diagnostic printing
`subwalk / concrete_frame / resumes_in_callee / topframe_is_vable` was added, the
whole 451-fixture synth suite was swept (0 timeouts, 0 errors), and exactly one
fixture reaches the bail at all — with `topframe_is_vable=false` on every one of
its 15 refusals. So the bail declines nothing the test below would have admitted.
The diagnostic was reverted; only the corrected comment remains.

### `dict_update_hot` ceiling 15 → 20

The `ubuntu-24.04` runner measures the **folded** state at 14.6x, 15.5x and 15.6x
across three runs — it straddled the ceiling of 15 and flipped the gate run to
run while the fold was working. Re-measured on darwin-arm64, user CPU less
startup, median of 3: pypy 0.169s, folded 1.996s (11.8x), and with
`builtin_dict_get` suppressed 4.596s (27.2x). 20 clears the worst folded reading
by 1.25x and stays 1.36x under the suppressed state, so the fixture still fails
if the fold stops working.

### README

The cited run 32465640260 had all three `pyre/check.py` jobs cancelled, which a
review flagged. The table, the startup figures and every prose claim read off
them now come from run 32534726733, and each claim was re-derived from the table
itself: eight of ten within 2.0x of PyPy on dynasm and all ten within 2.5x;
cranelift trails dynasm on eight by up to ~2.0x and matches it on `fib_loop` and
`inline_helper`; and where CPython was measured pyre runs it ~3.4x, ~2.9x and
~1.2x faster.

It also now records that the PyPy reference itself is noisy — `fib_recursive`
measured 0.31s on this run and 0.92s on another `ubuntu-24.04` run — so one run's
table is indicative rather than reproducible to the digit.

### Expected CI

`str_getitem_len_hot`'s wasm ratio is red on `main` by construction and is not
touched here: `WASM_MAX_DYNASM_RATIO`'s own comment forbids widening a gate to
bless a fixture, so the fix belongs in the wasm backend. The remaining timing
gates seen on recent runs (`foriter_exempt_nested_foriter`,
`mapdict_frozen_unboxing_fold`) carry check.py's `?` noise-floor prefix and move
with the PyPy denominator.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved formatted error handling with validation for unsupported formats, missing arguments, and mismatched value types.
  - Added safer conversions for text, numbers, bytes, objects, and other supported values.
  - Formatting failures now report errors more reliably instead of being silently ignored.

- **Documentation**
  - Updated development status, benchmark results, methodology notes, and performance comparisons.
  - Refreshed benchmark measurements and clarified timing variability and interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->