### PR TITLE
majit: bh-field layout identity, descr de-dup, and the #1394 review follow-ups

### DIFF
--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1190,17 +1190,9 @@ impl GcCache {
     /// defect. `setup_descrs` cannot serve — it stamps `descr_index` on every
     /// entry, so calling it merely to count would perturb the thing measured.
     pub fn all_descrs_len(&self) -> usize {
-        self._cache_size.len()
-            + self._cache_field.values().map(IndexMap::len).sum::<usize>()
-            + self._cache_array.len()
-            + self._cache_arraylen.len()
-            + self._cache_call.len()
-            + self._cache_interiorfield.len()
-            + self._external_size_order.len()
-            + self._external_field_order.len()
-            + self._external_array_order.len()
-            + self._external_arraylen_order.len()
-            + self._external_interiorfield_order.len()
+        let mut count = 0;
+        self.walk_descrs(|_| count += 1);
+        count
     }
 
     /// descr.py setup_descrs().
@@ -1210,36 +1202,54 @@ impl GcCache {
     /// order (insertion order). Assigns sequential descr_index.
     pub fn setup_descrs(&self) -> Vec<DescrRef> {
         let mut all_descrs: Vec<DescrRef> = Vec::new();
-        // One object, one dense slot.  Upstream gets that for free: a
-        // `_cache_*` dict holds each descr once and there is no second
-        // sequence to chain.  Pyre's keyed caches are chained WITH the
-        // `_external_*_order` migration Vecs, and a key can be aliased, so the
-        // same Arc can be reached twice — which would take two slots and leave
-        // the object carrying only the last `descr_index`, breaking the
-        // one-object/one-index assumption descriptor encoding and the bridge
-        // tables rely on.  Identity is `Arc::ptr_eq`, matching the
-        // `register_external_*` de-dup rule; structurally equal but distinct
-        // Arcs stay separate, as upstream's post-mint dict identity does.
-        let mut seen: std::collections::HashSet<*const ()> = std::collections::HashSet::new();
-        let mut push = |all_descrs: &mut Vec<DescrRef>, v: &DescrRef| {
-            if !seen.insert(Arc::as_ptr(v) as *const ()) {
-                return;
-            }
+        self.walk_descrs(|v| {
             v.set_descr_index(all_descrs.len() as i32);
             all_descrs.push(v.clone());
+        });
+        assert!(
+            all_descrs.len() < (1 << 15),
+            "descr.py:46: assert len(all_descrs) < 2**15"
+        );
+        all_descrs
+    }
+
+    /// The enumeration itself: the six caches in RPython's fixed group order,
+    /// each chained with its `_external_*_order` migration Vec, visiting each
+    /// descr object exactly once.
+    ///
+    /// One object, one dense slot.  Upstream gets that for free: a `_cache_*`
+    /// dict holds each descr once and there is no second sequence to chain.
+    /// Pyre's keyed caches are chained WITH the migration Vecs, and a key can
+    /// be aliased, so the same Arc can be reached twice — which would take two
+    /// slots and leave the object carrying only the last `descr_index`,
+    /// breaking the one-object/one-index assumption descriptor encoding and the
+    /// bridge tables rely on.  Identity is `Arc::ptr_eq`, matching the
+    /// `register_external_*` de-dup rule; structurally equal but distinct Arcs
+    /// stay separate, as upstream's post-mint dict identity does.
+    ///
+    /// [`Self::setup_descrs`] and [`Self::all_descrs_len`] must agree on which
+    /// entries exist — the selection-vs-pool fork compares one against the
+    /// other, so a count that included the duplicates this walk drops would
+    /// report a pool move that never happened.  Hence one walk, two callers.
+    fn walk_descrs(&self, mut visit: impl FnMut(&DescrRef)) {
+        let mut seen: std::collections::HashSet<*const ()> = std::collections::HashSet::new();
+        let mut visit_once = |v: &DescrRef| {
+            if seen.insert(Arc::as_ptr(v) as *const ()) {
+                visit(v);
+            }
         };
         // descr.py:27-29: _cache_size
         for v in self._cache_size.values().chain(&self._external_size_order) {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
         // descr.py:30-33: _cache_field (nested)
         for fields in self._cache_field.values() {
             for v in fields.values() {
-                push(&mut all_descrs, &(v.clone() as DescrRef));
+                visit_once(&(v.clone() as DescrRef));
             }
         }
         for v in &self._external_field_order {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
         // descr.py:34-36: _cache_array
         for v in self
@@ -1247,7 +1257,7 @@ impl GcCache {
             .values()
             .chain(&self._external_array_order)
         {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
         // descr.py:37-39: _cache_arraylen
         for v in self
@@ -1255,11 +1265,11 @@ impl GcCache {
             .values()
             .chain(&self._external_arraylen_order)
         {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
         // descr.py:40-42: _cache_call
         for v in self._cache_call.values() {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
         // descr.py:43-45: _cache_interiorfield
         for v in self
@@ -1267,13 +1277,8 @@ impl GcCache {
             .values()
             .chain(&self._external_interiorfield_order)
         {
-            push(&mut all_descrs, v);
+            visit_once(v);
         }
-        assert!(
-            all_descrs.len() < (1 << 15),
-            "descr.py:46: assert len(all_descrs) < 2**15"
-        );
-        all_descrs
     }
 
     /// Register the GC layouts of synthetic structs whose serialized

--- a/majit/majit-ir/src/descr.rs
+++ b/majit/majit-ir/src/descr.rs
@@ -1210,21 +1210,36 @@ impl GcCache {
     /// order (insertion order). Assigns sequential descr_index.
     pub fn setup_descrs(&self) -> Vec<DescrRef> {
         let mut all_descrs: Vec<DescrRef> = Vec::new();
-        // descr.py:27-29: _cache_size
-        for v in self._cache_size.values().chain(&self._external_size_order) {
+        // One object, one dense slot.  Upstream gets that for free: a
+        // `_cache_*` dict holds each descr once and there is no second
+        // sequence to chain.  Pyre's keyed caches are chained WITH the
+        // `_external_*_order` migration Vecs, and a key can be aliased, so the
+        // same Arc can be reached twice — which would take two slots and leave
+        // the object carrying only the last `descr_index`, breaking the
+        // one-object/one-index assumption descriptor encoding and the bridge
+        // tables rely on.  Identity is `Arc::ptr_eq`, matching the
+        // `register_external_*` de-dup rule; structurally equal but distinct
+        // Arcs stay separate, as upstream's post-mint dict identity does.
+        let mut seen: std::collections::HashSet<*const ()> = std::collections::HashSet::new();
+        let mut push = |all_descrs: &mut Vec<DescrRef>, v: &DescrRef| {
+            if !seen.insert(Arc::as_ptr(v) as *const ()) {
+                return;
+            }
             v.set_descr_index(all_descrs.len() as i32);
             all_descrs.push(v.clone());
+        };
+        // descr.py:27-29: _cache_size
+        for v in self._cache_size.values().chain(&self._external_size_order) {
+            push(&mut all_descrs, v);
         }
         // descr.py:30-33: _cache_field (nested)
         for fields in self._cache_field.values() {
             for v in fields.values() {
-                v.set_descr_index(all_descrs.len() as i32);
-                all_descrs.push(v.clone() as DescrRef);
+                push(&mut all_descrs, &(v.clone() as DescrRef));
             }
         }
         for v in &self._external_field_order {
-            v.set_descr_index(all_descrs.len() as i32);
-            all_descrs.push(v.clone());
+            push(&mut all_descrs, v);
         }
         // descr.py:34-36: _cache_array
         for v in self
@@ -1232,8 +1247,7 @@ impl GcCache {
             .values()
             .chain(&self._external_array_order)
         {
-            v.set_descr_index(all_descrs.len() as i32);
-            all_descrs.push(v.clone());
+            push(&mut all_descrs, v);
         }
         // descr.py:37-39: _cache_arraylen
         for v in self
@@ -1241,13 +1255,11 @@ impl GcCache {
             .values()
             .chain(&self._external_arraylen_order)
         {
-            v.set_descr_index(all_descrs.len() as i32);
-            all_descrs.push(v.clone());
+            push(&mut all_descrs, v);
         }
         // descr.py:40-42: _cache_call
         for v in self._cache_call.values() {
-            v.set_descr_index(all_descrs.len() as i32);
-            all_descrs.push(v.clone());
+            push(&mut all_descrs, v);
         }
         // descr.py:43-45: _cache_interiorfield
         for v in self
@@ -1255,8 +1267,7 @@ impl GcCache {
             .values()
             .chain(&self._external_interiorfield_order)
         {
-            v.set_descr_index(all_descrs.len() as i32);
-            all_descrs.push(v.clone());
+            push(&mut all_descrs, v);
         }
         assert!(
             all_descrs.len() < (1 << 15),
@@ -2658,6 +2669,15 @@ impl GcCache {
                 self._size_keepalive.push(old.clone());
             }
             self._cache_size.insert(key.clone(), descr.clone());
+            // `register_external_size` refuses an Arc the keyed cache already
+            // holds; this is the other direction of the same rule.  A mint site
+            // that published externally first and was later keyed — the exact
+            // migration this surface exists for — would otherwise sit in both,
+            // and `setup_descrs` chains the cache values WITH the order Vec, so
+            // the descr would take two dense slots and keep only the second
+            // `descr_index`.  Dedup is by `Arc::ptr_eq`, as documented above.
+            self._external_size_order
+                .retain(|external| !Arc::ptr_eq(external, &descr));
             if let Some(fields) = self._cache_field.get(&key) {
                 for field in fields.values() {
                     field.set_parent_descr(&descr);

--- a/majit/majit-ir/src/effectinfo.rs
+++ b/majit/majit-ir/src/effectinfo.rs
@@ -1731,7 +1731,15 @@ pub fn compute_frozen_bitstrings(all_eis: &mut [&mut EffectInfo]) -> FrozenBitst
     // semantics nor identity, so normalize it before forming cache keys.
     for ei in all_eis.iter_mut() {
         match ei.descr_set_keys.as_mut() {
-            Some(keys) => keys.canonicalize(),
+            // Matched per variant rather than through `DerefMut`: that impl
+            // materializes `Empty` into a boxed empty `DescrSetKeys`, so
+            // canonicalizing every image would spend the compact
+            // representation on every EI that has no keys — before
+            // serialization, which is what the representation exists for.
+            // `Empty` has no member order to normalize; it is already
+            // canonical.
+            Some(DescrSetKeysImage::Populated(keys)) => keys.canonicalize(),
+            Some(DescrSetKeysImage::Empty) => {}
             None => {
                 ei.readonly_descrs_fields = None;
                 ei.write_descrs_fields = None;

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3080,8 +3080,9 @@ impl OptHeap {
     /// one, which is why they stay listed.  Upstream lists its two for the same
     /// reason and marks them `# handled specially` in `emitting_operation`.
     ///
-    /// None of the other eleven can arrive on this tree today, and the reasons
-    /// differ enough to be worth recording:
+    /// Of the other eleven, ten cannot arrive on this tree today and one —
+    /// `LeavePortalFrame` — is only *not known* to arrive; the reasons differ
+    /// enough to be worth recording separately:
     ///   - `DebugMergePoint` has no producer at all; every occurrence is a
     ///     declaration or a consumer.
     ///   - `EnterPortalFrame` needs either a `newframe` carrying a greenkey —

--- a/majit/majit-metainterp/src/optimizeopt/heap.rs
+++ b/majit/majit-metainterp/src/optimizeopt/heap.rs
@@ -3060,11 +3060,12 @@ impl OptHeap {
         result
     }
 
-    /// heap.py:436-452: operations with no effect on the GC heap caches.
+    /// `heap.py OptHeap.emitting_operation`: operations with no effect on the
+    /// GC heap caches.
     ///
     /// Consulted at TWO sites here against upstream's one.  Upstream reaches the
-    /// list only from `emitting_operation` (heap.py:442, via `emit` at
-    /// heap.py:432 and `dispatch_opt`'s default at heap.py:898).  Here
+    /// list only from `emitting_operation`, via `OptHeap.emit` and
+    /// `dispatch_opt`'s `default=OptHeap.emit` (`heap.py`).  Here
     /// `emitting_operation` is a whole-optimizer callback that fires at final
     /// emission, after this pass has already dispatched — `propagate_forward`
     /// dispatches on its first line — so without the `handle_side_effects`
@@ -3077,7 +3078,7 @@ impl OptHeap {
     /// `SetarrayitemRaw` — have their own dispatch arm and so never reach the
     /// `handle_side_effects` test; they still reach the `emitting_operation`
     /// one, which is why they stay listed.  Upstream lists its two for the same
-    /// reason and marks them `# handled specially` (heap.py:452, :454).
+    /// reason and marks them `# handled specially` in `emitting_operation`.
     ///
     /// None of the other eleven can arrive on this tree today, and the reasons
     /// differ enough to be worth recording:
@@ -3087,7 +3088,8 @@ impl OptHeap {
     ///     both non-test callers pass `None` — or a runtime answering
     ///     `portal_jitcode`, which the production runtime leaves `None`.
     ///     `LeavePortalFrame` is NOT symmetric: it also rides `popframe`'s
-    ///     `jitdriver_sd` gate, and `call.py:148` does stamp one, so that arm is
+    ///     `jitdriver_sd` gate, and `call.py grab_initial_jitcodes` does stamp
+    ///     one, so that arm is
     ///     not known to be dead.  Do not read it as unreachable without
     ///     measuring.
     ///   - `setinteriorfield_raw` has no producer and no codewriter `OpKind`.

--- a/majit/majit-translate/src/codewriter/assembler.rs
+++ b/majit/majit-translate/src/codewriter/assembler.rs
@@ -18,7 +18,7 @@ use std::{
 
 use vecset::VecSet;
 
-use crate::call::CallControl;
+use crate::call::{CallControl, extract_element_type_from_str};
 use crate::flatten::{FlatOp, IntOvfOp, Label, RegKind, SSARepr};
 
 fn reg_label(reg: crate::flatten::Register) -> String {
@@ -4516,27 +4516,6 @@ fn vable_arraydescrof(
         // preserve the existing GUARD_GC_TYPE behavior.
         is_gc_managed: true,
     }
-}
-
-fn extract_element_type_from_str(type_str: &str) -> Option<String> {
-    let s = type_str.trim();
-    if let (Some(start), Some(end)) = (s.find('<'), s.rfind('>'))
-        && start < end
-    {
-        return Some(s[start + 1..end].trim().to_string());
-    }
-    if s.starts_with('[') && s.ends_with(']') {
-        let inner = &s[1..s.len() - 1];
-        let elem = if let Some(semi) = inner.find(';') {
-            inner[..semi].trim()
-        } else {
-            inner.trim()
-        };
-        if !elem.is_empty() {
-            return Some(elem.to_string());
-        }
-    }
-    None
 }
 
 /// Convert OpKind to an opname string for the assembler's instruction table.

--- a/majit/majit-translate/src/codewriter/jitcode.rs
+++ b/majit/majit-translate/src/codewriter/jitcode.rs
@@ -1177,8 +1177,27 @@ impl BhFieldSpec {
             && self.is_immutable == other.is_immutable
             && self.is_quasi_immutable == other.is_quasi_immutable
             && self.index_in_parent == other.index_in_parent
-            && majit_ir::descr::class_word_inferred_from_name(&self.name)
-                == majit_ir::descr::class_word_inferred_from_name(&other.name)
+            && self.effective_class_word() == other.effective_class_word()
+    }
+
+    /// The class-word answer this spec rebuilds to: the producer declaration
+    /// when it carried one, otherwise the display-name guess.  This is what
+    /// `make_descr_from_bh` reconstructs — it seeds from the name and lets a
+    /// declaration replace the guess — so it, not either half alone, is what
+    /// layout identity has to compare.
+    ///
+    /// Comparing only the name guess loses the declaration entirely, which is
+    /// the one thing the guess provably cannot recover: `Method`'s payload
+    /// field is spelled `"Method.w_class"` exactly like its inherited header
+    /// row, so both infer `true` and only the declaration separates them.  A
+    /// canonicalizer that called those one layout would share the first
+    /// parent across both and hand `SizeDescr::class_word_field` the wrong
+    /// row.  Comparing the raw `Option` instead would over-fragment: a
+    /// declared `Some(true)` and an undeclared row whose name infers `true`
+    /// rebuild identically and are one layout.
+    pub fn effective_class_word(&self) -> bool {
+        self.is_class_word
+            .unwrap_or_else(|| majit_ir::descr::class_word_inferred_from_name(&self.name))
     }
 
     /// Mirror an `Arc<dyn FieldDescr>` into the serializable
@@ -2290,9 +2309,8 @@ mod tests {
             index_in_parent: 0,
             // Nothing declared this field a class word, which is what
             // `bh_field_spec_from_parts` also records for a spec built with no
-            // layout in reach. `same_descr_layout` reads the name-derived
-            // inference rather than this field, so the test is unaffected
-            // either way.
+            // layout in reach.  Neither name here is a class-word spelling, so
+            // both resolve to `false` and the layout comparison is unaffected.
             is_class_word: None,
         }
     }
@@ -2310,6 +2328,33 @@ mod tests {
         let mut renamed = imported;
         renamed.field_key = "other".to_string();
         assert!(!canonical.same_descr_layout(&renamed));
+    }
+
+    #[test]
+    fn bh_field_layout_separates_rows_that_differ_only_in_the_class_word_declaration() {
+        // `Method` carries an inherited header row and a payload field spelled
+        // the same way, so the name guess answers `true` for both and only the
+        // declaration tells them apart.  A canonicalizer that called these one
+        // layout would share the first parent across both descriptors and let
+        // `SizeDescr::class_word_field` answer the payload.
+        let mut header = test_bh_field("Method.w_class");
+        header.field_key = "w_class".to_string();
+        let mut payload = header.clone();
+
+        header.is_class_word = Some(true);
+        payload.is_class_word = Some(false);
+        assert!(!header.same_descr_layout(&payload));
+
+        // An undeclared row rebuilds through the name guess, so it is the same
+        // layout as the row that declared what the guess would have said — the
+        // comparison must not fragment on the `Option` alone.
+        let undeclared = {
+            let mut spec = header.clone();
+            spec.is_class_word = None;
+            spec
+        };
+        assert!(header.same_descr_layout(&undeclared));
+        assert!(!payload.same_descr_layout(&undeclared));
     }
 
     #[test]

--- a/pyre/pyre-interpreter/src/baseobjspace.rs
+++ b/pyre/pyre-interpreter/src/baseobjspace.rs
@@ -12437,9 +12437,10 @@ pub unsafe fn exception_attr_slot_fold(
             ExceptionAttrSlot::Filename2
         }
         // `__traceback__` is a `W_BaseException` slot on every exception kind.
-        // `descr_gettraceback` also calls `tb.frame.mark_as_escaped()`; the
-        // fold folds only the slot read, so the specializer pairs it with a
-        // residual call that issues the mark.
+        // `descr_gettraceback` also calls `tb.frame.mark_as_escaped()`, which
+        // the fold cannot drop: it emits the flag OR inline, as a load of the
+        // frame's flags word followed by a `SetfieldGc` of it, so a compiled
+        // replay marks the frame without a residual call.
         "__traceback__" => ExceptionAttrSlot::Traceback,
         // `name` shares the `w_exc_name` slot across the kinds whose getattr
         // arm reads it; other kinds keep the regular attribute fall-through.

--- a/pyre/pyre-interpreter/src/module/marshal/mod.rs
+++ b/pyre/pyre-interpreter/src/module/marshal/mod.rs
@@ -668,8 +668,13 @@ impl PyreMarshalBag {
         constants: Vec<Rooted>,
         raw_code_bytes: Option<Vec<u8>>,
     ) -> Result<Rooted, wire::MarshalError> {
-        let code = Rooted::new(crate::pycode::box_code_constant(&code));
-        // `box_code_constant` allocates, so read each constant out of its
+        // Hand the decoded object over rather than copying it: `code` is owned
+        // here and dropped immediately after, so `box_code_constant`'s borrow
+        // form duplicated the whole recursive constants graph and then threw
+        // the original away — once per code object in every unmarshalled
+        // module.
+        let code = Rooted::new(crate::pycode::box_code_object(code));
+        // `box_code_object` allocates, so read each constant out of its
         // shadow-stack slot only now. PyPy gives the complete decoded wrapped
         // list to `PyCode.__init__`; replace the compiler-boundary eager values
         // with those exact marshal objects.
@@ -755,7 +760,9 @@ impl wire::MarshalBag for PyreMarshalBag {
     }
 
     fn make_code(&self, code: CodeObject<ConstantData>) -> Result<Rooted, wire::MarshalError> {
-        Ok(Rooted::new(crate::pycode::box_code_constant(&code)))
+        // Owned here and used nowhere else — hand it over rather than copying
+        // the recursive constants graph, as in `make_runtime_code`.
+        Ok(Rooted::new(crate::pycode::box_code_object(code)))
     }
 
     fn make_stop_iter(&self) -> Result<Rooted, wire::MarshalError> {

--- a/pyre/pyre-interpreter/src/pytraceback.rs
+++ b/pyre/pyre-interpreter/src/pytraceback.rs
@@ -368,18 +368,6 @@ pub unsafe fn mark_traceback_escaped(w_traceback: PyObjectRef) {
     }
 }
 
-/// `extern "C"` entry for the residual call the `__traceback__` attribute
-/// fold emits.  Compiled code folds that read to a raw slot load, so the
-/// getter's escape mark has to be issued separately; the fold pairs the
-/// load with a call here.
-///
-/// Cannot raise, allocates nothing, and writes only the frame's status
-/// byte, which no field descriptor exposes to the trace — so the call
-/// carries `cannot_raise_effect_info` and invalidates no heap cache entry.
-pub extern "C" fn jit_mark_traceback_escaped(w_traceback: i64) {
-    unsafe { mark_traceback_escaped(w_traceback as usize as PyObjectRef) };
-}
-
 /// `pytraceback.py record_application_traceback` parity:
 ///
 /// ```python

--- a/pyre/pyre-interpreter/src/typedef.rs
+++ b/pyre/pyre-interpreter/src/typedef.rs
@@ -7683,9 +7683,9 @@ fn init_dict_view_items_type(ns: PyObjectRef) {
 ///
 /// Pyre wires `tb_lasti`, `tb_lineno`, `tb_next`, `tb_frame`,
 /// `__new__`, `__dir__`.
-///   - `tb_frame` returns the live `PyFrame` (`FRAME_TYPE`) when it is
-///     GC-owned, else a `sys.namespace` stub for a non-Gc / freed
-///     frame (see the getter below).
+///   - `tb_frame` returns the live `PyFrame` (`FRAME_TYPE`), which is
+///     always GC-owned once the subsystem is installed at boot (see the
+///     getter below).
 ///   - `__new__` = `TracebackType(tb_next, tb_frame, tb_lasti,
 ///     tb_lineno)` (3.7+ constructor), taking a live `frame` object.
 ///   - `__reduce__` / `__setstate__` are intentionally NOT wired:
@@ -7911,21 +7911,14 @@ fn init_pytraceback_type(ns: PyObjectRef) {
         )
     };
 
-    // pytraceback.py:34 descr_get_tb_frame — return the live `PyFrame`
-    // itself (`FRAME_TYPE` typedef) as the user-visible `frame` object.
-    // The traceback keeps the raising frame's chain reachable through
-    // `pytraceback_object_custom_trace`, so a GC-owned frame is still
-    // alive here.  The guard must match the custom_trace's guard
-    // (`try_gc_owns_object`): only frames forwarded as managed edges
-    // survive; a non-Gc frame falls back to the `sys.namespace` stub
-    // built from the retained `w_code` + stamped line number.
-    //
-    // A frame is non-Gc only when the GC stable-alloc hook was never
-    // pytraceback.py:34 descr_get_tb_frame — return the live `PyFrame`
-    // itself (`FRAME_TYPE` typedef) as the user-visible `frame` object.
-    // The GC subsystem is installed at boot (`init_gc_subsystem`), so all
-    // frames — including under `PYRE_JIT=0` — are GC-owned oldgen blocks
-    // that stay alive as long as the traceback references them.
+    // `typedef.py PyTraceback.typedef` wires `tb_frame` as a bare
+    // `interp_attrproperty_w('frame')` — return the live `PyFrame` itself
+    // (`FRAME_TYPE` typedef) as the user-visible `frame` object.  The
+    // traceback keeps that frame reachable through
+    // `pytraceback_object_custom_trace`, and the GC subsystem is installed
+    // at boot (`init_gc_subsystem`), so all frames — including under
+    // `PYRE_JIT=0` — are GC-owned oldgen blocks that stay alive as long as
+    // the traceback references them.
     let frame_getter = make_builtin_function_with_arity(
         "tb_frame",
         |args| {
@@ -7938,8 +7931,13 @@ fn init_pytraceback_type(ns: PyObjectRef) {
                 return Ok(pyre_object::w_none());
             }
             // Mark escaped so the JIT keeps the frame materialised for
-            // the exposed reference (pyframe.py `mark_as_escaped`),
-            // mirroring `sys._getframe`.
+            // the exposed reference (pyframe.py `mark_as_escaped`), the
+            // way `sys/vm.py _getframe` does for the frame it hands out.
+            // This store has no counterpart on the upstream `tb_frame`,
+            // whose complete caller set is `executioncontext.py leave`,
+            // `error.py OperationError.get_traceback`,
+            // `interp_exceptions.py descr_gettraceback` and
+            // `sys/vm.py _getframe` — a deviation, not a port.
             unsafe { (*frame).mark_as_escaped() };
             Ok(frame as pyre_object::PyObjectRef)
         },

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/fbw_state.rs
@@ -439,7 +439,7 @@ pub(crate) fn fbw_store_journal_push(
     // gh#467: a journaled store still mutated the heap this iteration; the
     // forward-flush gate counts it so a callee sub-walk that appends/setitems
     // cannot be committed-then-re-executed (a double).
-    fbw_bump_executed_effect();
+    fbw_bump_executed_effect("store_journal");
 }
 
 /// Record the live length a walked eager list append grew past, for the
@@ -461,7 +461,7 @@ pub(crate) fn fbw_list_journal_push_append(
         })
     });
     // gh#467: see `fbw_store_journal_push`.
-    fbw_bump_executed_effect();
+    fbw_bump_executed_effect("list_append");
 }
 
 /// Record an eagerly executed Integer-strategy end-pop and its boxed displaced
@@ -479,7 +479,7 @@ pub(crate) fn fbw_list_journal_push_pop_end(
             w_item,
         })
     });
-    fbw_bump_executed_effect();
+    fbw_bump_executed_effect("list_pop_end");
 }
 
 /// Record an Empty-list first append whose eager execution promoted the list
@@ -512,7 +512,7 @@ pub(crate) fn fbw_cell_store_journal_push(cell: pyre_object::PyObjectRef, intval
     }
     FBW_CELL_STORE_JOURNAL.with(|j| j.borrow_mut().push((cell, intvalue_before)));
     // gh#467: see `fbw_store_journal_push`.
-    fbw_bump_executed_effect();
+    fbw_bump_executed_effect("cell_store_journal");
 }
 
 /// Record the `sys_exc_value` a walked eager `set_current_exception`
@@ -1468,8 +1468,18 @@ pub(crate) fn fbw_opcode_entry_effects_at(py_pc: usize) -> Option<usize> {
 }
 
 /// gh#467 bump the executed-effect odometer (see [`FBW_EXECUTED_EFFECT_COUNT`]).
-pub(crate) fn fbw_bump_executed_effect() {
-    FBW_EXECUTED_EFFECT_COUNT.with(|c| c.set(c.get() + 1));
+///
+/// `site` names the bumping journal or fold.  The forward-flush gate reads only
+/// the count, so a refusal reports `effects>0` without saying which of the six
+/// bumps moved it; the tag is what turns that into an attributable reading.
+pub(crate) fn fbw_bump_executed_effect(site: &'static str) {
+    FBW_EXECUTED_EFFECT_COUNT.with(|c| {
+        let count = c.get() + 1;
+        c.set(count);
+        if fbw_debug_abort_enabled() {
+            eprintln!("[fbw-effect-bump] site={site} count={count}");
+        }
+    });
 }
 
 /// gh#467 latch the inline-abort forward-flush carrier (see

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -1242,6 +1242,12 @@ impl Drop for LiveLastInstrGuard {
         // guard displaced (see [`capture_escape_flush_undo`]), so a later
         // commit withdrawal still restores the resume pc rather than the
         // executing one.
+        // The test is "did an escape happen on THIS frame", not "did a flush
+        // write a resume pc".  Both legs arm the capture and both leave the
+        // frame heap-authoritative at the published executing coordinate, so
+        // narrowing this to the committing leg restores the PRE-call coordinate
+        // on the locals-only escapes — the withdrawn-too-early defect
+        // `getframe_caller_resume_coord_two_call_sites` measures and prints.
         let flushed = ESCAPE_FLUSH_UNDO.with(|slot| {
             slot.borrow().as_ref().map(|undo| undo.frame) == Some(self.frame as usize)
         });

--- a/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_dispatch/residual_call.rs
@@ -3921,16 +3921,17 @@ pub(crate) fn try_execute_residual_call_via_executor<Sym: WalkSym>(
                 .find(|(_, a)| *a == func_ptr as i64)
                 .map(|(n, _)| *n);
             eprintln!(
-                "[fbw-effect] pc={op_pc} helper={helper:?} rtype={:?} writes_live={writes_live_heap} \
-                 entered_frame={} fn={:?}/{:#x}",
+                "[fbw-effect] pc={op_pc} helper={helper:?} rtype={:?} extraeffect={:?} \
+                 writes_live={writes_live_heap} entered_frame={} fn={:?}/{:#x}",
                 call_descr.result_type(),
+                ei.extraeffect,
                 heap_write_odometer_before
                     .is_some_and(|before| pyre_interpreter::call::frame_entry_count() != before),
                 name,
                 func_ptr as usize,
             );
         }
-        fbw_bump_executed_effect();
+        fbw_bump_executed_effect("residual");
     }
     match exec_result {
         Ok(result_i64) => {
@@ -6641,7 +6642,7 @@ pub(crate) fn dispatch_residual_call_iIRd_kind<Sym: WalkSym>(
                         }
                         WalkerStoreAttrSpecialization::Direct => {
                             fbw_mark_foriter_body_effect_since_consume();
-                            fbw_bump_executed_effect();
+                            fbw_bump_executed_effect("store_attr_direct");
                             return Ok((DispatchOutcome::Continue, op.next_pc));
                         }
                     }

--- a/pyre/pyre-jit-trace/src/jitcode_runtime.rs
+++ b/pyre/pyre-jit-trace/src/jitcode_runtime.rs
@@ -652,6 +652,15 @@ fn descr_layout_at(index: usize) -> std::sync::Arc<majit_translate::jitcode::BhS
     // the codewriter-to-runtime transport object that described it. Keep a
     // layout only when the lazy opcode `BhDescr::Field` itself keeps the Arc;
     // the eager GcCache replay drops this wire value after publication.
+    //
+    // Deliberately NOT interned behind a per-index `OnceLock`: two fields
+    // naming one layout index do each decode their own copy, but those copies
+    // are transport and die with the field that holds them.  A cache would
+    // instead pin every layout it ever decoded for the life of the process,
+    // trading a bounded transient for permanent retention — the opposite of
+    // what the canonical-owner rule above is for, and against the startup-RSS
+    // work that motivated it.  Share the canonical object through
+    // `_cache_size`, not through this decoder.
     std::sync::Arc::new(
         bincode::deserialize(&BYTES[start..end]).unwrap_or_else(|e| {
             panic!(

--- a/pyre/pyre-jit-trace/src/state.rs
+++ b/pyre/pyre-jit-trace/src/state.rs
@@ -5034,6 +5034,12 @@ pub(crate) fn concrete_nlocals(frame: usize) -> Option<usize> {
         pyre_interpreter::w_code_get_ptr(w_code as pyre_object::PyObjectRef)
             as *const pyre_interpreter::CodeObject
     };
+    // A non-null `w_code` does not make the inner pointer non-null; every other
+    // caller of `w_code_get_ptr` in the tree checks the result before
+    // dereferencing it.
+    if raw_code.is_null() {
+        return None;
+    }
     let code = unsafe { &*raw_code };
     let nlocals = code.varnames.len();
     let ncells = pyre_interpreter::pyframe::ncells(code);
@@ -5657,9 +5663,16 @@ pub(crate) fn flush_locals_region_to_frame(ctx: &TraceCtx, frame: usize) -> bool
     // `Value::Void` is the shadow's "no concrete half" sentinel, not a NULL
     // local: writing it back would box to `PY_NULL` and DESTROY the slot the
     // walk is holding in a register.  Decline instead.
+    //
+    // `Ref(NO_CONCRETE)` is the same answer in the other representation — "the
+    // shadow has no concrete pointer for this slot" — and it is worse to write
+    // back, because `boxed_slot_value_for_type` maps `Ref(r)` straight to
+    // `r.as_usize()`: the slot would receive `usize::MAX - 1` as if it were an
+    // object pointer.
     for abs in 0..nlocals {
         match ctx.virtualizable_entry_at(base + abs) {
             Some((_, Value::Void)) | None => return false,
+            Some((_, Value::Ref(gc))) if gc == majit_ir::GcRef::NO_CONCRETE => return false,
             Some(_) => {}
         }
     }

--- a/pyre/pyre-jit/src/call_jit.rs
+++ b/pyre/pyre-jit/src/call_jit.rs
@@ -783,7 +783,7 @@ pub(crate) extern "C" fn record_caught_blackhole_traceback(
     }
     m73_lastinstr_audit("caught", Some(jitcode_index), opcode_position, frame_ptr);
     // `dispatch_bytecode` (pyopcode.py) stamps `self.last_instr` before every
-    // opcode, so `pyopcode.py:147-148 handle_operation_error` always records its
+    // opcode, so `pyopcode.py handle_operation_error` always records its
     // node while the frame holds the instruction that raised, and every later
     // `tb_frame.f_lasti` / `f_lineno` read answers for that instruction.  Two
     // pyre paths already reproduce the store — the recording walk before its own

--- a/pyre/pyre-object/src/celldict.rs
+++ b/pyre/pyre-object/src/celldict.rs
@@ -1213,7 +1213,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
         crate::dictmultiobject::w_module_dict_items_inner(w_dict)
     }
 
-    /// `celldict.py:188-192 getiterkeys`/`getitervalues` — one entry, not the
+    /// `celldict.py getiterkeys`/`getitervalues` — one entry, not the
     /// whole storage.  The trait default rebuilds `items()` per step, and this
     /// strategy's `items` wraps every name into a fresh immortal string, so the
     /// default makes a single view walk quadratic in unreclaimable allocations.
@@ -1226,7 +1226,7 @@ impl crate::dictmultiobject::DictStrategy for ModuleDictStrategy {
     }
 
     /// A `values()` view needs no name at all, so it skips the wrap entirely
-    /// (`dictmultiobject.py:1095-1098`).
+    /// (`dictmultiobject.py AbstractTypedStrategy.getitem`).
     unsafe fn nth_value(&self, w_dict: PyObjectRef, index: usize) -> Option<PyObjectRef> {
         crate::dictmultiobject::w_module_dict_nth_value_inner(w_dict, index)
     }

--- a/pyre/pyre-object/src/dictmultiobject.rs
+++ b/pyre/pyre-object/src/dictmultiobject.rs
@@ -4525,7 +4525,8 @@ pub unsafe fn w_dict_nth_item(
 
 /// Read only the value at iteration position `index`.
 ///
-/// `dictmultiobject.py:1095-1098` reads the typed storage value without
+/// `dictmultiobject.py AbstractTypedStrategy.getitem` reads the typed storage
+/// value without
 /// wrapping its key.
 ///
 /// # Safety
@@ -5227,7 +5228,7 @@ pub unsafe fn w_module_dict_items_inner(obj: PyObjectRef) -> Vec<(PyObjectRef, P
 /// halves are `IndexMap`s, so this reads that entry rather than building the
 /// whole list. Only the one name is wrapped.
 ///
-/// `celldict.py:188-192 getiterkeys`/`getitervalues` are lazy iterators
+/// `celldict.py getiterkeys`/`getitervalues` are lazy iterators
 /// upstream; the cursor stands in for them here because the GC-object layout
 /// cannot hold a live iterator ([`DictStrategy::nth_item`]).  Serving that
 /// cursor from the default `nth_item` — `self.items(w_dict).into_iter()
@@ -5261,7 +5262,8 @@ pub unsafe fn w_module_dict_nth_item_inner(
 }
 
 /// [`w_module_dict_nth_item_inner`]'s value half, which wraps no name —
-/// `dictmultiobject.py:1095-1098` reads the typed storage value without
+/// `dictmultiobject.py AbstractTypedStrategy.getitem` reads the typed storage
+/// value without
 /// wrapping its key, and here that skips the whole allocation.
 ///
 /// # Safety
@@ -5964,7 +5966,8 @@ pub trait DictStrategy {
     }
 
     /// Read the value at iteration position `index` without requiring a
-    /// separately materialised key (`dictmultiobject.py:1095-1098`).
+    /// separately materialised key
+    /// (`dictmultiobject.py AbstractTypedStrategy.getitem`).
     ///
     /// # Safety
     /// `w_dict` must be a valid PyObjectRef.

--- a/pyre/pyre-object/src/identitydict.rs
+++ b/pyre/pyre-object/src/identitydict.rs
@@ -336,12 +336,13 @@ impl DictStrategy for IdentityDictStrategy {
             .collect()
     }
 
-    /// `dictmultiobject.py:1095-1098 AbstractTypedStrategy.getitem` reads one
+    /// `dictmultiobject.py AbstractTypedStrategy.getitem` reads one
     /// entry off the typed storage.  The trait default instead rebuilds the
     /// whole `items()` per step, which makes one view walk quadratic in the
     /// entry count — and unlike the empty strategies it is written for, this
     /// one backs every dict keyed on ordinary instances.  `wrap` is identity
-    /// here (`identitydict.py:26-27`), so the entry needs no allocation.
+    /// here (`identitydict.py IdentityDictStrategy.wrap`), so the entry needs
+    /// no allocation.
     unsafe fn nth_item(
         &self,
         w_dict: PyObjectRef,


### PR DESCRIPTION
Follow-up to #1394: the review findings that were adjudicated as fix-now, plus two
local tasks that came due.

## PR #1394 review findings

**Fixed**

- `BhFieldSpec::same_descr_layout` compared `class_word_inferred_from_name` on both
  names and ignored the producer's `is_class_word` declaration. `Method`'s payload
  field is spelled `"Method.w_class"` exactly like its inherited header row, so the
  guess answers `true` for both and only the declaration separates them — a
  canonicalizer that called them one layout would share the first parent across
  both and hand `SizeDescr::class_word_field` the wrong row. Now compares
  `effective_class_word()`, the declaration-or-guess pair that `make_descr_from_bh`
  actually rebuilds from. Comparing the raw `Option` instead would over-fragment,
  so that is not what this does; a regression test pins both directions.

- `GcCache::setup_descrs` chains each `_cache_*` map with its `_external_*_order`
  migration Vec, so a descr reachable from both — or from two aliased keys — took
  two dense slots and kept only the second `descr_index`. The walk now de-dups by
  `Arc::as_ptr`, matching the `Arc::ptr_eq` rule `register_external_*` already
  documents, and `register_keyed_size` drops the descr from `_external_size_order`
  when it keys it (the direction `register_external_size` already covered).

- `compute_frozen_bitstrings` canonicalized a `DescrSetKeysImage` through
  `DerefMut`, which materializes `Empty` into a boxed empty `DescrSetKeys` — so it
  spent the compact representation on every EffectInfo that has no keys, right
  before serialization, which is what the compact representation exists for. Now
  matched per variant.

**Documented, not changed**

- `descr_layout_at` is deliberately not interned behind a per-index `OnceLock`: the
  decoded layouts are transport and die with the field that holds them, whereas a
  cache would pin every layout it ever decoded for the life of the process. The
  reason is now on the function.

- The heap no-effect carve-out doc counted all eleven remaining opcodes as
  "cannot arrive"; ten cannot, and `LeavePortalFrame` is only *not known* to.

**Deferred** — `stamp_effect_info_descr`'s panic on an artifact/runtime member-set
mismatch. It needs a witness before the panic is relaxed to a counter; tracked
locally.

## Other

- `assembler.rs` carried a private copy of `extract_element_type_from_str` that
  disagreed with the `call` module's: it checked angle brackets before square
  brackets and never stripped a pointer prefix, so a pointer-to-slice type string
  yielded a different element type — and therefore a different itemsize and flag —
  than the copy the rest of the codewriter uses. The copy is deleted.

- `fbw_bump_executed_effect` now takes a `&'static str` site and prints it under
  `PYRE_FBW_DEBUG_ABORT`. The forward-flush gate reads only the count, so a refusal
  printed `effects>0` without naming which of the six bumps moved it; the
  `[fbw-effect]` line also prints the call's `extraeffect` now.

- A comment recording what `LiveLastInstrGuard`'s `flushed` test actually asks
  ("did an escape happen on this frame", not "did a flush write a resume pc").
  Narrowing it to the committing leg reintroduces the defect
  `getframe_caller_resume_coord_two_call_sites` already measures and prints by
  name; that was tried and reverted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate descriptor entries during serialization and registration.
  * Improved layout comparisons for differing class-word behavior.
  * Preserved empty descriptor metadata without unnecessary placeholders.
  * Improved traceback handling during compiled execution.
  * Added safeguards against invalid code and frame references.
  * Streamlined code-object ownership during loading and execution.

* **Diagnostics**
  * Added clearer effect-tracking labels for debugging execution paths.

* **Documentation**
  * Clarified traceback, heap-cache, descriptor layout, and dictionary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->