### PR TITLE
majit: fuse multiplied range tests, expand int_between at trace time, and add the native_identity vocabulary

### DIFF
--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2224,16 +2224,17 @@ impl<'a> AssemblerARM64<'a> {
                 // already swaps a leading immediate for the symmetric
                 // arithmetic ops, where no condition follows the operands.
                 let mut opcode = op.opcode;
-                let mut cmp_args = (&arglocs[0], &arglocs[1]);
                 if arglocs.len() >= 2 {
-                    if let (Loc::Immed(_), rhs) = cmp_args
-                        && !matches!(rhs, Loc::Immed(_))
+                    let (cmp0, cmp1) = if matches!(arglocs[0], Loc::Immed(_))
+                        && !matches!(arglocs[1], Loc::Immed(_))
                         && let Some(reflexed) = opcode.bool_reflex()
                     {
                         opcode = reflexed;
-                        cmp_args = (&arglocs[1], &arglocs[0]);
-                    }
-                    self.emit_cmp_loc_loc(cmp_args.0, cmp_args.1);
+                        (&arglocs[1], &arglocs[0])
+                    } else {
+                        (&arglocs[0], &arglocs[1])
+                    };
+                    self.emit_cmp_loc_loc(cmp0, cmp1);
                 }
                 let cc = Self::opcode_to_cc(opcode);
                 self.flush_cc(cc, result_loc);

--- a/majit/majit-backend-dynasm/src/aarch64/assembler.rs
+++ b/majit/majit-backend-dynasm/src/aarch64/assembler.rs
@@ -2215,10 +2215,27 @@ impl<'a> AssemblerARM64<'a> {
             | OpCode::PtrNe
             | OpCode::InstancePtrEq
             | OpCode::InstancePtrNe => {
+                // Only the right-hand operand has an immediate form, so a
+                // comparison whose constant sits on the left materializes it
+                // into a scratch register first. Swapping the operands folds
+                // it back into the `cmp` — but a comparison is not symmetric,
+                // so the swap has to move into the condition, which is what
+                // `resoperation.py`'s reflex table answers. `prepare_int_ri`
+                // already swaps a leading immediate for the symmetric
+                // arithmetic ops, where no condition follows the operands.
+                let mut opcode = op.opcode;
+                let mut cmp_args = (&arglocs[0], &arglocs[1]);
                 if arglocs.len() >= 2 {
-                    self.emit_cmp_loc_loc(&arglocs[0], &arglocs[1]);
+                    if let (Loc::Immed(_), rhs) = cmp_args
+                        && !matches!(rhs, Loc::Immed(_))
+                        && let Some(reflexed) = opcode.bool_reflex()
+                    {
+                        opcode = reflexed;
+                        cmp_args = (&arglocs[1], &arglocs[0]);
+                    }
+                    self.emit_cmp_loc_loc(cmp_args.0, cmp_args.1);
                 }
-                let cc = Self::opcode_to_cc(op.opcode);
+                let cc = Self::opcode_to_cc(opcode);
                 self.flush_cc(cc, result_loc);
             }
             OpCode::IntIsTrue => {

--- a/majit/majit-backend-dynasm/src/x86/assembler.rs
+++ b/majit/majit-backend-dynasm/src/x86/assembler.rs
@@ -2958,10 +2958,25 @@ impl<'a> Assembler386<'a> {
             | OpCode::PtrNe
             | OpCode::InstancePtrEq
             | OpCode::InstancePtrNe => {
+                let mut opcode = op.opcode;
                 if arglocs.len() >= 2 {
-                    self.emit_cmp_loc_loc(&arglocs[0], &arglocs[1]);
+                    // `cmp` reaches an immediate only on its right, so a
+                    // constant on the left is moved through a scratch
+                    // register first. Swapping the operands folds it back
+                    // into the instruction, and the order the swap destroys
+                    // is carried by `resoperation.py`'s reflex table.
+                    let (cmp0, cmp1) = if matches!(arglocs[0], Loc::Immed(_))
+                        && !matches!(arglocs[1], Loc::Immed(_))
+                        && let Some(reflexed) = op.opcode.bool_reflex()
+                    {
+                        opcode = reflexed;
+                        (&arglocs[1], &arglocs[0])
+                    } else {
+                        (&arglocs[0], &arglocs[1])
+                    };
+                    self.emit_cmp_loc_loc(cmp0, cmp1);
                 }
-                let cc = Self::opcode_to_cc(op.opcode);
+                let cc = Self::opcode_to_cc(opcode);
                 self.flush_cc(cc, result_loc);
             }
             OpCode::IntIsTrue => {

--- a/majit/majit-macros/src/jit_interp/codegen_trace.rs
+++ b/majit/majit-macros/src/jit_interp/codegen_trace.rs
@@ -48,6 +48,7 @@ pub fn generate_trace_fn(config: &JitInterpConfig, func: &ItemFn) -> TokenStream
         &config.inlined_prefix,
         &config.native_int_binops,
         &config.native_tag_small,
+        &config.native_identity,
         config.split_dispatch,
         config.switch_dispatch,
     );

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/api.rs
@@ -399,6 +399,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
     int_fields: &[crate::jit_interp::IntFieldEntry],
     native_int_binops: &[(Path, Ident)],
     native_tag_small: &[Path],
+    native_identity: &[Path],
     headerless_structs: &[Path],
     inlined_prefix: &[crate::jit_interp::InlinedPrefixEntry],
 ) -> syn::Result<Option<InlineHelperJitCode>> {
@@ -439,6 +440,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
         && int_fields.is_empty()
         && native_int_binops.is_empty()
         && native_tag_small.is_empty()
+        && native_identity.is_empty()
         && headerless_structs.is_empty()
         && inlined_prefix.is_empty()
     {
@@ -450,6 +452,7 @@ pub(crate) fn generate_inline_helper_jitcode_with_calls(
             int_fields,
             native_int_binops,
             native_tag_small,
+            native_identity,
             headerless_structs,
             inlined_prefix,
         ))

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/lower_value.rs
@@ -309,6 +309,13 @@ impl<'c> Lowerer<'c> {
                 if let Some(binding) = self.lower_native_tag_small_call(call) {
                     return Some(binding);
                 }
+                // A helper that hands its argument straight back is opened by
+                // the inliner upstream and its residue dropped by
+                // `jtransform.py` `rewrite_op_same_as`; the LLBC tracer sees
+                // the call, so drop it here instead.
+                if let Some(binding) = self.lower_native_identity_call(call) {
+                    return Some(binding);
+                }
                 // Raw native-memory load intrinsic `majit_raw_load_iXX(base, ea)`
                 // → raw_load_i (jtransform.py rewrite_op_raw_load).
                 if let Some(binding) = self.lower_raw_load_call(call) {
@@ -2043,6 +2050,23 @@ impl<'c> Lowerer<'c> {
             depends_on_stack: lhs.depends_on_stack || rhs.depends_on_stack,
             struct_type: None,
         })
+    }
+
+    /// Recognize a unary function call registered in `native_identity` and
+    /// bind its argument in place of the call, emitting nothing.
+    ///
+    /// The argument is still lowered, so a receiver that mutates state keeps
+    /// running; only the wrapper around its result goes away.
+    fn lower_native_identity_call(&mut self, call: &ExprCall) -> Option<Binding> {
+        let config = self.config?;
+        let func_segments = canonical_expr_segments(&call.func)?;
+        if !config.native_identity.contains(&func_segments) {
+            return None;
+        }
+        if call.args.len() != 1 {
+            return None;
+        }
+        self.lower_value_expr(&call.args[0])
     }
 
     /// Recognize a unary function call registered in `native_tag_small` and

--- a/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
+++ b/majit/majit-macros/src/jit_interp/jitcode_lower/mod.rs
@@ -261,6 +261,10 @@ pub struct LowererConfig {
     /// Pure unary tag-small helpers.  Key = canonical func path segments.
     /// `lower_native_tag_small_call` emits `(x << 1) | 1` directly.
     pub(super) native_tag_small: Vec<Vec<String>>,
+    /// Unary helpers that return their argument unchanged.  Key = canonical
+    /// func path segments.  `lower_native_identity_call` hands the argument's
+    /// binding to the consumer and emits nothing.
+    pub(super) native_identity: Vec<Vec<String>>,
     /// Source: `JitInterpConfig.split_dispatch`.  When set, the dispatch lowerer
     /// routes pure forward-advancing green-pc arms through the per-arm
     /// sub-JitCode path with a pc-returning `inline_call_<types>_i` instead of
@@ -967,6 +971,7 @@ impl LowererConfig {
         int_fields: &[crate::jit_interp::IntFieldEntry],
         native_int_binops: &[(syn::Path, syn::Ident)],
         native_tag_small: &[syn::Path],
+        native_identity: &[syn::Path],
         headerless_structs: &[syn::Path],
         inlined_prefix: &[crate::jit_interp::InlinedPrefixEntry],
     ) -> Self {
@@ -1029,6 +1034,10 @@ impl LowererConfig {
                 .iter()
                 .map(canonical_path_segments)
                 .collect(),
+            native_identity: native_identity
+                .iter()
+                .map(canonical_path_segments)
+                .collect(),
             split_dispatch: false,
             switch_dispatch: false,
         }
@@ -1059,6 +1068,7 @@ impl LowererConfig {
         inlined_prefix: &[crate::jit_interp::InlinedPrefixEntry],
         native_int_binops: &[(Path, Ident)],
         native_tag_small: &[Path],
+        native_identity: &[Path],
         split_dispatch: bool,
         switch_dispatch: bool,
     ) -> Self {
@@ -1305,6 +1315,10 @@ impl LowererConfig {
                 .map(|(path, op)| (canonical_path_segments(path), op.to_string()))
                 .collect(),
             native_tag_small: native_tag_small
+                .iter()
+                .map(canonical_path_segments)
+                .collect(),
+            native_identity: native_identity
                 .iter()
                 .map(canonical_path_segments)
                 .collect(),
@@ -2885,9 +2899,10 @@ mod tests {
             ),
             &[inline_policy("callee")],
             // ref_params, ref_fields, array_fields, int_fields,
-            // native_int_binops, native_tag_small, headerless_structs,
-            // inlined_prefix — the surface these tests assert is the call
-            // encoding, which none of them participate in.
+            // native_int_binops, native_tag_small, native_identity,
+            // headerless_structs, inlined_prefix — the surface these tests
+            // assert is the call encoding, which none of them participate in.
+            &[],
             &[],
             &[],
             &[],
@@ -2904,6 +2919,44 @@ mod tests {
         assert!(!body.contains("inline_call_with_typed_args"));
     }
 
+    /// A `native_identity` helper leaves no call behind: the argument's
+    /// binding is what the consumer reads.  The call policies are empty, so a
+    /// recognizer that failed to fire would reach the inference-failure panic
+    /// before any assertion below runs.
+    #[test]
+    fn inline_helper_codegen_drops_a_native_identity_call() {
+        let identity: syn::Path = syn::parse_str("unwrap_word").expect("path");
+        let helper = generate_inline_helper_jitcode_with_calls(
+            &parse_fn(
+                r#"
+                fn outer(arg: i64) -> i64 {
+                    unwrap_word(arg)
+                }
+                "#,
+            ),
+            &[],
+            // ref_params, ref_fields, array_fields, int_fields,
+            // native_int_binops, native_tag_small.
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            &[],
+            std::slice::from_ref(&identity),
+            // headerless_structs, inlined_prefix.
+            &[],
+            &[],
+        )
+        .expect("jit_inline lowering should succeed")
+        .expect("helper should lower");
+        let body = helper.body.to_string();
+        assert!(
+            !body.contains("call"),
+            "a native_identity call must not reach the jitcode: {body}"
+        );
+    }
+
     #[test]
     fn inline_helper_codegen_uses_canonical_ir_surface() {
         let helper = generate_inline_helper_jitcode_with_calls(
@@ -2916,9 +2969,10 @@ mod tests {
             ),
             &[inline_policy("callee")],
             // ref_params, ref_fields, array_fields, int_fields,
-            // native_int_binops, native_tag_small, headerless_structs,
-            // inlined_prefix — the surface these tests assert is the call
-            // encoding, which none of them participate in.
+            // native_int_binops, native_tag_small, native_identity,
+            // headerless_structs, inlined_prefix — the surface these tests
+            // assert is the call encoding, which none of them participate in.
+            &[],
             &[],
             &[],
             &[],
@@ -2947,9 +3001,10 @@ mod tests {
             ),
             &[inline_policy("callee")],
             // ref_params, ref_fields, array_fields, int_fields,
-            // native_int_binops, native_tag_small, headerless_structs,
-            // inlined_prefix — the surface these tests assert is the call
-            // encoding, which none of them participate in.
+            // native_int_binops, native_tag_small, native_identity,
+            // headerless_structs, inlined_prefix — the surface these tests
+            // assert is the call encoding, which none of them participate in.
+            &[],
             &[],
             &[],
             &[],

--- a/majit/majit-macros/src/jit_interp/mod.rs
+++ b/majit/majit-macros/src/jit_interp/mod.rs
@@ -195,6 +195,17 @@ pub struct JitInterpConfig {
     pub native_int_binops: Vec<(Path, Ident)>,
     /// native_tag_small = { jit_retag_small } — unary fns lowered to (x<<1)|1 native IR.
     pub native_tag_small: Vec<Path>,
+    /// Pure function → its own argument.  `native_identity = { unwrap_word }`.
+    /// A call whose path matches one of these is replaced by the binding of
+    /// its single argument, so the trace never sees a call at all.  RPython
+    /// needs no such declaration: `backendopt/inline.py` opens a helper this
+    /// small before the codewriter runs, and `jtransform.py`
+    /// `rewrite_op_same_as` drops the identity residue it leaves behind.  The
+    /// LLBC tracer still sees the Rust call, so the drop is declared here.
+    /// Declaring a function whose argument and result do not share a register
+    /// class is a miscompile — the argument's binding is handed straight to
+    /// the consumer.
+    pub native_identity: Vec<Path>,
     /// Opt-in: route pure forward-advancing dispatch arms (those whose body
     /// only does work then `pc += N`, with no back-edge / `can_enter_jit!` /
     /// early return) through the per-arm sub-JitCode path with a pc-returning
@@ -702,6 +713,7 @@ impl Parse for JitInterpConfig {
         let mut inlined_prefix: Vec<InlinedPrefixEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
+        let mut native_identity: Vec<Path> = Vec::new();
         let mut split_dispatch = false;
         let mut switch_dispatch = false;
 
@@ -783,6 +795,9 @@ impl Parse for JitInterpConfig {
                 "native_tag_small" => {
                     native_tag_small = parse_native_tag_small_list(input)?;
                 }
+                "native_identity" => {
+                    native_identity = parse_path_set(input)?;
+                }
                 "split_dispatch" => {
                     split_dispatch = input.parse::<LitBool>()?.value;
                 }
@@ -849,6 +864,7 @@ impl Parse for JitInterpConfig {
             inlined_prefix,
             native_int_binops,
             native_tag_small,
+            native_identity,
             split_dispatch,
             switch_dispatch,
         })

--- a/majit/majit-macros/src/lib.rs
+++ b/majit/majit-macros/src/lib.rs
@@ -38,6 +38,7 @@ struct JitInlineArgs {
     int_fields: Vec<jit_interp::IntFieldEntry>,
     native_int_binops: Vec<(Path, Ident)>,
     native_tag_small: Vec<Path>,
+    native_identity: Vec<Path>,
     struct_allocs: Vec<(Path, Path)>,
     headerless_structs: Vec<Path>,
     inlined_prefix: Vec<jit_interp::InlinedPrefixEntry>,
@@ -51,6 +52,7 @@ impl Parse for JitInlineArgs {
         let mut int_fields: Vec<jit_interp::IntFieldEntry> = Vec::new();
         let mut native_int_binops: Vec<(Path, Ident)> = Vec::new();
         let mut native_tag_small: Vec<Path> = Vec::new();
+        let mut native_identity: Vec<Path> = Vec::new();
         let mut struct_allocs: Vec<(Path, Path)> = Vec::new();
         let mut headerless_structs: Vec<Path> = Vec::new();
         let mut inlined_prefix: Vec<jit_interp::InlinedPrefixEntry> = Vec::new();
@@ -119,6 +121,9 @@ impl Parse for JitInlineArgs {
                 "native_tag_small" => {
                     native_tag_small = jit_interp::parse_native_tag_small_list(input)?;
                 }
+                "native_identity" => {
+                    native_identity = jit_interp::parse_path_set(input)?;
+                }
                 "struct_allocs" => {
                     struct_allocs = jit_interp::parse_call_returns_map(input)?;
                 }
@@ -145,6 +150,7 @@ impl Parse for JitInlineArgs {
             int_fields,
             native_int_binops,
             native_tag_small,
+            native_identity,
             struct_allocs,
             headerless_structs,
             inlined_prefix,
@@ -2553,6 +2559,7 @@ pub fn jit_inline(attr: TokenStream, item: TokenStream) -> TokenStream {
         &args.int_fields,
         &args.native_int_binops,
         &args.native_tag_small,
+        &args.native_identity,
         &args.headerless_structs,
         &args.inlined_prefix,
     ) {

--- a/majit/majit-metainterp/src/optimizeopt/rewrite.rs
+++ b/majit/majit-metainterp/src/optimizeopt/rewrite.rs
@@ -63,6 +63,13 @@ enum Nullness {
     Unknown,
 }
 
+/// Which end of a range a comparison against a constant pins down.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RangeBound {
+    Lower,
+    Upper,
+}
+
 /// Rewrite operations into equivalent, cheaper forms.
 ///
 /// Handles:
@@ -76,6 +83,7 @@ enum Nullness {
 /// - Pointer equality on same OpRef
 /// - Cast and convert round-trip elimination
 /// - Guard-no-exception removal after removed calls
+/// - Range-test fusion (two constant-bounded comparisons multiplied together)
 pub struct OptRewrite {
     /// pyre-only side-cache: (opcode, arg0, arg1) → result OpRef, populated by
     /// optimize_comparison. Upstream has no bool_result_cache; find_rewritable_bool
@@ -87,6 +95,18 @@ pub struct OptRewrite {
     /// subsystem. NOT a box-identity rekey target: rekeying the OpRef pair to operand
     /// would entrench a structure upstream does not have.
     bool_result_cache: indexmap::IndexMap<(OpCode, OpRef, OpRef), OpRef>,
+    /// Result OpRef → the comparison that produced it, the reverse of
+    /// `bool_result_cache` and populated from the same arm.
+    ///
+    /// A fold that reaches back from a consumer to its comparison operands
+    /// cannot use `get_producing_op`: that reports a producer only once it is
+    /// in `emitted_operations`, and `OptHeap` — last in the pipeline — holds
+    /// the most recent comparison in `postponed_op` instead of emitting it.
+    /// The comparison immediately preceding a consumer is therefore invisible
+    /// there, which is the common case rather than a corner one. This map is
+    /// written as the comparison passes through this pass, so nothing
+    /// downstream can hide it.
+    comparison_by_result: indexmap::IndexMap<OpRef, (OpCode, Operand, Operand)>,
     /// rewrite.py:39: loop_invariant_results — cache for CALL_LOOPINVARIANT results.
     /// Key: function pointer (arg0 as i64).
     /// Value: Direct(OpRef) or Preamble(PreambleOp) — RPython isinstance check.
@@ -100,6 +120,7 @@ impl OptRewrite {
     pub fn new() -> Self {
         OptRewrite {
             bool_result_cache: indexmap::IndexMap::new(),
+            comparison_by_result: indexmap::IndexMap::new(),
             loop_invariant_results: indexmap::IndexMap::new(),
             loop_invariant_producer: indexmap::IndexMap::new(),
         }
@@ -662,8 +683,107 @@ impl OptRewrite {
         let arg1 = op.arg(1);
         self.bool_result_cache
             .insert((op.opcode, arg0.to_opref(), arg1.to_opref()), op.pos.get());
+        self.comparison_by_result
+            .insert(op.pos.get(), (op.opcode, arg0, arg1));
 
         OptimizationResult::PassOn
+    }
+
+    /// One side of a range test: the value compared, its bound, and whether
+    /// the bound is the lower or the upper one.
+    ///
+    /// `IntGe(v, C)` is `v >= C`, so `C` is a lower bound; `IntGe(C, v)` is
+    /// `C >= v`, so `C` is an upper bound. A comparison of two constants is
+    /// not a range test side — constant folding owns it.
+    fn range_bound_of(
+        &self,
+        entry: &(OpCode, Operand, Operand),
+        ctx: &mut OptContext,
+    ) -> Option<(RangeBound, Operand, i64)> {
+        let (opcode, ref arg0, ref arg1) = *entry;
+        if opcode != OpCode::IntGe {
+            return None;
+        }
+        let const_of = |ctx: &mut OptContext, o: &Operand| {
+            ctx.resolve_operand_operand_opt(o)
+                .and_then(|b| ctx.get_constant_int_box(&b))
+        };
+        match (const_of(ctx, arg0), const_of(ctx, arg1)) {
+            (None, Some(lo)) => Some((RangeBound::Lower, arg0.clone(), lo)),
+            (Some(hi), None) => Some((RangeBound::Upper, arg1.clone(), hi)),
+            _ => None,
+        }
+    }
+
+    /// Fuse a pair of constant-bounded comparisons multiplied together into a
+    /// single unsigned compare.
+    ///
+    /// `IntMul(IntGe(v, LO), IntGe(HI, v))` is `LO <= v <= HI` computed as a
+    /// branchless product of two 0/1 results. The same predicate is one
+    /// unsigned compare against a constant span, `uint_lt(v - LO, HI+1-LO)`,
+    /// exact for every `v` because the subtraction wraps. The emitted shape
+    /// is the expansion `pyjitpl.py opimpl_int_between` performs, down to its
+    /// collapse to `int_eq` on a span of one, so the two spellings of the
+    /// predicate optimize to the same operations.
+    ///
+    /// Only the multiply is rewritten; both comparisons are left in the
+    /// trace. A guard's failargs may name one, and one that nothing reads
+    /// costs nothing to leave — the backend skips a pure op with no live
+    /// result rather than encoding it.
+    fn optimize_int_mul_range_test(&mut self, op: &Op, ctx: &mut OptContext) -> OptimizationResult {
+        let lhs = ctx.resolve_operand_operand(&op.arg(0)).to_opref();
+        let rhs = ctx.resolve_operand_operand(&op.arg(1)).to_opref();
+        let (Some(lhs_entry), Some(rhs_entry)) = (
+            self.comparison_by_result.get(&lhs).cloned(),
+            self.comparison_by_result.get(&rhs).cloned(),
+        ) else {
+            return OptimizationResult::PassOn;
+        };
+        let (Some(left), Some(right)) = (
+            self.range_bound_of(&lhs_entry, ctx),
+            self.range_bound_of(&rhs_entry, ctx),
+        ) else {
+            return OptimizationResult::PassOn;
+        };
+        // One bound of each kind, both against the same value. Two lower
+        // bounds (or two upper ones) are a different predicate entirely.
+        let ((var, lo), (other, hi)) = match (left, right) {
+            ((RangeBound::Lower, v, lo), (RangeBound::Upper, o, hi))
+            | ((RangeBound::Upper, o, hi), (RangeBound::Lower, v, lo)) => ((v, lo), (o, hi)),
+            _ => return OptimizationResult::PassOn,
+        };
+        if var.to_opref() != other.to_opref() {
+            return OptimizationResult::PassOn;
+        }
+        // An empty range is a constant-false predicate this fold does not
+        // spell, and a span that does not fit an i64 has no constant to
+        // compare against.
+        let Some(span) = hi
+            .checked_sub(lo)
+            .filter(|d| *d >= 0)
+            .and_then(|d| d.checked_add(1))
+        else {
+            return OptimizationResult::PassOn;
+        };
+        // The value rides on the inline-Const OpRef tag, so a bound needs no
+        // producing operation of its own.
+        let lo_operand = ctx.materialize_operand_at(majit_ir::OpRef::const_int(lo));
+        // opimpl_int_between: `a <= b < a+1` is `b == a`.
+        let mut fused = if span == 1 {
+            Op::new(OpCode::IntEq, &[var, lo_operand])
+        } else {
+            let offset = ctx.send_extra_operation(Op::new(OpCode::IntSub, &[var, lo_operand]));
+            let offset_operand = ctx.materialize_operand_at(offset);
+            let span_operand = ctx.materialize_operand_at(majit_ir::OpRef::const_int(span));
+            Op::new(OpCode::UintLt, &[offset_operand, span_operand])
+        };
+        fused.pos.set(op.pos.get());
+        // Re-dispatched from the head of the chain, not handed to the next
+        // pass: the bound of the fused result is what lets a later
+        // `OptIntBounds` rule keep the arithmetic that reads it on the
+        // unchecked opcodes. Skipping that pass leaves the result unbounded
+        // and promotes every such consumer to an overflow-checked form.
+        OptimizationResult::Restart(fused)
     }
 
     // ── Guards ──
@@ -1798,6 +1918,7 @@ impl Optimization for OptRewrite {
             OpCode::IntIsTrue => self.optimize_int_is_true(op, op_rc, ctx),
             OpCode::IntForceGeZero => self.optimize_int_force_ge_zero(op, op_rc, ctx),
             OpCode::IntBetween => self.optimize_int_between(op, ctx),
+            OpCode::IntMul => self.optimize_int_mul_range_test(op, ctx),
 
             // ── Comparisons ──
             OpCode::IntLt
@@ -2333,6 +2454,7 @@ impl Optimization for OptRewrite {
         // maintained cross-pass by propagate_from_pass_range +
         // emit_operation — no per-pass setup needed.
         self.bool_result_cache.clear();
+        self.comparison_by_result.clear();
         self.loop_invariant_results.clear();
         self.loop_invariant_producer.clear();
     }
@@ -2688,6 +2810,178 @@ mod tests {
 
         let new_ops: Vec<Op> = ctx.new_operations.iter().map(|rc| (**rc).clone()).collect();
         (new_ops, ctx)
+    }
+
+    /// `2025 <= v <= 5625` spelled as a product of two comparisons, the shape
+    /// a guest program produces when it has no range primitive of its own.
+    /// Both bounds are constants, so the fused form compares against a
+    /// constant span and the multiply disappears.
+    fn range_test_specs(lo: i64, hi: i64) -> (Vec<OpSpec>, Vec<(OpRef, Value)>) {
+        let specs = vec![
+            same_i(),                    // 0: v
+            same_i(),                    // 1: LO
+            same_i(),                    // 2: HI
+            bin_i(OpCode::IntGe, 0, 1),  // 3: v >= LO
+            bin_i(OpCode::IntGe, 2, 0),  // 4: HI >= v
+            bin_i(OpCode::IntMul, 3, 4), // 5: both
+        ];
+        let constants = vec![
+            (OpRef::int_op(1), Value::Int(lo)),
+            (OpRef::int_op(2), Value::Int(hi)),
+        ];
+        (specs, constants)
+    }
+
+    fn opcodes_of(ops: &[Op]) -> Vec<OpCode> {
+        ops.iter().map(|op| op.opcode).collect()
+    }
+
+    /// Like `run_one`, but every op from `num_inputs` on transits the chain,
+    /// so a fold that reads what an earlier op recorded is exercised. The
+    /// leading input ops are emitted directly, as `run_one` does — routing a
+    /// constant-valued placeholder through the chain would ask the executor
+    /// to fold it.
+    ///
+    /// Returns the emitted ops and, separately, the ops a pass parked in
+    /// `extra_operations_after`. Production propagates those through the
+    /// remaining passes and `Optimizer::emit_operation` lands each one ahead
+    /// of its consumer via `flush_queued_producer`; only the whole optimizer
+    /// drives that, so here they are reported rather than emitted.
+    fn run_rewrite_after_inputs(
+        specs: &[OpSpec],
+        num_inputs: usize,
+        constants: &[(OpRef, Value)],
+    ) -> (Vec<Op>, Vec<Op>) {
+        let ops = build_specs(specs);
+        let mut ctx = OptContext::new(ops.len());
+        for op in &ops[..num_inputs] {
+            ctx.emit((**op).clone());
+        }
+        for &(opref, value) in constants {
+            let b = ctx.materialize_operand_at(opref);
+            ctx.make_constant_box(&b, value);
+        }
+        let mut passes = test_pass_chain();
+        let mut queued: Vec<Op> = Vec::new();
+        for op in &ops[num_inputs..] {
+            let mut resolved = (**op).clone();
+            resolve_op_args_in_ctx(&mut resolved, &mut ctx);
+            let op_rc = std::rc::Rc::new(resolved.clone());
+            ctx.bind_input_resops(std::slice::from_ref(&op_rc));
+            let mut result = OptimizationResult::PassOn;
+            for pass in passes.iter_mut() {
+                result = pass.propagate_forward(&resolved, &op_rc, &mut ctx);
+                if !matches!(result, OptimizationResult::PassOn) {
+                    break;
+                }
+            }
+            while let Some((_, extra)) = ctx.extra_operations_after.pop_front() {
+                queued.push((*extra).clone());
+            }
+            match result {
+                OptimizationResult::Emit(op)
+                | OptimizationResult::Replace(op)
+                | OptimizationResult::Restart(op) => {
+                    ctx.emit(op);
+                }
+                OptimizationResult::PassOn => {
+                    ctx.emit(resolved);
+                }
+                OptimizationResult::Remove => {}
+                OptimizationResult::InvalidLoop(reason) => panic!("invalid loop: {reason}"),
+            }
+        }
+        let emitted = ctx.new_operations.iter().map(|rc| (**rc).clone()).collect();
+        (emitted, queued)
+    }
+
+    #[test]
+    fn a_multiplied_pair_of_constant_bounded_comparisons_becomes_one_unsigned_compare() {
+        let (specs, constants) = range_test_specs(2025, 5625);
+        let (ops, queued) = run_rewrite_after_inputs(&specs, 3, &constants);
+        let opcodes = opcodes_of(&ops);
+
+        assert!(
+            !opcodes.contains(&OpCode::IntMul),
+            "the multiply must be replaced, got {opcodes:?}"
+        );
+        let sub = queued
+            .iter()
+            .find(|op| op.opcode == OpCode::IntSub)
+            .unwrap_or_else(|| panic!("the offset subtraction must be queued, got {queued:?}"));
+        assert_eq!(sub.arg(1).const_int(), Some(2025), "offset is `v - LO`");
+        let cmp = ops
+            .iter()
+            .find(|op| op.opcode == OpCode::UintLt)
+            .expect("the fused compare must be emitted");
+        assert_eq!(
+            cmp.arg(0).to_opref(),
+            sub.pos.get(),
+            "the compare reads the queued offset"
+        );
+        // `HI + 1 - LO`, the exclusive span opimpl_int_between compares against.
+        assert_eq!(cmp.arg(1).const_int(), Some(3601));
+    }
+
+    /// The fold rewrites the multiply and nothing else. A comparison whose
+    /// result a guard names in its failargs is still needed to rebuild the
+    /// interpreter state, so removing it here would corrupt the deopt.
+    #[test]
+    fn a_fused_range_test_leaves_both_comparisons_in_the_trace() {
+        let (specs, constants) = range_test_specs(2025, 5625);
+        let (ops, _queued) = run_rewrite_after_inputs(&specs, 3, &constants);
+
+        assert_eq!(
+            opcodes_of(&ops)
+                .iter()
+                .filter(|opcode| **opcode == OpCode::IntGe)
+                .count(),
+            2,
+            "both bound comparisons must survive the fold"
+        );
+    }
+
+    /// opimpl_int_between collapses `a <= b < a+1` to `b == a`; a range whose
+    /// bounds meet is that case.
+    #[test]
+    fn a_range_test_of_one_value_becomes_an_equality() {
+        let (specs, constants) = range_test_specs(7, 7);
+        let (ops, queued) = run_rewrite_after_inputs(&specs, 3, &constants);
+        let opcodes = opcodes_of(&ops);
+
+        assert!(opcodes.contains(&OpCode::IntEq), "got {opcodes:?}");
+        assert!(!opcodes.contains(&OpCode::UintLt), "no span compare needed");
+        assert!(queued.is_empty(), "no offset needed, got {queued:?}");
+    }
+
+    /// Two bounds of the same kind are a different predicate, and an empty
+    /// range is not one this fold spells. Neither may be rewritten.
+    #[test]
+    fn only_an_opposed_pair_over_a_nonempty_range_fuses() {
+        let two_lower = vec![
+            same_i(),
+            same_i(),
+            same_i(),
+            bin_i(OpCode::IntGe, 0, 1),
+            bin_i(OpCode::IntGe, 0, 2),
+            bin_i(OpCode::IntMul, 3, 4),
+        ];
+        let constants = vec![
+            (OpRef::int_op(1), Value::Int(10)),
+            (OpRef::int_op(2), Value::Int(20)),
+        ];
+        assert!(
+            opcodes_of(&run_rewrite_after_inputs(&two_lower, 3, &constants).0)
+                .contains(&OpCode::IntMul),
+            "two lower bounds are not a range test"
+        );
+
+        let (specs, empty_range) = range_test_specs(100, 20);
+        assert!(
+            opcodes_of(&run_rewrite_after_inputs(&specs, 3, &empty_range).0)
+                .contains(&OpCode::IntMul),
+            "an empty range must not be rewritten"
+        );
     }
 
     // ── Binary integer operation tests (consolidated) ──

--- a/majit/majit-metainterp/src/pyjitpl/dispatch.rs
+++ b/majit/majit-metainterp/src/pyjitpl/dispatch.rs
@@ -5001,6 +5001,7 @@ where
             jitcode::insns::BC_UINT_LE => self.trace_binop_i(ctx, OpCode::UintLe),
             jitcode::insns::BC_UINT_GT => self.trace_binop_i(ctx, OpCode::UintGt),
             jitcode::insns::BC_UINT_GE => self.trace_binop_i(ctx, OpCode::UintGe),
+            jitcode::insns::BC_INT_BETWEEN => self.trace_int_between(ctx),
             jitcode::insns::BC_INT_NEG => self.trace_unary_i(ctx, OpCode::IntNeg),
             jitcode::insns::BC_INT_INVERT => self.trace_unary_i(ctx, OpCode::IntInvert),
             jitcode::insns::BC_INT_IS_TRUE => self.trace_unary_i(ctx, OpCode::IntIsTrue),
@@ -9068,13 +9069,28 @@ where
             let dst = frame.next_reg() as usize;
             (lhs_idx, rhs_idx, dst)
         };
-        let (lhs, lhs_value) = self.read_int_reg(lhs_idx);
-        let (rhs, rhs_value) = self.read_int_reg(rhs_idx);
+        let lhs = self.read_int_reg(lhs_idx);
+        let rhs = self.read_int_reg(rhs_idx);
+        let (opref, value) = self.execute_binop_i(ctx, opcode, lhs, rhs);
+        self.set_int_reg(dst, Some(opref), Some(value));
+    }
+
+    /// `pyjitpl.py MIFrame.execute(opnum, b1, b2)` over two int boxes.
+    ///
+    /// Returns the result box paired with the value the traced iteration
+    /// produced, which is what an opimpl that chains several of these needs
+    /// in order to test an intermediate for constancy.
+    fn execute_binop_i(
+        &mut self,
+        ctx: &mut TraceCtx,
+        opcode: OpCode,
+        (lhs, lhs_value): (OpRef, i64),
+        (rhs, rhs_value): (OpRef, i64),
+    ) -> (OpRef, i64) {
         if lhs == rhs
             && let Some(fast) = fastpath_same_boxes(opcode)
         {
-            self.set_int_reg(dst, Some(ctx.const_int(fast)), Some(fast));
-            return;
+            return (ctx.const_int(fast), fast);
         }
         let value = eval_binop_i(opcode, lhs_value, rhs_value);
         // pyjitpl.py `_record_helper_pure`: a pure op whose args are all
@@ -9082,14 +9098,43 @@ where
         // nothing.  Every opcode routed here is a pure int/uint arithmetic or
         // comparison, so an all-constant pair yields a constant destination.
         if lhs.is_constant() && rhs.is_constant() {
-            self.set_int_reg(dst, Some(ctx.const_int(value)), Some(value));
-            return;
+            return (ctx.const_int(value), value);
         }
         let opref = ctx.record_op(opcode, &[lhs, rhs]);
         // `Box(value)` parity: stamp the result OpRef with its
         // runtime concrete so downstream `box_value(opref)` consumers
         // see the value (matches PyPy `BoxInt(value)` carrier).
         ctx.set_opref_concrete(opref, majit_ir::Value::Int(value));
+        (opref, value)
+    }
+
+    /// `pyjitpl.py opimpl_int_between` — `a <= b < c`, expanded here into
+    /// `uint_lt(b - a, c - a)`, or into `int_eq(b, a)` when the span is one.
+    ///
+    /// The three-argument form is a jitcode op with no resop behind it: the
+    /// tracer never records one, which is why no backend has to lower it.
+    /// `blackhole.py bhimpl_int_between` evaluates the jitcode op directly,
+    /// so the op itself stays.
+    fn trace_int_between(&mut self, ctx: &mut TraceCtx) {
+        // `[a][b][c][dst]` matching the `bhhandler_iii_i!` decoder.
+        let (a_idx, b_idx, c_idx, dst) = {
+            let frame = self.frames.current_mut();
+            let a_idx = frame.next_reg() as usize;
+            let b_idx = frame.next_reg() as usize;
+            let c_idx = frame.next_reg() as usize;
+            let dst = frame.next_reg() as usize;
+            (a_idx, b_idx, c_idx, dst)
+        };
+        let a = self.read_int_reg(a_idx);
+        let b = self.read_int_reg(b_idx);
+        let c = self.read_int_reg(c_idx);
+        let span = self.execute_binop_i(ctx, OpCode::IntSub, c, a);
+        let (opref, value) = if span.0.is_constant() && span.1 == 1 {
+            self.execute_binop_i(ctx, OpCode::IntEq, b, a)
+        } else {
+            let offset = self.execute_binop_i(ctx, OpCode::IntSub, b, a);
+            self.execute_binop_i(ctx, OpCode::UintLt, offset, span)
+        };
         self.set_int_reg(dst, Some(opref), Some(value));
     }
 

--- a/majit/majit-translate/src/front/mir.rs
+++ b/majit/majit-translate/src/front/mir.rs
@@ -12464,10 +12464,26 @@ impl<'a> Lowering<'a> {
         if first.as_str() != "core" || module.as_str() != "num" || impl_seg.as_str() != "<Impl>" {
             return Ok(false);
         }
-        let op = match leaf.as_str() {
-            "wrapping_add" => "add",
-            "wrapping_sub" => "sub",
-            "wrapping_mul" => "mul",
+        // `wrapping_div` / `wrapping_rem` are the C-truncating primitives, so
+        // they are `llop.int_floordiv` / `llop.int_mod` the same way
+        // `wrapping_add` is `llop.int_add`: `jtransform.py`
+        // `rewrite_op_int_floordiv` / `rewrite_op_int_mod` route those two to
+        // `support.py` `_ll_2_int_floordiv` / `_ll_2_int_mod`, whose bodies are
+        // these same wrapping primitives. Left as a `Call`, the leaf is Opaque
+        // in the LLBC and every division becomes a symbolic host call the
+        // caller must guard for an exception it cannot raise.
+        //
+        // Unsigned does not follow here. The rename table that folds
+        // `uint_{add,sub,mul}` back onto `int_*` — one machine op under two
+        // rtyper dispatches — has no entry for `uint_floordiv` / `uint_mod`,
+        // which really are different instructions, so an unsigned receiver
+        // keeps the `Call` form.
+        let (op, signed_only) = match leaf.as_str() {
+            "wrapping_add" => ("add", false),
+            "wrapping_sub" => ("sub", false),
+            "wrapping_mul" => ("mul", false),
+            "wrapping_div" => ("floordiv", true),
+            "wrapping_rem" => ("mod", true),
             _ => return Ok(false),
         };
         let [lhs, rhs] = args else {
@@ -12487,6 +12503,9 @@ impl<'a> Lowering<'a> {
         let signed_word = matches!(self.tyref_literal_int_atom(src), Some("I64" | "Isize"));
         let unsigned_word = matches!(self.tyref_literal_uint_atom(src), Some("U64" | "Usize"));
         if !signed_word && !unsigned_word {
+            return Ok(false);
+        }
+        if signed_only && !signed_word {
             return Ok(false);
         }
         let bb_id = self.block_id[mir_bb];


### PR DESCRIPTION
Six commits on the majit side of the aheui work. The three most recent are described in detail below; the earlier three were already on this branch.

## `OptRewrite`: fuse a multiplied pair of constant-bounded comparisons

`IntMul(IntGe(v, LO), IntGe(HI, v))` — a range test computed as a branchless product of two 0/1 results — is rewritten to `UintLt(IntSub(v, LO), HI + 1 - LO)`, or to `IntEq(v, LO)` when the span is one. That is the expansion `pyjitpl.py opimpl_int_between` performs; what is new is the **trigger**, since a jitcode `int_between` reaches the same expansion from the source language rather than from a recorded pattern. A guest language with no range primitive of its own cannot spell `int_between`, so the pattern only ever arrives recorded.

Three implementation points worth review attention:

- **`Restart`, not `Replace`.** Handing the fused op to the next pass skips `OptIntBounds` (pass 0), which leaves the result unbounded and promotes every consumer of it to the overflow-checked opcodes. Measured on the trial program: guards went 71 → 161 with `Replace`, and back to 71 with `Restart`.
- **Both comparisons stay.** Only the multiply is rewritten. A guard's failargs may name a comparison result — measured, 15 of 250 do — so deleting them would corrupt deopt. The unreferenced ones are dropped by the backend's dead-pure-op skip rather than here.
- **A result-keyed comparison record.** `get_producing_op` reports the comparison immediately preceding a consumer as absent, because `OptHeap` holds it in `postponed_op` and it has therefore not entered `emitted_operations`. This is the common case, not a corner one: on the trial trace it hides one of the two operands for 123 of 127 sites. `OptRewrite` now records comparisons by result as they transit, which nothing downstream can hide — the same shape `bool_result_cache` already uses for `find_rewritable_bool`.

## `opimpl_int_between` at trace time

`int_between/iii>i` is a wired jitcode insn that the blackhole executes and cranelift lowers, but the tracer had no arm for it and its default is a hard panic. Ported line-for-line from `pyjitpl.py MIFrame.opimpl_int_between`: `INT_SUB`/`INT_SUB`/`UINT_LT`, collapsing to `INT_EQ` when the span is one. `trace_binop_i`'s body after the register reads is extracted into `execute_binop_i`, the two-int-box form of `MIFrame.execute`, which returns the box paired with the traced value so a chained expansion can test an intermediate for constancy.

No targeted test: the runtime jitcode assembler has no 3-argument emitter for `int_between` (`record_binop_i` is 2-argument) and the macro path never emits it, so a jitcode holding the op cannot be constructed. Standing in for one: line-by-line upstream correspondence, the prior behaviour was `panic!` so the worst case is bounded by today's, and the op is unreached in pyre today (`insns.bin` uses 103 of 201 names and this is not among them).

## `native_identity` macro vocabulary

A call to a listed path is replaced by the binding of its single argument, emitting nothing; the argument is still lowered, so a receiver that mutates state keeps running. Upstream needs no such declaration — `backendopt/inline.py` opens a helper this small before the codewriter runs and `jtransform.py rewrite_op_same_as` drops the identity residue — but the LLBC tracer still sees the Rust call, so the drop is declared here.

## Verification

- `cargo test -p majit-metainterp --no-default-features --features dynasm`: **1815 passed / 0 failed** on aarch64 and on x86_64 under Rosetta.
- Downstream guest corpus: 69/69 fast programs byte-identical between JIT and interpreter, 9/9 long-running ones prefix-identical.
- Trial program, JIT vs interpreter output byte-identical throughout.

Effect of the fusion commit alone, interleaved A/B against a rig-floor control (same binary in two arms), min/p50 of 41, quiet box, three independent runs:

| run | rig floor min / p50 | AFTER/BEFORE min / p50 |
|---|---|---|
| 1 | 1.001 / 1.008 | 0.962 / 0.967 |
| 2 | 0.992 / 1.005 | 0.938 / 0.957 |
| 3 | 0.996 / 1.006 | 0.953 / 0.961 |

**−3.8% CPU (p50 mean, range −3.3% to −4.3%)** against a floor of +0.6%. Emitted code 12204 → 11804 bytes. The optimized loop grows 854 → 987 operations — there is no trace-level DCE, so each site goes from 3 ops to 5 — and the win is entirely in what the backend then declines to encode.

## Not verified locally

`check.py` could not run in this tree: the LLBC artefacts for `majit-rlib`, `pyre-object`, `pyre-interpreter` and `pyre-jit` are stale for reasons unrelated to these commits, none of which touch those crates. CI owns that gate. Note that the fusion arm lives in shared majit, so its match predicate runs on every `IntMul` pyre traces.